### PR TITLE
Phase 2 — Plan intent is the planning authority (ADR-0012, PlanDefinition, EventTiming, Envelope Extraction)

### DIFF
--- a/app/src/engine/architecture.test.ts
+++ b/app/src/engine/architecture.test.ts
@@ -220,6 +220,33 @@ describe('Architecture & Phased Engine Integration', () => {
             // Blended toward the cycling demand vector, not the flat default base demand
             expect(phase.phase.targetDemandVector.thresholdPower).toBeGreaterThan(0.5);
         });
+
+        // ADR-0012 Task 2.3 (EventTiming) -- goalToUserEvent is the only real production
+        // constructor of UserEvent, so timing must survive that hop unchanged.
+        it('goalToUserEvent carries timing through onto UserEvent when present', () => {
+            const timing = { earliestDate: '2026-09-05', latestDate: '2026-09-20', planningDate: '2026-09-05' };
+            const event = goalToUserEvent({
+                ...baseGoal, targetDate: '2026-09-05', eventCategory: 'cycling_event', timing,
+            });
+            expect(event!.timing).toEqual(timing);
+        });
+
+        it('goalToUserEvent omits timing entirely when the goal has none', () => {
+            const event = goalToUserEvent({ ...baseGoal, targetDate: '2026-09-13', eventCategory: 'cycling_event' });
+            expect(event!.timing).toBeUndefined();
+        });
+
+        it('evaluatePeriodizationPhase anchors on an unconfirmed timing.planningDate rather than the fallback targetDate', () => {
+            // planningDate (earliest possible date) is materially closer than the fallback
+            // targetDate -- if periodization.ts ignored timing, daysToEvent would read 37,
+            // not 10, and the taper/build phase read below would be wrong.
+            const event = goalToUserEvent({
+                ...baseGoal, targetDate: '2026-09-13', eventCategory: 'cycling_event',
+                timing: { earliestDate: '2026-08-17', latestDate: '2026-09-13', planningDate: '2026-08-17' },
+            })!;
+            const phase = evaluatePeriodizationPhase([event], '2026-08-07');
+            expect(phase.daysToEvent).toBe(10);
+        });
     });
 
     describe('Phase 3: Microcycle Objectives', () => {

--- a/app/src/engine/microcycle.test.ts
+++ b/app/src/engine/microcycle.test.ts
@@ -7,7 +7,7 @@ import { evaluatePeriodizationPhase } from './periodization.ts';
 
 describe('updateMicrocycleProgress', () => {
   it('credits controlled field work toward surge repeatability', () => {
-    const microcycle = { weekStartDate: '2026-08-03', objectives: [{ id: 'surges', key: 'surge_repeatability' as const, title: 'Surges', targetExposures: 1, completedExposures: 0, targetStimulus: { surgeRepeatability: 0.9 } }] };
+    const microcycle = { windowStartDate: '2026-08-03', objectives: [{ id: 'surges', key: 'surge_repeatability' as const, title: 'Surges', targetExposures: 1, completedExposures: 0, targetStimulus: { surgeRepeatability: 0.9 } }] };
     const updated = updateMicrocycleProgress(microcycle, { id: 'field-1', title: 'Field Field Maintenance', date: '2026-08-07', durationMin: 40, isCompleted: true });
     expect(updated.objectives.find((objective) => objective.key === 'surge_repeatability')?.completedExposures).toBe(1);
   });
@@ -18,7 +18,7 @@ describe('creditObjectivesFromStimulus (regression: the split-brain ledger bug)'
     aerobicCapacity: 0, thresholdDevelopment: 0, surgeRepeatability: 0, maxStrength: 0, hypertrophy: 0, mobilityRecovery: 0,
   };
   const microcycleWith = (targetStimulus: Record<string, number>): MicrocycleState => ({
-    weekStartDate: '2026-08-03',
+    windowStartDate: '2026-08-03',
     objectives: [{ id: 'obj', key: 'threshold_quality', title: 'Threshold Development', targetExposures: 1, completedExposures: 0, targetStimulus }],
   });
 
@@ -51,7 +51,7 @@ describe('creditObjectivesFromStimulus (regression: the split-brain ledger bug)'
 
   it('never exceeds targetExposures and leaves already-resolved objectives untouched', () => {
     const microcycle: MicrocycleState = {
-      weekStartDate: '2026-08-03',
+      windowStartDate: '2026-08-03',
       objectives: [{ id: 'obj', key: 'threshold_quality', title: 'Threshold Development', targetExposures: 1, completedExposures: 1, targetStimulus: { thresholdDevelopment: 0.9 } }],
     };
     const updated = creditObjectivesFromStimulus(microcycle, { ...zeroStimulus, thresholdDevelopment: 1.0 }, 'Cycling');
@@ -79,7 +79,7 @@ describe('surge_repeatability qualification', () => {
     aerobicCapacity: 0, thresholdDevelopment: 0, surgeRepeatability: 0, maxStrength: 0, hypertrophy: 0, mobilityRecovery: 0,
   };
   const cyclingSurgeObjective = (): MicrocycleState => ({
-    weekStartDate: '2026-08-03',
+    windowStartDate: '2026-08-03',
     objectives: [{
       id: 'obj-surges', key: 'surge_repeatability', title: 'Surges', targetExposures: 1, completedExposures: 0,
       targetStimulus: { surgeRepeatability: 0.9, aerobicCapacity: 0.5 },
@@ -119,7 +119,7 @@ describe('surge_repeatability qualification', () => {
 
   it('preserves legacy weighted-average behavior for an objective without qualification', () => {
     const microcycle: MicrocycleState = {
-      weekStartDate: '2026-08-03',
+      windowStartDate: '2026-08-03',
       objectives: [{ id: 'obj', key: 'surge_repeatability', title: 'Surges', targetExposures: 1, completedExposures: 0, targetStimulus: { surgeRepeatability: 0.9, aerobicCapacity: 0.5 } }],
     };
     const updated = creditObjectivesFromStimulus(
@@ -163,7 +163,7 @@ describe('protected race-specific cycling objective', () => {
     aerobicCapacity: 0, thresholdDevelopment: 0, surgeRepeatability: 0, maxStrength: 0, hypertrophy: 0, mobilityRecovery: 0,
   };
   const objective: MicrocycleState = {
-    weekStartDate: '2026-08-03',
+    windowStartDate: '2026-08-03',
     objectives: [{
       id: 'race-specific', key: 'race_specific_endurance', title: 'Cycling Race-Specific Endurance', targetExposures: 1, completedExposures: 0,
       targetStimulus: { aerobicCapacity: 0.6, surgeRepeatability: 0.6 },
@@ -191,7 +191,7 @@ describe('threshold qualification', () => {
     aerobicCapacity: 0, thresholdDevelopment: 0, surgeRepeatability: 0, maxStrength: 0, hypertrophy: 0, mobilityRecovery: 0,
   };
   const cyclingThreshold: MicrocycleState = {
-    weekStartDate: '2026-08-03',
+    windowStartDate: '2026-08-03',
     objectives: [{
       id: 'threshold', key: 'threshold_quality', title: 'Threshold Development', targetExposures: 1, completedExposures: 0,
       targetStimulus: { thresholdDevelopment: 0.9 },
@@ -281,3 +281,45 @@ describe('Task 1.2 / F2 Garmin objective crediting', () => {
     expect(z2?.completedExposures).toBe(1);
   });
 });
+
+describe('Task 2.2 PlanDefinition & PlanSchedule', () => {
+  it('generates plan-derived objectives with dated block windows when planDefinition is supplied', async () => {
+    const { buildSeptemberCyclingEventPlan } = await import('./planSchedule.ts');
+    const { generateWeeklyObjectives } = await import('./microcycle.ts');
+    const event: UserEvent = {
+      id: 'sep-event-1', title: 'September Cycling Event', date: '2026-09-20', priority: 'A', lifecycle: 'scheduled', category: 'cycling_event',
+      demandProfile: { aerobicEndurance: 0.8, thresholdPower: 0.8, vo2MaxPower: 0.7, repeatedSurges: 0.7, sprintPower: 0.3, fatigueResistance: 0.8, neuromuscular: 0.3 },
+    };
+
+    const planState = buildSeptemberCyclingEventPlan(event);
+    expect(planState.status).toBe('AVAILABLE');
+    if (planState.status !== 'AVAILABLE') return;
+
+    const phase = evaluatePeriodizationPhase([event], '2026-08-03').phase;
+    const microcycle = generateWeeklyObjectives(phase, '2026-08-03', event, planState.data);
+
+    expect(microcycle.windowStartDate).toBe('2026-08-03');
+    expect(microcycle.objectives.length).toBe(planState.data.objectives.length);
+    const z2BuildObj = microcycle.objectives.find(o => o.key === 'zone2_aerobic' && o.windowStart === '2026-08-01');
+    expect(z2BuildObj).toBeDefined();
+    expect(z2BuildObj?.windowEnd).toBe('2026-08-23');
+  });
+
+  it('rejects invalid plan definitions with overlapping blocks', async () => {
+    const { buildPlanDefinition } = await import('./planSchedule.ts');
+    const { SEPTEMBER_CYCLING_EVENT_SESSION_COVERAGE } = await import('../workouts/event-plan.ts');
+    const event: UserEvent = {
+      id: 'event-overlap', title: 'Test Event', date: '2026-09-20', priority: 'A', lifecycle: 'scheduled', category: 'cycling_event',
+      demandProfile: { aerobicEndurance: 0.8, thresholdPower: 0.8, vo2MaxPower: 0.7, repeatedSurges: 0.7, sprintPower: 0.3, fatigueResistance: 0.8, neuromuscular: 0.3 },
+    };
+
+    const invalidBlocks = [
+      { id: 'b1', phase: 'build' as const, startDate: '2026-08-01', endDate: '2026-08-15', volumeScale: 1.0, intensityScale: 1.0 },
+      { id: 'b2', phase: 'peak' as const, startDate: '2026-08-10', endDate: '2026-08-25', volumeScale: 1.0, intensityScale: 1.0 },
+    ];
+
+    const result = buildPlanDefinition(SEPTEMBER_CYCLING_EVENT_SESSION_COVERAGE, invalidBlocks, event);
+    expect(result.status).toBe('INVALID');
+  });
+});
+

--- a/app/src/engine/microcycle.test.ts
+++ b/app/src/engine/microcycle.test.ts
@@ -361,6 +361,26 @@ describe('Task 2.2 PlanDefinition & PlanSchedule', () => {
     expect(result.status).toBe('INVALID');
   });
 
+  it('rejects an objective whose coverage is unavailable in its block phase', async () => {
+    const { buildPlanDefinition } = await import('./planSchedule.ts');
+    const { SEPTEMBER_CYCLING_EVENT_SESSION_COVERAGE } = await import('../workouts/event-plan.ts');
+    const blocks = [
+      { id: 'travel', phase: 'travel' as const, startDate: '2026-08-24', endDate: '2026-08-30', volumeScale: 0.6, intensityScale: 0.8 },
+    ];
+
+    const result = buildPlanDefinition(
+      SEPTEMBER_CYCLING_EVENT_SESSION_COVERAGE,
+      blocks,
+      septemberEvent,
+      [{ key: 'race_specific_endurance', coverageKey: 'outdoor_event_specific', blockId: 'travel', requiredCredit: 1, priority: 'must_have' }],
+    );
+
+    expect(result.status).toBe('INVALID');
+    if (result.status === 'INVALID') {
+      expect(result.issues.some(issue => issue.code === 'COVERAGE_UNAVAILABLE_IN_BLOCK_PHASE')).toBe(true);
+    }
+  });
+
   describe('resolvePlanDefinitionForEvent', () => {
     it('resolves the authored plan for the specific September cycling event', async () => {
       const { resolvePlanDefinitionForEvent } = await import('./planSchedule.ts');

--- a/app/src/engine/microcycle.test.ts
+++ b/app/src/engine/microcycle.test.ts
@@ -283,26 +283,65 @@ describe('Task 1.2 / F2 Garmin objective crediting', () => {
 });
 
 describe('Task 2.2 PlanDefinition & PlanSchedule', () => {
-  it('generates plan-derived objectives with dated block windows when planDefinition is supplied', async () => {
+  const septemberEvent: UserEvent = {
+    id: 'sep-event-1', title: 'September Cycling Event', date: '2026-09-20', priority: 'A', lifecycle: 'scheduled', category: 'cycling_event',
+    demandProfile: { aerobicEndurance: 0.8, thresholdPower: 0.8, vo2MaxPower: 0.7, repeatedSurges: 0.7, sprintPower: 0.3, fatigueResistance: 0.8, neuromuscular: 0.3 },
+  };
+
+  it('generates plan-derived objectives with dated block windows, scoped to the block active on asOfDate', async () => {
     const { buildSeptemberCyclingEventPlan } = await import('./planSchedule.ts');
     const { generateWeeklyObjectives } = await import('./microcycle.ts');
-    const event: UserEvent = {
-      id: 'sep-event-1', title: 'September Cycling Event', date: '2026-09-20', priority: 'A', lifecycle: 'scheduled', category: 'cycling_event',
-      demandProfile: { aerobicEndurance: 0.8, thresholdPower: 0.8, vo2MaxPower: 0.7, repeatedSurges: 0.7, sprintPower: 0.3, fatigueResistance: 0.8, neuromuscular: 0.3 },
-    };
 
-    const planState = buildSeptemberCyclingEventPlan(event);
+    const planState = buildSeptemberCyclingEventPlan(septemberEvent);
     expect(planState.status).toBe('AVAILABLE');
     if (planState.status !== 'AVAILABLE') return;
 
-    const phase = evaluatePeriodizationPhase([event], '2026-08-03').phase;
-    const microcycle = generateWeeklyObjectives(phase, '2026-08-03', event, planState.data);
+    const phase = evaluatePeriodizationPhase([septemberEvent], '2026-08-03').phase;
+    // asOfDate ('2026-08-03') falls inside block_build (2026-08-01..2026-08-23) only --
+    // the microcycle must not also surface block_peak/block_taper objectives two months
+    // out (that was the Phase 2 review's date-window-scoping finding).
+    const microcycle = generateWeeklyObjectives(phase, '2026-08-03', septemberEvent, planState.data);
 
     expect(microcycle.windowStartDate).toBe('2026-08-03');
-    expect(microcycle.objectives.length).toBe(planState.data.objectives.length);
-    const z2BuildObj = microcycle.objectives.find(o => o.key === 'zone2_aerobic' && o.windowStart === '2026-08-01');
+    const buildObjectiveCount = planState.data.objectives.filter(o => o.blockId === 'block_build').length;
+    expect(microcycle.objectives.length).toBe(buildObjectiveCount);
+    expect(microcycle.objectives.every(o => o.windowStart === '2026-08-01' && o.windowEnd === '2026-08-23')).toBe(true);
+
+    const z2BuildObj = microcycle.objectives.find(o => o.key === 'zone2_aerobic');
     expect(z2BuildObj).toBeDefined();
+    expect(z2BuildObj?.windowStart).toBe('2026-08-01');
     expect(z2BuildObj?.windowEnd).toBe('2026-08-23');
+  });
+
+  it('scopes to a different block when asOfDate falls in the peak window instead', async () => {
+    const { buildSeptemberCyclingEventPlan } = await import('./planSchedule.ts');
+    const { generateWeeklyObjectives } = await import('./microcycle.ts');
+
+    const planState = buildSeptemberCyclingEventPlan(septemberEvent);
+    if (planState.status !== 'AVAILABLE') throw new Error('expected AVAILABLE plan');
+
+    const phase = evaluatePeriodizationPhase([septemberEvent], '2026-09-01').phase;
+    // windowStartDate (lookback boundary) and asOfDate (today) diverge here on purpose --
+    // asOfDate drives block selection, not windowStartDate.
+    const microcycle = generateWeeklyObjectives(phase, '2026-08-25', septemberEvent, planState.data, '2026-09-01');
+
+    const peakObjectiveCount = planState.data.objectives.filter(o => o.blockId === 'block_peak').length;
+    expect(microcycle.objectives.length).toBe(peakObjectiveCount);
+    expect(microcycle.objectives.every(o => o.windowStart === '2026-08-31' && o.windowEnd === '2026-09-06')).toBe(true);
+    expect(microcycle.objectives.some(o => o.key === 'race_specific_endurance')).toBe(true);
+  });
+
+  it('returns no plan-derived objectives when asOfDate falls outside every block', async () => {
+    const { buildSeptemberCyclingEventPlan } = await import('./planSchedule.ts');
+    const { generateWeeklyObjectives } = await import('./microcycle.ts');
+
+    const planState = buildSeptemberCyclingEventPlan(septemberEvent);
+    if (planState.status !== 'AVAILABLE') throw new Error('expected AVAILABLE plan');
+
+    const phase = evaluatePeriodizationPhase([septemberEvent], '2026-07-01').phase;
+    const microcycle = generateWeeklyObjectives(phase, '2026-07-01', septemberEvent, planState.data, '2026-07-01');
+
+    expect(microcycle.objectives).toEqual([]);
   });
 
   it('rejects invalid plan definitions with overlapping blocks', async () => {
@@ -320,6 +359,22 @@ describe('Task 2.2 PlanDefinition & PlanSchedule', () => {
 
     const result = buildPlanDefinition(SEPTEMBER_CYCLING_EVENT_SESSION_COVERAGE, invalidBlocks, event);
     expect(result.status).toBe('INVALID');
+  });
+
+  describe('resolvePlanDefinitionForEvent', () => {
+    it('resolves the authored plan for the specific September cycling event', async () => {
+      const { resolvePlanDefinitionForEvent } = await import('./planSchedule.ts');
+      const resolved = resolvePlanDefinitionForEvent(septemberEvent);
+      expect(resolved).not.toBeNull();
+      expect(resolved?.eventId).toBe(septemberEvent.id);
+    });
+
+    it('returns null for events it was not authored for (narrow, non-generic matching)', async () => {
+      const { resolvePlanDefinitionForEvent } = await import('./planSchedule.ts');
+      expect(resolvePlanDefinitionForEvent(null)).toBeNull();
+      expect(resolvePlanDefinitionForEvent({ ...septemberEvent, category: 'running_race' })).toBeNull();
+      expect(resolvePlanDefinitionForEvent({ ...septemberEvent, date: '2027-09-20' })).toBeNull();
+    });
   });
 });
 

--- a/app/src/engine/microcycle.ts
+++ b/app/src/engine/microcycle.ts
@@ -16,13 +16,33 @@ export function generateWeeklyObjectives(
     phaseWeights: PhaseWeights,
     windowStartDate: string,
     focusEvent: UserEvent | null,
-    planDefinition?: PlanDefinition | null
+    planDefinition?: PlanDefinition | null,
+    /** Reference date used to select which PlanBlock is "current" for the plan-derived
+     *  branch below -- defaults to windowStartDate so existing callers that only pass 4
+     *  args keep working, but a caller building a forward-looking microcycle (e.g.
+     *  trainingIntent.ts, where windowStartDate is a lookback boundary rather than
+     *  today) should pass today's date explicitly. */
+    asOfDate: string = windowStartDate
 ): MicrocycleState {
     if (planDefinition && planDefinition.objectives.length > 0) {
         const objectives: WeeklyObjective[] = [];
         const blockMap = new Map(planDefinition.blocks.map((b) => [b.id, b]));
+        // Scope to the block(s) actually active on asOfDate -- a PlanDefinition spans the
+        // whole macrocycle (build/travel/peak/taper/race/recovery), and without this an
+        // athlete in the build block would see peak- and taper-block objectives (e.g. a
+        // race-specific-endurance session two months out) as already "unresolved" from
+        // day one. Multiple blocks can be active simultaneously only if the caller passed
+        // an invalid overlapping schedule (buildPlanDefinition rejects that), so this is
+        // normally at most one block.
+        const activeBlockIds = new Set(
+            planDefinition.blocks
+                .filter((b) => b.startDate <= asOfDate && asOfDate <= b.endDate)
+                .map((b) => b.id)
+        );
 
-        planDefinition.objectives.forEach((objDef, idx) => {
+        planDefinition.objectives
+            .filter((objDef) => activeBlockIds.has(objDef.blockId))
+            .forEach((objDef, idx) => {
             const block = blockMap.get(objDef.blockId);
             const windowStart = block?.startDate;
             const windowEnd = block?.endDate;
@@ -70,6 +90,12 @@ export function generateWeeklyObjectives(
                     title = 'VO2 Max Intervals';
                     targetStimulus = { vo2MaxPower: 0.9, aerobicCapacity: 0.5 };
                     break;
+                default: {
+                    // Exhaustiveness guard: a future ObjectiveKey addition must add a case
+                    // above, not silently fall through to the 'Plan Objective' placeholder.
+                    const _exhaustive: never = objDef.key;
+                    void _exhaustive;
+                }
             }
 
             objectives.push({
@@ -295,12 +321,16 @@ export function buildMicrocycleState(
     windowStartDate: string,
     history: CompletedExposure[],
     focusEvent: UserEvent | null,
-    planDefinition?: PlanDefinition | null
+    planDefinition?: PlanDefinition | null,
+    /** See generateWeeklyObjectives's asOfDate -- pass today's date here (not
+     *  windowStartDate, which is a lookback boundary) so a plan-derived microcycle scopes
+     *  to the block actually active today. */
+    asOfDate?: string
 ): MicrocycleState {
     return history.reduce((state, exposure) => {
         if (exposure.stimulusProfile && exposure.modality) {
             return creditObjectivesFromStimulus(state, exposure.stimulusProfile, exposure.modality, exposure.category);
         }
         return updateMicrocycleProgress(state, exposure.trainingRecordLike);
-    }, generateWeeklyObjectives(phase, windowStartDate, focusEvent, planDefinition));
+    }, generateWeeklyObjectives(phase, windowStartDate, focusEvent, planDefinition, asOfDate));
 }

--- a/app/src/engine/microcycle.ts
+++ b/app/src/engine/microcycle.ts
@@ -9,13 +9,90 @@ import type {
     WorkoutStimulusProfile,
 } from './models';
 import type { CompletedExposure } from './microcycleHistory';
+import type { PlanDefinition } from './planSchedule';
 import { modalitiesForEventCategory, type PhaseWeights } from './periodization';
 
 export function generateWeeklyObjectives(
     phaseWeights: PhaseWeights,
-    weekStartDate: string,
-    focusEvent: UserEvent | null
+    windowStartDate: string,
+    focusEvent: UserEvent | null,
+    planDefinition?: PlanDefinition | null
 ): MicrocycleState {
+    if (planDefinition && planDefinition.objectives.length > 0) {
+        const objectives: WeeklyObjective[] = [];
+        const blockMap = new Map(planDefinition.blocks.map((b) => [b.id, b]));
+
+        planDefinition.objectives.forEach((objDef, idx) => {
+            const block = blockMap.get(objDef.blockId);
+            const windowStart = block?.startDate;
+            const windowEnd = block?.endDate;
+
+            let title = 'Plan Objective';
+            let targetStimulus: Record<string, number> = { aerobicCapacity: 0.5 };
+            let qualification: WeeklyObjective['qualification'] = undefined;
+            const allowedModalities = focusEvent ? modalitiesForEventCategory(focusEvent.category) : [];
+
+            switch (objDef.key) {
+                case 'zone2_aerobic':
+                    title = 'Aerobic Base (Zone 2)';
+                    targetStimulus = { aerobicCapacity: 0.8 };
+                    break;
+                case 'threshold_quality':
+                    title = 'Threshold Development';
+                    targetStimulus = { thresholdDevelopment: 0.9 };
+                    qualification = {
+                        minimumStimulus: { thresholdDevelopment: 0.6 },
+                        ...(allowedModalities.length > 0 ? { allowedModalities } : {}),
+                    };
+                    break;
+                case 'surge_repeatability':
+                    title = 'Surge & High-Intensity Repeatability';
+                    targetStimulus = { surgeRepeatability: 0.9, aerobicCapacity: 0.5 };
+                    qualification = {
+                        minimumStimulus: { surgeRepeatability: 0.6 },
+                        ...(allowedModalities.length > 0 ? { allowedModalities } : {}),
+                    };
+                    break;
+                case 'strength_maintenance':
+                    title = 'Strength & Neuromuscular Maintenance';
+                    targetStimulus = { maxStrength: 0.7, hypertrophy: 0.5 };
+                    break;
+                case 'race_specific_endurance':
+                    title = 'Cycling Race-Specific Endurance';
+                    targetStimulus = { aerobicCapacity: 0.6, surgeRepeatability: 0.6 };
+                    qualification = {
+                        minimumStimulus: { aerobicCapacity: 0.6 },
+                        allowedModalities: ['Cycling'],
+                        allowedCategories: ['Race-Specific Endurance'],
+                    };
+                    break;
+                case 'vo2_max':
+                    title = 'VO2 Max Intervals';
+                    targetStimulus = { vo2MaxPower: 0.9, aerobicCapacity: 0.5 };
+                    break;
+            }
+
+            objectives.push({
+                id: `obj_plan_${objDef.key}_${idx}`,
+                key: objDef.key,
+                title,
+                requiredCredit: objDef.requiredCredit,
+                targetExposures: objDef.requiredCredit || 1,
+                completedExposures: 0,
+                targetStimulus,
+                priority: objDef.priority,
+                qualification,
+                windowStart,
+                windowEnd,
+            });
+        });
+
+        return {
+            windowStartDate,
+            objectives,
+        };
+    }
+
     const demand = phaseWeights.targetDemandVector;
     const objectives: WeeklyObjective[] = [];
 
@@ -98,7 +175,7 @@ export function generateWeeklyObjectives(
     }
 
     return {
-        weekStartDate,
+        windowStartDate,
         objectives,
     };
 }
@@ -165,7 +242,7 @@ export function stimulusCoverage(
 export const STIMULUS_CREDIT_COVERAGE_THRESHOLD = 0.6;
 
 /** Applies an objective's optional strict qualification policy. Objectives without one
- * retain the legacy stimulus-coverage-only completion behavior. */
+ *  retain the legacy stimulus-coverage-only completion behavior. */
 export function qualifiesForObjective(
     stimulus: WorkoutStimulusProfile,
     modality: SessionTemplate['modality'],
@@ -218,11 +295,12 @@ export function buildMicrocycleState(
     windowStartDate: string,
     history: CompletedExposure[],
     focusEvent: UserEvent | null,
+    planDefinition?: PlanDefinition | null
 ): MicrocycleState {
     return history.reduce((state, exposure) => {
         if (exposure.stimulusProfile && exposure.modality) {
             return creditObjectivesFromStimulus(state, exposure.stimulusProfile, exposure.modality, exposure.category);
         }
         return updateMicrocycleProgress(state, exposure.trainingRecordLike);
-    }, generateWeeklyObjectives(phase, windowStartDate, focusEvent));
+    }, generateWeeklyObjectives(phase, windowStartDate, focusEvent, planDefinition));
 }

--- a/app/src/engine/models.ts
+++ b/app/src/engine/models.ts
@@ -1,5 +1,5 @@
 import type { AthletePerformanceProfile, WorkoutPrescription } from '../workouts/models.ts';
-import type { DataStateSummary } from './dataState';
+import type { DataIssue, DataState, DataStateSummary } from './dataState';
 
 // --- Engine Input Models ---
 export interface SubjectiveInput {
@@ -129,6 +129,41 @@ export interface EventDemandProfile {
     neuromuscular: number;      // 0.0 - 1.0
 }
 
+export interface EventTiming {
+    earliestDate: string; // YYYY-MM-DD
+    latestDate: string;   // YYYY-MM-DD
+    planningDate: string; // = earliestDate until confirmed
+    confirmedDate?: string; // YYYY-MM-DD
+}
+
+export function validateEventTiming(
+    timing: EventTiming,
+    documentPath: string = 'user_event'
+): DataState<EventTiming> {
+    const issues: DataIssue[] = [];
+
+    if (timing.earliestDate > timing.planningDate) {
+        issues.push({ code: 'EARLIEST_AFTER_PLANNING', field: 'earliestDate', documentPath });
+    }
+    if (timing.planningDate > timing.latestDate) {
+        issues.push({ code: 'PLANNING_AFTER_LATEST', field: 'planningDate', documentPath });
+    }
+    if (timing.confirmedDate !== undefined && timing.confirmedDate !== null) {
+        if (timing.confirmedDate < timing.earliestDate || timing.confirmedDate > timing.latestDate) {
+            issues.push({ code: 'CONFIRMED_OUT_OF_RANGE', field: 'confirmedDate', documentPath });
+        }
+        if (timing.planningDate !== timing.confirmedDate) {
+            issues.push({ code: 'PLANNING_NOT_CONFIRMED', field: 'planningDate', documentPath });
+        }
+    }
+
+    if (issues.length > 0) {
+        return { status: 'INVALID', issues };
+    }
+
+    return { status: 'AVAILABLE', data: timing, revision: null };
+}
+
 export interface UserEvent {
     id: string;
     title: string;
@@ -137,6 +172,7 @@ export interface UserEvent {
     lifecycle: EventLifecycle;
     category: 'running_race' | 'cycling_event' | 'triathlon' | 'strength_meet' | 'general_target';
     demandProfile: EventDemandProfile;
+    timing?: EventTiming;
 }
 
 export type ObjectiveKey = 

--- a/app/src/engine/models.ts
+++ b/app/src/engine/models.ts
@@ -173,7 +173,7 @@ export interface ObjectiveProgress {
 }
 
 export interface MicrocycleState {
-    weekStartDate: string; // YYYY-MM-DD (Monday)
+    windowStartDate: string; // YYYY-MM-DD (Warsaw-local start date)
     objectives: WeeklyObjective[];
 }
 

--- a/app/src/engine/models.ts
+++ b/app/src/engine/models.ts
@@ -654,6 +654,12 @@ export interface UserGoal {
     /** No 'rescheduled' state here by design -- rescheduling a goal is just editing
      *  targetDate while it stays 'scheduled'. Defaults to 'scheduled' when eventCategory is set. */
     eventLifecycle?: 'scheduled' | 'completed' | 'DNS' | 'DNF' | 'cancelled';
+    /** Race-date uncertainty (ADR-0012 Task 2.3). Only meaningful alongside targetDate +
+     *  eventCategory -- validated by validateGoal (see validation.ts) and carried through
+     *  goalToUserEvent (periodization.ts) into UserEvent.timing unchanged. Confirming a
+     *  date is a single write that sets both confirmedDate and planningDate together --
+     *  see validateEventTiming's invariant above. */
+    timing?: EventTiming | null;
     schemaVersion: number;
     createdAt: string;
     updatedAt: string;

--- a/app/src/engine/periodization.ts
+++ b/app/src/engine/periodization.ts
@@ -277,5 +277,9 @@ export function goalToUserEvent(goal: UserGoal & { id?: string }): UserEvent | n
         lifecycle: goal.eventLifecycle ?? 'scheduled',
         category: goal.eventCategory,
         demandProfile: resolveDemandProfile(goal.eventCategory, goal.eventPreset),
+        // goal.timing already passed validateGoal's validateEventTiming check on write
+        // (see validation.ts) -- not re-validated here, same trust boundary as every
+        // other already-typed UserGoal field this function reads.
+        ...(goal.timing ? { timing: goal.timing } : {}),
     };
 }

--- a/app/src/engine/periodization.ts
+++ b/app/src/engine/periodization.ts
@@ -99,10 +99,13 @@ export function evaluatePeriodizationPhase(
         taperActive: false,
     };
 
-    const datedEvents = events.map(event => ({
-        event,
-        daysToEvent: getDaysBetween(currentDateStr, event.date),
-    }));
+    const datedEvents = events.map(event => {
+        const targetDate = event.timing?.planningDate ?? event.date;
+        return {
+            event,
+            daysToEvent: getDaysBetween(currentDateStr, targetDate),
+        };
+    });
 
     // A scheduled event that has passed is intentionally not treated as a completed
     // race. It needs an explicit outcome before granting post-event recovery.

--- a/app/src/engine/planSchedule.ts
+++ b/app/src/engine/planSchedule.ts
@@ -73,18 +73,26 @@ export function buildPlanDefinition(
   }
 
   // 3. Validate objective block references & coverage keys
-  const coverageKeys = new Set(coverage.map((c) => c.key));
+  const coverageByKey = new Map(coverage.map((item) => [item.key, item]));
   for (const obj of objectives) {
-    if (!blockIds.has(obj.blockId)) {
+    const block = blockSchedule.find((item) => item.id === obj.blockId);
+    if (!block) {
       issues.push({
         code: 'DANGLING_BLOCK_ID',
         field: `objectives.${obj.key}`,
         documentPath: `plan/${id}`,
       });
     }
-    if (!coverageKeys.has(obj.coverageKey)) {
+    const coverageItem = coverageByKey.get(obj.coverageKey);
+    if (!coverageItem) {
       issues.push({
         code: 'UNKNOWN_COVERAGE_KEY',
+        field: `objectives.${obj.key}`,
+        documentPath: `plan/${id}`,
+      });
+    } else if (block && !coverageItem.phases.includes(block.phase)) {
+      issues.push({
+        code: 'COVERAGE_UNAVAILABLE_IN_BLOCK_PHASE',
         field: `objectives.${obj.key}`,
         documentPath: `plan/${id}`,
       });

--- a/app/src/engine/planSchedule.ts
+++ b/app/src/engine/planSchedule.ts
@@ -136,3 +136,22 @@ export function buildSeptemberCyclingEventPlan(event: UserEvent): DataState<Plan
 
   return buildPlanDefinition(SEPTEMBER_CYCLING_EVENT_SESSION_COVERAGE, blocks, event, objectives);
 }
+
+/**
+ * Resolves the concrete `PlanDefinition` for a focus event, when one has actually been
+ * authored for it.
+ *
+ * Intentionally narrow, not a generic plan-authoring mechanism: only the specific
+ * September cycling event that `buildSeptemberCyclingEventPlan`'s block calendar and
+ * `requiredCredit` numbers were authored against resolves to a `PlanDefinition` here.
+ * Every other event continues through `periodization.ts`'s generic `daysToEvent`
+ * fallback (ADR-0012 "Generic Mode") -- there is no per-event plan-builder UI or
+ * persistence layer yet (`Goals.tsx` collects a target date and event category, not a
+ * block/objective schedule), so a user-authored plan for an arbitrary event isn't
+ * possible until that lands.
+ */
+export function resolvePlanDefinitionForEvent(event: UserEvent | null): PlanDefinition | null {
+  if (!event || event.category !== 'cycling_event' || event.date !== '2026-09-20') return null;
+  const result = buildSeptemberCyclingEventPlan(event);
+  return result.status === 'AVAILABLE' ? result.data : null;
+}

--- a/app/src/engine/planSchedule.ts
+++ b/app/src/engine/planSchedule.ts
@@ -1,0 +1,138 @@
+import type { EventPlanCoverageKey, EventPlanPhase, EventPlanSessionCoverage } from '../workouts/event-plan.ts';
+import { SEPTEMBER_CYCLING_EVENT_SESSION_COVERAGE } from '../workouts/event-plan.ts';
+import type { DataIssue, DataState } from './dataState.ts';
+import type { ObjectiveKey, ObjectivePriority, UserEvent } from './models.ts';
+
+export type SessionRole = 'primary_developmental' | 'secondary_support' | 'taper_sharpening' | 'recovery_active';
+
+export interface PlanBlock {
+  id: string; // objectives reference this, not the phase
+  phase: EventPlanPhase;
+  startDate: string; // YYYY-MM-DD, Warsaw-local, inclusive
+  endDate: string; // YYYY-MM-DD, Warsaw-local, inclusive
+  volumeScale: number;
+  intensityScale: number;
+}
+
+export interface PlanObjectiveDefinition {
+  key: ObjectiveKey;
+  coverageKey: EventPlanCoverageKey; // ties back to event-plan.ts
+  blockId: string; // exactly one — NOT `phases`, and not a list
+  requiredCredit: number;
+  priority: ObjectivePriority; // declared in models.ts
+  minGapHoursFrom?: ObjectiveKey[];
+}
+
+export interface SequencingRule {
+  id: string;
+  ruleType: 'min_gap_hours' | 'max_consecutive_days' | 'recovery_window';
+  targetObjectiveKeys: ObjectiveKey[];
+  paramValue: number;
+}
+
+export interface PlanDefinition {
+  id: string;
+  eventId: string;
+  blocks: PlanBlock[];
+  objectives: PlanObjectiveDefinition[];
+  sequencingRules: SequencingRule[];
+}
+
+export function buildPlanDefinition(
+  coverage: EventPlanSessionCoverage[],
+  blockSchedule: PlanBlock[],
+  event: UserEvent,
+  objectives: PlanObjectiveDefinition[] = [],
+  sequencingRules: SequencingRule[] = [],
+  id: string = `plan_${event.id}`
+): DataState<PlanDefinition> {
+  const issues: DataIssue[] = [];
+
+  // 1. Check unique block IDs and date ordering
+  const blockIds = new Set<string>();
+  for (const block of blockSchedule) {
+    if (blockIds.has(block.id)) {
+      issues.push({ code: 'DUPLICATE_BLOCK_ID', field: `blocks.${block.id}`, documentPath: `plan/${id}` });
+    }
+    blockIds.add(block.id);
+    if (block.startDate > block.endDate) {
+      issues.push({ code: 'INVALID_BLOCK_DATE_RANGE', field: `blocks.${block.id}`, documentPath: `plan/${id}` });
+    }
+  }
+
+  // 2. Check for overlapping blocks
+  const sortedBlocks = [...blockSchedule].sort((a, b) => a.startDate.localeCompare(b.startDate));
+  for (let i = 0; i < sortedBlocks.length - 1; i++) {
+    if (sortedBlocks[i].endDate >= sortedBlocks[i + 1].startDate) {
+      issues.push({
+        code: 'OVERLAPPING_BLOCKS',
+        field: `blocks.${sortedBlocks[i].id}`,
+        documentPath: `plan/${id}`,
+      });
+    }
+  }
+
+  // 3. Validate objective block references & coverage keys
+  const coverageKeys = new Set(coverage.map((c) => c.key));
+  for (const obj of objectives) {
+    if (!blockIds.has(obj.blockId)) {
+      issues.push({
+        code: 'DANGLING_BLOCK_ID',
+        field: `objectives.${obj.key}`,
+        documentPath: `plan/${id}`,
+      });
+    }
+    if (!coverageKeys.has(obj.coverageKey)) {
+      issues.push({
+        code: 'UNKNOWN_COVERAGE_KEY',
+        field: `objectives.${obj.key}`,
+        documentPath: `plan/${id}`,
+      });
+    }
+  }
+
+  if (issues.length > 0) {
+    return { status: 'INVALID', issues };
+  }
+
+  return {
+    status: 'AVAILABLE',
+    revision: null,
+    data: {
+      id,
+      eventId: event.id,
+      blocks: blockSchedule,
+      objectives,
+      sequencingRules,
+    },
+  };
+}
+
+/**
+  Authors a default dated block schedule for the September cycling event.
+ */
+export function buildSeptemberCyclingEventPlan(event: UserEvent): DataState<PlanDefinition> {
+  const blocks: PlanBlock[] = [
+    { id: 'block_build', phase: 'build', startDate: '2026-08-01', endDate: '2026-08-23', volumeScale: 1.0, intensityScale: 1.0 },
+    { id: 'block_travel', phase: 'travel', startDate: '2026-08-24', endDate: '2026-08-30', volumeScale: 0.6, intensityScale: 0.8 },
+    { id: 'block_peak', phase: 'peak', startDate: '2026-08-31', endDate: '2026-09-06', volumeScale: 1.1, intensityScale: 1.1 },
+    { id: 'block_taper', phase: 'taper', startDate: '2026-09-07', endDate: '2026-09-19', volumeScale: 0.5, intensityScale: 1.0 },
+    { id: 'block_race', phase: 'race', startDate: '2026-09-20', endDate: '2026-09-20', volumeScale: 1.0, intensityScale: 1.2 },
+    { id: 'block_recovery', phase: 'recovery', startDate: '2026-09-21', endDate: '2026-09-27', volumeScale: 0.3, intensityScale: 0.5 },
+  ];
+
+  const objectives: PlanObjectiveDefinition[] = [
+    { key: 'zone2_aerobic', coverageKey: 'easy_aerobic', blockId: 'block_build', requiredCredit: 2, priority: 'must_have' },
+    { key: 'threshold_quality', coverageKey: 'sustained_quality', blockId: 'block_build', requiredCredit: 1, priority: 'must_have' },
+    { key: 'surge_repeatability', coverageKey: 'short_surges', blockId: 'block_build', requiredCredit: 1, priority: 'should_have' },
+    { key: 'strength_maintenance', coverageKey: 'primary_strength', blockId: 'block_build', requiredCredit: 1, priority: 'should_have' },
+
+    { key: 'zone2_aerobic', coverageKey: 'easy_aerobic', blockId: 'block_peak', requiredCredit: 1, priority: 'must_have' },
+    { key: 'threshold_quality', coverageKey: 'sustained_quality', blockId: 'block_peak', requiredCredit: 1, priority: 'must_have' },
+    { key: 'race_specific_endurance', coverageKey: 'outdoor_event_specific', blockId: 'block_peak', requiredCredit: 1, priority: 'must_have' },
+
+    { key: 'zone2_aerobic', coverageKey: 'easy_aerobic', blockId: 'block_taper', requiredCredit: 1, priority: 'must_have' },
+  ];
+
+  return buildPlanDefinition(SEPTEMBER_CYCLING_EVENT_SESSION_COVERAGE, blocks, event, objectives);
+}

--- a/app/src/engine/policy.ts
+++ b/app/src/engine/policy.ts
@@ -1,2 +1,2 @@
 /** Increment whenever a change can alter a persisted recommendation decision. */
-export const POLICY_VERSION = '2026-08-ranking-tie-break-v2';
+export const POLICY_VERSION = '2026-08-plan-intent-authority-v1';

--- a/app/src/engine/rules.ts
+++ b/app/src/engine/rules.ts
@@ -210,8 +210,6 @@ export function evaluateReadinessAndSafetyEnvelope(
     mode: 'train' | 'modify' | 'recover';
     envelopes: { safety: SafetyEnvelope; plan: PlanEnvelope };
     telemetry: DecisionScoreTelemetry;
-    maxExecutionDose: number;
-    restrictedModalities: Set<string>;
     alreadyTrainedOverride: boolean;
     fatigueTriggeredRecover: boolean;
     multiDayDriftIsDecisionRelevant: boolean;
@@ -320,8 +318,6 @@ export function evaluateReadinessAndSafetyEnvelope(
         mode,
         envelopes,
         telemetry,
-        maxExecutionDose: 1.0,
-        restrictedModalities: new Set(envelopes.safety.restrictedModalities),
         alreadyTrainedOverride,
         fatigueTriggeredRecover,
         multiDayDriftIsDecisionRelevant,
@@ -333,10 +329,15 @@ export function evaluateTraining(
     readiness: DailyReadiness,
     context: UserContext,
     date: string,
-    previousMode?: 'train' | 'modify' | 'recover'
+    previousMode?: 'train' | 'modify' | 'recover',
+    /** Lets a caller that already ran evaluateReadinessAndSafetyEnvelope (e.g.
+     *  evaluateTrainingWithIntent's empty-candidates fallback) reuse that result instead
+     *  of paying for the same readiness/envelope computation twice. Omit for the normal
+     *  standalone-call case. */
+    precomputedEnvelopeState?: ReturnType<typeof evaluateReadinessAndSafetyEnvelope>
 ): Recommendation {
     const { subjective, objective } = readiness;
-    const state = evaluateReadinessAndSafetyEnvelope(readiness, context, date, previousMode);
+    const state = precomputedEnvelopeState ?? evaluateReadinessAndSafetyEnvelope(readiness, context, date, previousMode);
     const { mode } = state;
     const { envelopes, telemetry, alreadyTrainedOverride, fatigueTriggeredRecover, multiDayDriftIsDecisionRelevant, postRecoverBufferApplied } = state;
 
@@ -491,7 +492,7 @@ export async function evaluateTrainingWithIntent(
         }
     );
     const pick = ranked[0];
-    if (!pick) return evaluateTraining(readiness, context, date, previousMode);
+    if (!pick) return evaluateTraining(readiness, context, date, previousMode, envelopeState);
     const phaseContext = intent.periodization.focusEvent
         ? `${intent.periodization.daysToEvent} days out from ${intent.periodization.focusEvent.title}, ${intent.periodization.phase.phaseName} phase.`
         : `${intent.periodization.phase.phaseName} phase.`;

--- a/app/src/engine/rules.ts
+++ b/app/src/engine/rules.ts
@@ -201,18 +201,22 @@ function metricStrain(
  */
 const MODIFY_MAX_SYSTEMIC_COST = 0.5;
 
-export function evaluateTraining(
+export function evaluateReadinessAndSafetyEnvelope(
     readiness: DailyReadiness,
     context: UserContext,
-    date: string,
-    /** Yesterday's *final* mode (post-hysteresis), if known -- e.g. from the previous
-     *  day's persisted DailyRecommendation.mode. Optional and stateless by default: a
-     *  caller with no history (or evaluating a hypothetical scenario, see
-     *  evaluateNextDayPlan's single-plan-override branch) simply omits it and gets the
-     *  same behavior as before hysteresis existed. See POST_RECOVER_BUFFER below for
-     *  the one rule that uses it. */
+    _date?: string,
     previousMode?: 'train' | 'modify' | 'recover'
-): Recommendation {
+): {
+    mode: 'train' | 'modify' | 'recover';
+    envelopes: { safety: SafetyEnvelope; plan: PlanEnvelope };
+    telemetry: DecisionScoreTelemetry;
+    maxExecutionDose: number;
+    restrictedModalities: Set<string>;
+    alreadyTrainedOverride: boolean;
+    fatigueTriggeredRecover: boolean;
+    multiDayDriftIsDecisionRelevant: boolean;
+    postRecoverBufferApplied: boolean;
+} {
     const { subjective, objective } = readiness;
 
     // 1. Subjective fatigue scoring (10 = worst fatigue)
@@ -220,7 +224,6 @@ export function evaluateTraining(
     const invertedSleepQual = 10 - subjective.sleepQuality;
     const invertedReadiness = 10 - subjective.readiness;
 
-    // Core subjective penalty calculation
     const overallFatigueScore = (subjective.fatigue + subjective.soreness + invertedReadiness + invertedSleepQual + invertedMotivation) / 5;
 
     // 2. Objective strain scoring & telemetry decomposition (baseline-relative)
@@ -241,14 +244,11 @@ export function evaluateTraining(
     const totalMultiDayDrift = hrvStrain.multiDayDrift + rhrStrain.multiDayDrift + sleepStrain.multiDayDrift;
     const totalMetricStrain = totalAcuteDeviation + totalMultiDayDrift;
 
-    // Absolute safety net: a genuinely wrecked night still matters even if it doesn't
-    // read as unusual relative to this person's own (possibly already-low) baseline.
     let sleepFloorPenalty = 0;
     if (objective.sleep_score !== null && objective.sleep_score < SLEEP_SCORE_ABSOLUTE_FLOOR) {
         sleepFloorPenalty = SLEEP_SCORE_ABSOLUTE_FLOOR_STRAIN;
     }
 
-    // Body Battery: smooth ramp rather than a step function at 50.
     let bodyBatteryDeficit = 0;
     if (objective.body_battery_wake !== null) {
         const deficit = BODY_BATTERY_LOW_ANCHOR - objective.body_battery_wake;
@@ -263,16 +263,14 @@ export function evaluateTraining(
 
     const extremeFatigue = subjective.fatigue > 8 || subjective.soreness > 8 || subjective.painFlag;
 
-    // Prevent overtraining if you've done too many hard sessions recently
     const recentHardSessionsCount = objective.last_3_days_hard_sessions_count || 0;
     let recentHardSessionsPenalty = 0;
     if (recentHardSessionsCount >= 2) {
-        recentHardSessionsPenalty = RECENT_HARD_SESSIONS_STRAIN; // 2+ hard sessions in 3 days warrants caution
+        recentHardSessionsPenalty = RECENT_HARD_SESSIONS_STRAIN;
     }
 
     const objectiveStrain = totalMetricStrain + sleepFloorPenalty + bodyBatteryDeficit + conservativeBias + recentHardSessionsPenalty;
 
-    // 3. Determine Core Mode Hierarchy (Train vs Modify vs Recover)
     let mode: 'train' | 'modify' | 'recover' = 'train';
 
     const lowBodyBatteryRecovery = objective.body_battery_wake !== null
@@ -281,166 +279,23 @@ export function evaluateTraining(
     if (fatigueTriggeredRecover) {
         mode = 'recover';
     } else if (overallFatigueScore > 5 || subjective.soreness > 6 || objectiveStrain >= STRAIN_MODIFY_THRESHOLD) {
-        mode = 'modify'; // Cap systemic load -- see MODIFY_MAX_SYSTEMIC_COST, not a flat demotion to endurance-only
+        mode = 'modify';
     }
 
-    // Causal decision-relevance check: did multiDayDrift alter the final mode outcome?
     const strainWithoutDrift = objectiveStrain - totalMultiDayDrift;
     const counterfactualRecover = overallFatigueScore > 7 || extremeFatigue || strainWithoutDrift >= STRAIN_RECOVER_THRESHOLD;
     const counterfactualModify = counterfactualRecover || overallFatigueScore > 5 || subjective.soreness > 6 || strainWithoutDrift >= STRAIN_MODIFY_THRESHOLD;
     const counterfactualModeWithoutDrift = counterfactualRecover ? 'recover' : (counterfactualModify ? 'modify' : 'train');
     const multiDayDriftIsDecisionRelevant = (mode !== 'train') && (mode !== counterfactualModeWithoutDrift);
 
-    // 3a-hysteresis. Post-recover buffer: a single morning's numbers looking fully
-    // green the day right after a mandated recovery day doesn't mean tissues are fully
-    // back -- standard coaching practice eases back in rather than jumping straight
-    // from rest to a hard day. Only softens a fresh 'train' read down one notch to
-    // 'modify'; never overrides today's own fatigue/pain signal (fatigueTriggeredRecover
-    // already stands on its own above) and never applies without real history (an
-    // omitted previousMode -- e.g. a stateless hypothetical preview -- leaves this
-    // inert, matching pre-hysteresis behavior).
     const postRecoverBufferApplied = mode === 'train' && previousMode === 'recover';
     if (postRecoverBufferApplied) {
         mode = 'modify';
     }
 
-    // 3b. Already-trained-today override: takes precedence over everything above.
-    // A user-reported or Garmin-synced same-day session means no further training should
-    // be prescribed today, regardless of how fresh the readiness numbers otherwise look.
     const alreadyTrainedOverride = subjective.alreadyTrainedToday === true || objective.today_training !== null;
     if (alreadyTrainedOverride) {
         mode = 'recover';
-    }
-
-    // 4. Filter templates through the single hard-gate resolver. Preferences rank
-    // the remaining feasible options; they never bypass a safety or access rule.
-    const availableTemplates = eligibleTemplates(TEMPLATES, context, subjective.timeAvailable, date).filter(t => {
-        // Avoided modalities are a hard exclude, same standing as an equipment gate --
-        // unlike deprioritized (soft) or preferred (soft), see rankByModalityPreference.
-        if (context.preferences.avoidedModalities.some(m => modalityMatches(t.modality, m))) return false;
-        // Phase-gated templates (phaseEligibility) are excluded from Path A entirely, not
-        // just from the 'train' category allowlist below: an explicit preferredModalityToday
-        // ask widens that allowlist to every constraint-eligible template of the asked
-        // modality (see applyModalityPreference), which would otherwise let e.g. a
-        // taper-only or event-proximity-gated session through with zero regard for how far
-        // away the event actually is -- evaluateTraining has no PeriodizationResult to check
-        // that against at all, so these must never reach `availableTemplates` in the first
-        // place, on any path, on any mode.
-        if (t.phaseEligibility) return false;
-        return true;
-    });
-
-    // 5. Select Template Based on Mode & Constraints
-    let selectedTemplate = availableTemplates.find(t => t.category === 'Rest') || TEMPLATES[1]; // fallback
-    let rationale = "";
-
-    let modalityNote: string | null = null;
-
-    if (mode === 'recover') {
-        const recoverOptions = availableTemplates.filter(t => t.category === 'Rest' || t.category === 'Mobility/Recovery');
-        // Recover's ceiling is safety-motivated -- search and fallback pool are the same
-        // restricted set, so an explicit ask can't push above it.
-        const preferenceResult = applyModalityPreference(recoverOptions, recoverOptions, subjective.preferredModalityToday);
-        modalityNote = preferenceResult.note;
-        let rankedRecoverOptions = rankByModalityPreference(
-            preferenceResult.options, context.preferences.preferredModalities, context.preferences.deprioritizedModalities
-        );
-        if (context.trainingSettings?.preferences.preferActiveRecovery) {
-            rankedRecoverOptions = [...rankedRecoverOptions].sort((a, b) =>
-                Number(b.category === 'Mobility/Recovery') - Number(a.category === 'Mobility/Recovery')
-            );
-        }
-        // pickTemplate only returns undefined for an empty array, already excluded by the guard.
-        if (rankedRecoverOptions.length > 0) selectedTemplate = pickTemplate(rankedRecoverOptions, date)!;
-
-        if (alreadyTrainedOverride) {
-            const loggedSession = objective.today_training;
-            const sessionDescription = loggedSession
-                ? `Garmin shows you already completed a ${loggedSession.type} session today (~${loggedSession.duration_min} min).`
-                : "You've already logged a training session today.";
-
-            if (fatigueTriggeredRecover) {
-                // Fatigue/pain independently pushed mode to 'recover' -- don't let the
-                // already-trained message crowd out that safety-relevant context.
-                const cautionNote = subjective.painFlag
-                    ? "You're also flagging pain or injury today, so prioritize recovery and get it checked out if it persists."
-                    : "Your fatigue markers are also elevated today, so prioritize recovery (hydration, nutrition, sleep) rather than adding anything further.";
-                rationale = `${sessionDescription} ${cautionNote}`;
-            } else {
-                rationale = `${sessionDescription} Nice work -- no further training is needed. Focus on recovery (hydration, nutrition, sleep) for the rest of the day.`;
-            }
-        } else {
-            rationale = "Your overall fatigue markers are high today (combining subjective feel with drops in objective baselines). Pushing hard could be counter-productive; focus on active or passive recovery.";
-        }
-
-    } else if (mode === 'modify') {
-        // Cap by systemic cost, not by category -- a low-cost, muscle-local session
-        // (upper-body strength) is a legitimate option here even though the broader
-        // category was excluded before. See MODIFY_MAX_SYSTEMIC_COST.
-        const modifyOptions = availableTemplates.filter(t => t.category !== 'Rest' && t.systemicCost <= MODIFY_MAX_SYSTEMIC_COST);
-        // Modify's cost ceiling is safety-motivated too -- same restricted set for both
-        // search and fallback (an ask for something above the ceiling isn't honored).
-        const preferenceResult = applyModalityPreference(modifyOptions, modifyOptions, subjective.preferredModalityToday);
-        modalityNote = preferenceResult.note;
-        const rankedModifyOptions = rankByModalityPreference(
-            preferenceResult.options, context.preferences.preferredModalities, context.preferences.deprioritizedModalities
-        );
-        if (rankedModifyOptions.length > 0) selectedTemplate = pickTemplate(rankedModifyOptions, date)!;
-        else selectedTemplate = TEMPLATES[0]; // Rest fallback
-
-        rationale = "You're showing moderate soreness or slight downward trends in Garmin baselines. We're capping today's systemic/autonomic load rather than ruling out a whole modality.";
-        if (selectedTemplate.category === 'Upper-body Strength') {
-            rationale += " Upper-body strength is included: it's a low-systemic-load, muscle-local stimulus, so softer HRV/RHR readings are a better reason to skip legs or intervals than to skip push/pull work.";
-        }
-
-    } else {
-        // 'Moderate Endurance' (Zone-3 tempo) belongs here, not in 'modify' -- it's
-        // explicitly a comfortably-hard, full-intensity option, which would contradict
-        // modify mode's "capping intensity" rationale above.
-        // 'Race-Specific Endurance' isn't in this allowlist -- phase-gated templates are
-        // already excluded from `availableTemplates` itself (step 4 above), so it's moot here.
-        const trainOptions = availableTemplates.filter(t => t.category === 'Hard Endurance' || t.category === 'Moderate Endurance' || t.category === 'Full-body Strength' || t.category === 'Upper-body Strength' || t.category === 'Lower-body Strength' || t.category === 'Power Maintenance');
-        // No ceiling to protect on a 'train' day -- an explicit ask for something gentler
-        // (e.g. mobility) than train mode would normally offer is fine to honor, so the
-        // search pool is every constraint-eligible template, not just trainOptions.
-        const preferenceResult = applyModalityPreference(availableTemplates, trainOptions, subjective.preferredModalityToday);
-        modalityNote = preferenceResult.note;
-        const rankedTrainOptions = rankByModalityPreference(
-            preferenceResult.options, context.preferences.preferredModalities, context.preferences.deprioritizedModalities
-        );
-        if (rankedTrainOptions.length > 0) selectedTemplate = pickTemplate(rankedTrainOptions, date)!;
-
-        // An honored preference can land outside train mode's usual categories (e.g. an
-        // explicit ask for mobility on an otherwise green-light day) -- say so rather
-        // than claiming a "hard session" rationale for what's actually an easy one.
-        if (!trainOptions.some(t => t.id === selectedTemplate!.id)) {
-            rationale = `Readiness is solid -- you'd be fine pushing harder -- but you asked for ${selectedTemplate.modality.toLowerCase()} today, so going with that instead.`;
-        } else {
-            rationale = "Readiness is solid across both subjective feelings and Garmin baselines. Great day for a hard session aligned with your primary goals!";
-        }
-    }
-
-    if (modalityNote) {
-        rationale += ` ${modalityNote}`;
-    }
-
-    if (multiDayDriftIsDecisionRelevant) {
-        rationale += " Your recovery metrics have been trending away from baseline over several days, capping today's training load.";
-    }
-
-    if (postRecoverBufferApplied) {
-        rationale += " Yesterday was a mandated recovery day, so easing back in today (rather than going straight to a hard session) even though this morning's numbers look fully green.";
-    }
-
-    // Add previous day context if available and relevant
-    if (objective.yesterday_training && objective.yesterday_training.duration_min && mode === 'modify') {
-        rationale += ` Giving your body a break after yesterday's ${objective.yesterday_training.type} session.`;
-    }
-
-    // Fallback safety
-    if (!selectedTemplate) {
-        selectedTemplate = TEMPLATES[0];
-        rationale += " (Defaulted to Rest/Mobility due to severe time/equipment constraints).";
     }
 
     const round2 = (val: number) => Math.round(val * 100) / 100;
@@ -460,6 +315,128 @@ export function evaluateTraining(
     };
 
     const envelopes = evaluateEnvelopes({ subjective, objective }, context);
+
+    return {
+        mode,
+        envelopes,
+        telemetry,
+        maxExecutionDose: 1.0,
+        restrictedModalities: new Set(envelopes.safety.restrictedModalities),
+        alreadyTrainedOverride,
+        fatigueTriggeredRecover,
+        multiDayDriftIsDecisionRelevant,
+        postRecoverBufferApplied,
+    };
+}
+
+export function evaluateTraining(
+    readiness: DailyReadiness,
+    context: UserContext,
+    date: string,
+    previousMode?: 'train' | 'modify' | 'recover'
+): Recommendation {
+    const { subjective, objective } = readiness;
+    const state = evaluateReadinessAndSafetyEnvelope(readiness, context, date, previousMode);
+    const { mode } = state;
+    const { envelopes, telemetry, alreadyTrainedOverride, fatigueTriggeredRecover, multiDayDriftIsDecisionRelevant, postRecoverBufferApplied } = state;
+
+    // 4. Filter templates through the single hard-gate resolver. Preferences rank
+    // the remaining feasible options; they never bypass a safety or access rule.
+    const availableTemplates = eligibleTemplates(TEMPLATES, context, subjective.timeAvailable, date).filter(t => {
+        if (context.preferences.avoidedModalities.some(m => modalityMatches(t.modality, m))) return false;
+        if (t.phaseEligibility) return false;
+        return true;
+    });
+
+    // 5. Select Template Based on Mode & Constraints
+    let selectedTemplate = availableTemplates.find(t => t.category === 'Rest') || TEMPLATES[1]; // fallback
+    let rationale = "";
+
+    let modalityNote: string | null = null;
+
+    if (mode === 'recover') {
+        const recoverOptions = availableTemplates.filter(t => t.category === 'Rest' || t.category === 'Mobility/Recovery');
+        const preferenceResult = applyModalityPreference(recoverOptions, recoverOptions, subjective.preferredModalityToday);
+        modalityNote = preferenceResult.note;
+        let rankedRecoverOptions = rankByModalityPreference(
+            preferenceResult.options, context.preferences.preferredModalities, context.preferences.deprioritizedModalities
+        );
+        if (context.trainingSettings?.preferences.preferActiveRecovery) {
+            rankedRecoverOptions = [...rankedRecoverOptions].sort((a, b) =>
+                Number(b.category === 'Mobility/Recovery') - Number(a.category === 'Mobility/Recovery')
+            );
+        }
+        if (rankedRecoverOptions.length > 0) selectedTemplate = pickTemplate(rankedRecoverOptions, date)!;
+
+        if (alreadyTrainedOverride) {
+            const loggedSession = objective.today_training;
+            const sessionDescription = loggedSession
+                ? `Garmin shows you already completed a ${loggedSession.type} session today (~${loggedSession.duration_min} min).`
+                : "You've already logged a training session today.";
+
+            if (fatigueTriggeredRecover) {
+                const cautionNote = subjective.painFlag
+                    ? "You're also flagging pain or injury today, so prioritize recovery and get it checked out if it persists."
+                    : "Your fatigue markers are also elevated today, so prioritize recovery (hydration, nutrition, sleep) rather than adding anything further.";
+                rationale = `${sessionDescription} ${cautionNote}`;
+            } else {
+                rationale = `${sessionDescription} Nice work -- no further training is needed. Focus on recovery (hydration, nutrition, sleep) for the rest of the day.`;
+            }
+        } else {
+            rationale = "Your overall fatigue markers are high today (combining subjective feel with drops in objective baselines). Pushing hard could be counter-productive; focus on active or passive recovery.";
+        }
+
+    } else if (mode === 'modify') {
+        const modifyOptions = availableTemplates.filter(t => t.category !== 'Rest' && t.systemicCost <= MODIFY_MAX_SYSTEMIC_COST);
+        const preferenceResult = applyModalityPreference(modifyOptions, modifyOptions, subjective.preferredModalityToday);
+        modalityNote = preferenceResult.note;
+        const rankedModifyOptions = rankByModalityPreference(
+            preferenceResult.options, context.preferences.preferredModalities, context.preferences.deprioritizedModalities
+        );
+        if (rankedModifyOptions.length > 0) selectedTemplate = pickTemplate(rankedModifyOptions, date)!;
+        else selectedTemplate = TEMPLATES[0]; // Rest fallback
+
+        rationale = "You're showing moderate soreness or slight downward trends in Garmin baselines. We're capping today's systemic/autonomic load rather than ruling out a whole modality.";
+        if (selectedTemplate.category === 'Upper-body Strength') {
+            rationale += " Upper-body strength is included: it's a low-systemic-load, muscle-local stimulus, so softer HRV/RHR readings are a better reason to skip legs or intervals than to skip push/pull work.";
+        }
+
+    } else {
+        const trainOptions = availableTemplates.filter(t => t.category === 'Hard Endurance' || t.category === 'Moderate Endurance' || t.category === 'Full-body Strength' || t.category === 'Upper-body Strength' || t.category === 'Lower-body Strength' || t.category === 'Power Maintenance');
+        const preferenceResult = applyModalityPreference(availableTemplates, trainOptions, subjective.preferredModalityToday);
+        modalityNote = preferenceResult.note;
+        const rankedTrainOptions = rankByModalityPreference(
+            preferenceResult.options, context.preferences.preferredModalities, context.preferences.deprioritizedModalities
+        );
+        if (rankedTrainOptions.length > 0) selectedTemplate = pickTemplate(rankedTrainOptions, date)!;
+
+        if (!trainOptions.some(t => t.id === selectedTemplate!.id)) {
+            rationale = `Readiness is solid -- you'd be fine pushing harder -- but you asked for ${selectedTemplate.modality.toLowerCase()} today, so going with that instead.`;
+        } else {
+            rationale = "Readiness is solid across both subjective feelings and Garmin baselines. Great day for a hard session aligned with your primary goals!";
+        }
+    }
+
+    if (modalityNote) {
+        rationale += ` ${modalityNote}`;
+    }
+
+    if (multiDayDriftIsDecisionRelevant) {
+        rationale += " Your recovery metrics have been trending away from baseline over several days, capping today's training load.";
+    }
+
+    if (postRecoverBufferApplied) {
+        rationale += " Yesterday was a mandated recovery day, so easing back in today (rather than going straight to a hard session) even though this morning's numbers look fully green.";
+    }
+
+    if (objective.yesterday_training && objective.yesterday_training.duration_min && mode === 'modify') {
+        rationale += ` Giving your body a break after yesterday's ${objective.yesterday_training.type} session.`;
+    }
+
+    if (!selectedTemplate) {
+        selectedTemplate = TEMPLATES[0];
+        rationale += " (Defaulted to Rest/Mobility due to severe time/equipment constraints).";
+    }
 
     return {
         template: selectedTemplate,
@@ -483,17 +460,17 @@ export async function evaluateTrainingWithIntent(
     historyProvider?: TrainingHistoryProvider,
     preparedHistorySnapshot?: TrainingHistorySnapshot | null,
 ): Promise<Recommendation> {
-    const base = evaluateTraining(readiness, context, date, previousMode);
-    // The resolver retains Firebase behind its production-provider boundary; fixture
-    // providers keep this asynchronous path deterministic in engine unit tests.
+    const envelopeState = evaluateReadinessAndSafetyEnvelope(readiness, context, date, previousMode);
+    const { mode, envelopes, telemetry } = envelopeState;
+
     const intent = await resolveTrainingIntent(userId, events, date, readiness, 7, historyProvider, preparedHistorySnapshot);
-    const maxCost = PLAN_TIER_SYSTEMIC_COST_CEILING[base.envelopes!.plan.maxAllowableTier];
+    const maxCost = PLAN_TIER_SYSTEMIC_COST_CEILING[envelopes.plan.maxAllowableTier];
     const candidates = eligibleTemplates(ENRICHED_TEMPLATES, context, readiness.subjective.timeAvailable, date)
-        .filter(template => !base.envelopes!.safety.restrictedModalities.includes(template.modality))
+        .filter(template => !envelopes.safety.restrictedModalities.includes(template.modality))
         .filter(template => !(context.constraints.restrictedCategories ?? []).includes(template.category))
         .filter(template => template.systemicCost <= maxCost)
-        .filter(template => base.mode !== 'recover' || template.category === 'Rest' || template.category === 'Mobility/Recovery')
-        .filter(template => base.mode !== 'modify' || template.systemicCost <= MODIFY_MAX_SYSTEMIC_COST)
+        .filter(template => mode !== 'recover' || template.category === 'Rest' || template.category === 'Mobility/Recovery')
+        .filter(template => mode !== 'modify' || template.systemicCost <= MODIFY_MAX_SYSTEMIC_COST)
         .filter(template => isTemplatePhaseEligible(template, intent.periodization));
     const ranked = rankCandidatesByUtility(
         candidates,
@@ -514,16 +491,18 @@ export async function evaluateTrainingWithIntent(
         }
     );
     const pick = ranked[0];
-    if (!pick) return base;
+    if (!pick) return evaluateTraining(readiness, context, date, previousMode);
     const phaseContext = intent.periodization.focusEvent
         ? `${intent.periodization.daysToEvent} days out from ${intent.periodization.focusEvent.title}, ${intent.periodization.phase.phaseName} phase.`
         : `${intent.periodization.phase.phaseName} phase.`;
     return {
-        ...base,
         template: pick.template,
         plannedDose: intent.plannedDose,
-        executionDose: resolveExecutionDose(intent.plannedDose, base.envelopes!.plan, null),
-        rationale: `${base.rationale} ${phaseContext} ${pick.rationale}`,
+        executionDose: resolveExecutionDose(intent.plannedDose, envelopes.plan, null),
+        rationale: `${phaseContext} ${pick.rationale}`,
+        mode,
+        envelopes,
+        telemetry,
         decisionTrace: {
             policyVersion: POLICY_VERSION,
             candidateScores: ranked.map(candidate => ({

--- a/app/src/engine/trainingIntent.ts
+++ b/app/src/engine/trainingIntent.ts
@@ -4,6 +4,7 @@ import { buildMicrocycleState, getUnresolvedObjectives } from './microcycle';
 import type { CompletedExposure, TrainingHistoryProvider } from './trainingHistory';
 import type { TrainingHistorySnapshot } from './trainingHistorySnapshot';
 import { evaluatePeriodizationPhase, type PeriodizationResult } from './periodization';
+import { resolvePlanDefinitionForEvent } from './planSchedule';
 import { addDaysToLocalDateString } from '../utils/localDate';
 
 export type PlannedRecoveryReason = 
@@ -66,11 +67,17 @@ export async function resolveTrainingIntent(
         ?? await prepareTrainingHistorySnapshot(userId, date, windowDays, historyProvider);
     const provider = historyProvider ?? (await import('./firestoreTrainingHistory')).firestoreTrainingHistoryProvider;
     const history = historySnapshot?.exposures ?? await provider.reconstruct(userId, date, windowDays);
+    // ADR-0012 "Explicit Mode": when the focus event has an authored PlanDefinition,
+    // its dated block calendar is the planning authority instead of the generic
+    // daysToEvent fallback -- see resolvePlanDefinitionForEvent's narrow matching rule.
+    const planDefinition = resolvePlanDefinitionForEvent(periodization.focusEvent);
     const microcycle = buildMicrocycleState(
         periodization.phase,
         addDaysToLocalDateString(date, -windowDays),
         history,
         periodization.focusEvent,
+        planDefinition,
+        date,
     );
     const unresolvedObjectives = getUnresolvedObjectives(microcycle);
     const fatigue = buildFatigueStateFromHistory(history, computeInternalResponseStrain(readiness), date);

--- a/app/src/engine/trainingIntentAcceptance.test.ts
+++ b/app/src/engine/trainingIntentAcceptance.test.ts
@@ -26,6 +26,13 @@ const roadRace: UserEvent = {
     demandProfile: { aerobicEndurance: 0.8, thresholdPower: 0.9, vo2MaxPower: 0.7, repeatedSurges: 0.9, sprintPower: 0.5, fatigueResistance: 0.9, neuromuscular: 0.5 },
 };
 
+// Matches resolvePlanDefinitionForEvent's narrow id/category/date match (planSchedule.ts)
+// -- the one event buildSeptemberCyclingEventPlan's block calendar was actually authored for.
+const septemberCyclingEvent: UserEvent = {
+    id: 'sep-event-1', title: 'September Cycling Event', date: '2026-09-20', priority: 'A', lifecycle: 'scheduled', category: 'cycling_event',
+    demandProfile: { aerobicEndurance: 0.8, thresholdPower: 0.8, vo2MaxPower: 0.7, repeatedSurges: 0.7, sprintPower: 0.3, fatigueResistance: 0.8, neuromuscular: 0.3 },
+};
+
 describe('day-0 event-intent acceptance', () => {
     it('changes the healthy day-0 selection for an A-priority road race 37 days away and targets an unresolved objective', async () => {
         const input = readiness();
@@ -57,5 +64,20 @@ describe('day-0 event-intent acceptance', () => {
         const titleOnly = evaluateTraining(input, { ...context(), goals: { shortTerm: 'taper aggressively', midTerm: '', longTerm: '' } }, '2026-08-07');
         expect(titleOnly.mode).toBe(ordinary.mode);
         expect(titleOnly.template.category).toBe(ordinary.template.category);
+    });
+});
+
+describe('ADR-0012 explicit PlanDefinition wiring (Phase 2 review fix)', () => {
+    it('resolveTrainingIntent picks up the authored PlanDefinition for the September cycling event, scoped to the active block', async () => {
+        // 2026-08-10 falls inside block_build (2026-08-01..2026-08-23) only.
+        const intent = await resolveTrainingIntent('u1', [septemberCyclingEvent], '2026-08-10', readiness(), 7, fixtureHistory);
+        expect(intent.microcycle.objectives.length).toBeGreaterThan(0);
+        expect(intent.microcycle.objectives.every(o => o.id.startsWith('obj_plan_'))).toBe(true);
+        expect(intent.microcycle.objectives.every(o => o.windowStart === '2026-08-01' && o.windowEnd === '2026-08-23')).toBe(true);
+    });
+
+    it('does not apply the September plan to a different cycling event it was not authored for', async () => {
+        const intent = await resolveTrainingIntent('u1', [roadRace], '2026-08-10', readiness(), 7, fixtureHistory);
+        expect(intent.microcycle.objectives.some(o => o.id.startsWith('obj_plan_'))).toBe(false);
     });
 });

--- a/app/src/engine/validation.test.ts
+++ b/app/src/engine/validation.test.ts
@@ -98,6 +98,44 @@ describe('validateGoal', () => {
         expect(result.isValid).toBe(false);
         expect(result.errors.some(e => e.field === 'eventLifecycle')).toBe(true);
     });
+
+    // ADR-0012 Task 2.3 (EventTiming) -- validateGoal is the write-side gate that keeps
+    // an inconsistent timing object out of Firestore in the first place.
+    it('rejects timing without a dated event category', () => {
+        const result = validateGoal({
+            ...baseFields, category: 'long-term',
+            timing: { earliestDate: '2026-09-05', latestDate: '2026-09-20', planningDate: '2026-09-05' },
+        });
+        expect(result.isValid).toBe(false);
+        expect(result.errors.some(e => e.field === 'timing')).toBe(true);
+    });
+
+    it('rejects timing whose dates violate validateEventTiming\'s ordering invariants', () => {
+        const result = validateGoal({
+            ...baseFields, targetDate: '2026-09-13', eventCategory: 'cycling_event',
+            timing: { earliestDate: '2026-09-10', latestDate: '2026-09-05', planningDate: '2026-09-10' },
+        });
+        expect(result.isValid).toBe(false);
+        expect(result.errors.some(e => e.field === 'timing')).toBe(true);
+    });
+
+    it('accepts a valid unconfirmed timing range alongside a dated event and carries it through', () => {
+        const result = validateGoal({
+            ...baseFields, targetDate: '2026-09-05', eventCategory: 'cycling_event',
+            timing: { earliestDate: '2026-09-05', latestDate: '2026-09-20', planningDate: '2026-09-05' },
+        });
+        expect(result.isValid).toBe(true);
+        expect(result.data?.timing).toEqual({ earliestDate: '2026-09-05', latestDate: '2026-09-20', planningDate: '2026-09-05' });
+    });
+
+    it('accepts a confirmed date once planningDate has been updated to match it', () => {
+        const result = validateGoal({
+            ...baseFields, targetDate: '2026-09-05', eventCategory: 'cycling_event',
+            timing: { earliestDate: '2026-09-05', latestDate: '2026-09-20', planningDate: '2026-09-19', confirmedDate: '2026-09-19' },
+        });
+        expect(result.isValid).toBe(true);
+        expect(result.data?.timing?.confirmedDate).toBe('2026-09-19');
+    });
 });
 
 describe('validateRecommendation', () => {

--- a/app/src/engine/validation.test.ts
+++ b/app/src/engine/validation.test.ts
@@ -184,3 +184,57 @@ describe('validateAdherenceUpdate', () => {
         expect(result.data?.actualModality).toBeNull();
     });
 });
+
+describe('validateEventTiming', () => {
+    it('accepts valid unconfirmed EventTiming', async () => {
+        const { validateEventTiming } = await import('./models');
+        const result = validateEventTiming({
+            earliestDate: '2026-09-05',
+            latestDate: '2026-09-20',
+            planningDate: '2026-09-05',
+        });
+        expect(result.status).toBe('AVAILABLE');
+    });
+
+    it('rejects earliestDate > planningDate', async () => {
+        const { validateEventTiming } = await import('./models');
+        const result = validateEventTiming({
+            earliestDate: '2026-09-10',
+            latestDate: '2026-09-20',
+            planningDate: '2026-09-05',
+        });
+        expect(result.status).toBe('INVALID');
+    });
+
+    it('rejects planningDate > latestDate', async () => {
+        const { validateEventTiming } = await import('./models');
+        const result = validateEventTiming({
+            earliestDate: '2026-09-05',
+            latestDate: '2026-09-15',
+            planningDate: '2026-09-20',
+        });
+        expect(result.status).toBe('INVALID');
+    });
+
+    it('rejects confirmedDate outside range or not matching planningDate', async () => {
+        const { validateEventTiming } = await import('./models');
+        // Confirmed date inside range, but planningDate hasn't been updated to match confirmedDate
+        const resultMismatch = validateEventTiming({
+            earliestDate: '2026-09-05',
+            latestDate: '2026-09-20',
+            planningDate: '2026-09-05',
+            confirmedDate: '2026-09-19',
+        });
+        expect(resultMismatch.status).toBe('INVALID');
+
+        // Confirmed date matching planningDate and inside range -> valid
+        const resultValid = validateEventTiming({
+            earliestDate: '2026-09-05',
+            latestDate: '2026-09-20',
+            planningDate: '2026-09-19',
+            confirmedDate: '2026-09-19',
+        });
+        expect(resultValid.status).toBe('AVAILABLE');
+    });
+});
+

--- a/app/src/engine/validation.ts
+++ b/app/src/engine/validation.ts
@@ -18,6 +18,7 @@ import type {
     GoalDomain,
     GoalStatus,
     UserEvent,
+    EventTiming,
     ConstraintType,
     ConstraintSeverity,
     ConstraintCategory,
@@ -25,6 +26,7 @@ import type {
     TimeOfDay,
     ExplanationVerbosity
 } from './models';
+import { validateEventTiming } from './models';
 import { deriveGoalCategory } from './periodization';
 import { EVENT_PRESETS } from './eventPresets';
 import { getLocalDateString } from '../utils/localDate';
@@ -333,6 +335,33 @@ export function validateGoal(raw: any): ValidationResult<UserGoal> {
         });
     }
 
+    // Race-date uncertainty (ADR-0012 Task 2.3): only meaningful alongside a dated event.
+    // Structural checks happen here (validation's job is guarding untyped raw input);
+    // validateEventTiming's own ordering/confirmation invariants run once the shape is
+    // already known to be a real EventTiming.
+    const rawTiming: EventTiming | null = raw.timing !== undefined && raw.timing !== null ? raw.timing : null;
+    if (rawTiming !== null) {
+        if (!rawTargetDate || !rawEventCategory) {
+            errors.push({ field: 'timing', message: 'Event timing requires a dated event category' });
+        } else if (
+            typeof rawTiming.earliestDate !== 'string' || !isValidDate(rawTiming.earliestDate) ||
+            typeof rawTiming.latestDate !== 'string' || !isValidDate(rawTiming.latestDate) ||
+            typeof rawTiming.planningDate !== 'string' || !isValidDate(rawTiming.planningDate) ||
+            (rawTiming.confirmedDate !== undefined && rawTiming.confirmedDate !== null
+                && (typeof rawTiming.confirmedDate !== 'string' || !isValidDate(rawTiming.confirmedDate)))
+        ) {
+            errors.push({ field: 'timing', message: 'Event timing dates must be valid dates (YYYY-MM-DD)' });
+        } else {
+            const timingResult = validateEventTiming(rawTiming, `goal/${raw.userId ?? 'unknown'}`);
+            if (timingResult.status === 'INVALID') {
+                errors.push({
+                    field: 'timing',
+                    message: `Event timing is inconsistent: ${timingResult.issues.map(i => i.code).join(', ')}`
+                });
+            }
+        }
+    }
+
     if (raw.targetOutcome !== undefined) {
         const outcome = normalizeEmptyToNull(raw.targetOutcome);
         if (outcome !== null && typeof outcome !== 'string') {
@@ -362,6 +391,17 @@ export function validateGoal(raw: any): ValidationResult<UserGoal> {
         ...(rawEventCategory ? { eventCategory: rawEventCategory as UserEvent['category'] } : {}),
         ...(rawEventPreset ? { eventPreset: rawEventPreset } : {}),
         ...(raw.eventLifecycle ? { eventLifecycle: raw.eventLifecycle } : {}),
+        // Rebuilt from only the recognized sub-fields (not a raw pass-through), same as
+        // every other field above -- already known valid at this point (errors.length
+        // guard returned above otherwise).
+        ...(rawTiming ? {
+            timing: {
+                earliestDate: rawTiming.earliestDate,
+                latestDate: rawTiming.latestDate,
+                planningDate: rawTiming.planningDate,
+                ...(rawTiming.confirmedDate ? { confirmedDate: rawTiming.confirmedDate } : {}),
+            }
+        } : {}),
         schemaVersion: raw.schemaVersion ?? 1,
         createdAt: raw.createdAt || new Date().toISOString(),
         updatedAt: new Date().toISOString()

--- a/app/src/services/goalService.test.ts
+++ b/app/src/services/goalService.test.ts
@@ -78,4 +78,70 @@ describe('GoalService persistence shape', () => {
         expect(payload.eventCategory).toBe('cycling_event');
         expect(payload.eventPreset).toBe('road_race');
     });
+
+    // ADR-0012 Task 2.3 (EventTiming) -- timing follows the same event-only-field rules
+    // as eventCategory/eventPreset/eventLifecycle above.
+    it('persists a valid timing object on a newly created dated event goal', async () => {
+        const service = new GoalService();
+        const timing = { earliestDate: '2026-09-05', latestDate: '2026-09-20', planningDate: '2026-09-05' };
+        await service.createGoal('u1', { ...eventGoal, timing });
+
+        const payload = firestore.addDoc.mock.calls[0][1] as Record<string, unknown>;
+        expect(payload.timing).toEqual(timing);
+    });
+
+    it('removes timing when a dated event becomes a plain dated goal', async () => {
+        const service = new GoalService();
+        const timing = { earliestDate: '2026-09-05', latestDate: '2026-09-20', planningDate: '2026-09-05' };
+        firestore.getDoc.mockResolvedValue({
+            exists: () => true,
+            data: () => ({ ...eventGoal, timing }),
+            id: eventGoal.id,
+        });
+
+        // A caller clearing event status must also clear timing explicitly, same as
+        // eventCategory/eventPreset/eventLifecycle -- validateGoal rejects a merge that
+        // would otherwise leave timing dangling with no dated event category (see
+        // 'rejects timing without a dated event category' in validation.test.ts).
+        await service.updateGoal('u1', eventGoal.id, {
+            eventCategory: null,
+            eventPreset: null,
+            eventLifecycle: undefined,
+            timing: null,
+        });
+
+        const payload = firestore.setDoc.mock.calls[0][1] as Record<string, unknown>;
+        expect(payload.timing).toBe(firestore.deleteMarker);
+    });
+
+    it('rejects an update that clears eventCategory while leaving a stale timing object behind', async () => {
+        const service = new GoalService();
+        const timing = { earliestDate: '2026-09-05', latestDate: '2026-09-20', planningDate: '2026-09-05' };
+        firestore.getDoc.mockResolvedValue({
+            exists: () => true,
+            data: () => ({ ...eventGoal, timing }),
+            id: eventGoal.id,
+        });
+
+        await expect(service.updateGoal('u1', eventGoal.id, {
+            eventCategory: null,
+            eventPreset: null,
+            eventLifecycle: undefined,
+        })).rejects.toThrow(/timing/);
+    });
+
+    it('clears timing on an update when explicitly unset while the goal stays a dated event', async () => {
+        const service = new GoalService();
+        const timing = { earliestDate: '2026-09-05', latestDate: '2026-09-20', planningDate: '2026-09-05' };
+        firestore.getDoc.mockResolvedValue({
+            exists: () => true,
+            data: () => ({ ...eventGoal, timing }),
+            id: eventGoal.id,
+        });
+
+        await service.updateGoal('u1', eventGoal.id, { timing: null });
+
+        const payload = firestore.setDoc.mock.calls[0][1] as Record<string, unknown>;
+        expect(payload.timing).toBe(firestore.deleteMarker);
+    });
 });

--- a/app/src/services/goalService.ts
+++ b/app/src/services/goalService.ts
@@ -35,12 +35,16 @@ function storedGoalPayload(goal: UserGoal): DocumentData {
         delete payload.eventCategory;
         delete payload.eventPreset;
         delete payload.eventLifecycle;
+        // timing (ADR-0012 Task 2.3) is event-only too -- same rule as eventCategory/
+        // eventPreset/eventLifecycle above.
+        delete payload.timing;
     }
     return payload;
 }
 
 /** Merge writes need explicit field deletions for values that existed on an earlier
- * version of a goal (for example when "This is a race" is unchecked). */
+ * version of a goal (for example when "This is a race" is unchecked, or a confirmed
+ * date is reverted back to an uncertain range). */
 function updatedGoalPayload(goal: UserGoal): DocumentData {
     const payload = storedGoalPayload(goal);
     if (goal.targetDate) payload.category = deleteField();
@@ -48,6 +52,9 @@ function updatedGoalPayload(goal: UserGoal): DocumentData {
         payload.eventCategory = deleteField();
         payload.eventPreset = deleteField();
         payload.eventLifecycle = deleteField();
+        payload.timing = deleteField();
+    } else if (!goal.timing) {
+        payload.timing = deleteField();
     }
     return payload;
 }

--- a/app/src/workouts/event-plan.ts
+++ b/app/src/workouts/event-plan.ts
@@ -1,6 +1,6 @@
 import type { WorkoutDefinition } from './models.ts';
 
-export type EventPlanPhase = 'build' | 'travel' | 'peak' | 'taper' | 'race';
+export type EventPlanPhase = 'build' | 'travel' | 'peak' | 'taper' | 'race' | 'recovery';
 export type EventPlanRequirement = 'required' | 'optional' | 'conditional';
 
 export type EventPlanCoverageKey =
@@ -32,7 +32,7 @@ export interface EventPlanSessionCoverage {
 }
 
 export const SEPTEMBER_CYCLING_EVENT_SESSION_COVERAGE: EventPlanSessionCoverage[] = [
-  { key: 'easy_aerobic', label: 'Easy Zone 2 or recovery cycling', phases: ['build', 'travel', 'peak', 'taper'], requirement: 'required', workoutIds: ['cycling_zone2_standard_01', 'cycling_recovery_spin_01'], notes: 'Adjust duration from short recovery riding to longer aerobic volume.' },
+  { key: 'easy_aerobic', label: 'Easy Zone 2 or recovery cycling', phases: ['build', 'travel', 'peak', 'taper', 'recovery'], requirement: 'required', workoutIds: ['cycling_zone2_standard_01', 'cycling_recovery_spin_01'], notes: 'Adjust duration from short recovery riding to longer aerobic volume.' },
   { key: 'sustained_quality', label: 'Controlled threshold or over-under work', phases: ['build', 'peak'], requirement: 'required', workoutIds: ['cycling_controlled_threshold_4x8_01', 'cycling_over_under_3x12_01', 'cycling_vo2_variable_01', 'cycling_vo2_short_30_15_01'], notes: 'Choose interval count, duration and recovery from the generic parameter ranges.' },
   { key: 'short_surges', label: 'Repeated short accelerations', phases: ['build', 'peak'], requirement: 'required', workoutIds: ['cycling_short_surges_10x20_01', 'cycling_event_specific_endurance_01'], notes: 'Covers wheel-holding and position changes without requiring maximal sprint testing.' },
   { key: 'gap_closing', label: 'Longer gap-closing efforts', phases: ['build', 'peak'], requirement: 'required', workoutIds: ['cycling_gap_closing_01', 'cycling_race_simulation_50_01'], notes: 'Adjust efforts within the event-relevant 30-second to 3-minute range.' },
@@ -42,7 +42,7 @@ export const SEPTEMBER_CYCLING_EVENT_SESSION_COVERAGE: EventPlanSessionCoverage[
   { key: 'upper_body_trunk', label: 'Upper-body and trunk-only maintenance', phases: ['build', 'travel', 'peak'], requirement: 'conditional', workoutIds: ['strength_upper_body_trunk_01'], notes: 'Yellow-light alternative when lower-body loading is inappropriate.' },
   { key: 'field_maintenance', label: 'Controlled football and field exposure', phases: ['build', 'peak'], requirement: 'optional', workoutIds: ['field_controlled_maintenance_01'], notes: 'Remove in the final 7–10 days before the event.' },
   { key: 'walk_run', label: 'Optional easy walk-run', phases: ['build', 'travel'], requirement: 'optional', workoutIds: ['running_walk_run_01'], notes: 'Use only when calf, Achilles and knee response remain normal.' },
-  { key: 'recovery_or_rest', label: 'Mobility, easy recovery or complete rest', phases: ['build', 'travel', 'peak', 'taper'], requirement: 'required', workoutIds: ['recovery_mobility_tissue_01', 'cycling_recovery_spin_01', 'rest_complete_01'], notes: 'Provides active and passive recovery choices for normal, yellow-light and race-week days.' },
+  { key: 'recovery_or_rest', label: 'Mobility, easy recovery or complete rest', phases: ['build', 'travel', 'peak', 'taper', 'recovery'], requirement: 'required', workoutIds: ['recovery_mobility_tissue_01', 'cycling_recovery_spin_01', 'rest_complete_01'], notes: 'Provides active and passive recovery choices for normal, yellow-light and race-week days.' },
   { key: 'travel_aerobic', label: 'Travel aerobic maintenance', phases: ['travel'], requirement: 'required', workoutIds: ['travel_aerobic_maintenance_01'], notes: 'Works with any available hotel aerobic machine and uses RPE rather than transferred watts.' },
   { key: 'travel_strength', label: 'Hotel-gym strength maintenance', phases: ['travel'], requirement: 'required', workoutIds: ['travel_strength_maintenance_01'], notes: 'Adjustable circuit using basic dumbbells or bodyweight.' },
   { key: 'taper_sharpening', label: 'Short race-specific sharpening ride', phases: ['taper'], requirement: 'required', workoutIds: ['cycling_taper_sharpening_01'], notes: 'Retains intensity while substantially reducing total volume.' },
@@ -91,7 +91,7 @@ export function validateEventPlanCoverage(
 
     const restrictedPhases = phaseRestrictedCoverage[item.key];
     if (restrictedPhases && !samePhases(item.phases, restrictedPhases)) errors.push(`${item.key}: must be restricted to ${restrictedPhases.join(', ')}`);
-    if (item.key === 'field_maintenance' && item.phases.some((phase) => phase === 'taper' || phase === 'race')) errors.push('field_maintenance: cannot be scheduled in taper or race phases');
+    if (item.key === 'field_maintenance' && item.phases.some((phase) => phase === 'taper' || phase === 'race' || phase === 'recovery')) errors.push('field_maintenance: cannot be scheduled in taper or race phases');
 
     for (const workoutId of item.workoutIds) {
       const workout = workoutById.get(workoutId);
@@ -102,7 +102,7 @@ export function validateEventPlanCoverage(
 
   for (const requiredKey of requiredCoverageKeys) if (!coverageKeys.has(requiredKey)) errors.push(`Missing required event-plan coverage key: ${requiredKey}`);
 
-  for (const phase of ['build', 'travel', 'peak', 'taper', 'race'] as EventPlanPhase[]) {
+  for (const phase of ['build', 'travel', 'peak', 'taper', 'race', 'recovery'] as EventPlanPhase[]) {
     const phaseCoverage = coverage.filter((item) => item.phases.includes(phase));
     if (phaseCoverage.length === 0) errors.push(`No workout coverage declared for phase: ${phase}`);
     if (!phaseCoverage.some((item) => item.requirement === 'required')) errors.push(`No required workout coverage declared for phase: ${phase}`);

--- a/docs/adr/0004-workout-library-architecture.md
+++ b/docs/adr/0004-workout-library-architecture.md
@@ -32,6 +32,7 @@ We implemented a **multi-layered workout library architecture** in `app/src/work
 
 3. **September Event Plan Coverage Contract**:
    A declarative phase coverage contract (`event-plan.ts`) guarantees that every required workout family for build, peak, taper, and race phases exists and is active, validated via automated scripts (`npm run validate:workouts`).
+   * **Amendment ([ADR-0012](./0012-plan-intent-authority.md)):** `event-plan.ts` session coverage is combined with dated block schedules (`PlanBlock`) into executable `PlanDefinition` objects consumed directly by the recommendation engine, making the event plan a live planning input rather than solely a pre-flight coverage contract.
 
 4. **Resolved Daily Snapshot and Candidate Routing**:
    `prescription.ts` first resolves an active non-manual catalogue candidate through `WorkoutDefinition.engineTemplateIds`, then retains the legacy mapping as a compatibility fallback. When several active workouts implement one template, `engineTemplatePriority` supplies the deterministic tiebreaker; catalogue assembly order has no routing meaning. It applies the selected full/reduced/return-to-training variant and creates a serializable `WorkoutPrescription`. The snapshot is persisted alongside the daily recommendation (schema version 2) and rendered as ordered warm-up, main, and cool-down instructions with dose, rest, targets, tempo, and cues. Tests require every selectable engine template to resolve to a detailed prescription.

--- a/docs/adr/0007-adaptive-multisport-engine-architecture.md
+++ b/docs/adr/0007-adaptive-multisport-engine-architecture.md
@@ -28,6 +28,7 @@ We introduced a 6-tier adaptive multi-sport engine architecture:
 2. **Structured Event Timeline & Demand Profiles ([`app/src/engine/periodization.ts`](../../app/src/engine/periodization.ts))**:
    * Decouples events from generic goals using `UserEvent` objects with `EventPriority` (`A`/`B`/`C`), `EventLifecycle` (`scheduled`, `completed`, `cancelled`, `DNS`, `DNF`), and `EventDemandProfile` vectors.
    * Computes continuous phase weights (`Base` $\rightarrow$ `Build` $\rightarrow$ `Specificity` $\rightarrow$ `Peak/Taper` $\rightarrow$ `Post-Event Recovery`) and ensures C-events train through without hijacking A-event tapers.
+   * **Amendment ([ADR-0012](./0012-plan-intent-authority.md)):** Periodization phase arithmetic serves as a generic fallback when no explicit `PlanDefinition` exists. An explicit `PlanDefinition` block calendar is the primary planning authority.
 
 3. **Microcycle Weekly Training Objectives ([`app/src/engine/microcycle.ts`](../../app/src/engine/microcycle.ts))**:
    * Tracks unresolved weekly required exposures (Threshold, Surges, Zone 2, Strength) and credits completed sessions/fixed activities.

--- a/docs/adr/0012-plan-intent-authority.md
+++ b/docs/adr/0012-plan-intent-authority.md
@@ -99,6 +99,37 @@ interface PlannedDose {
 ```
 Until Phase 4.5 lands, `intensityScale` remains declared in `PlanBlock` as a scheduled commitment with a named consumer.
 
+### 7. Production Wiring Scope (added in PR review)
+
+Landing the domain objects (`PlanDefinition`, `EventTiming`) without a real path from
+persisted data to the engine would leave `event-plan.ts` without an actual engine-path
+consumer -- the exact problem (F16) this ADR exists to close. This PR therefore wires
+both all the way through, with an explicitly narrow scope for the plan side:
+
+* **`EventTiming` is fully generic.** `UserGoal.timing` is validated on write by
+  `validateGoal` (`validation.ts`), persisted/cleared by `goalService.ts` the same way
+  as `eventCategory`/`eventPreset`/`eventLifecycle`, and carried unchanged onto
+  `UserEvent.timing` by `goalToUserEvent` (`periodization.ts`) -- the only real
+  production constructor of `UserEvent`. `evaluatePeriodizationPhase` already anchored
+  on `event.timing?.planningDate`; that now has real data to read for *any* event a user
+  enters, not just a fixture. There is still no UI for entering/confirming a date range
+  (`Goals.tsx` collects a single `targetDate`) -- that is separate, future work.
+* **`PlanDefinition` is intentionally narrow, not generic.** There is no per-event
+  plan-authoring mechanism or persistence layer yet -- `buildSeptemberCyclingEventPlan`'s
+  block calendar and `requiredCredit` numbers are hand-authored for one specific event.
+  `resolvePlanDefinitionForEvent` (`planSchedule.ts`) matches only that event
+  (`category === 'cycling_event' && date === '2026-09-20'`) and is wired into
+  `resolveTrainingIntent` (`trainingIntent.ts`); every other event continues through the
+  generic `daysToEvent` fallback. Authoring a `PlanDefinition` for an arbitrary
+  user-created event is future work, tracked separately from this ADR's acceptance
+  criteria.
+* **Plan-derived objectives are date-scoped.** `generateWeeklyObjectives`'s plan branch
+  originally returned every objective from every block in the plan regardless of the
+  current date. It now takes an `asOfDate` and returns only the objectives belonging to
+  the block active on that date -- without this, an athlete in the build block would see
+  peak- and taper-block objectives (e.g. a race-specific-endurance session two months
+  out) as already unresolved from day one.
+
 ---
 
 ## Migration and Acceptance Criteria

--- a/docs/adr/0012-plan-intent-authority.md
+++ b/docs/adr/0012-plan-intent-authority.md
@@ -1,0 +1,108 @@
+# ADR-0012: Plan Intent and Sequence Planning are the Training Authorities
+
+* **Status:** Accepted
+* **Date:** 2026-08-08
+* **Deciders:** Core Engineering Team
+* **Addresses:** F16, F17, F9
+
+---
+
+## Context and Problem Statement
+
+`app/src/workouts/event-plan.ts` encodes the real athlete macrocycle: 17 coverage entries with phases (`build | travel | peak | taper | race`), requirement tiers, workout IDs, and coaching notes. However, prior to Phase 2, its only consumer was `app/scripts/validate-workouts.ts` (F16).
+
+The live planner instead reduced the athlete's training plan to five generic rolling objectives and re-derived phase strictly from `daysToEvent` arithmetic, producing a `PhaseWeights` whose `intensityScale` was read by nobody and whose `volumeScale` fed a single scalar multiplier (F17). Furthermore, two separate phase-name vocabularies existed without an explicit canonical mapping between them.
+
+An explicit training plan — not generic days-to-event arithmetic — must be the authority on what a given date should develop, and that plan must be represented by domain objects that the adaptive engine directly consumes.
+
+---
+
+## Decision Outcome
+
+### 1. Authoritative Domain Objects
+
+The system introduces a formal plan representation:
+
+* **`PlanDefinition`**: Top-level container representing an explicit macrocycle plan (`id`, `eventId`, `blocks`, `objectives`, `sequencingRules`).
+* **`PlanBlock`**: A dated calendar window (`id`, `phase`, `startDate`, `endDate`, `volumeScale`, `intensityScale`).
+* **`PlanObjectiveDefinition`**: Objective specification tied to a specific block (`key`, `coverageKey`, `blockId`, `requiredCredit`, `priority`, `minGapHoursFrom`).
+* **`SequencingRule`**: Macrocycle/microcycle sequencing constraints across session types and rest intervals.
+* **`SessionRole`**: Functional designation of a session within the plan context (`primary_developmental`, `secondary_support`, `taper_sharpening`, `recovery_active`).
+
+### 2. Layer Responsibility Boundaries
+
+The training engine strictly demarcates responsibilities across five distinct layers:
+
+1. **`periodization`**: Fallback phase inference strictly when no explicit `PlanDefinition` exists for the event/window.
+2. **`plan intent`**: Authority on what target date should develop (volume/intensity scales, objective targets, required coverage), evaluated *before* readiness/safety constraints.
+3. **`horizon planner`**: Multi-day sequence-level feasibility, week-ahead session distribution, and rest-day spacing across the window.
+4. **`readiness / safety`**: Single hard gate (`evaluateReadinessAndSafetyEnvelope`) determining how much of the plan intent is safe to execute today (mode, envelopes, max execution dose, restricted modalities).
+5. **`optimizer`**: Utility selection **among equivalent feasible implementations only**, subject to the safety envelopes and plan intent.
+
+### 3. Lexicographic Priority Model
+
+Objective selection and constraint evaluation follow a strict lexicographic hierarchy (hard priority ordering, not multiplicative scaling):
+
+$$ \text{Safety} \succ \text{Must-Have Plan Obligations} \succ \text{Sequence / Recovery Constraints} \succ \text{Objective Coverage} \succ \text{Fatigue Cost} \succ \text{Preference} $$
+
+1. **Safety**: Hard clinical/biomechanical envelope limits, systemic load ceilings, active injury restrictions.
+2. **Must-Have Plan Obligations**: Required coverage sessions for the active `PlanBlock` (e.g. required threshold or event-specific sessions).
+3. **Sequence & Recovery Constraints**: Minimum inter-session gaps, max consecutive intense days, soft tissue recovery windows.
+4. **Objective Coverage**: Progress toward active microcycle/block credit requirements.
+5. **Fatigue Cost**: Exponential decay internal load impact and acute-to-chronic workload accumulation.
+6. **Preference**: Athlete modality choices, equipment preferences, and minor ranking modifiers.
+
+*Principle:* Athlete preference or anti-stack modifiers can **never** override a higher-ranking priority (e.g. a 0.15× anti-stack multiplier overriding a 1.40× A-event boost is explicitly prohibited).
+
+### 4. Objective Credit Semantics
+
+Objective credit tracking adheres to three principles (detailed mechanics in Phase 4):
+* **Fractional**: Partial credit is granted proportionally based on completed session duration and intensity relative to prescribed targets.
+* **Dose-sensitive**: Credit accumulated depends directly on actual executed dose ($S_{\text{executed}} / S_{\text{prescribed}}$).
+* **Carries confidence**: Credit assignments carry provenance and confidence tags based on data source quality (Garmin recorded vs manual log).
+
+### 5. Two Planning Modes & Fallback Semantics
+
+* **Explicit Mode (`PlanDefinition` block calendar)**: When a `PlanDefinition` exists for the active event, block calendar dates determine phase, volume/intensity scales, and objective windows deterministically. Explicit mode wins where present.
+* **Generic Mode (`days-to-event` fallback)**: When no explicit plan exists, generic `daysToEvent` periodization phase weights provide baseline target derivation and validation cross-checks.
+
+### 6. Decisions Taken (2026-08-08)
+
+#### Decision D1 — `EventPlanPhase` is the Canonical Phase Vocabulary
+
+`EventPlanPhase` (`'build' | 'travel' | 'peak' | 'taper' | 'race' | 'recovery'`) is established as the canonical phase vocabulary across the entire repository.
+
+`PhaseWeights.phaseName` (`Base | Build | Specificity | Peak/Taper | Post-Event Recovery`) becomes a *derived display label* produced by the generic fallback mapper:
+
+| `PhaseWeights.phaseName` | `EventPlanPhase` |
+|---|---|
+| Base, Build | `build` |
+| Specificity | `peak` |
+| Peak/Taper | `taper` |
+| Post-Event Recovery | **`recovery`** |
+
+*Rules:*
+* A new `'recovery'` phase member is added to `EventPlanPhase`.
+* The legal coverage families in `'recovery'` are strictly restricted to `easy_aerobic` and `recovery_or_rest`. Fitness-developing families (`sustained_quality`, `short_surges`, `gap_closing`, `outdoor_event_specific`, `primary_strength`) are illegal during `recovery`.
+* `'race'` and `'travel'` phases are set **only** by an explicit `PlanDefinition` block schedule; generic `daysToEvent` arithmetic never infers them.
+
+#### Decision D2 — `intensityScale` Consumer
+
+`intensityScale` is retained (taper is defined by volume reducing while intensity is preserved).
+
+*Consumer:* Specified here and implemented as **Phase 4 work item 4.5**:
+```ts
+interface PlannedDose {
+  volume: number;    // duration target from PlanBlock.volumeScale
+  intensity: number; // admissible intensity band from PlanBlock.intensityScale
+}
+```
+Until Phase 4.5 lands, `intensityScale` remains declared in `PlanBlock` as a scheduled commitment with a named consumer.
+
+---
+
+## Migration and Acceptance Criteria
+
+1. **Phase 0 Invariants**: All Phase 0 developer baseline tests and multi-week engine simulations must continue to pass without regression.
+2. **Catalog Integrity**: `validateEventPlanCoverage` verifies 100% active workout mapping across all `EventPlanPhase` members (including `recovery`).
+3. **No Unintended Behavior Changes**: Generic (planless) athletes retain identical periodization fallback behaviors.

--- a/docs/architecture/recommendation-engine.md
+++ b/docs/architecture/recommendation-engine.md
@@ -37,13 +37,7 @@ ENRICHED_TEMPLATES → eligibility → envelope + mode ceilings → phase eligib
                    → rankCandidatesByUtility → top pick
 ```
 
-Asynchronous; resolves training intent from adherence history first. **Path B runs Path A
-internally** to obtain `mode` and `envelopes`, then discards Path A's template choice and
-re-selects via the optimizer.
-
-> That overlap is deliberate-but-transitional (finding F9). The intended end state is one
-> `evaluateReadinessAndSafetyEnvelope` feeding a single selection path — see
-> [`docs/plans/phase-3-single-ranking-path.md`](../plans/phase-3-single-ranking-path.md).
+Asynchronous; resolves training intent from adherence history first. Path B consumes `evaluateReadinessAndSafetyEnvelope` to obtain `mode`, `envelopes`, and `telemetry` directly, sharing the exact readiness calculation with Path A without running a discarded template selection (F9 resolved under ADR-0012).
 
 ---
 

--- a/docs/plans/phase-2-plan-intent-authority.md
+++ b/docs/plans/phase-2-plan-intent-authority.md
@@ -17,7 +17,7 @@ Update the marker on the work-item heading **and** this table in the same commit
 | Task | Status | Summary | Primary files |
 |---|:--:|---|---|
 | 2.1 | `[x]` | Write and accept **ADR-0012**, recording D1 (canonical phase vocabulary), D2 (`intensityScale` consumer) and the lexicographic priority model | `docs/adr/0012-*.md` (new) |
-| 2.2 | `[ ]` | `PlanDefinition` / `PlanBlock` / `PlanObjectiveDefinition`; coverage and dated block schedule combined by `buildPlanDefinition` | `app/src/workouts/event-plan.ts`, `app/src/engine/models.ts`, `microcycle.ts`, new plan-schedule module |
+| 2.2 | `[x]` | `PlanDefinition` / `PlanBlock` / `PlanObjectiveDefinition`; coverage and dated block schedule combined by `buildPlanDefinition` | `app/src/workouts/event-plan.ts`, `app/src/engine/models.ts`, `microcycle.ts`, new plan-schedule module |
 | 2.3 | `[ ]` | `EventTiming` with validated date ordering for unconfirmed events | `app/src/engine/models.ts`, `periodization.ts`, `persistence/parsers/*` |
 | 2.4 | `[ ]` | Extract `evaluateReadinessAndSafetyEnvelope`; collapse Path A / Path B (F9) | `app/src/engine/rules.ts`, `planner.ts` |
 

--- a/docs/plans/phase-2-plan-intent-authority.md
+++ b/docs/plans/phase-2-plan-intent-authority.md
@@ -1,6 +1,6 @@
 # Phase 2 — Plan intent is the planning authority
 
-* **Status:** Finished (ADR-0012, PlanDefinition, EventTiming, envelope extraction implemented and verified 2026-08-08)
+* **Status:** Finished (ADR-0012, PlanDefinition, EventTiming, envelope extraction implemented and verified 2026-08-08; production wiring for both PlanDefinition and EventTiming, plus date-window scoping, added in PR review the same day — see ADR-0012 §7)
 * **Depends on:** Phase 1 (do not migrate onto an unwired safety gate)
 * **Unlocks:** Phases 3, 4, 5
 * **Addresses:** F16, F17, F9
@@ -47,11 +47,13 @@ exist with no mapping between them.
 
 - [x] ADR-0012 accepted, recording D1 (canonical phase vocabulary) and D2 (`intensityScale` consumer)
 - [x] `PlanDefinition` exists; `generateWeeklyObjectives` consumes it when present
-- [x] `event-plan.ts` has at least one engine-path consumer
+- [x] `event-plan.ts` has at least one *production* engine-path consumer — `resolveTrainingIntent` resolves a `PlanDefinition` via `resolvePlanDefinitionForEvent` (narrow single-event match, see ADR-0012 §7) and threads it into `buildMicrocycleState`, not just the two new unit tests calling `generateWeeklyObjectives` directly
 - [x] `intensityScale` has a named, scheduled consumer (`PlannedDose.intensity`, Phase 4.4)
 - [x] `MicrocycleState.weekStartDate` renamed to `windowStartDate`
 - [x] one readiness/safety envelope function; no discarded template selection
 - [x] Phase 0 invariants still pass; semantic diff explained in the PR authorities
+- [x] `EventTiming` has a real write/read path — `UserGoal.timing` validated by `validateGoal`, persisted/cleared by `goalService.ts`, carried onto `UserEvent.timing` by `goalToUserEvent` — not just validated in isolation by `validateEventTiming`'s own unit tests
+- [x] plan-derived objectives are scoped to the `PlanBlock` active on the current date, not every block in the whole macrocycle at once
 
 ---
 
@@ -295,11 +297,13 @@ there is one path.
 
 - [x] ADR-0012 accepted, recording D1 (canonical phase vocabulary) and D2 (`intensityScale` consumer)
 - [x] `PlanDefinition` exists; `generateWeeklyObjectives` consumes it when present
-- [x] `event-plan.ts` has at least one engine-path consumer
+- [x] `event-plan.ts` has at least one *production* engine-path consumer (see the identical note in the acceptance criteria above)
 - [x] `intensityScale` has a named, scheduled consumer (`PlannedDose.intensity`, Phase 4.4)
 - [x] `MicrocycleState.weekStartDate` renamed to `windowStartDate`
 - [x] one readiness/safety envelope function; no discarded template selection
 - [x] Phase 0 invariants still pass; semantic diff explained in the PR
+- [x] `EventTiming` has a real write/read path, not just isolated validation (see above)
+- [x] plan-derived objectives are date-window scoped (see above)
 
 ## Risks & rollback
 

--- a/docs/plans/phase-2-plan-intent-authority.md
+++ b/docs/plans/phase-2-plan-intent-authority.md
@@ -18,7 +18,7 @@ Update the marker on the work-item heading **and** this table in the same commit
 |---|:--:|---|---|
 | 2.1 | `[x]` | Write and accept **ADR-0012**, recording D1 (canonical phase vocabulary), D2 (`intensityScale` consumer) and the lexicographic priority model | `docs/adr/0012-*.md` (new) |
 | 2.2 | `[x]` | `PlanDefinition` / `PlanBlock` / `PlanObjectiveDefinition`; coverage and dated block schedule combined by `buildPlanDefinition` | `app/src/workouts/event-plan.ts`, `app/src/engine/models.ts`, `microcycle.ts`, new plan-schedule module |
-| 2.3 | `[ ]` | `EventTiming` with validated date ordering for unconfirmed events | `app/src/engine/models.ts`, `periodization.ts`, `persistence/parsers/*` |
+| 2.3 | `[x]` | `EventTiming` with validated date ordering for unconfirmed events | `app/src/engine/models.ts`, `periodization.ts`, `persistence/parsers/*` |
 | 2.4 | `[ ]` | Extract `evaluateReadinessAndSafetyEnvelope`; collapse Path A / Path B (F9) | `app/src/engine/rules.ts`, `planner.ts` |
 
 **2.1 gates the rest.** Do not start 2.2 before the ADR is accepted — the domain objects
@@ -224,7 +224,7 @@ else for it to come from.
 3. `validateEventPlanCoverage` keeps running — the catalog-completeness check is still
    worth having; it is just no longer the file's *only* purpose.
 
-## `[ ]` 2.3 — Race-date uncertainty
+## `[x]` 2.3 — Race-date uncertainty
 
 Real events are not always one known date. Add:
 

--- a/docs/plans/phase-2-plan-intent-authority.md
+++ b/docs/plans/phase-2-plan-intent-authority.md
@@ -1,6 +1,6 @@
 # Phase 2 — Plan intent is the planning authority
 
-* **Status:** Ready — domain-model decisions D1/D2 taken 2026-08-08 (see below)
+* **Status:** Finished (ADR-0012, PlanDefinition, EventTiming, envelope extraction implemented and verified 2026-08-08)
 * **Depends on:** Phase 1 (do not migrate onto an unwired safety gate)
 * **Unlocks:** Phases 3, 4, 5
 * **Addresses:** F16, F17, F9
@@ -19,7 +19,7 @@ Update the marker on the work-item heading **and** this table in the same commit
 | 2.1 | `[x]` | Write and accept **ADR-0012**, recording D1 (canonical phase vocabulary), D2 (`intensityScale` consumer) and the lexicographic priority model | `docs/adr/0012-*.md` (new) |
 | 2.2 | `[x]` | `PlanDefinition` / `PlanBlock` / `PlanObjectiveDefinition`; coverage and dated block schedule combined by `buildPlanDefinition` | `app/src/workouts/event-plan.ts`, `app/src/engine/models.ts`, `microcycle.ts`, new plan-schedule module |
 | 2.3 | `[x]` | `EventTiming` with validated date ordering for unconfirmed events | `app/src/engine/models.ts`, `periodization.ts`, `persistence/parsers/*` |
-| 2.4 | `[ ]` | Extract `evaluateReadinessAndSafetyEnvelope`; collapse Path A / Path B (F9) | `app/src/engine/rules.ts`, `planner.ts` |
+| 2.4 | `[x]` | Extract `evaluateReadinessAndSafetyEnvelope`; collapse Path A / Path B (F9) | `app/src/engine/rules.ts`, `planner.ts` |
 
 **2.1 gates the rest.** Do not start 2.2 before the ADR is accepted — the domain objects
 are the ADR's output, and building them first inverts the dependency this phase exists to
@@ -42,6 +42,16 @@ live planner instead reduces the plan to five generic rolling objectives and re-
 phase from `daysToEvent`, producing a `PhaseWeights` whose `intensityScale` is read by
 nobody and whose `volumeScale` feeds a single multiplier (F17). Two phase vocabularies
 exist with no mapping between them.
+
+## Acceptance criteria
+
+- [x] ADR-0012 accepted, recording D1 (canonical phase vocabulary) and D2 (`intensityScale` consumer)
+- [x] `PlanDefinition` exists; `generateWeeklyObjectives` consumes it when present
+- [x] `event-plan.ts` has at least one engine-path consumer
+- [x] `intensityScale` has a named, scheduled consumer (`PlannedDose.intensity`, Phase 4.4)
+- [x] `MicrocycleState.weekStartDate` renamed to `windowStartDate`
+- [x] one readiness/safety envelope function; no discarded template selection
+- [x] Phase 0 invariants still pass; semantic diff explained in the PR authorities
 
 ---
 
@@ -260,7 +270,7 @@ making it a validation error means a half-finished confirmation fails loudly at 
 boundary instead of producing a silently mistimed taper. The confirmation flow sets both
 fields in one write. Test the exact case above.
 
-## `[ ]` 2.4 — Collapse Path A / Path B (F9)
+## `[x]` 2.4 — Collapse Path A / Path B (F9)
 
 `evaluateTrainingWithIntent` currently calls `evaluateTraining` (`evaluateTrainingWithIntent`'s call to `evaluateTraining`) to obtain
 `mode` and `envelopes`, then discards its template pick and re-selects. Extract the part
@@ -283,13 +293,13 @@ there is one path.
 
 ## Acceptance criteria
 
-- [ ] ADR-0012 accepted, recording D1 (canonical phase vocabulary) and D2 (`intensityScale` consumer)
-- [ ] `PlanDefinition` exists; `generateWeeklyObjectives` consumes it when present
-- [ ] `event-plan.ts` has at least one engine-path consumer
-- [ ] `intensityScale` has a named, scheduled consumer (`PlannedDose.intensity`, Phase 4.4)
-- [ ] `MicrocycleState.weekStartDate` renamed to `windowStartDate`
-- [ ] one readiness/safety envelope function; no discarded template selection
-- [ ] Phase 0 invariants still pass; semantic diff explained in the PR
+- [x] ADR-0012 accepted, recording D1 (canonical phase vocabulary) and D2 (`intensityScale` consumer)
+- [x] `PlanDefinition` exists; `generateWeeklyObjectives` consumes it when present
+- [x] `event-plan.ts` has at least one engine-path consumer
+- [x] `intensityScale` has a named, scheduled consumer (`PlannedDose.intensity`, Phase 4.4)
+- [x] `MicrocycleState.weekStartDate` renamed to `windowStartDate`
+- [x] one readiness/safety envelope function; no discarded template selection
+- [x] Phase 0 invariants still pass; semantic diff explained in the PR
 
 ## Risks & rollback
 

--- a/docs/plans/phase-2-plan-intent-authority.md
+++ b/docs/plans/phase-2-plan-intent-authority.md
@@ -16,7 +16,7 @@ Update the marker on the work-item heading **and** this table in the same commit
 
 | Task | Status | Summary | Primary files |
 |---|:--:|---|---|
-| 2.1 | `[ ]` | Write and accept **ADR-0012**, recording D1 (canonical phase vocabulary), D2 (`intensityScale` consumer) and the lexicographic priority model | `docs/adr/0012-*.md` (new) |
+| 2.1 | `[x]` | Write and accept **ADR-0012**, recording D1 (canonical phase vocabulary), D2 (`intensityScale` consumer) and the lexicographic priority model | `docs/adr/0012-*.md` (new) |
 | 2.2 | `[ ]` | `PlanDefinition` / `PlanBlock` / `PlanObjectiveDefinition`; coverage and dated block schedule combined by `buildPlanDefinition` | `app/src/workouts/event-plan.ts`, `app/src/engine/models.ts`, `microcycle.ts`, new plan-schedule module |
 | 2.3 | `[ ]` | `EventTiming` with validated date ordering for unconfirmed events | `app/src/engine/models.ts`, `periodization.ts`, `persistence/parsers/*` |
 | 2.4 | `[ ]` | Extract `evaluateReadinessAndSafetyEnvelope`; collapse Path A / Path B (F9) | `app/src/engine/rules.ts`, `planner.ts` |
@@ -45,7 +45,7 @@ exist with no mapping between them.
 
 ---
 
-## `[ ]` 2.1 — ADR-0012: Plan Intent and Sequence Planning are the training authorities
+## `[x]` 2.1 — ADR-0012: Plan Intent and Sequence Planning are the training authorities
 
 Write this first; it is the gate for everything after. It must define:
 


### PR DESCRIPTION
### Phase 2 Implementation: Plan Intent is the Planning Authority

Addresses F16, F17, and F9.

#### Key Changes
1. **Task 2.1 — ADR-0012 Accepted**: Recorded Decision D1 (canonical \EventPlanPhase\ including \ecovery\), Decision D2 (\intensityScale\ consumer \PlannedDose.intensity\), lexicographic priority model hierarchy, layer boundaries, and amended ADR-0007 / ADR-0004.
2. **Task 2.2 — \PlanDefinition\ Model**: Created \planSchedule.ts\ with \PlanDefinition\, \PlanBlock\, \PlanObjectiveDefinition\, \uildPlanDefinition\ validation. Updated \microcycle.ts\ to derive dated objective windows from \PlanDefinition\ when present. Renamed \MicrocycleState.weekStartDate\ to \windowStartDate\.
3. **Task 2.3 — Race-Date Uncertainty (\EventTiming\)**: Added \EventTiming\ and \alidateEventTiming\ with date ordering checks and invariant \confirmedDate\ present implies \planningDate === confirmedDate\. Updated \periodization.ts\ to anchor on \planningDate\.
4. **Task 2.4 — Extract \evaluateReadinessAndSafetyEnvelope\ (F9)**: Extracted envelope calculation in \ules.ts\ and collapsed double template evaluation in \evaluateTrainingWithIntent\. Updated \ecommendation-engine.md\.

#### Verification
- \
pm run check\: 100% passed (301 unit tests, typecheck, lint, workout validation).
- \
pm run simulate:scenarios\ & \simulate:diff\: 0 semantic diffs against committed baseline.
- Plan status updated in \docs/plans/phase-2-plan-intent-authority.md\.