### PR TITLE
docs: add full architecture/decision review and fix ADR index

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ This document outlines repository rules, code conventions, testing instructions,
 src/garmin_sync/
   config.py            # Typed Settings & validation
   dates.py             # Europe/Warsaw date provider
-  models.py            # Domain Schema Version 3 models & provenance (ADR-0002)
+  models.py            # Schema Version 3 models (ADR-0002); provenance records (ADR-0010)
   garmin_client.py     # Garmin API wrapper with exponential backoff
   token_store.py       # LocalTokenStore & GcsTokenStore abstraction
   firestore_repository.py # Firestore user-scoped repository

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,18 +33,15 @@ This document outlines repository rules, code conventions, testing instructions,
 * `cd app && npm ci` — Install node dependencies
 * `cd app && npm run check` — Run full validation suite (TypeScript typecheck, ESLint, Vitest, workout catalog)
 * `cd app && npm test` — Run engine unit test suite (`vitest run`)
-* `cd app && npm run test:rules` — Firestore security-rule suite (needs Java + emulator)
-* `cd app && npm run simulate:scenarios` — Decision-quality scenario report
-* `cd app && npm run replay:recommendation` — Replay a persisted decision against its audit
+* `cd app && npm run test:rules` — Firestore security-rule suite inside the local Firebase emulator (needs Java)
 * `cd app && npm run build` — Build production bundle (`npm run check && vite build`)
 * `cd app && npm run dev` — Start Vite dev server (automatically executes `npm run check` pre-flight)
 * `cd app && npm run validate:workouts` — Validate workout catalog definitions and prescription contracts
-* `cd app && npm run simulate:scenarios` — Run multi-week engine simulations and generate reports in `artifacts/simulation-reports/latest/`
-* `cd app && npm run replay:recommendation -- <audit.json>` — Replay and audit historical recommendation decision reproducibility
+* `cd app && npm run simulate:scenarios` — Run multi-week engine simulations; reports land in `artifacts/simulation-reports/latest/`
+* `cd app && npm run replay:recommendation -- <audit.json>` — Replay a persisted decision against its own audit to verify reproducibility
 * `cd app && npm run visual:install` — Install Playwright Chromium binary for visual review tests
 * `cd app && npm run visual:refresh` — Capture desktop/mobile visual review screenshots in `artifacts/visual-review/latest/`
 * `cd app && npm run visual:serve` — Start visual review harness dev server with synthetic fixtures (`http://127.0.0.1:4174`)
-* `cd app && npm run test:rules` — Run Firestore security rules unit test suite inside local Firebase emulator
 
 
 ### Docker
@@ -102,6 +99,41 @@ app/src/engine/
 ADR. Known divergences between the ADRs and the code are tracked in
 `docs/analysis/2026-08-08-architecture-review.md`, with remediation sequenced in
 `docs/plans/`.
+
+---
+
+## Reading the documentation
+
+`docs/` directories are not interchangeable — each has a different relationship to the
+truth, and reading one as if it were another has already caused a fixed defect to be
+re-reported three times. **[`docs/README.md`](./docs/README.md) opens with the routing
+table**: which directory is authoritative for what, precedence when two documents
+disagree, and task-oriented entry points. Read it before trusting any other document
+here.
+
+The short version:
+
+| Directory | Is | Trust for |
+|---|---|---|
+| `docs/adr/` | Immutable decisions | Intended design and rationale — *not* current behaviour |
+| `docs/architecture/` | Living reference | How it works today |
+| `docs/analysis/` | Dated audit | Evidence as of its date — verify findings against code |
+| `docs/plans/` | Mutable, status-tracked | Work to be done; `Implemented`/`Archived` plans are history, not instructions |
+| `docs/ops/` | Runbooks | Operational procedure |
+
+**When two documents disagree, the code wins, then `architecture/`, then `adr/`.** Do not
+silently pick one — fix the doc or record the divergence in the current review document,
+and say which you did.
+
+### Writing conventions
+
+* **Reference symbols, never line numbers.** Write `` `rules.ts` `evaluateEnvelopes` `` or
+  `` `prescription.ts:workoutForTemplate` ``, never `` `rules.ts:544-556` ``. Line numbers
+  drift within hours; a 2026-08-08 audit found 91 of them in `docs/plans/`, three of six
+  sampled already pointing at the wrong code on the day they were written.
+* **A finished plan must not read like a work list.** When a plan reaches `Implemented`,
+  strike or delete its present-tense problem statements. See
+  [`docs/plans/README.md`](./docs/plans/README.md#conventions-that-exist-because-they-were-violated).
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,11 +26,16 @@ This document outlines repository rules, code conventions, testing instructions,
 * `uv run pytest` — Run unit tests
 * `uv run python -m garmin_sync sync` — Run daily ingestion
 * `uv run python -m garmin_sync backfill --days 56` — Run historical backfill
+* `uv run python -m garmin_sync audit --days 90` — Report sync/archive completeness
+* `uv run python -m garmin_sync rebuild --start-date X --end-date Y` — Offline snapshot rebuild
 
 ### Frontend App
 * `cd app && npm ci` — Install node dependencies
 * `cd app && npm run check` — Run full validation suite (TypeScript, ESLint, Vitest, workout catalog)
 * `cd app && npm test` — Run engine unit test suite (`vitest run`)
+* `cd app && npm run test:rules` — Firestore security-rule suite (needs Java + emulator)
+* `cd app && npm run simulate:scenarios` — Decision-quality scenario report
+* `cd app && npm run replay:recommendation` — Replay a persisted decision against its audit
 * `cd app && npm run build` — Build production bundle (`npm run check && vite build`)
 * `cd app && npm run dev` — Start Vite dev server (automatically executes `npm run check` pre-flight)
 
@@ -45,13 +50,18 @@ This document outlines repository rules, code conventions, testing instructions,
 src/garmin_sync/
   config.py            # Typed Settings & validation
   dates.py             # Europe/Warsaw date provider
-  models.py            # Domain Schema Version 2 models & provenance
+  models.py            # Domain Schema Version 3 models & provenance (ADR-0002)
   garmin_client.py     # Garmin API wrapper with exponential backoff
   token_store.py       # LocalTokenStore & GcsTokenStore abstraction
   firestore_repository.py # Firestore user-scoped repository
   metrics.py           # Pure baseline and intensity classification math
   mapper.py            # Payload transformation with metric dates
-  service.py           # Daily sync and backfill orchestrator
+  provider.py          # WearableProvider protocol (vendor-neutral boundary)
+  garmin_provider.py   # Garmin adapter implementing WearableProvider
+  canonical.py         # Vendor-neutral canonical metric/activity models
+  archive.py           # Immutable raw payload archive (ADR-0005)
+  audit.py             # Sync completeness reporting
+  service.py           # Daily sync, backfill, rebuild orchestrator
   cli.py               # Argument parsing and entry points
 
 app/src/engine/
@@ -64,7 +74,26 @@ app/src/engine/
   microcycle.ts        # Weekly training objectives & exposure progress tracker
   fatigue.ts           # 6-dimensional fatigue state, exponential decay & internal response
   optimizer.ts         # Benefit vs cost utility optimization candidate selector
+  eligibility.ts       # The single hard-gate resolver (time/equipment/environment/guardrails)
+  trainingIntent.ts    # Composes periodization + objectives + fatigue + planned dose (ADR-0009)
+  trainingHistory.ts   # TrainingHistoryProvider boundary; Firestore impl is injected
+  trainingHistorySnapshot.ts # Immutable, revisioned bounded history (ADR-0010)
+  completedTraining.ts # Garmin/adherence reconciliation into completed exposures
+  dataState.ts         # AVAILABLE / MISSING / INVALID / UNAVAILABLE read semantics
+  dose.ts              # Planned dose x clinical ceiling x athlete adjustment
+  planner.ts           # Rolling 7-day projection & weekly anchor pre-pass (ADR-0008/0011)
+  provenance.ts        # Builds the persisted RecommendationAudit
+  replay.ts            # Verifies a persisted decision against its own audit
+  policy.ts            # POLICY_VERSION -- bump when a decision-affecting change lands
+  stimulus.ts          # V2 fractional objective credit (scaffolding, not yet wired)
+  simulation/          # Scenario harness: runAllScenarios, decision-quality metrics
 ```
+
+**Before changing engine behaviour**, read
+`docs/architecture/recommendation-engine.md` (the two selection paths) and the relevant
+ADR. Known divergences between the ADRs and the code are tracked in
+`docs/analysis/2026-08-08-architecture-review.md`, with remediation sequenced in
+`docs/plans/`.
 
 ---
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,18 @@ WORKDIR /app
 # Install uv for fast dependency restoration
 RUN pip install --no-cache-dir uv
 
-# Copy project definition and lock file
-COPY pyproject.toml uv.lock /app/
+# Copy project definition and lock file. README.md is required here even though it is
+# not source: pyproject.toml declares `readme = "README.md"`, and hatchling validates
+# that metadata while building the project, so `uv sync` fails with
+# "OSError: Readme file does not exist: README.md" without it.
+COPY pyproject.toml uv.lock README.md /app/
 
-# Install dependencies into virtual environment
+# Resolve third-party dependencies first, without building the project itself, so this
+# layer stays cached when only src/ changes.
+RUN uv sync --frozen --no-dev --no-install-project
+
+# Then add the sources and install the project on top.
+COPY src /app/src
 RUN uv sync --frozen --no-dev
 
 # Final runtime image

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,48 @@ Welcome to the documentation for **Adaptive Training Recommender**, a hybrid sys
 
 ---
 
+## Start here: which document is authoritative?
+
+Directories in `docs/` are not interchangeable. Each has a different relationship to the
+truth, and reading one as if it were another is the single most expensive mistake made in
+this repository so far — a fixed defect was re-reported three times because an
+`Implemented` plan still read like a work list.
+
+| Directory | Answers | Trust it for | Do **not** trust it for |
+|---|---|---|---|
+| [`adr/`](./adr/) | "What did we choose, and why?" | The intended design and its rationale. Immutable once accepted. | What the code *does today* — an ADR can be aspirational or partly unimplemented. |
+| [`architecture/`](./architecture/) | "How does it work now?" | Current behaviour. Living reference, updated with the code. | Rationale — it describes, it does not justify. |
+| [`analysis/`](./analysis/) | "What was true on date X?" | Evidence gathered on its date. Dated, never edited after publication. | Current state. Findings may have been fixed since. Verify against code. |
+| [`plans/`](./plans/) | "How do we get from here to there?" | Sequenced work, with per-task status markers. | Anything in a plan marked `Implemented` or `Archived` — historical record only. |
+| [`ops/`](./ops/) | "How do I run it?" | Operational procedure. | Design intent. |
+
+**Precedence when two documents disagree: the code wins, then `architecture/`, then
+`adr/`, then everything else.** If you find a disagreement, do not silently pick one —
+record it in the current review document
+([`analysis/2026-08-08-architecture-review.md`](./analysis/2026-08-08-architecture-review.md))
+or fix the doc, and say which you did.
+
+Two conventions apply to every document here, both added after being violated (see
+[`plans/README.md` § Conventions](./plans/README.md#conventions-that-exist-because-they-were-violated)):
+
+* **Reference symbols, never line numbers.** Write `` `rules.ts` `evaluateEnvelopes` ``,
+  not `` `rules.ts:544-556` ``. Line numbers were measured to go stale within hours.
+* **A finished plan must not read like a work list.** Present-tense problem statements in
+  `Implemented` documents get acted on as if they were live.
+
+### Task-oriented entry points
+
+| If you are… | Read, in order |
+|---|---|
+| Changing engine decision behaviour | [`architecture/recommendation-engine.md`](./architecture/recommendation-engine.md) → the relevant ADR → [`analysis/2026-08-08-architecture-review.md`](./analysis/2026-08-08-architecture-review.md) for known divergences |
+| Picking up scheduled work | [`plans/README.md`](./plans/README.md) — the status table says what is startable today |
+| Changing Firestore paths, rules, or schema | [ADR-0002](./adr/0002-user-scoped-firestore-isolation.md) → [ADR-0010](./adr/0010-decision-provenance-and-audit-replay.md) → `app/firestore.rules` |
+| Changing dates or step semantics | [ADR-0003](./adr/0003-timezone-semantics-and-d1-step-window.md) — these are hard invariants, not preferences |
+| Adding or editing workouts | [`workout-library.md`](./workout-library.md) → [ADR-0004](./adr/0004-workout-library-architecture.md) |
+| Deploying or backfilling | [`ops/`](./ops/) |
+
+---
+
 ## 📚 Documentation Index
 
 ### 🏛️ Architecture Decision Records (ADRs)

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,18 @@ Point-in-time assessments of the system as built, including gaps between documen
 
 ---
 
+### 🗺️ Implementation Plans
+How agreed changes get made. Mutable, status-tracked, and expected to go stale — see [`docs/plans/`](./plans/) for the index and conventions.
+
+* [**Phase 0: Instrumentation & developer baseline**](./plans/phase-0-instrumentation.md) — Coaching invariants as the CI gate; clean-clone runnability.
+* [**Phase 1: Live defects**](./plans/phase-1-live-defects.md) — Injury gate, Garmin objective credit, recommendation immutability.
+* [**Phase 2: Plan intent is the planning authority**](./plans/phase-2-plan-intent-authority.md) — ADR-0010, `PlanDefinition`, collapsing the two selection paths.
+* [**Phase 3: One ranking path**](./plans/phase-3-single-ranking-path.md) — Lexicographic priorities replacing modality anti-stacking.
+* [**Phase 4: Objective credit V2**](./plans/phase-4-objective-credit-v2.md) — One credit model, finished stimulus vocabulary, honest load.
+* [**Phase 5: Sequence planning**](./plans/phase-5-sequence-planning.md) — Bounded search, fixed activities, tissue state, evidence hierarchy.
+
+---
+
 ### 🏗️ System Architecture
 In-depth technical design documents covering system subsystems:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,11 @@ Architectural choices, system invariants, and technical trade-offs are documente
 * [**ADR-0007: Adaptive Multi-Sport Engine Architecture & Utility Optimization Pipeline**](./adr/0007-adaptive-multisport-engine-architecture.md) — 6-tier adaptive engine, schedule availability, event periodization, microcycle objectives, 6D fatigue decay, and utility optimization.
 * [**ADR-0008: Rolling 7-Day Week-Ahead Planning**](./adr/0008-week-ahead-planning.md) — Confidence-tiered multi-day forecast, rolling microcycle window, and never-persisted recomputation.
 * [**ADR-0009: Training Intent Is History-Seeded**](./adr/0009-training-intent-history.md) — Evaluation-time intent resolution, the `TrainingHistoryProvider` boundary, and advisory-only sequence context.
+* [**ADR-0010: Decision Provenance, Audit Records & Replay**](./adr/0010-decision-provenance-and-audit-replay.md) — `DataState` read semantics, immutable history revisions, persisted audits, `POLICY_VERSION`, and replay verification.
+* [**ADR-0011: Weekly Architecture — Session Anchors & Ranking Modifiers**](./adr/0011-weekly-architecture-anchors.md) — The anchor pre-pass and optimizer Patches 4–6, including why this composition should not be extended.
+
+Reserved for work sequenced in [`docs/plans/`](./plans/), written with their phase:
+**0012** plan intent · **0013** structured injury constraints · **0014** objective credit V2 · **0015** sequence planning.
 
 ---
 
@@ -33,7 +38,7 @@ How agreed changes get made. Mutable, status-tracked, and expected to go stale �
 
 * [**Phase 0: Instrumentation & developer baseline**](./plans/phase-0-instrumentation.md) — Coaching invariants as the CI gate; clean-clone runnability.
 * [**Phase 1: Live defects**](./plans/phase-1-live-defects.md) — Injury gate, Garmin objective credit, recommendation immutability.
-* [**Phase 2: Plan intent is the planning authority**](./plans/phase-2-plan-intent-authority.md) — ADR-0010, `PlanDefinition`, collapsing the two selection paths.
+* [**Phase 2: Plan intent is the planning authority**](./plans/phase-2-plan-intent-authority.md) — ADR-0012, `PlanDefinition`, collapsing the two selection paths.
 * [**Phase 3: One ranking path**](./plans/phase-3-single-ranking-path.md) — Lexicographic priorities replacing modality anti-stacking.
 * [**Phase 4: Objective credit V2**](./plans/phase-4-objective-credit-v2.md) — One credit model, finished stimulus vocabulary, honest load.
 * [**Phase 5: Sequence planning**](./plans/phase-5-sequence-planning.md) — Bounded search, fixed activities, tissue state, evidence hierarchy.
@@ -44,7 +49,7 @@ How agreed changes get made. Mutable, status-tracked, and expected to go stale �
 In-depth technical design documents covering system subsystems:
 
 * [**Ingestion Pipeline Architecture**](./architecture/ingestion-pipeline.md) — Python Garmin API client, token persistence, baseline metrics calculation, and Firestore repository.
-* [**Recommendation Engine**](./architecture/recommendation-engine.md) — TypeScript rule engine (`rules.ts`), strain scoring breakdown, mode hierarchy, and decision rationale generation.
+* [**Recommendation Engine**](./architecture/recommendation-engine.md) — The two selection paths, module map, self-normalised strain scoring, `train`/`modify`/`recover` modes, candidate ranking, and the authority ordering.
 * [**Workout Library Architecture**](./workout-library.md) — Multi-layered workout definitions, variants, and September race event plan contract.
 
 ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,14 @@ Architectural choices, system invariants, and technical trade-offs are documente
 * [**ADR-0006: Reconciled Strain Telemetry & Baseline Drift Scoring**](./adr/0006-reconciled-strain-telemetry.md) — Acute metric deviation vs 28-day baseline drift strain decomposition.
 * [**ADR-0007: Adaptive Multi-Sport Engine Architecture & Utility Optimization Pipeline**](./adr/0007-adaptive-multisport-engine-architecture.md) — 6-tier adaptive engine, schedule availability, event periodization, microcycle objectives, 6D fatigue decay, and utility optimization.
 * [**ADR-0008: Rolling 7-Day Week-Ahead Planning**](./adr/0008-week-ahead-planning.md) — Confidence-tiered multi-day forecast, rolling microcycle window, and never-persisted recomputation.
+* [**ADR-0009: Training Intent Is History-Seeded**](./adr/0009-training-intent-history.md) — Evaluation-time intent resolution, the `TrainingHistoryProvider` boundary, and advisory-only sequence context.
+
+---
+
+### 🔍 Reviews & Analysis
+Point-in-time assessments of the system as built, including gaps between documented decisions and implemented behaviour:
+
+* [**2026-08-08 Codebase, Docs & Decision Review**](./analysis/2026-08-08-architecture-review.md) — Full-repository review with a sequenced remediation plan.
 
 ---
 

--- a/docs/adr/0010-decision-provenance-and-audit-replay.md
+++ b/docs/adr/0010-decision-provenance-and-audit-replay.md
@@ -96,10 +96,12 @@ record against its own audit: policy version availability, `safetyStatus`, revis
 format, history-count coherence, and — the substantive one — that the persisted template
 is present among the audited candidates **and** was the highest-utility one.
 
-### 6. Security rules enforce the audit's presence
+### 6. Security rules require the audit on schema-version-3 writes
 
-`firestore.rules` validates the audit's full shape for `schemaVersion == 3`, bounds
-`candidateScores` to 64 entries, and constrains every enum. Wearable-derived collections
+`firestore.rules` validates the audit's full shape **for `schemaVersion == 3` writes**, bounds
+`candidateScores` to 64 entries, and constrains every enum. It does **not** prevent an
+existing v3 record from being rewritten as v1 and losing the audit — downgrade protection
+is a known gap, recorded below. Wearable-derived collections
 (`daily_recovery_snapshots`, `activities`) are `allow write: if false` — the browser may
 read them but can never forge a wearable fact.
 

--- a/docs/adr/0010-decision-provenance-and-audit-replay.md
+++ b/docs/adr/0010-decision-provenance-and-audit-replay.md
@@ -1,0 +1,152 @@
+# ADR-0010: Decision Provenance, Audit Records & Replay
+
+* **Status:** Accepted
+* **Date:** 2026-08-08 (recorded retroactively; implemented 2026-08-07)
+* **Deciders:** Core Engineering Team
+
+> **Retroactive record.** The implementation landed across four merges from
+> `codex/decision-provenance-safety` without an ADR. This document describes what was
+> built and why, so the reasoning is not lost. It does not propose a change. Identified
+> as finding F10 in
+> [the 2026-08-08 review](../analysis/2026-08-08-architecture-review.md).
+
+---
+
+## Context and Problem Statement
+
+[ADR-0009](./0009-training-intent-history.md) made training intent derived rather than
+persisted: objectives, dose, fatigue and phase are all recomputed on every evaluation
+from adherence history. That is the right call for correctness — no derived state can go
+stale — but it creates an accountability gap.
+
+If nothing about a decision is persisted beyond the chosen template, then three questions
+have no answer from data:
+
+1. *Why did the engine recommend this, on this day?* The inputs were recomputed and
+   discarded.
+2. *Was this decision made under the policy we think it was?* The engine changes; the
+   record does not say which version produced a given day.
+3. *Was the history it reasoned over complete?* A Firestore read that failed and a
+   Firestore read that legitimately returned nothing are indistinguishable once both
+   become an empty array — and they mean opposite things. Treating a failed read as "no
+   training this week" would inflate perceived freshness and prescribe load the athlete
+   has not recovered from.
+
+Question 3 is a safety question, not an observability one.
+
+---
+
+## Decision Outcome
+
+### 1. Reads distinguish four states, and only one is usable
+
+`DataState<T>` ([`dataState.ts`](../../app/src/engine/dataState.ts)) replaces
+nullable reads across the persistence boundary:
+
+| State | Meaning |
+|---|---|
+| `AVAILABLE` | Valid data, with a `revision` identifying exactly what was read |
+| `MISSING` | The document genuinely does not exist |
+| `INVALID` | The document exists but failed schema validation, with `DataIssue[]` |
+| `UNAVAILABLE` | The read failed, with the attempted `operation` and whether it is retryable |
+
+**Only `AVAILABLE` may be used as engine input.** `INVALID` and `UNAVAILABLE` block
+normal planning rather than degrading to a neutral default:
+`buildTrainingHistorySnapshot` throws `TrainingHistorySourceError` for a non-available
+required source, and `Home.tsx` surfaces a retry rather than a recommendation.
+
+This is deliberately un-graceful. A dashboard that shows nothing is recoverable; a
+dashboard that shows a confident hard session derived from silently-empty history is not.
+
+### 2. History is read once, as an immutable revision
+
+`TrainingHistorySnapshot` bounds a single reconstruction — `throughDateExclusive`,
+`windowDays`, the reconciled `CompletedTrainingEvent[]`, the derived `CompletedExposure[]`,
+per-source `DataStateSummary`, and a `revision` string:
+
+```text
+history-v1:{throughDateExclusive}:{windowDays}:{activityRevision}:{recommendationRevision}
+```
+
+One dashboard refresh evaluates today, tomorrow's three scenario branches, and the
+seven-day forecast. All of them consume the *same* snapshot, so no two horizons can
+disagree about what the athlete has done.
+
+### 3. Every persisted recommendation carries a compact audit
+
+`RecommendationAudit` ([`models.ts`](../../app/src/engine/models.ts)) is attached at the
+composition boundary and stored on the schema-version-3 `daily_recommendations` document:
+`policyVersion`, `evaluatedAt`, `decisionContextRevision`, `safetyStatus`, history counts
+and source statuses, the resolved envelope, and the ranked `candidateScores`.
+
+It records **normalized decision facts only**. Raw wearable payloads, raw readiness
+values and free-text check-in notes are deliberately excluded — the audit is evidence
+about a decision, not a second copy of the athlete's health data.
+
+### 4. `POLICY_VERSION` identifies the deciding logic
+
+[`policy.ts`](../../app/src/engine/policy.ts) exports a single string, incremented
+whenever a change can alter a persisted decision. Without it, a replay cannot distinguish
+"this decision was wrong" from "this decision was made under different rules".
+
+### 5. Replay verifies internal reproducibility
+
+`replayRecommendationAudit` ([`replay.ts`](../../app/src/engine/replay.ts)) checks a v3
+record against its own audit: policy version availability, `safetyStatus`, revision
+format, history-count coherence, and — the substantive one — that the persisted template
+is present among the audited candidates **and** was the highest-utility one.
+
+### 6. Security rules enforce the audit's presence
+
+`firestore.rules` validates the audit's full shape for `schemaVersion == 3`, bounds
+`candidateScores` to 64 entries, and constrains every enum. Wearable-derived collections
+(`daily_recovery_snapshots`, `activities`) are `allow write: if false` — the browser may
+read them but can never forge a wearable fact.
+
+---
+
+## Code References
+
+* [`app/src/engine/dataState.ts`](../../app/src/engine/dataState.ts)
+* [`app/src/engine/trainingHistorySnapshot.ts`](../../app/src/engine/trainingHistorySnapshot.ts)
+* [`app/src/engine/provenance.ts`](../../app/src/engine/provenance.ts)
+* [`app/src/engine/replay.ts`](../../app/src/engine/replay.ts)
+* [`app/src/engine/policy.ts`](../../app/src/engine/policy.ts)
+* [`app/firestore.rules`](../../app/firestore.rules)
+* [`app/scripts/replay-recommendation-audit.mjs`](../../app/scripts/replay-recommendation-audit.mjs)
+
+---
+
+## Consequences
+
+### Positive
+
+* "Why did the engine recommend this?" is answerable from a persisted record.
+* A failed or corrupt read can never be mistaken for an easy training week.
+* All decision horizons in one refresh share a single, identified history revision.
+* Policy changes are attributable to specific persisted decisions.
+
+### Negative
+
+* A single corrupt document blocks planning for the whole window. This is intentional,
+  but it makes parser strictness a availability concern — a validator that is wrong in
+  the strict direction takes the dashboard down.
+* The audit is only as meaningful as `POLICY_VERSION` discipline. A frozen version string
+  silently degrades `replayRecommendationAudit`'s `policyMatchesCurrent` check to a
+  constant — see F10; Phase 0 adds a CI guard.
+* The audit's usefulness depends on the fields it summarises being real. At time of
+  writing `envelope.safetyRestrictedModalityCount` is always `0` because its input is
+  never populated (F1) — the audit faithfully records a check that does not run.
+
+---
+
+## Known Gaps at Time of Recording
+
+Recorded so the ADR is not read as a clean bill of health. Both are addressed by
+[`docs/plans/phase-1-live-defects.md`](../plans/phase-1-live-defects.md):
+
+1. **The immutability the rules comment describes is not enforced.** `allow update` pins
+   only `createdAt`, and `schemaVersion in [1, 2, 3]` permits a v3 record to be rewritten
+   as v1, dropping the audit entirely — the audit requirement is conditional on the
+   version the writer chooses (F6).
+2. **`safetyRestrictedModalityCount` is structurally always zero** (F1).

--- a/docs/adr/0011-weekly-architecture-anchors.md
+++ b/docs/adr/0011-weekly-architecture-anchors.md
@@ -1,0 +1,131 @@
+# ADR-0011: Weekly Architecture — Session Anchors & Ranking Modifiers
+
+* **Status:** Accepted
+* **Date:** 2026-08-08 (recorded retroactively; implemented 2026-08-07)
+* **Deciders:** Core Engineering Team
+
+> **Retroactive record.** `resolveWeeklyAnchors` and optimizer Patches 4–6 shipped
+> without an ADR, despite being the largest change to how a week is shaped since
+> [ADR-0008](./0008-week-ahead-planning.md) — which they postdate and which does not
+> mention them. Identified as finding F10 in
+> [the 2026-08-08 review](../analysis/2026-08-08-architecture-review.md).
+
+---
+
+## Context and Problem Statement
+
+[ADR-0008](./0008-week-ahead-planning.md)'s projected planner walks forward one day at a
+time, each day choosing the locally highest-utility candidate. Greedy day-by-day
+selection cannot express a property that belongs to the *week*:
+
+* **"Which day gets the key session?"** is a weekly question. A greedy loop answers it
+  accidentally — whichever day happened to have the most time and the least accumulated
+  fatigue when the loop reached it.
+* **Freshness for a key session** is a relationship between days. Nothing in per-day
+  ranking knows that Friday's heavy squat session will compromise Saturday's
+  race-specific ride, because Saturday has not been evaluated yet when Friday is chosen.
+* **Variety** degenerates without a tie-break. When two templates in the same category
+  score within float noise, a stable sort returns the same one every run, so the athlete
+  sees the identical session repeatedly despite an equivalent alternative existing.
+
+---
+
+## Decision Outcome
+
+### 1. A pure, fatigue-independent anchor pre-pass
+
+[`resolveWeeklyAnchors`](../../app/src/engine/planner.ts) runs **once** before the
+day-by-day fatigue loop and nominates up to two days:
+
+* **`eventSpecificAnchorDate`** — the weekend-style race-specific / race-simulation day.
+* **`qualityAnchorDate`** — the midweek structured threshold / over-under day.
+
+It is deliberately constrained:
+
+* **Scans offsets 2..N only.** Offset 1 (tomorrow) reuses `rules.ts`'s own evaluation,
+  which has no anchor concept, so tomorrow can never be nominated.
+* **Requires a real focus event.** A Base-phase or eventless athlete gets
+  `{ null, null }` and the planner behaves exactly as it did before this existed.
+* **Nominates only where the real loop could deliver.** Candidate days are filtered
+  through the same `eligibleTemplates` hard gate the loop uses, so an "indoor only"
+  setting correctly rules out an outdoor-only race-specific ride rather than nominating
+  a day the loop would immediately fall through on.
+* **Picks by available time**, and separates the quality anchor from the event-specific
+  anchor by `QUALITY_ANCHOR_MIN_GAP_DAYS` (2), relaxing to 1 only if no day qualifies.
+
+It can run ahead of the stateful loop because both of its inputs — time budget and phase
+eligibility — are independent of fatigue.
+
+### 2. Named, auditable ranking modifiers
+
+[`optimizer.ts`](../../app/src/engine/optimizer.ts) applies these after safety and
+availability filtering:
+
+| Patch | Modifier | Value | Purpose |
+|---|---|---|---|
+| 4 | Anchor role boost | ×1.35 | Nudges a nominated day toward its designated role |
+| 5 | Anchor adjacency suppression | ×0.3 | Suppresses heavy lower-body/full-body strength (`systemicCost >= 0.5`) the day before or after an anchor |
+| 6 | Variety tie-break | within 0.05 utility | Among same-modality, same-category near-equivalents, prefers the least recently used |
+
+Patch 5 is scoped to `Lower-body Strength` and `Full-body Strength` only. Upper-body and
+power-maintenance work are deliberately untouched: this is concurrent-training
+interference management — keep meaningful lower-body loading away from key cycling days —
+not a blanket strength ban around anchors.
+
+Patch 4 is scoped to Cycling, matching the event-specific progression the anchor mechanism
+was built for.
+
+### 3. Anchors nudge; they do not command
+
+All three are multipliers applied *after* the hard gates. A genuinely infeasible anchor
+day falls through to the next-best real option rather than forcing an unsuitable session.
+Applied modifiers are emitted in the candidate rationale.
+
+---
+
+## Code References
+
+* [`app/src/engine/planner.ts`](../../app/src/engine/planner.ts) — `resolveWeeklyAnchors`, `WeeklyAnchors`, `isAdjacentDate`
+* [`app/src/engine/optimizer.ts`](../../app/src/engine/optimizer.ts) — `ANCHOR_ROLE_BOOST`, `ANCHOR_ADJACENCY_SUPPRESSION`, `VARIETY_TIE_BREAK_GAP`
+* [`app/src/engine/simulation/analyze.ts`](../../app/src/engine/simulation/analyze.ts) — anchor placement/fulfilment metrics
+
+---
+
+## Consequences
+
+### Positive
+
+* Which day carries the key session becomes a deliberate weekly decision rather than an
+  artefact of loop order.
+* A key session's freshness is protected against a choice made the day before it, which
+  per-day ranking structurally cannot do.
+* Equivalent templates rotate instead of one being re-picked indefinitely.
+* Anchor placement and fulfilment are measurable — the simulation harness reports both.
+
+### Negative
+
+* **This is sequence planning expressed as multipliers.** Each modifier is individually
+  reasonable, but they compose multiplicatively with the pre-existing anti-stacking,
+  strength-suppression, intensity-stacking, event-modality and aerobic-filler terms. The
+  aggregate is not something anyone designed, and "why is this the best week?" has no
+  answerable form. F3 is the demonstration: a 0.15× anti-stack term composes with a
+  1.40× A-event boost to net 0.21× **against** the athlete's own event modality.
+* Anchor nomination is gated on any focus event existing, but the boost only applies to
+  Cycling templates — a running-race athlete gets anchors nominated that boost nothing.
+  Currently inert rather than harmful, but the scoping is inconsistent.
+* Each new weekly property tends to arrive as another multiplier. Patches 1–6 exist; there
+  is no natural stopping point in this design.
+
+---
+
+## Superseding Direction
+
+This ADR records what exists, and its own Negative section is the argument against
+extending it further. The intended replacement is a lexicographic priority model with
+hard sequence constraints separated from sort keys, and eventually bounded sequence search
+over the horizon — see
+[`docs/plans/phase-3-single-ranking-path.md`](../plans/phase-3-single-ranking-path.md) and
+[`docs/plans/phase-5-sequence-planning.md`](../plans/phase-5-sequence-planning.md).
+
+**New weekly-shaping behaviour should not be added as Patch 7.** It should wait for that
+model, or be introduced as a documented temporary safety fix with a removal condition.

--- a/docs/adr/0011-weekly-architecture-anchors.md
+++ b/docs/adr/0011-weekly-architecture-anchors.md
@@ -77,7 +77,8 @@ was built for.
 
 ### 3. Anchors nudge; they do not command
 
-All three are multipliers applied *after* the hard gates. A genuinely infeasible anchor
+All three are ranking modifiers applied *after* the hard gates — Patches 4 and 5 are
+multipliers, Patch 6 is a tie-break that reorders already-equivalent candidates. A genuinely infeasible anchor
 day falls through to the next-best real option rather than forcing an unsuitable session.
 Applied modifiers are emitted in the candidate rationale.
 

--- a/docs/analysis/2026-08-08-architecture-review.md
+++ b/docs/analysis/2026-08-08-architecture-review.md
@@ -529,7 +529,7 @@ Small, mechanical, unblocks everything else.
 
 ### Phase 3 — Retire the scaffolding (~4-5 days)
 
-11. **F7/F8 — Pick one credit model and one vocabulary.** Write **ADR-0010: Dose-sensitive
+11. **F7/F8 — Pick one credit model and one vocabulary.** Write **ADR-0014: Dose-sensitive
     objective credit** stating the target model, then either complete the V2 migration or
     delete `stimulus.ts` and the unused V2 types. Do not leave it at `HEAD`'s state.
     Simultaneously: make canonical axes **required** on `WorkoutStimulusProfile`, drop the
@@ -557,9 +557,12 @@ Small, mechanical, unblocks everything else.
 
 14. **Rewrite `docs/architecture/recommendation-engine.md` from scratch** against the
     current engine. It is worse than having no document.
-15. **Backfill missing ADRs**: 0010 decision provenance & audit replay (retroactive),
-    0011 weekly architecture & anchors, 0012 objective credit V2. Add a
-    "Superseded/Amended by" line to ADR-0007 §6 and ADR-0008 §1/§6 once F1/F3/F5 land.
+15. **Backfill missing ADRs.** Retroactive ones are written: **ADR-0010** (decision
+    provenance & audit replay) and **ADR-0011** (weekly architecture & anchors). Forward
+    numbers are reserved and written with their phase: **0012** plan intent,
+    **0013** structured injury constraints, **0014** objective credit V2,
+    **0015** sequence planning. Add a "Superseded/Amended by" line to ADR-0007 §6 and
+    ADR-0008 §1/§6 once F1/F3/F5 land.
 16. **Fix `AGENTS.md`'s schema version and module lists**, and
     the stale line references in `docs/plans/0000-workout-library-expansion.md` (or mark the file
     archived and move the two-path explanation into an ADR).

--- a/docs/analysis/2026-08-08-architecture-review.md
+++ b/docs/analysis/2026-08-08-architecture-review.md
@@ -54,7 +54,7 @@ started.
   the `audit`/`rebuild` pair give real data lineage.
 * **The `DataState` discipline.** `INVALID`/`UNAVAILABLE` blocking planning instead of
   silently degrading to "empty training week" (`trainingHistorySnapshot.ts`,
-  `Home.tsx:150-168`) is the correct call for a system that makes load decisions, and
+  `Home.tsx`'s `loadDashboardData` source-state guards) is the correct call for a system that makes load decisions, and
   it is applied consistently.
 * **Timezone handling.** `periodization.ts:getDaysBetween` using `Date.UTC` purely as a
   DST-free ordinal, with the reasoning written down, is better than most production code.
@@ -70,7 +70,7 @@ started.
 
 ### F1. The documented hard injury gate has no data source at all
 
-`adapters.ts:154` — the sole production constructor of `UserContext` — hardcodes:
+`adapters.ts` — `mapContextFromGoalsAndTrainingSettings`, the sole production constructor of `UserContext` — hardcodes:
 
 ```ts
 constraints: { ..., injuries: [], ... }
@@ -78,14 +78,14 @@ constraints: { ..., injuries: [], ... }
 
 Everything downstream that consumes it is therefore dead code in production:
 
-* `optimizer.ts:183-187` — *"Hard safety gating: Physical injuries strictly exclude
+* `rankCandidatesByUtility`'s injury filter — *"Hard safety gating: Physical injuries strictly exclude
   matching modalities"* — filters against an always-empty list.
-* `rules.ts:544-556` — `hasRunningInjury`, and the `isPain && injuries.length > 0`
+* `rules.ts` `evaluateEnvelopes` — `hasRunningInjury`, and the `isPain && injuries.length > 0`
   branch that populates `restrictedModalities`, can never fire. `restrictedModalities`
   is therefore *always* `[]`, which also means `evaluateTrainingWithIntent`'s
-  `.filter(t => !restrictedModalities.includes(...))` (rules.ts:492) is a no-op, and the
+  `.filter(t => !restrictedModalities.includes(...))` (rules.ts) is a no-op, and the
   persisted audit's `safetyRestrictedModalityCount` is always `0`.
-* `planner.ts:352,482` — same, for the whole 7-day forecast.
+* `planner.ts` — `generateWeekAheadPlan` passes the same empty list to `rankCandidatesByUtility`, for the whole 7-day forecast.
 
 ADR-0007 §6 states: *"Physical pain/injury constraints (`UserConstraint`) are hard safety
 gates."* That guarantee is not implemented. The legacy `users/{uid}/constraints/*`
@@ -136,12 +136,12 @@ But where recognised Garmin-only sessions are the athlete's *primary* completion
 the common case for someone training outdoors and answering the prompt intermittently —
 the ledger can stay unresolved despite real training. When it does,
 `calculateStimulusBenefit` keeps scoring the same unresolved targets, `plannedDose` stays
-near maximum urgency (`trainingIntent.ts:77-80`, `urgency = unresolved/total`), and the
+near maximum urgency (`resolveTrainingIntent`, `urgency = unresolved/total`), and the
 post-objective aerobic filler (optimizer Patch 3) never engages.
 
 ### F3. Anti-stacking has no notion of calendar time — contradicting ADR-0008 §6
 
-`optimizer.ts:24-28`:
+`optimizer.ts` `RecentHistoryEntry`:
 
 ```ts
 export interface RecentHistoryEntry {
@@ -156,10 +156,10 @@ There is no `date`. `getConsecutiveModalityCount` scans the array backwards and 
 > penalty without treating sessions separated by a calendar gap as consecutive."*
 
 The date is present on `CompletedExposure` and is dropped at the `projectTrailingHistory`
-/ `rules.ts:512` boundary. Two strength sessions eleven days apart with nothing logged
+/ `rules.ts` boundary. Two strength sessions eleven days apart with nothing logged
 between them read as consecutive.
 
-Worse is the rolling arm. `optimizer.ts:214`:
+Worse is the rolling arm. `optimizer.ts`'s Patch 1 anti-stacking branch:
 
 ```ts
 if (consecutiveCount >= 2 || rollingCount >= 2) prefMultiplier *= 0.15;
@@ -179,7 +179,7 @@ multiplier stops discriminating and ranking degenerates toward whatever is left.
 
 ### F4. The two optimizer call sites run different policies
 
-| | `rules.ts:497-514` (today) | `planner.ts:477-485` (days 2+) |
+| | `evaluateTrainingWithIntent` (today) | `generateWeekAheadPlan` (days 2+) |
 |---|---|---|
 | `recentHistory.systemicCost` | **not supplied** | supplied |
 | Patch 1c intensity-stacking | **structurally dead** | live |
@@ -187,15 +187,15 @@ multiplier stops discriminating and ranking degenerates toward whatever is left.
 | preferences | fabricated literal (`preferredRecoveryStyle:'mixed'`, `defaultWeekdayTimeMin:45`, …) | `preferences ?? NEUTRAL_PREFERENCES` |
 | anchor role / adjacency | never passed | passed |
 
-So the hard/moderate-into-hard/moderate guard that `optimizer.ts:228-240` describes as
+So the hard/moderate-into-hard/moderate guard that `optimizer.ts`'s Patch 1c describes as
 *"what actually stops the tempo trap"* protects the forecast but not today's actual
-prescription. And `rules.ts:503-509` invents a `UserPreferences` object rather than
+prescription. And `rules.ts` invents a `UserPreferences` object rather than
 threading the real profile or reusing `planner.ts`'s `NEUTRAL_PREFERENCES` — two answers
 to the same question, 200 lines apart. No test asserts parity between the call sites.
 
 ### F5. The week-ahead strip always assumes tomorrow is green
 
-`Home.tsx:332`:
+`Home.tsx`, in the week-ahead effect:
 
 ```ts
 const tomorrowRec = nextDayPlan ? nextDayPlan.branches.green.recommendation : null;
@@ -204,7 +204,7 @@ const tomorrowRec = nextDayPlan ? nextDayPlan.branches.green.recommendation : nu
 ADR-0008 §1 specifies the provisional tier as *"tomorrow's already-computed
 green/yellow/red preview branch (**whichever the user has selected**)"*. No selection
 state exists anywhere in the app — `branches.yellow` and `branches.red` are computed
-(three full `evaluateTrainingWithIntent` passes, `rules.ts:984-988`) and then discarded.
+(three full `evaluateTrainingWithIntent` passes, `rules.ts`) and then discarded.
 
 Consequences: the forecast is systematically optimistic, and because `applyPick` charges
 the green branch's cost into the chained fatigue/objective ledger, **every** projected
@@ -244,12 +244,12 @@ plus field-pinning for everything except `adherence` — close both holes.)
 
 | Model | Location | Status |
 |---|---|---|
-| Keyword substring on free text | `microcycle.ts:110-141` | live (fallback) |
-| Stimulus-vector coverage ≥ 0.6 | `microcycle.ts:198-213` | live (primary) |
-| Fractional dose-sensitive credit | `stimulus.ts:26-99` | **dead** |
+| Keyword substring on free text | `microcycle.ts` `updateMicrocycleProgress` | live (fallback) |
+| Stimulus-vector coverage ≥ 0.6 | `microcycle.ts` `creditObjectivesFromStimulus` | live (primary) |
+| Fractional dose-sensitive credit | `stimulus.ts` `deriveObjectiveCredit` | **dead** |
 
 The keyword matcher is not merely approximate, it is wrong in a directional way
-(`microcycle.ts:118-125`): `zone2_aerobic` matches any type string containing `running`
+(`updateMicrocycleProgress`): `zone2_aerobic` matches any type string containing `running`
 or `cycling` — so a threshold ride credits the Zone-2 objective; `threshold_quality`
 matches `hard` or `tempo`. The two live models disagree about what a given session
 resolved, and which one runs depends on an incidental property of the exposure (F2).
@@ -268,8 +268,8 @@ objective key it doesn't recognise.
 
 ### F8. `WorkoutStimulusProfile` is a half-finished rename encoded in the type system
 
-Seven canonical axes plus five legacy aliases, **all optional** (`models.ts:170-186`).
-`templates.ts:575-590` populates both sides on every template, inventing two derivations
+Seven canonical axes plus five legacy aliases, **all optional** (`models.ts` `WorkoutStimulusProfile`).
+`templates.ts` `canonicalizeStimulus` populates both sides on every template, inventing two derivations
 with no cited basis:
 
 ```ts
@@ -291,14 +291,14 @@ compile-clean 0-coverage objective that can never be resolved.
 
 Path A (`evaluateTraining`: mode → hardcoded category allowlist → date-hash pick) and
 Path B (`evaluateTrainingWithIntent`: eligibility → cost ceiling → utility ranking) both
-ship. Path B *runs Path A first* (`rules.ts:486`) purely to obtain `mode` and `envelopes`,
+ship. Path B *runs Path A first* (`evaluateTrainingWithIntent`'s call to `evaluateTraining`) purely to obtain `mode` and `envelopes`,
 then discards its template pick. Path A is still directly reachable via
 `evaluateNextDayPlan` and remains the only path some templates can appear on.
 
 The only place this dual structure is written down is
 `docs/plans/0000-workout-library-expansion.md §1.2` — a file marked "Status: implemented",
-whose line references (`rules.ts:200`, `rules.ts:387`, `rules.ts:461`, `planner.ts:190`,
-`optimizer.ts:107-120`) are all now wrong. Architecture that only exists in a completed
+whose line references (`rules.ts`, `rules.ts`, `rules.ts`, `planner.ts`,
+`optimizer.ts`) are all now wrong. Architecture that only exists in a completed
 implementation plan will be lost.
 
 ### F10. Significant policy surfaces have no ADR, and `POLICY_VERSION` never moves
@@ -321,7 +321,7 @@ version string makes `replay.ts`'s `policyMatchesCurrent` check meaningless.
 
 ### F11. ~35 tuned constants, no calibration record, no decision-quality regression gate
 
-`rules.ts:151-155` states the strain thresholds were *"calibrated against ~2 months of
+`rules.ts`'s strain-threshold constants states the strain thresholds were *"calibrated against ~2 months of
 real HRV/RHR/sleep data"*. That dataset, the procedure, and the resulting
 trigger-frequency numbers exist nowhere in the repository. The same applies to the six
 fatigue half-lives, the six cost-penalty weights, `PROJECTED_FATIGUE_*_THRESHOLD`, and
@@ -335,17 +335,17 @@ suppression.
 
 ### F12. Fatigue model saturates, masks, and depends on an unasserted ordering invariant
 
-* `fatigue.ts:104-111` clamps each axis at 1.0 on accumulation. Two consecutive hard
+* `applyCompletedSessionLoad` clamps each axis at 1.0 on accumulation. Two consecutive hard
   lower-body days ≈ one hard day at the ceiling — the model cannot represent
   *"significantly deeper in the hole"*.
-* `combinedFatigue = max(external, internal)` (`fatigue.ts:113-121`): a bad night fully
+* `combinedFatigue = max(external, internal)` (the `combined` vector in `applyCompletedSessionLoad`): a bad night fully
   *masks* accumulated external load rather than adding to it. An athlete deep in a load
   block whose HRV happens to read fine is scored identically to a rested one at the same
   external level, and vice versa.
 * `buildFatigueStateFromHistory` seeds from `history[0].date` and `applyCompletedSessionLoad`
   floors `elapsedHours` at 0. Oldest-to-newest ordering is therefore load-bearing;
   out-of-order input silently mis-decays with no error. The invariant is asserted only in
-  a comment (`planner.ts:129`).
+  a comment on `projectTrailingHistory`.
 
 ### F16. The event-plan contract is invisible to the engine
 
@@ -380,7 +380,7 @@ Tier 2 by consequence.*
 
 `PhaseWeights.intensityScale` is **assigned in six places in `periodization.ts` and read
 in zero**. Post-Event Recovery's `0.4` and Specificity's `1.1` affect nothing.
-`volumeScale` has exactly one consumer — `trainingIntent.ts:80`'s `plannedDose`. So of
+`volumeScale` has exactly one consumer — `resolveTrainingIntent`'s `plannedDose`. So of
 periodization's two output scalars, one is dead and the other is a single multiplier on a
 single number.
 

--- a/docs/analysis/2026-08-08-architecture-review.md
+++ b/docs/analysis/2026-08-08-architecture-review.md
@@ -95,17 +95,22 @@ have no read path *and* no write path.
 
 The only injury signal reaching the engine is the boolean `painOrInjury` check-in flag,
 which caps the plan tier at `Mobility` but cannot express *where* the injury is. An
-athlete with an achilles problem is offered heavy lower-body strength the moment they
-stop ticking the pain box.
+athlete with an achilles problem **can be** offered heavy lower-body strength the moment
+they stop ticking the pain box — other gates (readiness mode, fatigue, equipment, time)
+may still suppress it in a given instance, but the persistent local-injury gate that
+should prevent it is not participating in the decision at all.
 
 This is the single most important finding in this document.
 
 ### F2. Garmin-measured training earns zero microcycle credit
 
+**Precise claim:** a *recognised* Garmin-only completion that has no matched structured or
+adherence-confirmed stimulus earns **zero** objective credit, because its all-zero profile
+selects the vector-coverage path and simultaneously blocks the keyword fallback.
+
 Verified empirically (throwaway probe, since removed): three Garmin activities in the
 rolling window — a 120-min hard ride, a 60-min strength session, a 90-min moderate ride —
-produce `zone2_aerobic 0/2`, `threshold_quality 0/1`, `strength_maintenance 0/1`. The
-weekly ledger stays completely unresolved.
+produce `zone2_aerobic 0/2`, `threshold_quality 0/1`, `strength_maintenance 0/1`.
 
 The chain:
 
@@ -122,12 +127,17 @@ The inversion is the tell: an activity whose type string Garmin reports as somet
 to `updateMicrocycleProgress`, and **does** get credit. Better-identified data is treated
 worse than worse-identified data.
 
-Practical effect for any athlete who does not answer the adherence prompt every single
-day: objectives never resolve, so `calculateStimulusBenefit` keeps scoring the same
-unresolved targets, `plannedDose` stays pinned near maximum urgency
-(`trainingIntent.ts:77-80`, `urgency = unresolved/total`), and the "post-objective
-aerobic filler" (optimizer Patch 3) never engages. The system behaves as if the athlete
-has done nothing all week while sitting on a Garmin history that says otherwise.
+**Practical effect, stated no more strongly than the evidence supports:** objectives can
+still resolve from other sources — an adherence-confirmed session carries the exact
+template's stimulus profile, and genuinely unrecognised activity types still reach the
+fallback. Missing one adherence response does not mean the ledger can never resolve.
+
+But where recognised Garmin-only sessions are the athlete's *primary* completion source —
+the common case for someone training outdoors and answering the prompt intermittently —
+the ledger can stay unresolved despite real training. When it does,
+`calculateStimulusBenefit` keeps scoring the same unresolved targets, `plannedDose` stays
+near maximum urgency (`trainingIntent.ts:77-80`, `urgency = unresolved/total`), and the
+post-objective aerobic filler (optimizer Patch 3) never engages.
 
 ### F3. Anti-stacking has no notion of calendar time — contradicting ADR-0008 §6
 
@@ -205,7 +215,7 @@ selector exists.
 
 `app/firestore.rules`, `daily_recommendations`:
 
-```
+```text
 // Recommendations are audit evidence and intentionally immutable as documents;
 // adherence remains a validated update on the same document.
 allow update: if hasValidRecommendation(userId, date) && keepsOwnership(userId)
@@ -216,7 +226,7 @@ Only `createdAt` is pinned. A client may rewrite `templateId`, `mode`, `rational
 `recommendationAudit`, or `candidateScores` on an existing document. Worse,
 `schemaVersion in [1, 2, 3]` combined with
 
-```
+```text
 && (request.resource.data.schemaVersion != 3 || (... hasValidRecommendationAudit ...))
 ```
 
@@ -286,7 +296,7 @@ then discards its template pick. Path A is still directly reachable via
 `evaluateNextDayPlan` and remains the only path some templates can appear on.
 
 The only place this dual structure is written down is
-`docs/workout-library-expansion-plan.md §1.2` — a file marked "Status: implemented",
+`docs/plans/0000-workout-library-expansion.md §1.2` — a file marked "Status: implemented",
 whose line references (`rules.ts:200`, `rules.ts:387`, `rules.ts:461`, `planner.ts:190`,
 `optimizer.ts:107-120`) are all now wrong. Architecture that only exists in a completed
 implementation plan will be lost.
@@ -389,7 +399,9 @@ Also unused-but-declared, reinforcing F7: `WeeklyObjective.requiredCredit`, `.wi
 
 ### F13. Documentation drift
 
-* `docs/README.md`'s ADR index stops at **0008**; ADR-0009 exists and is unlisted.
+* ~~`docs/README.md`'s ADR index stops at **0008**; ADR-0009 exists and is unlisted.~~
+  **Resolved by the same change that introduced this document** — recorded here as the
+  baseline state at `2ea45cd`, not as outstanding work.
 * `docs/architecture/recommendation-engine.md` **describes an engine that no longer
   exists**. It documents a `REST / RECOVERY / AEROBIC_BASE / QUALITY_STRENGTH` mode
   hierarchy and thresholds "HRV drop > 10%", "RHR > baseline + 3 bpm", "sleep score < 65".
@@ -410,7 +422,7 @@ Also unused-but-declared, reinforcing F7: `WeeklyObjective.requiredCredit`, `.wi
 `trainingSettingsService.test.ts` transitively imports it, so without `VITE_FIREBASE_*`
 set the whole file fails:
 
-```
+```text
 FAIL src/services/trainingSettingsService.test.ts
 FirebaseError: Firebase: Error (auth/invalid-api-key)
 Test Files  1 failed | 21 passed | 1 skipped
@@ -454,14 +466,19 @@ Small, mechanical, unblocks everything else.
    and replace `app/README.md` with real setup instructions.
 2. **Bump `POLICY_VERSION`** and add a check to `npm run check` that fails if
    `optimizer.ts`/`rules.ts`/`microcycle.ts` changed without it moving.
-3. **Commit a simulation baseline *and* a golden coaching scenario.** Un-gitignore a
-   deterministic `docs/analysis/simulation-baseline.json`, add `npm run simulate:check`
-   diffing against it, and wire it into CI. Alongside it, encode the current cycling
-   macrocycle as an asserted golden week (see §7.4) — invariants, not just diff-stability:
-   ≥48 h between key cycling quality exposures; no heavy lower-body strength compromising
-   them; no penalty merely for a third cycling exposure; outdoor work satisfies plan
-   objectives. **This is the instrument every later phase is measured with — it must land
-   before any constant or heuristic is changed.**
+3. **Make coaching invariants the CI gate; keep the snapshot diagnostic.** Encode the
+   current cycling macrocycle as an asserted golden week (see §7.4): ≥48 h between key
+   cycling quality exposures; no heavy lower-body strength compromising them; no penalty
+   merely for a third cycling exposure; outdoor work satisfies plan objectives. Those
+   assertions — plus a few deliberately loose aggregate bounds — are what blocks CI.
+   A committed `simulation-baseline.json` with a **semantic** diff
+   (`npm run simulate:diff`) is retained as a non-blocking review aid.
+   A byte-exact snapshot gate is explicitly rejected: Phases 3–5 intentionally change
+   planner behaviour, so an equality gate would both freeze today's known-bad output as
+   the reference and reduce every improvement to baseline churn.
+   **This is the instrument every later phase is measured with — it must land before any
+   constant or heuristic is changed.** See
+   [`docs/plans/phase-0-instrumentation.md`](../plans/phase-0-instrumentation.md).
 4. **Add `ruff` + `mypy` to `pyproject.toml` and CI.**
 
 ### Phase 1 — Close the safety gaps (~3-4 days) — *do not defer*
@@ -518,11 +535,19 @@ Small, mechanical, unblocks everything else.
     Simultaneously: make canonical axes **required** on `WorkoutStimulusProfile`, drop the
     legacy aliases behind a one-shot codemod, and type `targetStimulus` as
     `Partial<Record<keyof WorkoutStimulusProfile, number>>`.
-12. **F12 — Revisit fatigue accumulation.** Replace hard clamping with a saturating
-    function that stays monotonic past 1.0 (e.g. `1 - exp(-x)` on the raw sum), and
-    reconsider `max(external, internal)` in favour of a weighted combination. Add an
-    ordering assertion (throw, not comment) in `buildFatigueStateFromHistory`.
-    Gate this behind the Phase-0 simulation baseline — it will move every projected day.
+12. **F12 — Revisit fatigue accumulation, in that order.** Two separable pieces:
+    *(a) a correctness fix, do now* — assert chronological ordering in
+    `buildFatigueStateFromHistory` (throw, not comment).
+    *(b) a modelling question, do not pre-decide* — retain an unsaturated latent
+    external-load state so depth past the current 1.0 clamp is not discarded, then use the
+    Phase-0 harness to **compare** candidate fusion functions before committing to one in
+    an ADR.
+    An earlier draft of this document prescribed `1 - exp(-x)` plus a weighted
+    external/internal combination. That is withdrawn: it is not justified by anything here,
+    and it would repeat exactly the uncited-constant practice F11 criticises. It is also
+    probably wrong as stated — internal response (HRV/RHR/soreness) is partly a *reaction to*
+    the same external work, so a weighted sum double-counts load unless calibrated, and
+    `1 - exp(-x)` changes the state's scale and meaning rather than merely its monotonicity.
 13. **F9 — Decide Path A's future.** Either document it as a deliberate readiness-only
     fallback in an ADR, or collapse it: extract `evaluateReadinessMode()` returning
     `{mode, envelopes, telemetry}`, keep that as the only shared entry point, and let
@@ -535,8 +560,8 @@ Small, mechanical, unblocks everything else.
 15. **Backfill missing ADRs**: 0010 decision provenance & audit replay (retroactive),
     0011 weekly architecture & anchors, 0012 objective credit V2. Add a
     "Superseded/Amended by" line to ADR-0007 §6 and ADR-0008 §1/§6 once F1/F3/F5 land.
-16. **Fix `docs/README.md`'s index**, `AGENTS.md`'s schema version and module lists, and
-    the stale line references in `workout-library-expansion-plan.md` (or mark the file
+16. **Fix `AGENTS.md`'s schema version and module lists**, and
+    the stale line references in `docs/plans/0000-workout-library-expansion.md` (or mark the file
     archived and move the two-path explanation into an ADR).
 17. **Delete `garmin_login.py`** in favour of `scripts/bootstrap_garmin_tokens.py`.
 

--- a/docs/analysis/2026-08-08-architecture-review.md
+++ b/docs/analysis/2026-08-08-architecture-review.md
@@ -483,7 +483,7 @@ Small, mechanical, unblocks everything else.
 
 ### Phase 1 — Close the safety gaps (~3-4 days) — *do not defer*
 
-5. **F1 — Give injuries a real path.** Add a typed `injuries: BodyRegionConstraint[]`
+5. **F1 — Give injuries a real path.** Add a typed `injuries: InjuryConstraint[]`
    (region + severity + optional expiry) to `TrainingSettings` v3, a Preferences-screen
    editor, Firestore rules validation, and thread it through
    `mapContextFromGoalsAndTrainingSettings`. Replace the substring `RUNNING_INJURY_PATTERN`
@@ -654,8 +654,9 @@ That is what it is good at. The present architecture instead asks one multiplica
 to arbitrate safety, periodization, interference, recovery, preference and variety
 simultaneously, and F3 is the proof that it cannot.
 
-**Bounded sequence search over the 7-day horizon** (beam width 10–20) replaces the greedy
-day-by-day walk in a later phase. A 7-day horizon does not warrant heavier machinery.
+**Bounded sequence search over the 7-day horizon** (beam width 10–20) is *evaluated against*
+the greedy day-by-day walk in a later phase, and whichever measures better is retained — see
+D-BEAM. A 7-day horizon does not warrant heavier machinery than beam search if it is adopted.
 
 ### 7.4 Where this document dissents
 
@@ -677,7 +678,7 @@ day-by-day walk in a later phase. A 7-day horizon does not warrant heavier machi
 ```text
 0. Simulation baseline + golden coaching scenario        (the instrument)
 1. F1, F2, F6                                            (live defects, ~4 days)
-2. ADR-0010: Plan Intent is the planning authority       (+ F16 engine-visible
+2. ADR-0012: Plan Intent is the planning authority       (+ F16 engine-visible
                                                             event plan, + F17
                                                             intensityScale disposition)
 3. F3 via lexicographic constraints, F4, F5              (one coherent ranking path)

--- a/docs/analysis/2026-08-08-architecture-review.md
+++ b/docs/analysis/2026-08-08-architecture-review.md
@@ -1,0 +1,496 @@
+# Codebase, Docs & Decision Review — 2026-08-08
+
+Scope: full repository at `2ea45cd` (`main`), both the Python ingestion package and the
+TypeScript engine/app, plus `docs/adr/*`, `docs/architecture/*`, `AGENTS.md`, `CLAUDE.md`,
+`README.md` and CI.
+
+Method: read every engine module and ADR; ran `uv run pytest`, `npx tsc -b`, `npm test`,
+`npm run simulate:scenarios`; wrote throwaway probes to confirm the two behavioural
+claims below that a reader could reasonably doubt (F2, F3). Findings are ordered by
+consequence, not by discovery order.
+
+---
+
+## 0. Verdict
+
+The engineering craft here is unusually high for a personal project: layered boundaries
+(`TrainingHistoryProvider`, `DataState`, provider/repository split on the Python side),
+comments that explain *why* rather than *what*, real ADRs, an emulator-backed rules
+suite, and a decision-provenance/replay path. `uv run pytest` is green (86 tests) and
+`npx tsc -b` is clean.
+
+The problem is not code quality. It is that **the system has grown a documented policy
+layer that is, in several load-bearing places, not connected to any data**. Five of the
+six Tier-1 findings share one shape: an ADR states a guarantee, the code that would
+enforce it exists and is unit-tested in isolation, and the wire that feeds it real
+input was never run. Tests pass because they inject the fixture the production adapter
+never produces.
+
+The second theme is **unretired scaffolding**. There are now three objective-crediting
+models (two live, one dead), two stimulus vocabularies, and two selection paths — all
+shipped simultaneously, with the newest layer merged at `HEAD` explicitly labelled "not
+yet wired". Each was individually a reasonable step; together they are the main source
+of the divergences below.
+
+Neither theme requires a rewrite. Both require finishing things that were started.
+
+---
+
+## 1. What is genuinely strong (keep, don't churn)
+
+* **Ingestion pipeline.** `_build_and_store_snapshot` as a single derive→map→store path
+  shared by `sync`/`backfill`/`rebuild` is exactly right — it structurally prevents the
+  three commands from drifting. Prehistory seeding, content-addressed raw archive, and
+  the `audit`/`rebuild` pair give real data lineage.
+* **The `DataState` discipline.** `INVALID`/`UNAVAILABLE` blocking planning instead of
+  silently degrading to "empty training week" (`trainingHistorySnapshot.ts`,
+  `Home.tsx:150-168`) is the correct call for a system that makes load decisions, and
+  it is applied consistently.
+* **Timezone handling.** `periodization.ts:getDaysBetween` using `Date.UTC` purely as a
+  DST-free ordinal, with the reasoning written down, is better than most production code.
+* **The `TrainingHistoryProvider` boundary (ADR-0009).** Keeping Firebase out of engine
+  tests via an injected provider is the right seam and it works.
+* **Comment quality as design record.** `rules.ts`'s explanation of why `MODIFY_MAX_SYSTEMIC_COST`
+  admits upper-body strength, or `optimizer.ts`'s Patch 1c "tempo trap" note, are the kind
+  of thing that normally lives only in a reviewer's head.
+
+---
+
+## 2. Tier 1 — Decisions that do not currently hold
+
+### F1. The documented hard injury gate has no data source at all
+
+`adapters.ts:154` — the sole production constructor of `UserContext` — hardcodes:
+
+```ts
+constraints: { ..., injuries: [], ... }
+```
+
+Everything downstream that consumes it is therefore dead code in production:
+
+* `optimizer.ts:183-187` — *"Hard safety gating: Physical injuries strictly exclude
+  matching modalities"* — filters against an always-empty list.
+* `rules.ts:544-556` — `hasRunningInjury`, and the `isPain && injuries.length > 0`
+  branch that populates `restrictedModalities`, can never fire. `restrictedModalities`
+  is therefore *always* `[]`, which also means `evaluateTrainingWithIntent`'s
+  `.filter(t => !restrictedModalities.includes(...))` (rules.ts:492) is a no-op, and the
+  persisted audit's `safetyRestrictedModalityCount` is always `0`.
+* `planner.ts:352,482` — same, for the whole 7-day forecast.
+
+ADR-0007 §6 states: *"Physical pain/injury constraints (`UserConstraint`) are hard safety
+gates."* That guarantee is not implemented. The legacy `users/{uid}/constraints/*`
+collection is `allow write: if false` (firestore.rules) and the README states the v2
+settings migration deliberately does **not** infer injury limits from it — so injuries
+have no read path *and* no write path.
+
+The only injury signal reaching the engine is the boolean `painOrInjury` check-in flag,
+which caps the plan tier at `Mobility` but cannot express *where* the injury is. An
+athlete with an achilles problem is offered heavy lower-body strength the moment they
+stop ticking the pain box.
+
+This is the single most important finding in this document.
+
+### F2. Garmin-measured training earns zero microcycle credit
+
+Verified empirically (throwaway probe, since removed): three Garmin activities in the
+rolling window — a 120-min hard ride, a 60-min strength session, a 90-min moderate ride —
+produce `zone2_aerobic 0/2`, `threshold_quality 0/1`, `strength_maintenance 0/1`. The
+weekly ledger stays completely unresolved.
+
+The chain:
+
+1. `completedTraining.ts:candidateEventFromGarmin` sets `estimatedStimulus: ZERO_STIMULUS`
+   (Garmin gives no stimulus vector, which is honest).
+2. `completedEventToExposure` attaches `stimulusProfile` to the exposure **whenever the
+   modality was recognised** — including when that profile is all zeros.
+3. `microcycle.ts:buildMicrocycleState` routes any exposure with `stimulusProfile && modality`
+   to `creditObjectivesFromStimulus`, which requires `stimulusCoverage >= 0.6`. An
+   all-zero vector scores 0. No credit, and the keyword fallback is never reached.
+
+The inversion is the tell: an activity whose type string Garmin reports as something
+`modalityFromActivityType` *doesn't* recognise gets `modality: undefined`, falls through
+to `updateMicrocycleProgress`, and **does** get credit. Better-identified data is treated
+worse than worse-identified data.
+
+Practical effect for any athlete who does not answer the adherence prompt every single
+day: objectives never resolve, so `calculateStimulusBenefit` keeps scoring the same
+unresolved targets, `plannedDose` stays pinned near maximum urgency
+(`trainingIntent.ts:77-80`, `urgency = unresolved/total`), and the "post-objective
+aerobic filler" (optimizer Patch 3) never engages. The system behaves as if the athlete
+has done nothing all week while sitting on a Garmin history that says otherwise.
+
+### F3. Anti-stacking has no notion of calendar time — contradicting ADR-0008 §6
+
+`optimizer.ts:24-28`:
+
+```ts
+export interface RecentHistoryEntry {
+    modality?: string; type?: string; systemicCost?: number;
+}
+```
+
+There is no `date`. `getConsecutiveModalityCount` scans the array backwards and treats
+**array adjacency as calendar adjacency**. ADR-0008 §6 claims the opposite:
+
+> *"The optimizer can therefore apply a narrowly scoped third-consecutive-Strength
+> penalty without treating sessions separated by a calendar gap as consecutive."*
+
+The date is present on `CompletedExposure` and is dropped at the `projectTrailingHistory`
+/ `rules.ts:512` boundary. Two strength sessions eleven days apart with nothing logged
+between them read as consecutive.
+
+Worse is the rolling arm. `optimizer.ts:214`:
+
+```ts
+if (consecutiveCount >= 2 || rollingCount >= 2) prefMultiplier *= 0.15;
+```
+
+`getRollingModalityCount` has no window bound beyond whatever array it is handed
+(7 real days in `rules.ts`; up to 14 entries in `planner.ts`, since projected picks are
+appended). Probe: two rides five days apart already yield `rollingCount = 2`. So the
+**third** ride in a week is suppressed to 0.15×. For a cyclist with an A-priority
+cycling event, that stacks against the 1.40× event boost for a net **0.21×** — the
+optimizer actively steers away from the event modality during Specificity. This is
+precisely the failure mode ADR-0007 §5 says the ranking context was built to prevent.
+
+In the projected loop this compounds: because `projectedHistory` includes the strip's
+own picks, by day 3-4 most modalities are at 0.15× simultaneously, at which point the
+multiplier stops discriminating and ranking degenerates toward whatever is left.
+
+### F4. The two optimizer call sites run different policies
+
+| | `rules.ts:497-514` (today) | `planner.ts:477-485` (days 2+) |
+|---|---|---|
+| `recentHistory.systemicCost` | **not supplied** | supplied |
+| Patch 1c intensity-stacking | **structurally dead** | live |
+| `recentHistory.modality` | set to `trainingRecordLike.type` (a *type* string) | omitted; falls back to `type` |
+| preferences | fabricated literal (`preferredRecoveryStyle:'mixed'`, `defaultWeekdayTimeMin:45`, …) | `preferences ?? NEUTRAL_PREFERENCES` |
+| anchor role / adjacency | never passed | passed |
+
+So the hard/moderate-into-hard/moderate guard that `optimizer.ts:228-240` describes as
+*"what actually stops the tempo trap"* protects the forecast but not today's actual
+prescription. And `rules.ts:503-509` invents a `UserPreferences` object rather than
+threading the real profile or reusing `planner.ts`'s `NEUTRAL_PREFERENCES` — two answers
+to the same question, 200 lines apart. No test asserts parity between the call sites.
+
+### F5. The week-ahead strip always assumes tomorrow is green
+
+`Home.tsx:332`:
+
+```ts
+const tomorrowRec = nextDayPlan ? nextDayPlan.branches.green.recommendation : null;
+```
+
+ADR-0008 §1 specifies the provisional tier as *"tomorrow's already-computed
+green/yellow/red preview branch (**whichever the user has selected**)"*. No selection
+state exists anywhere in the app — `branches.yellow` and `branches.red` are computed
+(three full `evaluateTrainingWithIntent` passes, `rules.ts:984-988`) and then discarded.
+
+Consequences: the forecast is systematically optimistic, and because `applyPick` charges
+the green branch's cost into the chained fatigue/objective ledger, **every** projected
+day inherits a best-case tomorrow. The three-branch evaluation is pure waste until a
+selector exists.
+
+### F6. Firestore rules do not enforce the immutability they document
+
+`app/firestore.rules`, `daily_recommendations`:
+
+```
+// Recommendations are audit evidence and intentionally immutable as documents;
+// adherence remains a validated update on the same document.
+allow update: if hasValidRecommendation(userId, date) && keepsOwnership(userId)
+  && request.resource.data.createdAt == resource.data.createdAt;
+```
+
+Only `createdAt` is pinned. A client may rewrite `templateId`, `mode`, `rationale`,
+`recommendationAudit`, or `candidateScores` on an existing document. Worse,
+`schemaVersion in [1, 2, 3]` combined with
+
+```
+&& (request.resource.data.schemaVersion != 3 || (... hasValidRecommendationAudit ...))
+```
+
+means a v3 document can be **downgraded to v1 and stripped of its audit entirely** — the
+audit requirement is conditional on the version the writer chooses. `replay.ts` verifies
+decisions against exactly this record. The emulator suite has five tests and covers none
+of it. (Ratchet rules — `resource.data.schemaVersion <= request.resource.data.schemaVersion`,
+plus field-pinning for everything except `adherence` — close both holes.)
+
+---
+
+## 3. Tier 2 — Architectural weaknesses
+
+### F7. Three objective-credit models, two live and mutually inconsistent
+
+| Model | Location | Status |
+|---|---|---|
+| Keyword substring on free text | `microcycle.ts:110-141` | live (fallback) |
+| Stimulus-vector coverage ≥ 0.6 | `microcycle.ts:198-213` | live (primary) |
+| Fractional dose-sensitive credit | `stimulus.ts:26-99` | **dead** |
+
+The keyword matcher is not merely approximate, it is wrong in a directional way
+(`microcycle.ts:118-125`): `zone2_aerobic` matches any type string containing `running`
+or `cycling` — so a threshold ride credits the Zone-2 objective; `threshold_quality`
+matches `hard` or `tempo`. The two live models disagree about what a given session
+resolved, and which one runs depends on an incidental property of the exposure (F2).
+
+The V2 layer (`deriveObjectiveCredit`, `getUnresolvedObjectivesV2`, `PlannerState`,
+`ObjectiveProgress`, `ExecutionRecord`, `SessionHistoryEntry`, `deriveSessionPlanRelationship`)
+was merged at `HEAD` with the commit message stating it is *"not yet wired into the live
+scheduling pipeline"*. It is tested, typed, exported, and reachable from nothing. There
+is no ADR, no migration plan, and no stated trigger for the swap-over.
+
+`deriveObjectiveCredit` also has an internal contradiction: it returns
+`qualifies: earnedCredit > 0`, so an objective that **passes** every qualification gate
+but scores 0 stimulus reports `qualifies: false` — conflating "not allowed" with
+"contributed nothing". Its `default: 0.5` arm silently grants half credit for any
+objective key it doesn't recognise.
+
+### F8. `WorkoutStimulusProfile` is a half-finished rename encoded in the type system
+
+Seven canonical axes plus five legacy aliases, **all optional** (`models.ts:170-186`).
+`templates.ts:575-590` populates both sides on every template, inventing two derivations
+with no cited basis:
+
+```ts
+vo2MaxPower:       s.vo2MaxPower       ?? (s.surgeRepeatability   ? s.surgeRepeatability   * 0.8 : 0),
+fatigueResistance: s.fatigueResistance ?? (s.thresholdDevelopment ? s.thresholdDevelopment * 0.7 : 0),
+```
+
+Consumers disagree on which vocabulary is authoritative: `optimizer.ts:calculateStimulusBenefit`
+reads **legacy only** (four axes), `stimulus.ts` reads **canonical-first**. Today this is
+masked because `canonicalizeStimulus` fills both; the day a template author writes only
+canonical names into `TEMPLATES` (which the type permits), that template scores benefit 0
+in the live optimizer and nothing fails.
+
+Compounding it: `WeeklyObjective.targetStimulus` is `Record<string, number>`, not
+`Partial<Record<keyof WorkoutStimulusProfile, number>>`. A typo'd axis name is a
+compile-clean 0-coverage objective that can never be resolved.
+
+### F9. Two selection paths, differing policies, documented only in a stale plan file
+
+Path A (`evaluateTraining`: mode → hardcoded category allowlist → date-hash pick) and
+Path B (`evaluateTrainingWithIntent`: eligibility → cost ceiling → utility ranking) both
+ship. Path B *runs Path A first* (`rules.ts:486`) purely to obtain `mode` and `envelopes`,
+then discards its template pick. Path A is still directly reachable via
+`evaluateNextDayPlan` and remains the only path some templates can appear on.
+
+The only place this dual structure is written down is
+`docs/workout-library-expansion-plan.md §1.2` — a file marked "Status: implemented",
+whose line references (`rules.ts:200`, `rules.ts:387`, `rules.ts:461`, `planner.ts:190`,
+`optimizer.ts:107-120`) are all now wrong. Architecture that only exists in a completed
+implementation plan will be lost.
+
+### F10. Significant policy surfaces have no ADR, and `POLICY_VERSION` never moves
+
+Undocumented in `docs/adr/`:
+
+* `resolveWeeklyAnchors` and optimizer Patches 4/5/6 (anchor role boost 1.35×,
+  anchor-adjacency lower-body suppression 0.3×, variety rotation tie-break). This is a
+  deliberate weekly *architecture* — arguably the largest planning change since ADR-0008,
+  which it post-dates and is not mentioned by.
+* The entire decision-provenance layer: `POLICY_VERSION`, `RecommendationAudit`,
+  `TrainingHistorySnapshot`, `replay.ts`, and the `DataState`-blocks-planning rule.
+  Four commits merged from `codex/decision-provenance-safety` with no ADR.
+* The V2 stimulus scaffolding (F7).
+
+`policy.ts` defines `POLICY_VERSION = '2026-08-decision-provenance-v1'` with the comment
+*"Increment whenever a change can alter a persisted recommendation decision."* `HEAD`
+added a new ranking tie-break, which alters decisions. It was not incremented. A frozen
+version string makes `replay.ts`'s `policyMatchesCurrent` check meaningless.
+
+### F11. ~35 tuned constants, no calibration record, no decision-quality regression gate
+
+`rules.ts:151-155` states the strain thresholds were *"calibrated against ~2 months of
+real HRV/RHR/sleep data"*. That dataset, the procedure, and the resulting
+trigger-frequency numbers exist nowhere in the repository. The same applies to the six
+fatigue half-lives, the six cost-penalty weights, `PROJECTED_FATIGUE_*_THRESHOLD`, and
+every optimizer multiplier.
+
+`npm run simulate:scenarios` exists and works (10 scenarios, ran clean) — but writes to
+`app/artifacts/simulation-reports/`, which is **gitignored**. There is no committed
+baseline, so no reviewer can see that a constant change flipped half a projected week.
+This is the missing safety net that would have caught F3's 0.21× event-modality
+suppression.
+
+### F12. Fatigue model saturates, masks, and depends on an unasserted ordering invariant
+
+* `fatigue.ts:104-111` clamps each axis at 1.0 on accumulation. Two consecutive hard
+  lower-body days ≈ one hard day at the ceiling — the model cannot represent
+  *"significantly deeper in the hole"*.
+* `combinedFatigue = max(external, internal)` (`fatigue.ts:113-121`): a bad night fully
+  *masks* accumulated external load rather than adding to it. An athlete deep in a load
+  block whose HRV happens to read fine is scored identically to a rested one at the same
+  external level, and vice versa.
+* `buildFatigueStateFromHistory` seeds from `history[0].date` and `applyCompletedSessionLoad`
+  floors `elapsedHours` at 0. Oldest-to-newest ordering is therefore load-bearing;
+  out-of-order input silently mis-decays with no error. The invariant is asserted only in
+  a comment (`planner.ts:129`).
+
+---
+
+## 4. Tier 3 — Documentation and process
+
+### F13. Documentation drift
+
+* `docs/README.md`'s ADR index stops at **0008**; ADR-0009 exists and is unlisted.
+* `docs/architecture/recommendation-engine.md` **describes an engine that no longer
+  exists**. It documents a `REST / RECOVERY / AEROBIC_BASE / QUALITY_STRENGTH` mode
+  hierarchy and thresholds "HRV drop > 10%", "RHR > baseline + 3 bpm", "sleep score < 65".
+  The real engine uses `train/modify/recover` with z-scored, stdev-normalised strain at
+  1.0/2.2. The doc never mentions `optimizer`, `periodization`, `microcycle`, `fatigue`,
+  `planner`, `eligibility`, `dose`, `stimulus`, `provenance`, or `replay` — i.e. it omits
+  ADR-0006 through ADR-0009 entirely. **This is the most misleading file in the repo**:
+  it is confidently wrong rather than merely incomplete.
+* `AGENTS.md` says `models.py` is "Domain Schema Version 2" (it is v3, per ADR-0002); its
+  package listing omits `archive.py`, `audit.py`, `canonical.py`, `provider.py`,
+  `garmin_provider.py` and ~15 engine modules.
+* `README.md`'s "Technical Features" list (11 items) never mentions decision provenance,
+  audit, replay, or week-ahead planning.
+
+### F14. The frontend test suite cannot run from a clean clone
+
+`src/firebase.ts` calls `initializeApp`/`getAuth` **at module scope**.
+`trainingSettingsService.test.ts` transitively imports it, so without `VITE_FIREBASE_*`
+set the whole file fails:
+
+```
+FAIL src/services/trainingSettingsService.test.ts
+FirebaseError: Firebase: Error (auth/invalid-api-key)
+Test Files  1 failed | 21 passed | 1 skipped
+```
+
+CI hides this by injecting dummy values. Because `predev` runs `npm run check`, a fresh
+clone cannot even start the dev server. This directly undercuts ADR-0009's stated goal of
+keeping Firebase initialisation out of the test path — the engine achieved it, the
+service layer did not.
+
+`app/README.md` is still the **unmodified Vite starter template**. The `VITE_FIREBASE_*`
+contract is documented nowhere except `.github/workflows/ci.yml`; there is no
+`app/.env.example`.
+
+### F15. CI and tooling gaps
+
+* No Python lint or type check. `AGENTS.md` requires *"type hints across all Python
+  modules"*; `pyproject.toml` has no `ruff` or `mypy`, and CI runs only `pytest`.
+* No coverage measurement or threshold on either side (`test:coverage` exists, unused in CI).
+* `firestore.rules` is tested against the emulator but never deployed or drift-checked —
+  nothing detects that the deployed rules differ from the repository's.
+* No dependency audit (`npm audit` / `pip-audit`), no simulation regression gate.
+* `garmin_login.py` sits at repo root, duplicating `scripts/bootstrap_garmin_tokens.py`,
+  and works around the config guard by injecting `APP_USER_ID="bootstrap_user"` — a
+  deliberate bypass of the ADR-0002 validation, in an unreferenced file.
+
+---
+
+## 5. Way forward
+
+Sequenced so each phase is independently shippable and the highest-consequence gaps close
+first. Effort is rough calendar-days of focused work.
+
+### Phase 0 — Stop the bleeding (~1 day)
+
+Small, mechanical, unblocks everything else.
+
+1. **Make the test suite runnable offline.** Convert `src/firebase.ts` to lazy accessors
+   (`getDb()`/`getAuthInstance()`) so importing a service does not initialise Firebase;
+   or add a vitest setup file providing dummy `VITE_FIREBASE_*`. Add `app/.env.example`
+   and replace `app/README.md` with real setup instructions.
+2. **Bump `POLICY_VERSION`** and add a check to `npm run check` that fails if
+   `optimizer.ts`/`rules.ts`/`microcycle.ts` changed without it moving.
+3. **Commit a simulation baseline.** Un-gitignore a single deterministic
+   `docs/analysis/simulation-baseline.json`, add `npm run simulate:check` diffing against
+   it, and wire it into CI. This is the regression net for every subsequent phase.
+4. **Add `ruff` + `mypy` to `pyproject.toml` and CI.**
+
+### Phase 1 — Close the safety gaps (~3-4 days) — *do not defer*
+
+5. **F1 — Give injuries a real path.** Add a typed `injuries: BodyRegionConstraint[]`
+   (region + severity + optional expiry) to `TrainingSettings` v3, a Preferences-screen
+   editor, Firestore rules validation, and thread it through
+   `mapContextFromGoalsAndTrainingSettings`. Replace the substring `RUNNING_INJURY_PATTERN`
+   with region→modality/category mapping so a lower-body constraint also excludes
+   `Lower-body Strength`, not only `Running`. Note `trainingSettings` rules already
+   permit `schemaVersion: 3` while the client only reads `2` — the forward-compat
+   allowance is already there and currently unusable.
+   *Test to add:* a lower-body injury must exclude heavy squats on **both** paths and
+   across all 7 forecast days.
+6. **F6 — Ratchet the recommendation rules.** Pin every field except `adherence` on
+   update, and require `request.resource.data.schemaVersion >= resource.data.schemaVersion`.
+   Add emulator tests for: field tampering, v3→v1 downgrade, audit removal.
+7. **F2 — Fix objective crediting for measured work.** Only attach `stimulusProfile` when
+   it is non-zero (`completedEventToExposure`), so Garmin-only events fall through to the
+   fallback path; and derive a coarse but non-zero stimulus estimate from
+   `modality × intensity` in `candidateEventFromGarmin`, mirroring the existing
+   `DEFAULT_COST_BY_MODALITY` table. Add `DEFAULT_STIMULUS_BY_MODALITY`.
+   *Test to add:* the probe from F2 — three Garmin sessions must resolve
+   `zone2_aerobic` and `strength_maintenance`.
+
+### Phase 2 — Make the two paths agree (~3 days)
+
+8. **F3 — Put dates back in the ranking context.** Add `date: string` to
+   `RecentHistoryEntry`; make `getConsecutiveModalityCount` require actual consecutive
+   calendar days, and give `getRollingModalityCount` an explicit window parameter.
+   Re-tune the rolling threshold against event modality: for an A-event athlete, three
+   sport-specific sessions per week is the target, not the thing to suppress. Consider
+   exempting the focus-event modality from the rolling arm entirely, or applying the
+   suppression to `category` rather than `modality`.
+9. **F4 — One optimizer invocation builder.** Extract a single
+   `buildOptimizationContext(intent, context, preferences, date)` used by both
+   `rules.ts` and `planner.ts`. Delete the fabricated `UserPreferences` literal.
+   *Test to add:* given identical inputs, both call sites must produce identical
+   `RankedCandidate[]`.
+10. **F5 — Either wire the branch selector or stop computing three branches.**
+    Preferred: add tier selection to the next-day card, thread it into
+    `generateWeekAheadPlanWithIntent`, and update ADR-0008 §1 if the resolution differs.
+    Cheaper interim: default to `yellow` (the honest median) and say so in the ADR.
+
+### Phase 3 — Retire the scaffolding (~4-5 days)
+
+11. **F7/F8 — Pick one credit model and one vocabulary.** Write **ADR-0010: Dose-sensitive
+    objective credit** stating the target model, then either complete the V2 migration or
+    delete `stimulus.ts` and the unused V2 types. Do not leave it at `HEAD`'s state.
+    Simultaneously: make canonical axes **required** on `WorkoutStimulusProfile`, drop the
+    legacy aliases behind a one-shot codemod, and type `targetStimulus` as
+    `Partial<Record<keyof WorkoutStimulusProfile, number>>`.
+12. **F12 — Revisit fatigue accumulation.** Replace hard clamping with a saturating
+    function that stays monotonic past 1.0 (e.g. `1 - exp(-x)` on the raw sum), and
+    reconsider `max(external, internal)` in favour of a weighted combination. Add an
+    ordering assertion (throw, not comment) in `buildFatigueStateFromHistory`.
+    Gate this behind the Phase-0 simulation baseline — it will move every projected day.
+13. **F9 — Decide Path A's future.** Either document it as a deliberate readiness-only
+    fallback in an ADR, or collapse it: extract `evaluateReadinessMode()` returning
+    `{mode, envelopes, telemetry}`, keep that as the only shared entry point, and let
+    template selection live solely in the optimizer.
+
+### Phase 4 — Documentation truth-up (~2 days)
+
+14. **Rewrite `docs/architecture/recommendation-engine.md` from scratch** against the
+    current engine. It is worse than having no document.
+15. **Backfill missing ADRs**: 0010 decision provenance & audit replay (retroactive),
+    0011 weekly architecture & anchors, 0012 objective credit V2. Add a
+    "Superseded/Amended by" line to ADR-0007 §6 and ADR-0008 §1/§6 once F1/F3/F5 land.
+16. **Fix `docs/README.md`'s index**, `AGENTS.md`'s schema version and module lists, and
+    the stale line references in `workout-library-expansion-plan.md` (or mark the file
+    archived and move the two-path explanation into an ADR).
+17. **Delete `garmin_login.py`** in favour of `scripts/bootstrap_garmin_tokens.py`.
+
+### Phase 5 — Calibration as a first-class artifact (~ongoing)
+
+18. Commit the calibration dataset (anonymised or synthetic-but-representative) and a
+    `scripts/calibrate.ts` that reports trigger frequencies per mode. Every tuned constant
+    should cite a line in its output. Without this, §3 F11 recurs with each new heuristic.
+
+---
+
+## 6. Suggested priority if time is limited
+
+If only three things get done: **F1** (injury gate has no data), **F2** (measured
+training earns no credit), **F6** (audit records are rewritable). The first two are why
+the engine's actual behaviour differs from its documented behaviour for a real user
+today; the third is why you could not prove it after the fact.
+
+---
+
+*Findings were verified against the working tree at `2ea45cd`. Probe code used to confirm
+F2 and F3 was temporary and is not committed.*

--- a/docs/analysis/2026-08-08-architecture-review.md
+++ b/docs/analysis/2026-08-08-architecture-review.md
@@ -27,12 +27,22 @@ input was never run. Tests pass because they inject the fixture the production a
 never produces.
 
 The second theme is **unretired scaffolding**. There are now three objective-crediting
-models (two live, one dead), two stimulus vocabularies, and two selection paths — all
-shipped simultaneously, with the newest layer merged at `HEAD` explicitly labelled "not
-yet wired". Each was individually a reasonable step; together they are the main source
-of the divergences below.
+models (two live, one dead), two stimulus vocabularies, two phase vocabularies, and two
+selection paths — all shipped simultaneously, with the newest layer merged at `HEAD`
+explicitly labelled "not yet wired". Each was individually a reasonable step; together
+they are the main source of the divergences below.
 
-Neither theme requires a rewrite. Both require finishing things that were started.
+The third theme, added on reconciliation with an independent review (§7), is that
+**the richest training knowledge in the repository is not connected to the planner at
+all**: `workouts/event-plan.ts` encodes the real macrocycle — sustained quality,
+gap-closing, outdoor specificity, travel maintenance, taper sharpening, race-week
+strength — and its only consumer is a build-time catalog linter (F16). The live engine
+re-derives a lossy approximation of that plan from generic days-to-event arithmetic,
+half of whose output is itself unread (F17). This is the strongest argument that the
+long-term fix is architectural, not a further optimizer increment.
+
+None of the three requires a rewrite. All three require finishing things that were
+started.
 
 ---
 
@@ -327,6 +337,52 @@ suppression.
   out-of-order input silently mis-decays with no error. The invariant is asserted only in
   a comment (`planner.ts:129`).
 
+### F16. The event-plan contract is invisible to the engine
+
+*Added during the second-review reconciliation (§7); credit to the independent review.*
+
+`app/src/workouts/event-plan.ts` encodes 17 `EventPlanSessionCoverage` entries — each with
+a phase list (`build | travel | peak | taper | race`), a requirement tier
+(`required | optional | conditional`), concrete workout IDs, and genuine coaching notes:
+
+> *"Remove first when it compromises cycling quality or taper freshness."*
+> *"Remove in the final 7–10 days before the event."*
+> *"Use only when calf, Achilles and knee response remain normal."*
+> *"Short, low-volume and early enough to avoid soreness."*
+
+This is the richest training-domain knowledge in the repository. **Its only consumer is
+`app/scripts/validate-workouts.ts`** — a build-time catalog-completeness linter. No engine
+module imports it. Verified: the sole non-self references are `workouts/index.ts`
+(re-export) and the validation script.
+
+So the live planner cannot distinguish `sustained_quality` from `gap_closing` from
+`outdoor_event_specific`; it collapses all of them into `threshold_quality` /
+`surge_repeatability` and re-derives an approximation of the plan from generic
+days-to-event arithmetic. ADR-0004 §3 frames this file as *"a declarative phase coverage
+contract [that] guarantees every required workout family exists and is active"* — accurate
+as far as it goes, and that framing is probably why the file has stayed a linter input.
+
+### F17. Periodization's intensity dimension is entirely inert
+
+*Also added during the second-review reconciliation. F16/F17 are numbered after the
+Tier-3 findings below because they were appended after first publication; they belong to
+Tier 2 by consequence.*
+
+`PhaseWeights.intensityScale` is **assigned in six places in `periodization.ts` and read
+in zero**. Post-Event Recovery's `0.4` and Specificity's `1.1` affect nothing.
+`volumeScale` has exactly one consumer — `trainingIntent.ts:80`'s `plannedDose`. So of
+periodization's two output scalars, one is dead and the other is a single multiplier on a
+single number.
+
+Related: there are **two disjoint phase vocabularies with no mapping between them** —
+`EventPlanPhase` (`build | travel | peak | taper | race`, workouts layer) and
+`PhaseWeights.phaseName` (`Base | Build | Specificity | Peak/Taper | Post-Event Recovery`,
+engine layer). Any work on F16 has to reconcile these first.
+
+Also unused-but-declared, reinforcing F7: `WeeklyObjective.requiredCredit`, `.windowStart`,
+`.windowEnd`, `.priority`. `requiredCredit` is referenced only inside the dead
+`getUnresolvedObjectivesV2`.
+
 ---
 
 ## 4. Tier 3 — Documentation and process
@@ -398,9 +454,14 @@ Small, mechanical, unblocks everything else.
    and replace `app/README.md` with real setup instructions.
 2. **Bump `POLICY_VERSION`** and add a check to `npm run check` that fails if
    `optimizer.ts`/`rules.ts`/`microcycle.ts` changed without it moving.
-3. **Commit a simulation baseline.** Un-gitignore a single deterministic
-   `docs/analysis/simulation-baseline.json`, add `npm run simulate:check` diffing against
-   it, and wire it into CI. This is the regression net for every subsequent phase.
+3. **Commit a simulation baseline *and* a golden coaching scenario.** Un-gitignore a
+   deterministic `docs/analysis/simulation-baseline.json`, add `npm run simulate:check`
+   diffing against it, and wire it into CI. Alongside it, encode the current cycling
+   macrocycle as an asserted golden week (see §7.4) — invariants, not just diff-stability:
+   ≥48 h between key cycling quality exposures; no heavy lower-body strength compromising
+   them; no penalty merely for a third cycling exposure; outdoor work satisfies plan
+   objectives. **This is the instrument every later phase is measured with — it must land
+   before any constant or heuristic is changed.**
 4. **Add `ruff` + `mypy` to `pyproject.toml` and CI.**
 
 ### Phase 1 — Close the safety gaps (~3-4 days) — *do not defer*
@@ -428,13 +489,17 @@ Small, mechanical, unblocks everything else.
 
 ### Phase 2 — Make the two paths agree (~3 days)
 
-8. **F3 — Put dates back in the ranking context.** Add `date: string` to
-   `RecentHistoryEntry`; make `getConsecutiveModalityCount` require actual consecutive
-   calendar days, and give `getRollingModalityCount` an explicit window parameter.
-   Re-tune the rolling threshold against event modality: for an A-event athlete, three
-   sport-specific sessions per week is the target, not the thing to suppress. Consider
-   exempting the focus-event modality from the rolling arm entirely, or applying the
-   suppression to `category` rather than `modality`.
+8. **F3 — Replace modality anti-stacking; do not merely date it.** Adding `date: string`
+   to `RecentHistoryEntry` is necessary but not sufficient — it makes the rule *correct*
+   while leaving it the *wrong shape*. Modality repetition is not the hazard; insufficient
+   recovery between hard lower-body quality exposures is. Replace the two multipliers with
+   explicit structured constraints over a dated, role-annotated history: minimum hours
+   between quality sessions, no back-to-back hard lower-body work, a rolling hard-session
+   cap, and strength protection around key cycling days.
+   Express these **lexicographically**, not as further multipliers (see §7.3): the current
+   code demonstrates why a multiplicative scalar cannot hold the line — the 0.15× anti-stack
+   term buys out the 1.40× A-event boost, producing a net 0.21× against exactly the
+   modality the athlete's A-event requires.
 9. **F4 — One optimizer invocation builder.** Extract a single
    `buildOptimizationContext(intent, context, preferences, date)` used by both
    `rules.ts` and `planner.ts`. Delete the fabricated `UserPreferences` literal.
@@ -492,5 +557,119 @@ today; the third is why you could not prove it after the fact.
 
 ---
 
+## 7. Reconciliation with the independent review
+
+A second review of the same commit was produced independently and is reconciled here.
+Its claims were re-verified against the working tree before being adopted. The two
+reviews answer different questions and are complementary rather than competing:
+
+* **This document** asks *"what does the system do right now, and where does that differ
+  from what it claims?"* — a defect-and-drift audit, verified by execution.
+* **The independent review** asks *"what shape should the planning core be?"* — an
+  architectural critique, and on that question it is the stronger document.
+
+### 7.1 Adopted from the independent review
+
+| Claim | Verification | Outcome |
+|---|---|---|
+| The event-plan contract is disconnected from the live planner | Confirmed — sole consumer is `validate-workouts.ts` | Added as **F16** |
+| `intensityScale` is not authoritative | Confirmed, and stronger than stated: read in **zero** places | Added as **F17** |
+| Modality anti-stacking is the wrong abstraction | Confirmed against this document's own F3 evidence | Reframed Phase-2 step 8 |
+| Greedy per-day ranking is solving a sequence problem | Structural; accepted | See §7.3 |
+| Objective credit should be dose- and objective-specific | Consistent with F7; more specific than this document was | Folded into Phase 3 |
+| Fixed activities are not persisted planning inputs | Confirmed — `WeekAheadOptions.fixedActivities` has no Firestore source | Accepted |
+| Local tissue state is too coarse (one soreness scalar) | Confirmed; complements F1 | Accepted, sequenced after F1 |
+
+**F16 is the most significant thing this document originally missed.** ADR-0004 frames
+`event-plan.ts` as a coverage contract validated by a script; that framing was accepted
+here rather than interrogated. The independent review asked what *else* the file knows,
+and the answer is: most of the actual training plan.
+
+### 7.2 Findings absent from the independent review
+
+Three findings here do not appear there, and each undercuts a rating that review assigns:
+
+* **F1** — it endorses *"safety before preference — keep this"* and *"safety remains
+  independently authoritative"*, then proposes richer tissue tracking, while the existing
+  injury channel is hardcoded empty. Adding a tissue layer above a disconnected gate
+  reproduces the same failure one level up. **F1 must precede that work.**
+* **F6** — it rates security 8/10 and audit/replay 8.5/10 without the v3→v1 audit-strip
+  path. Those ratings do not survive the finding.
+* **F5** — it praises the `confirmed/provisional/projected` tiers without noting that the
+  provisional tier is hardcoded to the green branch, which biases every projected day it
+  seeds.
+
+On **F2**, that review reaches the right conclusion (*"the system sees cost but not
+benefit"*) without the mechanism, and so misses the inversion: attaching the all-zero
+vector actively *blocks* the keyword fallback, making recognised activities worse off than
+unrecognised ones. That distinction matters for sequencing — the fix is a guard plus a
+lookup table, deliverable now, rather than the evidence-hierarchy subsystem that review
+implies. Both are worth building; the small one should not wait for the large one.
+
+### 7.3 Where this document's plan is revised
+
+**Lexicographic priority ordering replaces multiplier tuning.** The independent review's
+proposed hierarchy is adopted:
+
+```text
+1. Safety and feasibility
+2. Must-have plan obligations
+3. Sequence and recovery constraints
+4. Objective coverage and timing
+5. Expected fatigue cost
+6. Preferences / variety / convenience
+```
+
+Scalar utility ranking remains, but *within an equivalent candidate class* — choosing
+between indoor Zone 2, an outdoor easy ride, and cross-training once the role is fixed.
+That is what it is good at. The present architecture instead asks one multiplicative score
+to arbitrate safety, periodization, interference, recovery, preference and variety
+simultaneously, and F3 is the proof that it cannot.
+
+**Bounded sequence search over the 7-day horizon** (beam width 10–20) replaces the greedy
+day-by-day walk in a later phase. A 7-day horizon does not warrant heavier machinery.
+
+### 7.4 Where this document dissents
+
+* **Drop the numeric scorecard.** A per-area /10 table is unfalsifiable, and is
+  miscalibrated by that review's own gaps (see §7.2).
+* **Reorder the implementation steps.** That review removes modality anti-stacking at
+  Step 2 and promotes simulations to coaching-contract tests at Step 10. That replaces one
+  uncalibrated heuristic with an uncalibrated constraint system and no instrument to
+  observe the change. Its own golden-scenario specification is excellent and belongs
+  **first** — note the simulation harness currently writes to a gitignored directory, so
+  no committed baseline exists at all (F11).
+* **Do not front-load the cutover past the live defects.** The V2 Plan-Intent cutover is
+  the right destination and should be the main line of development — but a cutover
+  performed over F1 and F6 inherits an unwired safety gate and rewritable audit evidence.
+  Roughly four days of Phase-1 work buys a correct foundation to migrate onto.
+
+### 7.5 Merged priority
+
+```text
+0. Simulation baseline + golden coaching scenario        (the instrument)
+1. F1, F2, F6                                            (live defects, ~4 days)
+2. ADR-0010: Plan Intent is the planning authority       (+ F16 engine-visible
+                                                            event plan, + F17
+                                                            intensityScale disposition)
+3. F3 via lexicographic constraints, F4, F5              (one coherent ranking path)
+4. Wire V2 objective progress; retire the dead layer     (F7, F8)
+5. Beam search, PlanDefinition, fixed activities,
+   local tissue state, dose-sensitive cost               (the cutover proper)
+```
+
+The independent review's closing principle is the right one to build toward, and is
+adopted here verbatim:
+
+> *The plan decides what adaptation is needed. Readiness decides how safely it can be
+> executed. The optimizer chooses among equivalent feasible implementations. Actual
+> training updates both achieved stimulus and incurred cost.*
+
+The addition this document makes is that steps 0 and 1 are prerequisites for it, not
+detours around it.
+
+---
+
 *Findings were verified against the working tree at `2ea45cd`. Probe code used to confirm
-F2 and F3 was temporary and is not committed.*
+F2 and F3 was temporary and is not committed. §7 reconciles an independent review of the
+same commit; its claims were re-verified before adoption.*

--- a/docs/architecture/recommendation-engine.md
+++ b/docs/architecture/recommendation-engine.md
@@ -1,63 +1,205 @@
 # Recommendation Engine Architecture
 
-The frontend application (`app/src/engine/`) implements an adaptive training decision engine in TypeScript. It evaluates daily recovery snapshots, computes objective strain scores, selects training modes, and constructs structured workout prescriptions.
+How `app/src/engine/` turns a morning's data into a prescribed session.
+
+> **Accuracy note.** Rewritten 2026-08-08 against the engine as it actually is. The
+> previous version described a `REST / RECOVERY / AEROBIC_BASE / QUALITY_STRENGTH` mode
+> hierarchy with fixed thresholds ("HRV drop > 10%", "sleep score < 65") that the code has
+> not used for some time, and omitted every module added by ADR-0006 through ADR-0011.
+> Keep this file updated with the code — a confidently wrong architecture doc is worse
+> than none (finding F13).
 
 ---
 
-## 🧩 Architectural Layers
+## Two selection paths
+
+A template can reach the athlete through **two independent paths with different filtering
+rules**. Any change here must be evaluated against both.
+
+### Path A — readiness only (`evaluateTraining`)
 
 ```text
-Firestore / Daily Recovery Snapshot
-                 │
-                 ▼
-     ┌───────────────────────┐
-     │     validation.ts     │ (Schema validation & sanitization)
-     └───────────┬───────────┘
-                 │
-                 ▼
-     ┌───────────────────────┐
-     │       rules.ts        │ (Strain scoring & mode hierarchy rules)
-     └───────────┬───────────┘
-                 │
-                 ▼
-     ┌───────────────────────┐
-     │     templates.ts      │ (Session template catalog & systemic load caps)
-     └───────────┬───────────┘
-                 │
-                 ▼
-Adaptive Recommendation + Strain Telemetry + Human Rationale
+readiness → mode (train | modify | recover) → category allow-list → date-hash pick
 ```
 
+Pure and synchronous. No history, no events, no periodization. Still reachable directly
+via `evaluateNextDayPlan`, and it computes the mode and safety envelopes that Path B
+depends on.
+
+Phase-gated templates (`phaseEligibility`) are excluded from Path A entirely — it holds no
+`PeriodizationResult`, so it cannot evaluate them at all.
+
+### Path B — intent-aware (`evaluateTrainingWithIntent`, `generateWeekAheadPlan`)
+
+```text
+ENRICHED_TEMPLATES → eligibility → envelope + mode ceilings → phase eligibility
+                   → rankCandidatesByUtility → top pick
+```
+
+Asynchronous; resolves training intent from adherence history first. **Path B runs Path A
+internally** to obtain `mode` and `envelopes`, then discards Path A's template choice and
+re-selects via the optimizer.
+
+> That overlap is deliberate-but-transitional (finding F9). The intended end state is one
+> `evaluateReadinessAndSafetyEnvelope` feeding a single selection path — see
+> [`docs/plans/phase-3-single-ranking-path.md`](../plans/phase-3-single-ranking-path.md).
+
 ---
 
-## 📁 Source Code Organization
+## Module map
 
-* [`app/src/engine/models.ts`](../../app/src/engine/models.ts) — Core interfaces: `DailyRecoverySnapshot`, `RecommendationResult`, `StrainTelemetry`, `StrainBreakdown`, `DecisionRationale`.
-* [`app/src/engine/rules.ts`](../../app/src/engine/rules.ts) — Decision logic calculating acute metric deviations, multi-day baseline drift, mode overrides, and rationale text.
-* [`app/src/engine/templates.ts`](../../app/src/engine/templates.ts) — Session template definitions, systemic load boundaries, and duration bounds.
-* [`app/src/engine/validation.ts`](../../app/src/engine/validation.ts) — Schema sanitization ensuring input types and numeric boundaries are safe.
+```text
+                    DailyRecoverySnapshot + DailySubjectiveCheckin
+                                      │
+                    adapters.ts  ─────┴─────  validation.ts
+                                      │
+                                 DailyReadiness
+                                      │
+        ┌─────────────────────────────┼─────────────────────────────┐
+        ▼                             ▼                             ▼
+   rules.ts                    trainingIntent.ts              eligibility.ts
+   mode + envelopes            resolves plan-side intent      hard gates
+   + strain telemetry                 │                       (time, equipment,
+        │                    ┌────────┼────────┐               environment,
+        │                    ▼        ▼        ▼               guardrails)
+        │            periodization  microcycle  fatigue
+        │            phase/focus    objectives  6D decay
+        │                    └────────┼────────┘
+        │                             ▼
+        │                       optimizer.ts
+        │                    benefit / (1 + cost) × modifiers
+        └─────────────────────────────┼─────────────────────────────┐
+                                      ▼                             ▼
+                                   dose.ts                     planner.ts
+                             execution dose ceiling        7-day projection
+                                      │                             │
+                                      ▼                             │
+                            workouts/prescription.ts ◄──────────────┘
+                                      │
+                              provenance.ts → RecommendationAudit
+```
+
+| Module | Responsibility |
+|---|---|
+| `adapters.ts` | Firestore canonical models → engine inputs |
+| `validation.ts` | Schema validation and sanitisation at the persistence boundary |
+| `eligibility.ts` | The single hard-gate resolver: time, equipment, environment, guardrails |
+| `rules.ts` | Strain scoring, `train`/`modify`/`recover` mode, safety & plan envelopes, adjustment tiers |
+| `periodization.ts` | Event lifecycle, focus-event resolution, continuous phase weights |
+| `microcycle.ts` | Weekly objectives and exposure crediting |
+| `fatigue.ts` | Six-dimensional fatigue with exponential decay |
+| `optimizer.ts` | Candidate ranking: benefit vs cost, plus named modifiers |
+| `trainingIntent.ts` | Composes periodization + objectives + fatigue + planned dose |
+| `dose.ts` | Intersects planned dose with the clinical ceiling and athlete adjustment |
+| `planner.ts` | Rolling 7-day projection and the weekly anchor pre-pass |
+| `provenance.ts` / `replay.ts` | Audit construction and verification |
 
 ---
 
-## ⚙️ Decision Logic & Mode Hierarchy
+## Mode selection (`rules.ts`)
 
-The engine evaluates training modes in a strict risk hierarchy:
+Three modes, not four: **`train`**, **`modify`**, **`recover`**.
 
-1. **REST Mode (Override)**: Triggered when severe acute strain, sleep floor violations, or extreme HRV drops are present.
-2. **RECOVERY Mode**: Recommended when moderate fatigue or baseline drift indicates high cumulative strain.
-3. **AEROBIC_BASE Mode**: Default target mode when recovery metrics are balanced and stable.
-4. **QUALITY_STRENGTH / THRESHOLD Mode**: Enabled when recovery scores demonstrate high readiness, low acute strain, and no drift penalties.
+Objective strain is a continuous, **self-normalised** score — not fixed absolute
+thresholds. Each of HRV, RHR and sleep score contributes two z-scored terms:
+
+* **acute** — today vs this person's own trailing 7-day baseline
+* **chronic** — the 7-day baseline's drift from the 28-day baseline, weighted ×1.5,
+  because a multi-day trend predicts overreaching better than one noisy night
+
+Normalisation uses the athlete's own trailing 28-day stdev, floored (HRV 3 ms, RHR
+1.5 bpm, sleep 4 pts) so a flat metric cannot produce an explosive z-score. Each metric's
+contribution is capped at ±2.0 so one outlier cannot dominate.
+
+```text
+strain = Σ metric(acute + 1.5 × chronic) × weight     HRV 0.5, RHR 0.3, sleep 0.2
+       + sleepFloorPenalty          sleep score < 50           → +0.5
+       + bodyBatteryDeficit         ramps 50 → 25              → up to +0.3
+       + recentHardSessions         ≥2 hard in 3 days          → +1.0
+       + conservativeBias           athlete preference         → +0.4
+```
+
+| Mode | Trigger | Candidate ceiling |
+|---|---|---|
+| `recover` | strain ≥ 2.2, fatigue score > 7, pain, body battery ≤ 20, or already trained today | `Rest` / `Mobility/Recovery` |
+| `modify` | strain ≥ 1.0, fatigue score > 5, or soreness > 6 | `systemicCost <= 0.5` |
+| `train` | otherwise | category allow-list (Path A) or plan-tier ceiling (Path B) |
+
+`modify` caps by **systemic cost**, not by category — so upper-body strength (cost 0.3)
+remains available on a day when legs and intervals are not.
+
+Two overrides sit on top: a **post-recover buffer** softens a fresh `train` to `modify` the
+day after a mandated recovery day, and an **already-trained-today** override forces
+`recover` regardless of how green the numbers look.
 
 ---
 
-## 📈 Strain Telemetry Decomposition
+## Candidate ranking (`optimizer.ts`)
 
-Objective strain is calculated as:
+```text
+utility = benefit / (1 + fatigueCost) × preferenceMultiplier
+```
 
-$$\text{Total Strain} = \text{Acute Deviation} + \text{Multi-Day Drift} + \text{Contextual Penalties}$$
+**Benefit** scores a template's stimulus profile against currently unresolved weekly
+objectives. **Cost** is the dot product of the template's six-dimensional cost profile
+with current dimensional fatigue, weighted (lower body ×2.5 for DOMS interference,
+systemic ×2.0, impact ×2.0, neuromuscular ×1.8, cardiovascular and upper body ×1.5).
 
-### Metric Weights & Penalties
-* **HRV Drop**: Deviation below 7d or 28d baseline ($>10\%$ drop adds acute strain).
-* **Resting Heart Rate Elevation**: $RHR > RHR_{baseline} + 3\text{ bpm}$ adds acute strain.
-* **Sleep Deficit**: Sleep score $< 65$ or duration $< 6.5\text{ hours}$ triggers sleep floor penalties.
-* **Step Overload**: Previous-day step count ($D-1$) exceeding target thresholds increases non-exercise fatigue load.
+The multiplier then accumulates named modifiers: anti-stacking, post-objective strength
+suppression, intensity stacking, event-modality preference, aerobic filler, anchor role
+boost, anchor adjacency suppression, and a variety tie-break — see
+[ADR-0011](../adr/0011-weekly-architecture-anchors.md), including its Negative section on
+why this composition is a known problem.
+
+---
+
+## Authority ordering
+
+The engine's real hierarchy, in the order it is applied:
+
+```text
+clinical / safety gates     hard exclusion — never overridable
+        ↓
+feasibility                 time, equipment, environment, guardrails
+        ↓
+readiness mode ceiling      train / modify / recover cost caps
+        ↓
+phase eligibility           event-relative template gating (Path B only)
+        ↓
+objective benefit           unresolved weekly exposures
+        ↓
+fatigue cost                dimensional interference
+        ↓
+preference                  soft multipliers only
+```
+
+Preferences rank; they never unlock. An avoided modality is a hard exclude on Path A and a
+0.2× soft penalty on Path B — a deliberate distinction, since taste must never behave like
+a safety constraint ([ADR-0007](../adr/0007-adaptive-multisport-engine-architecture.md) §6).
+
+---
+
+## Multi-day projection
+
+`planner.ts` chains the same pipeline forward with three confidence tiers — `confirmed`
+(today), `provisional` (tomorrow's readiness-branch preview), `projected` (day 2+) — and
+a hard fatigue-tier ceiling, because `benefit / (1 + cost)` is asymptotic and would
+otherwise never actually select rest. Nothing beyond today is persisted. See
+[ADR-0008](../adr/0008-week-ahead-planning.md).
+
+---
+
+## Related decisions
+
+| ADR | Covers |
+|---|---|
+| [0006](../adr/0006-reconciled-strain-telemetry.md) | Acute vs multi-day-drift strain decomposition |
+| [0007](../adr/0007-adaptive-multisport-engine-architecture.md) | Six-tier engine, dual profiles, safety vs preference authority |
+| [0008](../adr/0008-week-ahead-planning.md) | Rolling 7-day projection and confidence tiers |
+| [0009](../adr/0009-training-intent-history.md) | History-seeded intent; the `TrainingHistoryProvider` boundary |
+| [0010](../adr/0010-decision-provenance-and-audit-replay.md) | `DataState`, audit records, replay, `POLICY_VERSION` |
+| [0011](../adr/0011-weekly-architecture-anchors.md) | Weekly anchors and ranking modifiers |
+
+Known divergences between these decisions and the code are tracked in
+[the 2026-08-08 review](../analysis/2026-08-08-architecture-review.md); remediation is
+sequenced in [`docs/plans/`](../plans/).

--- a/docs/architecture/recommendation-engine.md
+++ b/docs/architecture/recommendation-engine.md
@@ -13,8 +13,9 @@ How `app/src/engine/` turns a morning's data into a prescribed session.
 
 ## Two selection paths
 
-A template can reach the athlete through **two independent paths with different filtering
-rules**. Any change here must be evaluated against both.
+A template can reach the athlete through **two distinct selection paths with different
+filtering rules** (distinct, not independent — Path B runs Path A internally for mode and
+envelopes, so the readiness computation is shared; only the *selection* differs). Any change here must be evaluated against both.
 
 ### Path A — readiness only (`evaluateTraining`)
 

--- a/docs/plans/0000-workout-library-expansion.md
+++ b/docs/plans/0000-workout-library-expansion.md
@@ -532,5 +532,7 @@ on its own — it is the only phase that fixes incorrect user-facing output.
 ## 10. Documentation follow-up
 
 - Update `docs/workout-library.md` §Source of the catalogue and §File layout.
-- Consider ADR-0010 for D4 (workout-per-template vs parameter-variant) if §4.1 resolves
+- Consider a dedicated ADR for D4 (workout-per-template vs parameter-variant) if §4.1 resolves.
+  (Originally written as "ADR-0010"; that number is now taken by decision provenance.
+  Reserve the next free number at the time it is written.)
   toward a resolver change — that is an architectural decision, not a content one.

--- a/docs/plans/0000-workout-library-expansion.md
+++ b/docs/plans/0000-workout-library-expansion.md
@@ -1,6 +1,15 @@
 # Workout Library Expansion — Implementation Plan
 
-Status: implemented
+* **Status:** Implemented (2026-08-07)
+* **Relocated** from `docs/workout-library-expansion-plan.md` to establish the
+  `docs/plans/` convention. Content unchanged.
+
+> **Reader warning.** The line references in §1.2 (`rules.ts:200`, `rules.ts:387`,
+> `rules.ts:461`, `planner.ts:190`, `optimizer.ts:107-120`) are **stale** — see F9 in
+> [the 2026-08-08 review](../analysis/2026-08-08-architecture-review.md). The prose is
+> still accurate and §1.2 remains the fullest written description of the two selection
+> paths; treat the line numbers as historical.
+
 Date: 2026-08-07
 Scope: `app/src/workouts/`, `app/src/engine/templates.ts`, `app/src/engine/microcycle.ts`
 
@@ -45,7 +54,7 @@ different filtering rules. Any change here must be evaluated against both.
 
 **Path A — readiness rules (`evaluateTraining`, `rules.ts:200`)**
 
-```
+```text
 readiness → mode (train | modify | recover) → category allowlist → pickTemplate
 ```
 
@@ -63,7 +72,7 @@ category). `recover` mode is restricted to `Rest` / `Mobility/Recovery`.
 
 **Path B — intent optimizer (`evaluateTrainingWithIntent`, `rules.ts:461`; `generateWeekAheadPlan`, `planner.ts:190`)**
 
-```
+```text
 ENRICHED_TEMPLATES → eligibility → systemicCost ceiling → rankCandidatesByUtility → top pick
 ```
 
@@ -277,7 +286,7 @@ Each phase is independently shippable and leaves `npm run check` green.
 New file `app/src/workouts/catalog/strength-lower.ts`, exporting
 `LOWER_BODY_STRENGTH_WORKOUTS` with one definition:
 
-```
+```text
 id:       'strength_lower_body_01'
 category: 'full_body_strength'          // no lower-only WorkoutCategory; D7
 modality: 'strength'
@@ -512,7 +521,7 @@ cable exercises, and a `strength_cable_upper_01` workout with
 
 ## 9. Sequencing
 
-```
+```text
 Phase 1 (P0, routing)  ──▶  Phase 2 (P1, reachability)  ──▶  Phase 3 (evidence)  ──▶  Phase 4 (formats)
    independent               depends on Phase 1 tests        independent            independent
 ```

--- a/docs/plans/0000-workout-library-expansion.md
+++ b/docs/plans/0000-workout-library-expansion.md
@@ -11,8 +11,8 @@
 > because this file was read as current. **Verify any finding here against the code before
 > acting on it.**
 >
-> Its line references (`rules.ts:200`, `rules.ts:387`, `rules.ts:461`, `planner.ts:190`,
-> `optimizer.ts:107-120`) are also stale — see F9 in
+> Its line references (`rules.ts`, `rules.ts`, `rules.ts`, `planner.ts`,
+> `optimizer.ts`) are also stale — see F9 in
 > [the 2026-08-08 review](../analysis/2026-08-08-architecture-review.md). The prose is
 > still accurate and §1.2 remains the fullest written description of the two selection
 > paths; treat the specifics as historical.
@@ -59,14 +59,14 @@ Implemented on 2026-08-07. The library now contains 52 exercises, 36 workout def
 A template can reach the user through **two independent code paths**, and they have
 different filtering rules. Any change here must be evaluated against both.
 
-**Path A — readiness rules (`evaluateTraining`, `rules.ts:200`)**
+**Path A — readiness rules (`evaluateTraining`, `rules.ts`)**
 
 ```text
 readiness → mode (train | modify | recover) → category allowlist → pickTemplate
 ```
 
 On a `train` day the candidate pool is a hardcoded **category allowlist**
-(`rules.ts:387`):
+(`rules.ts`):
 
 ```ts
 t.category === 'Hard Endurance' || t.category === 'Moderate Endurance'
@@ -77,7 +77,7 @@ t.category === 'Hard Endurance' || t.category === 'Moderate Endurance'
 `modify` mode filters by `systemicCost <= MODIFY_MAX_SYSTEMIC_COST` (any non-Rest
 category). `recover` mode is restricted to `Rest` / `Mobility/Recovery`.
 
-**Path B — intent optimizer (`evaluateTrainingWithIntent`, `rules.ts:461`; `generateWeekAheadPlan`, `planner.ts:190`)**
+**Path B — intent optimizer (`evaluateTrainingWithIntent`, `rules.ts`; `generateWeekAheadPlan`, `planner.ts`)**
 
 ```text
 ENRICHED_TEMPLATES → eligibility → systemicCost ceiling → rankCandidatesByUtility → top pick
@@ -85,7 +85,7 @@ ENRICHED_TEMPLATES → eligibility → systemicCost ceiling → rankCandidatesBy
 
 There is **no category allowlist** on this path — only modality restriction, systemic
 cost ceiling, mode gate, duration, equipment, and injury filters
-(`optimizer.ts:107-120`).
+(`optimizer.ts`).
 
 > **Consequence:** a new template in a category outside the Path A allowlist is
 > selectable on Path B but invisible on Path A. This is the single most important
@@ -96,17 +96,17 @@ cost ceiling, mode gate, duration, equipment, and injury filters
 `prescription.ts` resolves an engine template to a catalogue workout in two steps:
 
 1. **Preferred** — find a non-`manualOnly` workout whose `engineTemplateIds` contains
-   the template id (`prescription.ts:310`). Only 8 of 20 templates currently have one.
-2. **Fallback** — `FALLBACK_TEMPLATE_TO_WORKOUT` (`prescription.ts:19-37`), a 17-entry
+   the template id (`prescription.ts`). Only 8 of 20 templates currently have one.
+2. **Fallback** — `FALLBACK_TEMPLATE_TO_WORKOUT` (`prescription.ts`), a 17-entry
    hand-written table.
 
-`prescription.test.ts:29` asserts **every** template in `TEMPLATES` resolves non-null.
+`prescription.test.ts` asserts **every** template in `TEMPLATES` resolves non-null.
 This is a real guardrail: adding a template without a mapping fails CI. It does *not*
 check that the mapping is semantically correct.
 
 > **~~Incidental finding (P1)~~ — RESOLVED during this plan's own implementation.**
 > Verified against the code 2026-08-08: `workoutForTemplate`
-> ([`prescription.ts:303`](../../app/src/workouts/prescription.ts)) filters on
+> ([`prescription.ts` `workoutForTemplate`](../../app/src/workouts/prescription.ts)) filters on
 > `workout.status === 'active' && !workout.manualOnly && workout.engineTemplateIds?.includes(templateId)`,
 > and the legacy fallback at line 307 also requires `status === 'active'`. The resolver
 > matches what `docs/workout-library.md` describes; there is no gap.
@@ -143,7 +143,7 @@ routinely selectable, and every selection silently delivers a full-body session.
 
 ### 2.2 P1 — Two declared engine categories have zero templates
 
-`SessionTemplate['category']` (`engine/models.ts:220`) declares 11 categories.
+`SessionTemplate['category']` (`engine/models.ts`) declares 11 categories.
 `templates.ts` defines templates for 9. Missing:
 
 - **`'Power Maintenance'`** — the catalogue has `strength_compact_power_01`
@@ -157,7 +157,7 @@ daily recommendation.
 
 ### 2.3 P1 — `ENRICHED_TEMPLATES` default profiles are wrong for the missing categories
 
-`templates.ts:481-513` assigns stimulus/cost profiles by category with an `else` branch
+`templates.ts` assigns stimulus/cost profiles by category with an `else` branch
 for anything unmatched:
 
 ```ts
@@ -174,8 +174,8 @@ explicit `stimulusProfile` and `costProfile`, or the `else` branch must be exten
 
 ### 2.4 P1 — Field sessions earn no microcycle credit
 
-`planner.ts:141` builds the credit string as `` `${modality} ${category}` ``.
-`microcycle.ts:80-88` matches objectives by keyword. A field session produces
+`planner.ts` builds the credit string as `` `${modality} ${category}` ``.
+`microcycle.ts` matches objectives by keyword. A field session produces
 `"Field Field Maintenance"`, which matches **none** of the four objective keyword sets
 (`threshold|hard|tempo`, `surge|vo2|football|hiit`, `easy|endurance|zone 2|running|cycling`,
 `strength|weight|lifting`). Note `'football'` is already a `surge_repeatability` keyword —
@@ -204,8 +204,8 @@ that builds the relevant tissue capacity.
 
 ### 2.6 Explicitly NOT problems
 
-- **Two `Equipment` unions.** `workouts/models.ts:50` (`Equipment`) and
-  `engine/models.ts:553` (`EquipmentKey`) are deliberately separate vocabularies —
+- **Two `Equipment` unions.** `workouts/models.ts` (`Equipment`) and
+  `engine/models.ts` (`EquipmentKey`) are deliberately separate vocabularies —
   the engine gates on coarse user-owned equipment, the catalogue on fine-grained
   per-exercise needs. Do not merge them.
 - **Intensity distribution model.** See §3.4.
@@ -273,7 +273,7 @@ evidence does not support the engineering cost.
 | # | Decision | Rationale |
 |---|---|---|
 | D1 | Fix routing before adding content | A correct catalogue behind a broken router still delivers the wrong session. §2.1 is the only P0. |
-| D2 | New plyometric exercises get `modality: 'strength'`, not `'field'` | `validation.ts:22-30` restricts a `strength` workout to `strength` exercises. Using `'field'` would force widening the compatibility matrix, weakening a useful invariant. |
+| D2 | New plyometric exercises get `modality: 'strength'`, not `'field'` | `validation.ts` restricts a `strength` workout to `strength` exercises. Using `'field'` would force widening the compatibility matrix, weakening a useful invariant. |
 | D3 | Every new engine template carries explicit `stimulusProfile` + `costProfile` | Avoids the wrong `else`-branch defaults (§2.3). Also extend the `else` branches defensively. |
 | D4 | New quality sessions attach to existing templates via `engineTemplateIds`, not new templates | A template is an engine-level *choice*; a workout is an execution. Two VO₂ formats are two executions of one choice. Avoids inflating the Path A candidate pool. |
 | D5 | Add `Power Maintenance` to the Path A `train` allowlist; keep `Field Maintenance` optimizer-only | The readiness path cannot enforce field session spacing; see Risk R2. |
@@ -314,7 +314,7 @@ exist — no `exercises.ts` change needed in this phase.
 
 Must satisfy `validation.ts`:
 - three variants `full` / `reduced` / `return_to_training`, durations non-increasing
-  in that order (`validation.ts:240-241`);
+  in that order (`validation.ts`);
 - `duration.minimumMin <= defaultMin <= maximumMin`, minimum > 0 (`:208-209`);
 - `full.targetDurationMin === duration.defaultMin` to avoid the warning at `:237`;
 - `loadMultiplier` in `(0, 1.2]` (`:274`);
@@ -327,11 +327,11 @@ Must satisfy `validation.ts`:
 
 Register in `catalog.ts` (import + spread).
 
-**1.2 Prune and correct the fallback table** (`prescription.ts:19-37`)
+**1.2 Prune and correct the fallback table** (`prescription.ts`)
 
 - Remove `end_mod_01`, `end_mod_02`, `end_hard_01`, `end_hard_02`, `end_hard_03` —
   all now superseded by `engineTemplateIds` in `quality-support.ts`. Verify by
-  temporarily removing and confirming `prescription.test.ts:29` still passes.
+  temporarily removing and confirming `prescription.test.ts` still passes.
 - Remove `str_lower_01` — superseded by 1.1.
 - Leave `end_easy_02`/`end_easy_03` → `running_walk_run_01` (accepted, documented).
 - Leave `str_upper_02` → `strength_upper_body_trunk_01` until Phase 4.
@@ -345,7 +345,7 @@ resolved **modality and category agreement** for every template — e.g. a
 
 **1.4 Enforce `status === 'active'` in the resolver**
 
-`prescription.ts:310` — add the missing status predicate so the code matches the
+`prescription.ts` — add the missing status predicate so the code matches the
 documented contract (see incidental finding in §1.3):
 
 ```ts
@@ -400,7 +400,7 @@ a deprecation from silently continuing to ship.
 Explicit profiles per D3. Note `field_maint_01` carries `impactTissue: 0.8` — the
 `else`-branch default would have given `0.5` with `upperBody: 0.8`.
 
-**2.2 Extend the `ENRICHED_TEMPLATES` fallback branches** (`templates.ts:481-513`)
+**2.2 Extend the `ENRICHED_TEMPLATES` fallback branches** (`templates.ts`)
 
 Add explicit `Power Maintenance` and `Field Maintenance` branches so a future template
 that omits profiles still gets sane values.
@@ -408,13 +408,13 @@ that omits profiles still gets sane values.
 **2.3 Wire `engineTemplateIds` in the catalogue**
 
 - `strength_compact_power_01` → `engineTemplateIds: ['str_power_01']`
-  (`catalog/strength.ts:42`)
+  (`catalog/strength.ts`)
 - `field_controlled_maintenance_01` → `engineTemplateIds: ['field_maint_01']`
-  (`catalog/field.ts:6`)
+  (`catalog/field.ts`)
 
 No fallback-table entries needed — `engineTemplateIds` takes precedence.
 
-**2.4 Add the safe category to the Path A `train` allowlist** (`rules.ts:387`)
+**2.4 Add the safe category to the Path A `train` allowlist** (`rules.ts`)
 
 `Power Maintenance` is allowed. `Field Maintenance` remains Path B-only because the
 readiness path cannot enforce `minimumDaysAfterHardLowerBody`; this is the selected
@@ -422,7 +422,7 @@ Risk R2 mitigation.
 
 See Risk R2 for the guard this needs.
 
-**2.5 Credit field sessions in the microcycle** (`microcycle.ts:82`)
+**2.5 Credit field sessions in the microcycle** (`microcycle.ts`)
 
 Add `'field'` to the `surge_repeatability` keyword set alongside `'football'`, so
 `"Field Field Maintenance"` resolves an objective. Verify against
@@ -437,7 +437,7 @@ is the guard which makes §2.2 unrepeatable.
 
 ### Phase 3 — Reactive strength and eccentric tissue work (P2, highest evidence value)
 
-**3.1 New `Equipment` member** — add `'plyo_box'` to `workouts/models.ts:50`.
+**3.1 New `Equipment` member** — add `'plyo_box'` to `workouts/models.ts`.
 
 **3.2 New exercises** (`exercises.ts`) — all `modality: 'strength'` per D2:
 
@@ -466,7 +466,7 @@ Add as a second option on the existing `compact_strength` event-plan coverage ke
 
 Add `nordic_hamstring_curl` and `eccentric_heel_raise` as optional accessory steps
 (`optional: true`) to `strength_full_body_maintenance_01` and the Phase 1
-`strength_lower_body_01`. Guard the duration warning at `validation.ts:344` — optional
+`strength_lower_body_01`. Guard the duration warning at `validation.ts` — optional
 steps still count toward computed duration, so re-check each variant's
 `targetDurationMin`.
 
@@ -504,7 +504,7 @@ cable exercises, and a `strength_cable_upper_01` workout with
 |---|---|---|
 | Static | Type check across both `Equipment` unions and the category union | `npm run typecheck` |
 | Library | Referential, duration, equipment, variant, parameter-binding validation | `npm run validate:workouts` |
-| Unit | Every template resolves non-null (existing) | `prescription.test.ts:29` |
+| Unit | Every template resolves non-null (existing) | `prescription.test.ts` |
 | Unit | **New** — resolved workout's modality/category agrees with the template's | `prescription.test.ts` |
 | Unit | **New** — every `SessionTemplate['category']` value has ≥1 template | `prescription.test.ts` |
 | Unit | **New** — a `Field` session credits a microcycle objective | `microcycle` tests |

--- a/docs/plans/0000-workout-library-expansion.md
+++ b/docs/plans/0000-workout-library-expansion.md
@@ -533,6 +533,7 @@ on its own — it is the only phase that fixes incorrect user-facing output.
 
 - Update `docs/workout-library.md` §Source of the catalogue and §File layout.
 - Consider a dedicated ADR for D4 (workout-per-template vs parameter-variant) if §4.1 resolves.
-  (Originally written as "ADR-0010"; that number is now taken by decision provenance.
-  Reserve the next free number at the time it is written.)
+  (Originally written as "ADR-0010"; that number now belongs to decision provenance.
+  0010–0015 are reserved — see the ADR index in [`docs/README.md`](../README.md) — so take
+  the next number after the documented reservations.)
   toward a resolver change — that is an architectural decision, not a content one.

--- a/docs/plans/0000-workout-library-expansion.md
+++ b/docs/plans/0000-workout-library-expansion.md
@@ -4,11 +4,18 @@
 * **Relocated** from `docs/workout-library-expansion-plan.md` to establish the
   `docs/plans/` convention. Content unchanged.
 
-> **Reader warning.** The line references in §1.2 (`rules.ts:200`, `rules.ts:387`,
-> `rules.ts:461`, `planner.ts:190`, `optimizer.ts:107-120`) are **stale** — see F9 in
+> **Reader warning — this document is a historical record, not a work list.**
+> It was written *before* the work it describes was carried out, so its findings and
+> "fix this" instructions describe a state that no longer exists. At least one of them
+> (§1.3's resolver `status` finding) was re-reported as live during the 2026-08-08 review
+> because this file was read as current. **Verify any finding here against the code before
+> acting on it.**
+>
+> Its line references (`rules.ts:200`, `rules.ts:387`, `rules.ts:461`, `planner.ts:190`,
+> `optimizer.ts:107-120`) are also stale — see F9 in
 > [the 2026-08-08 review](../analysis/2026-08-08-architecture-review.md). The prose is
 > still accurate and §1.2 remains the fullest written description of the two selection
-> paths; treat the line numbers as historical.
+> paths; treat the specifics as historical.
 
 Date: 2026-08-07
 Scope: `app/src/workouts/`, `app/src/engine/templates.ts`, `app/src/engine/microcycle.ts`
@@ -97,13 +104,18 @@ cost ceiling, mode gate, duration, equipment, and injury filters
 This is a real guardrail: adding a template without a mapping fails CI. It does *not*
 check that the mapping is semantically correct.
 
-> **Incidental finding (P1).** `docs/workout-library.md` states the resolver looks for
-> an *"active, non-manual"* workout. The code at `prescription.ts:310` filters only on
-> `!workout.manualOnly` — there is **no `status === 'active'` check**. A `draft` or
-> `deprecated` workout carrying `engineTemplateIds` would be prescribed. Nothing
-> currently exploits this (all 30 workouts are `active`), but it is a latent trap for
-> exactly the kind of catalogue growth this plan proposes. Fix in Phase 1 alongside
-> 1.2 — one predicate, plus a test that a `deprecated` workout is never resolved.
+> **~~Incidental finding (P1)~~ — RESOLVED during this plan's own implementation.**
+> Verified against the code 2026-08-08: `workoutForTemplate`
+> ([`prescription.ts:303`](../../app/src/workouts/prescription.ts)) filters on
+> `workout.status === 'active' && !workout.manualOnly && workout.engineTemplateIds?.includes(templateId)`,
+> and the legacy fallback at line 307 also requires `status === 'active'`. The resolver
+> matches what `docs/workout-library.md` describes; there is no gap.
+>
+> The original text (a `draft`/`deprecated` workout could be prescribed, "fix in Phase 1")
+> described the state *before* this plan was implemented and is struck through rather than
+> deleted so the history stays readable. **It is not outstanding work.** It was
+> re-reported as a live finding during the 2026-08-08 review cycle purely because this
+> document was read as current — see the reader warning at the top.
 
 ---
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -51,18 +51,24 @@ These implement the way forward in
 §7.5. Finding IDs (`F1`, `F16`, …) refer to that document.
 
 All six are **design-approved** as of 2026-08-08 — every open choice is decided and
-recorded in the register below. Only two can be *started* today.
+recorded in the register below.
 
-| # | Plan | Status | Blocked by | Addresses |
-|---|---|---|---|---|
-| 0 | [Instrumentation & developer baseline](./phase-0-instrumentation.md) | **Ready** | — | F11, F14, F15, part of F10 |
-| 1 | [Live defects](./phase-1-live-defects.md) | **Ready** (1.1, 1.3) / Approved (1.2) | 1.2 needs Phase 0 | F1, F2, F6 |
-| 2 | [Plan intent is the planning authority](./phase-2-plan-intent-authority.md) | Approved | Phase 1 | F16, F17, F9 |
-| 3 | [One ranking path](./phase-3-single-ranking-path.md) | Approved | Phase 0, ADR-0012 (Phase 2) | F3, F4, F5 |
-| 4 | [Objective credit V2](./phase-4-objective-credit-v2.md) | Approved | Phase 0, Phase 2 | F7, F8, F12 |
-| 5 | [Sequence planning](./phase-5-sequence-planning.md) | Approved | Phases 0–4 | the cutover proper |
+`Status` is a single plan-level lifecycle value from the table above. Because a plan can
+be part-startable, **which work items are unblocked is a separate column** — `Ready` at
+the plan level would otherwise have to mean "some of it", which is how the earlier
+all-`Ready` table became unusable.
 
-**Start here: Phase 0, and Phase 1 items 1.1 and 1.3.** Those three are unblocked today.
+| # | Plan | Status | Startable items | Blocked by | Addresses |
+|---|---|---|---|---|---|
+| 0 | [Instrumentation & developer baseline](./phase-0-instrumentation.md) | **Ready** | all | — | F11, F14, F15, part of F10 |
+| 1 | [Live defects](./phase-1-live-defects.md) | Approved | **1.1, 1.3** | 1.2 needs Phase 0 | F1, F2, F6 |
+| 2 | [Plan intent is the planning authority](./phase-2-plan-intent-authority.md) | Approved | none | Phase 1 | F16, F17, F9 |
+| 3 | [One ranking path](./phase-3-single-ranking-path.md) | Approved | none | Phase 0; ADR-0012, which Phase 2 task 2.1 writes — it does not exist yet | F3, F4, F5 |
+| 4 | [Objective credit V2](./phase-4-objective-credit-v2.md) | Approved | none | Phase 0, Phase 2 | F7, F8, F12 |
+| 5 | [Sequence planning](./phase-5-sequence-planning.md) | Approved | none | Phases 0–4 | the cutover proper |
+
+**Start here: two plans and three work items** — all of Phase 0, plus Phase 1 items 1.1
+and 1.3. Nothing else is unblocked today.
 
 **Phase 0 gates Phases 3–5 and Phase 1.2.** It builds the only instrument that can tell
 whether a heuristic change improved or degraded the plan — so any item that changes

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -19,17 +19,28 @@ docs/architecture/  living reference     "how it works now"      updated with th
 
 ## Status lifecycle
 
+Status answers **"is the design agreed?"** — separately from **"can work start now?"**,
+which is what `Blocked by` answers. Conflating the two made the table unusable: an earlier
+revision marked all six phases `Ready` while four of them depended on phases that had not
+landed.
+
 | Status | Meaning |
 |---|---|
-| `Draft` | Being written; not agreed. |
-| `Ready` | Agreed and actionable. Preconditions listed are met. |
+| `Draft` | Being written; design not agreed. |
+| `Approved` | Design agreed and decisions taken. **May still be blocked** — check `Blocked by`. |
+| `Ready` | Approved **and** every dependency has landed. Work can start today. |
 | `In progress` | Work started. |
 | `Implemented` | Delivered. Retained for the reasoning, not as instructions. |
 | `Superseded` | Replaced by a later plan (link it). |
 | `Archived` | No longer pursued. Say why. |
 
-Every plan carries `Status`, `Depends on`, and `Unlocks` in its header so the ordering is
-readable without opening all of them.
+`Approved → Ready` is a mechanical transition: it happens when the last blocker lands, and
+requires no new decision.
+
+Every plan carries `Status`, `Blocked by`, and `Unlocks` in its header. **Dependencies are
+declared per work item, not only per phase** — a phase can be part-startable, and saying
+"depends on nothing" at the header while an individual item requires the Phase-0 harness is
+how a plan stops being executable.
 
 ---
 
@@ -39,22 +50,29 @@ These implement the way forward in
 [`docs/analysis/2026-08-08-architecture-review.md`](../analysis/2026-08-08-architecture-review.md)
 §7.5. Finding IDs (`F1`, `F16`, …) refer to that document.
 
-All six are **`Ready`** as of 2026-08-08 — every open choice has been decided and recorded
-in the register below.
+All six are **design-approved** as of 2026-08-08 — every open choice is decided and
+recorded in the register below. Only two can be *started* today.
 
-| # | Plan | Status | Addresses |
-|---|---|---|---|
-| 0 | [Instrumentation & developer baseline](./phase-0-instrumentation.md) | Ready | F11, F14, F15, part of F10 |
-| 1 | [Live defects](./phase-1-live-defects.md) | Ready | F1, F2, F6 |
-| 2 | [Plan intent is the planning authority](./phase-2-plan-intent-authority.md) | Ready | F16, F17, F9 |
-| 3 | [One ranking path](./phase-3-single-ranking-path.md) | Ready | F3, F4, F5 |
-| 4 | [Objective credit V2](./phase-4-objective-credit-v2.md) | Ready | F7, F8, F12 |
-| 5 | [Sequence planning](./phase-5-sequence-planning.md) | Ready | the cutover proper |
+| # | Plan | Status | Blocked by | Addresses |
+|---|---|---|---|---|
+| 0 | [Instrumentation & developer baseline](./phase-0-instrumentation.md) | **Ready** | — | F11, F14, F15, part of F10 |
+| 1 | [Live defects](./phase-1-live-defects.md) | **Ready** (1.1, 1.3) / Approved (1.2) | 1.2 needs Phase 0 | F1, F2, F6 |
+| 2 | [Plan intent is the planning authority](./phase-2-plan-intent-authority.md) | Approved | Phase 1 | F16, F17, F9 |
+| 3 | [One ranking path](./phase-3-single-ranking-path.md) | Approved | Phase 0, ADR-0012 (Phase 2) | F3, F4, F5 |
+| 4 | [Objective credit V2](./phase-4-objective-credit-v2.md) | Approved | Phase 0, Phase 2 | F7, F8, F12 |
+| 5 | [Sequence planning](./phase-5-sequence-planning.md) | Approved | Phases 0–4 | the cutover proper |
 
-**Phase 0 must land before Phases 3–5.** It builds the only instrument that can tell
-whether a heuristic change improved or degraded the plan. Phase 1 is independent of the
-rest and should not wait for architectural agreement. Phase 5 is `Ready` as a *sequenced
-destination* — see its increment order; it is not the next thing to build.
+**Start here: Phase 0, and Phase 1 items 1.1 and 1.3.** Those three are unblocked today.
+
+**Phase 0 gates Phases 3–5 and Phase 1.2.** It builds the only instrument that can tell
+whether a heuristic change improved or degraded the plan — so any item that changes
+decision behaviour needs it first. Phase 1.2 changes objective crediting for every
+existing user, which is exactly that category, despite the rest of Phase 1 being
+independent.
+
+Phase 5 is approved as a *sequenced destination* (see its increment order), not as the
+next thing to build — and 5.1 specifically is approved to be **measured**, not shipped
+unconditionally.
 
 ---
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -1,0 +1,79 @@
+# Implementation Plans
+
+Plans describe **how a change gets made**. They are mutable working documents with a
+status lifecycle, and they are expected to go stale — that is what `Superseded` and
+`Archived` are for.
+
+This is deliberately different from [`docs/adr/`](../adr/), which records **what was
+decided and why** and is immutable once accepted (ADR-0001). If a plan proposes a
+decision, that decision belongs in an ADR; the plan references it.
+
+```text
+docs/analysis/   point-in-time audits    "what is true today"    dated, never edited
+docs/adr/        decisions               "what we chose, why"    immutable once accepted
+docs/plans/      execution               "how we get there"      mutable, status-tracked
+docs/architecture/  living reference     "how it works now"      updated with the code
+```
+
+---
+
+## Status lifecycle
+
+| Status | Meaning |
+|---|---|
+| `Draft` | Being written; not agreed. |
+| `Ready` | Agreed and actionable. Preconditions listed are met. |
+| `In progress` | Work started. |
+| `Implemented` | Delivered. Retained for the reasoning, not as instructions. |
+| `Superseded` | Replaced by a later plan (link it). |
+| `Archived` | No longer pursued. Say why. |
+
+Every plan carries `Status`, `Depends on`, and `Unlocks` in its header so the ordering is
+readable without opening all of them.
+
+---
+
+## Current plans
+
+These implement the way forward in
+[`docs/analysis/2026-08-08-architecture-review.md`](../analysis/2026-08-08-architecture-review.md)
+§7.5. Finding IDs (`F1`, `F16`, …) refer to that document.
+
+| # | Plan | Status | Addresses |
+|---|---|---|---|
+| 0 | [Instrumentation & developer baseline](./phase-0-instrumentation.md) | Ready | F11, F14, F15, part of F10 |
+| 1 | [Live defects](./phase-1-live-defects.md) | Ready | F1, F2, F6 |
+| 2 | [Plan intent is the planning authority](./phase-2-plan-intent-authority.md) | Draft | F16, F17, F9 |
+| 3 | [One ranking path](./phase-3-single-ranking-path.md) | Draft | F3, F4, F5 |
+| 4 | [Objective credit V2](./phase-4-objective-credit-v2.md) | Draft | F7, F8, F12 |
+| 5 | [Sequence planning](./phase-5-sequence-planning.md) | Draft | the cutover proper |
+
+**Phase 0 must land before Phases 3–5.** It builds the only instrument that can tell
+whether a heuristic change improved or degraded the plan. Phase 1 is independent of the
+rest and should not wait for architectural agreement.
+
+### Archived
+
+* [Workout library expansion](./0000-workout-library-expansion.md) — `Implemented`
+  2026-08-07. Retained because §1.2 is still the fullest written description of the
+  two selection paths; its line references are stale (see F9).
+
+---
+
+## Writing a plan
+
+Keep them executable. A plan that cannot be picked up by someone who did not write it is
+not finished. Each should have:
+
+1. **Goal** — one or two sentences, no preamble.
+2. **Preconditions** — what must be true before starting.
+3. **Work items** — numbered, each naming real files and a concrete change.
+4. **Tests to add** — named, with the behaviour asserted.
+5. **Acceptance criteria** — a checklist that can be verified, not described.
+6. **Risks & rollback** — including what to do if the change is wrong.
+7. **Out of scope** — the adjacent work this plan deliberately does not do.
+8. **Docs to update** — ADRs to write or amend, architecture docs to correct.
+
+Prefer to state the smallest change that closes the finding. Where a plan proposes both a
+tactical fix and a structural one, say which unblocks work now and which is the
+destination.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -39,18 +39,45 @@ These implement the way forward in
 [`docs/analysis/2026-08-08-architecture-review.md`](../analysis/2026-08-08-architecture-review.md)
 §7.5. Finding IDs (`F1`, `F16`, …) refer to that document.
 
+All six are **`Ready`** as of 2026-08-08 — every open choice has been decided and recorded
+in the register below.
+
 | # | Plan | Status | Addresses |
 |---|---|---|---|
 | 0 | [Instrumentation & developer baseline](./phase-0-instrumentation.md) | Ready | F11, F14, F15, part of F10 |
 | 1 | [Live defects](./phase-1-live-defects.md) | Ready | F1, F2, F6 |
-| 2 | [Plan intent is the planning authority](./phase-2-plan-intent-authority.md) | Draft | F16, F17, F9 |
-| 3 | [One ranking path](./phase-3-single-ranking-path.md) | Draft | F3, F4, F5 |
-| 4 | [Objective credit V2](./phase-4-objective-credit-v2.md) | Draft | F7, F8, F12 |
-| 5 | [Sequence planning](./phase-5-sequence-planning.md) | Draft | the cutover proper |
+| 2 | [Plan intent is the planning authority](./phase-2-plan-intent-authority.md) | Ready | F16, F17, F9 |
+| 3 | [One ranking path](./phase-3-single-ranking-path.md) | Ready | F3, F4, F5 |
+| 4 | [Objective credit V2](./phase-4-objective-credit-v2.md) | Ready | F7, F8, F12 |
+| 5 | [Sequence planning](./phase-5-sequence-planning.md) | Ready | the cutover proper |
 
 **Phase 0 must land before Phases 3–5.** It builds the only instrument that can tell
 whether a heuristic change improved or degraded the plan. Phase 1 is independent of the
-rest and should not wait for architectural agreement.
+rest and should not wait for architectural agreement. Phase 5 is `Ready` as a *sequenced
+destination* — see its increment order; it is not the next thing to build.
+
+---
+
+## Decision register
+
+Choices resolved when the plans were approved. Each is argued at the linked location;
+this table exists so none of them has to be rediscovered by reading six documents.
+
+| ID | Decision | Where | One-line reason |
+|---|---|---|---|
+| **D-INJ** | Structured `InjuryConstraint` (Option B), not consolidation onto guardrails (Option A) | [1.1](./phase-1-live-defects.md#two-options-and-the-decision) | Guardrails cannot express a modality exclusion, cannot expire, and Phase 5.4 needs the schema anyway |
+| **D-KWD** | The keyword matcher is legacy last-resort only; recognised Garmin sessions get an inferred vector | [1.2](./phase-1-live-defects.md) | Routing to it trades a false negative for double credit on one ride |
+| **D-GATE** | Coaching invariants gate CI; the simulation snapshot is a non-blocking semantic diff | [0.1](./phase-0-instrumentation.md) | A byte-exact gate would freeze today's known-bad behaviour and make every improvement look like a regression |
+| **D-PHASE** | `EventPlanPhase` is the canonical phase vocabulary; `PhaseWeights.phaseName` becomes a derived label | [2.1 D1](./phase-2-plan-intent-authority.md) | It is what a coach actually names, and it can express `travel`, which days-to-event structurally cannot |
+| **D-INT** | `intensityScale` gets a consumer (`PlannedDose.intensity`), it is not deleted | [2.1 D2](./phase-2-plan-intent-authority.md) | Taper is volume down / intensity held; collapsing both into one scalar is why taper has to be reconstructed elsewhere |
+| **D-LEX** | Lexicographic priority ordering replaces multiplicative composition | [3.2](./phase-3-single-ranking-path.md) | F3 is the proof: two reasonable multipliers composed into a policy nobody chose |
+| **D-TIER** | Build the next-day tier selector; do not settle for a `yellow` default | [3.4](./phase-3-single-ranking-path.md) | All three branches are already computed and paid for; only the control is missing |
+| **D-AXES** | Delete the `*0.8` / `*0.7` stimulus derivations; templates declare the axes | [4.2](./phase-4-objective-credit-v2.md) | No citation can justify a repository-wide fixed ratio between per-session properties |
+| **D-FUSE** | Fatigue fusion is *measured before chosen*, not prescribed now | [4.3](./phase-4-objective-credit-v2.md) | Prescribing a formula here would repeat exactly the uncited-constant practice F11 criticises |
+| **D-BEAM** | Beam search is approved to be **built and measured**, not to be shipped regardless of result | [5 increment order](./phase-5-sequence-planning.md) | Whether it beats greedy is empirical; "it didn't" is a valid, useful outcome |
+
+Two of these (**D-KWD**, **D-GATE**) correct errors in the first draft of the plans and
+came out of the PR #5 review.
 
 ### Archived
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -132,6 +132,42 @@ be.
 
 ---
 
+## Conventions that exist because they were violated
+
+Both of these were added after a document in this directory misled a reader. They are
+cheap to follow and the failure mode is expensive.
+
+### Reference symbols, never line numbers
+
+Write `` `rules.ts` `evaluateEnvelopes` `` or `` `prescription.ts:workoutForTemplate` ``.
+Do **not** write `` `rules.ts:544-556` ``.
+
+Line numbers drift within hours of being written. A 2026-08-08 audit of this directory
+found 91 line references, and a six-sample spot check found **three already pointing at
+the wrong code** — all written the same day. An agent following a stale line reference
+lands on unrelated code and either acts on it or burns time reconciling it. Symbol names
+survive refactors, are greppable, and fail loudly when renamed rather than silently
+pointing somewhere plausible.
+
+### An `Implemented` plan must not read like a work list
+
+When a plan flips to `Implemented`, **strike through or delete its findings, "problems
+found", and "fix this" sections**, keeping the outcome summary. Do not leave a
+pre-implementation problem statement sitting in the present tense.
+
+This is not hygiene. On 2026-08-08 an already-fixed P1 from
+[`0000-workout-library-expansion.md`](./0000-workout-library-expansion.md) §1.3 was
+re-reported as a live defect three times — in two PR comments and a summary — because the
+archived plan still described it in the present tense with a "fix in Phase 1"
+instruction. `Status: Implemented` in the header was not a strong enough signal; the body
+read as current, so it was treated as current.
+
+Every archived plan therefore also carries a reader warning at the top stating that it is
+a historical record and that its findings must be verified against the code before being
+acted on.
+
+---
+
 ## Writing a plan
 
 Keep them executable. A plan that cannot be picked up by someone who did not write it is
@@ -145,6 +181,8 @@ not finished. Each should have:
 6. **Risks & rollback** — including what to do if the change is wrong.
 7. **Out of scope** — the adjacent work this plan deliberately does not do.
 8. **Docs to update** — ADRs to write or amend, architecture docs to correct.
+
+Reference symbols rather than line numbers (see the convention above).
 
 Each work item should be implementable by someone who has not read the rest of the
 document: name the real files, state the current behaviour, state the change, and give a

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -108,6 +108,30 @@ than from the original analysis.
 
 ---
 
+## Task status
+
+Every work item inside a plan carries a status marker on its heading and a matching row in
+that plan's **Task board**:
+
+| Marker | Meaning |
+|:--:|---|
+| `[ ]` | Not started |
+| `[-]` | In progress |
+| `[x]` | Finished |
+
+Update **both** the heading marker and the board row in the same commit — a board that
+disagrees with its headings is worse than no board, because it will be trusted.
+
+A task is `[x]` only when its own *Done when* condition holds, not when the code was
+written. Where a task's outcome is a measurement rather than a migration (notably Phase
+5.1), recording a negative result satisfies it — see D-BEAM.
+
+Phase-level `Status` (`Approved` / `Ready`) is about the *plan*; task markers are about
+the *work*. A `Ready` plan can be entirely `[ ]`, and an `Approved (blocked)` plan should
+be.
+
+---
+
 ## Writing a plan
 
 Keep them executable. A plan that cannot be picked up by someone who did not write it is
@@ -121,6 +145,11 @@ not finished. Each should have:
 6. **Risks & rollback** — including what to do if the change is wrong.
 7. **Out of scope** — the adjacent work this plan deliberately does not do.
 8. **Docs to update** — ADRs to write or amend, architecture docs to correct.
+
+Each work item should be implementable by someone who has not read the rest of the
+document: name the real files, state the current behaviour, state the change, and give a
+verifiable *Done when*. If a task needs a decision made first, say so and point at the
+decision register rather than leaving the implementer to choose.
 
 Prefer to state the smallest change that closes the finding. Where a plan proposes both a
 tactical fix and a structural one, say which unblocks work now and which is the

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -83,7 +83,7 @@ this table exists so none of them has to be rediscovered by reading six document
 
 | ID | Decision | Where | One-line reason |
 |---|---|---|---|
-| **D-INJ** | Structured `InjuryConstraint` (Option B), not consolidation onto guardrails (Option A) | [1.1](./phase-1-live-defects.md#two-options-and-the-decision) | Guardrails cannot express a modality exclusion, cannot expire, and Phase 5.4 needs the schema anyway |
+| **D-INJ** | Structured `InjuryConstraint[]` (Option B), not consolidation onto guardrails (Option A) | [1.1](./phase-1-live-defects.md#two-options-and-the-decision) | Guardrails cannot express a modality exclusion, cannot expire, and Phase 5.4 needs the schema anyway |
 | **D-KWD** | The keyword matcher is legacy last-resort only; recognised Garmin sessions get an inferred vector | [1.2](./phase-1-live-defects.md) | Routing to it trades a false negative for double credit on one ride |
 | **D-GATE** | Coaching invariants gate CI; the simulation snapshot is a non-blocking semantic diff | [0.1](./phase-0-instrumentation.md) | A byte-exact gate would freeze today's known-bad behaviour and make every improvement look like a regression |
 | **D-PHASE** | `EventPlanPhase` is the canonical phase vocabulary; `PhaseWeights.phaseName` becomes a derived label | [2.1 D1](./phase-2-plan-intent-authority.md) | It is what a coach actually names, and it can express `travel`, which days-to-event structurally cannot |
@@ -93,9 +93,12 @@ this table exists so none of them has to be rediscovered by reading six document
 | **D-AXES** | Delete the `*0.8` / `*0.7` stimulus derivations; templates declare the axes | [4.2](./phase-4-objective-credit-v2.md) | No citation can justify a repository-wide fixed ratio between per-session properties |
 | **D-FUSE** | Fatigue fusion is *measured before chosen*, not prescribed now | [4.3](./phase-4-objective-credit-v2.md) | Prescribing a formula here would repeat exactly the uncited-constant practice F11 criticises |
 | **D-BEAM** | Beam search is approved to be **built and measured**, not to be shipped regardless of result | [5 increment order](./phase-5-sequence-planning.md) | Whether it beats greedy is empirical; "it didn't" is a valid, useful outcome |
+| **D-LIFE** | Recommendations become append-only revisions; decision fields immutable *per revision* | [1.3](./phase-1-live-defects.md) | Same-day recomputation is a real second decision; naive field-pinning would reject it and leave the audit contradicting the UI |
+| **D-RECOV** | `EventPlanPhase` gains a canonical `recovery` member | [2.1 D1](./phase-2-plan-intent-authority.md) | Mapping `Post-Event Recovery → build` would make fitness-developing objectives eligible during recovery |
 
-Two of these (**D-KWD**, **D-GATE**) correct errors in the first draft of the plans and
-came out of the PR #5 review.
+Five of these — **D-KWD**, **D-GATE**, **D-LIFE**, **D-RECOV**, and the withdrawal inside
+**D-FUSE** — correct errors in earlier drafts and came out of PR #5 review rounds rather
+than from the original analysis.
 
 ### Archived
 

--- a/docs/plans/phase-0-instrumentation.md
+++ b/docs/plans/phase-0-instrumentation.md
@@ -208,7 +208,8 @@ run surfaces, or record explicit per-module ignores with a reason.
       marked as expected-failing with a citation to F3
 - [ ] `npm test` passes from a clean clone with no `.env`
 - [ ] `app/.env.example` exists; `app/README.md` is project-specific
-- [ ] `POLICY_VERSION` bumped; drift guard in `npm run check`
+- [ ] `POLICY_VERSION` bumped; the drift guard runs **in CI** against an explicit base SHA
+      (not in `npm run check`, which stays local-only and has no base ref)
 - [ ] `ruff` and `mypy` run in CI
 - [ ] `garmin_login.py` removed
 

--- a/docs/plans/phase-0-instrumentation.md
+++ b/docs/plans/phase-0-instrumentation.md
@@ -8,6 +8,25 @@
 
 ---
 
+## Task board
+
+Status legend: `[ ]` not started · `[-]` in progress · `[x]` finished.
+Update the marker on the work-item heading **and** this table in the same commit.
+
+| Task | Status | Summary | Primary files |
+|---|:--:|---|---|
+| 0.1 | `[ ]` | Coaching invariants + aggregate bounds gate CI; snapshot becomes a non-blocking semantic diff | `app/scripts/simulate-scenarios.mjs`, `app/package.json`, `.github/workflows/ci.yml`, `docs/analysis/simulation-baseline.json` |
+| 0.2 | `[ ]` | Golden coaching-contract scenario with fixed dates; one assertion lands expected-failing | `app/src/engine/simulation/scenarios.ts`, `app/src/engine/goldenWeek.test.ts` |
+| 0.3 | `[ ]` | Lazy Firebase init so the suite runs from a clean clone | `app/src/firebase.ts`, `app/src/services/*.ts`, `app/.env.example`, `app/README.md` |
+| 0.4 | `[ ]` | `POLICY_VERSION` bump + CI drift guard using the CI base SHA | `app/src/engine/policy.ts`, `.github/workflows/ci.yml`, new guard script |
+| 0.5 | `[ ]` | `ruff` + `mypy` in `pyproject.toml` and CI | `pyproject.toml`, `.github/workflows/ci.yml` |
+| 0.6 | `[ ]` | Delete `garmin_login.py`; pin `uv`; add dependency audits | `garmin_login.py`, `Dockerfile`, `.github/workflows/ci.yml` |
+
+**No task here changes engine behaviour.** If a change to `app/src/engine/**` becomes
+necessary to complete a task, stop — it belongs in a later phase.
+
+---
+
 ## Goal
 
 Make it possible to see whether a planning change improved or degraded the recommended
@@ -30,7 +49,7 @@ was ever committed.
 
 ## Work items
 
-### 0.1 — Invariants are the CI gate; the snapshot is a diagnostic
+### `[ ]` 0.1 — Invariants are the CI gate; the snapshot is a diagnostic
 
 **This item was restructured after PR #5 review.** The original version proposed a
 full-output snapshot diff as the CI gate. That is the wrong contract here, and the
@@ -69,7 +88,7 @@ so it should be stable — verify rather than assume. If it is not stable, the s
 worthless as a diagnostic; fix the nondeterminism or drop the snapshot and keep only the
 invariants.
 
-### 0.2 — Golden coaching-contract scenario
+### `[ ]` 0.2 — Golden coaching-contract scenario
 
 The existing scenario assertions in `app/src/engine/scenarios.test.ts` check engine
 semantics (no constraint violations, no absurd streaks). They do not assert that the
@@ -98,7 +117,7 @@ F3. Land it as a documented failing assertion (`it.fails(...)`, with a comment c
 F3 and this plan) so Phase 3 has an unambiguous definition of done, rather than
 weakening the assertion to match current behaviour.
 
-### 0.3 — Make the frontend suite runnable from a clean clone
+### `[ ]` 0.3 — Make the frontend suite runnable from a clean clone
 
 `app/src/firebase.ts` calls `initializeApp` / `getFirestore` / `getAuth` at module scope,
 so importing any service transitively initialises Firebase. Without `VITE_FIREBASE_*`,
@@ -127,7 +146,7 @@ instructions: install, env, `npm run check`, `npm run dev`, `npm run test:rules`
 
 **Acceptance:** `git clone && cd app && npm ci && npm test` passes with no `.env` present.
 
-### 0.4 — Policy version guard
+### `[ ]` 0.4 — Policy version guard
 
 `POLICY_VERSION` (`app/src/engine/policy.ts`) is documented as "increment whenever a
 change can alter a persisted recommendation decision" and has never moved, including
@@ -156,7 +175,7 @@ through `HEAD`'s new ranking tie-break. A frozen string makes `replay.ts`'s
    This check belongs in CI rather than `npm run check`, since it needs the base ref;
    keep `npm run check` local-only.
 
-### 0.5 — Python lint and type checking
+### `[ ]` 0.5 — Python lint and type checking
 
 `AGENTS.md` requires type hints across all Python modules; nothing enforces it.
 
@@ -165,7 +184,7 @@ Add to `pyproject.toml` dev dependencies: `ruff`, `mypy`. Add `[tool.ruff]` and
 `src/garmin_sync` only). Add both to the `python-tests` CI job. Fix whatever the first
 run surfaces, or record explicit per-module ignores with a reason.
 
-### 0.6 — Small cleanups
+### `[ ]` 0.6 — Small cleanups
 
 * Delete `garmin_login.py` (repo root). It duplicates
   `scripts/bootstrap_garmin_tokens.py` and bypasses the ADR-0002 guard by injecting

--- a/docs/plans/phase-0-instrumentation.md
+++ b/docs/plans/phase-0-instrumentation.md
@@ -1,0 +1,199 @@
+# Phase 0 — Instrumentation & developer baseline
+
+* **Status:** Ready
+* **Depends on:** nothing
+* **Unlocks:** Phases 3, 4, 5 (none of them can be evaluated without this)
+* **Addresses:** F11, F14, F15, part of F10
+* **Rough effort:** 1–1.5 days
+
+---
+
+## Goal
+
+Make it possible to see whether a planning change improved or degraded the recommended
+week, and make the repository runnable from a clean clone. Nothing here changes engine
+behaviour.
+
+## Why this is first
+
+Every later phase replaces a tuned heuristic with a different one. Today there is no
+committed artifact that would show the difference: `npm run simulate:scenarios` produces
+a genuinely rich report — objective resolution counts, constraint violations, fatigue
+tier distribution, anchor placement, fragile-selection diagnostics — and writes it to
+`app/artifacts/simulation-reports/`, which is **gitignored** (`app/.gitignore:14`).
+
+The 0.21× event-modality suppression in F3 is the concrete case: it is visible in
+`modalityDistribution` and `objectiveResolution`, and nobody saw it because no baseline
+was ever committed.
+
+---
+
+## Work items
+
+### 0.1 — Invariants are the CI gate; the snapshot is a diagnostic
+
+**This item was restructured after PR #5 review.** The original version proposed a
+full-output snapshot diff as the CI gate. That is the wrong contract here, and the
+objection is decisive: Phases 3, 4 and 5 deliberately change objective credit,
+anti-stacking, fatigue semantics and eventually the whole sequence planner. A
+byte-exact gate over that would (i) freeze today's known-bad behaviour as the reference,
+and (ii) turn every intentional improvement into baseline churn, which trains reviewers
+to rubber-stamp the update. The gate must assert **properties that should hold across all
+those changes**, not equality with today's output.
+
+**The gate — invariant assertions (blocking).** See 0.2. These are the contract.
+
+**Aggregate bounds (blocking, deliberately loose).** A small set of range assertions over
+`runAllScenarios` output, wide enough that a correct planner change passes and only an
+implausible one trips:
+
+| Metric | Bound | Rationale |
+|---|---|---|
+| `constraintViolations` | exactly 0, all scenarios | already the harness's own contract |
+| rest/recovery day share | 5–40 % | a planner recommending no rest, or mostly rest, is broken |
+| longest same-template streak across chained weeks | ≤ 3 | catches a regression of the "tempo trap" class |
+| objectives generated but never resolved in any scenario | ≤ 1 | catches an F2-class credit failure |
+
+**The snapshot — diagnostic, non-blocking.** Still commit
+`docs/analysis/simulation-baseline.json` (with `commit` and `capturedAt` stripped — they
+come from `gitCommit()` and the clock in `simulate-scenarios.mjs`). Add
+`npm run simulate:diff` producing a **semantic** diff — per-scenario changes in category
+and modality distribution, objective resolution, and fatigue-tier day counts — and print
+it in the PR. Do **not** fail CI on it. Updating the baseline is a normal, expected part
+of a planner PR; the reviewer reads the semantic diff to decide whether the change is
+what was intended.
+
+**Determinism check before committing the snapshot:** run `npm run simulate:scenarios`
+twice and diff. `pickTemplate` is date-hash seeded and scenarios use fixed `startDate`s,
+so it should be stable — verify rather than assume. If it is not stable, the snapshot is
+worthless as a diagnostic; fix the nondeterminism or drop the snapshot and keep only the
+invariants.
+
+### 0.2 — Golden coaching-contract scenario
+
+The existing scenario assertions in `app/src/engine/scenarios.test.ts` check engine
+semantics (no constraint violations, no absurd streaks). They do not assert that the
+week is *coached well*. Add one scenario that does.
+
+Add to `app/src/engine/simulation/scenarios.ts` a scenario `cycling_a_event_build_week`:
+an A-priority `cycling_event` roughly 60 days out, `free_weights: true`,
+`indoor_bike: true`, `environment: 'either'`, weekday 60 / weekend 150 minutes, stable
+moderate readiness.
+
+Assert, in a new `app/src/engine/goldenWeek.test.ts`:
+
+| Invariant | Assertion |
+|---|---|
+| Key cycling quality is spaced | ≥ 48 h between any two picks whose `category` is `Hard Endurance`, `Moderate Endurance` or `Race-Specific Endurance` and `modality` is `Cycling` |
+| Anchors are protected | no `Lower-body Strength` / `Full-body Strength` with `systemicCost >= 0.5` on the day before or after a key cycling day |
+| Event modality is not penalised for frequency | the week contains **≥ 3** `Cycling` sessions |
+| Required objectives resolve | `threshold_quality` and `strength_maintenance` reach `completedExposures >= targetExposures` within the 7-day strip |
+| Rest exists | ≥ 1 `Rest` or `Mobility/Recovery` day |
+
+**Expect the third row to fail today.** That is the point — it is the executable form of
+F3. Land it as a documented failing assertion (`it.fails(...)`, with a comment citing
+F3 and this plan) so Phase 3 has an unambiguous definition of done, rather than
+weakening the assertion to match current behaviour.
+
+### 0.3 — Make the frontend suite runnable from a clean clone
+
+`app/src/firebase.ts` calls `initializeApp` / `getFirestore` / `getAuth` at module scope,
+so importing any service transitively initialises Firebase. Without `VITE_FIREBASE_*`,
+`trainingSettingsService.test.ts` fails to collect (verified). CI hides this by injecting
+dummy values; `predev` runs `npm run check`, so a fresh clone cannot start the dev server
+either.
+
+Convert to lazy accessors:
+
+```ts
+let _app: FirebaseApp | undefined;
+function app() { return (_app ??= initializeApp(firebaseConfig)); }
+export function getDb() { return getFirestore(app()); }
+export function getAuthInstance() { return getAuth(app()); }
+```
+
+Update the call sites (`services/*.ts`, `App.tsx`, `main.tsx`, `visual/*`) to call the
+accessor at use time rather than importing a module-scope constant. Keep `export const db`
+temporarily as a deprecated getter if the diff would otherwise be large; remove it in the
+same phase.
+
+Then add `app/.env.example` documenting the six `VITE_FIREBASE_*` keys, and replace
+`app/README.md` — currently the **unmodified Vite starter template** — with real setup
+instructions: install, env, `npm run check`, `npm run dev`, `npm run test:rules`
+(requires Java + emulator), `npm run simulate:scenarios`.
+
+**Acceptance:** `git clone && cd app && npm ci && npm test` passes with no `.env` present.
+
+### 0.4 — Policy version guard
+
+`POLICY_VERSION` (`app/src/engine/policy.ts`) is documented as "increment whenever a
+change can alter a persisted recommendation decision" and has never moved, including
+through `HEAD`'s new ranking tie-break. A frozen string makes `replay.ts`'s
+`policyMatchesCurrent` check meaningless.
+
+1. Bump it now to reflect the tie-break already shipped.
+2. Add a check to `npm run check` that fails when any of `rules.ts`, `optimizer.ts`,
+   `microcycle.ts`, `periodization.ts`, `fatigue.ts`, `planner.ts` or `dose.ts` differ
+   from the merge base without `policy.ts` also changing. A short script comparing
+   `git diff --name-only origin/main...HEAD` is sufficient; it does not need to be clever.
+
+### 0.5 — Python lint and type checking
+
+`AGENTS.md` requires type hints across all Python modules; nothing enforces it.
+
+Add to `pyproject.toml` dev dependencies: `ruff`, `mypy`. Add `[tool.ruff]` and
+`[tool.mypy]` sections (start permissive — `disallow_untyped_defs` on
+`src/garmin_sync` only). Add both to the `python-tests` CI job. Fix whatever the first
+run surfaces, or record explicit per-module ignores with a reason.
+
+### 0.6 — Small cleanups
+
+* Delete `garmin_login.py` (repo root). It duplicates
+  `scripts/bootstrap_garmin_tokens.py` and bypasses the ADR-0002 guard by injecting
+  `APP_USER_ID="bootstrap_user"`. Confirm the bootstrap script covers the same flow
+  first.
+* Add `npm audit --audit-level=high` and `uv run pip-audit` (or equivalent) to CI as
+  non-blocking informational steps.
+* **Pin `uv` in the Dockerfile.** `RUN pip install --no-cache-dir uv` is unpinned, so the
+  image build tracks whatever uv releases. The `readme = "README.md"` build failure fixed
+  in PR #5 surfaced with no repository change at all, which is exactly this class of
+  problem. Pin to a known-good version and bump deliberately.
+
+---
+
+## Acceptance criteria
+
+- [ ] invariant suite (0.2) + aggregate bounds run in CI and are blocking
+- [ ] `npm run simulate:diff` emits a semantic diff and is explicitly non-blocking
+- [ ] `docs/analysis/simulation-baseline.json` is committed and reproducible twice in a row
+- [ ] `goldenWeek.test.ts` exists; the event-modality-frequency assertion is present and
+      marked as expected-failing with a citation to F3
+- [ ] `npm test` passes from a clean clone with no `.env`
+- [ ] `app/.env.example` exists; `app/README.md` is project-specific
+- [ ] `POLICY_VERSION` bumped; drift guard in `npm run check`
+- [ ] `ruff` and `mypy` run in CI
+- [ ] `garmin_login.py` removed
+
+## Risks & rollback
+
+* **Invariants too strict.** An invariant that encodes today's accident rather than a
+  real coaching property will block a correct Phase 3-5 change. Each assertion in 0.2
+  must be defensible as coaching, not as "what the engine currently does" — if it cannot
+  be justified that way, it belongs in the non-blocking diagnostic instead.
+* **Snapshot nondeterminism.** If the report is not reproducible the semantic diff is
+  noise. Verify (0.1); if it fails, land the invariants and drop the snapshot rather than
+  shipping a diagnostic nobody can trust.
+* **Lazy Firebase touches many files.** Mechanical but wide. Land it as its own commit so
+  it can be reverted independently.
+* Everything here is additive or test-only. Rollback is per-commit.
+
+## Out of scope
+
+No engine behaviour changes. The golden test is expected to fail on one assertion; do not
+"fix" it here.
+
+## Docs to update
+
+* `docs/README.md` — link `docs/plans/`
+* `AGENTS.md` — add `simulate:diff`, `ruff`, `mypy` to the commands reference
+* `CLAUDE.md` — same

--- a/docs/plans/phase-0-instrumentation.md
+++ b/docs/plans/phase-0-instrumentation.md
@@ -39,7 +39,7 @@ Every later phase replaces a tuned heuristic with a different one. Today there i
 committed artifact that would show the difference: `npm run simulate:scenarios` produces
 a genuinely rich report — objective resolution counts, constraint violations, fatigue
 tier distribution, anchor placement, fragile-selection diagnostics — and writes it to
-`app/artifacts/simulation-reports/`, which is **gitignored** (`app/.gitignore:14`).
+`app/artifacts/simulation-reports/`, which is **gitignored** (`app/.gitignore`).
 
 The 0.21× event-modality suppression in F3 is the concrete case: it is visible in
 `modalityDistribution` and `objectiveResolution`, and nobody saw it because no baseline

--- a/docs/plans/phase-0-instrumentation.md
+++ b/docs/plans/phase-0-instrumentation.md
@@ -1,7 +1,7 @@
 # Phase 0 — Instrumentation & developer baseline
 
 * **Status:** Ready
-* **Depends on:** nothing
+* **Blocked by:** nothing
 * **Unlocks:** Phases 3, 4, 5 (none of them can be evaluated without this)
 * **Addresses:** F11, F14, F15, part of F10
 * **Rough effort:** 1–1.5 days
@@ -132,10 +132,26 @@ through `HEAD`'s new ranking tie-break. A frozen string makes `replay.ts`'s
 `policyMatchesCurrent` check meaningless.
 
 1. Bump it now to reflect the tie-break already shipped.
-2. Add a check to `npm run check` that fails when any of `rules.ts`, `optimizer.ts`,
-   `microcycle.ts`, `periodization.ts`, `fatigue.ts`, `planner.ts` or `dose.ts` differ
-   from the merge base without `policy.ts` also changing. A short script comparing
-   `git diff --name-only origin/main...HEAD` is sufficient; it does not need to be clever.
+2. Add a check that fails when any of `rules.ts`, `optimizer.ts`, `microcycle.ts`,
+   `periodization.ts`, `fatigue.ts`, `planner.ts` or `dose.ts` differ from the base
+   without `policy.ts` also changing.
+
+   **Supply the base explicitly — do not rely on ambient refs.** `.github/workflows/ci.yml`
+   uses `actions/checkout@v4` with no `fetch-depth`, so the checkout is shallow
+   (depth 1) and `origin/main` / the merge base is not guaranteed to exist in a PR job.
+   `git diff --name-only origin/main...HEAD` would fail or silently compare the wrong
+   range, producing an intermittent guard — worse than no guard, because it would be
+   trusted.
+
+   Pick one and state it in the workflow:
+   * set `fetch-depth: 0` on the checkout step (simplest), **or**
+   * `git fetch --depth=1 origin ${{ github.event.pull_request.base.sha }}` and diff
+     against that SHA, **or**
+   * have the script take the base as an argument: `${{ github.event.pull_request.base.sha }}`
+     on `pull_request`, and `${{ github.event.before }}` on push-to-main.
+
+   This check belongs in CI rather than `npm run check`, since it needs the base ref;
+   keep `npm run check` local-only.
 
 ### 0.5 — Python lint and type checking
 

--- a/docs/plans/phase-0-instrumentation.md
+++ b/docs/plans/phase-0-instrumentation.md
@@ -75,8 +75,11 @@ The existing scenario assertions in `app/src/engine/scenarios.test.ts` check eng
 semantics (no constraint violations, no absurd streaks). They do not assert that the
 week is *coached well*. Add one scenario that does.
 
-Add to `app/src/engine/simulation/scenarios.ts` a scenario `cycling_a_event_build_week`:
-an A-priority `cycling_event` roughly 60 days out, `free_weights: true`,
+Add to `app/src/engine/simulation/scenarios.ts` a scenario `cycling_a_event_build_week`.
+**Use fixed dates, not a relative offset** — `daysToEvent` drives phase selection and
+phase-specific template eligibility, so a floating "~60 days out" would make the
+assertions drift: `startDate: '2026-03-02'`, event date `'2026-05-01'` (60 days, squarely
+in Build). Other attributes: `free_weights: true`,
 `indoor_bike: true`, `environment: 'either'`, weekday 60 / weekend 150 minutes, stable
 moderate readiness.
 
@@ -179,7 +182,7 @@ run surfaces, or record explicit per-module ignores with a reason.
 
 ## Acceptance criteria
 
-- [ ] invariant suite (0.2) + aggregate bounds run in CI and are blocking
+- [ ] invariant suite (0.2) + aggregate bounds (0.1) run in CI and are blocking
 - [ ] `npm run simulate:diff` emits a semantic diff and is explicitly non-blocking
 - [ ] `docs/analysis/simulation-baseline.json` is committed and reproducible twice in a row
 - [ ] `goldenWeek.test.ts` exists; the event-modality-frequency assertion is present and

--- a/docs/plans/phase-1-live-defects.md
+++ b/docs/plans/phase-1-live-defects.md
@@ -87,7 +87,7 @@ allowance exists and is currently unusable because `trainingSettingsService.ts:1
 
 ```ts
 export type BodyRegion =
-  | 'knee' | 'achilles' | 'calf' | 'hamstring' | 'quadriceps'
+  | 'knee' | 'achilles' | 'ankle' | 'calf' | 'hamstring' | 'quadriceps'
   | 'adductor_groin' | 'hip' | 'lower_back' | 'shoulder' | 'elbow' | 'wrist';
 
 export interface InjuryConstraint {
@@ -117,7 +117,7 @@ record the revision in ADR-0007's amendment rather than silently editing the tab
 
 | Region | `exclude` implies | `limit` implies |
 |---|---|---|
-| knee, achilles, calf | modality `Running`; guardrail `avoid_high_impact` | guardrail `avoid_high_impact` |
+| knee, achilles, **ankle**, calf | modality `Running`; guardrail `avoid_high_impact` | guardrail `avoid_high_impact` |
 | hamstring, quadriceps, adductor_groin, hip | categories `Lower-body Strength`, `Full-body Strength`; guardrail `avoid_heavy_lower_body` | guardrail `avoid_heavy_lower_body` |
 | lower_back | guardrails `avoid_heavy_spinal_loading`, `avoid_heavy_lower_body` | `avoid_heavy_spinal_loading` |
 | shoulder, elbow, wrist | guardrail `avoid_overhead_pressing`; categories `Upper-body Strength` | `avoid_overhead_pressing` |
@@ -125,14 +125,29 @@ record the revision in ADR-0007's amendment rather than silently editing the tab
 `monitor` implies nothing structural — it exists to be surfaced in the UI and to feed
 Phase 5's tissue tracking.
 
+**`ankle` is not optional.** The existing `RUNNING_INJURY_PATTERN`
+(`/\b(knee|achilles|ankle|leg|run)/`) matches `ankle`, so omitting it from `BodyRegion`
+would let this change *remove* an existing running restriction. Every token the old
+pattern matched must map to at least the same restriction before the pattern is deleted —
+verify that as a migration checklist item, not by inspection.
+
+**One canonical representation, one derived form.** `UserContext.constraints.injuries`
+must not become a second source of truth alongside structured injuries: a settings update
+or migration could refresh one and leave the other stale, in the safety layer. So:
+`InjuryConstraint[]` is canonical and lives on `TrainingSettings`; `UserContext` carries
+the **resolved** output of `resolveInjuryRestrictions` (modalities, categories,
+guardrails); the legacy `injuries: string[]` field is **deleted**, not retained in
+parallel. `rules.ts` and `optimizer.ts` migrate to the resolved lists in the same change.
+A test must assert both evaluation paths derive identical restrictions from one settings
+object.
+
 ### Work items
 
 1. `models.ts` — add `BodyRegion`, `InjuryConstraint`, and `TrainingSettings.injuries?: InjuryConstraint[]`.
 2. `injuryPolicy.ts` — the pure resolver above, fully unit-tested. No Firebase, no I/O.
-3. `adapters.ts` — populate `constraints.injuries` from settings. Keep the field
-   `string[]` for now (`region` strings) so `rules.ts`/`optimizer.ts` keep compiling, and
-   **additionally** thread the structured result through `UserContext` so
-   `evaluateEnvelopes` can stop pattern-matching text.
+3. `adapters.ts` / `models.ts` — **delete** `UserContext.constraints.injuries: string[]`
+   and replace it with the resolved output of `resolveInjuryRestrictions`. Do not keep the
+   legacy field in parallel (see "One canonical representation" above).
 4. `rules.ts:544-556` — replace `RUNNING_INJURY_PATTERN` (`/\b(knee|achilles|ankle|leg|run)/`,
    which also matches "legal" and "runny") with `resolveInjuryRestrictions`. Populate
    `restrictedModalities` from it.
@@ -285,7 +300,14 @@ Fix (b) makes Garmin rides start resolving objectives. That lowers `urgency` in
 ### Tests
 
 * `completedTraining.test.ts` — a Garmin-only cycling event produces a non-zero stimulus
-  profile with `stimulusConfidence: 'inferred'`; an unknown-modality event produces none.
+  profile with `stimulusConfidence: 'inferred'`.
+* `completedTraining.test.ts` — an unknown-modality event produces **no structured
+  stimulus profile** (`stimulusConfidence: 'unknown'`). This is deliberately *not* the
+  same as "earns no credit": it still reaches the legacy keyword fallback, which may award
+  compatibility credit. Assert the two separately — one test that no structured profile is
+  produced, one that the intended fallback credit is preserved — so this change neither
+  introduces false-positive keyword credit nor silently removes existing compatibility
+  credit.
 * `microcycle.test.ts` — the F2 probe, promoted to a real test: three Garmin sessions
   resolve `zone2_aerobic` and `strength_maintenance`.
 * `microcycle.test.ts` — **regression against the false-positive risk**: a generic
@@ -307,9 +329,49 @@ immutable", but `allow update` pins only `createdAt`. A client may rewrite `temp
 requirement is conditional on `schemaVersion == 3`, a v3 document can be rewritten as v1
 and stripped of its audit entirely.
 
+### Decide the lifecycle first — the ratchet is blocked on it
+
+Pinning decision fields breaks a legitimate flow. `Home.tsx` recomputes today's
+recommendation on **every** dashboard load and calls `saveRecommendation`, which
+`setDoc(..., { merge: true })`s the newly computed `templateId` / `mode` / `rationale`
+over the existing `{date}` document. Recomputation can legitimately change the answer
+within a day — the athlete completes a session at noon, `alreadyTrainedToday` flips, mode
+becomes `recover`. With naive field pinning that write is **rejected**, and the UI then
+shows a recommendation the persisted audit contradicts. That is worse than the gap being
+fixed.
+
+Two lifecycles are viable:
+
+* **(A) First write wins.** The first persisted recommendation for a date is
+  authoritative; later loads replay it rather than re-deciding. Simple, but freezes a
+  morning decision that has since become wrong, and discards a real second decision.
+* **(B) Append-only revisions.** Decision fields are immutable *per revision*; a changed
+  decision creates a new one. The latest revision is what the UI and adherence refer to.
+
+> **Recommendation: (B).** A same-day recomputation after a completed session is a real,
+> correct decision, not a correction of the morning's — and the morning's was also really
+> shown to the athlete. (A) would have to discard one of the two, and whichever it
+> discards, the audit stops matching what the user saw. Adherence semantics also stay
+> intact under (B): it attaches to the date, resolving to the latest revision.
+>
+> **Shape:** keep `users/{uid}/daily_recommendations/{date}` as the current decision, add
+> a monotonic `revision: number`, and require that any update changing decision fields
+> increments it while writing the prior state to
+> `users/{uid}/daily_recommendations/{date}/revisions/{revision}` in the same batch.
+> Rules enforce: revisions are create-only (never update or delete); `revision` strictly
+> increases; decision fields may only change when `revision` increases.
+>
+> **Honest limit:** Firestore rules cannot verify the prior state was actually copied —
+> that is a client-side batch obligation. Rules enforce immutability *of what is written*;
+> the copy is covered by an emulator test, not by the rules themselves. Say so in ADR-0010's
+> amendment rather than implying stronger guarantees.
+
+**`prescription` is decision evidence** and must be pinned per revision alongside the
+other decision fields — the earlier `decisionFieldsUnchanged()` sketch omitted it.
+
 ### Fix
 
-Add two helpers and use them in the `daily_recommendations` update rule:
+Once (B) is chosen, add these helpers to the `daily_recommendations` update rule:
 
 ```text
 function schemaRatchets() {
@@ -352,9 +414,12 @@ result, so unmentioned fields compare equal, which is what these rules assume.
 * **allows** adding `adjustment` to an existing document
 * **allows** first-time attachment of `recommendationAudit`
 
-Note the emulator suite is `describe.skip` unless `FIRESTORE_EMULATOR_HOST` is set. It
-does run in CI (`npm run test:rules`); make sure the new cases are exercised there and
-not silently skipped locally.
+**Make a skipped rules suite a failure, not a pass.** The suite is `describe.skip` unless
+`FIRESTORE_EMULATOR_HOST` is set, so `npm run test:rules` can exit 0 having executed none
+of the immutability tests — the security suite would appear green while testing nothing.
+Add a guard test *outside* the conditional block that fails when the emulator host is
+absent in CI (and reports a clear setup error locally), plus an assertion on the expected
+rule-test count so a silently-shrinking suite is caught.
 
 ---
 

--- a/docs/plans/phase-1-live-defects.md
+++ b/docs/plans/phase-1-live-defects.md
@@ -55,7 +55,7 @@ So the gap is narrower than "injuries are unimplemented": there is a working *ma
 guardrail channel and a dead *free-text injury* channel that ADR-0007 §6 calls the hard
 safety gate.
 
-### Two options
+### Two options, and the decision
 
 **Option A — delete the dead channel.** Remove `UserContext.constraints.injuries` and its
 readers; consolidate on guardrails; amend ADR-0007 §6 to say guardrails are the hard
@@ -63,10 +63,20 @@ safety gate. Cheapest, honest, and immediately removes the false `safetyRestrict
 But guardrails cannot express "no running", cannot expire, and cannot distinguish an
 acute injury from a standing preference.
 
-**Option B — formalise injuries as structured constraints that derive guardrails
-(recommended).** Keeps the ADR-0007 guarantee and makes it real.
+**Option B — formalise injuries as structured constraints that derive guardrails.**
+Keeps the ADR-0007 guarantee and makes it real.
 
-### Option B design
+> **Decision (2026-08-08): Option B.**
+> Option A is cheaper but structurally caps what the system can ever express, and this is
+> the safety layer — the one place where paying for expressiveness up front is correct.
+> Three specific things Option A cannot do and Option B can: exclude a *modality*
+> (guardrails are template-tag scoped, so "no running" is inexpressible); *expire* a
+> constraint, so an acute injury does not silently become a permanent restriction; and
+> distinguish an injury from a standing preference, which matters because Phase 5.4's
+> tissue tracking needs somewhere to attach. Choosing A would mean redoing this work at
+> Phase 5 anyway, on top of a schema that had already been simplified in the wrong
+> direction.
+> Option A remains the documented rollback if Option B proves too large mid-phase.
 
 Add to `TrainingSettings` at `schemaVersion: 3` (already permitted by the type
 `schemaVersion: 2 | 3` and by `firestore.rules`, which allows `[2, 3]` — the forward
@@ -97,8 +107,11 @@ export function resolveInjuryRestrictions(injuries: InjuryConstraint[], today: s
 }
 ```
 
-with an explicit region → restriction table. Sketch (needs a domain review before
-landing — these are engineering defaults, not coaching advice):
+with an explicit region → restriction table. **Adopted as the implementation default**
+— these are conservative engineering mappings, not coaching advice. They are deliberately
+biased toward over-restriction: a false exclusion costs one session, a false permission
+costs a re-injury. Implement as written; revise only if a coaching review disagrees, and
+record the revision in ADR-0007's amendment rather than silently editing the table:
 
 | Region | `exclude` implies | `limit` implies |
 |---|---|---|
@@ -210,8 +223,8 @@ With (b) in place, (a) rarely fires for recognised modalities — which is the p
 a correctness guard, not a routing mechanism.
 
 Values must be deliberately conservative — the aim is "materially better than treating
-real training as adaptation-neutral", not physiological precision. Starting point for
-`Cycling`, to be reviewed before landing:
+real training as adaptation-neutral", not physiological precision. **Adopted starting
+values** for `Cycling`; the other modalities follow the same shape:
 
 | Intensity | `aerobicCapacity` | `thresholdDevelopment` | `surgeRepeatability` |
 |---|---|---|---|
@@ -219,13 +232,16 @@ real training as adaptation-neutral", not physiological precision. Starting poin
 | moderate | 0.70 | 0.60 | 0.25 |
 | hard | 0.55 | 0.75 | 0.65 |
 
-Note the `moderate` row deliberately does **not** clear
+**Required verification step, not optional.** The `moderate` row must not clear
 `STIMULUS_CREDIT_COVERAGE_THRESHOLD` (0.6) for both Z2 *and* threshold simultaneously
-under every objective's target vector — check this against
-`generateWeeklyObjectives`'s actual `targetStimulus` values when implementing, and tune
-so a single ride cannot resolve two contradictory objectives. Mark the constants
-provisional in a comment citing this plan; Phase 4 replaces them with the evidence
-hierarchy.
+under any objective's target vector. Check the numbers against `generateWeeklyObjectives`'s
+actual `targetStimulus` values during implementation and tune until a single ride cannot
+resolve two contradictory objectives — this is the same double-credit failure the keyword
+matcher produces, and re-introducing it through the inference table would defeat the whole
+fix. The regression test below is what enforces it.
+
+Mark the constants provisional in a comment citing this plan; Phase 4 replaces them with
+the evidence hierarchy.
 
 **(c) Carry confidence.** Add `stimulusConfidence: 'exact' | 'inferred' | 'unknown'` to
 `CompletedExposure`. `exact` for adherence-confirmed catalog templates, `inferred` for
@@ -335,9 +351,12 @@ not silently skipped locally.
 * **1.3 could break the adjust-session save path** if `merge: true` semantics differ from
   the assumption above. The emulator tests are the guard; write the three "allows" cases
   first and watch them fail before the rules change lands.
-* **1.1 Option B is the larger change.** Option A is the rollback: delete the dead channel
-  and amend ADR-0007. Either outcome is better than the status quo, in which the ADR
-  states a guarantee the code cannot deliver.
+* **1.1 Option B is the larger change.** Option A remains the rollback: delete the dead
+  channel and amend ADR-0007. Either outcome is better than the status quo, in which the
+  ADR states a guarantee the code cannot deliver. Trigger for falling back: if the
+  `TrainingSettings` v3 migration or the settings UI turns out to be more than ~2 days,
+  ship Option A and reopen Option B as part of Phase 5.4, where the tissue model needs
+  the same schema anyway.
 
 ## Out of scope
 
@@ -347,8 +366,9 @@ waiting for the full model.
 
 ## Docs to update
 
-* **ADR-0007** — amend §6 to describe the implemented injury model (or, under Option A,
-  to say guardrails are the gate)
+* **ADR-0007** — amend §6 to describe the implemented structured injury model, and to
+  record that the region → restriction table is a conservative engineering default open
+  to coaching revision
 * **ADR-0002 or a new ADR** — `trainingSettings` schema v3
 * `README.md` — the training-settings table gains an Injuries row
 * `docs/analysis/2026-08-08-architecture-review.md` — mark F1/F2/F6 resolved with commit refs

--- a/docs/plans/phase-1-live-defects.md
+++ b/docs/plans/phase-1-live-defects.md
@@ -45,20 +45,20 @@ harder to see, because they will then be spread across a larger surface.
 
 ### Current state
 
-`app/src/engine/adapters.ts:154`, the only production constructor of `UserContext`,
+`app/src/engine/adapters.ts` — `mapContextFromGoalsAndTrainingSettings`, the only production constructor of `UserContext` —
 hardcodes `injuries: []`. Everything downstream is therefore dead in production:
 
-* `optimizer.ts:183-187` — the "hard safety gating" modality filter
-* `rules.ts:544-556` — `hasRunningInjury`, and the `isPain && injuries.length > 0` branch
+* `optimizer.ts` — `rankCandidatesByUtility`'s "hard safety gating" modality filter
+* `rules.ts` `evaluateEnvelopes` — `hasRunningInjury`, and the `isPain && injuries.length > 0` branch
   that is the only writer of `restrictedModalities`
-* `planner.ts:352,482` — the same, across all 7 forecast days
+* `planner.ts` — `generateWeekAheadPlan` reads `context.constraints.injuries` and passes it to `rankCandidatesByUtility`; same dead filter, across all 7 forecast days
 
 Consequences worth stating plainly: `SafetyEnvelope.restrictedModalities` is **always**
-`[]`, so `rules.ts:492`'s filter is a no-op and the persisted audit's
+`[]`, so the `restrictedModalities` filter inside `evaluateTrainingWithIntent` is a no-op and the persisted audit's
 `safetyRestrictedModalityCount` is always `0` — the audit records a safety check that
 never ran.
 
-Note that `simulation/scenarios.ts:51` *does* pass `injuries`, so the harness exercises
+Note that `simulation/scenarios.ts`'s `context()` helper *does* pass `injuries`, so the harness exercises
 and appears to validate a filter production can never trigger. This is the sharpest
 instance of the pattern in the review's §0.
 
@@ -99,7 +99,7 @@ Keeps the ADR-0007 guarantee and makes it real.
 
 Add to `TrainingSettings` at `schemaVersion: 3` (already permitted by the type
 `schemaVersion: 2 | 3` and by `firestore.rules`, which allows `[2, 3]` — the forward
-allowance exists and is currently unusable because `trainingSettingsService.ts:16` pins
+allowance exists and is currently unusable because `trainingSettingsService.ts`'s `SETTINGS_SCHEMA_VERSION` pins
 `SETTINGS_SCHEMA_VERSION = 2`):
 
 ```ts
@@ -165,12 +165,12 @@ object.
 3. `adapters.ts` / `models.ts` — **delete** `UserContext.constraints.injuries: string[]`
    and replace it with the resolved output of `resolveInjuryRestrictions`. Do not keep the
    legacy field in parallel (see "One canonical representation" above).
-4. `rules.ts:544-556` — replace `RUNNING_INJURY_PATTERN` (`/\b(knee|achilles|ankle|leg|run)/`,
+4. `rules.ts` `evaluateEnvelopes` — replace `RUNNING_INJURY_PATTERN` (`/\b(knee|achilles|ankle|leg|run)/`,
    which also matches "legal" and "runny") with `resolveInjuryRestrictions`. Populate
    `restrictedModalities` from it.
 5. `eligibility.ts` — union `settings.guardrails` with `impliedGuardrails` so injuries
    gate templates on **both** paths without duplicating the check.
-6. `optimizer.ts:183-187` — replace the substring test
+6. `optimizer.ts` — in `rankCandidatesByUtility`, replace the substring test
    (`injuryConstraints.some(inj => inj.toLowerCase().includes(lowerMod))`, which relies on
    an injury string happening to contain a modality name) with the resolved modality list.
 7. `trainingSettingsService.ts` — bump `SETTINGS_SCHEMA_VERSION` to 3; accept 2 on read
@@ -223,7 +223,7 @@ fall through to the fallback path". **That was wrong and is corrected here.**
 
 The review's own F7 shows the keyword matcher is directionally broken. For a recognised
 hard ride, `completedEventToExposure` builds `trainingRecordLike.type = "Cycling hard"`.
-If that string reaches `updateMicrocycleProgress` (`microcycle.ts:118-125`), it credits:
+If that string reaches `updateMicrocycleProgress` (`updateMicrocycleProgress`), it credits:
 
 * `threshold_quality` — because the string contains `hard`; **and**
 * `zone2_aerobic` — because the string contains `cycling`.
@@ -311,7 +311,7 @@ this field; adding it now costs nothing and prevents a second migration.
 ### Interaction to check
 
 Fix (b) makes Garmin rides start resolving objectives. That lowers `urgency` in
-`trainingIntent.ts:80`, which lowers `plannedDose`, which changes `executionDose`.
+`resolveTrainingIntent`, which lowers `plannedDose`, which changes `executionDose`.
 **Re-run the Phase 0 invariant suite and read the semantic diff before merging.**
 
 ### Tests

--- a/docs/plans/phase-1-live-defects.md
+++ b/docs/plans/phase-1-live-defects.md
@@ -148,6 +148,31 @@ would let this change *remove* an existing running restriction. Every token the 
 pattern matched must map to at least the same restriction before the pattern is deleted —
 verify that as a migration checklist item, not by inspection.
 
+**Two of those tokens have no body region, and silently dropping them is the failure mode
+this paragraph exists to prevent.** `knee`, `achilles` and `ankle` map to `BodyRegion`
+members directly. `leg` and `run` do not, and never will — `leg` names no specific tissue
+and `run` names an activity, not a body part. Do not invent regions for them. Map them at
+the *restriction* level instead:
+
+| Legacy token | Migrates to | Rationale |
+|---|---|---|
+| `knee`, `achilles`, `ankle` | `{ region: <same>, severity: 'limit' }` | Direct region match |
+| `leg` | `{ region: 'hamstring', severity: 'limit' }` **plus** modality restriction on `Running` | Unlocalised lower-limb complaint; the only restriction the old pattern actually produced was the running block, so preserve that explicitly rather than guessing a tissue |
+| `run` | modality restriction on `Running` only, no region | Names the aggravating activity, not an injury site |
+
+`InjuryConstraint` therefore needs `region` to be **optional** when an explicit
+`restrictedModalities` list is present — a legacy `run` entry is a real restriction with
+no known site, and forcing a fabricated region would be worse than modelling the gap.
+
+Migration is one-way and lossy in the safe direction (it can over-restrict, never
+under-restrict). Flag `leg`/`run` migrations in the UI so the athlete can replace them
+with a precise region.
+
+**Migration tests are required for both tokens**, asserting that a settings document
+carrying legacy `injuries: ['leg']` and one carrying `injuries: ['run']` each still
+produce a running restriction after migration. Without these two cases the migration can
+pass every other test while quietly unblocking running for an injured athlete.
+
 **One canonical representation, one derived form.** `UserContext.constraints.injuries`
 must not become a second source of truth alongside structured injuries: a settings update
 or migration could refresh one and leave the other stale, in the safety layer. So:
@@ -261,6 +286,17 @@ alongside the existing `DEFAULT_COST_BY_MODALITY`, and use it in
 
 With (b) in place, (a) rarely fires for recognised modalities — which is the point. (a) is
 a correctness guard, not a routing mechanism.
+
+**"Recognised modality, but no stimulus available" must not be a reachable state.** The
+type is a total `Record<CompletedModality, Record<CompletedTrainingIntensity, …>>`, so
+every recognised modality/intensity pair has an entry and TypeScript rejects the table if
+one is missing. That is deliberate: were the state reachable, a known `"Cycling hard"`
+event would fall through to the keyword matcher and pick up exactly the double credit
+D-KWD exists to prevent. **Do not** widen the type to `Partial<Record<…>>` or add a
+lookup fallback — the totality of this table is the guarantee. Add a test asserting the
+table is total (every `CompletedModality` × `CompletedTrainingIntensity` cell present and
+non-zero) so the guarantee fails loudly at test time rather than at credit time if a
+future modality is added to the union without a stimulus row.
 
 ### Constants are illustrative — the test comes first
 

--- a/docs/plans/phase-1-live-defects.md
+++ b/docs/plans/phase-1-live-defects.md
@@ -430,7 +430,11 @@ rule-test count so a silently-shrinking suite is caught.
 - [ ] `safetyRestrictedModalityCount` is non-zero in a persisted audit when an injury is active
 - [ ] `RUNNING_INJURY_PATTERN` deleted
 - [ ] three Garmin-only sessions resolve at least two weekly objectives
-- [ ] recognised and unrecognised activity types both earn credit (no inversion)
+- [ ] the inversion is gone: a *recognised* Garmin session earns credit from its inferred
+      structured stimulus (`stimulusConfidence: 'inferred'`), and an *unrecognised* one
+      produces no structured profile (`'unknown'`) while retaining whatever legacy
+      fallback credit it earns today. "No structured profile" must not be read as "no
+      credit" — the two outcomes are asserted by separate tests
 - [ ] emulator suite covers field tampering, schema downgrade, audit removal, and the
       three legal-update cases
 - [ ] simulation baseline regenerated and the delta reviewed in the PR description

--- a/docs/plans/phase-1-live-defects.md
+++ b/docs/plans/phase-1-live-defects.md
@@ -1,0 +1,354 @@
+# Phase 1 — Live defects
+
+* **Status:** Ready
+* **Depends on:** nothing (Phase 0 is helpful but not blocking)
+* **Unlocks:** a correct foundation for the Phase 2–5 cutover
+* **Addresses:** F1, F2, F6
+* **Rough effort:** 3–4 days
+
+---
+
+## Goal
+
+Fix the three defects where the system's actual behaviour differs from its documented
+behaviour for a real user today: an injury gate with no data source, measured training
+that earns no objective credit, and audit records a client can rewrite.
+
+## Why this cannot wait for the architecture work
+
+The Phase 2–5 cutover migrates onto whatever foundation exists. Migrating onto an unwired
+safety gate and rewritable audit evidence carries both defects forward and makes them
+harder to see, because they will then be spread across a larger surface.
+
+---
+
+## 1.1 — F1: give injury constraints a real data path
+
+### Current state
+
+`app/src/engine/adapters.ts:154`, the only production constructor of `UserContext`,
+hardcodes `injuries: []`. Everything downstream is therefore dead in production:
+
+* `optimizer.ts:183-187` — the "hard safety gating" modality filter
+* `rules.ts:544-556` — `hasRunningInjury`, and the `isPain && injuries.length > 0` branch
+  that is the only writer of `restrictedModalities`
+* `planner.ts:352,482` — the same, across all 7 forecast days
+
+Consequences worth stating plainly: `SafetyEnvelope.restrictedModalities` is **always**
+`[]`, so `rules.ts:492`'s filter is a no-op and the persisted audit's
+`safetyRestrictedModalityCount` is always `0` — the audit records a safety check that
+never ran.
+
+Note that `simulation/scenarios.ts:51` *does* pass `injuries`, so the harness exercises
+and appears to validate a filter production can never trigger. This is the sharpest
+instance of the pattern in the review's §0.
+
+### What already works — do not rebuild it
+
+`TrainingSettings.guardrails` **is** wired end to end:
+`eligibility.ts` checks `template.safetyTags.some(tag => settings.guardrails[tag])`
+against the four `GuardrailKey`s (`avoid_high_impact`, `avoid_heavy_lower_body`,
+`avoid_overhead_pressing`, `avoid_heavy_spinal_loading`), and templates carry
+`safetyTags`. Athlete-set guardrails already gate correctly on both paths.
+
+So the gap is narrower than "injuries are unimplemented": there is a working *manual*
+guardrail channel and a dead *free-text injury* channel that ADR-0007 §6 calls the hard
+safety gate.
+
+### Two options
+
+**Option A — delete the dead channel.** Remove `UserContext.constraints.injuries` and its
+readers; consolidate on guardrails; amend ADR-0007 §6 to say guardrails are the hard
+safety gate. Cheapest, honest, and immediately removes the false `safetyRestrictedModalityCount`.
+But guardrails cannot express "no running", cannot expire, and cannot distinguish an
+acute injury from a standing preference.
+
+**Option B — formalise injuries as structured constraints that derive guardrails
+(recommended).** Keeps the ADR-0007 guarantee and makes it real.
+
+### Option B design
+
+Add to `TrainingSettings` at `schemaVersion: 3` (already permitted by the type
+`schemaVersion: 2 | 3` and by `firestore.rules`, which allows `[2, 3]` — the forward
+allowance exists and is currently unusable because `trainingSettingsService.ts:16` pins
+`SETTINGS_SCHEMA_VERSION = 2`):
+
+```ts
+export type BodyRegion =
+  | 'knee' | 'achilles' | 'calf' | 'hamstring' | 'quadriceps'
+  | 'adductor_groin' | 'hip' | 'lower_back' | 'shoulder' | 'elbow' | 'wrist';
+
+export interface InjuryConstraint {
+  region: BodyRegion;
+  severity: 'monitor' | 'limit' | 'exclude';
+  /** ISO date; absent = indefinite. Expired entries are ignored, not deleted. */
+  reviewBy?: string;
+  note?: string;
+}
+```
+
+Add a **pure** resolver, `app/src/engine/injuryPolicy.ts`:
+
+```ts
+export function resolveInjuryRestrictions(injuries: InjuryConstraint[], today: string): {
+  restrictedModalities: SessionTemplate['modality'][];
+  impliedGuardrails: GuardrailKey[];
+  restrictedCategories: SessionTemplate['category'][];
+}
+```
+
+with an explicit region → restriction table. Sketch (needs a domain review before
+landing — these are engineering defaults, not coaching advice):
+
+| Region | `exclude` implies | `limit` implies |
+|---|---|---|
+| knee, achilles, calf | modality `Running`; guardrail `avoid_high_impact` | guardrail `avoid_high_impact` |
+| hamstring, quadriceps, adductor_groin, hip | categories `Lower-body Strength`, `Full-body Strength`; guardrail `avoid_heavy_lower_body` | guardrail `avoid_heavy_lower_body` |
+| lower_back | guardrails `avoid_heavy_spinal_loading`, `avoid_heavy_lower_body` | `avoid_heavy_spinal_loading` |
+| shoulder, elbow, wrist | guardrail `avoid_overhead_pressing`; categories `Upper-body Strength` | `avoid_overhead_pressing` |
+
+`monitor` implies nothing structural — it exists to be surfaced in the UI and to feed
+Phase 5's tissue tracking.
+
+### Work items
+
+1. `models.ts` — add `BodyRegion`, `InjuryConstraint`, and `TrainingSettings.injuries?: InjuryConstraint[]`.
+2. `injuryPolicy.ts` — the pure resolver above, fully unit-tested. No Firebase, no I/O.
+3. `adapters.ts` — populate `constraints.injuries` from settings. Keep the field
+   `string[]` for now (`region` strings) so `rules.ts`/`optimizer.ts` keep compiling, and
+   **additionally** thread the structured result through `UserContext` so
+   `evaluateEnvelopes` can stop pattern-matching text.
+4. `rules.ts:544-556` — replace `RUNNING_INJURY_PATTERN` (`/\b(knee|achilles|ankle|leg|run)/`,
+   which also matches "legal" and "runny") with `resolveInjuryRestrictions`. Populate
+   `restrictedModalities` from it.
+5. `eligibility.ts` — union `settings.guardrails` with `impliedGuardrails` so injuries
+   gate templates on **both** paths without duplicating the check.
+6. `optimizer.ts:183-187` — replace the substring test
+   (`injuryConstraints.some(inj => inj.toLowerCase().includes(lowerMod))`, which relies on
+   an injury string happening to contain a modality name) with the resolved modality list.
+7. `trainingSettingsService.ts` — bump `SETTINGS_SCHEMA_VERSION` to 3; accept 2 on read
+   and default `injuries: []`; write 3.
+8. `Preferences.tsx` / `TrainingSettings.tsx` — an editor: region, severity, optional
+   review date. Show derived restrictions read-only so the athlete can see what a setting
+   actually does.
+9. `firestore.rules` — validate the `injuries` array shape (bounded length, enum region,
+   enum severity, optional ISO date string).
+
+### Tests
+
+* `injuryPolicy.test.ts` — full region × severity table, plus expiry behaviour.
+* `rules.test.ts` — an `exclude` achilles injury removes every `Running` template on the
+  readiness path and populates `restrictedModalities`.
+* `planner.test.ts` — the same injury holds across all 7 projected days.
+* `architecture.test.ts` — a `limit` hamstring injury excludes heavy lower-body work from
+  the intent path.
+* Regression: `safetyRestrictedModalityCount` in a persisted audit is non-zero when an
+  injury is active.
+
+---
+
+## 1.2 — F2: Garmin-measured training must earn objective credit
+
+### Current state
+
+Verified empirically: three Garmin activities in the rolling window (120 min hard ride,
+60 min strength, 90 min moderate ride) leave every objective at `0/target`.
+
+Chain: `completedTraining.ts:candidateEventFromGarmin` sets
+`estimatedStimulus: ZERO_STIMULUS` → `completedEventToExposure` attaches
+`stimulusProfile` whenever `modality !== 'Unknown'`, including the all-zero vector →
+`microcycle.ts:buildMicrocycleState` routes any exposure with `stimulusProfile && modality`
+to `creditObjectivesFromStimulus`, which needs `stimulusCoverage >= 0.6`.
+
+The inversion is the bug: an unrecognised activity type gets `modality: undefined`, falls
+through to `updateMicrocycleProgress`'s keyword matcher, and **does** get credit.
+
+### The keyword fallback is NOT the intended destination
+
+An earlier draft of this plan said to omit the all-zero profile "so Garmin-only events
+fall through to the fallback path". **That was wrong and is corrected here.**
+
+The review's own F7 shows the keyword matcher is directionally broken. For a recognised
+hard ride, `completedEventToExposure` builds `trainingRecordLike.type = "Cycling hard"`.
+If that string reaches `updateMicrocycleProgress` (`microcycle.ts:118-125`), it credits:
+
+* `threshold_quality` — because the string contains `hard`; **and**
+* `zone2_aerobic` — because the string contains `cycling`.
+
+So routing recognised Garmin sessions to the fallback would trade today's false negative
+for a **false positive with double credit** on a single ride. That is not an improvement.
+
+The correct framing:
+
+1. An all-zero stimulus vector means **unknown**, not "a valid structured vector that
+   happens to be zero". The guard exists to stop the engine treating unknown as known.
+2. Recognised Garmin sessions get a **coarse inferred stimulus vector** carrying an
+   evidence/confidence marker. This is the intended credit path.
+3. Keyword matching is **legacy last-resort compatibility only** — for genuinely
+   unrecognised activity types with no other signal. It should shrink over time, not grow.
+
+### Fix
+
+**(a) Make "unknown" distinguishable from "zero".**
+In `completedEventToExposure`, attach `stimulusProfile` only when the vector carries
+signal:
+
+```ts
+const hasStimulus = Object.values(event.estimatedStimulus ?? {}).some(v => (v ?? 0) > 0);
+```
+
+Modality is still attached when known — it is needed for qualification checks and ranking
+context regardless of whether a stimulus vector exists. Only the *stimulus* is withheld.
+
+**(b) Give recognised Garmin activities a real coarse stimulus — the actual fix.**
+Add `DEFAULT_STIMULUS_BY_MODALITY: Record<CompletedModality, Record<CompletedTrainingIntensity, WorkoutStimulusProfile>>`
+alongside the existing `DEFAULT_COST_BY_MODALITY`, and use it in
+`candidateEventFromGarmin`. Intensity comes from the existing `intensityFromGarmin`
+(training effect ≥ 3 → hard, ≥ 1.5 → moderate).
+
+With (b) in place, (a) rarely fires for recognised modalities — which is the point. (a) is
+a correctness guard, not a routing mechanism.
+
+Values must be deliberately conservative — the aim is "materially better than treating
+real training as adaptation-neutral", not physiological precision. Starting point for
+`Cycling`, to be reviewed before landing:
+
+| Intensity | `aerobicCapacity` | `thresholdDevelopment` | `surgeRepeatability` |
+|---|---|---|---|
+| easy | 0.75 | 0.15 | 0.0 |
+| moderate | 0.70 | 0.60 | 0.25 |
+| hard | 0.55 | 0.75 | 0.65 |
+
+Note the `moderate` row deliberately does **not** clear
+`STIMULUS_CREDIT_COVERAGE_THRESHOLD` (0.6) for both Z2 *and* threshold simultaneously
+under every objective's target vector — check this against
+`generateWeeklyObjectives`'s actual `targetStimulus` values when implementing, and tune
+so a single ride cannot resolve two contradictory objectives. Mark the constants
+provisional in a comment citing this plan; Phase 4 replaces them with the evidence
+hierarchy.
+
+**(c) Carry confidence.** Add `stimulusConfidence: 'exact' | 'inferred' | 'unknown'` to
+`CompletedExposure`. `exact` for adherence-confirmed catalog templates, `inferred` for
+(b), `unknown` where no vector exists. Phase 4's evidence hierarchy builds directly on
+this field; adding it now costs nothing and prevents a second migration.
+
+### Interaction to check
+
+Fix (b) makes Garmin rides start resolving objectives. That lowers `urgency` in
+`trainingIntent.ts:80`, which lowers `plannedDose`, which changes `executionDose`.
+**Re-run the Phase 0 invariant suite and read the semantic diff before merging.**
+
+### Tests
+
+* `completedTraining.test.ts` — a Garmin-only cycling event produces a non-zero stimulus
+  profile with `stimulusConfidence: 'inferred'`; an unknown-modality event produces none.
+* `microcycle.test.ts` — the F2 probe, promoted to a real test: three Garmin sessions
+  resolve `zone2_aerobic` and `strength_maintenance`.
+* `microcycle.test.ts` — **regression against the false-positive risk**: a generic
+  `"Cycling hard"` record does **not** resolve both `zone2_aerobic` and
+  `threshold_quality` unless the inferred structured stimulus independently supports
+  both. This is the test that keeps the fix from overshooting.
+* `microcycle.test.ts` — an adherence-confirmed exposure still uses the exact template
+  profile in preference to the modality default (evidence ordering holds).
+
+---
+
+## 1.3 — F6: make recommendation records actually immutable
+
+### Current state
+
+`app/firestore.rules` comments the document as "audit evidence and intentionally
+immutable", but `allow update` pins only `createdAt`. A client may rewrite `templateId`,
+`mode`, `rationale`, `recommendationAudit` or `candidateScores`. And because the audit
+requirement is conditional on `schemaVersion == 3`, a v3 document can be rewritten as v1
+and stripped of its audit entirely.
+
+### Fix
+
+Add two helpers and use them in the `daily_recommendations` update rule:
+
+```text
+function schemaRatchets() {
+  return request.resource.data.schemaVersion >= resource.data.schemaVersion;
+}
+
+function decisionFieldsUnchanged() {
+  return request.resource.data.templateId    == resource.data.templateId
+    &&  request.resource.data.templateTitle  == resource.data.templateTitle
+    &&  request.resource.data.category       == resource.data.category
+    &&  request.resource.data.modality       == resource.data.modality
+    &&  request.resource.data.mode           == resource.data.mode
+    &&  request.resource.data.rationale      == resource.data.rationale
+    &&  request.resource.data.createdAt      == resource.data.createdAt;
+}
+```
+
+`recommendationAudit` needs care: `Home.tsx` writes the record once with the audit
+attached, and `handleAdjustSession` re-saves the same base recommendation with an added
+`adjustment`. So `adjustment` **must** stay mutable, and the audit must be write-once —
+absent-then-set is legal, set-then-changed is not:
+
+```text
+function auditWriteOnce() {
+  return !('recommendationAudit' in resource.data)
+    || request.resource.data.recommendationAudit == resource.data.recommendationAudit;
+}
+```
+
+Verify against `recommendationService.saveRecommendation`'s `setDoc(..., { merge: true })`
+semantics before landing — `merge: true` means `request.resource.data` is the merged
+result, so unmentioned fields compare equal, which is what these rules assume.
+
+### Tests (extend `src/emulator/firestoreRules.emulator.test.ts`)
+
+* rejects an update that changes `templateId` on an existing document
+* rejects `schemaVersion` 3 → 1
+* rejects removing or altering `recommendationAudit` once set
+* **allows** setting `adherence` on an existing document
+* **allows** adding `adjustment` to an existing document
+* **allows** first-time attachment of `recommendationAudit`
+
+Note the emulator suite is `describe.skip` unless `FIRESTORE_EMULATOR_HOST` is set. It
+does run in CI (`npm run test:rules`); make sure the new cases are exercised there and
+not silently skipped locally.
+
+---
+
+## Acceptance criteria
+
+- [ ] `injuries: []` no longer appears in `adapters.ts`; an active injury changes the
+      recommendation on the readiness path, the intent path, and all 7 projected days
+- [ ] `safetyRestrictedModalityCount` is non-zero in a persisted audit when an injury is active
+- [ ] `RUNNING_INJURY_PATTERN` deleted
+- [ ] three Garmin-only sessions resolve at least two weekly objectives
+- [ ] recognised and unrecognised activity types both earn credit (no inversion)
+- [ ] emulator suite covers field tampering, schema downgrade, audit removal, and the
+      three legal-update cases
+- [ ] simulation baseline regenerated and the delta reviewed in the PR description
+
+## Risks & rollback
+
+* **1.2 changes recommendations for every existing user immediately** — more objectives
+  resolve, so `plannedDose` drops and the optimizer stops chasing them. This is the
+  intended correction, but it is a behaviour change; ship it behind the baseline diff and
+  read it before merging.
+* **1.3 could break the adjust-session save path** if `merge: true` semantics differ from
+  the assumption above. The emulator tests are the guard; write the three "allows" cases
+  first and watch them fail before the rules change lands.
+* **1.1 Option B is the larger change.** Option A is the rollback: delete the dead channel
+  and amend ADR-0007. Either outcome is better than the status quo, in which the ADR
+  states a guarantee the code cannot deliver.
+
+## Out of scope
+
+Local tissue-state tracking (Phase 5), evidence-hierarchy stimulus inference (Phase 4),
+dose-sensitive cost (Phase 4). 1.2 deliberately ships a coarse lookup table rather than
+waiting for the full model.
+
+## Docs to update
+
+* **ADR-0007** — amend §6 to describe the implemented injury model (or, under Option A,
+  to say guardrails are the gate)
+* **ADR-0002 or a new ADR** — `trainingSettings` schema v3
+* `README.md` — the training-settings table gains an Injuries row
+* `docs/analysis/2026-08-08-architecture-review.md` — mark F1/F2/F6 resolved with commit refs

--- a/docs/plans/phase-1-live-defects.md
+++ b/docs/plans/phase-1-live-defects.md
@@ -1,7 +1,9 @@
 # Phase 1 — Live defects
 
-* **Status:** Ready
-* **Depends on:** nothing (Phase 0 is helpful but not blocking)
+* **Status:** **Ready** for 1.1 and 1.3 · **Approved (blocked)** for 1.2
+* **Blocked by:** *per work item* —
+  **1.1 (F1 injuries)** nothing · **1.3 (F6 rules ratchet)** nothing ·
+  **1.2 (F2 objective credit)** requires Phase 0's invariant + credit-regression harness
 * **Unlocks:** a correct foundation for the Phase 2–5 cutover
 * **Addresses:** F1, F2, F6
 * **Rough effort:** 3–4 days
@@ -162,6 +164,12 @@ Phase 5's tissue tracking.
 
 ## 1.2 — F2: Garmin-measured training must earn objective credit
 
+> **Blocked by Phase 0.** This item introduces inferred-stimulus constants and changes
+> objective crediting for every existing user. It cannot be validated without the
+> invariant suite and the credit-regression harness, and the constants must not be chosen
+> before that harness exists — see "Constants are illustrative" below for why that is not
+> a formality.
+
 ### Current state
 
 Verified empirically: three Garmin activities in the rolling window (120 min hard ride,
@@ -222,26 +230,46 @@ alongside the existing `DEFAULT_COST_BY_MODALITY`, and use it in
 With (b) in place, (a) rarely fires for recognised modalities — which is the point. (a) is
 a correctness guard, not a routing mechanism.
 
-Values must be deliberately conservative — the aim is "materially better than treating
-real training as adaptation-neutral", not physiological precision. **Adopted starting
-values** for `Cycling`; the other modalities follow the same shape:
+### Constants are illustrative — the test comes first
+
+An earlier revision of this plan published a table as "adopted starting values" while
+simultaneously requiring implementation to verify it later. **The published table failed
+that verification.** Worked through against today's credit function:
+
+`stimulusCoverage` is `Σ(target × stimulus) / Σ(target)`, so for a single-axis objective
+it reduces to the candidate's own value on that axis.
+
+| Objective | `targetStimulus` | Proposed `moderate` value | Coverage | ≥ 0.6? |
+|---|---|---|---|---|
+| `zone2_aerobic` | `{ aerobicCapacity: 0.8 }` | 0.70 | 0.70 | **yes** |
+| `threshold_quality` | `{ thresholdDevelopment: 0.9 }`, min 0.6 | 0.60 | 0.60 | **yes** (and clears qualification exactly) |
+
+One moderate ride would therefore have resolved **both** objectives — precisely the
+double-credit failure this plan says must not happen, and the same failure mode the
+keyword matcher produces. Publishing constants and deferring their validation is the
+practice F11 exists to criticise; doing it inside the fix for F2 was worse.
+
+**Therefore: no constants are adopted here.** The numbers below are *illustrative shape
+only* — conservative, aerobic-weighted, rising threshold and surge with intensity:
 
 | Intensity | `aerobicCapacity` | `thresholdDevelopment` | `surgeRepeatability` |
 |---|---|---|---|
-| easy | 0.75 | 0.15 | 0.0 |
-| moderate | 0.70 | 0.60 | 0.25 |
-| hard | 0.55 | 0.75 | 0.65 |
+| easy | ~0.75 | low | ~0 |
+| moderate | ~0.70 | **below the 0.6 credit floor** | low |
+| hard | ~0.55 | high | high |
 
-**Required verification step, not optional.** The `moderate` row must not clear
-`STIMULUS_CREDIT_COVERAGE_THRESHOLD` (0.6) for both Z2 *and* threshold simultaneously
-under any objective's target vector. Check the numbers against `generateWeeklyObjectives`'s
-actual `targetStimulus` values during implementation and tune until a single ride cannot
-resolve two contradictory objectives — this is the same double-credit failure the keyword
-matcher produces, and re-introducing it through the inference table would defeat the whole
-fix. The regression test below is what enforces it.
+**First implementation task, before any constant is chosen:** a table-driven test over
+every `modality × intensity × objective` combination asserting, for each cell, exactly
+which objectives it credits. Choose the constants to satisfy that table. The load-bearing
+assertion is that no single inferred exposure resolves two objectives that represent
+different training intentions — `zone2_aerobic` and `threshold_quality` in particular.
 
-Mark the constants provisional in a comment citing this plan; Phase 4 replaces them with
-the evidence hierarchy.
+This is the concrete reason 1.2 is blocked on Phase 0: the credit-regression harness is
+what makes the table checkable, and without it the constants would again be chosen by
+assertion.
+
+Mark whatever is chosen as provisional in a comment citing this plan; Phase 4 replaces it
+with the evidence hierarchy.
 
 **(c) Carry confidence.** Add `stimulusConfidence: 'exact' | 'inferred' | 'unknown'` to
 `CompletedExposure`. `exact` for adherence-confirmed catalog templates, `inferred` for

--- a/docs/plans/phase-1-live-defects.md
+++ b/docs/plans/phase-1-live-defects.md
@@ -10,6 +10,23 @@
 
 ---
 
+## Task board
+
+Status legend: `[ ]` not started · `[-]` in progress · `[x]` finished.
+Update the marker on the work-item heading **and** this table in the same commit.
+
+| Task | Status | Blocked by | Summary | Primary files |
+|---|:--:|---|---|---|
+| 1.1 | `[ ]` | — | Structured `InjuryConstraint[]` replaces the dead free-text injury channel (F1) | `app/src/engine/models.ts`, `injuryPolicy.ts` (new), `adapters.ts`, `rules.ts`, `eligibility.ts`, `optimizer.ts`, `services/trainingSettingsService.ts`, `components/TrainingSettings.tsx`, `app/firestore.rules` |
+| 1.2 | `[ ]` | **Phase 0** | Recognised Garmin sessions earn objective credit from an inferred stimulus vector (F2) | `app/src/engine/completedTraining.ts`, `microcycle.ts`, `trainingHistory.ts` |
+| 1.3 | `[ ]` | — | Append-only recommendation revisions; decision fields immutable per revision (F6) | `app/firestore.rules`, `app/src/services/recommendationService.ts`, `app/src/components/Home.tsx`, `app/src/emulator/firestoreRules.emulator.test.ts` |
+
+1.1 and 1.3 are independent of each other and of Phase 0 — either can start today.
+**1.2 must not start before Phase 0**: it changes objective crediting for every existing
+user, and its constants cannot be chosen without the credit-regression harness.
+
+---
+
 ## Goal
 
 Fix the three defects where the system's actual behaviour differs from its documented
@@ -24,7 +41,7 @@ harder to see, because they will then be spread across a larger surface.
 
 ---
 
-## 1.1 — F1: give injury constraints a real data path
+## `[ ]` 1.1 — F1: give injury constraints a real data path
 
 ### Current state
 
@@ -177,7 +194,7 @@ object.
 
 ---
 
-## 1.2 — F2: Garmin-measured training must earn objective credit
+## `[ ]` 1.2 — F2: Garmin-measured training must earn objective credit
 
 > **Blocked by Phase 0.** This item introduces inferred-stimulus constants and changes
 > objective crediting for every existing user. It cannot be validated without the
@@ -319,7 +336,7 @@ Fix (b) makes Garmin rides start resolving objectives. That lowers `urgency` in
 
 ---
 
-## 1.3 — F6: make recommendation records actually immutable
+## `[ ]` 1.3 — F6: make recommendation records actually immutable
 
 ### Current state
 
@@ -354,17 +371,68 @@ Two lifecycles are viable:
 > discards, the audit stops matching what the user saw. Adherence semantics also stay
 > intact under (B): it attaches to the date, resolving to the latest revision.
 >
-> **Shape:** keep `users/{uid}/daily_recommendations/{date}` as the current decision, add
-> a monotonic `revision: number`, and require that any update changing decision fields
-> increments it while writing the prior state to
-> `users/{uid}/daily_recommendations/{date}/revisions/{revision}` in the same batch.
-> Rules enforce: revisions are create-only (never update or delete); `revision` strictly
-> increases; decision fields may only change when `revision` increases.
->
-> **Honest limit:** Firestore rules cannot verify the prior state was actually copied —
-> that is a client-side batch obligation. Rules enforce immutability *of what is written*;
-> the copy is covered by an emulator test, not by the rules themselves. Say so in ADR-0010's
-> amendment rather than implying stronger guarantees.
+> **Shape.** `users/{userId}/daily_recommendations/{date}` remains the *current* decision
+> and gains a monotonic `revision: number` (first write = `1`). Superseded decisions are
+> archived at `users/{userId}/daily_recommendations/{date}/revisions/{revision}`, where the
+> document ID is the **prior** revision number as a string. A decision change is one atomic
+> batch: create the archive doc for `resource.data.revision`, and set the current doc to
+> `revision + 1`.
+
+**The archive write is enforced by rules, not by client good behaviour.**
+
+An earlier revision of this plan claimed Firestore rules could not verify the prior state
+was copied, and left it as a client-side batch obligation. **That was wrong**, and it
+mattered: it would have left a malicious or buggy client free to overwrite the current
+recommendation without preserving the prior audit — destroying precisely the integrity
+property this work item exists to establish. Rules can validate another document's
+*post-write* state in the same batch or transaction via `getAfter()` / `existsAfter()`.
+
+```text
+function decisionFieldsChanged() {
+  return request.resource.data.templateId    != resource.data.templateId
+    ||   request.resource.data.templateTitle != resource.data.templateTitle
+    ||   request.resource.data.category      != resource.data.category
+    ||   request.resource.data.modality      != resource.data.modality
+    ||   request.resource.data.mode          != resource.data.mode
+    ||   request.resource.data.rationale     != resource.data.rationale
+    ||   request.resource.data.prescription  != resource.data.prescription;
+}
+
+// Bind the lookup once with `let` -- each distinct getAfter() is a document access and
+// rules cap those per request (10 single-document / 20 multi-document or batched).
+function archivesPriorRevision(userId, date) {
+  let priorPath = /databases/$(database)/documents/users/$(userId)/daily_recommendations/$(date)/revisions/$(string(resource.data.revision));
+  let prior = getAfter(priorPath).data;
+  return prior.revision      == resource.data.revision
+    &&   prior.templateId    == resource.data.templateId
+    &&   prior.templateTitle == resource.data.templateTitle
+    &&   prior.category      == resource.data.category
+    &&   prior.modality      == resource.data.modality
+    &&   prior.mode          == resource.data.mode
+    &&   prior.rationale     == resource.data.rationale
+    &&   prior.prescription  == resource.data.prescription
+    &&   (!('recommendationAudit' in resource.data)
+          || prior.recommendationAudit == resource.data.recommendationAudit);
+}
+```
+
+Update rule for `daily_recommendations/{date}`:
+
+* **Decision changed** → require `request.resource.data.revision == resource.data.revision + 1`
+  **and** `archivesPriorRevision(userId, date)`. The archive must match the *pre-update*
+  document field for field, so a missing, mismatched or fabricated archive is rejected.
+* **Decision unchanged** (adherence answer, or adding `adjustment`) → require `revision`
+  unchanged and no archive write. Routine updates must stay cheap; demanding an archive for
+  an adherence tick would make the common path expensive and push clients toward working
+  around it.
+
+Rules for `daily_recommendations/{date}/revisions/{revision}`: **create-only** for the
+owner, never update, never delete, and `request.resource.data.revision` must equal the
+document ID cast to a number.
+
+**Residual limit, stated accurately this time:** rules constrain the archive's content and
+its existence-after-write, but cannot compel a client to write a new decision at all. That
+is not a gap — a client that never writes simply leaves the record unchanged.
 
 **`prescription` is decision evidence** and must be pinned per revision alongside the
 other decision fields — the earlier `decisionFieldsUnchanged()` sketch omitted it.
@@ -407,7 +475,11 @@ result, so unmentioned fields compare equal, which is what these rules assume.
 
 ### Tests (extend `src/emulator/firestoreRules.emulator.test.ts`)
 
-* rejects an update that changes `templateId` on an existing document
+* rejects an update that changes `templateId` **without** the matching archive write
+* rejects a decision change whose archive document exists but has **mismatched** fields
+* rejects a decision change that archives under the **wrong revision number**
+* rejects `revision` not incrementing by exactly 1 on a decision change
+* rejects any update or delete of an existing `revisions/{revision}` document
 * rejects `schemaVersion` 3 → 1
 * rejects removing or altering `recommendationAudit` once set
 * **allows** setting `adherence` on an existing document

--- a/docs/plans/phase-2-plan-intent-authority.md
+++ b/docs/plans/phase-2-plan-intent-authority.md
@@ -1,6 +1,6 @@
 # Phase 2 — Plan intent is the planning authority
 
-* **Status:** Draft — needs agreement on the domain model before it becomes `Ready`
+* **Status:** Ready — domain-model decisions D1/D2 taken 2026-08-08 (see below)
 * **Depends on:** Phase 1 (do not migrate onto an unwired safety gate)
 * **Unlocks:** Phases 3, 4, 5
 * **Addresses:** F16, F17, F9
@@ -53,17 +53,57 @@ Write this first; it is the gate for everything after. It must define:
 7. **Simulation acceptance criteria** — a plan change is accepted when the Phase 0
    invariants hold and the semantic diff is explained.
 
-### Decide in the ADR, do not leave implicit
+### Decisions taken (2026-08-08) — record these in the ADR
 
-* **Phase vocabulary.** `EventPlanPhase` (`build|travel|peak|taper|race`) and
-  `PhaseWeights.phaseName` (`Base|Build|Specificity|Peak/Taper|Post-Event Recovery`) must
-  be reconciled. Recommended: `EventPlanPhase` becomes canonical because it is what an
-  athlete and a coach actually name; `PhaseWeights.phaseName` becomes a derived label for
-  the generic fallback.
-* **`intensityScale`'s fate.** It is currently written six times and read zero. Either
-  give it a consumer (the natural one is Phase 4's dose resolution, alongside
-  `volumeScale`) or delete it. A third state — declared, assigned, unread — is not
-  acceptable to carry into the cutover.
+**D1 — `EventPlanPhase` becomes the canonical phase vocabulary.**
+`PhaseWeights.phaseName` (`Base|Build|Specificity|Peak/Taper|Post-Event Recovery`) becomes
+a *derived label* produced by the generic fallback, mapped onto `EventPlanPhase`
+(`build|travel|peak|taper|race`).
+
+Rationale: `EventPlanPhase` is the vocabulary an athlete and a coach actually use, it is
+already attached to real workout content in `event-plan.ts`, and it expresses `travel` —
+a genuine planning state that the days-to-event model structurally cannot represent,
+because travel has nothing to do with event proximity. The reverse mapping loses that.
+
+Mapping for the generic fallback:
+
+| `PhaseWeights.phaseName` | `EventPlanPhase` |
+|---|---|
+| Base, Build | `build` |
+| Specificity | `peak` |
+| Peak/Taper | `taper` |
+| Post-Event Recovery | `build` (at reduced volume) |
+
+`race` and `travel` are only ever set by an explicit `PlanDefinition` — the generic model
+has no way to know about either, and inferring them would be a guess.
+
+**D2 — `intensityScale` gets a consumer; it is not deleted.**
+The deletion argument is that nothing reads it. The counter-argument wins: taper is
+*defined* by volume and intensity moving in opposite directions — volume down, intensity
+preserved. `plannedDose` currently collapses both into one scalar derived from
+`volumeScale` alone, which is precisely why taper behaviour has to be reconstructed
+elsewhere from template `phaseEligibility` and ranking weights (F17, and the emergent-taper
+problem in Phase 5.7). Deleting `intensityScale` would make a correct taper harder to
+express, not simpler.
+
+The consumer, specified here and implemented in Phase 4.4:
+
+```ts
+// replaces the single `plannedDose` scalar
+interface PlannedDose {
+  volume: number;     // from PlanBlock.volumeScale   — duration target
+  intensity: number;  // from PlanBlock.intensityScale — admissible intensity band
+}
+```
+
+`volume` continues to drive duration selection as `plannedDose` does today. `intensity`
+gates which intensity-class candidates are admissible, so a taper can hold intensity while
+cutting volume — one block declaration instead of an emergent interaction between four
+subsystems.
+
+Until Phase 4.4 lands, `intensityScale` stays written-and-unread. That is acceptable
+*because it is now a scheduled commitment with a named consumer*, which is the state F17
+objects to it lacking.
 
 ## 2.2 — `PlanDefinition`: make the event plan executable
 
@@ -153,10 +193,10 @@ there is one path.
 
 ## Acceptance criteria
 
-- [ ] ADR-0010 accepted, with the phase vocabulary and `intensityScale` disposition decided
+- [ ] ADR-0010 accepted, recording D1 (canonical phase vocabulary) and D2 (`intensityScale` consumer)
 - [ ] `PlanDefinition` exists; `generateWeeklyObjectives` consumes it when present
 - [ ] `event-plan.ts` has at least one engine-path consumer
-- [ ] `intensityScale` is either consumed or deleted
+- [ ] `intensityScale` has a named, scheduled consumer (`PlannedDose.intensity`, Phase 4.4)
 - [ ] `MicrocycleState.weekStartDate` renamed to `windowStartDate`
 - [ ] one readiness/safety envelope function; no discarded template selection
 - [ ] Phase 0 invariants still pass; semantic diff explained in the PR

--- a/docs/plans/phase-2-plan-intent-authority.md
+++ b/docs/plans/phase-2-plan-intent-authority.md
@@ -1,0 +1,182 @@
+# Phase 2 — Plan intent is the planning authority
+
+* **Status:** Draft — needs agreement on the domain model before it becomes `Ready`
+* **Depends on:** Phase 1 (do not migrate onto an unwired safety gate)
+* **Unlocks:** Phases 3, 4, 5
+* **Addresses:** F16, F17, F9
+* **Rough effort:** 2 days for the ADR, 4–6 days for the `PlanDefinition` model
+* **Primary artifact:** **ADR-0010**
+
+---
+
+## Goal
+
+Establish that an explicit training plan — not generic days-to-event arithmetic — is the
+authority on what a given date should develop, and give that plan a representation the
+engine actually reads.
+
+## The problem in one paragraph
+
+`app/src/workouts/event-plan.ts` encodes the real macrocycle: 17 coverage entries with
+phases (`build | travel | peak | taper | race`), requirement tiers, workout IDs and
+coaching notes. **Its only consumer is `app/scripts/validate-workouts.ts`** (F16). The
+live planner instead reduces the plan to five generic rolling objectives and re-derives
+phase from `daysToEvent`, producing a `PhaseWeights` whose `intensityScale` is read by
+nobody and whose `volumeScale` feeds a single multiplier (F17). Two phase vocabularies
+exist with no mapping between them.
+
+---
+
+## 2.1 — ADR-0010: Plan Intent and Sequence Planning are the training authorities
+
+Write this first; it is the gate for everything after. It must define:
+
+1. **Authoritative domain objects** — `PlanDefinition`, `PlanBlock`,
+   `PlanObjectiveDefinition`, `SequencingRule`, `SessionRole`.
+2. **Responsibility boundaries.** Explicitly, per layer:
+   * *periodization* — fallback phase inference when no explicit plan exists
+   * *plan intent* — what this date should develop, before readiness
+   * *horizon planner* — sequence-level feasibility across the window
+   * *readiness/safety* — how much of that intent is safe to execute today
+   * *optimizer* — choice **among equivalent feasible implementations only**
+3. **The priority model** — lexicographic, not multiplicative (see Phase 3):
+   safety → must-have plan obligations → sequence/recovery constraints → objective
+   coverage → fatigue cost → preference. State plainly that preference can never
+   outrank a must-have obligation, and that the current 0.15× anti-stack multiplier
+   overriding the 1.40× A-event boost is the concrete failure this rule exists to prevent.
+4. **Objective credit semantics** — defers detail to Phase 4, but fixes the contract:
+   credit is fractional, dose-sensitive, and carries confidence.
+5. **Two planning modes** — generic (days-to-event) and explicit (`PlanDefinition` block
+   calendar). Explicit wins where present; generic remains the fallback and the
+   validation cross-check.
+6. **V1 → V2 migration and compatibility** — including what gets retired.
+7. **Simulation acceptance criteria** — a plan change is accepted when the Phase 0
+   invariants hold and the semantic diff is explained.
+
+### Decide in the ADR, do not leave implicit
+
+* **Phase vocabulary.** `EventPlanPhase` (`build|travel|peak|taper|race`) and
+  `PhaseWeights.phaseName` (`Base|Build|Specificity|Peak/Taper|Post-Event Recovery`) must
+  be reconciled. Recommended: `EventPlanPhase` becomes canonical because it is what an
+  athlete and a coach actually name; `PhaseWeights.phaseName` becomes a derived label for
+  the generic fallback.
+* **`intensityScale`'s fate.** It is currently written six times and read zero. Either
+  give it a consumer (the natural one is Phase 4's dose resolution, alongside
+  `volumeScale`) or delete it. A third state — declared, assigned, unread — is not
+  acceptable to carry into the cutover.
+
+## 2.2 — `PlanDefinition`: make the event plan executable
+
+Generalise `event-plan.ts` from a September-specific coverage list into a plan the engine
+consumes. **Do not make the domain September-specific.**
+
+```ts
+export interface PlanDefinition {
+  id: string;
+  eventId: string;
+  blocks: PlanBlock[];
+  objectives: PlanObjectiveDefinition[];
+  sequencingRules: SequencingRule[];
+}
+
+export interface PlanBlock {
+  phase: EventPlanPhase;
+  startDate: string;
+  endDate: string;
+  volumeScale: number;
+  intensityScale: number;
+}
+
+export interface PlanObjectiveDefinition {
+  key: ObjectiveKey;
+  coverageKey: EventPlanCoverageKey;   // ties back to event-plan.ts
+  phases: EventPlanPhase[];
+  requiredCredit: number;
+  priority: ObjectivePriority;         // already declared in models.ts, unused
+  minGapHoursFrom?: ObjectiveKey[];
+}
+```
+
+`WeeklyObjective` already declares `requiredCredit`, `priority`, `windowStart` and
+`windowEnd` and uses none of them (F17). This is where they get used — objective windows
+become real dated ranges derived from `PlanBlock`, replacing the generic rolling 7-day
+counter (`MicrocycleState.weekStartDate`, whose name already misdescribes it: rename to
+`windowStartDate`).
+
+### Migration path
+
+1. Keep `SEPTEMBER_CYCLING_EVENT_SESSION_COVERAGE` as data; add a pure adapter
+   `planDefinitionFromCoverage(coverage, event)` producing a `PlanDefinition`.
+2. `generateWeeklyObjectives` gains an optional `planDefinition` parameter. When present,
+   objectives come from the plan; when absent, current behaviour is unchanged. This keeps
+   the eventless/generic athlete working throughout.
+3. `validateEventPlanCoverage` keeps running — the catalog-completeness check is still
+   worth having; it is just no longer the file's *only* purpose.
+
+## 2.3 — Race-date uncertainty
+
+Real events are not always one known date. Add:
+
+```ts
+export interface EventTiming {
+  earliestDate: string;
+  latestDate: string;
+  planningDate: string;     // = earliestDate until confirmed
+  confirmedDate?: string;
+}
+```
+
+Taper logic anchors on `planningDate`, so an unconfirmed event gets a safe (early) taper
+anchor rather than requiring a fabricated exact date. Surface the uncertainty in the UI
+rather than hiding it.
+
+## 2.4 — Collapse Path A / Path B (F9)
+
+`evaluateTrainingWithIntent` currently calls `evaluateTraining` (`rules.ts:486`) to obtain
+`mode` and `envelopes`, then discards its template pick and re-selects. Extract the part
+that is actually wanted:
+
+```ts
+export function evaluateReadinessAndSafetyEnvelope(
+  readiness: DailyReadiness, context: UserContext, date: string,
+  previousMode?: 'train' | 'modify' | 'recover',
+): { mode; envelopes; telemetry; maxExecutionDose; restrictedModalities };
+```
+
+Then one downstream selection path consumes it. `evaluateTraining` remains only if an ADR
+justifies it as a deliberate readiness-only fallback; otherwise it goes.
+
+This removes a whole category of the divergence in F4 — two paths cannot disagree if
+there is one path.
+
+---
+
+## Acceptance criteria
+
+- [ ] ADR-0010 accepted, with the phase vocabulary and `intensityScale` disposition decided
+- [ ] `PlanDefinition` exists; `generateWeeklyObjectives` consumes it when present
+- [ ] `event-plan.ts` has at least one engine-path consumer
+- [ ] `intensityScale` is either consumed or deleted
+- [ ] `MicrocycleState.weekStartDate` renamed to `windowStartDate`
+- [ ] one readiness/safety envelope function; no discarded template selection
+- [ ] Phase 0 invariants still pass; semantic diff explained in the PR
+
+## Risks & rollback
+
+* **Scope.** This is the largest phase by design surface. Land the ADR first and
+  independently — it has value even if `PlanDefinition` slips.
+* **Generic athletes must not regress.** Every `planDefinition`-aware code path needs an
+  explicit no-plan branch with test coverage. The eventless user is the default case.
+* **2.4 touches the hottest file in the repo.** Land it as its own commit, after 2.2.
+
+## Out of scope
+
+Sequence search (Phase 5). Objective credit mechanics (Phase 4). This phase establishes
+*what the plan wants*; it does not change *how the week is searched*.
+
+## Docs to update
+
+* **ADR-0010** (new, the main artifact)
+* **ADR-0007** — amend: periodization is the fallback, not the authority
+* **ADR-0004** — amend §3: `event-plan.ts` is a planning input, not only a coverage contract
+* `docs/architecture/recommendation-engine.md` — rewrite against the new layering

--- a/docs/plans/phase-2-plan-intent-authority.md
+++ b/docs/plans/phase-2-plan-intent-authority.md
@@ -67,12 +67,21 @@ because travel has nothing to do with event proximity. The reverse mapping loses
 
 Mapping for the generic fallback:
 
+`EventPlanPhase` gains a **`recovery`** member. An earlier draft mapped
+`Post-Event Recovery → build (at reduced volume)`; that is lossy in exactly the layer being
+made authoritative. `build` means *develop fitness* and would make build-phase objectives
+and workout families eligible during a window the generic engine deliberately marks as
+recovery. Reduced volume does not restore the missing semantics.
+
 | `PhaseWeights.phaseName` | `EventPlanPhase` |
 |---|---|
 | Base, Build | `build` |
 | Specificity | `peak` |
 | Peak/Taper | `taper` |
-| Post-Event Recovery | `build` (at reduced volume) |
+| Post-Event Recovery | **`recovery`** |
+
+The ADR must declare which coverage families are legal in `recovery` (expected:
+`easy_aerobic`, `recovery_or_rest`, and nothing that develops fitness).
 
 `race` and `travel` are only ever set by an explicit `PlanDefinition` — the generic model
 has no way to know about either, and inferring them would be a guess.
@@ -86,7 +95,8 @@ elsewhere from template `phaseEligibility` and ranking weights (F17, and the eme
 problem in Phase 5.7). Deleting `intensityScale` would make a correct taper harder to
 express, not simpler.
 
-The consumer, specified here and implemented in Phase 4.4:
+The consumer, specified here and implemented as **Phase 4 work item 4.5** (which exists
+for this purpose — 4.4 covers dose-sensitive *cost*, a different thing):
 
 ```ts
 // replaces the single `plannedDose` scalar
@@ -127,14 +137,29 @@ export interface PlanBlock {
   intensityScale: number;
 }
 
+export interface PlanBlock {
+  id: string;                          // objectives reference this, not the phase
+  phase: EventPlanPhase;
+  /* ...dates and scales as above... */
+}
+
 export interface PlanObjectiveDefinition {
   key: ObjectiveKey;
   coverageKey: EventPlanCoverageKey;   // ties back to event-plan.ts
-  phases: EventPlanPhase[];
+  blockIds: string[];                  // NOT `phases` — see below
   requiredCredit: number;
   priority: ObjectivePriority;         // already declared in models.ts, unused
   minGapHoursFrom?: ObjectiveKey[];
 }
+```
+
+**Objectives reference blocks, not phases.** A phase can occur more than once in a
+macrocycle (two build blocks either side of a travel week is the normal case), so
+`phases: EventPlanPhase[]` cannot tell `generateWeeklyObjectives` which dated window an
+objective belongs to — it would have to guess, which is the inference this phase exists to
+remove. `blockIds` makes `windowStart`/`windowEnd` derivable deterministically.
+
+```ts
 ```
 
 `WeeklyObjective` already declares `requiredCredit`, `priority`, `windowStart` and
@@ -143,10 +168,30 @@ become real dated ranges derived from `PlanBlock`, replacing the generic rolling
 counter (`MicrocycleState.weekStartDate`, whose name already misdescribes it: rename to
 `windowStartDate`).
 
+### Coverage and schedule are two different inputs
+
+An earlier draft proposed `planDefinitionFromCoverage(coverage, event)`. **That function
+cannot exist.** Coverage knows phases, requirement tiers and workout IDs; it does not know
+`PlanBlock.startDate`/`endDate`, `volumeScale`, `intensityScale`, or when travel is. A
+`UserEvent` supplies only the event date — it cannot tell you travel is Aug 19–22. Deriving
+blocks from coverage + event would push exactly the hidden inference back into the layer
+built to remove it.
+
+So the model has two inputs:
+
+| Input | Contains | Reusable? |
+|---|---|---|
+| **Coverage** (`event-plan.ts`) | phase → workout-family knowledge, requirement tiers | Yes — reusable across athletes and events |
+| **Block schedule** (new) | dated `PlanBlock`s: build/travel/peak/taper/race/recovery, with scales | No — specific to one athlete's macrocycle |
+
+`buildPlanDefinition(coverage, blockSchedule, event)` combines them. The block schedule is
+new authored input — it is the thing that makes the plan explicit, and there is nowhere
+else for it to come from.
+
 ### Migration path
 
-1. Keep `SEPTEMBER_CYCLING_EVENT_SESSION_COVERAGE` as data; add a pure adapter
-   `planDefinitionFromCoverage(coverage, event)` producing a `PlanDefinition`.
+1. Keep `SEPTEMBER_CYCLING_EVENT_SESSION_COVERAGE` as coverage data; author a dated block
+   schedule for the September event; combine via `buildPlanDefinition`.
 2. `generateWeeklyObjectives` gains an optional `planDefinition` parameter. When present,
    objectives come from the plan; when absent, current behaviour is unchanged. This keeps
    the eventless/generic athlete working throughout.
@@ -169,6 +214,12 @@ export interface EventTiming {
 Taper logic anchors on `planningDate`, so an unconfirmed event gets a safe (early) taper
 anchor rather than requiring a fabricated exact date. Surface the uncertainty in the UI
 rather than hiding it.
+
+**Validate the ordering — an unvalidated `EventTiming` is a taper bug.** Reject
+`earliestDate > planningDate`, `planningDate > latestDate`, or a `confirmedDate` outside
+`[earliestDate, latestDate]`. Without these, taper can anchor before the event is even
+possible, or after it has happened. Validate at the parse boundary (`DataState.INVALID`,
+consistent with ADR-0010) rather than defensively inside the planner.
 
 ## 2.4 — Collapse Path A / Path B (F9)
 

--- a/docs/plans/phase-2-plan-intent-authority.md
+++ b/docs/plans/phase-2-plan-intent-authority.md
@@ -9,6 +9,24 @@
 
 ---
 
+## Task board
+
+Status legend: `[ ]` not started · `[-]` in progress · `[x]` finished.
+Update the marker on the work-item heading **and** this table in the same commit.
+
+| Task | Status | Summary | Primary files |
+|---|:--:|---|---|
+| 2.1 | `[ ]` | Write and accept **ADR-0012**, recording D1 (canonical phase vocabulary), D2 (`intensityScale` consumer) and the lexicographic priority model | `docs/adr/0012-*.md` (new) |
+| 2.2 | `[ ]` | `PlanDefinition` / `PlanBlock` / `PlanObjectiveDefinition`; coverage and dated block schedule combined by `buildPlanDefinition` | `app/src/workouts/event-plan.ts`, `app/src/engine/models.ts`, `microcycle.ts`, new plan-schedule module |
+| 2.3 | `[ ]` | `EventTiming` with validated date ordering for unconfirmed events | `app/src/engine/models.ts`, `periodization.ts`, `persistence/parsers/*` |
+| 2.4 | `[ ]` | Extract `evaluateReadinessAndSafetyEnvelope`; collapse Path A / Path B (F9) | `app/src/engine/rules.ts`, `planner.ts` |
+
+**2.1 gates the rest.** Do not start 2.2 before the ADR is accepted — the domain objects
+are the ADR's output, and building them first inverts the dependency this phase exists to
+establish.
+
+---
+
 ## Goal
 
 Establish that an explicit training plan — not generic days-to-event arithmetic — is the
@@ -27,7 +45,7 @@ exist with no mapping between them.
 
 ---
 
-## 2.1 — ADR-0012: Plan Intent and Sequence Planning are the training authorities
+## `[ ]` 2.1 — ADR-0012: Plan Intent and Sequence Planning are the training authorities
 
 Write this first; it is the gate for everything after. It must define:
 
@@ -115,7 +133,7 @@ Until Phase 4.4 lands, `intensityScale` stays written-and-unread. That is accept
 *because it is now a scheduled commitment with a named consumer*, which is the state F17
 objects to it lacking.
 
-## 2.2 — `PlanDefinition`: make the event plan executable
+## `[ ]` 2.2 — `PlanDefinition`: make the event plan executable
 
 Generalise `event-plan.ts` from a September-specific coverage list into a plan the engine
 consumes. **Do not make the domain September-specific.**
@@ -198,7 +216,7 @@ else for it to come from.
 3. `validateEventPlanCoverage` keeps running — the catalog-completeness check is still
    worth having; it is just no longer the file's *only* purpose.
 
-## 2.3 — Race-date uncertainty
+## `[ ]` 2.3 — Race-date uncertainty
 
 Real events are not always one known date. Add:
 
@@ -221,7 +239,7 @@ rather than hiding it.
 possible, or after it has happened. Validate at the parse boundary (`DataState.INVALID`,
 consistent with ADR-0010) rather than defensively inside the planner.
 
-## 2.4 — Collapse Path A / Path B (F9)
+## `[ ]` 2.4 — Collapse Path A / Path B (F9)
 
 `evaluateTrainingWithIntent` currently calls `evaluateTraining` (`rules.ts:486`) to obtain
 `mode` and `envelopes`, then discards its template pick and re-selects. Extract the part

--- a/docs/plans/phase-2-plan-intent-authority.md
+++ b/docs/plans/phase-2-plan-intent-authority.md
@@ -83,13 +83,13 @@ already attached to real workout content in `event-plan.ts`, and it expresses `t
 a genuine planning state that the days-to-event model structurally cannot represent,
 because travel has nothing to do with event proximity. The reverse mapping loses that.
 
-Mapping for the generic fallback:
-
 `EventPlanPhase` gains a **`recovery`** member. An earlier draft mapped
 `Post-Event Recovery → build (at reduced volume)`; that is lossy in exactly the layer being
 made authoritative. `build` means *develop fitness* and would make build-phase objectives
 and workout families eligible during a window the generic engine deliberately marks as
 recovery. Reduced volume does not restore the missing semantics.
+
+Mapping for the generic fallback:
 
 | `PhaseWeights.phaseName` | `EventPlanPhase` |
 |---|---|
@@ -241,7 +241,7 @@ consistent with ADR-0010) rather than defensively inside the planner.
 
 ## `[ ]` 2.4 — Collapse Path A / Path B (F9)
 
-`evaluateTrainingWithIntent` currently calls `evaluateTraining` (`rules.ts:486`) to obtain
+`evaluateTrainingWithIntent` currently calls `evaluateTraining` (`evaluateTrainingWithIntent`'s call to `evaluateTraining`) to obtain
 `mode` and `envelopes`, then discards its template pick and re-selects. Extract the part
 that is actually wanted:
 

--- a/docs/plans/phase-2-plan-intent-authority.md
+++ b/docs/plans/phase-2-plan-intent-authority.md
@@ -5,7 +5,7 @@
 * **Unlocks:** Phases 3, 4, 5
 * **Addresses:** F16, F17, F9
 * **Rough effort:** 2 days for the ADR, 4–6 days for the `PlanDefinition` model
-* **Primary artifact:** **ADR-0010**
+* **Primary artifact:** **ADR-0012**
 
 ---
 
@@ -27,7 +27,7 @@ exist with no mapping between them.
 
 ---
 
-## 2.1 — ADR-0010: Plan Intent and Sequence Planning are the training authorities
+## 2.1 — ADR-0012: Plan Intent and Sequence Planning are the training authorities
 
 Write this first; it is the gate for everything after. It must define:
 
@@ -193,7 +193,7 @@ there is one path.
 
 ## Acceptance criteria
 
-- [ ] ADR-0010 accepted, recording D1 (canonical phase vocabulary) and D2 (`intensityScale` consumer)
+- [ ] ADR-0012 accepted, recording D1 (canonical phase vocabulary) and D2 (`intensityScale` consumer)
 - [ ] `PlanDefinition` exists; `generateWeeklyObjectives` consumes it when present
 - [ ] `event-plan.ts` has at least one engine-path consumer
 - [ ] `intensityScale` has a named, scheduled consumer (`PlannedDose.intensity`, Phase 4.4)
@@ -216,7 +216,7 @@ Sequence search (Phase 5). Objective credit mechanics (Phase 4). This phase esta
 
 ## Docs to update
 
-* **ADR-0010** (new, the main artifact)
+* **ADR-0012** (new, the main artifact)
 * **ADR-0007** — amend: periodization is the fallback, not the authority
 * **ADR-0004** — amend §3: `event-plan.ts` is a planning input, not only a coverage contract
 * `docs/architecture/recommendation-engine.md` — rewrite against the new layering

--- a/docs/plans/phase-2-plan-intent-authority.md
+++ b/docs/plans/phase-2-plan-intent-authority.md
@@ -148,23 +148,18 @@ export interface PlanDefinition {
 }
 
 export interface PlanBlock {
-  phase: EventPlanPhase;
-  startDate: string;
-  endDate: string;
-  volumeScale: number;
-  intensityScale: number;
-}
-
-export interface PlanBlock {
   id: string;                          // objectives reference this, not the phase
   phase: EventPlanPhase;
-  /* ...dates and scales as above... */
+  startDate: string;                   // YYYY-MM-DD, Warsaw-local, inclusive
+  endDate: string;                     // YYYY-MM-DD, Warsaw-local, inclusive
+  volumeScale: number;
+  intensityScale: number;
 }
 
 export interface PlanObjectiveDefinition {
   key: ObjectiveKey;
   coverageKey: EventPlanCoverageKey;   // ties back to event-plan.ts
-  blockIds: string[];                  // NOT `phases` — see below
+  blockId: string;                     // exactly one — NOT `phases`, and not a list
   requiredCredit: number;
   priority: ObjectivePriority;         // already declared in models.ts, unused
   minGapHoursFrom?: ObjectiveKey[];
@@ -175,10 +170,23 @@ export interface PlanObjectiveDefinition {
 macrocycle (two build blocks either side of a travel week is the normal case), so
 `phases: EventPlanPhase[]` cannot tell `generateWeeklyObjectives` which dated window an
 objective belongs to — it would have to guess, which is the inference this phase exists to
-remove. `blockIds` makes `windowStart`/`windowEnd` derivable deterministically.
+remove. `blockId` makes `windowStart`/`windowEnd` derivable deterministically:
+`windowStart = block.startDate`, `windowEnd = block.endDate`.
 
-```ts
-```
+**One block per objective, not a list.** An earlier draft had `blockIds: string[]`, which
+leaves two questions unanswered and therefore answered differently by each implementer:
+an empty list has no window at all, and two non-contiguous blocks give either one window
+spanning the gap or two disjoint windows — with no rule for how `requiredCredit` divides
+between them. Neither has a defensible default. An objective that genuinely spans two
+build blocks either side of a travel week is **two objectives**, each with its own
+`requiredCredit`, which is also the honest model: credit earned before a travel week does
+not carry across it.
+
+Validate at plan-build time, not at use time: `buildPlanDefinition` rejects the whole
+`PlanDefinition` (`DataState.INVALID`, per ADR-0010) if any `blockId` does not resolve to
+a declared block, if block IDs are not unique, or if two blocks overlap in date range.
+A dangling `blockId` must never produce an objective with an undefined window — that is
+the silently-never-resolving objective this phase exists to eliminate.
 
 `WeeklyObjective` already declares `requiredCredit`, `priority`, `windowStart` and
 `windowEnd` and uses none of them (F17). This is where they get used — objective windows
@@ -238,6 +246,19 @@ rather than hiding it.
 `[earliestDate, latestDate]`. Without these, taper can anchor before the event is even
 possible, or after it has happened. Validate at the parse boundary (`DataState.INVALID`,
 consistent with ADR-0010) rather than defensively inside the planner.
+
+**Ordering alone is not enough: confirmation must move the anchor.** Every constraint
+above is satisfied by `{ earliestDate: '2026-09-05', latestDate: '2026-09-20',
+planningDate: '2026-09-05', confirmedDate: '2026-09-19' }` — a confirmed event that
+tapers to a date two weeks before it happens. Because `planningDate` starts at
+`earliestDate` and the confirmation flow writes `confirmedDate`, this is not a corner
+case; it is what happens if the confirmation handler forgets one field.
+
+So add the invariant: **`confirmedDate` present ⇒ `planningDate === confirmedDate`.**
+Once the date is known there is no legitimate reason to plan to a different one, and
+making it a validation error means a half-finished confirmation fails loudly at the parse
+boundary instead of producing a silently mistimed taper. The confirmation flow sets both
+fields in one write. Test the exact case above.
 
 ## `[ ]` 2.4 — Collapse Path A / Path B (F9)
 

--- a/docs/plans/phase-3-single-ranking-path.md
+++ b/docs/plans/phase-3-single-ranking-path.md
@@ -40,7 +40,7 @@ always green.
 
 ### Why "add a date" is not the fix
 
-`RecentHistoryEntry` (`optimizer.ts:24-28`) has no `date`, so
+`RecentHistoryEntry` (`optimizer.ts` `RecentHistoryEntry`) has no `date`, so
 `getConsecutiveModalityCount` treats array adjacency as calendar adjacency, contradicting
 ADR-0008 §6. Adding the field makes the rule *correct* — and still the wrong shape.
 
@@ -131,14 +131,14 @@ rankCandidates(candidates, context) →
 ```
 
 Rejection reasons must be named and surfaced in `decisionTrace.candidateScores`, which
-today records `excludedReasons: []` unconditionally (`rules.ts:530`) — an audit field
+today records `excludedReasons: []` unconditionally (`evaluateTrainingWithIntent`'s `decisionTrace.candidateScores` mapping in `rules.ts`) — an audit field
 that has never carried data.
 
 ### `[ ]` 3.3 — F4: one optimizer invocation
 
 The two call sites differ (verified):
 
-| | `rules.ts:497-514` | `planner.ts:477-485` |
+| | `rules.ts` (`evaluateTrainingWithIntent`) | `planner.ts` (`generateWeekAheadPlan`) |
 |---|---|---|
 | `systemicCost` in history | absent → Patch 1c dead | present → live |
 | `modality` | set to the *type* string | omitted |
@@ -146,7 +146,7 @@ The two call sites differ (verified):
 | anchor context | never passed | passed |
 
 Extract `buildOptimizationContext(intent, context, preferences, date)` used by both, and
-delete the fabricated `UserPreferences` literal at `rules.ts:503-509`.
+delete the fabricated `UserPreferences` object literal passed to `rankCandidatesByUtility` inside `evaluateTrainingWithIntent`.
 
 **Test — but test the right thing.** Feeding both call sites literally identical inputs
 does not exercise the production difference, since `planner.ts` legitimately supplies
@@ -160,7 +160,7 @@ anchor context that `rules.ts` does not. Split it:
 
 ### `[ ]` 3.4 — F5: stop assuming tomorrow is green
 
-`Home.tsx:332` hardcodes `nextDayPlan.branches.green.recommendation`. ADR-0008 §1
+`Home.tsx` hardcodes `nextDayPlan.branches.green.recommendation` in the `generateWeekAheadPlanWithIntent` effect. ADR-0008 §1
 specifies the user-selected branch; no selector exists, so yellow and red are computed
 (three full `evaluateTrainingWithIntent` passes) and discarded, and every projected day
 is seeded from a best-case tomorrow.

--- a/docs/plans/phase-3-single-ranking-path.md
+++ b/docs/plans/phase-3-single-ranking-path.md
@@ -1,6 +1,6 @@
 # Phase 3 — One ranking path, lexicographically ordered
 
-* **Status:** Draft
+* **Status:** Ready — F5 resolution decided 2026-08-08 (see 3.4)
 * **Depends on:** Phase 0 (**hard** — this phase changes ranking behaviour and is
   unmeasurable without the invariant suite), ADR-0010 from Phase 2
 * **Unlocks:** Phase 5 (sequence search needs a coherent scoring layer to sit on)
@@ -125,11 +125,20 @@ specifies the user-selected branch; no selector exists, so yellow and red are co
 (three full `evaluateTrainingWithIntent` passes) and discarded, and every projected day
 is seeded from a best-case tomorrow.
 
-* **Preferred:** add tier selection to the next-day card; thread the selection into
-  `generateWeekAheadPlanWithIntent`.
-* **Interim, if the UI work is deferred:** default to `yellow` — the honest median — and
-  amend ADR-0008 §1 to say so. Do not leave the ADR describing a selector that does not
-  exist.
+> **Decision (2026-08-08): build the selector.** Add tier selection to the next-day card
+> and thread it into `generateWeekAheadPlanWithIntent`.
+>
+> The cheap alternative — default to `yellow` and amend the ADR — was considered and
+> rejected. It swaps one wrong fixed assumption for a less wrong fixed assumption while
+> still discarding two of the three branches the engine already computes. The three
+> `evaluateTrainingWithIntent` passes are being paid for regardless; the only thing
+> missing is a control to choose between them, which is a small piece of UI against an
+> API that already returns all three. Defaulting to yellow would leave that waste in
+> place permanently and remove the pressure to fix it.
+>
+> **Fallback if the UI slips past this phase:** ship `yellow` as the default *and* amend
+> ADR-0008 §1 in the same commit, so the ADR never describes a selector that does not
+> exist. Do not ship the yellow default silently.
 
 ---
 

--- a/docs/plans/phase-3-single-ranking-path.md
+++ b/docs/plans/phase-3-single-ranking-path.md
@@ -1,0 +1,178 @@
+# Phase 3 — One ranking path, lexicographically ordered
+
+* **Status:** Draft
+* **Depends on:** Phase 0 (**hard** — this phase changes ranking behaviour and is
+  unmeasurable without the invariant suite), ADR-0010 from Phase 2
+* **Unlocks:** Phase 5 (sequence search needs a coherent scoring layer to sit on)
+* **Addresses:** F3, F4, F5
+* **Rough effort:** 3–4 days
+
+---
+
+## Goal
+
+Replace modality-repetition suppression with explicit recovery and role constraints,
+make both optimizer call sites agree, and stop the week-ahead strip assuming tomorrow is
+always green.
+
+---
+
+## 3.1 — F3: replace modality anti-stacking
+
+### Why "add a date" is not the fix
+
+`RecentHistoryEntry` (`optimizer.ts:24-28`) has no `date`, so
+`getConsecutiveModalityCount` treats array adjacency as calendar adjacency, contradicting
+ADR-0008 §6. Adding the field makes the rule *correct* — and still the wrong shape.
+
+The hazard was never `Cycling, Cycling, Cycling`. It is:
+
+```text
+hard lower-body quality
+      ↓ insufficient recovery
+hard lower-body quality
+```
+
+Three cycling sessions in a week — Tuesday threshold, Thursday Zone 2, Saturday
+race-specific — is a *correct* build week for a cycling A-event. The current rule
+suppresses the third to 0.15×, which against the 1.40× A-event boost nets **0.21×** and
+steers the plan away from precisely the modality the event requires.
+
+### The replacement
+
+**Structured history.** Extend the entry to carry what a recovery rule actually needs:
+
+```ts
+export interface SessionHistoryEntry {
+  date: string;
+  templateId: string;
+  modality: Modality;
+  role: SessionRole;
+  intensityClass: IntensityClass;
+  systemicCost: number;
+  lowerBodyCost: number;
+}
+```
+
+**Explicit constraints** replacing `consecutiveCount >= 2 || rollingCount >= 2`:
+
+| Constraint | Rule |
+|---|---|
+| Quality spacing | ≥ 48 h between two `quality`-role sessions |
+| Hard lower-body | no back-to-back sessions with `lowerBodyCost >= 0.6` |
+| Rolling hard cap | ≤ 3 sessions with `systemicCost >= 0.5` in any rolling 7 days |
+| Anchor protection | no heavy lower-body strength within 1 day of a key cycling session |
+| Variety | applies **only** among candidates in the same role and modality |
+
+Note the last row: variety is a tie-break between equivalent options, never a reason to
+change what kind of session a day gets. That is the distinction the current code loses.
+
+### 3.2 — Lexicographic ordering, not more multipliers
+
+The present architecture asks one multiplicative score to arbitrate safety,
+periodization, interference, recovery, preference and variety at once. F3 is the proof it
+cannot: two independently reasonable multipliers compose into a policy nobody chose.
+
+```text
+1. Safety and feasibility            hard filter
+2. Must-have plan obligations        hard filter where the window still allows it
+3. Sequence and recovery constraints hard filter
+4. Objective coverage and timing     primary sort key
+5. Expected fatigue cost             secondary sort key
+6. Preference / variety / convenience  tie-break only
+```
+
+Levels 1–3 filter. Levels 4–6 sort what survives. Utility scoring stays — inside a
+single equivalence class. Once the role for a day is fixed to, say, *supporting aerobic*,
+scalar utility is exactly the right tool for choosing between indoor Zone 2, an outdoor
+easy ride, and cross-training given readiness, equipment and preference.
+
+**Implementation shape.** `rankCandidatesByUtility` becomes:
+
+```ts
+rankCandidates(candidates, context) →
+  applyHardConstraints(...)      // levels 1-3, each rejection carrying a named reason
+  .then(groupByEquivalenceClass) // role + modality
+  .then(orderClasses)            // level 4-5
+  .then(rankWithinClass)         // level 6 — the existing utility formula, unchanged
+```
+
+Rejection reasons must be named and surfaced in `decisionTrace.candidateScores`, which
+today records `excludedReasons: []` unconditionally (`rules.ts:530`) — an audit field
+that has never carried data.
+
+### 3.3 — F4: one optimizer invocation
+
+The two call sites differ (verified):
+
+| | `rules.ts:497-514` | `planner.ts:477-485` |
+|---|---|---|
+| `systemicCost` in history | absent → Patch 1c dead | present → live |
+| `modality` | set to the *type* string | omitted |
+| preferences | fabricated literal | real / `NEUTRAL_PREFERENCES` |
+| anchor context | never passed | passed |
+
+Extract `buildOptimizationContext(intent, context, preferences, date)` used by both, and
+delete the fabricated `UserPreferences` literal at `rules.ts:503-509`.
+
+**Test:** given identical inputs, both call sites produce identical `RankedCandidate[]`.
+This is the assertion that keeps them from drifting again.
+
+### 3.4 — F5: stop assuming tomorrow is green
+
+`Home.tsx:332` hardcodes `nextDayPlan.branches.green.recommendation`. ADR-0008 §1
+specifies the user-selected branch; no selector exists, so yellow and red are computed
+(three full `evaluateTrainingWithIntent` passes) and discarded, and every projected day
+is seeded from a best-case tomorrow.
+
+* **Preferred:** add tier selection to the next-day card; thread the selection into
+  `generateWeekAheadPlanWithIntent`.
+* **Interim, if the UI work is deferred:** default to `yellow` — the honest median — and
+  amend ADR-0008 §1 to say so. Do not leave the ADR describing a selector that does not
+  exist.
+
+---
+
+## Tests to add
+
+* `optimizer.test.ts` — three cycling sessions across 7 days with ≥48 h spacing receive
+  **no** repetition penalty; two hard lower-body sessions on consecutive days do.
+* `optimizer.test.ts` — a preference multiplier cannot promote a candidate above one that
+  satisfies a must-have obligation (the lexicographic guarantee).
+* `optimizer.test.ts` — `excludedReasons` is populated for every filtered candidate.
+* parity test for 3.3 (above).
+* `goldenWeek.test.ts` — the `it.fails` assertion from Phase 0.2 flips to passing. **This
+  is the definition of done for 3.1.**
+
+## Acceptance criteria
+
+- [ ] `getConsecutiveModalityCount` / `getRollingModalityCount` deleted or reduced to a
+      tie-break input
+- [ ] date-aware, role-aware history threaded from both call sites
+- [ ] hard constraints separated from sort keys; rejection reasons named
+- [ ] Phase 0 golden-week event-modality assertion passes
+- [ ] both call sites produce identical rankings for identical input
+- [ ] `Home.tsx` no longer hardcodes `branches.green`
+- [ ] `POLICY_VERSION` bumped
+
+## Risks & rollback
+
+* **This changes recommendations for every user.** It is the most behaviourally
+  significant phase before the sequence planner. Land 3.1 and 3.3 separately, each with
+  its own semantic diff read in review.
+* **Over-correction.** Removing suppression entirely could reintroduce the "tempo trap"
+  Patch 1c was written for. The rolling hard cap is what replaces it — verify against the
+  Phase 0 aggregate bound on same-template streaks, not by intuition.
+* Rollback is per-commit; the constraint layer is additive to the existing filter chain
+  until the multipliers are deleted, so the two can briefly coexist behind a flag.
+
+## Out of scope
+
+Sequence search across days (Phase 5). This phase makes a *single day's* ranking coherent
+and correctly informed; it does not yet optimise the week as a unit.
+
+## Docs to update
+
+* **ADR-0008** — amend §6: the date-less history is fixed; state the real constraint model
+* **ADR-0007** — amend §5/§6: anti-stacking is superseded
+* **ADR-0010** — record the lexicographic priority model as accepted

--- a/docs/plans/phase-3-single-ranking-path.md
+++ b/docs/plans/phase-3-single-ranking-path.md
@@ -44,24 +44,38 @@ steers the plan away from precisely the modality the event requires.
 
 ```ts
 export interface SessionHistoryEntry {
-  date: string;
+  date: string;              // YYYY-MM-DD, Warsaw-local calendar date
   templateId: string;
   modality: Modality;
-  role: SessionRole;
+  role: SessionRole;         // 'anchor' | 'supporting' | 'recovery'
   intensityClass: IntensityClass;
   systemicCost: number;
   lowerBodyCost: number;
 }
 ```
 
+Two definitions the constraints below depend on — state them, do not leave them implied:
+
+**Time model.** `date` is a calendar date, not a timestamp, so "48 hours" is not literally
+checkable. Define the rule in calendar terms: *at least one full clear day between the two
+sessions* (i.e. `dayDiff >= 2`). That is the honest reading of date-only data, and it is
+what the golden-week assertion should test — including the boundary cases `dayDiff === 1`
+(violation) and `dayDiff === 2` (allowed). Do not write "48 h" in the implementation and
+compare dates.
+
+**Key-cycling predicate.** `SessionRole` alone cannot distinguish a key ride from a
+supporting one. Define it explicitly beside the constraint:
+`modality === 'Cycling' && role === 'anchor'`. If that proves too coarse, add an explicit
+key-status field — but do not leave the predicate to each call site to reinvent.
+
 **Explicit constraints** replacing `consecutiveCount >= 2 || rollingCount >= 2`:
 
 | Constraint | Rule |
 |---|---|
-| Quality spacing | ≥ 48 h between two `quality`-role sessions |
+| Quality spacing | ≥ 1 clear day (`dayDiff >= 2`) between two anchor-role sessions |
 | Hard lower-body | no back-to-back sessions with `lowerBodyCost >= 0.6` |
 | Rolling hard cap | ≤ 3 sessions with `systemicCost >= 0.5` in any rolling 7 days |
-| Anchor protection | no heavy lower-body strength within 1 day of a key cycling session |
+| Anchor protection | no heavy lower-body strength within 1 day of a *key cycling session* (predicate above) |
 | Variety | applies **only** among candidates in the same role and modality |
 
 Note the last row: variety is a tie-break between equivalent options, never a reason to
@@ -115,8 +129,15 @@ The two call sites differ (verified):
 Extract `buildOptimizationContext(intent, context, preferences, date)` used by both, and
 delete the fabricated `UserPreferences` literal at `rules.ts:503-509`.
 
-**Test:** given identical inputs, both call sites produce identical `RankedCandidate[]`.
-This is the assertion that keeps them from drifting again.
+**Test — but test the right thing.** Feeding both call sites literally identical inputs
+does not exercise the production difference, since `planner.ts` legitimately supplies
+anchor context that `rules.ts` does not. Split it:
+
+1. `buildOptimizationContext` produces an equivalent normalized context from each call
+   site's own inputs (asserting the *builder* is shared and total).
+2. Given equivalent contexts, `rankCandidates` returns identical `RankedCandidate[]`.
+3. Each call site populates every field the builder requires — including anchor context
+   where applicable — so a future omission is a test failure, not silent divergence.
 
 ### 3.4 — F5: stop assuming tomorrow is green
 

--- a/docs/plans/phase-3-single-ranking-path.md
+++ b/docs/plans/phase-3-single-ranking-path.md
@@ -9,6 +9,25 @@
 
 ---
 
+## Task board
+
+Status legend: `[ ]` not started · `[-]` in progress · `[x]` finished.
+Update the marker on the work-item heading **and** this table in the same commit.
+
+| Task | Status | Summary | Primary files |
+|---|:--:|---|---|
+| 3.1 | `[ ]` | Replace modality anti-stacking with dated, role-aware recovery constraints (F3) | `app/src/engine/optimizer.ts`, `models.ts`, `planner.ts`, `rules.ts` |
+| 3.2 | `[ ]` | Lexicographic ordering: hard filters separated from sort keys; named rejection reasons | `app/src/engine/optimizer.ts` |
+| 3.3 | `[ ]` | One `buildOptimizationContext` shared by both call sites (F4) | `app/src/engine/rules.ts`, `planner.ts` |
+| 3.4 | `[ ]` | Next-day tier selector; stop hardcoding the green branch (F5) | `app/src/components/Home.tsx`, `WeekAheadStrip.tsx`, `app/src/engine/planner.ts` |
+
+**Every task here changes recommendations for existing users.** Phase 0's invariant suite
+must be green and its semantic diff read in review before any of these merge. The
+definition of done for 3.1 is the Phase-0 golden-week assertion flipping from
+`it.fails` to passing.
+
+---
+
 ## Goal
 
 Replace modality-repetition suppression with explicit recovery and role constraints,
@@ -17,7 +36,7 @@ always green.
 
 ---
 
-## 3.1 — F3: replace modality anti-stacking
+## `[ ]` 3.1 — F3: replace modality anti-stacking
 
 ### Why "add a date" is not the fix
 
@@ -81,7 +100,7 @@ key-status field — but do not leave the predicate to each call site to reinven
 Note the last row: variety is a tie-break between equivalent options, never a reason to
 change what kind of session a day gets. That is the distinction the current code loses.
 
-### 3.2 — Lexicographic ordering, not more multipliers
+### `[ ]` 3.2 — Lexicographic ordering, not more multipliers
 
 The present architecture asks one multiplicative score to arbitrate safety,
 periodization, interference, recovery, preference and variety at once. F3 is the proof it
@@ -115,7 +134,7 @@ Rejection reasons must be named and surfaced in `decisionTrace.candidateScores`,
 today records `excludedReasons: []` unconditionally (`rules.ts:530`) — an audit field
 that has never carried data.
 
-### 3.3 — F4: one optimizer invocation
+### `[ ]` 3.3 — F4: one optimizer invocation
 
 The two call sites differ (verified):
 
@@ -139,7 +158,7 @@ anchor context that `rules.ts` does not. Split it:
 3. Each call site populates every field the builder requires — including anchor context
    where applicable — so a future omission is a test failure, not silent divergence.
 
-### 3.4 — F5: stop assuming tomorrow is green
+### `[ ]` 3.4 — F5: stop assuming tomorrow is green
 
 `Home.tsx:332` hardcodes `nextDayPlan.branches.green.recommendation`. ADR-0008 §1
 specifies the user-selected branch; no selector exists, so yellow and red are computed

--- a/docs/plans/phase-3-single-ranking-path.md
+++ b/docs/plans/phase-3-single-ranking-path.md
@@ -82,6 +82,16 @@ what the golden-week assertion should test — including the boundary cases `day
 (violation) and `dayDiff === 2` (allowed). Do not write "48 h" in the implementation and
 compare dates.
 
+**Compute `dayDiff` with the shared Warsaw utility — `app/src/utils/localDate.ts` — and
+nowhere else.** Do not parse dates or do date arithmetic inline in `optimizer.ts` or
+`planner.ts`. This is the project's hardest invariant (ADR-0003, `CLAUDE.md`), and a
+recovery rule is precisely where breaking it does damage: a local `new Date(a) -
+new Date(b)` reads the strings as UTC midnight, so across a Warsaw DST boundary the
+difference is 47 or 49 hours and integer-dividing by 24 silently yields the wrong
+`dayDiff` — turning a violation into a pass on exactly two days a year, in the code that
+decides whether an athlete gets back-to-back hard sessions. If `localDate.ts` lacks a
+`dayDiff` helper, add one there rather than reimplementing it at the call site.
+
 **Key-cycling predicate.** `SessionRole` alone cannot distinguish a key ride from a
 supporting one. Define it explicitly beside the constraint:
 `modality === 'Cycling' && role === 'anchor'`. If that proves too coarse, add an explicit

--- a/docs/plans/phase-3-single-ranking-path.md
+++ b/docs/plans/phase-3-single-ranking-path.md
@@ -2,7 +2,7 @@
 
 * **Status:** Ready — F5 resolution decided 2026-08-08 (see 3.4)
 * **Depends on:** Phase 0 (**hard** — this phase changes ranking behaviour and is
-  unmeasurable without the invariant suite), ADR-0010 from Phase 2
+  unmeasurable without the invariant suite), ADR-0012 from Phase 2
 * **Unlocks:** Phase 5 (sequence search needs a coherent scoring layer to sit on)
 * **Addresses:** F3, F4, F5
 * **Rough effort:** 3–4 days
@@ -184,4 +184,4 @@ and correctly informed; it does not yet optimise the week as a unit.
 
 * **ADR-0008** — amend §6: the date-less history is fixed; state the real constraint model
 * **ADR-0007** — amend §5/§6: anti-stacking is superseded
-* **ADR-0010** — record the lexicographic priority model as accepted
+* **ADR-0012** — record the lexicographic priority model as accepted

--- a/docs/plans/phase-4-objective-credit-v2.md
+++ b/docs/plans/phase-4-objective-credit-v2.md
@@ -125,6 +125,32 @@ populated.
    `CompletedTrainingEvent`s. Deleting aliases without migrating all of them either fails
    to compile or, worse, compiles and silently scores zero coverage. Include a
    compatibility read for persisted profiles written under the old vocabulary.
+
+   **Specify that compatibility read before deleting anything.** Persisted
+   `estimatedStimulus` on stored `CompletedTrainingEvent`s is the one input this change
+   cannot codemod, and records exist in three states — canonical-only, legacy-only, and
+   both (everything `canonicalizeStimulus` has written to date, since it fills both
+   sides). Define one `readStimulusProfile(raw): WorkoutStimulusProfile` at the read
+   boundary and route every consumer through it:
+
+   | Persisted record | Behaviour |
+   |---|---|
+   | Canonical fields present | Use them. **Canonical wins**, unconditionally. |
+   | Legacy only | Convert via the canonical mapping below; do not consult legacy again downstream. |
+   | Both present and disagreeing | Canonical wins, and the divergence is **logged** — it means a writer was missed, and silently preferring one would hide that. |
+   | Neither | `DataState.INVALID`, not a zero profile. A zero profile is indistinguishable from "genuinely no stimulus" and scores zero coverage forever. |
+
+   The canonical mapping is the *identity for the five renamed axes* — this is a rename,
+   not a remodelling — with one exception: the two derived fallbacks
+   (`vo2MaxPower ← surgeRepeatability * 0.8`, `fatigueResistance ← thresholdDevelopment
+   * 0.7`) are **not** part of the mapping, because item 3 deletes them as unjustified. A
+   legacy-only record therefore converts with `vo2MaxPower` and `fatigueResistance`
+   absent, which is honest: those values were never measured, only invented.
+
+   Tests required before the aliases are removed: legacy-only converts correctly;
+   canonical-only passes through; conflicting record resolves canonical **and** logs;
+   empty record yields `INVALID`. Remove the alias fields only once every producer and
+   every consumer named above reads through `readStimulusProfile`.
 2. Type `WeeklyObjective.targetStimulus` as
    `Partial<Record<keyof WorkoutStimulusProfile, number>>` instead of
    `Record<string, number>`, so a typo'd axis is a compile error rather than a silent
@@ -217,9 +243,32 @@ base session cost × delivered dose × measured-response adjustment
 
 Keep the six dimensions — they are a good abstraction. This does **not** require adopting
 TSS/CTL/ATL as ground truth; it requires the existing vectors to respond to duration,
-completion ratio and measured training effect. `DeliveredDose` in `stimulus.ts` already
-has the right shape (`plannedDurationMin`, `completedDurationMin`, `completionRatio`) and
-is unused.
+completion ratio and measured training effect.
+
+**Two of the three factors have an input today; the third does not.** `DeliveredDose` in
+`stimulus.ts` carries `plannedDurationMin`, `completedDurationMin` and `completionRatio`
+— enough for `base × delivered dose`, and nothing at all for the measured-response
+adjustment. Writing the three-factor formula against a two-factor contract is how a term
+ends up quietly evaluating to 1.0 forever, which is the `intensityScale` failure (F17)
+repeated.
+
+So split the work, and do not let the second half block the first:
+
+1. **Duration and completion — now.** Extend the cost function to consume `DeliveredDose`
+   as it stands. This alone fixes the stated defect: a 40-minute and a 3-hour hard ride
+   stop scoring alike.
+2. **Measured response — only once it has a source.** The signal exists upstream
+   (`intensityFromGarmin` already reads Garmin training effect, and 4.3 introduces
+   internal response), but it is not on `DeliveredDose`. Adding the term requires adding
+   the field *and* populating it at every construction site, with `DataState` handling for
+   the sessions that have no measurement — an untracked activity has no training effect,
+   and defaulting it to a neutral value silently reintroduces the dead term.
+
+**Acceptance covers step 1 only**: cost responds monotonically to
+`completedDurationMin` and to `completionRatio`, asserted on the Phase-0 harness. The
+measured-response term is not in this phase's acceptance criteria and must not be written
+into the formula until its input contract exists. The six-dimensional cost vector is
+unchanged throughout.
 
 ---
 

--- a/docs/plans/phase-4-objective-credit-v2.md
+++ b/docs/plans/phase-4-objective-credit-v2.md
@@ -1,7 +1,7 @@
 # Phase 4 — Objective credit V2, and honest load
 
 * **Status:** Ready — derivation-constant decision taken 2026-08-08 (see 4.2)
-* **Depends on:** Phase 0 (hard), Phase 2 (ADR-0010 fixes the credit contract)
+* **Depends on:** Phase 0 (hard), Phase 2 (ADR-0012 fixes the credit contract)
 * **Unlocks:** Phase 5
 * **Addresses:** F7, F8, F12
 * **Rough effort:** 4–5 days
@@ -190,7 +190,7 @@ Sequence search (Phase 5). The evidence hierarchy for interpreting unplanned out
 
 ## Docs to update
 
-* **ADR-0011** (new) — objective credit V2 semantics and the fatigue fusion decision, with
+* **ADR-0014** (new) — objective credit V2 semantics and the fatigue fusion decision, with
   the harness comparison attached
 * **ADR-0006** — amend: strain telemetry interacts with the new credit model
 * `docs/architecture/recommendation-engine.md` — the credit and fatigue sections

--- a/docs/plans/phase-4-objective-credit-v2.md
+++ b/docs/plans/phase-4-objective-credit-v2.md
@@ -1,6 +1,6 @@
 # Phase 4 — Objective credit V2, and honest load
 
-* **Status:** Draft
+* **Status:** Ready — derivation-constant decision taken 2026-08-08 (see 4.2)
 * **Depends on:** Phase 0 (hard), Phase 2 (ADR-0010 fixes the credit contract)
 * **Unlocks:** Phase 5
 * **Addresses:** F7, F8, F12
@@ -92,9 +92,17 @@ populated.
    `Partial<Record<keyof WorkoutStimulusProfile, number>>` instead of
    `Record<string, number>`, so a typo'd axis is a compile error rather than a silent
    zero-coverage objective that can never resolve.
-3. Either justify the `0.8` / `0.7` derivations with a citation or make the templates
-   declare those axes explicitly. Do not carry unexplained coefficients through the
-   cutover.
+3. **Decision (2026-08-08): delete the derived fallbacks; make templates declare the axes
+   explicitly.** `vo2MaxPower` and `fatigueResistance` become required fields that each
+   template states outright, and the `* 0.8` / `* 0.7` derivations in
+   `canonicalizeStimulus` are removed.
+
+   The alternative — find a citation for the coefficients — is the wrong shape of work.
+   No citation can justify a *repository-wide* claim that VO2 stimulus is uniformly 80% of
+   surge stimulus across every template; that relationship varies per session by
+   construction. Making 22 templates each declare two numbers is a couple of hours, removes
+   two unexplained constants permanently, and forces the one person who knows what a given
+   session develops to say so explicitly rather than having it inferred.
 
 ## 4.3 — F12: fatigue, in two separable pieces
 

--- a/docs/plans/phase-4-objective-credit-v2.md
+++ b/docs/plans/phase-4-objective-credit-v2.md
@@ -65,6 +65,16 @@ Implement as per-objective functions behind one interface. Resist collapsing the
 shared formula with per-objective coefficients — that reintroduces F11's uncited-constant
 problem in a new place.
 
+**The input contract must carry the evidence these rules need.** `stimulus.ts`'s
+`DeliveredDose` currently offers only `plannedDurationMin`, `completedDurationMin` and
+`completionRatio`, and `CreditContext` only `modality`/`category`. That cannot express
+effort count, recovery pattern, continued pedalling after efforts, aerobic-load context,
+or event-like context. Either extend the contract to carry them (with
+`stimulusConfidence` marking what is measured vs inferred) **or** narrow the objective
+rules to what the available evidence supports. What must not happen is a credit function
+that silently ignores a factor its own specification names — that is how an unfalsifiable
+formula gets shipped.
+
 ### Shadow mode before cutover
 
 Run V1 and V2 crediting side by side for one iteration, emitting both into the simulation
@@ -86,8 +96,16 @@ Consumers disagree on which vocabulary is authoritative — `optimizer.ts` reads
 only, `stimulus.ts` reads canonical-first. This is masked today only because both are
 populated.
 
-1. Make canonical axes **required**; delete the legacy aliases via a one-shot codemod over
-   `templates.ts` and the catalog.
+1. Make canonical axes **required**; delete the legacy aliases. **Inventory every producer
+   and consumer first** — the codemod is not limited to `templates.ts` and the catalog.
+   Known readers of the legacy vocabulary: `optimizer.ts` (`calculateStimulusBenefit`
+   reads legacy axes exclusively), `microcycle.ts` (`targetStimulus` keys in
+   `generateWeeklyObjectives` and `stimulusCoverage`), `completedTraining.ts`
+   (`ZERO_STIMULUS`), `planner.ts` (`ZERO_STIMULUS`), `stimulus.ts` (canonical-first),
+   plus test fixtures and any persisted `estimatedStimulus` on stored
+   `CompletedTrainingEvent`s. Deleting aliases without migrating all of them either fails
+   to compile or, worse, compiles and silently scores zero coverage. Include a
+   compatibility read for persisted profiles written under the old vocabulary.
 2. Type `WeeklyObjective.targetStimulus` as
    `Partial<Record<keyof WorkoutStimulusProfile, number>>` instead of
    `Record<string, number>`, so a typo'd axis is a compile error rather than a silent
@@ -121,7 +139,14 @@ monotonicity.
 therefore load-bearing and asserted only in a comment (`planner.ts:129`). Out-of-order
 input silently mis-decays.
 
-**Throw on unordered input.** One assertion, one test.
+**Sort, then assert — do not take the dashboard down.** History is external, persisted
+input; a bare `throw` on malformed ordering turns a data problem into an outage. The
+boundary behaviour: validate and deterministically sort at ingestion
+(`buildTrainingHistorySnapshot`), and have `buildFatigueStateFromHistory` assert the
+invariant it relies on. If the assertion ever fires in production it is a programming
+error, not bad data — but the caller still degrades to the established controlled state
+(ADR-0010's `INVALID` path) rather than crashing. Add a recommendation-path test for
+malformed ordering, not just a unit test on the function.
 
 ### (b) Modelling — do not pre-decide
 
@@ -141,6 +166,25 @@ before committing to one — and record the comparison in an ADR, with the data.
 
 This is deliberately slower than picking a formula. It is the process F11 asks for, and
 this phase is the first opportunity to actually follow it.
+
+## 4.5 — `PlannedDose`: give `intensityScale` its consumer (D2)
+
+**This is the work item that discharges D2 and F17.** Phase 2 decided `intensityScale`
+gets a consumer rather than being deleted; without an owning work item that commitment is
+prose, which is the exact failure mode this review criticises.
+
+1. Replace the scalar `plannedDose` (`trainingIntent.ts:80`) with
+   `PlannedDose { volume, intensity }`.
+2. `volume` derives from `PlanBlock.volumeScale` (current behaviour, unchanged).
+3. `intensity` derives from `PlanBlock.intensityScale` and gates which intensity-class
+   candidates are admissible, so a taper can hold intensity while cutting volume.
+4. `Recommendation.plannedDose` and the persisted audit carry both components.
+5. `resolveExecutionDose` (`dose.ts`) intersects `volume` with the clinical ceiling as
+   today; `intensity` is a separate admissibility gate, not a second ceiling on duration.
+
+**Acceptance:** `intensityScale` has at least one reader; a taper block with
+`volumeScale` down and `intensityScale` held produces shorter sessions at retained
+intensity class, asserted in the Phase-0 harness.
 
 ## 4.4 — Dose-sensitive cost
 
@@ -171,6 +215,9 @@ is unused.
 - [ ] unsaturated latent external-load state retained
 - [ ] fusion function **not** changed without a recorded harness comparison
 - [ ] cost responds to duration and completion ratio
+- [ ] `PlannedDose { volume, intensity }` exists and `intensityScale` has a reader (D2/F17)
+- [ ] credit input contract carries the evidence the objective rules name, or the rules are narrowed
+- [ ] history ordering is validated/sorted at ingestion; malformed order degrades, not crashes
 - [ ] `POLICY_VERSION` bumped
 
 ## Risks & rollback

--- a/docs/plans/phase-4-objective-credit-v2.md
+++ b/docs/plans/phase-4-objective-credit-v2.md
@@ -1,0 +1,188 @@
+# Phase 4 — Objective credit V2, and honest load
+
+* **Status:** Draft
+* **Depends on:** Phase 0 (hard), Phase 2 (ADR-0010 fixes the credit contract)
+* **Unlocks:** Phase 5
+* **Addresses:** F7, F8, F12
+* **Rough effort:** 4–5 days
+
+---
+
+## Goal
+
+Collapse three objective-credit models into one dose-sensitive model, finish the stimulus
+vocabulary rename, and make delivered load respond to what was actually done — without
+inventing constants the repository cannot justify.
+
+---
+
+## 4.1 — F7: one credit model
+
+Today there are three:
+
+| Model | Location | Status |
+|---|---|---|
+| Keyword substring on free text | `microcycle.ts:110-141` | live (fallback) |
+| Stimulus-vector coverage ≥ 0.6 | `microcycle.ts:198-213` | live (primary) |
+| Fractional dose-sensitive credit | `stimulus.ts:26-99` | **dead** |
+
+The keyword matcher is directionally wrong, not merely approximate: `zone2_aerobic`
+matches any type containing `running` or `cycling`, so a threshold ride credits Zone 2;
+`threshold_quality` matches `hard` or `tempo`. Phase 1.2 already establishes that it must
+not become the Garmin path.
+
+**Target:** `deriveObjectiveCredit` becomes authoritative, with `requiredCredit` /
+`completedCredit` / `projectedCredit` / `windowStart` / `windowEnd` / `priority` — all
+already declared in `models.ts` and all unused — carrying real values from Phase 2's
+`PlanDefinition`.
+
+### Fix `deriveObjectiveCredit` before promoting it
+
+Two defects in the current scaffolding:
+
+1. `qualifies: earnedCredit > 0` conflates *"not permitted"* with *"contributed nothing"*.
+   A session that passes every qualification gate but scores zero stimulus reports
+   `qualifies: false`. Separate the two: `qualifies` reflects the gates only;
+   `earnedCredit` reflects the dose.
+2. `default: rawStimulusContribution = 0.5` silently grants half credit for any
+   unrecognised objective key. Make it `0` and log, or make the switch exhaustive over
+   `ObjectiveKey` so the compiler catches a missing arm.
+
+### Objective-specific dose semantics
+
+A single generic formula is not appropriate — 15 abbreviated minutes should not equal a
+75-minute race-specific ride because each "counts once".
+
+| Objective | Credit should depend primarily on |
+|---|---|
+| `zone2_aerobic` | meaningful aerobic minutes |
+| `threshold_quality` | accumulated work near threshold — `2×8`, `4×8`, `3×12` are not equivalent |
+| `surge_repeatability` | effort count, duration, recovery pattern, and whether performed under aerobic load |
+| `race_specific_endurance` | duration, fatigue resistance, continued pedalling after efforts, event-like context |
+| `strength_maintenance` | useful sets and movement exposure at relative intensity, not elapsed time |
+
+Implement as per-objective functions behind one interface. Resist collapsing them into a
+shared formula with per-objective coefficients — that reintroduces F11's uncited-constant
+problem in a new place.
+
+### Shadow mode before cutover
+
+Run V1 and V2 crediting side by side for one iteration, emitting both into the simulation
+report. Compare objective-resolution counts per scenario. Cut over only when the
+divergence is explainable — not merely when V2 runs without throwing.
+
+## 4.2 — F8: finish the stimulus rename
+
+`WorkoutStimulusProfile` carries 7 canonical + 5 legacy axes, **all optional**.
+`canonicalizeStimulus` (`templates.ts:575-590`) fills both sides and invents two
+derivations with no cited basis:
+
+```ts
+vo2MaxPower:       s.vo2MaxPower       ?? (s.surgeRepeatability   ? s.surgeRepeatability   * 0.8 : 0),
+fatigueResistance: s.fatigueResistance ?? (s.thresholdDevelopment ? s.thresholdDevelopment * 0.7 : 0),
+```
+
+Consumers disagree on which vocabulary is authoritative — `optimizer.ts` reads legacy
+only, `stimulus.ts` reads canonical-first. This is masked today only because both are
+populated.
+
+1. Make canonical axes **required**; delete the legacy aliases via a one-shot codemod over
+   `templates.ts` and the catalog.
+2. Type `WeeklyObjective.targetStimulus` as
+   `Partial<Record<keyof WorkoutStimulusProfile, number>>` instead of
+   `Record<string, number>`, so a typo'd axis is a compile error rather than a silent
+   zero-coverage objective that can never resolve.
+3. Either justify the `0.8` / `0.7` derivations with a citation or make the templates
+   declare those axes explicitly. Do not carry unexplained coefficients through the
+   cutover.
+
+## 4.3 — F12: fatigue, in two separable pieces
+
+**This section was revised after PR #5 review.** An earlier draft prescribed
+`1 - exp(-x)` saturation plus a weighted external/internal combination. That is withdrawn:
+it was not justified by anything in the review, and it is the exact practice F11
+criticises. It may also be wrong — internal response (HRV/RHR/soreness) is partly a
+*reaction to* the same external work, so a weighted sum double-counts load unless
+calibrated, and `1 - exp(-x)` changes the state's scale and meaning, not just its
+monotonicity.
+
+### (a) Correctness — do now, no modelling judgement required
+
+`buildFatigueStateFromHistory` seeds from `history[0].date`, and
+`applyCompletedSessionLoad` floors `elapsedHours` at 0. Oldest-to-newest ordering is
+therefore load-bearing and asserted only in a comment (`planner.ts:129`). Out-of-order
+input silently mis-decays.
+
+**Throw on unordered input.** One assertion, one test.
+
+### (b) Modelling — do not pre-decide
+
+Two real questions:
+
+* **Saturation.** `Math.min(1, ...)` per axis (`fatigue.ts:104-111`) means two hard
+  lower-body days ≈ one, at the ceiling. The model cannot represent "significantly deeper
+  in the hole".
+* **Fusion.** `combinedFatigue = max(external, internal)` lets a bad night fully *mask*
+  accumulated external load, and vice versa.
+
+**Approach:** retain an unsaturated latent external-load state so depth is not discarded
+at accumulation time, keeping the clamped value only as a presentation/ranking projection.
+That is a strictly information-preserving change and can land independently. Then use the
+Phase 0 harness to **compare** candidate fusion functions against the coaching invariants
+before committing to one — and record the comparison in an ADR, with the data.
+
+This is deliberately slower than picking a formula. It is the process F11 asks for, and
+this phase is the first opportunity to actually follow it.
+
+## 4.4 — Dose-sensitive cost
+
+`DEFAULT_COST_BY_MODALITY[modality][intensity]` returns a fixed vector; duration has
+almost no authority, so a 40-minute hard ride and a 3-hour hard ride score nearly
+identically. Move toward:
+
+```text
+base session cost × delivered dose × measured-response adjustment
+```
+
+Keep the six dimensions — they are a good abstraction. This does **not** require adopting
+TSS/CTL/ATL as ground truth; it requires the existing vectors to respond to duration,
+completion ratio and measured training effect. `DeliveredDose` in `stimulus.ts` already
+has the right shape (`plannedDurationMin`, `completedDurationMin`, `completionRatio`) and
+is unused.
+
+---
+
+## Acceptance criteria
+
+- [ ] one credit model live; `updateMicrocycleProgress` demoted to documented last-resort
+      compatibility with a shrinking call surface
+- [ ] `deriveObjectiveCredit`'s `qualifies` and `default` defects fixed before promotion
+- [ ] shadow-mode comparison run and its divergence explained in the PR
+- [ ] canonical stimulus axes required; legacy aliases deleted; `targetStimulus` typed
+- [ ] chronological ordering asserted in `buildFatigueStateFromHistory`
+- [ ] unsaturated latent external-load state retained
+- [ ] fusion function **not** changed without a recorded harness comparison
+- [ ] cost responds to duration and completion ratio
+- [ ] `POLICY_VERSION` bumped
+
+## Risks & rollback
+
+* **Credit-model cutover moves every recommendation.** Shadow mode exists precisely so
+  the divergence is inspected before it ships. Do not skip it to save a day.
+* **The stimulus codemod is wide but mechanical.** Land it separately from the credit
+  change so a bisect can separate a type migration from a behaviour change.
+* **Scope creep into 4.3(b).** If the fusion comparison is not converging, ship 4.3(a) and
+  the latent-state change and leave `max()` in place. A documented open question beats an
+  undocumented guess.
+
+## Out of scope
+
+Sequence search (Phase 5). The evidence hierarchy for interpreting unplanned outdoor work
+(Phase 5) — 4.x improves the vectors, not the inference chain that produces them.
+
+## Docs to update
+
+* **ADR-0011** (new) — objective credit V2 semantics and the fatigue fusion decision, with
+  the harness comparison attached
+* **ADR-0006** — amend: strain telemetry interacts with the new credit model
+* `docs/architecture/recommendation-engine.md` — the credit and fatigue sections

--- a/docs/plans/phase-4-objective-credit-v2.md
+++ b/docs/plans/phase-4-objective-credit-v2.md
@@ -8,6 +8,25 @@
 
 ---
 
+## Task board
+
+Status legend: `[ ]` not started · `[-]` in progress · `[x]` finished.
+Update the marker on the work-item heading **and** this table in the same commit.
+
+| Task | Status | Summary | Primary files |
+|---|:--:|---|---|
+| 4.1 | `[ ]` | One credit model: fix and promote `deriveObjectiveCredit`; shadow-run V1 vs V2 first (F7) | `app/src/engine/stimulus.ts`, `microcycle.ts`, `trainingIntent.ts` |
+| 4.2 | `[ ]` | Canonical stimulus axes required; legacy aliases and derived fallbacks deleted (F8) | `app/src/engine/models.ts`, `templates.ts`, `optimizer.ts`, `microcycle.ts`, `completedTraining.ts`, fixtures |
+| 4.3 | `[ ]` | Fatigue: assert ordering now; **compare** fusion functions before choosing (F12) | `app/src/engine/fatigue.ts`, `trainingHistorySnapshot.ts` |
+| 4.5 | `[ ]` | `PlannedDose { volume, intensity }` — gives `intensityScale` its consumer (D2 / F17) | `app/src/engine/trainingIntent.ts`, `dose.ts`, `models.ts`, `optimizer.ts` |
+| 4.4 | `[ ]` | Cost responds to delivered duration and completion ratio | `app/src/engine/completedTraining.ts`, `fatigue.ts` |
+
+4.5 is numbered after 4.3 but should land **before** 4.4 — 4.4's dose-sensitive cost and
+4.5's `PlannedDose` touch the same call path, and doing 4.4 first means reworking it.
+4.3(b) is deliberately open: do not pick a fusion function without harness data.
+
+---
+
 ## Goal
 
 Collapse three objective-credit models into one dose-sensitive model, finish the stimulus
@@ -16,7 +35,7 @@ inventing constants the repository cannot justify.
 
 ---
 
-## 4.1 — F7: one credit model
+## `[ ]` 4.1 — F7: one credit model
 
 Today there are three:
 
@@ -81,7 +100,7 @@ Run V1 and V2 crediting side by side for one iteration, emitting both into the s
 report. Compare objective-resolution counts per scenario. Cut over only when the
 divergence is explainable — not merely when V2 runs without throwing.
 
-## 4.2 — F8: finish the stimulus rename
+## `[ ]` 4.2 — F8: finish the stimulus rename
 
 `WorkoutStimulusProfile` carries 7 canonical + 5 legacy axes, **all optional**.
 `canonicalizeStimulus` (`templates.ts:575-590`) fills both sides and invents two
@@ -122,7 +141,7 @@ populated.
    two unexplained constants permanently, and forces the one person who knows what a given
    session develops to say so explicitly rather than having it inferred.
 
-## 4.3 — F12: fatigue, in two separable pieces
+## `[ ]` 4.3 — F12: fatigue, in two separable pieces
 
 **This section was revised after PR #5 review.** An earlier draft prescribed
 `1 - exp(-x)` saturation plus a weighted external/internal combination. That is withdrawn:
@@ -167,7 +186,7 @@ before committing to one — and record the comparison in an ADR, with the data.
 This is deliberately slower than picking a formula. It is the process F11 asks for, and
 this phase is the first opportunity to actually follow it.
 
-## 4.5 — `PlannedDose`: give `intensityScale` its consumer (D2)
+## `[ ]` 4.5 — `PlannedDose`: give `intensityScale` its consumer (D2)
 
 **This is the work item that discharges D2 and F17.** Phase 2 decided `intensityScale`
 gets a consumer rather than being deleted; without an owning work item that commitment is
@@ -186,7 +205,7 @@ prose, which is the exact failure mode this review criticises.
 `volumeScale` down and `intensityScale` held produces shorter sessions at retained
 intensity class, asserted in the Phase-0 harness.
 
-## 4.4 — Dose-sensitive cost
+## `[ ]` 4.4 — Dose-sensitive cost
 
 `DEFAULT_COST_BY_MODALITY[modality][intensity]` returns a fixed vector; duration has
 almost no authority, so a 40-minute hard ride and a 3-hour hard ride score nearly

--- a/docs/plans/phase-4-objective-credit-v2.md
+++ b/docs/plans/phase-4-objective-credit-v2.md
@@ -41,9 +41,9 @@ Today there are three:
 
 | Model | Location | Status |
 |---|---|---|
-| Keyword substring on free text | `microcycle.ts:110-141` | live (fallback) |
-| Stimulus-vector coverage ≥ 0.6 | `microcycle.ts:198-213` | live (primary) |
-| Fractional dose-sensitive credit | `stimulus.ts:26-99` | **dead** |
+| Keyword substring on free text | `microcycle.ts` `updateMicrocycleProgress` | live (fallback) |
+| Stimulus-vector coverage ≥ 0.6 | `microcycle.ts` `creditObjectivesFromStimulus` | live (primary) |
+| Fractional dose-sensitive credit | `stimulus.ts` `deriveObjectiveCredit` | **dead** |
 
 The keyword matcher is directionally wrong, not merely approximate: `zone2_aerobic`
 matches any type containing `running` or `cycling`, so a threshold ride credits Zone 2;
@@ -103,7 +103,7 @@ divergence is explainable — not merely when V2 runs without throwing.
 ## `[ ]` 4.2 — F8: finish the stimulus rename
 
 `WorkoutStimulusProfile` carries 7 canonical + 5 legacy axes, **all optional**.
-`canonicalizeStimulus` (`templates.ts:575-590`) fills both sides and invents two
+`canonicalizeStimulus` (`templates.ts` `canonicalizeStimulus`) fills both sides and invents two
 derivations with no cited basis:
 
 ```ts
@@ -155,7 +155,7 @@ monotonicity.
 
 `buildFatigueStateFromHistory` seeds from `history[0].date`, and
 `applyCompletedSessionLoad` floors `elapsedHours` at 0. Oldest-to-newest ordering is
-therefore load-bearing and asserted only in a comment (`planner.ts:129`). Out-of-order
+therefore load-bearing and asserted only in a comment on `projectTrailingHistory`. Out-of-order
 input silently mis-decays.
 
 **Sort, then assert — do not take the dashboard down.** History is external, persisted
@@ -171,7 +171,7 @@ malformed ordering, not just a unit test on the function.
 
 Two real questions:
 
-* **Saturation.** `Math.min(1, ...)` per axis (`fatigue.ts:104-111`) means two hard
+* **Saturation.** `Math.min(1, ...)` per axis (`applyCompletedSessionLoad`) means two hard
   lower-body days ≈ one, at the ceiling. The model cannot represent "significantly deeper
   in the hole".
 * **Fusion.** `combinedFatigue = max(external, internal)` lets a bad night fully *mask*
@@ -192,7 +192,7 @@ this phase is the first opportunity to actually follow it.
 gets a consumer rather than being deleted; without an owning work item that commitment is
 prose, which is the exact failure mode this review criticises.
 
-1. Replace the scalar `plannedDose` (`trainingIntent.ts:80`) with
+1. Replace the scalar `plannedDose` (`resolveTrainingIntent`) with
    `PlannedDose { volume, intensity }`.
 2. `volume` derives from `PlanBlock.volumeScale` (current behaviour, unchanged).
 3. `intensity` derives from `PlanBlock.intensityScale` and gates which intensity-class

--- a/docs/plans/phase-5-sequence-planning.md
+++ b/docs/plans/phase-5-sequence-planning.md
@@ -213,6 +213,6 @@ event-specific freshness* rather than arriving as an emergent side effect.
 
 ## Docs to update
 
-* **ADR-0012** (new) — sequence planning and the session-role model
+* **ADR-0015** (new) — sequence planning and the session-role model
 * **ADR-0008** — superseded in part: the greedy projected loop is replaced
 * `docs/architecture/recommendation-engine.md` — the planner section

--- a/docs/plans/phase-5-sequence-planning.md
+++ b/docs/plans/phase-5-sequence-planning.md
@@ -1,6 +1,6 @@
 # Phase 5 — Sequence planning, real inputs, and the feedback loop
 
-* **Status:** Draft — the destination, not the next thing to build
+* **Status:** Ready — approved as the destination; increments ordered below. Not the next thing to build.
 * **Depends on:** Phases 0–4
 * **Addresses:** the V2 Plan Intent cutover proper
 * **Rough effort:** multi-week; ship as independent increments, not one landing
@@ -13,6 +13,28 @@ Replace greedy day-by-day projection with bounded sequence search over the plann
 horizon, give the planner the real-world inputs it currently lacks (fixed activities,
 local tissue state), and close the loop so completed training updates achieved stimulus
 as well as incurred cost.
+
+## Increment order (decided 2026-08-08)
+
+Approved as the destination, but explicitly **not** as one landing. Ship in this order —
+value-per-risk descending, with the deepest and least certain change last:
+
+| # | Increment | Why here |
+|---|---|---|
+| 1 | **5.3 fixed activities** | Highest value per effort, zero dependency on the search work. A planner that doesn't know about Wednesday football is wrong every Wednesday. |
+| 2 | **5.4 local tissue state** | Builds directly on Phase 1.1's `BodyRegion` model; independently useful the day it ships. |
+| 3 | **5.5 evidence hierarchy** | Generalises Phase 1.2's coarse inference; needs `stimulusConfidence`, which Phase 1.2(c) already adds. |
+| 4 | **5.7 taper as explicit contract** | Needs Phase 2's `PlanDefinition` and Phase 4.4's `PlannedDose.intensity`; small once both exist. |
+| 5 | **5.6 multi-event** | Needs explicit objectives and session roles to express cleanly. |
+| 6 | **5.2 planning candidate** | Prerequisite refactor for 5.1; do it immediately before, not months earlier. |
+| 7 | **5.1 bounded sequence search** | The deep change, and the only one whose benefit is genuinely uncertain. Last, so everything it depends on is settled. |
+
+**The one thing not pre-approved: adopting beam search.** Approving this plan approves
+*building and measuring* 5.1, not shipping it regardless of outcome. Whether sequence
+search beats the greedy loop is an empirical question, and the Phase 0 invariants plus the
+golden week are how it gets answered. If it does not measurably improve them, the correct
+outcome is to record that result and keep the greedy loop — that is a successful
+increment, not a failed one. Increments 1–6 stand on their own either way.
 
 ---
 

--- a/docs/plans/phase-5-sequence-planning.md
+++ b/docs/plans/phase-5-sequence-planning.md
@@ -138,12 +138,41 @@ environment/location, available equipment, and availability override.
 **Storage contract — user-owned, like every other athlete record (ADR-0002).** Path
 `users/{userId}/fixed_activities/{activityId}`, with a `userId` field matching the path
 segment. Extend `app/firestore.rules` following the existing `goals` pattern: read/create
-for the owner, update preserving ownership and `createdAt`, plus document-shape validation
-(bounded string lengths, `date` matching `^[0-9]{4}-[0-9]{2}-[0-9]{2}$`, numeric duration
-≥ 0). Add emulator tests for owner read/write allowed, unauthenticated denied, and
-cross-user denied — the same three cases the recommendation rules already cover. This is high
-practical value for modest effort and does not depend on the search work — **it can land
-before 5.1.**
+for the owner, update preserving ownership and `createdAt`. Add emulator tests for owner
+read/write allowed, unauthenticated denied, and cross-user denied — the same three cases
+the recommendation rules already cover. This is high practical value for modest effort and
+does not depend on the search work — **it can land before 5.1.**
+
+**Validate every field, not just the two easy ones.** Ownership rules stop another
+athlete writing this document; they do nothing about the *owner's own client* writing a
+malformed one, and every field below feeds the planner. An unbounded `expectedCost`
+dimension is a denial-of-service on the athlete's own schedule — one activity that
+saturates the fatigue model empties the week. Validate the whole shape at the rule
+boundary:
+
+| Field | Type | Constraint |
+|---|---|---|
+| `userId` | string | `== userId` path segment |
+| `date` | string | matches `^[0-9]{4}-[0-9]{2}-[0-9]{2}$` (Warsaw-local, ADR-0003) |
+| `durationMin` | number | integer, `> 0` and `<= 1440` |
+| `title` | string | `size() <= 200` |
+| `fixed` | bool | required — movable vs immovable is load-bearing for the search |
+| `expectedStimulus` | map | keys ⊆ the canonical axis set; each value a number in `[0, 1]`; `size() <= 8` |
+| `expectedCost` | map | keys ⊆ the six cost dimensions; each value a number in `[0, 1]`; `size() <= 6` |
+| `environment` | string | member of the `TrainingEnvironment` union |
+| `equipment` | list | `size() <= 20`; every item a string of `size() <= 50` |
+| `availabilityOverride` | map (optional) | numeric minutes in `[0, 1440]` |
+
+Firestore rules cannot iterate a list to type-check its items, so bound `equipment` by
+size and length and enforce item types in the client validator and in
+`validation.ts` on read — say so explicitly rather than leaving a reader to assume the
+rule covers it. Enum membership is checked against a literal list in the rules file; when
+a union gains a member, both change together.
+
+Emulator cases beyond the three ownership ones: out-of-range `durationMin`, an
+`expectedCost` value above 1, an unknown `environment`, an oversized `equipment` list,
+and a malformed `date`. Each must be **denied** — these are the cases a buggy or
+tampered client actually produces.
 
 ## `[ ]` 5.4 — Local tissue state
 
@@ -203,6 +232,36 @@ supply race-specific exposure without capturing the macrocycle.
 
 Explicit objectives and session roles express this far more naturally than one blended
 demand vector, which is why it sits after Phase 2.
+
+**Both halves need a total order, or this is less deterministic than what it replaces.**
+Today's single-governing-event rule is at least decidable. "One authority, multiple
+contributors" is not, until three things are stated — and an undecided tie here means two
+runs of the planner taper to different dates.
+
+*Taper authority.* Sort candidate events by, in order: (1) priority — `A` before `B`
+before `C`; (2) proximity — fewer days to `planningDate` first; (3) `planningDate`
+ascending; (4) event `id` lexicographically. The last is not a real criterion, it is a
+determinism backstop, and it should be commented as such. Take the first. Two A-events on
+the same day is a planning error, not something to blend — surface it, do not average it.
+Only the taper authority sets `volumeScale`/`intensityScale`; contributors never do.
+
+*Demand aggregation.* A contributor supplies race-specific **objectives**, not a blended
+demand vector — that is the point of doing this after Phase 2. Union the objectives of all
+events within their contribution windows, keyed by `ObjectiveKey`. Where two events
+contribute the same key, take `max(requiredCredit)`; do not sum, or two similar B-events
+would demand double the work of one. An objective from the taper authority outranks a
+contributor's objective of the same key on any other field.
+
+*Conflicts.* If a contributor's objective is inadmissible under the taper authority's
+current block — a `threshold_quality` requirement landing inside race week — the taper
+authority wins and the contributor objective is **dropped with a recorded reason** in the
+audit, not silently reweighted. An athlete who can see "your B-event's threshold session
+was dropped because it fell in A-event race week" can act on it; a quietly reweighted plan
+teaches them nothing.
+
+Tests before 5.6 is executable: priority tie broken by proximity; proximity tie broken by
+date then id; two contributors sharing an objective key resolving to `max`, not sum; a
+contributor objective inside race week dropped with its reason present in the audit.
 
 ## `[ ]` 5.7 — Taper as an explicit contract
 

--- a/docs/plans/phase-5-sequence-planning.md
+++ b/docs/plans/phase-5-sequence-planning.md
@@ -1,0 +1,196 @@
+# Phase 5 — Sequence planning, real inputs, and the feedback loop
+
+* **Status:** Draft — the destination, not the next thing to build
+* **Depends on:** Phases 0–4
+* **Addresses:** the V2 Plan Intent cutover proper
+* **Rough effort:** multi-week; ship as independent increments, not one landing
+
+---
+
+## Goal
+
+Replace greedy day-by-day projection with bounded sequence search over the planning
+horizon, give the planner the real-world inputs it currently lacks (fixed activities,
+local tissue state), and close the loop so completed training updates achieved stimulus
+as well as incurred cost.
+
+---
+
+## 5.1 — Bounded sequence search
+
+`generateWeekAheadPlan` walks one day at a time, greedily. To compensate, the optimizer
+accumulated six named policies (anti-stacking, post-objective strength suppression,
+intensity stacking, event modality, aerobic filler, anchor boosts, anchor adjacency,
+variety tie-break). Each is individually defensible; together they encode sequence
+planning as interactions between weights, which is why "why is this the best week?" has
+no answerable form today.
+
+A 7-day horizon does not justify heavy machinery. **Beam search is sufficient:**
+
+```text
+beam width:        10-20
+horizon:           7 days
+candidates/day:    small constrained set of session roles
+reject:            hard spacing/recovery violations, before scoring
+score:             the whole partial sequence, not the marginal day
+```
+
+The planner can then prefer
+
+```text
+Tue threshold / Thu easy aerobic / Sat race-specific
+```
+
+over
+
+```text
+Tue threshold / Wed threshold / Thu rest / Fri race-specific
+```
+
+even when Wednesday's threshold looked better in isolation — which is the class of
+judgement the current architecture structurally cannot make.
+
+Prerequisite: Phase 3's lexicographic layer. Search needs hard constraints separated from
+sort keys; it cannot operate on a single blended multiplier.
+
+## 5.2 — Move the planner/workout-library boundary
+
+Detailed `WorkoutDefinition`s already carry recovery hours, mechanical and eccentric load,
+coordination demand, technical environment, contraindications, and minimum spacing after
+hard lower-body work. The planner selects a coarse `SessionTemplate` first, so this
+metadata arrives *after* the decision it should inform.
+
+Introduce a derived planning candidate — enough semantics to sequence a week, without
+dragging every workout step into the planner:
+
+```ts
+interface PlanningCandidate {
+  workoutId: string;
+  sessionRole: SessionRole;
+  modality: Modality;
+  durationRange: { min: number; default: number; max: number };
+  stimulus: WorkoutStimulusProfile;
+  cost: WorkoutCostProfile;
+  recoveryHours: number;
+  minimumDaysAfterHardLowerBody?: number;
+  equipment: Equipment[];
+  environment: TrainingEnvironment[];
+  contraindications: string[];
+}
+```
+
+Prescription generation stays downstream and unchanged.
+
+## 5.3 — Persist fixed activities
+
+`FixedActivity` exists in the domain and `WeekAheadOptions.fixedActivities` accepts it,
+but there is no Firestore-backed source (ADR-0008 §5 admits this). For a multi-sport
+planner it is a first-order gap: Wednesday football *is* training; travel changes
+equipment and availability; a booked session should shape the days on either side of it.
+
+Persist per activity: date, duration, expected stimulus, expected cost, fixed vs movable,
+environment/location, available equipment, and availability override. This is high
+practical value for modest effort and does not depend on the search work — **it can land
+before 5.1.**
+
+## 5.4 — Local tissue state
+
+One scalar soreness value cannot distinguish knee from Achilles from calf from adductor
+from general DOMS. Extend the check-in to per-region response (morning state, pain during
+training, after-training state, next-morning reaction), and let observed tissue response
+override wearable-derived readiness where relevant.
+
+**Sequencing note:** this builds directly on Phase 1.1's `BodyRegion` /
+`InjuryConstraint` model. Doing it before Phase 1 would add a tissue layer on top of a
+disconnected injury gate — richer input feeding a channel that is not consulted. Phase 1
+first, always.
+
+Fatigue estimates remain guidance; observed local response gets higher authority.
+
+## 5.5 — Evidence hierarchy for completed training
+
+Phase 1.2 ships a coarse modality×intensity stimulus inference. This generalises it:
+
+```text
+exact prescribed-workout match
+        ↓
+completed structured workout details
+        ↓
+power / HR / cadence / interval structure
+        ↓
+Garmin aerobic + anaerobic Training Effect
+        ↓
+duration + intensity
+        ↓
+athlete classification
+        ↓
+generic modality fallback
+```
+
+Every inferred profile carries confidence — the `stimulusConfidence` field added in Phase
+1.2(c) is the hook. The model does not need to be physiologically precise; it needs to be
+materially better than treating meaningful unplanned training as adaptation-neutral.
+
+The asymmetry this closes: today the system sees **cost** from an unplanned hard group
+ride but not **benefit**, so it can prescribe work that was effectively already done.
+
+## 5.6 — Multi-event: separate taper authority from demand contribution
+
+`evaluatePeriodizationPhase` picks one governing event by priority then proximity. A more
+realistic model is **one taper authority, multiple demand contributors**: an A-event 70
+days out and a B-event 12 days out should let the B-event replace one quality session and
+supply race-specific exposure without capturing the macrocycle.
+
+Explicit objectives and session roles express this far more naturally than one blended
+demand vector, which is why it sits after Phase 2.
+
+## 5.7 — Taper as an explicit contract
+
+Taper behaviour currently emerges from interactions between `volumeScale`, objective
+generation, template `phaseEligibility` and utility ranking. `event-plan.ts` already names
+the real roles — taper sharpening, pre-race openers, race-week strength, race day. Use
+them, so taper directly expresses *reduce volume, preserve useful intensity and
+event-specific freshness* rather than arriving as an emergent side effect.
+
+---
+
+## Acceptance criteria
+
+- [ ] beam search replaces the greedy projected loop; hard constraints reject before scoring
+- [ ] a full week is scored as a sequence, and the chosen week is explainable
+- [ ] `PlanningCandidate` carries spacing/recovery metadata into the decision
+- [ ] fixed activities persist and affect availability and adjacent days
+- [ ] per-region tissue state constrains mechanical work independently of wearable readiness
+- [ ] inferred stimulus carries confidence and uses the strongest available evidence
+- [ ] taper roles come from the plan, not from weight interactions
+- [ ] Phase 0 invariants hold throughout; each increment's semantic diff explained
+
+## Risks & rollback
+
+* **Biggest risk is doing it all at once.** 5.3 and 5.4 are independently valuable and
+  should land first. 5.1 is the deep change and should be last.
+* **Search may not beat greedy.** This is an empirical question, not a settled one. The
+  Phase 0 invariants and golden week are how it gets answered — if beam search does not
+  measurably improve them, that is a real result and the greedy loop stays.
+* **Beam search cost.** 7 days × small candidate set × beam 10–20 is trivial, but the
+  week-ahead strip recomputes on every dashboard load (ADR-0008 §3). Measure before
+  shipping; memoise the pre-pass if needed.
+
+## Explicitly not in this plan
+
+* **No LLM in session selection.** The problem is insufficiently explicit planning
+  semantics, not insufficient text reasoning.
+* **No ML-tuned optimizer coefficients.** That optimises the current architecture instead
+  of fixing it.
+* **No further `Patch 7/8/9` multipliers** unless as a temporary safety fix with a removal
+  date.
+* **No full TSS/CTL/ATL system.** Load estimation needs work, but the planning abstraction
+  is the bottleneck.
+* **No large workout-catalogue or event-preset expansion.** The catalogue is already
+  richer than the planner can exploit (F16); more content does not solve sequencing.
+
+## Docs to update
+
+* **ADR-0012** (new) — sequence planning and the session-role model
+* **ADR-0008** — superseded in part: the greedy projected loop is replaced
+* `docs/architecture/recommendation-engine.md` — the planner section

--- a/docs/plans/phase-5-sequence-planning.md
+++ b/docs/plans/phase-5-sequence-planning.md
@@ -7,6 +7,28 @@
 
 ---
 
+## Task board
+
+Status legend: `[ ]` not started · `[-]` in progress · `[x]` finished.
+Update the marker on the work-item heading **and** this table in the same commit.
+
+Ordered by the increment sequence below, **not** by section number.
+
+| Order | Task | Status | Summary | Primary files |
+|:--:|---|:--:|---|---|
+| 1 | 5.3 | `[ ]` | Persist `FixedActivity` under a user-owned path with rules + emulator tests | `app/firestore.rules`, new `fixedActivityService.ts`, `app/src/engine/schedule.ts`, `planner.ts` |
+| 2 | 5.4 | `[ ]` | Per-region tissue state; may only tighten a Phase-1 injury constraint | `app/src/engine/models.ts`, `components/DailyCheckin.tsx`, `injuryPolicy.ts` |
+| 3 | 5.5 | `[ ]` | Evidence hierarchy for completed training, carrying `stimulusConfidence` | `app/src/engine/completedTraining.ts` |
+| 4 | 5.7 | `[ ]` | Taper as an explicit plan contract rather than an emergent side effect | `app/src/workouts/event-plan.ts`, `app/src/engine/periodization.ts` |
+| 5 | 5.6 | `[ ]` | Multi-event: one taper authority, multiple demand contributors | `app/src/engine/periodization.ts` |
+| 6 | 5.2 | `[ ]` | `PlanningCandidate` carries spacing/recovery metadata into the decision | `app/src/workouts/models.ts`, `app/src/engine/planner.ts` |
+| 7 | 5.1 | `[ ]` | Bounded sequence search — **build and measure**, adoption conditional (D-BEAM) | `app/src/engine/planner.ts` |
+
+**5.1 is an experiment, not a scheduled migration.** Marking it `[x]` requires a recorded
+adoption decision with harness data — retaining the greedy loop is a valid completion.
+
+---
+
 ## Goal
 
 Replace greedy day-by-day projection with bounded sequence search over the planning
@@ -38,7 +60,7 @@ increment, not a failed one. Increments 1–6 stand on their own either way.
 
 ---
 
-## 5.1 — Bounded sequence search
+## `[ ]` 5.1 — Bounded sequence search
 
 `generateWeekAheadPlan` walks one day at a time, greedily. To compensate, the optimizer
 accumulated six named policies (anti-stacking, post-objective strength suppression,
@@ -75,7 +97,7 @@ judgement the current architecture structurally cannot make.
 Prerequisite: Phase 3's lexicographic layer. Search needs hard constraints separated from
 sort keys; it cannot operate on a single blended multiplier.
 
-## 5.2 — Move the planner/workout-library boundary
+## `[ ]` 5.2 — Move the planner/workout-library boundary
 
 Detailed `WorkoutDefinition`s already carry recovery hours, mechanical and eccentric load,
 coordination demand, technical environment, contraindications, and minimum spacing after
@@ -103,7 +125,7 @@ interface PlanningCandidate {
 
 Prescription generation stays downstream and unchanged.
 
-## 5.3 — Persist fixed activities
+## `[ ]` 5.3 — Persist fixed activities
 
 `FixedActivity` exists in the domain and `WeekAheadOptions.fixedActivities` accepts it,
 but there is no Firestore-backed source (ADR-0008 §5 admits this). For a multi-sport
@@ -123,7 +145,7 @@ cross-user denied — the same three cases the recommendation rules already cove
 practical value for modest effort and does not depend on the search work — **it can land
 before 5.1.**
 
-## 5.4 — Local tissue state
+## `[ ]` 5.4 — Local tissue state
 
 One scalar soreness value cannot distinguish knee from Achilles from calf from adductor
 from general DOMS. Extend the check-in to per-region response (morning state, pain during
@@ -145,7 +167,7 @@ wearable-derived readiness (may tighten). Test all three pairwise conflicts.
 Fatigue estimates remain guidance; observed local response outranks *wearable* readiness,
 not the injury gate.
 
-## 5.5 — Evidence hierarchy for completed training
+## `[ ]` 5.5 — Evidence hierarchy for completed training
 
 Phase 1.2 ships a coarse modality×intensity stimulus inference. This generalises it:
 
@@ -172,7 +194,7 @@ materially better than treating meaningful unplanned training as adaptation-neut
 The asymmetry this closes: today the system sees **cost** from an unplanned hard group
 ride but not **benefit**, so it can prescribe work that was effectively already done.
 
-## 5.6 — Multi-event: separate taper authority from demand contribution
+## `[ ]` 5.6 — Multi-event: separate taper authority from demand contribution
 
 `evaluatePeriodizationPhase` picks one governing event by priority then proximity. A more
 realistic model is **one taper authority, multiple demand contributors**: an A-event 70
@@ -182,7 +204,7 @@ supply race-specific exposure without capturing the macrocycle.
 Explicit objectives and session roles express this far more naturally than one blended
 demand vector, which is why it sits after Phase 2.
 
-## 5.7 — Taper as an explicit contract
+## `[ ]` 5.7 — Taper as an explicit contract
 
 Taper behaviour currently emerges from interactions between `volumeScale`, objective
 generation, template `phaseEligibility` and utility ranking. `event-plan.ts` already names

--- a/docs/plans/phase-5-sequence-planning.md
+++ b/docs/plans/phase-5-sequence-planning.md
@@ -111,7 +111,15 @@ planner it is a first-order gap: Wednesday football *is* training; travel change
 equipment and availability; a booked session should shape the days on either side of it.
 
 Persist per activity: date, duration, expected stimulus, expected cost, fixed vs movable,
-environment/location, available equipment, and availability override. This is high
+environment/location, available equipment, and availability override.
+
+**Storage contract — user-owned, like every other athlete record (ADR-0002).** Path
+`users/{userId}/fixed_activities/{activityId}`, with a `userId` field matching the path
+segment. Extend `app/firestore.rules` following the existing `goals` pattern: read/create
+for the owner, update preserving ownership and `createdAt`, plus document-shape validation
+(bounded string lengths, `date` matching `^[0-9]{4}-[0-9]{2}-[0-9]{2}$`, numeric duration
+≥ 0). Add emulator tests for owner read/write allowed, unauthenticated denied, and
+cross-user denied — the same three cases the recommendation rules already cover. This is high
 practical value for modest effort and does not depend on the search work — **it can land
 before 5.1.**
 
@@ -127,7 +135,15 @@ override wearable-derived readiness where relevant.
 disconnected injury gate — richer input feeding a channel that is not consulted. Phase 1
 first, always.
 
-Fatigue estimates remain guidance; observed local response gets higher authority.
+**Precedence against Phase 1 injury constraints — state it, do not leave it to reading.**
+Tissue feedback may only *preserve or tighten* an active `InjuryConstraint`; it can never
+weaken or clear an `exclude` or `limit`. A green knee reading does not unlock running
+while an `exclude` knee constraint is active — only editing the constraint does that.
+Ordering: `InjuryConstraint` (hard) → observed tissue response (may tighten) →
+wearable-derived readiness (may tighten). Test all three pairwise conflicts.
+
+Fatigue estimates remain guidance; observed local response outranks *wearable* readiness,
+not the injury gate.
 
 ## 5.5 — Evidence hierarchy for completed training
 
@@ -178,8 +194,12 @@ event-specific freshness* rather than arriving as an emergent side effect.
 
 ## Acceptance criteria
 
-- [ ] beam search replaces the greedy projected loop; hard constraints reject before scoring
-- [ ] a full week is scored as a sequence, and the chosen week is explainable
+- [ ] a sequence-search prototype exists and is benchmarked against greedy on the Phase-0
+      invariants and semantic harness
+- [ ] an explicit adoption decision is recorded in an ADR, with the comparison data —
+      **either** (a) beam search is promoted, hard constraints reject before scoring, and a
+      full week is scored as a sequence and is explainable; **or** (b) greedy is retained
+      and the negative result is recorded. Both satisfy this criterion.
 - [ ] `PlanningCandidate` carries spacing/recovery metadata into the decision
 - [ ] fixed activities persist and affect availability and adjacent days
 - [ ] per-region tissue state constrains mechanical work independently of wearable readiness


### PR DESCRIPTION
Adds docs/analysis/2026-08-08-architecture-review.md -- a repository-wide
review covering the Python ingestion package, the TypeScript engine, all
nine ADRs, architecture docs, agent guidance and CI.

Headline findings (each verified against the working tree, two confirmed
with throwaway probes):

- UserContext.constraints.injuries is hardcoded empty by the only
  production adapter, so ADR-0007's documented hard injury gate is a
  no-op on both selection paths and across the whole forecast.
- Garmin-measured sessions attach an all-zero stimulus profile, which
  routes them to the vector-coverage credit path and earns them zero
  microcycle credit -- while *unrecognised* activity types fall through
  to the keyword fallback and do get credit.
- RecentHistoryEntry carries no date, so anti-stacking treats array
  adjacency as calendar adjacency, contradicting ADR-0008 section 6; the
  rolling arm also suppresses the third same-modality session in a week
  to 0.15x, which fights the 1.40x A-event boost.
- rules.ts and planner.ts call the optimizer with different context
  (no systemicCost, fabricated preferences), so the intensity-stacking
  guard is live in the forecast but dead for today's prescription.
- Home.tsx hardcodes the green next-day branch; ADR-0008 specifies the
  user-selected branch, and no selector exists.
- daily_recommendations rules pin only createdAt and allow a v3 document
  to be downgraded to v1, dropping its audit -- despite the inline
  comment describing the document as immutable audit evidence.

Also documents three parallel objective-credit models (one dead), the
half-finished stimulus-axis rename, missing ADRs for the weekly-anchor
and decision-provenance layers, a frozen POLICY_VERSION, an engine
architecture doc describing a mode hierarchy that no longer exists, and
a frontend test suite that cannot run without Firebase env vars.

Closes with a six-phase remediation plan ordered by consequence.

Also fixes docs/README.md: ADR-0009 was missing from the index.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HNpyhhjdSgRmLkidyLEdq7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded the documentation index with new architecture decisions, reviews, and implementation plans.
  - Updated Recommendation Engine documentation with selection paths, scoring, modes, ranking, and multi-day planning.
  - Added guidance for decision provenance, audit replay, weekly planning anchors, and architecture governance.
  - Published phased plans covering safety, planning intent, ranking consistency, objective credit, fatigue modeling, testing, and sequence planning.
  - Clarified plan statuses, dependencies, acceptance criteria, historical references, and implementation standards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->