### PR TITLE
Phase 5 — Sequence planning, real inputs, and the feedback loop

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -12,6 +12,7 @@ dist
 dist-ssr
 artifacts/visual-review/
 artifacts/simulation-reports/
+artifacts/sequence-search-comparison/
 test-results/
 playwright-report/
 *.local

--- a/app/firestore.rules
+++ b/app/firestore.rules
@@ -155,7 +155,22 @@ service cloud.firestore {
     // must stay aligned with (models.ts FixedActivity, validation.ts validateFixedActivity).
 
     function isValidActivityDate(date) {
-      return date is string && date.matches('^[0-9]{4}-[0-9]{2}-[0-9]{2}$');
+      return date is string && date.matches('^[0-9]{4}-[0-9]{2}-[0-9]{2}$') && isRealCalendarDate(date.split('-'));
+    }
+
+    // Rejects a date that merely matches YYYY-MM-DD shape but isn't a real calendar date
+    // (e.g. 2026-02-30) -- matches validation.ts's isValidDate, which does full calendar
+    // validation client-side. A direct authenticated write bypassing validation.ts must not
+    // be able to persist a date the client-side layer would have rejected.
+    function isRealCalendarDate(parts) {
+      let year = int(parts[0]);
+      let month = int(parts[1]);
+      let day = int(parts[2]);
+      let isLeapYear = (year % 4 == 0 && year % 100 != 0) || year % 400 == 0;
+      let daysInMonth = month == 2 ? (isLeapYear ? 29 : 28)
+        : (month == 4 || month == 6 || month == 9 || month == 11) ? 30
+        : 31;
+      return month >= 1 && month <= 12 && day >= 1 && day <= daysInMonth;
     }
 
     // A single reusable "is this map entry, if present, a 0..1 number" check -- shared by

--- a/app/firestore.rules
+++ b/app/firestore.rules
@@ -150,6 +150,89 @@ service cloud.firestore {
       allow delete: if isOwner(userId);
     }
 
+    // --- Fixed activities (Phase 5.3) ---
+    // See docs/plans/phase-5-sequence-planning.md 5.3 for the full storage contract this
+    // must stay aligned with (models.ts FixedActivity, validation.ts validateFixedActivity).
+
+    function isValidActivityDate(date) {
+      return date is string && date.matches('^[0-9]{4}-[0-9]{2}-[0-9]{2}$');
+    }
+
+    // A single reusable "is this map entry, if present, a 0..1 number" check -- shared by
+    // both expectedStimulus and expectedCost below, since both are just differently-keyed
+    // instances of the same 0..1 axis-map shape.
+    function hasValidAxisValue(m, key) {
+      return !(key in m) || (m[key] is number && m[key] >= 0 && m[key] <= 1);
+    }
+
+    // Firestore rules cannot loop over an arbitrary-length map, so every recognized axis
+    // is checked by name -- this is only tractable because the canonical axis set is
+    // small and fixed (WorkoutStimulusProfile has exactly 8 axes; keep this list and
+    // models.ts in sync when a axis is added).
+    function hasValidExpectedStimulus(m) {
+      return m is map
+        && m.keys().hasOnly(['aerobicEndurance', 'thresholdPower', 'vo2MaxPower', 'repeatedSurges', 'sprintPower', 'fatigueResistance', 'maxStrength', 'hypertrophy'])
+        && m.size() <= 8
+        && hasValidAxisValue(m, 'aerobicEndurance')
+        && hasValidAxisValue(m, 'thresholdPower')
+        && hasValidAxisValue(m, 'vo2MaxPower')
+        && hasValidAxisValue(m, 'repeatedSurges')
+        && hasValidAxisValue(m, 'sprintPower')
+        && hasValidAxisValue(m, 'fatigueResistance')
+        && hasValidAxisValue(m, 'maxStrength')
+        && hasValidAxisValue(m, 'hypertrophy');
+    }
+
+    // Same rationale as above -- WorkoutCostProfile has exactly 6 dimensions.
+    function hasValidExpectedCost(m) {
+      return m is map
+        && m.keys().hasOnly(['systemic', 'cardiovascular', 'lowerBody', 'upperBody', 'impactTissue', 'neuromuscular'])
+        && m.size() <= 6
+        && hasValidAxisValue(m, 'systemic')
+        && hasValidAxisValue(m, 'cardiovascular')
+        && hasValidAxisValue(m, 'lowerBody')
+        && hasValidAxisValue(m, 'upperBody')
+        && hasValidAxisValue(m, 'impactTissue')
+        && hasValidAxisValue(m, 'neuromuscular');
+    }
+
+    // Bounds equipment by length and item count only. Firestore rules cannot iterate a
+    // list to type-check each item, so per-item type/length (string, <= 50 chars) is
+    // enforced client-side by validation.ts's validateFixedActivity, not by this rule --
+    // stated explicitly per the 5.3 plan rather than left for a reader to assume covered.
+    function hasValidEquipmentList(list) {
+      return list is list && list.size() <= 20;
+    }
+
+    function hasValidFixedActivity(userId) {
+      let data = request.resource.data;
+      return hasOwnedUserId(userId)
+        && isValidActivityDate(data.date)
+        && data.keys().hasOnly(['userId', 'title', 'date', 'startTime', 'durationMin', 'fixed', 'expectedStimulus', 'expectedCost', 'environment', 'equipment', 'availabilityOverride', 'isCompleted', 'createdAt', 'updatedAt'])
+        && data.keys().hasAll(['userId', 'title', 'date', 'durationMin', 'fixed', 'environment', 'isCompleted', 'createdAt', 'updatedAt'])
+        && data.title is string && data.title.size() <= 200
+        && data.durationMin is int && data.durationMin > 0 && data.durationMin <= 1440
+        && data.fixed is bool
+        && data.environment in ['indoor', 'outdoor', 'either']
+        && data.isCompleted is bool
+        && data.createdAt is string
+        && data.updatedAt is string
+        && (!('startTime' in data) || data.startTime is string)
+        && (!('expectedStimulus' in data) || hasValidExpectedStimulus(data.expectedStimulus))
+        && (!('expectedCost' in data) || hasValidExpectedCost(data.expectedCost))
+        && (!('equipment' in data) || hasValidEquipmentList(data.equipment))
+        && (!('availabilityOverride' in data) || (data.availabilityOverride is number && data.availabilityOverride >= 0 && data.availabilityOverride <= 1440));
+    }
+
+    match /users/{userId}/fixed_activities/{activityId} {
+      allow read: if isOwner(userId);
+      allow create: if hasValidFixedActivity(userId);
+      allow update: if hasValidFixedActivity(userId)
+        && keepsOwnership(userId)
+        && request.resource.data.createdAt == resource.data.createdAt;
+      allow delete: if isOwner(userId);
+    }
+
     // Legacy constraints are retained solely for one-time migration reads.
     match /users/{userId}/constraints/{constraintId} {
       allow read: if isOwner(userId);

--- a/app/package.json
+++ b/app/package.json
@@ -14,6 +14,7 @@
     "validate:workouts": "node --experimental-strip-types scripts/validate-workouts.ts",
     "simulate:scenarios": "node scripts/simulate-scenarios.mjs",
     "simulate:diff": "node scripts/simulate-diff.mjs",
+    "compare:sequence-search": "node scripts/compare-sequence-search.mjs",
     "replay:recommendation": "node scripts/replay-recommendation-audit.mjs",
     "preview": "vite preview",
     "test": "vitest run",

--- a/app/scripts/compare-sequence-search.mjs
+++ b/app/scripts/compare-sequence-search.mjs
@@ -39,23 +39,24 @@ function keyCyclingDates(result, templateById) {
   return Array.from(dates).sort();
 }
 
-function goldenWeekInvariants(result, templateById, categoryByTemplateId) {
+function goldenWeekInvariants(result, templateById, categoryByTemplateId, getDayDiff) {
   const violations = [];
   const dates = keyCyclingDates(result, templateById);
-  const timestamps = dates.map((d) => new Date(`${d}T00:00:00`).getTime());
-  for (let i = 1; i < timestamps.length; i++) {
-    const diffHours = (timestamps[i] - timestamps[i - 1]) / (1000 * 60 * 60);
-    if (diffHours < 48) violations.push(`key cycling spacing violation: ${dates[i - 1]} -> ${dates[i]} (${diffHours}h)`);
+  // Calendar-day arithmetic via getDayDiff (Date.UTC on the literal YYYY-MM-DD components)
+  // rather than `new Date(`${d}T00:00:00`).getTime()`, which parses in the host's local
+  // timezone and would silently mis-measure spacing across a DST transition inside the
+  // simulated week.
+  for (let i = 1; i < dates.length; i++) {
+    const diffDays = getDayDiff(dates[i], dates[i - 1]);
+    if (diffDays < 2) violations.push(`key cycling spacing violation: ${dates[i - 1]} -> ${dates[i]} (${diffDays}d)`);
   }
 
   const heavyStrengthCategories = new Set(['Lower-body Strength', 'Full-body Strength']);
   const keyDateSet = new Set(dates);
   result.objectiveCredits.forEach((c) => {
     if (heavyStrengthCategories.has(categoryByTemplateId.get(c.templateId) ?? '')) {
-      const strengthTime = new Date(`${c.date}T00:00:00`).getTime();
       keyDateSet.forEach((cycleDate) => {
-        const cycleTime = new Date(`${cycleDate}T00:00:00`).getTime();
-        const diffDays = Math.abs(strengthTime - cycleTime) / (1000 * 60 * 60 * 24);
+        const diffDays = Math.abs(getDayDiff(c.date, cycleDate));
         if (diffDays === 1) violations.push(`heavy strength adjacent to key cycling day: ${c.date} / ${cycleDate}`);
       });
     }
@@ -79,6 +80,7 @@ try {
   const { runScenario } = await server.ssrLoadModule('/src/engine/simulation/analyze.ts');
   const { generateWeekAheadPlanWithIntentBeamSearch } = await server.ssrLoadModule('/src/engine/sequenceSearch.ts');
   const { ENRICHED_TEMPLATES } = await server.ssrLoadModule('/src/engine/templates.ts');
+  const { getDayDiff } = await server.ssrLoadModule('/src/utils/localDate.ts');
 
   const templateById = new Map(ENRICHED_TEMPLATES.map((t) => [t.id, t]));
   const categoryByTemplateId = new Map(ENRICHED_TEMPLATES.map((t) => [t.id, t.category]));
@@ -112,8 +114,8 @@ try {
     },
     goldenWeek: {
       scenarioFound: !!goldenWeekScenario,
-      greedyViolations: greedyGolden ? goldenWeekInvariants(greedyGolden, templateById, categoryByTemplateId) : ['scenario result missing'],
-      beamViolations: beamGolden ? goldenWeekInvariants(beamGolden, templateById, categoryByTemplateId) : ['scenario result missing'],
+      greedyViolations: greedyGolden ? goldenWeekInvariants(greedyGolden, templateById, categoryByTemplateId, getDayDiff) : ['scenario result missing'],
+      beamViolations: beamGolden ? goldenWeekInvariants(beamGolden, templateById, categoryByTemplateId, getDayDiff) : ['scenario result missing'],
     },
     perScenario: SCENARIOS.map((scenario, i) => {
       const g = greedyResults[i];
@@ -155,3 +157,12 @@ comparison.perScenario.forEach((s) => {
   }
 });
 console.log('');
+
+// Non-zero exit on a golden-week invariant violation (greedy is the live production path
+// -- a beam-only violation is comparison data, not a regression, so it doesn't fail the
+// script) so this stays a usable CI gate if `compare:sequence-search` is ever wired in,
+// rather than always exiting 0 regardless of what it found.
+if (comparison.goldenWeek.greedyViolations.length > 0) {
+  console.error(`Golden week invariant violations in greedy output: ${comparison.goldenWeek.greedyViolations.join('; ')}`);
+  process.exitCode = 1;
+}

--- a/app/scripts/compare-sequence-search.mjs
+++ b/app/scripts/compare-sequence-search.mjs
@@ -1,0 +1,157 @@
+// Phase 5.1 adoption-decision harness: runs every scenario in
+// src/engine/simulation/scenarios.ts through BOTH the production greedy planner
+// (generateWeekAheadPlanWithIntent) and the Phase 5.1 beam-search prototype
+// (generateWeekAheadPlanWithIntentBeamSearch), using the identical `runScenario` harness
+// and metrics for each, and reports the comparison. See docs/adr/0015-sequence-planning-and-session-role-model.md
+// for how this data feeds the recorded adoption decision.
+import { writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { createServer } from 'vite';
+
+const server = await createServer({
+  configFile: false,
+  root: resolve('.'),
+  logLevel: 'warn',
+  server: { middlewareMode: true },
+  appType: 'custom',
+});
+
+function aggregateRestPct(results) {
+  const totalDays = results.reduce((sum, r) => sum + r.totalDays, 0);
+  const totalRest = results.reduce((sum, r) => sum + r.restOrRecoveryDayCount, 0);
+  return totalDays > 0 ? (totalRest / totalDays) * 100 : 0;
+}
+
+function keyCyclingDates(result, templateById) {
+  const keyCategories = new Set(['Hard Endurance', 'Moderate Endurance', 'Race-Specific Endurance']);
+  const dates = new Set(
+    result.objectiveCredits
+      .filter((credit) => {
+        const template = templateById.get(credit.templateId);
+        return credit.modality === 'Cycling' && template?.modality === 'Cycling' && keyCategories.has(template.category);
+      })
+      .map((credit) => credit.date),
+  );
+  result.anchorWeeks.forEach((week) => {
+    if (week.qualityAnchorHit && week.qualityAnchorDate) dates.add(week.qualityAnchorDate);
+    week.eventSpecificExposureDates.forEach((date) => dates.add(date));
+  });
+  return Array.from(dates).sort();
+}
+
+function goldenWeekInvariants(result, templateById, categoryByTemplateId) {
+  const violations = [];
+  const dates = keyCyclingDates(result, templateById);
+  const timestamps = dates.map((d) => new Date(`${d}T00:00:00`).getTime());
+  for (let i = 1; i < timestamps.length; i++) {
+    const diffHours = (timestamps[i] - timestamps[i - 1]) / (1000 * 60 * 60);
+    if (diffHours < 48) violations.push(`key cycling spacing violation: ${dates[i - 1]} -> ${dates[i]} (${diffHours}h)`);
+  }
+
+  const heavyStrengthCategories = new Set(['Lower-body Strength', 'Full-body Strength']);
+  const keyDateSet = new Set(dates);
+  result.objectiveCredits.forEach((c) => {
+    if (heavyStrengthCategories.has(categoryByTemplateId.get(c.templateId) ?? '')) {
+      const strengthTime = new Date(`${c.date}T00:00:00`).getTime();
+      keyDateSet.forEach((cycleDate) => {
+        const cycleTime = new Date(`${cycleDate}T00:00:00`).getTime();
+        const diffDays = Math.abs(strengthTime - cycleTime) / (1000 * 60 * 60 * 24);
+        if (diffDays === 1) violations.push(`heavy strength adjacent to key cycling day: ${c.date} / ${cycleDate}`);
+      });
+    }
+  });
+
+  if (dates.length < 2) violations.push(`fewer than 2 key/race-specific cycling sessions (${dates.length})`);
+
+  const threshold = result.objectiveResolution.find((o) => o.key === 'threshold_quality');
+  const strength = result.objectiveResolution.find((o) => o.key === 'strength_maintenance');
+  if (!threshold || threshold.timesResolved < threshold.timesGenerated) violations.push('threshold_quality objective not fully resolved');
+  if (!strength || strength.timesResolved < strength.timesGenerated) violations.push('strength_maintenance objective not fully resolved');
+
+  if (result.restOrRecoveryDayCount < 1) violations.push('no Rest/Mobility-Recovery day in the week');
+
+  return violations;
+}
+
+let comparison;
+try {
+  const { SCENARIOS } = await server.ssrLoadModule('/src/engine/simulation/scenarios.ts');
+  const { runScenario } = await server.ssrLoadModule('/src/engine/simulation/analyze.ts');
+  const { generateWeekAheadPlanWithIntentBeamSearch } = await server.ssrLoadModule('/src/engine/sequenceSearch.ts');
+  const { ENRICHED_TEMPLATES } = await server.ssrLoadModule('/src/engine/templates.ts');
+
+  const templateById = new Map(ENRICHED_TEMPLATES.map((t) => [t.id, t]));
+  const categoryByTemplateId = new Map(ENRICHED_TEMPLATES.map((t) => [t.id, t.category]));
+
+  const greedyResults = [];
+  const beamResults = [];
+  const greedyStart = Date.now();
+  for (const scenario of SCENARIOS) greedyResults.push(await runScenario(scenario));
+  const greedyMs = Date.now() - greedyStart;
+
+  const beamStart = Date.now();
+  for (const scenario of SCENARIOS) beamResults.push(await runScenario(scenario, generateWeekAheadPlanWithIntentBeamSearch));
+  const beamMs = Date.now() - beamStart;
+
+  const goldenWeekScenario = SCENARIOS.find((s) => s.id === 'cycling_a_event_build_week');
+  const greedyGolden = greedyResults.find((r) => r.scenarioId === 'cycling_a_event_build_week');
+  const beamGolden = beamResults.find((r) => r.scenarioId === 'cycling_a_event_build_week');
+
+  comparison = {
+    scenarioCount: SCENARIOS.length,
+    timing: { greedyMs, beamMs, beamOverheadFactor: greedyMs > 0 ? beamMs / greedyMs : null },
+    aggregate: {
+      greedy: {
+        restPct: aggregateRestPct(greedyResults),
+        constraintViolations: greedyResults.reduce((sum, r) => sum + r.constraintViolations.length, 0),
+      },
+      beam: {
+        restPct: aggregateRestPct(beamResults),
+        constraintViolations: beamResults.reduce((sum, r) => sum + r.constraintViolations.length, 0),
+      },
+    },
+    goldenWeek: {
+      scenarioFound: !!goldenWeekScenario,
+      greedyViolations: greedyGolden ? goldenWeekInvariants(greedyGolden, templateById, categoryByTemplateId) : ['scenario result missing'],
+      beamViolations: beamGolden ? goldenWeekInvariants(beamGolden, templateById, categoryByTemplateId) : ['scenario result missing'],
+    },
+    perScenario: SCENARIOS.map((scenario, i) => {
+      const g = greedyResults[i];
+      const b = beamResults[i];
+      return {
+        scenarioId: scenario.id,
+        label: scenario.label,
+        greedy: { restOrRecoveryDayPct: g.restOrRecoveryDayPct, constraintViolations: g.constraintViolations.length, objectivesUnresolved: g.objectiveResolution.filter((o) => o.timesResolved < o.timesGenerated).length },
+        beam: { restOrRecoveryDayPct: b.restOrRecoveryDayPct, constraintViolations: b.constraintViolations.length, objectivesUnresolved: b.objectiveResolution.filter((o) => o.timesResolved < o.timesGenerated).length },
+        categoryDistributionDelta: Object.keys({ ...g.categoryDistribution, ...b.categoryDistribution }).reduce((acc, cat) => {
+          const delta = (b.categoryDistribution[cat] ?? 0) - (g.categoryDistribution[cat] ?? 0);
+          if (delta !== 0) acc[cat] = delta;
+          return acc;
+        }, {}),
+      };
+    }),
+  };
+} finally {
+  await server.close();
+}
+
+const outputDir = resolve('artifacts/sequence-search-comparison');
+if (!existsSync(outputDir)) mkdirSync(outputDir, { recursive: true });
+writeFileSync(resolve(outputDir, 'comparison.json'), `${JSON.stringify(comparison, null, 2)}\n`);
+
+console.log(`\n=== Phase 5.1 sequence-search comparison (beam vs greedy) ===\n`);
+console.log(`Scenarios: ${comparison.scenarioCount}`);
+console.log(`Timing: greedy ${comparison.timing.greedyMs}ms, beam ${comparison.timing.beamMs}ms (${comparison.timing.beamOverheadFactor?.toFixed(1)}x)`);
+console.log(`Aggregate rest/recovery share: greedy ${comparison.aggregate.greedy.restPct.toFixed(1)}%, beam ${comparison.aggregate.beam.restPct.toFixed(1)}%`);
+console.log(`Aggregate constraint violations: greedy ${comparison.aggregate.greedy.constraintViolations}, beam ${comparison.aggregate.beam.constraintViolations}`);
+console.log(`\nGolden week (cycling_a_event_build_week) invariant violations:`);
+console.log(`  greedy: ${comparison.goldenWeek.greedyViolations.length === 0 ? 'none' : comparison.goldenWeek.greedyViolations.join('; ')}`);
+console.log(`  beam:   ${comparison.goldenWeek.beamViolations.length === 0 ? 'none' : comparison.goldenWeek.beamViolations.join('; ')}`);
+console.log(`\nPer-scenario deltas (beam - greedy) written to ${resolve(outputDir, 'comparison.json')}`);
+comparison.perScenario.forEach((s) => {
+  const changed = Object.keys(s.categoryDistributionDelta).length > 0;
+  if (changed || s.beam.constraintViolations !== s.greedy.constraintViolations || s.beam.objectivesUnresolved !== s.greedy.objectivesUnresolved) {
+    console.log(`  ${s.scenarioId}: rest% ${s.greedy.restOrRecoveryDayPct}->${s.beam.restOrRecoveryDayPct}, violations ${s.greedy.constraintViolations}->${s.beam.constraintViolations}, unresolved ${s.greedy.objectivesUnresolved}->${s.beam.objectivesUnresolved}, category deltas: ${JSON.stringify(s.categoryDistributionDelta)}`);
+  }
+});
+console.log('');

--- a/app/src/components/DailyCheckin.css
+++ b/app/src/components/DailyCheckin.css
@@ -236,6 +236,57 @@
   cursor: pointer;
 }
 
+/* Per-region tissue response (Phase 5.4) */
+.tissue-response-section {
+  margin: 2rem 0;
+  padding-top: 1.5rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.tissue-response-section h3 {
+  margin: 0 0 0.25rem;
+  font-size: 1.1rem;
+}
+
+.tissue-response-section > p {
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+  margin: 0 0 1rem;
+}
+
+.tissue-region-card {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 8px;
+  padding: 1rem;
+  margin-top: 1rem;
+}
+
+.tissue-region-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.75rem;
+}
+
+.tissue-region-remove {
+  background: transparent;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 1rem;
+  padding: 0.25rem 0.5rem;
+}
+
+.tissue-region-remove:hover {
+  color: white;
+}
+
+.tissue-region-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
 .textarea-input {
   resize: vertical;
   font-family: inherit;

--- a/app/src/components/DailyCheckin.tsx
+++ b/app/src/components/DailyCheckin.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { checkinService } from '../services/checkinService';
 import { recoverySnapshotService } from '../services/recoverySnapshotService';
-import type { DailySubjectiveCheckin } from '../engine/models';
+import type { BodyRegion, DailySubjectiveCheckin, RegionTissueResponse, TissueResponseLevel } from '../engine/models';
 import { getLocalDateString } from '../utils/localDate';
 import { getErrorMessage } from '../utils/errors';
 import './DailyCheckin.css';
@@ -11,6 +11,23 @@ interface DailyCheckinProps {
   onNavigate: (screen: 'home' | 'checkin' | 'goals' | 'constraints' | 'preferences') => void;
   onBack?: () => void;
 }
+
+const BODY_REGIONS: BodyRegion[] = [
+  'knee', 'achilles', 'ankle', 'calf', 'hamstring', 'quadriceps',
+  'adductor_groin', 'hip', 'lower_back', 'shoulder', 'elbow', 'wrist',
+];
+
+const REGION_LABELS: Record<BodyRegion, string> = {
+  knee: 'Knee', achilles: 'Achilles', ankle: 'Ankle', calf: 'Calf',
+  hamstring: 'Hamstring', quadriceps: 'Quadriceps', adductor_groin: 'Adductor/Groin',
+  hip: 'Hip', lower_back: 'Lower Back', shoulder: 'Shoulder', elbow: 'Elbow', wrist: 'Wrist',
+};
+
+const TISSUE_LEVELS: TissueResponseLevel[] = ['normal', 'mild', 'moderate', 'severe'];
+
+const TISSUE_LEVEL_LABELS: Record<TissueResponseLevel, string> = {
+  normal: 'Normal', mild: 'Mild', moderate: 'Moderate', severe: 'Severe',
+};
 
 const READINESS_FIELDS = [
   { key: 'readiness', label: 'Overall Readiness', desc: 'How ready do you feel to train today?' },
@@ -133,6 +150,40 @@ export function DailyCheckin({ userId, onNavigate, onBack }: DailyCheckinProps) 
   const handleBooleanToggle = (field: 'painOrInjury' | 'illnessSymptoms' | 'unusuallyLimitedTime' | 'alreadyTrainedToday') => {
     if (!checkin) return;
     setCheckin({ ...checkin, [field]: !checkin[field] });
+  };
+
+  // Per-region tissue response (Phase 5.4) -- see injuryPolicy.ts resolveEffectiveInjuryConstraints
+  // for how these feed the engine: preserve-or-tighten only against the athlete's
+  // standing InjuryConstraint[], never persisted anywhere but this day's check-in.
+  const handleAddTissueRegion = (region: BodyRegion) => {
+    if (!checkin) return;
+    const existing = checkin.tissueResponses ?? {};
+    if (existing[region]) return;
+    const entry: RegionTissueResponse = { region, morningState: 'mild' };
+    setCheckin({ ...checkin, tissueResponses: { ...existing, [region]: entry } });
+  };
+
+  const handleRemoveTissueRegion = (region: BodyRegion) => {
+    if (!checkin) return;
+    const remaining = { ...(checkin.tissueResponses ?? {}) };
+    delete remaining[region];
+    setCheckin({ ...checkin, tissueResponses: remaining });
+  };
+
+  const handleTissueFieldChange = (
+    region: BodyRegion,
+    field: keyof RegionTissueResponse,
+    value: TissueResponseLevel | ''
+  ) => {
+    if (!checkin) return;
+    const existing = checkin.tissueResponses?.[region];
+    if (!existing) return;
+    const updated: RegionTissueResponse = { ...existing };
+    if (field !== 'region') {
+      if (value === '') delete updated[field];
+      else updated[field] = value;
+    }
+    setCheckin({ ...checkin, tissueResponses: { ...checkin.tissueResponses, [region]: updated } });
   };
 
   const handleAvailabilityChange = (field: string, value: number | string | boolean | null) => {
@@ -297,6 +348,17 @@ export function DailyCheckin({ userId, onNavigate, onBack }: DailyCheckinProps) 
                   {checkin.painOrInjury ? 'Pain Flag' : checkin.illnessSymptoms ? 'Unwell' : 'None'}
                 </span>
               </div>
+              {checkin.tissueResponses && Object.keys(checkin.tissueResponses).length > 0 && (
+                <div className="summary-item">
+                  <span className="summary-label">Affected Areas:</span>
+                  <span className="summary-val">
+                    {Object.values(checkin.tissueResponses)
+                      .filter((response): response is NonNullable<typeof response> => !!response)
+                      .map(response => REGION_LABELS[response.region])
+                      .join(', ')}
+                  </span>
+                </div>
+              )}
               <div className="summary-item">
                 <span className="summary-label">Time Available:</span>
                 <span className="summary-val">{checkin.availability?.timeAvailableMin ?? 60} min</span>
@@ -490,6 +552,111 @@ export function DailyCheckin({ userId, onNavigate, onBack }: DailyCheckinProps) 
               </div>
             </label>
           </div>
+
+          {checkin.painOrInjury && (
+            <div className="tissue-response-section">
+              <h3>Which areas?</h3>
+              <p>Pinpointing where and when helps distinguish a sore knee from general fatigue.</p>
+
+              <div className="form-group">
+                <label htmlFor="add-tissue-region">Add affected area</label>
+                <select
+                  id="add-tissue-region"
+                  className="select-input"
+                  value=""
+                  onChange={(e) => {
+                    if (e.target.value) handleAddTissueRegion(e.target.value as BodyRegion);
+                  }}
+                >
+                  <option value="">Select a region...</option>
+                  {BODY_REGIONS.filter(region => !checkin.tissueResponses?.[region]).map(region => (
+                    <option key={region} value={region}>{REGION_LABELS[region]}</option>
+                  ))}
+                </select>
+              </div>
+
+              {Object.values(checkin.tissueResponses ?? {}).map(response => {
+                if (!response) return null;
+                const region = response.region;
+                return (
+                  <div className="tissue-region-card" key={region}>
+                    <div className="tissue-region-header">
+                      <strong>{REGION_LABELS[region]}</strong>
+                      <button
+                        type="button"
+                        className="tissue-region-remove"
+                        onClick={() => handleRemoveTissueRegion(region)}
+                        aria-label={`Remove ${REGION_LABELS[region]}`}
+                      >
+                        ✕
+                      </button>
+                    </div>
+
+                    <div className="tissue-region-fields">
+                      <div className="form-group">
+                        <label htmlFor={`${region}-morningState`}>This morning (before training)</label>
+                        <select
+                          id={`${region}-morningState`}
+                          className="select-input"
+                          value={response.morningState}
+                          onChange={(e) => handleTissueFieldChange(region, 'morningState', e.target.value as TissueResponseLevel)}
+                        >
+                          {TISSUE_LEVELS.map(level => (
+                            <option key={level} value={level}>{TISSUE_LEVEL_LABELS[level]}</option>
+                          ))}
+                        </select>
+                      </div>
+
+                      <div className="form-group">
+                        <label htmlFor={`${region}-painDuringTraining`}>Pain during training (if any)</label>
+                        <select
+                          id={`${region}-painDuringTraining`}
+                          className="select-input"
+                          value={response.painDuringTraining ?? ''}
+                          onChange={(e) => handleTissueFieldChange(region, 'painDuringTraining', e.target.value as TissueResponseLevel | '')}
+                        >
+                          <option value="">Did not train / not applicable</option>
+                          {TISSUE_LEVELS.map(level => (
+                            <option key={level} value={level}>{TISSUE_LEVEL_LABELS[level]}</option>
+                          ))}
+                        </select>
+                      </div>
+
+                      <div className="form-group">
+                        <label htmlFor={`${region}-afterTrainingState`}>Right after training</label>
+                        <select
+                          id={`${region}-afterTrainingState`}
+                          className="select-input"
+                          value={response.afterTrainingState ?? ''}
+                          onChange={(e) => handleTissueFieldChange(region, 'afterTrainingState', e.target.value as TissueResponseLevel | '')}
+                        >
+                          <option value="">Did not train / not applicable</option>
+                          {TISSUE_LEVELS.map(level => (
+                            <option key={level} value={level}>{TISSUE_LEVEL_LABELS[level]}</option>
+                          ))}
+                        </select>
+                      </div>
+
+                      <div className="form-group">
+                        <label htmlFor={`${region}-nextMorningReaction`}>This morning's reaction to yesterday's session</label>
+                        <select
+                          id={`${region}-nextMorningReaction`}
+                          className="select-input"
+                          value={response.nextMorningReaction ?? ''}
+                          onChange={(e) => handleTissueFieldChange(region, 'nextMorningReaction', e.target.value as TissueResponseLevel | '')}
+                        >
+                          <option value="">No session yesterday / not applicable</option>
+                          {TISSUE_LEVELS.map(level => (
+                            <option key={level} value={level}>{TISSUE_LEVEL_LABELS[level]}</option>
+                          ))}
+                        </select>
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
 
           <button className="next-btn" onClick={handleNext}>
             Next

--- a/app/src/components/DailyCheckin.tsx
+++ b/app/src/components/DailyCheckin.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { checkinService } from '../services/checkinService';
 import { recoverySnapshotService } from '../services/recoverySnapshotService';
 import type { BodyRegion, DailySubjectiveCheckin, RegionTissueResponse, TissueResponseLevel } from '../engine/models';
+import { BODY_REGIONS, TISSUE_LEVELS } from '../engine/models';
 import { getLocalDateString } from '../utils/localDate';
 import { getErrorMessage } from '../utils/errors';
 import './DailyCheckin.css';
@@ -12,18 +13,11 @@ interface DailyCheckinProps {
   onBack?: () => void;
 }
 
-const BODY_REGIONS: BodyRegion[] = [
-  'knee', 'achilles', 'ankle', 'calf', 'hamstring', 'quadriceps',
-  'adductor_groin', 'hip', 'lower_back', 'shoulder', 'elbow', 'wrist',
-];
-
 const REGION_LABELS: Record<BodyRegion, string> = {
   knee: 'Knee', achilles: 'Achilles', ankle: 'Ankle', calf: 'Calf',
   hamstring: 'Hamstring', quadriceps: 'Quadriceps', adductor_groin: 'Adductor/Groin',
   hip: 'Hip', lower_back: 'Lower Back', shoulder: 'Shoulder', elbow: 'Elbow', wrist: 'Wrist',
 };
-
-const TISSUE_LEVELS: TissueResponseLevel[] = ['normal', 'mild', 'moderate', 'severe'];
 
 const TISSUE_LEVEL_LABELS: Record<TissueResponseLevel, string> = {
   normal: 'Normal', mild: 'Mild', moderate: 'Moderate', severe: 'Severe',

--- a/app/src/components/DailyCheckin.tsx
+++ b/app/src/components/DailyCheckin.tsx
@@ -143,7 +143,20 @@ export function DailyCheckin({ userId, onNavigate, onBack }: DailyCheckinProps) 
 
   const handleBooleanToggle = (field: 'painOrInjury' | 'illnessSymptoms' | 'unusuallyLimitedTime' | 'alreadyTrainedToday') => {
     if (!checkin) return;
-    setCheckin({ ...checkin, [field]: !checkin[field] });
+    const next = !checkin[field];
+    if (field === 'painOrInjury' && !next) {
+      // The tissue-response editor below only renders while painOrInjury is true -- clear
+      // any previously entered tissueResponses the moment the flag flips false, rather than
+      // leaving them hidden-but-persisted. mapContextFromGoalsAndTrainingSettings consumes
+      // tissueResponses regardless of this flag, so a stale entry would keep restricting
+      // the athlete on a region they can no longer see or edit, after explicitly reporting
+      // "no pain/injury".
+      const cleared: Partial<DailySubjectiveCheckin> = { ...checkin, [field]: next };
+      delete cleared.tissueResponses;
+      setCheckin(cleared);
+      return;
+    }
+    setCheckin({ ...checkin, [field]: next });
   };
 
   // Per-region tissue response (Phase 5.4) -- see injuryPolicy.ts resolveEffectiveInjuryConstraints
@@ -252,7 +265,7 @@ export function DailyCheckin({ userId, onNavigate, onBack }: DailyCheckinProps) 
       setError(null);
       const now = new Date().toISOString();
       const isFirstSubmission = !checkin.initialSubmittedAt || !checkin.dataQuality?.isComplete;
-      
+
       const checkinToSave: Partial<DailySubjectiveCheckin> = {
         ...checkin,
         submittedAt: now,

--- a/app/src/components/Home.tsx
+++ b/app/src/components/Home.tsx
@@ -8,9 +8,10 @@ import type { TrainingHistorySnapshot } from '../engine/trainingHistorySnapshot'
 import { buildRecommendationAudit } from '../engine/provenance';
 import { evaluatePeriodizationPhase, getDaysToEvent } from '../engine/periodization';
 import { resolveExecutionDose } from '../engine/dose';
-import type { DailyDecisionInput, Recommendation, NextDayPotentialPlan, DailyRecommendation } from '../engine/models';
+import type { DailyDecisionInput, Recommendation, NextDayPotentialPlan, DailyRecommendation, FixedActivity } from '../engine/models';
 import { recommendationService } from '../services/recommendationService';
-import { getPreviousLocalDateString } from '../utils/localDate';
+import { fixedActivityService } from '../services/fixedActivityService';
+import { getPreviousLocalDateString, addDaysToLocalDateString } from '../utils/localDate';
 import { getPrescriptionLegend, resolveWorkoutPrescription } from '../workouts';
 import type { WorkoutPrescription } from '../workouts';
 import { AdherencePrompt } from './AdherencePrompt';
@@ -318,6 +319,29 @@ export function Home({ userId, onNavigate, onViewData }: HomeProps) {
     };
   }, [decisionInput]);
 
+  // Matches generateWeekAheadPlan's own WeekAheadOptions.days default (planner.ts) -- the
+  // fixed-activity read below must cover the same horizon the planner actually walks.
+  const WEEK_AHEAD_DAYS = 7;
+
+  // Fixed activities (Phase 5.3) persisted at users/{userId}/fixed_activities -- read
+  // once per user/date, same lifecycle as the other week-ahead inputs below.
+  const [fixedActivities, setFixedActivities] = useState<FixedActivity[]>([]);
+  useEffect(() => {
+    let cancelled = false;
+    if (!decisionInput) {
+      setFixedActivities([]);
+      return () => { cancelled = true; };
+    }
+    const endDate = addDaysToLocalDateString(decisionInput.date, WEEK_AHEAD_DAYS);
+    fixedActivityService.getActivitiesInRange(userId, decisionInput.date, endDate)
+      .then(activities => { if (!cancelled) setFixedActivities(activities); })
+      .catch(err => {
+        console.warn('Failed to load fixed activities:', err);
+        if (!cancelled) setFixedActivities([]);
+      });
+    return () => { cancelled = true; };
+  }, [userId, decisionInput]);
+
   // The production planner reads adherence history once, so it must run outside render.
   // Cancellation ensures a prior user/date/goals/check-in/settings state cannot replace
   // the forecast after a newer dashboard snapshot has been composed.
@@ -342,7 +366,7 @@ export function Home({ userId, onNavigate, onViewData }: HomeProps) {
       decisionInput.date,
       activeRec,
       tomorrowRec,
-      {},
+      { days: WEEK_AHEAD_DAYS, fixedActivities },
       undefined,
       historySnapshot,
     ).then(plan => {
@@ -354,7 +378,7 @@ export function Home({ userId, onNavigate, onViewData }: HomeProps) {
       }
     });
     return () => { cancelled = true; };
-  }, [userId, engineInputs, decisionInput, activeRec, canGenerateNormalPlan, nextDayPlan, selectedNextDayTier, eventPeriodization, historySnapshot]);
+  }, [userId, engineInputs, decisionInput, activeRec, canGenerateNormalPlan, nextDayPlan, selectedNextDayTier, eventPeriodization, historySnapshot, fixedActivities]);
 
   if (loading) {
     return (

--- a/app/src/components/Home.tsx
+++ b/app/src/components/Home.tsx
@@ -9,6 +9,7 @@ import { buildRecommendationAudit } from '../engine/provenance';
 import { evaluatePeriodizationPhase, getDaysToEvent } from '../engine/periodization';
 import { resolveExecutionDose } from '../engine/dose';
 import type { DailyDecisionInput, Recommendation, NextDayPotentialPlan, DailyRecommendation, FixedActivity } from '../engine/models';
+import type { DataState } from '../engine/dataState';
 import { recommendationService } from '../services/recommendationService';
 import { fixedActivityService } from '../services/fixedActivityService';
 import { getPreviousLocalDateString, addDaysToLocalDateString } from '../utils/localDate';
@@ -185,6 +186,14 @@ export function Home({ userId, onNavigate, onViewData }: HomeProps) {
         const objective = mapSnapshotToEngineInput(input.recoverySnapshot);
         const subjective = mapCheckinToSubjectiveInput(input.subjectiveCheckin);
         const context = mapContextFromGoalsAndTrainingSettings(input.activeGoals, input.trainingSettings, input.preferences, input.date, input.subjectiveCheckin);
+        // injuryPolicy.ts's resolveEffectiveInjuryConstraints documents tissue-derived
+        // restrictions as a single TODAY-only decision (reviewBy: today, never persisted).
+        // `context` above bakes today's checkin into restrictedModalities/impliedGuardrails
+        // for `evaluateTrainingWithIntent` below, which is correct for today's own
+        // decision -- but tomorrow's provisional plan is a different day's decision, so it
+        // must not inherit it. `forecastContext` omits todaysCheckin, leaving only the
+        // athlete's standing InjuryConstraint[] in force.
+        const forecastContext = mapContextFromGoalsAndTrainingSettings(input.activeGoals, input.trainingSettings, input.preferences, input.date, null);
         const events = mapGoalsToUserEvents(input.activeGoals);
         const preparedSnapshot = await prepareTrainingHistorySnapshot(userId, input.date);
         if (!isCurrent()) return;
@@ -207,7 +216,7 @@ export function Home({ userId, onNavigate, onViewData }: HomeProps) {
         setRecommendation(todayRec);
 
         const tomorrowPlan = await evaluateNextDayPlanWithIntent(
-          userId, events, { subjective, objective }, context, input.date, todayRec, undefined, preparedSnapshot,
+          userId, events, { subjective, objective }, forecastContext, input.date, todayRec, undefined, preparedSnapshot,
         );
         if (!isCurrent()) return;
         setNextDayPlan(tomorrowPlan);
@@ -260,6 +269,20 @@ export function Home({ userId, onNavigate, onViewData }: HomeProps) {
     const subjective = mapCheckinToSubjectiveInput(decisionInput.subjectiveCheckin);
     const objective = mapSnapshotToEngineInput(decisionInput.recoverySnapshot);
     const context = mapContextFromGoalsAndTrainingSettings(decisionInput.activeGoals, decisionInput.trainingSettings, decisionInput.preferences, decisionInput.date, decisionInput.subjectiveCheckin);
+    return { subjective, objective, context };
+  }, [decisionInput]);
+
+  // Same subjective/objective inputs as `engineInputs`, but `context` omits today's
+  // checkin so its tissue-derived restrictions (single-day only, per
+  // injuryPolicy.ts's resolveEffectiveInjuryConstraints) don't leak into the week-ahead
+  // strip -- only the athlete's standing InjuryConstraint[] should constrain any of those
+  // future days. `engineInputs.context` remains correct for adjusting TODAY's own
+  // recommendation (computeAdjustedRecommendation below).
+  const forecastEngineInputs = useMemo(() => {
+    if (!decisionInput || !decisionInput.recoverySnapshot) return null;
+    const subjective = mapCheckinToSubjectiveInput(decisionInput.subjectiveCheckin);
+    const objective = mapSnapshotToEngineInput(decisionInput.recoverySnapshot);
+    const context = mapContextFromGoalsAndTrainingSettings(decisionInput.activeGoals, decisionInput.trainingSettings, decisionInput.preferences, decisionInput.date, null);
     return { subjective, objective, context };
   }, [decisionInput]);
 
@@ -325,22 +348,34 @@ export function Home({ userId, onNavigate, onViewData }: HomeProps) {
 
   // Fixed activities (Phase 5.3) persisted at users/{userId}/fixed_activities -- read
   // once per user/date, same lifecycle as the other week-ahead inputs below.
-  const [fixedActivities, setFixedActivities] = useState<FixedActivity[]>([]);
+  //
+  // Uses the State-returning read, not the plain-array convenience wrapper: the wrapper
+  // deliberately collapses both INVALID (malformed documents) and UNAVAILABLE (read
+  // failure) into `[]`, which is correct for a "just show me what you have" UI list, but
+  // wrong for the planner path -- it would make the week-ahead generator interpret a
+  // failed or malformed read as "the athlete has no commitments this week" and schedule
+  // straight through a real (unreadable) evening football game or similar. The week-ahead
+  // effect below only runs generateWeekAheadPlanWithIntent once this state is AVAILABLE.
+  const [fixedActivitiesState, setFixedActivitiesState] = useState<DataState<FixedActivity[]>>({ status: 'AVAILABLE', data: [], revision: null });
   useEffect(() => {
     let cancelled = false;
     if (!decisionInput) {
-      setFixedActivities([]);
+      setFixedActivitiesState({ status: 'AVAILABLE', data: [], revision: null });
       return () => { cancelled = true; };
     }
     const endDate = addDaysToLocalDateString(decisionInput.date, WEEK_AHEAD_DAYS);
-    fixedActivityService.getActivitiesInRange(userId, decisionInput.date, endDate)
-      .then(activities => { if (!cancelled) setFixedActivities(activities); })
+    fixedActivityService.getActivitiesInRangeState(userId, decisionInput.date, endDate)
+      .then(state => { if (!cancelled) setFixedActivitiesState(state); })
       .catch(err => {
         console.warn('Failed to load fixed activities:', err);
-        if (!cancelled) setFixedActivities([]);
+        if (!cancelled) setFixedActivitiesState({ status: 'UNAVAILABLE', operation: 'read fixed activities', retryable: true });
       });
     return () => { cancelled = true; };
   }, [userId, decisionInput]);
+  const fixedActivities = useMemo(
+    () => (fixedActivitiesState.status === 'AVAILABLE' ? fixedActivitiesState.data : []),
+    [fixedActivitiesState]
+  );
 
   // The production planner reads adherence history once, so it must run outside render.
   // Cancellation ensures a prior user/date/goals/check-in/settings state cannot replace
@@ -349,11 +384,21 @@ export function Home({ userId, onNavigate, onViewData }: HomeProps) {
   const [weekAheadPlan, setWeekAheadPlan] = useState<WeekAheadPlan | null>(null);
   useEffect(() => {
     let cancelled = false;
-    if (!engineInputs || !decisionInput || !activeRec || !canGenerateNormalPlan || !historySnapshot) {
+    if (!forecastEngineInputs || !decisionInput || !activeRec || !canGenerateNormalPlan || !historySnapshot) {
       setWeekAheadPlan(null);
       return () => { cancelled = true; };
     }
-    const { subjective, objective, context } = engineInputs;
+    if (fixedActivitiesState.status !== 'AVAILABLE') {
+      // Do not generate a week-ahead plan on an INVALID/UNAVAILABLE fixed-activities read
+      // -- silently treating that as "no commitments this week" (what the plain-array
+      // convenience wrapper would have done) could schedule straight through a real,
+      // merely-unreadable commitment. WeekAheadStrip already renders nothing for a null
+      // plan, matching how every other week-ahead precondition above fails closed.
+      console.warn(`Skipping week-ahead plan generation: fixed activities read is ${fixedActivitiesState.status}, not AVAILABLE.`);
+      setWeekAheadPlan(null);
+      return () => { cancelled = true; };
+    }
+    const { subjective, objective, context } = forecastEngineInputs;
     const tomorrowRec = nextDayPlan
       ? (nextDayPlan.branches[selectedNextDayTier]?.recommendation ?? nextDayPlan.branches.green.recommendation)
       : null;
@@ -378,7 +423,7 @@ export function Home({ userId, onNavigate, onViewData }: HomeProps) {
       }
     });
     return () => { cancelled = true; };
-  }, [userId, engineInputs, decisionInput, activeRec, canGenerateNormalPlan, nextDayPlan, selectedNextDayTier, eventPeriodization, historySnapshot, fixedActivities]);
+  }, [userId, forecastEngineInputs, decisionInput, activeRec, canGenerateNormalPlan, nextDayPlan, selectedNextDayTier, eventPeriodization, historySnapshot, fixedActivitiesState, fixedActivities]);
 
   if (loading) {
     return (

--- a/app/src/components/Home.tsx
+++ b/app/src/components/Home.tsx
@@ -184,7 +184,7 @@ export function Home({ userId, onNavigate, onViewData }: HomeProps) {
       if (input.recoverySnapshot && canGenerateNormalRecommendation(safetyStatus)) {
         const objective = mapSnapshotToEngineInput(input.recoverySnapshot);
         const subjective = mapCheckinToSubjectiveInput(input.subjectiveCheckin);
-        const context = mapContextFromGoalsAndTrainingSettings(input.activeGoals, input.trainingSettings, input.preferences);
+        const context = mapContextFromGoalsAndTrainingSettings(input.activeGoals, input.trainingSettings, input.preferences, input.date, input.subjectiveCheckin);
         const events = mapGoalsToUserEvents(input.activeGoals);
         const preparedSnapshot = await prepareTrainingHistorySnapshot(userId, input.date);
         if (!isCurrent()) return;
@@ -259,7 +259,7 @@ export function Home({ userId, onNavigate, onViewData }: HomeProps) {
     if (!decisionInput || !decisionInput.recoverySnapshot) return null;
     const subjective = mapCheckinToSubjectiveInput(decisionInput.subjectiveCheckin);
     const objective = mapSnapshotToEngineInput(decisionInput.recoverySnapshot);
-    const context = mapContextFromGoalsAndTrainingSettings(decisionInput.activeGoals, decisionInput.trainingSettings, decisionInput.preferences);
+    const context = mapContextFromGoalsAndTrainingSettings(decisionInput.activeGoals, decisionInput.trainingSettings, decisionInput.preferences, decisionInput.date, decisionInput.subjectiveCheckin);
     return { subjective, objective, context };
   }, [decisionInput]);
 

--- a/app/src/emulator/firestoreRules.emulator.test.ts
+++ b/app/src/emulator/firestoreRules.emulator.test.ts
@@ -2,7 +2,7 @@
 import { readFileSync } from 'node:fs';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import { assertFails, assertSucceeds, initializeTestEnvironment, type RulesTestEnvironment } from '@firebase/rules-unit-testing';
-import { doc, getDoc, setDoc } from 'firebase/firestore';
+import { doc, getDoc, setDoc, deleteDoc } from 'firebase/firestore';
 
 const emulatorDescribe = process.env.FIRESTORE_EMULATOR_HOST ? describe : describe.skip;
 let testEnvironment: RulesTestEnvironment;
@@ -10,6 +10,24 @@ let testEnvironment: RulesTestEnvironment;
 const ownerId = 'athlete-a';
 const otherUserId = 'athlete-b';
 const recommendationPath = `users/${ownerId}/daily_recommendations/2026-08-07`;
+const fixedActivityPath = `users/${ownerId}/fixed_activities/activity-1`;
+
+function validFixedActivity() {
+    return {
+        userId: ownerId,
+        title: 'Evening Football',
+        date: '2026-08-12',
+        durationMin: 90,
+        fixed: true,
+        environment: 'outdoor',
+        equipment: ['cleats'],
+        expectedStimulus: { aerobicEndurance: 0.6, repeatedSurges: 0.4 },
+        expectedCost: { systemic: 0.8, lowerBody: 0.5 },
+        isCompleted: false,
+        createdAt: '2026-08-01T00:00:00Z',
+        updatedAt: '2026-08-01T00:00:00Z',
+    };
+}
 
 function validRecommendation(auditEvaluatedAt = '2026-08-07T08:00:00Z') {
     return {
@@ -237,6 +255,84 @@ emulatorDescribe('Firestore security rules', () => {
         await expect(assertSucceeds(
             setDoc(doc(ownerDb, recommendationPath), { ...original, revision: 1 }, { merge: true }),
         )).resolves.toBeUndefined();
+    });
+
+    it('allows an owner to create and read a valid fixed activity', async () => {
+        const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+        await expect(assertSucceeds(setDoc(doc(ownerDb, fixedActivityPath), validFixedActivity()))).resolves.toBeUndefined();
+        await expect(assertSucceeds(getDoc(doc(ownerDb, fixedActivityPath)))).resolves.toBeDefined();
+    });
+
+    it('rejects unauthenticated fixed activity access', async () => {
+        const anonDb = testEnvironment.unauthenticatedContext().firestore();
+        await assertFails(setDoc(doc(anonDb, fixedActivityPath), validFixedActivity()));
+        await testEnvironment.withSecurityRulesDisabled(async context => {
+            await setDoc(doc(context.firestore(), fixedActivityPath), validFixedActivity());
+        });
+        await assertFails(getDoc(doc(anonDb, fixedActivityPath)));
+    });
+
+    it('rejects cross-user fixed activity reads and writes', async () => {
+        await testEnvironment.withSecurityRulesDisabled(async context => {
+            await setDoc(doc(context.firestore(), fixedActivityPath), validFixedActivity());
+        });
+        const otherDb = testEnvironment.authenticatedContext(otherUserId).firestore();
+        await assertFails(getDoc(doc(otherDb, fixedActivityPath)));
+        // Writing to the owner's document path as a different authenticated user.
+        await assertFails(setDoc(doc(otherDb, fixedActivityPath), validFixedActivity()));
+        // Writing under otherUserId's own path but forging userId to the real owner's id.
+        await assertFails(setDoc(doc(otherDb, `users/${otherUserId}/fixed_activities/activity-2`), { ...validFixedActivity(), userId: ownerId }));
+    });
+
+    it('rejects a fixed activity with an out-of-range durationMin', async () => {
+        const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+        await assertFails(setDoc(doc(ownerDb, fixedActivityPath), { ...validFixedActivity(), durationMin: 0 }));
+        await assertFails(setDoc(doc(ownerDb, fixedActivityPath), { ...validFixedActivity(), durationMin: 1500 }));
+    });
+
+    it('rejects a fixed activity with an expectedCost value above 1', async () => {
+        const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+        await assertFails(setDoc(doc(ownerDb, fixedActivityPath), { ...validFixedActivity(), expectedCost: { systemic: 1.5 } }));
+    });
+
+    it('rejects a fixed activity with an unknown environment', async () => {
+        const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+        await assertFails(setDoc(doc(ownerDb, fixedActivityPath), { ...validFixedActivity(), environment: 'space' }));
+    });
+
+    it('rejects a fixed activity with an oversized equipment list', async () => {
+        const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+        await assertFails(setDoc(doc(ownerDb, fixedActivityPath), { ...validFixedActivity(), equipment: Array.from({ length: 21 }, (_, i) => `item-${i}`) }));
+    });
+
+    it('rejects a fixed activity with a malformed date', async () => {
+        const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+        await assertFails(setDoc(doc(ownerDb, fixedActivityPath), { ...validFixedActivity(), date: '08/12/2026' }));
+    });
+
+    it('rejects a fixed activity missing the required fixed field', async () => {
+        const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+        const withoutFixed: Record<string, unknown> = validFixedActivity();
+        delete withoutFixed.fixed;
+        await assertFails(setDoc(doc(ownerDb, fixedActivityPath), withoutFixed));
+    });
+
+    it('rejects updating a fixed activity that forges a different owner or createdAt', async () => {
+        await testEnvironment.withSecurityRulesDisabled(async context => {
+            await setDoc(doc(context.firestore(), fixedActivityPath), validFixedActivity());
+        });
+        const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+        await assertFails(setDoc(doc(ownerDb, fixedActivityPath), { ...validFixedActivity(), userId: otherUserId }, { merge: true }));
+        await assertFails(setDoc(doc(ownerDb, fixedActivityPath), { ...validFixedActivity(), createdAt: '2099-01-01T00:00:00Z' }, { merge: true }));
+    });
+
+    it('allows an owner to update and delete their own fixed activity', async () => {
+        await testEnvironment.withSecurityRulesDisabled(async context => {
+            await setDoc(doc(context.firestore(), fixedActivityPath), validFixedActivity());
+        });
+        const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+        await expect(assertSucceeds(setDoc(doc(ownerDb, fixedActivityPath), { ...validFixedActivity(), isCompleted: true }, { merge: true }))).resolves.toBeUndefined();
+        await expect(assertSucceeds(deleteDoc(doc(ownerDb, fixedActivityPath)))).resolves.toBeUndefined();
     });
 
     it('rejects re-saving the same decision with a different audit than what is stored', async () => {

--- a/app/src/emulator/firestoreRules.emulator.test.ts
+++ b/app/src/emulator/firestoreRules.emulator.test.ts
@@ -310,6 +310,13 @@ emulatorDescribe('Firestore security rules', () => {
         await assertFails(setDoc(doc(ownerDb, fixedActivityPath), { ...validFixedActivity(), date: '08/12/2026' }));
     });
 
+    it('rejects a fixed activity with a YYYY-MM-DD-shaped but calendar-impossible date', async () => {
+        // Regex-only shape validation would accept this; a direct authenticated write
+        // (bypassing validation.ts's client-side isValidDate) must still be rejected.
+        const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+        await assertFails(setDoc(doc(ownerDb, fixedActivityPath), { ...validFixedActivity(), date: '2026-02-30' }));
+    });
+
     it('rejects a fixed activity missing the required fixed field', async () => {
         const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
         const withoutFixed: Record<string, unknown> = validFixedActivity();

--- a/app/src/engine/adapters.test.ts
+++ b/app/src/engine/adapters.test.ts
@@ -55,4 +55,24 @@ describe('mapContextFromGoalsAndTrainingSettings (Phase 5.4 tissue response wiri
         const context = mapContextFromGoalsAndTrainingSettings([], settings, null, '2026-08-08');
         expect(context.constraints.impliedGuardrails).toContain('avoid_overhead_pressing');
     });
+
+    // Regression coverage for the Home.tsx forecast-leak bug: a today-only tissue-derived
+    // restriction (no standing InjuryConstraint at all) must restrict a decision built WITH
+    // today's checkin, but must NOT restrict a decision built without one -- which is
+    // exactly the distinction Home.tsx's `context` (today) vs `forecastContext`
+    // (tomorrow's provisional plan and the week-ahead strip) relies on to keep a single
+    // day's tissue flag from silently blocking Running on every projected day of the week.
+    it("a today-only tissue-derived restriction (no standing InjuryConstraint) restricts today's context but not a forecast context built without the checkin", () => {
+        const settings = testTrainingSettings({ injuries: [] });
+        const checkin = testCheckin({
+            painOrInjury: true,
+            tissueResponses: { knee: { region: 'knee', morningState: 'severe' } },
+        });
+
+        const todayContext = mapContextFromGoalsAndTrainingSettings([], settings, null, '2026-08-08', checkin);
+        expect(todayContext.constraints.restrictedModalities).toContain('Running');
+
+        const forecastContext = mapContextFromGoalsAndTrainingSettings([], settings, null, '2026-08-08', null);
+        expect(forecastContext.constraints.restrictedModalities).not.toContain('Running');
+    });
 });

--- a/app/src/engine/adapters.test.ts
+++ b/app/src/engine/adapters.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { mapContextFromGoalsAndTrainingSettings } from './adapters';
+import type { DailySubjectiveCheckin, TrainingSettings } from './models';
+
+function testTrainingSettings(overrides: Partial<TrainingSettings> = {}): TrainingSettings {
+    return {
+        userId: 'athlete', schemaVersion: 2,
+        equipment: { free_weights: true, cable_machine: false, treadmill: false, indoor_bike: true, pullup_bar: false },
+        guardrails: { avoid_high_impact: false, avoid_heavy_lower_body: false, avoid_overhead_pressing: false, avoid_heavy_spinal_loading: false },
+        defaults: { weekdayMaxMinutes: 45, weekendMaxMinutes: 120, environment: 'either' },
+        preferences: { preferActiveRecovery: false },
+        migration: { legacyReviewed: true, migratedAt: null },
+        createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z',
+        ...overrides,
+    };
+}
+
+function testCheckin(overrides: Partial<DailySubjectiveCheckin> = {}): DailySubjectiveCheckin {
+    return {
+        userId: 'athlete', date: '2026-08-08',
+        readiness: 8, sleepQuality: 8, fatigue: 3, soreness: 3, mentalStress: 3, motivation: 8,
+        painOrInjury: false, illnessSymptoms: false, unusuallyLimitedTime: false, alreadyTrainedToday: false,
+        availability: { timeAvailableMin: 60, preferredModalityToday: null, indoorOnly: false },
+        notes: null, submittedAt: '2026-08-08T07:00:00.000Z',
+        dataQuality: { isComplete: true, missingFields: [] },
+        schemaVersion: 1, createdAt: '2026-08-08T07:00:00.000Z', updatedAt: '2026-08-08T07:00:00.000Z',
+        ...overrides,
+    };
+}
+
+describe('mapContextFromGoalsAndTrainingSettings (Phase 5.4 tissue response wiring)', () => {
+    it("threads today's tissue response into the injury gate, tightening a monitor-only knee constraint", () => {
+        const settings = testTrainingSettings({ injuries: [{ region: 'knee', severity: 'monitor' }] });
+        const checkin = testCheckin({
+            painOrInjury: true,
+            tissueResponses: { knee: { region: 'knee', morningState: 'normal', painDuringTraining: 'severe' } },
+        });
+
+        const context = mapContextFromGoalsAndTrainingSettings([], settings, null, '2026-08-08', checkin);
+
+        expect(context.constraints.restrictedModalities).toContain('Running');
+    });
+
+    it("a high-readiness, no-pain check-in leaves an existing constraint's restrictions exactly as they were", () => {
+        const settings = testTrainingSettings({ injuries: [{ region: 'knee', severity: 'exclude', reviewBy: '2026-09-01' }] });
+        const checkin = testCheckin({ readiness: 10 });
+
+        const context = mapContextFromGoalsAndTrainingSettings([], settings, null, '2026-08-08', checkin);
+
+        expect(context.constraints.restrictedModalities).toContain('Running');
+    });
+
+    it('behaves the same with no check-in supplied at all (backward compatible)', () => {
+        const settings = testTrainingSettings({ injuries: [{ region: 'shoulder', severity: 'limit' }] });
+        const context = mapContextFromGoalsAndTrainingSettings([], settings, null, '2026-08-08');
+        expect(context.constraints.impliedGuardrails).toContain('avoid_overhead_pressing');
+    });
+});

--- a/app/src/engine/adapters.ts
+++ b/app/src/engine/adapters.ts
@@ -11,7 +11,7 @@ import type {
     UserPreferences,
     TrainingSettings,
 } from './models';
-import { resolveInjuryRestrictions } from './injuryPolicy';
+import { resolveInjuryRestrictions, resolveEffectiveInjuryConstraints } from './injuryPolicy';
 import { goalToUserEvent } from './periodization';
 import { getLocalDateString } from '../utils/localDate';
 
@@ -130,12 +130,19 @@ const DEFAULT_MAX_TIME_MINUTES = 180;
  * modality lists and conservativeBias existed only in Firestore/the Preferences screen.
  * Null (no preferences record yet) maps to all-empty/false, matching
  * preferencesService's own defaults.
+ *
+ * `todaysCheckin` feeds Phase 5.4's per-region tissue response into the injury gate: it
+ * may only tighten the standing InjuryConstraint[] for today's decision, never persisted
+ * back (see injuryPolicy.ts resolveEffectiveInjuryConstraints). Wearable-derived
+ * readiness plays no part here at all -- it acts through the separate fatigue/mode
+ * pipeline, so it cannot loosen what tissue response or the injury constraint decided.
  */
 export function mapContextFromGoalsAndTrainingSettings(
     goals: UserGoal[],
     trainingSettings: TrainingSettings,
     preferences: UserPreferences | null,
-    today?: string
+    today?: string,
+    todaysCheckin?: DailySubjectiveCheckin | null
 ): UserContext {
     const topGoalTitle = (category: UserGoal['category']): string => {
         const inCategory = goals.filter(g => g.category === category);
@@ -144,7 +151,8 @@ export function mapContextFromGoalsAndTrainingSettings(
     };
 
     const dateStr = today ?? getLocalDateString();
-    const resolvedInjuries = resolveInjuryRestrictions(trainingSettings.injuries, dateStr);
+    const effectiveInjuries = resolveEffectiveInjuryConstraints(trainingSettings.injuries, todaysCheckin?.tissueResponses, dateStr);
+    const resolvedInjuries = resolveInjuryRestrictions(effectiveInjuries, dateStr);
 
     return {
         goals: {

--- a/app/src/engine/architecture.test.ts
+++ b/app/src/engine/architecture.test.ts
@@ -61,13 +61,48 @@ describe('Architecture & Phased Engine Integration', () => {
         it('deducts fixed activity duration and reserves capacity for future scheduled activities', () => {
             const fixedActivities = [
                 {
-                    id: 'fixed_1', title: 'Evening Football', date: '2026-08-12', durationMin: 90,
-                    isCompleted: false, expectedCost: { systemic: 0.8 },
+                    id: 'fixed_1', userId: 'athlete-1', title: 'Evening Football', date: '2026-08-12', durationMin: 90,
+                    isCompleted: false, expectedCost: { systemic: 0.8 }, fixed: true, environment: 'outdoor' as const,
+                    equipment: [], createdAt: '2026-08-01T00:00:00Z', updatedAt: '2026-08-01T00:00:00Z',
                 },
             ];
             const availability = resolveAvailability('2026-08-12', null, fixedActivities, testContext());
             expect(availability.maxTimeMinutes).toBe(0);
             expect(availability.reservedCapacityCost).toBe(0.8);
+        });
+
+        it('caps the whole day budget with availabilityOverride before deducting fixed-activity duration', () => {
+            // 2026-08-08 is a Saturday -- the athlete's normal weekend budget is 120 min
+            // (see testTrainingSettings above), but a travel day shrinks that outright.
+            const fixedActivities = [
+                {
+                    id: 'travel', userId: 'athlete-1', title: 'Travel day', date: '2026-08-08', durationMin: 30,
+                    isCompleted: false, fixed: true, environment: 'either' as const, equipment: [],
+                    availabilityOverride: 60,
+                    createdAt: '2026-08-01T00:00:00Z', updatedAt: '2026-08-01T00:00:00Z',
+                },
+            ];
+            const availability = resolveAvailability('2026-08-08', null, fixedActivities, testContext());
+            expect(availability.maxTimeMinutes).toBe(30); // min(120, 60) override - 30 min activity
+        });
+
+        it('takes the most restrictive availabilityOverride when several activities disagree', () => {
+            const fixedActivities = [
+                {
+                    id: 'a', userId: 'athlete-1', title: 'A', date: '2026-08-08', durationMin: 0,
+                    isCompleted: false, fixed: true, environment: 'either' as const, equipment: [],
+                    availabilityOverride: 90,
+                    createdAt: '2026-08-01T00:00:00Z', updatedAt: '2026-08-01T00:00:00Z',
+                },
+                {
+                    id: 'b', userId: 'athlete-1', title: 'B', date: '2026-08-08', durationMin: 0,
+                    isCompleted: false, fixed: true, environment: 'either' as const, equipment: [],
+                    availabilityOverride: 20,
+                    createdAt: '2026-08-01T00:00:00Z', updatedAt: '2026-08-01T00:00:00Z',
+                },
+            ];
+            const availability = resolveAvailability('2026-08-08', null, fixedActivities, testContext());
+            expect(availability.maxTimeMinutes).toBe(20);
         });
 
         it('grants equipment strictly from the athlete\'s own constraints -- never fabricates a "gym day" bundle', () => {

--- a/app/src/engine/completedTraining.test.ts
+++ b/app/src/engine/completedTraining.test.ts
@@ -104,11 +104,28 @@ describe('completed training reconciliation', () => {
         expect(exposure.modality).toBe('Cycling');
     });
 
-    it('withholds stimulus profile and sets unknown confidence for unknown modality', () => {
+    it('still infers a generic stimulus profile from real Garmin measured-effort evidence even when the modality itself is unknown', () => {
+        // Phase 5.5: modality and evidence quality are independent axes -- this activity's
+        // sport couldn't be classified, but it still carries real trainingEffect +
+        // activityTrainingLoad, so it must not be treated as adaptation-neutral.
         const [event] = reconcileCompletedTrainingEvents([activity({ type: 'unknown_sport' })], []);
+        expect(event.evidenceTier).toBe('measuredEffort');
+        const exposure = completedEventToExposure(event);
+        expect(exposure.stimulusConfidence).toBe('inferred');
+        expect(exposure.stimulusProfile).toBeDefined();
+        expect(exposure.stimulusProfile?.aerobicEndurance).toBeGreaterThan(0);
+        expect(exposure.modality).toBeUndefined(); // genuinely unknown -- never fabricated
+    });
+
+    it('withholds stimulus profile and sets unknown confidence when there is genuinely no evidence at all', () => {
+        const [event] = reconcileCompletedTrainingEvents([activity({
+            type: 'unknown_sport', trainingEffectAerobic: 0, trainingEffectAnaerobic: 0, activityTrainingLoad: null, intensityTag: '',
+        })], []);
+        expect(event.evidenceTier).toBe('genericModalityFallback');
         const exposure = completedEventToExposure(event);
         expect(exposure.stimulusConfidence).toBe('unknown');
-        expect(exposure.stimulusProfile).toBeUndefined();
+        expect(exposure.stimulusProfile).toBeDefined(); // still non-zero -- see DEFAULT_STIMULUS_BY_MODALITY.Unknown
+        expect(exposure.modality).toBeUndefined();
     });
 
     it('asserts DEFAULT_STIMULUS_BY_MODALITY table totality for all recognized modalities and intensities', () => {
@@ -183,5 +200,75 @@ describe('deriveSessionPlanRelationship', () => {
         const rec = recommendation({ date: '2026-08-06', modality: 'Cycling' });
         const event = completedEvent({ date: '2026-08-07', modality: 'Running' });
         expect(deriveSessionPlanRelationship(rec, event)).toBe('unplanned');
+    });
+});
+
+// Phase 5.5: docs/plans/phase-5-sequence-planning.md 5.5 -- every rung of the evidence
+// hierarchy that's actually reachable given current ingested data.
+describe('evidence hierarchy (Phase 5.5)', () => {
+    it('measuredEffort: known modality with both trainingEffect and activityTrainingLoad', () => {
+        const [event] = reconcileCompletedTrainingEvents([activity()], []); // base fixture has both
+        expect(event.evidenceTier).toBe('measuredEffort');
+        expect(completedEventToExposure(event).stimulusConfidence).toBe('inferred');
+    });
+
+    it('garminTrainingEffect: trainingEffect present but no activityTrainingLoad', () => {
+        const [event] = reconcileCompletedTrainingEvents([activity({ activityTrainingLoad: null })], []);
+        expect(event.evidenceTier).toBe('garminTrainingEffect');
+        expect(completedEventToExposure(event).stimulusConfidence).toBe('inferred');
+    });
+
+    it('durationIntensity: only an intensity tag, no trainingEffect or trainingLoad', () => {
+        const [event] = reconcileCompletedTrainingEvents([activity({
+            trainingEffectAerobic: 0, trainingEffectAnaerobic: 0, activityTrainingLoad: null, intensityTag: 'moderate',
+        })], []);
+        expect(event.evidenceTier).toBe('durationIntensity');
+        expect(completedEventToExposure(event).stimulusConfidence).toBe('inferred');
+    });
+
+    it('athleteClassification: modality guessed from free text, no other signal at all', () => {
+        const [event] = reconcileCompletedTrainingEvents([activity({
+            type: 'cycling', trainingEffectAerobic: 0, trainingEffectAnaerobic: 0, activityTrainingLoad: null, intensityTag: '',
+        })], []);
+        expect(event.evidenceTier).toBe('athleteClassification');
+        expect(completedEventToExposure(event).stimulusConfidence).toBe('inferred');
+    });
+
+    it('genericModalityFallback: nothing known at all', () => {
+        const [event] = reconcileCompletedTrainingEvents([activity({
+            type: 'unknown_sport', trainingEffectAerobic: 0, trainingEffectAnaerobic: 0, activityTrainingLoad: null, intensityTag: '',
+        })], []);
+        expect(event.evidenceTier).toBe('genericModalityFallback');
+        expect(completedEventToExposure(event).stimulusConfidence).toBe('unknown');
+    });
+
+    it('exactPrescribedMatch: adherence-only event confirming a template with an authored stimulusProfile', () => {
+        const [event] = reconcileCompletedTrainingEvents([], [recommendation()]);
+        expect(event.evidenceTier).toBe('exactPrescribedMatch');
+        expect(completedEventToExposure(event).stimulusConfidence).toBe('exact');
+    });
+
+    it('athleteClassification: adherence-only event with a self-reported modality and no template match', () => {
+        const rec = recommendation({
+            templateId: 'nonexistent',
+            adherence: { respondedAt: 'x', followed: false, actualModality: 'Strength', actualDurationMin: 40, skipped: false, notes: null },
+        });
+        const [event] = reconcileCompletedTrainingEvents([], [rec]);
+        expect(event.evidenceTier).toBe('athleteClassification');
+        expect(completedEventToExposure(event).stimulusConfidence).toBe('inferred');
+    });
+
+    it('mergeAdherenceIntoGarmin upgrades a Garmin-only tier to exactPrescribedMatch when adherence confirms the exact template', () => {
+        const events = reconcileCompletedTrainingEvents([activity()], [recommendation()]);
+        expect(events).toHaveLength(1);
+        expect(events[0].evidenceTier).toBe('exactPrescribedMatch');
+        expect(completedEventToExposure(events[0]).stimulusConfidence).toBe('exact');
+    });
+
+    it('mergeAdherenceIntoGarmin retains the Garmin-derived tier when adherence does not confirm the exact template', () => {
+        const rec = recommendation({ adherence: { respondedAt: 'x', followed: false, actualModality: 'Cycling', actualDurationMin: 45, skipped: false, notes: null } });
+        const events = reconcileCompletedTrainingEvents([activity()], [rec]);
+        expect(events).toHaveLength(1);
+        expect(events[0].evidenceTier).toBe('measuredEffort'); // unchanged from the Garmin-only classification
     });
 });

--- a/app/src/engine/completedTraining.ts
+++ b/app/src/engine/completedTraining.ts
@@ -2,6 +2,7 @@ import type {
     CompletedTrainingEvent,
     CompletedTrainingIntensity,
     DailyRecommendation,
+    EvidenceTier,
     NormalizedGarminActivity,
     SessionTemplate,
     TrainingRecord,
@@ -9,6 +10,7 @@ import type {
     WorkoutStimulusProfile,
 } from './models';
 import type { CompletedExposure } from './trainingHistory';
+import type { StimulusConfidence } from './stimulus';
 import { ENRICHED_TEMPLATES } from './templates';
 import type { DeliveredDose } from './models';
 
@@ -94,6 +96,55 @@ function intensityFromGarmin(activity: NormalizedGarminActivity): CompletedTrain
     if (trainingEffect >= 3) return 'hard';
     if (trainingEffect >= 1.5) return 'moderate';
     return trainingEffect > 0 ? 'easy' : 'unknown';
+}
+
+// --- Evidence hierarchy (Phase 5.5) ---
+// docs/plans/phase-5-sequence-planning.md 5.5: generalises the coarse modality x
+// intensity inference below into a named, ordered hierarchy so every inferred profile
+// carries a legible reason for how confident it is, not just a flat true/false.
+
+/** Signals classifyGarminTier actually has available. `activityTrainingLoad` is Garmin's
+ *  own proprietary composite (derived from HR/pace/power across the session) -- a
+ *  materially different, richer signal than the coarse 0-5 trainingEffect scalar alone,
+ *  even though it still isn't per-interval structure. `averageHr` is deliberately not
+ *  consulted: a single session-average HR number without zone/interval context isn't
+ *  meaningfully more informative than trainingEffect, and treating it as if it were would
+ *  overclaim precision this data doesn't have. */
+interface GarminEvidenceSignals {
+    trainingEffectAerobic: number | null;
+    trainingEffectAnaerobic: number | null;
+    intensityTag: string;
+    activityTrainingLoad: number | null;
+    modalityKnown: boolean;
+}
+
+function classifyGarminTier(signals: GarminEvidenceSignals): EvidenceTier {
+    const hasTrainingEffect = (signals.trainingEffectAerobic ?? 0) > 0 || (signals.trainingEffectAnaerobic ?? 0) > 0;
+    const hasTrainingLoad = signals.activityTrainingLoad !== null && signals.activityTrainingLoad > 0;
+    if (hasTrainingEffect && hasTrainingLoad) return 'measuredEffort';
+    if (hasTrainingEffect) return 'garminTrainingEffect';
+    if (signals.intensityTag.trim() !== '') return 'durationIntensity';
+    if (signals.modalityKnown) return 'athleteClassification';
+    return 'genericModalityFallback';
+}
+
+/** Maps a tier to the coarse 3-value confidence CompletedExposure.stimulusConfidence
+ *  (and, downstream, stimulus.ts's CONFIDENCE_CREDIT_WEIGHT) already expects -- this is
+ *  the "hook" Phase 1.2(c) added; this function is what finally drives it from something
+ *  more legible than an ad hoc exact/modality/hasStimulus check. */
+export function stimulusConfidenceForTier(tier: EvidenceTier): StimulusConfidence {
+    switch (tier) {
+        case 'exactPrescribedMatch':
+        case 'completedStructuredWorkout':
+            return 'exact';
+        case 'measuredEffort':
+        case 'garminTrainingEffect':
+        case 'durationIntensity':
+        case 'athleteClassification':
+            return 'inferred';
+        case 'genericModalityFallback':
+            return 'unknown';
+    }
 }
 
 function catalogIntensity(template: SessionTemplate): CompletedTrainingIntensity {
@@ -225,7 +276,20 @@ export const DEFAULT_STIMULUS_BY_MODALITY: Record<CompletedModality, Record<Comp
         unknown: { aerobicEndurance: 0.60, thresholdPower: 0.20, vo2MaxPower: 0.10, repeatedSurges: 0.15, sprintPower: 0, fatigueResistance: 0.15, maxStrength: 0.15, hypertrophy: 0.15 },
     },
     None: { easy: ZERO_STIMULUS, moderate: ZERO_STIMULUS, hard: ZERO_STIMULUS, unknown: ZERO_STIMULUS },
-    Unknown: { easy: ZERO_STIMULUS, moderate: ZERO_STIMULUS, hard: ZERO_STIMULUS, unknown: ZERO_STIMULUS },
+    // Phase 5.5: this used to be all-zero, the literal asymmetry the plan calls out --
+    // DEFAULT_COST_BY_MODALITY.Unknown above already charges real cost for an
+    // unclassified session, while stimulus stayed at zero, so the system saw the fatigue
+    // but not the fitness benefit. Deliberately conservative and aerobic-leaning (lower
+    // magnitude than every known-modality table above) since genuinely nothing is known
+    // about what quality of work happened -- see genericModalityFallback's stimulusConfidence
+    // ('unknown') and CONFIDENCE_CREDIT_WEIGHT.unknown, which further discount how much
+    // objective credit this is allowed to redeem.
+    Unknown: {
+        easy: { aerobicEndurance: 0.35, thresholdPower: 0.05, vo2MaxPower: 0, repeatedSurges: 0.05, sprintPower: 0, fatigueResistance: 0.15, maxStrength: 0.05, hypertrophy: 0.05 },
+        moderate: { aerobicEndurance: 0.50, thresholdPower: 0.15, vo2MaxPower: 0.05, repeatedSurges: 0.10, sprintPower: 0, fatigueResistance: 0.25, maxStrength: 0.10, hypertrophy: 0.10 },
+        hard: { aerobicEndurance: 0.40, thresholdPower: 0.35, vo2MaxPower: 0.25, repeatedSurges: 0.30, sprintPower: 0.10, fatigueResistance: 0.35, maxStrength: 0.15, hypertrophy: 0.15 },
+        unknown: { aerobicEndurance: 0.30, thresholdPower: 0.10, vo2MaxPower: 0, repeatedSurges: 0.05, sprintPower: 0, fatigueResistance: 0.15, maxStrength: 0.05, hypertrophy: 0.05 },
+    },
 };
 
 function candidateEventFromGarmin(activity: NormalizedGarminActivity): CompletedTrainingEvent {
@@ -236,6 +300,13 @@ function candidateEventFromGarmin(activity: NormalizedGarminActivity): Completed
         plannedDurationMin: catalogReferenceDurationMin(modality, intensity),
         completedDurationMin: activity.durationMin ?? undefined,
     };
+    const evidenceTier = classifyGarminTier({
+        trainingEffectAerobic: activity.trainingEffectAerobic,
+        trainingEffectAnaerobic: activity.trainingEffectAnaerobic,
+        intensityTag: activity.intensityTag,
+        activityTrainingLoad: activity.activityTrainingLoad,
+        modalityKnown: modality !== 'Unknown',
+    });
     return {
         id: `garmin:${activity.activityId}`,
         date: activity.date,
@@ -249,6 +320,7 @@ function candidateEventFromGarmin(activity: NormalizedGarminActivity): Completed
         exactTemplateMatch: false,
         sources: ['garmin'],
         confidence: modality === 'Unknown' ? 'medium' : 'high',
+        evidenceTier,
         linkedActivityId: activity.activityId,
         linkedRecommendationDate: null,
         athleteFeedback: { followed: null, notes: null },
@@ -262,6 +334,10 @@ function candidateEventFromAdherence(recommendation: DailyRecommendation, candid
         plannedDurationMin: candidate.plannedDurationMin ?? catalogReferenceDurationMin(candidate.modality, intensity),
         completedDurationMin: candidate.durationMin ?? undefined,
     };
+    // No Garmin signals at all on this path -- either the athlete confirmed the exact
+    // prescribed template (exactPrescribedMatch), or all that's known is a self-reported
+    // modality with no measured evidence behind it (athleteClassification).
+    const evidenceTier: EvidenceTier = candidate.template?.stimulusProfile ? 'exactPrescribedMatch' : 'athleteClassification';
     return {
         id: `adherence:${recommendation.date}`,
         date: recommendation.date,
@@ -275,6 +351,7 @@ function candidateEventFromAdherence(recommendation: DailyRecommendation, candid
         exactTemplateMatch: !!candidate.template?.stimulusProfile,
         sources: ['adherence'],
         confidence: candidate.template ? 'medium' : 'low',
+        evidenceTier,
         linkedActivityId: null,
         linkedRecommendationDate: recommendation.date,
         athleteFeedback: { followed: recommendation.adherence.followed, notes: recommendation.adherence.notes },
@@ -294,10 +371,16 @@ function mergeAdherenceIntoGarmin(
         plannedDurationMin: candidate.plannedDurationMin ?? catalogReferenceDurationMin(event.modality, intensity),
         completedDurationMin: event.durationMin ?? undefined,
     };
+    // An adherence-confirmed exact template match upgrades whatever Garmin-derived tier
+    // this event already carried; otherwise the real measured Garmin evidence stands.
+    const evidenceTier: EvidenceTier = recommendation.adherence.followed && candidate.template?.stimulusProfile
+        ? 'exactPrescribedMatch'
+        : (event.evidenceTier ?? 'garminTrainingEffect');
     return {
         ...event,
         sources: ['garmin', 'adherence'],
         confidence: 'high',
+        evidenceTier,
         linkedRecommendationDate: recommendation.date,
         deliveredDose,
         // Garmin remains the measured duration/training-effect authority. Template
@@ -362,10 +445,13 @@ export function completedEventToExposure(event: CompletedTrainingEvent): Complet
     };
     const modality = event.modality === 'Unknown' ? undefined : event.modality;
     const hasStimulus = Object.values(event.estimatedStimulus ?? {}).some(v => (v ?? 0) > 0);
-    const confidence: 'exact' | 'inferred' | 'unknown' =
-        event.exactTemplateMatch
-            ? 'exact'
-            : (hasStimulus && modality ? 'inferred' : 'unknown');
+    // Phase 5.5: driven by the named evidence tier rather than an ad hoc
+    // exact/hasStimulus/modality check -- event.evidenceTier is the source of truth when
+    // present; the exactTemplateMatch/hasStimulus fallback only covers legacy/test
+    // construction paths that predate this field.
+    const tier: EvidenceTier = event.evidenceTier
+        ?? (event.exactTemplateMatch ? 'exactPrescribedMatch' : (hasStimulus && modality ? 'garminTrainingEffect' : 'genericModalityFallback'));
+    const confidence = stimulusConfidenceForTier(tier);
 
     return {
         date: event.date,
@@ -373,12 +459,16 @@ export function completedEventToExposure(event: CompletedTrainingEvent): Complet
         trainingRecordLike: record,
         ...(event.deliveredDose ? { deliveredDose: event.deliveredDose } : {}),
         stimulusConfidence: confidence,
-        ...(modality && hasStimulus ? {
-            modality,
+        // A stimulus profile no longer requires a *known* modality to be attached (Phase
+        // 5.5) -- genericModalityFallback still carries a real, if conservative, profile
+        // (see DEFAULT_STIMULUS_BY_MODALITY.Unknown) that can credit a modality-agnostic
+        // objective. `modality` itself is only ever set when genuinely known, so a
+        // modality-SCOPED objective still can't be satisfied by this
+        // (deriveObjectiveCreditFromProfile fails closed on that -- see stimulus.ts).
+        ...(hasStimulus ? {
             stimulusProfile: { ...ZERO_STIMULUS, ...event.estimatedStimulus },
-        } : modality ? {
-            modality,
         } : {}),
+        ...(modality ? { modality } : {}),
     };
 }
 

--- a/app/src/engine/goldenWeek.test.ts
+++ b/app/src/engine/goldenWeek.test.ts
@@ -3,6 +3,7 @@ import { runScenario, type ScenarioResult } from './simulation/analyze';
 import { SCENARIOS } from './simulation/scenarios';
 import { ENRICHED_TEMPLATES } from './templates';
 import type { SessionTemplate } from './models';
+import { generateWeekAheadPlanWithIntentBeamSearch } from './sequenceSearch';
 
 /**
  * Golden coaching-contract test suite asserting standard coaching principles over a
@@ -100,5 +101,75 @@ describe('goldenWeek coaching contract: cycling_a_event_build_week', () => {
     it('contains at least 1 Rest or Mobility/Recovery day', async () => {
         const result = await getBuildWeekResult();
         expect(result.restOrRecoveryDayCount).toBeGreaterThanOrEqual(1);
+    });
+});
+
+// Phase 5.1: the same golden-week coaching contract, run through the beam-search
+// prototype (sequenceSearch.ts) instead of the production greedy planner. This is the
+// permanent form of "benchmarked against greedy on the Phase-0 invariants and semantic
+// harness" -- see docs/adr/0015-sequence-planning-and-session-role-model.md for the full
+// recorded comparison and adoption decision (greedy retained as the live default; this
+// suite guards the prototype against regressing below what made that decision
+// defensible in the first place).
+describe('goldenWeek coaching contract via the Phase 5.1 beam-search prototype', () => {
+    async function getBuildWeekResultBeamSearch() {
+        const scenario = SCENARIOS.find((s) => s.id === 'cycling_a_event_build_week');
+        if (!scenario) throw new Error('cycling_a_event_build_week scenario missing');
+        return runScenario(scenario, generateWeekAheadPlanWithIntentBeamSearch);
+    }
+
+    it('key cycling quality sessions are spaced by >= 48 hours', async () => {
+        const result = await getBuildWeekResultBeamSearch();
+        const keyCyclingDates = actualKeyCyclingDates(result);
+
+        const timestamps = keyCyclingDates.map((d) => new Date(d + 'T00:00:00').getTime());
+        for (let i = 1; i < timestamps.length; i++) {
+            const diffHours = (timestamps[i] - timestamps[i - 1]) / (1000 * 60 * 60);
+            expect(diffHours).toBeGreaterThanOrEqual(48);
+        }
+    });
+
+    it('protects key cycling days from adjacent heavy strength sessions', async () => {
+        const result = await getBuildWeekResultBeamSearch();
+        const keyCyclingDates = new Set(actualKeyCyclingDates(result));
+        const heavyStrengthCategories = new Set(['Lower-body Strength', 'Full-body Strength']);
+
+        result.objectiveCredits.forEach((c) => {
+            if (heavyStrengthCategories.has(categoryByTemplateId.get(c.templateId) ?? '')) {
+                const strengthTime = new Date(c.date + 'T00:00:00').getTime();
+                keyCyclingDates.forEach((cycleDate) => {
+                    const cycleTime = new Date(cycleDate + 'T00:00:00').getTime();
+                    const diffDays = Math.abs(strengthTime - cycleTime) / (1000 * 60 * 60 * 24);
+                    expect(diffDays).not.toBe(1);
+                });
+            }
+        });
+    });
+
+    it('delivers at least two key/race-specific Cycling sessions in the 7-day Build strip (F3)', async () => {
+        const result = await getBuildWeekResultBeamSearch();
+        expect(actualKeyCyclingDates(result).length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('resolves required weekly objectives (threshold_quality and strength_maintenance)', async () => {
+        const result = await getBuildWeekResultBeamSearch();
+        const threshold = result.objectiveResolution.find((o) => o.key === 'threshold_quality');
+        const strength = result.objectiveResolution.find((o) => o.key === 'strength_maintenance');
+
+        expect(threshold).toBeDefined();
+        expect(threshold!.timesResolved).toBeGreaterThanOrEqual(threshold!.timesGenerated);
+
+        expect(strength).toBeDefined();
+        expect(strength!.timesResolved).toBeGreaterThanOrEqual(strength!.timesGenerated);
+    });
+
+    it('contains at least 1 Rest or Mobility/Recovery day', async () => {
+        const result = await getBuildWeekResultBeamSearch();
+        expect(result.restOrRecoveryDayCount).toBeGreaterThanOrEqual(1);
+    });
+
+    it('produces zero hard constraint violations, matching the greedy planner', async () => {
+        const result = await getBuildWeekResultBeamSearch();
+        expect(result.constraintViolations).toEqual([]);
     });
 });

--- a/app/src/engine/goldenWeek.test.ts
+++ b/app/src/engine/goldenWeek.test.ts
@@ -4,6 +4,7 @@ import { SCENARIOS } from './simulation/scenarios';
 import { ENRICHED_TEMPLATES } from './templates';
 import type { SessionTemplate } from './models';
 import { generateWeekAheadPlanWithIntentBeamSearch } from './sequenceSearch';
+import { getDayDiff } from '../utils/localDate';
 
 /**
  * Golden coaching-contract test suite asserting standard coaching principles over a
@@ -55,10 +56,12 @@ describe('goldenWeek coaching contract: cycling_a_event_build_week', () => {
         const result = await getBuildWeekResult();
         const keyCyclingDates = actualKeyCyclingDates(result);
 
-        const timestamps = keyCyclingDates.map((d) => new Date(d + 'T00:00:00').getTime());
-        for (let i = 1; i < timestamps.length; i++) {
-            const diffHours = (timestamps[i] - timestamps[i - 1]) / (1000 * 60 * 60);
-            expect(diffHours).toBeGreaterThanOrEqual(48);
+        // getDayDiff parses the YYYY-MM-DD components directly (Date.UTC), unlike
+        // `new Date(d + 'T00:00:00')` which parses in the host's local timezone and could
+        // silently mis-measure spacing across a DST transition inside the simulated week.
+        for (let i = 1; i < keyCyclingDates.length; i++) {
+            const diffDays = getDayDiff(keyCyclingDates[i], keyCyclingDates[i - 1]);
+            expect(diffDays).toBeGreaterThanOrEqual(2);
         }
     });
 
@@ -69,10 +72,8 @@ describe('goldenWeek coaching contract: cycling_a_event_build_week', () => {
 
         result.objectiveCredits.forEach((c) => {
             if (heavyStrengthCategories.has(categoryByTemplateId.get(c.templateId) ?? '')) {
-                const strengthTime = new Date(c.date + 'T00:00:00').getTime();
                 keyCyclingDates.forEach((cycleDate) => {
-                    const cycleTime = new Date(cycleDate + 'T00:00:00').getTime();
-                    const diffDays = Math.abs(strengthTime - cycleTime) / (1000 * 60 * 60 * 24);
+                    const diffDays = Math.abs(getDayDiff(c.date, cycleDate));
                     expect(diffDays).not.toBe(1);
                 });
             }
@@ -112,20 +113,26 @@ describe('goldenWeek coaching contract: cycling_a_event_build_week', () => {
 // suite guards the prototype against regressing below what made that decision
 // defensible in the first place).
 describe('goldenWeek coaching contract via the Phase 5.1 beam-search prototype', () => {
-    async function getBuildWeekResultBeamSearch() {
-        const scenario = SCENARIOS.find((s) => s.id === 'cycling_a_event_build_week');
-        if (!scenario) throw new Error('cycling_a_event_build_week scenario missing');
-        return runScenario(scenario, generateWeekAheadPlanWithIntentBeamSearch);
+    // Memoized at suite scope -- the beam search evaluates rankCandidates for every branch
+    // and day, so it costs far more than the greedy run, and each of the 6 tests below
+    // would otherwise re-run the full scenario from scratch.
+    let cached: Promise<ScenarioResult> | null = null;
+    function getBuildWeekResultBeamSearch(): Promise<ScenarioResult> {
+        if (!cached) {
+            const scenario = SCENARIOS.find((s) => s.id === 'cycling_a_event_build_week');
+            if (!scenario) throw new Error('cycling_a_event_build_week scenario missing');
+            cached = runScenario(scenario, generateWeekAheadPlanWithIntentBeamSearch);
+        }
+        return cached;
     }
 
     it('key cycling quality sessions are spaced by >= 48 hours', async () => {
         const result = await getBuildWeekResultBeamSearch();
         const keyCyclingDates = actualKeyCyclingDates(result);
 
-        const timestamps = keyCyclingDates.map((d) => new Date(d + 'T00:00:00').getTime());
-        for (let i = 1; i < timestamps.length; i++) {
-            const diffHours = (timestamps[i] - timestamps[i - 1]) / (1000 * 60 * 60);
-            expect(diffHours).toBeGreaterThanOrEqual(48);
+        for (let i = 1; i < keyCyclingDates.length; i++) {
+            const diffDays = getDayDiff(keyCyclingDates[i], keyCyclingDates[i - 1]);
+            expect(diffDays).toBeGreaterThanOrEqual(2);
         }
     });
 
@@ -136,10 +143,8 @@ describe('goldenWeek coaching contract via the Phase 5.1 beam-search prototype',
 
         result.objectiveCredits.forEach((c) => {
             if (heavyStrengthCategories.has(categoryByTemplateId.get(c.templateId) ?? '')) {
-                const strengthTime = new Date(c.date + 'T00:00:00').getTime();
                 keyCyclingDates.forEach((cycleDate) => {
-                    const cycleTime = new Date(cycleDate + 'T00:00:00').getTime();
-                    const diffDays = Math.abs(strengthTime - cycleTime) / (1000 * 60 * 60 * 24);
+                    const diffDays = Math.abs(getDayDiff(c.date, cycleDate));
                     expect(diffDays).not.toBe(1);
                 });
             }

--- a/app/src/engine/injuryPolicy.test.ts
+++ b/app/src/engine/injuryPolicy.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { migrateLegacyInjuries, resolveInjuryRestrictions } from './injuryPolicy';
-import type { InjuryConstraint } from './models';
+import { deriveTissueSeverity, migrateLegacyInjuries, resolveEffectiveInjuryConstraints, resolveInjuryRestrictions } from './injuryPolicy';
+import type { InjuryConstraint, RegionTissueResponse } from './models';
 
 describe('injuryPolicy', () => {
     describe('resolveInjuryRestrictions', () => {
@@ -142,6 +142,105 @@ describe('injuryPolicy', () => {
 
             const resolved = resolveInjuryRestrictions(migrated, '2026-08-08');
             expect(resolved.impliedGuardrails).toContain('avoid_high_impact');
+        });
+    });
+
+    describe('deriveTissueSeverity', () => {
+        it('returns null when every observed signal is normal or absent', () => {
+            expect(deriveTissueSeverity({ region: 'knee', morningState: 'normal' })).toBeNull();
+        });
+
+        it('takes the worst of the four observation points, not just morningState', () => {
+            const response: RegionTissueResponse = {
+                region: 'knee', morningState: 'normal', painDuringTraining: 'severe', afterTrainingState: 'mild',
+            };
+            expect(deriveTissueSeverity(response)).toBe('exclude');
+        });
+
+        it('maps mild -> monitor and moderate -> limit', () => {
+            expect(deriveTissueSeverity({ region: 'calf', morningState: 'mild' })).toBe('monitor');
+            expect(deriveTissueSeverity({ region: 'calf', morningState: 'moderate' })).toBe('limit');
+        });
+    });
+
+    // Phase 5.4's required precedence tests: InjuryConstraint (hard) -> observed tissue
+    // response (may tighten) -> wearable-derived readiness (may tighten). All three
+    // pairwise conflicts must hold.
+    describe('resolveEffectiveInjuryConstraints (precedence)', () => {
+        it('[InjuryConstraint vs tissue response] a normal tissue reading never clears or weakens an active exclude constraint', () => {
+            const baseInjuries: InjuryConstraint[] = [{ region: 'knee', severity: 'exclude', reviewBy: '2026-09-01' }];
+            const tissueResponses = { knee: { region: 'knee' as const, morningState: 'normal' as const } };
+
+            const effective = resolveEffectiveInjuryConstraints(baseInjuries, tissueResponses, '2026-08-08');
+            const knee = effective.find(i => i.region === 'knee');
+            expect(knee?.severity).toBe('exclude');
+
+            // And the actual gate still restricts Running, same as with no tissue response at all.
+            const restrictions = resolveInjuryRestrictions(effective, '2026-08-08');
+            expect(restrictions.restrictedModalities).toContain('Running');
+        });
+
+        it('[InjuryConstraint vs tissue response] a severe tissue reading tightens a monitor-only constraint on the same region', () => {
+            const baseInjuries: InjuryConstraint[] = [{ region: 'shoulder', severity: 'monitor' }];
+            const tissueResponses = { shoulder: { region: 'shoulder' as const, morningState: 'normal' as const, painDuringTraining: 'severe' as const } };
+
+            const effective = resolveEffectiveInjuryConstraints(baseInjuries, tissueResponses, '2026-08-08');
+            const shoulder = effective.find(i => i.region === 'shoulder');
+            expect(shoulder?.severity).toBe('exclude');
+
+            const restrictions = resolveInjuryRestrictions(effective, '2026-08-08');
+            expect(restrictions.restrictedCategories).toContain('Upper-body Strength');
+        });
+
+        it('[tissue response vs wearable readiness] a severe tissue reading restricts even when nothing about wearable readiness is consulted', () => {
+            // resolveEffectiveInjuryConstraints takes no readiness input at all -- this is
+            // a structural guarantee, not just a test outcome: wearable-derived readiness
+            // has no parameter through which it could weaken what tissue response set.
+            const tissueResponses = { hamstring: { region: 'hamstring' as const, morningState: 'severe' as const } };
+            const effective = resolveEffectiveInjuryConstraints(undefined, tissueResponses, '2026-08-08');
+            const restrictions = resolveInjuryRestrictions(effective, '2026-08-08');
+            expect(restrictions.impliedGuardrails).toContain('avoid_heavy_lower_body');
+            expect(restrictions.restrictedCategories.sort()).toEqual(['Lower-body Strength', 'Full-body Strength'].sort());
+        });
+
+        it('[InjuryConstraint vs wearable readiness] a persisted exclude constraint restricts independent of any readiness/tissue input at all', () => {
+            const baseInjuries: InjuryConstraint[] = [{ region: 'ankle', severity: 'exclude', reviewBy: '2026-09-01' }];
+            const effective = resolveEffectiveInjuryConstraints(baseInjuries, undefined, '2026-08-08');
+            const restrictions = resolveInjuryRestrictions(effective, '2026-08-08');
+            expect(restrictions.restrictedModalities).toContain('Running');
+        });
+
+        it('leaves regionless constraints untouched', () => {
+            const baseInjuries: InjuryConstraint[] = [{ severity: 'limit', restrictedModalities: ['Running'], note: 'general caution' }];
+            const effective = resolveEffectiveInjuryConstraints(baseInjuries, { knee: { region: 'knee', morningState: 'severe' } }, '2026-08-08');
+            expect(effective).toContainEqual(baseInjuries[0]);
+        });
+
+        it('adds a today-only constraint for a region with no standing InjuryConstraint at all', () => {
+            const effective = resolveEffectiveInjuryConstraints([], { elbow: { region: 'elbow', morningState: 'moderate' } }, '2026-08-08');
+            const elbow = effective.find(i => i.region === 'elbow');
+            expect(elbow?.severity).toBe('limit');
+            expect(elbow?.reviewBy).toBe('2026-08-08');
+        });
+
+        it('does not resurrect an expired standing constraint, but still surfaces a fresh tissue-derived one for the same region', () => {
+            const baseInjuries: InjuryConstraint[] = [{ region: 'knee', severity: 'exclude', reviewBy: '2026-08-01' }];
+            const effective = resolveEffectiveInjuryConstraints(baseInjuries, { knee: { region: 'knee', morningState: 'moderate' } }, '2026-08-08');
+
+            // The expired exclude constraint is passed through as-is (still expired) --
+            expect(effective.some(i => i.region === 'knee' && i.severity === 'exclude' && i.reviewBy === '2026-08-01')).toBe(true);
+            // -- and a fresh, active, today-only 'limit' entry is added alongside it.
+            expect(effective.some(i => i.region === 'knee' && i.severity === 'limit' && i.reviewBy === '2026-08-08')).toBe(true);
+
+            const restrictions = resolveInjuryRestrictions(effective, '2026-08-08');
+            expect(restrictions.restrictedModalities).toEqual([]); // limit alone doesn't restrict Running
+            expect(restrictions.impliedGuardrails).toContain('avoid_high_impact');
+        });
+
+        it('is a no-op when no tissue responses are supplied', () => {
+            const baseInjuries: InjuryConstraint[] = [{ region: 'hip', severity: 'limit' }];
+            expect(resolveEffectiveInjuryConstraints(baseInjuries, undefined, '2026-08-08')).toEqual(baseInjuries);
+            expect(resolveEffectiveInjuryConstraints(baseInjuries, {}, '2026-08-08')).toEqual(baseInjuries);
         });
     });
 });

--- a/app/src/engine/injuryPolicy.test.ts
+++ b/app/src/engine/injuryPolicy.test.ts
@@ -242,5 +242,28 @@ describe('injuryPolicy', () => {
             expect(resolveEffectiveInjuryConstraints(baseInjuries, undefined, '2026-08-08')).toEqual(baseInjuries);
             expect(resolveEffectiveInjuryConstraints(baseInjuries, {}, '2026-08-08')).toEqual(baseInjuries);
         });
+
+        it('keeps every same-region base constraint, not just the highest-severity one, and tightens each independently', () => {
+            // Two standing knee constraints: a general monitor plus an explicit
+            // modality-specific limit. A collapse-to-one-per-region bug would silently
+            // drop one of these, along with its restrictedModalities.
+            const baseInjuries: InjuryConstraint[] = [
+                { region: 'knee', severity: 'monitor', note: 'general knee caution' },
+                { region: 'knee', severity: 'limit', restrictedModalities: ['Running'], note: 'no running on knee' },
+            ];
+            const tissueResponses = { knee: { region: 'knee' as const, morningState: 'moderate' as const } };
+
+            const effective = resolveEffectiveInjuryConstraints(baseInjuries, tissueResponses, '2026-08-08');
+            const kneeConstraints = effective.filter(i => i.region === 'knee');
+
+            // Both base constraints survive, each tightened by the moderate tissue reading
+            // (monitor -> limit; limit stays limit since 'limit' already outranks the
+            // derived 'limit') and neither constraint's restrictedModalities is lost.
+            expect(kneeConstraints).toHaveLength(2);
+            expect(kneeConstraints.find(i => i.note === 'general knee caution')?.severity).toBe('limit');
+            const explicitLimit = kneeConstraints.find(i => i.note === 'no running on knee');
+            expect(explicitLimit?.severity).toBe('limit');
+            expect(explicitLimit?.restrictedModalities).toEqual(['Running']);
+        });
     });
 });

--- a/app/src/engine/injuryPolicy.ts
+++ b/app/src/engine/injuryPolicy.ts
@@ -1,4 +1,4 @@
-import type { BodyRegion, GuardrailKey, InjuryConstraint, SessionTemplate } from './models.ts';
+import type { BodyRegion, GuardrailKey, InjuryConstraint, RegionTissueResponse, SessionTemplate, TissueResponseLevel } from './models.ts';
 
 export interface InjuryRestrictions {
     restrictedModalities: SessionTemplate['modality'][];
@@ -93,6 +93,92 @@ export function resolveInjuryRestrictions(
         impliedGuardrails: Array.from(guardrailsSet),
         restrictedCategories: Array.from(categoriesSet),
     };
+}
+
+const SEVERITY_RANK: Record<InjuryConstraint['severity'], number> = { monitor: 0, limit: 1, exclude: 2 };
+const TISSUE_LEVEL_RANK: Record<TissueResponseLevel, number> = { normal: 0, mild: 1, moderate: 2, severe: 3 };
+
+/** Tightens only -- never returns a less-severe value than either input. */
+function moreSevere(a: InjuryConstraint['severity'], b: InjuryConstraint['severity']): InjuryConstraint['severity'] {
+    return SEVERITY_RANK[a] >= SEVERITY_RANK[b] ? a : b;
+}
+
+/**
+ * Worst signal across a day's four tissue-response observation points, translated into
+ * the InjuryConstraint severity it would justify on its own: severe -> exclude,
+ * moderate -> limit, mild -> monitor, normal/no signal -> null (nothing to add).
+ */
+export function deriveTissueSeverity(response: RegionTissueResponse): InjuryConstraint['severity'] | null {
+    const levels = [response.morningState, response.painDuringTraining, response.afterTrainingState, response.nextMorningReaction]
+        .filter((level): level is TissueResponseLevel => level !== undefined);
+    if (levels.length === 0) return null;
+    const worst = levels.reduce((worst, level) => (TISSUE_LEVEL_RANK[level] > TISSUE_LEVEL_RANK[worst] ? level : worst));
+    if (worst === 'severe') return 'exclude';
+    if (worst === 'moderate') return 'limit';
+    if (worst === 'mild') return 'monitor';
+    return null;
+}
+
+/**
+ * Merges today's observed per-region tissue response into the athlete's standing
+ * InjuryConstraint[]. Per docs/plans/phase-5-sequence-planning.md 5.4, this is
+ * PRESERVE-OR-TIGHTEN ONLY:
+ *
+ *   InjuryConstraint (hard) -> observed tissue response (may tighten) -> ...
+ *
+ * An active exclude/limit constraint is never weakened or cleared by a good day's tissue
+ * response (a green knee reading does not unlock running while an exclude knee
+ * constraint stands -- only editing the constraint does that). The result is a read-time
+ * value for a single day's decision; the caller must never persist it back as
+ * TrainingSettings.injuries.
+ */
+export function resolveEffectiveInjuryConstraints(
+    baseInjuries: InjuryConstraint[] | undefined,
+    tissueResponses: Partial<Record<BodyRegion, RegionTissueResponse>> | undefined,
+    today: string
+): InjuryConstraint[] {
+    const base = baseInjuries ?? [];
+    if (!tissueResponses || Object.keys(tissueResponses).length === 0) return base;
+
+    const regionless = base.filter(injury => !injury.region);
+    const byRegion = new Map<BodyRegion, InjuryConstraint>();
+    for (const injury of base) {
+        if (!injury.region) continue;
+        // Total order even if a caller somehow supplies two constraints for one region.
+        const existing = byRegion.get(injury.region);
+        if (!existing || SEVERITY_RANK[injury.severity] > SEVERITY_RANK[existing.severity]) {
+            byRegion.set(injury.region, injury);
+        }
+    }
+
+    const allRegions = new Set<BodyRegion>([...byRegion.keys(), ...(Object.keys(tissueResponses) as BodyRegion[])]);
+    const merged: InjuryConstraint[] = [...regionless];
+
+    for (const region of allRegions) {
+        const injury = byRegion.get(region);
+        const response = tissueResponses[region];
+        const derived = response ? deriveTissueSeverity(response) : null;
+        const isActive = !!injury && !(injury.reviewBy !== undefined && injury.reviewBy < today);
+
+        if (injury && isActive && derived) {
+            merged.push({ ...injury, severity: moreSevere(injury.severity, derived) });
+            continue;
+        }
+        if (injury) {
+            // Pass the base constraint through unchanged -- resolveInjuryRestrictions is
+            // what actually drops an expired one; this function never resurrects it.
+            merged.push(injury);
+        }
+        if (derived && (!injury || !isActive)) {
+            // Either a brand-new region with no standing constraint, or the standing
+            // constraint has lapsed and today's tissue response found a fresh problem --
+            // either way this is today-only, so it gets its own bounded reviewBy rather
+            // than silently persisting if this result were ever mistakenly saved.
+            merged.push({ region, severity: derived, reviewBy: today, note: "Derived from today's tissue check-in" });
+        }
+    }
+
+    return merged;
 }
 
 /**

--- a/app/src/engine/injuryPolicy.ts
+++ b/app/src/engine/injuryPolicy.ts
@@ -141,39 +141,46 @@ export function resolveEffectiveInjuryConstraints(
     if (!tissueResponses || Object.keys(tissueResponses).length === 0) return base;
 
     const regionless = base.filter(injury => !injury.region);
-    const byRegion = new Map<BodyRegion, InjuryConstraint>();
+    // Every same-region base constraint is kept -- a region can legitimately carry more
+    // than one (e.g. a general limit plus a modality-specific exclude), each with its own
+    // restrictedModalities. Collapsing to a single "worst" constraint would silently drop
+    // the others' restrictedModalities.
+    const byRegion = new Map<BodyRegion, InjuryConstraint[]>();
     for (const injury of base) {
         if (!injury.region) continue;
-        // Total order even if a caller somehow supplies two constraints for one region.
         const existing = byRegion.get(injury.region);
-        if (!existing || SEVERITY_RANK[injury.severity] > SEVERITY_RANK[existing.severity]) {
-            byRegion.set(injury.region, injury);
-        }
+        if (existing) existing.push(injury);
+        else byRegion.set(injury.region, [injury]);
     }
 
     const allRegions = new Set<BodyRegion>([...byRegion.keys(), ...(Object.keys(tissueResponses) as BodyRegion[])]);
     const merged: InjuryConstraint[] = [...regionless];
 
     for (const region of allRegions) {
-        const injury = byRegion.get(region);
+        const injuriesForRegion = byRegion.get(region) ?? [];
         const response = tissueResponses[region];
         const derived = response ? deriveTissueSeverity(response) : null;
-        const isActive = !!injury && !(injury.reviewBy !== undefined && injury.reviewBy < today);
 
-        if (injury && isActive && derived) {
-            merged.push({ ...injury, severity: moreSevere(injury.severity, derived) });
-            continue;
+        let anyActive = false;
+        for (const injury of injuriesForRegion) {
+            const isActive = !(injury.reviewBy !== undefined && injury.reviewBy < today);
+            if (isActive) anyActive = true;
+            if (isActive && derived) {
+                // Tighten this constraint's severity -- restrictedModalities and every
+                // other field pass through unchanged.
+                merged.push({ ...injury, severity: moreSevere(injury.severity, derived) });
+            } else {
+                // Pass the base constraint through unchanged -- resolveInjuryRestrictions is
+                // what actually drops an expired one; this function never resurrects it.
+                merged.push(injury);
+            }
         }
-        if (injury) {
-            // Pass the base constraint through unchanged -- resolveInjuryRestrictions is
-            // what actually drops an expired one; this function never resurrects it.
-            merged.push(injury);
-        }
-        if (derived && (!injury || !isActive)) {
-            // Either a brand-new region with no standing constraint, or the standing
-            // constraint has lapsed and today's tissue response found a fresh problem --
-            // either way this is today-only, so it gets its own bounded reviewBy rather
-            // than silently persisting if this result were ever mistakenly saved.
+        if (derived && !anyActive) {
+            // Either a brand-new region with no standing constraint, or every standing
+            // constraint for it has lapsed and today's tissue response found a fresh
+            // problem -- either way this is today-only, so it gets its own bounded
+            // reviewBy rather than silently persisting if this result were ever mistakenly
+            // saved.
             merged.push({ region, severity: derived, reviewBy: today, note: "Derived from today's tissue check-in" });
         }
     }

--- a/app/src/engine/microcycle.test.ts
+++ b/app/src/engine/microcycle.test.ts
@@ -8,7 +8,11 @@ import { evaluatePeriodizationPhase } from './periodization.ts';
 describe('updateMicrocycleProgress', () => {
   it('credits controlled field work toward surge repeatability', () => {
     const microcycle = { windowStartDate: '2026-08-03', objectives: [{ id: 'surges', key: 'surge_repeatability' as const, title: 'Surges', targetExposures: 1, completedExposures: 0, targetStimulus: { repeatedSurges: 0.9 } }] };
-    const updated = updateMicrocycleProgress(microcycle, { id: 'field-1', title: 'Field Field Maintenance', date: '2026-08-07', durationMin: 40, isCompleted: true });
+    const updated = updateMicrocycleProgress(microcycle, {
+      id: 'field-1', userId: 'athlete-1', title: 'Field Field Maintenance', date: '2026-08-07', durationMin: 40,
+      isCompleted: true, fixed: true, environment: 'outdoor', equipment: [],
+      createdAt: '2026-08-01T00:00:00Z', updatedAt: '2026-08-01T00:00:00Z',
+    });
     expect(updated.objectives.find((objective) => objective.key === 'surge_repeatability')?.completedExposures).toBe(1);
   });
 });

--- a/app/src/engine/microcycle.test.ts
+++ b/app/src/engine/microcycle.test.ts
@@ -158,6 +158,64 @@ describe('structured completed-history credit', () => {
   });
 });
 
+describe('evidence hierarchy confidence weighting (Phase 5.5)', () => {
+  const zeroStimulus: WorkoutStimulusProfile = {
+    aerobicEndurance: 0, thresholdPower: 0, vo2MaxPower: 0, repeatedSurges: 0, sprintPower: 0, fatigueResistance: 0, maxStrength: 0, hypertrophy: 0,
+  };
+  const zone2Microcycle = (): MicrocycleState => ({
+    windowStartDate: '2026-08-03',
+    objectives: [{ id: 'obj', key: 'zone2_aerobic', title: 'Aerobic Base', targetExposures: 1, completedExposures: 0, requiredCredit: 0.8, completedCredit: 0, targetStimulus: { aerobicEndurance: 0.8 } }],
+  });
+
+  it('credits full weight with the default confidence (unchanged from before this parameter existed)', () => {
+    const updated = creditObjectivesFromStimulus(zone2Microcycle(), { ...zeroStimulus, aerobicEndurance: 0.8 }, 'Cycling');
+    expect(updated.objectives[0].completedCredit).toBe(0.8);
+  });
+
+  it('discounts credit for inferred confidence', () => {
+    const updated = creditObjectivesFromStimulus(zone2Microcycle(), { ...zeroStimulus, aerobicEndurance: 0.8 }, 'Cycling', undefined, {}, 'inferred');
+    expect(updated.objectives[0].completedCredit).toBe(0.6); // 0.8 * 0.75, matches CONFIDENCE_CREDIT_WEIGHT.inferred
+  });
+
+  it('still credits a modality-agnostic objective from an exposure with no known modality at all', () => {
+    // Phase 5.5: a generic-fallback exposure (unknown sport, real measured evidence) can
+    // satisfy an objective that doesn't require a specific modality.
+    const updated = creditObjectivesFromStimulus(zone2Microcycle(), { ...zeroStimulus, aerobicEndurance: 0.8 }, undefined, undefined, {}, 'unknown');
+    expect(updated.objectives[0].completedCredit).toBeGreaterThan(0);
+    expect(updated.objectives[0].completedCredit).toBe(0.32); // 0.8 * 0.4, matches CONFIDENCE_CREDIT_WEIGHT.unknown
+  });
+
+  it('buildMicrocycleState credits an exposure that has a stimulusProfile but no modality (Phase 5.5 relaxed gate)', () => {
+    const exposure: CompletedExposure = {
+      date: '2026-08-06',
+      costProfile: { systemic: 0.3, cardiovascular: 0.3, lowerBody: 0.2, upperBody: 0, impactTissue: 0.1, neuromuscular: 0.2 },
+      trainingRecordLike: { type: 'Unknown unknown', duration_min: 40, training_effect: 0, intensity_tag: '' },
+      stimulusProfile: { ...zeroStimulus, aerobicEndurance: 0.5 },
+      stimulusConfidence: 'unknown',
+      // modality intentionally absent -- see completedTraining.ts genericModalityFallback
+    };
+    const phase = evaluatePeriodizationPhase([], '2026-08-03').phase;
+    const microcycle = buildMicrocycleState(phase, '2026-08-03', [exposure], null);
+    const z2 = microcycle.objectives.find(o => o.key === 'zone2_aerobic');
+    expect(z2?.completedCredit).toBeGreaterThan(0);
+  });
+
+  it('buildMicrocycleState defaults an exposure with no stimulusConfidence field to exact (legacy compatibility)', () => {
+    const exposure: CompletedExposure = {
+      date: '2026-08-06',
+      costProfile: { systemic: 0.3, cardiovascular: 0.3, lowerBody: 0.2, upperBody: 0, impactTissue: 0.1, neuromuscular: 0.2 },
+      trainingRecordLike: { type: 'Cycling moderate', duration_min: 40, training_effect: 0, intensity_tag: '' },
+      modality: 'Cycling',
+      stimulusProfile: { ...zeroStimulus, aerobicEndurance: 0.8 },
+      // stimulusConfidence intentionally absent
+    };
+    const phase = evaluatePeriodizationPhase([], '2026-08-03').phase;
+    const microcycle = buildMicrocycleState(phase, '2026-08-03', [exposure], null);
+    const z2 = microcycle.objectives.find(o => o.key === 'zone2_aerobic');
+    expect(z2?.completedCredit).toBe(0.8); // full credit, same as pre-5.5 behavior
+  });
+});
+
 describe('protected race-specific cycling objective', () => {
   const zeroStimulus: WorkoutStimulusProfile = {
     aerobicEndurance: 0, thresholdPower: 0, vo2MaxPower: 0, repeatedSurges: 0, sprintPower: 0, fatigueResistance: 0, maxStrength: 0, hypertrophy: 0,

--- a/app/src/engine/microcycle.test.ts
+++ b/app/src/engine/microcycle.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildMicrocycleState, creditObjectivesFromStimulus, stimulusCoverage, updateMicrocycleProgress } from './microcycle.ts';
+import { buildMicrocycleState, creditObjectivesFromStimulus, generateWeeklyObjectives, stimulusCoverage, updateMicrocycleProgress } from './microcycle.ts';
 import type { MicrocycleState, UserEvent, WorkoutStimulusProfile } from './models.ts';
 import type { CompletedExposure } from './trainingHistory.ts';
 import { completedEventToExposure, DEFAULT_COST_BY_MODALITY, DEFAULT_STIMULUS_BY_MODALITY } from './completedTraining.ts';
@@ -217,6 +217,88 @@ describe('evidence hierarchy confidence weighting (Phase 5.5)', () => {
     const microcycle = buildMicrocycleState(phase, '2026-08-03', [exposure], null);
     const z2 = microcycle.objectives.find(o => o.key === 'zone2_aerobic');
     expect(z2?.completedCredit).toBe(0.8); // full credit, same as pre-5.5 behavior
+  });
+});
+
+describe('taper as an explicit contract (Phase 5.7)', () => {
+  const aCyclingEvent = (): UserEvent => ({
+    id: 'race', title: 'A-Priority Road Race', date: '2026-08-14', priority: 'A', lifecycle: 'scheduled', category: 'cycling_event',
+    demandProfile: { aerobicEndurance: 0.7, thresholdPower: 0.6, vo2MaxPower: 0.4, repeatedSurges: 0.7, sprintPower: 0.2, fatigueResistance: 0.85, neuromuscular: 0.3 },
+  });
+
+  it('generates a taper-calibrated race_specific_endurance objective instead of silently dropping it', () => {
+    // 2026-08-07 is 7 days out from the 2026-08-14 A-event -- inside its 14-day taper window.
+    const result = evaluatePeriodizationPhase([aCyclingEvent()], '2026-08-07');
+    expect(result.phase.taperActive).toBe(true);
+
+    const microcycle = generateWeeklyObjectives(result.phase, '2026-08-03', result.focusEvent);
+    const taperObjective = microcycle.objectives.find(o => o.key === 'race_specific_endurance');
+    expect(taperObjective).toBeDefined();
+    expect(taperObjective?.title).toBe('Taper Sharpening (event-specific freshness)');
+    // Deliberately below the full-volume peak-block bar (aerobicEndurance 0.6) --
+    // end_taper_sharpen_01's own profile (templates.ts) could never clear that.
+    expect(taperObjective?.qualification?.minimumStimulus?.aerobicEndurance).toBeUndefined();
+    expect(taperObjective?.qualification?.minimumStimulus?.thresholdPower).toBe(0.3);
+  });
+
+  it('the taper objective is actually satisfiable by end_taper_sharpen_01\'s real stimulus profile', () => {
+    // Mirrors templates.ts's end_taper_sharpen_01 stimulusProfile exactly.
+    const taperSharpeningStimulus: WorkoutStimulusProfile = {
+      aerobicEndurance: 0.3, thresholdPower: 0.6, vo2MaxPower: 0.5, repeatedSurges: 0.5,
+      sprintPower: 0.1, fatigueResistance: 0.4, maxStrength: 0, hypertrophy: 0,
+    };
+    const result = evaluatePeriodizationPhase([aCyclingEvent()], '2026-08-07');
+    const microcycle = generateWeeklyObjectives(result.phase, '2026-08-03', result.focusEvent);
+
+    const updated = creditObjectivesFromStimulus(microcycle, taperSharpeningStimulus, 'Cycling', 'Race-Specific Endurance');
+    const taperObjective = updated.objectives.find(o => o.key === 'race_specific_endurance');
+    expect(taperObjective?.completedCredit ?? taperObjective?.completedExposures).toBeGreaterThan(0);
+  });
+
+  it('reduces the strength_maintenance target during taper (race-week primer, not full volume)', () => {
+    const result = evaluatePeriodizationPhase([aCyclingEvent()], '2026-08-07');
+    const microcycle = generateWeeklyObjectives(result.phase, '2026-08-03', result.focusEvent);
+    const strengthObjective = microcycle.objectives.find(o => o.key === 'strength_maintenance');
+    expect(strengthObjective?.title).toBe('Race-Week Strength Primer');
+    expect(strengthObjective?.targetStimulus.maxStrength).toBe(0.3);
+    expect(strengthObjective?.targetStimulus.maxStrength).toBeLessThan(0.7); // below the non-taper target
+  });
+
+  it('keeps the full-volume race_specific_endurance target outside taper (regression guard)', () => {
+    // 2026-07-01 is well outside any taper window for this event.
+    const result = evaluatePeriodizationPhase([aCyclingEvent()], '2026-07-01');
+    expect(result.phase.taperActive).toBe(false);
+    const microcycle = generateWeeklyObjectives(result.phase, '2026-06-27', result.focusEvent);
+    const objective = microcycle.objectives.find(o => o.key === 'race_specific_endurance');
+    expect(objective?.title).toBe('Cycling Race-Specific Endurance');
+    expect(objective?.qualification?.minimumStimulus?.aerobicEndurance).toBe(0.6);
+  });
+
+  it('plan-derived: the authored September event plan requests taper_sharpening and race_week_strength coverage during its taper block', async () => {
+    const { buildSeptemberCyclingEventPlan } = await import('./planSchedule.ts');
+    const septemberEvent: UserEvent = {
+      id: 'sep-event-1', title: 'September Cycling Event', date: '2026-09-20', priority: 'A', lifecycle: 'scheduled', category: 'cycling_event',
+      demandProfile: { aerobicEndurance: 0.8, thresholdPower: 0.8, vo2MaxPower: 0.7, repeatedSurges: 0.7, sprintPower: 0.3, fatigueResistance: 0.8, neuromuscular: 0.3 },
+    };
+    const planState = buildSeptemberCyclingEventPlan(septemberEvent);
+    expect(planState.status).toBe('AVAILABLE');
+    if (planState.status !== 'AVAILABLE') return;
+
+    // Taper-role objectives exist and are tagged with their PlanSessionRole.
+    const taperSharpening = planState.data.objectives.find(o => o.coverageKey === 'taper_sharpening');
+    const raceWeekStrength = planState.data.objectives.find(o => o.coverageKey === 'race_week_strength');
+    expect(taperSharpening?.role).toBe('taper_sharpening');
+    expect(raceWeekStrength?.role).toBe('secondary_support');
+
+    // 2026-09-10 falls inside block_taper (2026-09-07..2026-09-19).
+    const phase = evaluatePeriodizationPhase([septemberEvent], '2026-09-10').phase;
+    const microcycle = generateWeeklyObjectives(phase, '2026-09-10', septemberEvent, planState.data);
+
+    const sharpening = microcycle.objectives.find(o => o.key === 'race_specific_endurance');
+    expect(sharpening?.title).toBe('Taper Sharpening (event-specific freshness)');
+    const strength = microcycle.objectives.find(o => o.key === 'strength_maintenance');
+    expect(strength?.title).toBe('Race-Week Strength Primer');
+    expect(strength?.targetStimulus.maxStrength).toBe(0.3);
   });
 });
 

--- a/app/src/engine/microcycle.ts
+++ b/app/src/engine/microcycle.ts
@@ -13,6 +13,34 @@ import type { CompletedExposure } from './microcycleHistory';
 import type { PlanDefinition } from './planSchedule';
 import { modalitiesForEventCategory, type PhaseWeights } from './periodization';
 
+/**
+ * Phase 5.7: taper as an explicit contract, not an emergent side effect.
+ *
+ * Before this, a taper day either silently dropped the race_specific_endurance objective
+ * entirely (the generic path's `!phaseWeights.taperActive` guard) or -- if reached via the
+ * full-volume qualification below -- demanded a bar (`aerobicEndurance >= 0.6`) that a
+ * genuine taper session structurally cannot and should not clear. Either way, "preserve
+ * useful intensity and event-specific freshness" during taper was never itself
+ * represented; it only ever emerged from `volumeScale`/`phaseEligibility.requiresTaper`
+ * interactions with whatever survived. These two constants give it a name and a real,
+ * reachable target -- calibrated against `end_taper_sharpen_01`'s own (deliberately
+ * lower) stimulus profile in templates.ts, matching event-plan.ts's `taper_sharpening`
+ * coverage role, rather than the peak-block `end_race_sim_01`/`end_event_specific_01`
+ * bar `race_specific_endurance` uses everywhere else.
+ */
+const TAPER_SHARPENING_TARGET_STIMULUS: WeeklyObjective['targetStimulus'] = { thresholdPower: 0.5, repeatedSurges: 0.4 };
+const TAPER_SHARPENING_QUALIFICATION: ObjectiveQualification = {
+    minimumStimulus: { thresholdPower: 0.3 },
+    allowedModalities: ['Cycling'],
+    allowedCategories: ['Race-Specific Endurance'],
+};
+
+/** Same rationale as TAPER_SHARPENING_TARGET_STIMULUS above, for event-plan.ts's
+ *  `race_week_strength` role: a taper day's strength_maintenance objective should pull
+ *  toward a short, low-volume primer (strength_race_week_primer_01's own intent) rather
+ *  than the same full-volume target every other phase uses. */
+const TAPER_STRENGTH_TARGET_STIMULUS: WeeklyObjective['targetStimulus'] = { maxStrength: 0.3, hypertrophy: 0.2 };
+
 export function generateWeeklyObjectives(
     phaseWeights: PhaseWeights,
     windowStartDate: string,
@@ -45,6 +73,11 @@ export function generateWeeklyObjectives(
             let targetStimulus: WeeklyObjective['targetStimulus'] = { aerobicEndurance: 0.5 };
             let qualification: WeeklyObjective['qualification'] = undefined;
             const allowedModalities = focusEvent ? modalitiesForEventCategory(focusEvent.category) : [];
+            // Phase 5.7: a block's own declared phase -- not just its objective key --
+            // decides whether race_specific_endurance/strength_maintenance mean the
+            // full-volume peak-block target or the taper_sharpening/race_week_strength
+            // primer-level one. See TAPER_SHARPENING_TARGET_STIMULUS above.
+            const isTaperBlock = block?.phase === 'taper';
 
             switch (objDef.key) {
                 case 'zone2_aerobic':
@@ -68,17 +101,23 @@ export function generateWeeklyObjectives(
                     };
                     break;
                 case 'strength_maintenance':
-                    title = 'Strength & Neuromuscular Maintenance';
-                    targetStimulus = { maxStrength: 0.7, hypertrophy: 0.5 };
+                    title = isTaperBlock ? 'Race-Week Strength Primer' : 'Strength & Neuromuscular Maintenance';
+                    targetStimulus = isTaperBlock ? TAPER_STRENGTH_TARGET_STIMULUS : { maxStrength: 0.7, hypertrophy: 0.5 };
                     break;
                 case 'race_specific_endurance':
-                    title = 'Cycling Race-Specific Endurance';
-                    targetStimulus = { aerobicEndurance: 0.6, repeatedSurges: 0.6 };
-                    qualification = {
-                        minimumStimulus: { aerobicEndurance: 0.6 },
-                        allowedModalities: ['Cycling'],
-                        allowedCategories: ['Race-Specific Endurance'],
-                    };
+                    if (isTaperBlock) {
+                        title = 'Taper Sharpening (event-specific freshness)';
+                        targetStimulus = TAPER_SHARPENING_TARGET_STIMULUS;
+                        qualification = TAPER_SHARPENING_QUALIFICATION;
+                    } else {
+                        title = 'Cycling Race-Specific Endurance';
+                        targetStimulus = { aerobicEndurance: 0.6, repeatedSurges: 0.6 };
+                        qualification = {
+                            minimumStimulus: { aerobicEndurance: 0.6 },
+                            allowedModalities: ['Cycling'],
+                            allowedCategories: ['Race-Specific Endurance'],
+                        };
+                    }
                     break;
                 case 'vo2_max':
                     title = 'VO2 Max Intervals';
@@ -147,24 +186,36 @@ export function generateWeeklyObjectives(
     }
 
     objectives.push({
-        id: 'obj_strength', key: 'strength_maintenance', title: 'Strength & Neuromuscular Maintenance',
+        id: 'obj_strength', key: 'strength_maintenance',
+        title: phaseWeights.taperActive ? 'Race-Week Strength Primer' : 'Strength & Neuromuscular Maintenance',
         targetExposures: 1, completedExposures: 0,
-        targetStimulus: { maxStrength: 0.7, hypertrophy: 0.5 },
+        // Phase 5.7: event-plan.ts's race_week_strength role -- a taper day still
+        // maintains strength, just at primer volume, not full-volume as if nothing changed.
+        targetStimulus: phaseWeights.taperActive ? TAPER_STRENGTH_TARGET_STIMULUS : { maxStrength: 0.7, hypertrophy: 0.5 },
     });
 
-    if (focusEvent?.category === 'cycling_event'
-        && !phaseWeights.taperActive
-        && (demand.fatigueResistance >= 0.7 || demand.repeatedSurges >= 0.6)) {
-        objectives.push({
-            id: 'obj_cycling_race_specific', key: 'race_specific_endurance', title: 'Cycling Race-Specific Endurance',
-            targetExposures: 1, completedExposures: 0,
-            targetStimulus: { aerobicEndurance: 0.6, repeatedSurges: 0.6 },
-            qualification: {
-                minimumStimulus: { aerobicEndurance: 0.6 },
-                allowedModalities: ['Cycling'],
-                allowedCategories: ['Race-Specific Endurance'],
-            },
-        });
+    if (focusEvent?.category === 'cycling_event' && phaseWeights.phaseName !== 'Post-Event Recovery') {
+        if (!phaseWeights.taperActive && (demand.fatigueResistance >= 0.7 || demand.repeatedSurges >= 0.6)) {
+            objectives.push({
+                id: 'obj_cycling_race_specific', key: 'race_specific_endurance', title: 'Cycling Race-Specific Endurance',
+                targetExposures: 1, completedExposures: 0,
+                targetStimulus: { aerobicEndurance: 0.6, repeatedSurges: 0.6 },
+                qualification: {
+                    minimumStimulus: { aerobicEndurance: 0.6 },
+                    allowedModalities: ['Cycling'],
+                    allowedCategories: ['Race-Specific Endurance'],
+                },
+            });
+        } else if (phaseWeights.taperActive) {
+            // Phase 5.7: previously this branch was silently skipped for the entire
+            // taper window -- see TAPER_SHARPENING_TARGET_STIMULUS above for why.
+            objectives.push({
+                id: 'obj_taper_sharpening', key: 'race_specific_endurance', title: 'Taper Sharpening (event-specific freshness)',
+                targetExposures: 1, completedExposures: 0,
+                targetStimulus: TAPER_SHARPENING_TARGET_STIMULUS,
+                qualification: TAPER_SHARPENING_QUALIFICATION,
+            });
+        }
     }
 
     return { windowStartDate, objectives };

--- a/app/src/engine/microcycle.ts
+++ b/app/src/engine/microcycle.ts
@@ -16,6 +16,8 @@ import {
     objectivesFromDemand,
     TAPER_SHARPENING_QUALIFICATION,
     TAPER_SHARPENING_TARGET_STIMULUS,
+    TAPER_SHARPENING_TITLE,
+    TAPER_STRENGTH_PRIMER_TITLE,
     TAPER_STRENGTH_TARGET_STIMULUS,
     type PhaseWeights,
 } from './periodization';
@@ -80,12 +82,12 @@ export function generateWeeklyObjectives(
                     };
                     break;
                 case 'strength_maintenance':
-                    title = isTaperBlock ? 'Race-Week Strength Primer' : 'Strength & Neuromuscular Maintenance';
+                    title = isTaperBlock ? TAPER_STRENGTH_PRIMER_TITLE : 'Strength & Neuromuscular Maintenance';
                     targetStimulus = isTaperBlock ? TAPER_STRENGTH_TARGET_STIMULUS : { maxStrength: 0.7, hypertrophy: 0.5 };
                     break;
                 case 'race_specific_endurance':
                     if (isTaperBlock) {
-                        title = 'Taper Sharpening (event-specific freshness)';
+                        title = TAPER_SHARPENING_TITLE;
                         targetStimulus = TAPER_SHARPENING_TARGET_STIMULUS;
                         qualification = TAPER_SHARPENING_QUALIFICATION;
                     } else {

--- a/app/src/engine/microcycle.ts
+++ b/app/src/engine/microcycle.ts
@@ -170,7 +170,7 @@ export function generateWeeklyObjectives(
     return { windowStartDate, objectives };
 }
 
-import { deriveObjectiveCreditFromProfile, readStimulusProfile } from './stimulus';
+import { deriveObjectiveCreditFromProfile, readStimulusProfile, type StimulusConfidence } from './stimulus';
 
 /** Keyword-only evidence is deliberately worth less than a structured measured exposure.
  * It remains useful for old/external records, but cannot resolve a one-credit objective by
@@ -275,13 +275,24 @@ export function qualifiesForObjective(
  * Credits weekly objectives from a workout's numeric stimulus profile. The profile is
  * validated/canonicalized once at the exposure boundary, then reused for every objective;
  * this avoids duplicate migration warnings for the same persisted record.
+ *
+ * `modality` is now optional (Phase 5.5): a generic/unclassified exposure can still
+ * carry a genuine stimulus profile (see completedTraining.ts's genericModalityFallback
+ * tier) and credit a modality-agnostic objective, while deriveObjectiveCreditFromProfile
+ * fails closed on any objective that actually requires a known modality.
+ *
+ * `confidence` (Phase 5.5) discounts earned credit for anything short of an exact match
+ * -- see stimulus.ts CONFIDENCE_CREDIT_WEIGHT. Defaults to 'exact' so a caller supplying
+ * only authored/hypothetical data (e.g. planner.ts scoring a candidate template) is
+ * unaffected.
  */
 export function creditObjectivesFromStimulus(
     microcycle: MicrocycleState,
     rawStimulus: WorkoutStimulusProfile,
-    modality: SessionTemplate['modality'],
+    modality: SessionTemplate['modality'] | undefined,
     category?: SessionTemplate['category'],
     dose: DeliveredDose = {},
+    confidence: StimulusConfidence = 'exact',
 ): MicrocycleState {
     if (!microcycle || !microcycle.objectives) return microcycle;
     const stimulusState = readStimulusProfile(rawStimulus);
@@ -294,7 +305,7 @@ export function creditObjectivesFromStimulus(
             const requiredCredit = obj.requiredCredit ?? obj.targetExposures;
             const completedCredit = obj.completedCredit ?? obj.completedExposures;
             if (completedCredit >= requiredCredit) return obj;
-            const credit = deriveObjectiveCreditFromProfile(obj, stimulus, dose, { modality, category });
+            const credit = deriveObjectiveCreditFromProfile(obj, stimulus, dose, { modality, category }, confidence);
             if (!credit.qualifies || credit.earnedCredit <= 0) return obj;
             const nextCredit = Math.min(requiredCredit, completedCredit + credit.earnedCredit);
             return {
@@ -317,13 +328,18 @@ export function buildMicrocycleState(
     asOfDate?: string
 ): MicrocycleState {
     return history.reduce((state, exposure) => {
-        if (exposure.stimulusProfile && exposure.modality) {
+        // Phase 5.5: a stimulus profile no longer requires a known modality to be
+        // creditable -- see creditObjectivesFromStimulus's doc comment. An exposure with
+        // neither (e.g. legacy free-text-only evidence) still falls back to the
+        // deprecated keyword matcher below.
+        if (exposure.stimulusProfile) {
             return creditObjectivesFromStimulus(
                 state,
                 exposure.stimulusProfile,
                 exposure.modality,
                 exposure.category,
                 exposure.deliveredDose,
+                exposure.stimulusConfidence ?? 'exact',
             );
         }
         return updateMicrocycleProgress(state, exposure.trainingRecordLike);

--- a/app/src/engine/microcycle.ts
+++ b/app/src/engine/microcycle.ts
@@ -11,35 +11,14 @@ import type {
 } from './models';
 import type { CompletedExposure } from './microcycleHistory';
 import type { PlanDefinition } from './planSchedule';
-import { modalitiesForEventCategory, type PhaseWeights } from './periodization';
-
-/**
- * Phase 5.7: taper as an explicit contract, not an emergent side effect.
- *
- * Before this, a taper day either silently dropped the race_specific_endurance objective
- * entirely (the generic path's `!phaseWeights.taperActive` guard) or -- if reached via the
- * full-volume qualification below -- demanded a bar (`aerobicEndurance >= 0.6`) that a
- * genuine taper session structurally cannot and should not clear. Either way, "preserve
- * useful intensity and event-specific freshness" during taper was never itself
- * represented; it only ever emerged from `volumeScale`/`phaseEligibility.requiresTaper`
- * interactions with whatever survived. These two constants give it a name and a real,
- * reachable target -- calibrated against `end_taper_sharpen_01`'s own (deliberately
- * lower) stimulus profile in templates.ts, matching event-plan.ts's `taper_sharpening`
- * coverage role, rather than the peak-block `end_race_sim_01`/`end_event_specific_01`
- * bar `race_specific_endurance` uses everywhere else.
- */
-const TAPER_SHARPENING_TARGET_STIMULUS: WeeklyObjective['targetStimulus'] = { thresholdPower: 0.5, repeatedSurges: 0.4 };
-const TAPER_SHARPENING_QUALIFICATION: ObjectiveQualification = {
-    minimumStimulus: { thresholdPower: 0.3 },
-    allowedModalities: ['Cycling'],
-    allowedCategories: ['Race-Specific Endurance'],
-};
-
-/** Same rationale as TAPER_SHARPENING_TARGET_STIMULUS above, for event-plan.ts's
- *  `race_week_strength` role: a taper day's strength_maintenance objective should pull
- *  toward a short, low-volume primer (strength_race_week_primer_01's own intent) rather
- *  than the same full-volume target every other phase uses. */
-const TAPER_STRENGTH_TARGET_STIMULUS: WeeklyObjective['targetStimulus'] = { maxStrength: 0.3, hypertrophy: 0.2 };
+import {
+    modalitiesForEventCategory,
+    objectivesFromDemand,
+    TAPER_SHARPENING_QUALIFICATION,
+    TAPER_SHARPENING_TARGET_STIMULUS,
+    TAPER_STRENGTH_TARGET_STIMULUS,
+    type PhaseWeights,
+} from './periodization';
 
 export function generateWeeklyObjectives(
     phaseWeights: PhaseWeights,
@@ -147,76 +126,19 @@ export function generateWeeklyObjectives(
         return { windowStartDate, objectives };
     }
 
-    const demand = phaseWeights.targetDemandVector;
-    const objectives: WeeklyObjective[] = [];
-
-    if (demand.aerobicEndurance >= 0.4) {
-        objectives.push({
-            id: 'obj_z2_aerobic', key: 'zone2_aerobic', title: 'Aerobic Base (Zone 2)',
-            targetExposures: demand.aerobicEndurance >= 0.7 ? 2 : 1,
-            completedExposures: 0,
-            targetStimulus: { aerobicEndurance: 0.8 },
-        });
-    }
-
-    if (demand.thresholdPower >= 0.5 && !phaseWeights.taperActive) {
-        const allowedModalities = focusEvent ? modalitiesForEventCategory(focusEvent.category) : [];
-        objectives.push({
-            id: 'obj_threshold', key: 'threshold_quality', title: 'Threshold Development',
-            targetExposures: 1, completedExposures: 0,
-            targetStimulus: { thresholdPower: 0.9 },
-            qualification: {
-                minimumStimulus: { thresholdPower: 0.6 },
-                ...(allowedModalities.length > 0 ? { allowedModalities } : {}),
-            },
-        });
-    }
-
-    if ((demand.vo2MaxPower >= 0.6 || demand.repeatedSurges >= 0.6) && phaseWeights.phaseName !== 'Post-Event Recovery') {
-        const allowedModalities = focusEvent ? modalitiesForEventCategory(focusEvent.category) : [];
-        objectives.push({
-            id: 'obj_surges', key: 'surge_repeatability', title: 'Surge & High-Intensity Repeatability',
-            targetExposures: 1, completedExposures: 0,
-            targetStimulus: { repeatedSurges: 0.9, aerobicEndurance: 0.5 },
-            qualification: {
-                minimumStimulus: { repeatedSurges: 0.6 },
-                ...(allowedModalities.length > 0 ? { allowedModalities } : {}),
-            },
-        });
-    }
-
-    objectives.push({
-        id: 'obj_strength', key: 'strength_maintenance',
-        title: phaseWeights.taperActive ? 'Race-Week Strength Primer' : 'Strength & Neuromuscular Maintenance',
-        targetExposures: 1, completedExposures: 0,
-        // Phase 5.7: event-plan.ts's race_week_strength role -- a taper day still
-        // maintains strength, just at primer volume, not full-volume as if nothing changed.
-        targetStimulus: phaseWeights.taperActive ? TAPER_STRENGTH_TARGET_STIMULUS : { maxStrength: 0.7, hypertrophy: 0.5 },
-    });
-
-    if (focusEvent?.category === 'cycling_event' && phaseWeights.phaseName !== 'Post-Event Recovery') {
-        if (!phaseWeights.taperActive && (demand.fatigueResistance >= 0.7 || demand.repeatedSurges >= 0.6)) {
-            objectives.push({
-                id: 'obj_cycling_race_specific', key: 'race_specific_endurance', title: 'Cycling Race-Specific Endurance',
-                targetExposures: 1, completedExposures: 0,
-                targetStimulus: { aerobicEndurance: 0.6, repeatedSurges: 0.6 },
-                qualification: {
-                    minimumStimulus: { aerobicEndurance: 0.6 },
-                    allowedModalities: ['Cycling'],
-                    allowedCategories: ['Race-Specific Endurance'],
-                },
-            });
-        } else if (phaseWeights.taperActive) {
-            // Phase 5.7: previously this branch was silently skipped for the entire
-            // taper window -- see TAPER_SHARPENING_TARGET_STIMULUS above for why.
-            objectives.push({
-                id: 'obj_taper_sharpening', key: 'race_specific_endurance', title: 'Taper Sharpening (event-specific freshness)',
-                targetExposures: 1, completedExposures: 0,
-                targetStimulus: TAPER_SHARPENING_TARGET_STIMULUS,
-                qualification: TAPER_SHARPENING_QUALIFICATION,
-            });
-        }
-    }
+    // Phase 5.6: this translation (demand vector + category + taper state -> objective
+    // set) is now shared with resolveMultiEventObjectives (periodization.ts), which
+    // reuses it unchanged for each contributor event's OWN demand vector -- never a
+    // blended one. This call is the taper authority's own objectives, identical
+    // behavior to before the extraction.
+    const allowedModalities = focusEvent ? modalitiesForEventCategory(focusEvent.category) : [];
+    const objectives = objectivesFromDemand(
+        phaseWeights.targetDemandVector,
+        focusEvent?.category,
+        phaseWeights.taperActive,
+        phaseWeights.phaseName === 'Post-Event Recovery',
+        allowedModalities
+    );
 
     return { windowStartDate, objectives };
 }

--- a/app/src/engine/models.ts
+++ b/app/src/engine/models.ts
@@ -923,6 +923,23 @@ export type CompletedTrainingSource = 'garmin' | 'adherence' | 'manual';
 export type CompletedTrainingIntensity = 'easy' | 'moderate' | 'hard' | 'unknown';
 export type CompletedTrainingConfidence = 'high' | 'medium' | 'low';
 
+/** The evidence hierarchy for inferring completed-training stimulus (Phase 5.5) -- see
+ *  docs/plans/phase-5-sequence-planning.md 5.5 and completedTraining.ts's
+ *  classifyGarminTier/stimulusConfidenceForTier. Strongest to weakest evidence.
+ *  `completedStructuredWorkout` and `measuredEffort` are named for completeness against
+ *  the plan's full ladder but are not currently reachable -- no ingested source yet
+ *  carries a structured completed-workout record independent of the prescribed template
+ *  (the former) or per-interval power/cadence structure (the latter); Garmin's aggregate
+ *  Training Load stands in for the closest available approximation of the latter. */
+export type EvidenceTier =
+    | 'exactPrescribedMatch'
+    | 'completedStructuredWorkout'
+    | 'measuredEffort'
+    | 'garminTrainingEffect'
+    | 'durationIntensity'
+    | 'athleteClassification'
+    | 'genericModalityFallback';
+
 /**
  * One real-world completed session after all available evidence is reconciled. It is an
  * engine-domain model, derived from durable source records; it is not itself persisted
@@ -946,6 +963,9 @@ export interface CompletedTrainingEvent {
     exactTemplateMatch: boolean;
     sources: CompletedTrainingSource[];
     confidence: CompletedTrainingConfidence;
+    /** Which rung of the Phase 5.5 evidence hierarchy this event's stimulus was derived
+     *  from. Optional only for legacy construction paths that predate this field. */
+    evidenceTier?: EvidenceTier;
     linkedActivityId: string | null;
     linkedRecommendationDate: string | null;
     athleteFeedback: {

--- a/app/src/engine/models.ts
+++ b/app/src/engine/models.ts
@@ -643,6 +643,10 @@ export interface DailySubjectiveCheckin {
     illnessSymptoms: boolean;
     unusuallyLimitedTime: boolean;
     alreadyTrainedToday: boolean; // Already completed a session today -- recommendation should be rest/recovery only
+    /** Per-region detail (Phase 5.4), populated when painOrInjury is flagged. Keyed by
+     *  BodyRegion; see injuryPolicy.ts resolveEffectiveInjuryConstraints for how this
+     *  combines with the athlete's standing InjuryConstraint[]. */
+    tissueResponses?: Partial<Record<BodyRegion, RegionTissueResponse>>;
     // Availability block
     availability: {
         timeAvailableMin: number | null;
@@ -743,6 +747,30 @@ export interface InjuryConstraint {
   reviewBy?: string;
   note?: string;
   restrictedModalities?: SessionTemplate['modality'][];
+}
+
+/** A single tissue-response observation point, shared across the four signals below --
+ * 'normal' means no restriction warranted by that signal alone. */
+export type TissueResponseLevel = 'normal' | 'mild' | 'moderate' | 'severe';
+
+/** Per-region subjective tissue feedback for one check-in day (Phase 5.4). One scalar
+ * `soreness` value can't distinguish a knee from an Achilles from general DOMS -- this
+ * captures WHERE and WHEN a response was felt, since "knee hurt during yesterday's run"
+ * and "knee felt stiff this morning with no training" call for different caution.
+ * Never persisted as an `InjuryConstraint` itself and never written back to
+ * TrainingSettings -- see injuryPolicy.ts's resolveEffectiveInjuryConstraints for how a
+ * day's tissue response may only tighten (never weaken or clear) the athlete's standing
+ * InjuryConstraint[]. */
+export interface RegionTissueResponse {
+  region: BodyRegion;
+  /** How the region felt on waking, independent of any training. */
+  morningState: TissueResponseLevel;
+  /** Only meaningful when a session actually happened; absent = nothing to report. */
+  painDuringTraining?: TissueResponseLevel;
+  /** Immediately after that session. */
+  afterTrainingState?: TissueResponseLevel;
+  /** The following morning's reaction to that session. */
+  nextMorningReaction?: TissueResponseLevel;
 }
 
 export interface TrainingSettings {

--- a/app/src/engine/models.ts
+++ b/app/src/engine/models.ts
@@ -234,6 +234,24 @@ export interface ObjectiveProgress {
     rawCompletedCredit: number;
 }
 
+// --- Phase 5.6: one taper authority, multiple demand contributors ---
+// Canonical location for periodization.ts's resolveMultiEventObjectives result shape --
+// lives here (not periodization.ts) so decisionTrace/RecommendationAudit below can
+// reference it without periodization.ts importing back from models.ts.
+
+export type ObjectiveDropReason = 'inadmissible_during_taper';
+
+export interface DroppedContributorObjective {
+    eventId: string;
+    eventTitle: string;
+    objectiveKey: ObjectiveKey;
+    reason: ObjectiveDropReason;
+    /** Athlete-facing explanation, not just a machine code -- see the plan's own framing:
+     *  "your B-event's threshold session was dropped because it fell in A-event race
+     *  week" is actionable; a quietly reweighted plan teaches the athlete nothing. */
+    message: string;
+}
+
 export interface MicrocycleState {
     windowStartDate: string; // YYYY-MM-DD (Warsaw-local start date)
     objectives: WeeklyObjective[];
@@ -468,6 +486,11 @@ export interface Recommendation {
             utilityScore: number;
             excludedReasons: string[];
         }>;
+        /** Phase 5.6: contributor objectives dropped from this decision's microcycle
+         *  because they fell inadmissible during the taper authority's taper window -- see
+         *  periodization.ts resolveMultiEventObjectives. Empty in the overwhelmingly
+         *  common single-or-no-event case. */
+        droppedContributorObjectives: DroppedContributorObjective[];
     };
 }
 
@@ -1009,6 +1032,10 @@ export interface RecommendationAudit {
         utilityScore: number;
         excludedReasons: string[];
     }>;
+    /** Phase 5.6: carried through from the decision's decisionTrace -- see
+     *  DroppedContributorObjective's own doc comment. Empty in the overwhelmingly common
+     *  single-or-no-event case. */
+    droppedContributorObjectives: DroppedContributorObjective[];
 }
 
 // --- Type Utilities ---

--- a/app/src/engine/models.ts
+++ b/app/src/engine/models.ts
@@ -105,15 +105,36 @@ export interface UserContext {
     trainingSettings?: TrainingSettings;
 }
 
+/** Persisted at `users/{userId}/fixed_activities/{activityId}` (ADR-0002 user-owned
+ *  path, Phase 5.3) -- see docs/plans/phase-5-sequence-planning.md 5.3 for the storage
+ *  contract and firestore.rules validation table this type must stay aligned with. */
 export interface FixedActivity {
     id: string;
+    userId: string;
     title: string;
-    date: string; // YYYY-MM-DD
+    date: string; // YYYY-MM-DD, Warsaw-local (ADR-0003)
     startTime?: string;
     durationMin: number;
-    expectedStimulus?: Record<string, number>;
-    expectedCost?: Record<string, number>;
+    /** Keys are the canonical WorkoutStimulusProfile axes; each value 0..1. */
+    expectedStimulus?: Partial<Record<keyof WorkoutStimulusProfile, number>>;
+    /** Keys are the six WorkoutCostProfile dimensions; each value 0..1. */
+    expectedCost?: Partial<Record<keyof WorkoutCostProfile, number>>;
+    /** Immovable (booked class, match kickoff) vs a movable placeholder the athlete could
+     *  reschedule around. Load-bearing for the planner/search -- see 5.3's storage table. */
+    fixed: boolean;
+    environment: TrainingEnvironment;
+    /** Equipment available *at* this activity, not the athlete's general profile
+     *  equipment (e.g. away-game gear, a hotel gym's limited rack). Size/type bounds are
+     *  enforced in validation.ts and the FixedActivity form -- firestore.rules can only
+     *  bound the list's length, not iterate to check each item (see 5.3). */
+    equipment: string[];
+    /** Overrides the day's total available training minutes outright (e.g. a travel day:
+     *  the whole day's budget shrinks, not just this activity's own duration). Absent =
+     *  the normal weekday/weekend profile budget applies, reduced only by durationMin. */
+    availabilityOverride?: number;
     isCompleted: boolean;
+    createdAt: string;
+    updatedAt: string;
 }
 
 export type EventPriority = 'A' | 'B' | 'C';

--- a/app/src/engine/models.ts
+++ b/app/src/engine/models.ts
@@ -736,9 +736,15 @@ export type EquipmentKey = 'free_weights' | 'cable_machine' | 'treadmill' | 'ind
 export type TrainingEnvironment = 'indoor' | 'outdoor' | 'either';
 export type GuardrailKey = 'avoid_high_impact' | 'avoid_heavy_lower_body' | 'avoid_overhead_pressing' | 'avoid_heavy_spinal_loading';
 
-export type BodyRegion =
-  | 'knee' | 'achilles' | 'ankle' | 'calf' | 'hamstring' | 'quadriceps'
-  | 'adductor_groin' | 'hip' | 'lower_back' | 'shoulder' | 'elbow' | 'wrist';
+/** Canonical list -- the single source of truth for BodyRegion. validation.ts and any UI
+ * enumerating regions (e.g. DailyCheckin.tsx) must import this rather than re-listing the
+ * union, so an added region can't compile while silently missing from a validator or UI. */
+export const BODY_REGIONS = [
+  'knee', 'achilles', 'ankle', 'calf', 'hamstring', 'quadriceps',
+  'adductor_groin', 'hip', 'lower_back', 'shoulder', 'elbow', 'wrist',
+] as const;
+
+export type BodyRegion = typeof BODY_REGIONS[number];
 
 export interface InjuryConstraint {
   region?: BodyRegion;
@@ -749,9 +755,13 @@ export interface InjuryConstraint {
   restrictedModalities?: SessionTemplate['modality'][];
 }
 
+/** Canonical list -- the single source of truth for TissueResponseLevel; see BODY_REGIONS
+ * above for why this is exported rather than re-enumerated at each call site. */
+export const TISSUE_LEVELS = ['normal', 'mild', 'moderate', 'severe'] as const;
+
 /** A single tissue-response observation point, shared across the four signals below --
  * 'normal' means no restriction warranted by that signal alone. */
-export type TissueResponseLevel = 'normal' | 'mild' | 'moderate' | 'severe';
+export type TissueResponseLevel = typeof TISSUE_LEVELS[number];
 
 /** Per-region subjective tissue feedback for one check-in day (Phase 5.4). One scalar
  * `soreness` value can't distinguish a knee from an Achilles from general DOMS -- this
@@ -926,11 +936,13 @@ export type CompletedTrainingConfidence = 'high' | 'medium' | 'low';
 /** The evidence hierarchy for inferring completed-training stimulus (Phase 5.5) -- see
  *  docs/plans/phase-5-sequence-planning.md 5.5 and completedTraining.ts's
  *  classifyGarminTier/stimulusConfidenceForTier. Strongest to weakest evidence.
- *  `completedStructuredWorkout` and `measuredEffort` are named for completeness against
- *  the plan's full ladder but are not currently reachable -- no ingested source yet
- *  carries a structured completed-workout record independent of the prescribed template
- *  (the former) or per-interval power/cadence structure (the latter); Garmin's aggregate
- *  Training Load stands in for the closest available approximation of the latter. */
+ *  `completedStructuredWorkout` is named for completeness against the plan's full ladder
+ *  but is not currently reachable -- no ingested source yet carries a structured
+ *  completed-workout record independent of the prescribed template. `measuredEffort` IS
+ *  reachable: classifyGarminTier returns it when a Garmin activity has both a training
+ *  effect and a positive `activityTrainingLoad`, Garmin's own proprietary composite
+ *  (derived from HR/pace/power across the session) standing in as the closest available
+ *  approximation of true per-interval power/cadence structure. */
 export type EvidenceTier =
     | 'exactPrescribedMatch'
     | 'completedStructuredWorkout'

--- a/app/src/engine/optimizer.test.ts
+++ b/app/src/engine/optimizer.test.ts
@@ -93,6 +93,58 @@ describe('optimizer — dated, role-aware recovery constraints (F3 / 3.1)', () =
         expect(result.rejected[0].excludedReasons).toContain('HARD_LOWER_BODY_SPACING_VIOLATION');
     });
 
+    // Phase 5.2: a detailed workout's own minimumDaysAfterHardLowerBody can require a
+    // longer (or shorter) gap than the flat default -- resolveMinimumDaysAfterHardLowerBody
+    // is the injection point (planningCandidate.ts is the real, catalog-backed resolver;
+    // these tests exercise the mechanism directly with a synthetic one).
+    describe('per-workout hard-lower-body spacing override (Phase 5.2)', () => {
+        const heavySquat = () => ENRICHED_TEMPLATES.find(t => t.category === 'Lower-body Strength') ?? ENRICHED_TEMPLATES.find(t => t.modality === 'Strength')!;
+        const oneDayPriorHistory: RecentHistoryEntry[] = [
+            { date: '2026-03-04', modality: 'Strength', category: 'Lower-body Strength', role: 'anchor', systemicCost: 0.7, lowerBodyCost: 0.8, type: 'Lower-body Strength' },
+        ];
+
+        it('a stricter (3-day) workout-level requirement rejects a candidate that the flat 2-day default would already reject, and also rejects at day 2', () => {
+            const template = heavySquat();
+            const twoDaysPriorHistory: RecentHistoryEntry[] = [
+                { date: '2026-03-03', modality: 'Strength', category: 'Lower-body Strength', role: 'anchor', systemicCost: 0.7, lowerBodyCost: 0.8, type: 'Lower-body Strength' },
+            ];
+            // Default (no resolver): day-2 gap already clears the flat 2-day rule.
+            const defaultResult = rankCandidates(
+                [template], [], DEFAULT_FATIGUE, DEFAULT_AVAILABILITY, [], DEFAULT_PREFERENCES,
+                { date: '2026-03-05', recentHistory: twoDaysPriorHistory },
+            );
+            expect(defaultResult.accepted).toHaveLength(1);
+
+            // A workout that declares it needs 3 full days still rejects at day 2.
+            const strictResult = rankCandidates(
+                [template], [], DEFAULT_FATIGUE, DEFAULT_AVAILABILITY, [], DEFAULT_PREFERENCES,
+                { date: '2026-03-05', recentHistory: twoDaysPriorHistory, resolveMinimumDaysAfterHardLowerBody: () => 3 },
+            );
+            expect(strictResult.rejected).toHaveLength(1);
+            expect(strictResult.rejected[0].excludedReasons).toContain('HARD_LOWER_BODY_SPACING_VIOLATION');
+        });
+
+        it('a more lenient (1-day) workout-level requirement accepts a candidate the flat 2-day default would reject', () => {
+            const template = heavySquat();
+            const result = rankCandidates(
+                [template], [], DEFAULT_FATIGUE, DEFAULT_AVAILABILITY, [], DEFAULT_PREFERENCES,
+                { date: '2026-03-05', recentHistory: oneDayPriorHistory, resolveMinimumDaysAfterHardLowerBody: () => 1 },
+            );
+            expect(result.accepted).toHaveLength(1);
+            expect(result.accepted[0].excludedReasons).not.toContain('HARD_LOWER_BODY_SPACING_VIOLATION');
+        });
+
+        it('a resolver that returns undefined for this template falls back to the flat 2-day default, unchanged', () => {
+            const template = heavySquat();
+            const result = rankCandidates(
+                [template], [], DEFAULT_FATIGUE, DEFAULT_AVAILABILITY, [], DEFAULT_PREFERENCES,
+                { date: '2026-03-05', recentHistory: oneDayPriorHistory, resolveMinimumDaysAfterHardLowerBody: () => undefined },
+            );
+            expect(result.rejected).toHaveLength(1);
+            expect(result.rejected[0].excludedReasons).toContain('HARD_LOWER_BODY_SPACING_VIOLATION');
+        });
+    });
+
     it('rejects a hard session with ROLLING_HARD_CAP_EXCEEDED once 3 hard sessions already sit in the rolling 7-day window', () => {
         const moderateRide = ENRICHED_TEMPLATES.find(t => t.category === 'Moderate Endurance' && t.modality === 'Cycling')!;
         const history: RecentHistoryEntry[] = [

--- a/app/src/engine/optimizer.test.ts
+++ b/app/src/engine/optimizer.test.ts
@@ -98,12 +98,19 @@ describe('optimizer — dated, role-aware recovery constraints (F3 / 3.1)', () =
     // is the injection point (planningCandidate.ts is the real, catalog-backed resolver;
     // these tests exercise the mechanism directly with a synthetic one).
     describe('per-workout hard-lower-body spacing override (Phase 5.2)', () => {
-        const heavySquat = () => ENRICHED_TEMPLATES.find(t => t.category === 'Lower-body Strength') ?? ENRICHED_TEMPLATES.find(t => t.modality === 'Strength')!;
+        // No fallback to "any Strength template" -- a fallback that isn't heavy lower-body
+        // would silently defeat evaluateRecoveryConstraints' hard-lower-body spacing rule
+        // these tests exist to exercise, so a missing fixture template must fail loudly.
+        const heavySquat = () => {
+            const template = ENRICHED_TEMPLATES.find(t => t.category === 'Lower-body Strength');
+            if (!template) throw new Error('No Lower-body Strength template in ENRICHED_TEMPLATES');
+            return template;
+        };
         const oneDayPriorHistory: RecentHistoryEntry[] = [
             { date: '2026-03-04', modality: 'Strength', category: 'Lower-body Strength', role: 'anchor', systemicCost: 0.7, lowerBodyCost: 0.8, type: 'Lower-body Strength' },
         ];
 
-        it('a stricter (3-day) workout-level requirement rejects a candidate that the flat 2-day default would already reject, and also rejects at day 2', () => {
+        it('a stricter (3-day) workout-level requirement rejects at a day-2 gap that the flat 2-day default accepts', () => {
             const template = heavySquat();
             const twoDaysPriorHistory: RecentHistoryEntry[] = [
                 { date: '2026-03-03', modality: 'Strength', category: 'Lower-body Strength', role: 'anchor', systemicCost: 0.7, lowerBodyCost: 0.8, type: 'Lower-body Strength' },

--- a/app/src/engine/optimizer.ts
+++ b/app/src/engine/optimizer.ts
@@ -258,8 +258,11 @@ export function evaluateRecoveryConstraints(
     const candidateLowerBodyCost = template.costProfile?.lowerBody ?? (STRENGTH_CATEGORIES.includes(template.category) ? 0.6 : 0);
     if (candidateLowerBodyCost >= 0.6) {
         // Phase 5.2: a detailed workout's own eligibility.minimumDaysAfterHardLowerBody
-        // (planningCandidate.ts) can require a longer gap than the flat 2-day default
-        // below -- the default reproduces the exact prior behavior (diff === 1 was the
+        // (planningCandidate.ts) can override the flat 2-day default below in EITHER
+        // direction -- most catalog overrides are 1 (e.g. race-week/taper primers and
+        // quality-support sessions deliberately allow a shorter gap than the flat
+        // default), and a few are stricter (e.g. `field.ts`'s technical field sessions use
+        // 2). The default itself reproduces the exact prior behavior (diff === 1 was the
         // only violation) for every template with no such workout-level override.
         const minGapDays = options.resolveMinimumDaysAfterHardLowerBody?.(template.id) ?? 2;
         const priorHardLower = history.find(h => {

--- a/app/src/engine/optimizer.ts
+++ b/app/src/engine/optimizer.ts
@@ -53,6 +53,11 @@ export interface OptimizationOptions {
     anchorRole?: 'event-specific' | 'quality' | null;
     adjacentToAnchor?: boolean;
     plannedDose?: PlannedDose;
+    /** Phase 5.2: per-workout hard-lower-body spacing (planningCandidate.ts's
+     *  `PlanningCandidate.minimumDaysAfterHardLowerBody`), keyed by engine template id.
+     *  Optional and unset by default -- every existing caller keeps today's flat
+     *  2-day-minimum-gap rule (see evaluateRecoveryConstraints) unchanged. */
+    resolveMinimumDaysAfterHardLowerBody?: (templateId: string) => number | undefined;
 }
 
 export interface OptimizationContext {
@@ -252,9 +257,14 @@ export function evaluateRecoveryConstraints(
 
     const candidateLowerBodyCost = template.costProfile?.lowerBody ?? (STRENGTH_CATEGORIES.includes(template.category) ? 0.6 : 0);
     if (candidateLowerBodyCost >= 0.6) {
+        // Phase 5.2: a detailed workout's own eligibility.minimumDaysAfterHardLowerBody
+        // (planningCandidate.ts) can require a longer gap than the flat 2-day default
+        // below -- the default reproduces the exact prior behavior (diff === 1 was the
+        // only violation) for every template with no such workout-level override.
+        const minGapDays = options.resolveMinimumDaysAfterHardLowerBody?.(template.id) ?? 2;
         const priorHardLower = history.find(h => {
             const diff = getDayDiff(targetDate, h.date);
-            return diff === 1 && h.lowerBodyCost >= 0.6;
+            return diff >= 1 && diff < minGapDays && h.lowerBodyCost >= 0.6;
         });
         if (priorHardLower) reasons.push('HARD_LOWER_BODY_SPACING_VIOLATION');
     }
@@ -424,6 +434,7 @@ export function buildOptimizationContext(
             anchorRole: options.anchorRole ?? null,
             adjacentToAnchor: options.adjacentToAnchor ?? false,
             ...(intent.plannedDose ? { plannedDose: intent.plannedDose } : {}),
+            ...(options.resolveMinimumDaysAfterHardLowerBody ? { resolveMinimumDaysAfterHardLowerBody: options.resolveMinimumDaysAfterHardLowerBody } : {}),
         },
     };
 }

--- a/app/src/engine/periodization.test.ts
+++ b/app/src/engine/periodization.test.ts
@@ -103,6 +103,34 @@ describe('resolveMultiEventObjectives (Phase 5.6)', () => {
         expect(resolution.droppedContributorObjectives).toEqual([]);
     });
 
+    it('two contributors of different modalities sharing an objective key union their allowedModalities, order-invariant', () => {
+        // A Running B-event and a Cycling B-event both produce threshold_quality
+        // (thresholdPower >= 0.5, not tapering). objectivesFromDemand scopes each
+        // contributor's own qualification.allowedModalities to its own event category, so
+        // a naive first-contributor-wins merge would let whichever one is processed first
+        // silently exclude the other modality's sessions from satisfying the shared key.
+        const aEvent = event({ id: 'a-event', date: '2026-10-17', priority: 'A', demandProfile: ZERO_DEMAND }); // far out, not tapering
+        const bRunning = event({ id: 'b-running', date: '2026-08-25', priority: 'B', category: 'running_race', demandProfile: cyclingDemand });
+        const bCycling = event({ id: 'b-cycling', date: '2026-08-20', priority: 'B', category: 'cycling_event', demandProfile: cyclingDemand });
+        const currentDate = '2026-08-08';
+
+        const authorityResult = evaluatePeriodizationPhase([aEvent, bRunning, bCycling], currentDate);
+        expect(authorityResult.phase.taperActive).toBe(false);
+
+        const forward = resolveMultiEventObjectives([aEvent, bRunning, bCycling], currentDate, authorityResult, []);
+        const reversed = resolveMultiEventObjectives([aEvent, bCycling, bRunning], currentDate, authorityResult, []);
+
+        const forwardThreshold = forward.objectives.find(o => o.key === 'threshold_quality');
+        const reversedThreshold = reversed.objectives.find(o => o.key === 'threshold_quality');
+
+        expect(forwardThreshold).toBeDefined();
+        expect(reversedThreshold).toBeDefined();
+        expect(forwardThreshold?.qualification?.allowedModalities?.slice().sort()).toEqual(['Cycling', 'Running']);
+        // Order-invariant: swapping which contributor is processed first must not change
+        // the merged result.
+        expect(reversedThreshold?.qualification?.allowedModalities?.slice().sort()).toEqual(['Cycling', 'Running']);
+    });
+
     it('two contributors sharing an objective key resolve to max(requiredCredit), not sum', () => {
         const aEvent = event({ id: 'a-event', date: '2026-10-17', priority: 'A', demandProfile: ZERO_DEMAND });
         const bEvent1 = event({ id: 'b-1', date: '2026-08-20', priority: 'B', demandProfile: { ...cyclingDemand, aerobicEndurance: 0.9 } });

--- a/app/src/engine/periodization.test.ts
+++ b/app/src/engine/periodization.test.ts
@@ -37,6 +37,20 @@ describe('evaluatePeriodizationPhase: taper authority total order (Phase 5.6)', 
         expect(result.focusEvent?.id).toBe('aaa');
     });
 
+    it('planning date ranks ahead of the id backstop when it differs from the event date', () => {
+        // Same priority and event date (so the id backstop alone would pick 'aaa'
+        // lexicographically), but 'zzz' has the earlier timing.planningDate -- proving the
+        // ordering actually consults planningDate rather than only ever falling through to
+        // the id tie-breaker.
+        const events = [
+            event({ id: 'aaa', date: '2026-08-20', priority: 'A', timing: { earliestDate: '2026-08-20', latestDate: '2026-08-20', planningDate: '2026-08-21' } }),
+            event({ id: 'zzz', date: '2026-08-20', priority: 'A', timing: { earliestDate: '2026-08-20', latestDate: '2026-08-20', planningDate: '2026-08-19' } }),
+        ];
+        const result = evaluatePeriodizationPhase(events, '2026-08-08');
+        expect(result.focusEvent?.id).toBe('zzz');
+        expect(result.governingEventTie).toEqual([]);
+    });
+
     it('a genuine tie through every real criterion is surfaced via governingEventTie, not silently resolved', () => {
         const events = [
             event({ id: 'race-a', date: '2026-08-20', priority: 'A' }),
@@ -139,7 +153,9 @@ describe('resolveMultiEventObjectives (Phase 5.6)', () => {
         const zone2 = resolution.objectives.find(o => o.key === 'zone2_aerobic');
         expect(zone2?.id).toBe('obj_z2_authority'); // authority's identity wins
         expect(zone2?.title).toBe('Authority Aerobic Base'); // authority's title wins
-        expect(zone2?.targetExposures).toBeGreaterThanOrEqual(1); // required amount may still grow
+        // The contributor's cyclingDemand.aerobicEndurance (0.8, >= 0.7) yields
+        // targetExposures 2, which the max-merge raises the authority's 1 to.
+        expect(zone2?.targetExposures).toBe(2);
     });
 
     it('ignores a contributor outside its contribution window (too far out) and a non-scheduled event', () => {

--- a/app/src/engine/periodization.test.ts
+++ b/app/src/engine/periodization.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest';
+import { evaluatePeriodizationPhase, resolveMultiEventObjectives } from './periodization';
+import type { UserEvent } from './models';
+
+const ZERO_DEMAND = {
+    aerobicEndurance: 0, thresholdPower: 0, vo2MaxPower: 0, repeatedSurges: 0,
+    sprintPower: 0, fatigueResistance: 0, neuromuscular: 0,
+};
+
+function event(overrides: Partial<UserEvent> & Pick<UserEvent, 'id' | 'date' | 'priority'>): UserEvent {
+    return {
+        title: overrides.id, lifecycle: 'scheduled', category: 'cycling_event',
+        demandProfile: ZERO_DEMAND,
+        ...overrides,
+    };
+}
+
+describe('evaluatePeriodizationPhase: taper authority total order (Phase 5.6)', () => {
+    it('priority tie is broken by proximity (fewer days first)', () => {
+        const events = [
+            event({ id: 'far', date: '2026-09-01', priority: 'A' }),
+            event({ id: 'near', date: '2026-08-20', priority: 'A' }),
+        ];
+        const result = evaluatePeriodizationPhase(events, '2026-08-08');
+        expect(result.focusEvent?.id).toBe('near');
+        expect(result.governingEventTie).toEqual([]);
+    });
+
+    it('proximity tie is broken by planning date ascending, then event id lexicographically', () => {
+        // Same priority, same daysToEvent (both 2026-08-20 relative to 2026-08-08) --
+        // decidable only by id.
+        const events = [
+            event({ id: 'zzz', date: '2026-08-20', priority: 'A' }),
+            event({ id: 'aaa', date: '2026-08-20', priority: 'A' }),
+        ];
+        const result = evaluatePeriodizationPhase(events, '2026-08-08');
+        expect(result.focusEvent?.id).toBe('aaa');
+    });
+
+    it('a genuine tie through every real criterion is surfaced via governingEventTie, not silently resolved', () => {
+        const events = [
+            event({ id: 'race-a', date: '2026-08-20', priority: 'A' }),
+            event({ id: 'race-b', date: '2026-08-20', priority: 'A' }),
+        ];
+        const result = evaluatePeriodizationPhase(events, '2026-08-08');
+        expect(result.governingEventTie.map(e => e.id).sort()).toEqual(['race-a', 'race-b']);
+        // The id backstop still deterministically picks one as focusEvent.
+        expect(result.focusEvent?.id).toBe('race-a');
+    });
+
+    it('a proximity difference (not a tie) does not trigger governingEventTie even at the same priority', () => {
+        const events = [
+            event({ id: 'far', date: '2026-09-01', priority: 'A' }),
+            event({ id: 'near', date: '2026-08-20', priority: 'A' }),
+        ];
+        const result = evaluatePeriodizationPhase(events, '2026-08-08');
+        expect(result.governingEventTie).toEqual([]);
+    });
+
+    it('priority strictly outranks proximity (a closer B-event never beats a farther A-event)', () => {
+        const events = [
+            event({ id: 'a-far', date: '2026-10-01', priority: 'A' }),
+            event({ id: 'b-near', date: '2026-08-15', priority: 'B' }),
+        ];
+        const result = evaluatePeriodizationPhase(events, '2026-08-08');
+        expect(result.focusEvent?.id).toBe('a-far');
+    });
+});
+
+describe('resolveMultiEventObjectives (Phase 5.6)', () => {
+    const cyclingDemand = { aerobicEndurance: 0.8, thresholdPower: 0.8, vo2MaxPower: 0.5, repeatedSurges: 0.7, sprintPower: 0.2, fatigueResistance: 0.8, neuromuscular: 0.3 };
+
+    it('a B-event 12 days out contributes race-specific exposure without capturing the macrocycle (the plan\'s own example)', () => {
+        // A-event 70 days out is the taper authority (Base/Build phase, not tapering).
+        // B-event 12 days out is a contributor -- outside its own 5-day B-taper window,
+        // so it contributes full-strength race-specific work, not a tapered version.
+        const aEvent = event({ id: 'a-event', date: '2026-10-17', priority: 'A', demandProfile: cyclingDemand }); // ~70 days out
+        const bEvent = event({ id: 'b-event', date: '2026-08-20', priority: 'B', demandProfile: cyclingDemand }); // 12 days out
+        const currentDate = '2026-08-08';
+
+        const authorityResult = evaluatePeriodizationPhase([aEvent, bEvent], currentDate);
+        expect(authorityResult.focusEvent?.id).toBe('a-event');
+        expect(authorityResult.phase.taperActive).toBe(false);
+
+        const resolution = resolveMultiEventObjectives([aEvent, bEvent], currentDate, authorityResult, []);
+        const raceSpecific = resolution.objectives.find(o => o.key === 'race_specific_endurance');
+        expect(raceSpecific).toBeDefined();
+        expect(raceSpecific?.title).toBe('Cycling Race-Specific Endurance'); // full-strength, not taper-calibrated
+        expect(resolution.droppedContributorObjectives).toEqual([]);
+    });
+
+    it('two contributors sharing an objective key resolve to max(requiredCredit), not sum', () => {
+        const aEvent = event({ id: 'a-event', date: '2026-10-17', priority: 'A', demandProfile: ZERO_DEMAND });
+        const bEvent1 = event({ id: 'b-1', date: '2026-08-20', priority: 'B', demandProfile: { ...cyclingDemand, aerobicEndurance: 0.9 } });
+        const bEvent2 = event({ id: 'b-2', date: '2026-08-25', priority: 'B', demandProfile: { ...cyclingDemand, aerobicEndurance: 0.5 } });
+        const currentDate = '2026-08-08';
+
+        const authorityResult = evaluatePeriodizationPhase([aEvent, bEvent1, bEvent2], currentDate);
+        const resolution = resolveMultiEventObjectives([aEvent, bEvent1, bEvent2], currentDate, authorityResult, []);
+
+        const zone2 = resolution.objectives.find(o => o.key === 'zone2_aerobic');
+        expect(zone2).toBeDefined();
+        // Both contributors' aerobicEndurance >= 0.4 -> targetExposures 2 (>=0.7) from
+        // b-1 and 1 from b-2; the merged result takes the max (2), never 2+1=3.
+        expect(zone2?.targetExposures).toBe(2);
+    });
+
+    it('a contributor threshold_quality objective inside the authority\'s taper window is dropped with its reason recorded', () => {
+        const aEvent = event({ id: 'a-event', date: '2026-08-15', priority: 'A', demandProfile: cyclingDemand }); // 7 days out -- tapering
+        const bEvent = event({ id: 'b-event', date: '2026-08-25', priority: 'B', demandProfile: { ...cyclingDemand, thresholdPower: 0.9, vo2MaxPower: 0, repeatedSurges: 0 } });
+        const currentDate = '2026-08-08';
+
+        const authorityResult = evaluatePeriodizationPhase([aEvent, bEvent], currentDate);
+        expect(authorityResult.focusEvent?.id).toBe('a-event');
+        expect(authorityResult.phase.taperActive).toBe(true);
+
+        const resolution = resolveMultiEventObjectives([aEvent, bEvent], currentDate, authorityResult, []);
+
+        expect(resolution.objectives.some(o => o.key === 'threshold_quality')).toBe(false);
+        const dropped = resolution.droppedContributorObjectives.find(d => d.objectiveKey === 'threshold_quality');
+        expect(dropped).toBeDefined();
+        expect(dropped?.eventId).toBe('b-event');
+        expect(dropped?.reason).toBe('inadmissible_during_taper');
+        expect(dropped?.message).toContain('taper window');
+    });
+
+    it('an authority objective of the same key outranks a contributor\'s on every field except the required amount', () => {
+        const aEvent = event({ id: 'a-event', date: '2026-10-17', priority: 'A', demandProfile: ZERO_DEMAND });
+        const bEvent = event({ id: 'b-event', date: '2026-08-20', priority: 'B', demandProfile: cyclingDemand });
+        const currentDate = '2026-08-08';
+        const authorityResult = evaluatePeriodizationPhase([aEvent, bEvent], currentDate);
+
+        const authorityObjectives = [{
+            id: 'obj_z2_authority', key: 'zone2_aerobic' as const, title: 'Authority Aerobic Base',
+            targetExposures: 1, completedExposures: 0, targetStimulus: { aerobicEndurance: 0.8 },
+        }];
+        const resolution = resolveMultiEventObjectives([aEvent, bEvent], currentDate, authorityResult, authorityObjectives);
+
+        const zone2 = resolution.objectives.find(o => o.key === 'zone2_aerobic');
+        expect(zone2?.id).toBe('obj_z2_authority'); // authority's identity wins
+        expect(zone2?.title).toBe('Authority Aerobic Base'); // authority's title wins
+        expect(zone2?.targetExposures).toBeGreaterThanOrEqual(1); // required amount may still grow
+    });
+
+    it('ignores a contributor outside its contribution window (too far out) and a non-scheduled event', () => {
+        const aEvent = event({ id: 'a-event', date: '2026-10-17', priority: 'A', demandProfile: ZERO_DEMAND });
+        const tooFar = event({ id: 'too-far', date: '2027-06-01', priority: 'B', demandProfile: cyclingDemand });
+        const cancelled = event({ id: 'cancelled', date: '2026-08-20', priority: 'B', lifecycle: 'cancelled', demandProfile: cyclingDemand });
+        const currentDate = '2026-08-08';
+        const authorityResult = evaluatePeriodizationPhase([aEvent, tooFar, cancelled], currentDate);
+
+        const resolution = resolveMultiEventObjectives([aEvent, tooFar, cancelled], currentDate, authorityResult, []);
+        expect(resolution.objectives.find(o => o.key === 'race_specific_endurance')).toBeUndefined();
+        expect(resolution.droppedContributorObjectives).toEqual([]);
+    });
+
+    it('is a no-op when there is no eligible authority event at all', () => {
+        const authorityResult = evaluatePeriodizationPhase([], '2026-08-08');
+        const resolution = resolveMultiEventObjectives([], '2026-08-08', authorityResult, []);
+        expect(resolution).toEqual({ objectives: [], droppedContributorObjectives: [] });
+    });
+});

--- a/app/src/engine/periodization.ts
+++ b/app/src/engine/periodization.ts
@@ -87,6 +87,13 @@ export const TAPER_SHARPENING_QUALIFICATION: NonNullable<WeeklyObjective['qualif
  *  than the same full-volume target every other phase uses. */
 export const TAPER_STRENGTH_TARGET_STIMULUS: WeeklyObjective['targetStimulus'] = { maxStrength: 0.3, hypertrophy: 0.2 };
 
+/** Exported alongside the taper target-stimulus constants above so `objectivesFromDemand`
+ *  below and microcycle.ts's plan-derived branch use exactly the same title text for the
+ *  same taper-phase objective, rather than two independently-typed string literals that
+ *  could silently drift apart. */
+export const TAPER_STRENGTH_PRIMER_TITLE = 'Race-Week Strength Primer';
+export const TAPER_SHARPENING_TITLE = 'Taper Sharpening (event-specific freshness)';
+
 /**
  * Translates one event's demand vector + category into the generic (non-plan-derived)
  * objective set a day governed by it would want. Pure function of the event's OWN
@@ -141,7 +148,7 @@ export function objectivesFromDemand(
 
     objectives.push({
         id: 'obj_strength', key: 'strength_maintenance',
-        title: taperActive ? 'Race-Week Strength Primer' : 'Strength & Neuromuscular Maintenance',
+        title: taperActive ? TAPER_STRENGTH_PRIMER_TITLE : 'Strength & Neuromuscular Maintenance',
         targetExposures: 1, completedExposures: 0,
         targetStimulus: taperActive ? TAPER_STRENGTH_TARGET_STIMULUS : { maxStrength: 0.7, hypertrophy: 0.5 },
     });
@@ -160,7 +167,7 @@ export function objectivesFromDemand(
             });
         } else if (taperActive) {
             objectives.push({
-                id: 'obj_taper_sharpening', key: 'race_specific_endurance', title: 'Taper Sharpening (event-specific freshness)',
+                id: 'obj_taper_sharpening', key: 'race_specific_endurance', title: TAPER_SHARPENING_TITLE,
                 targetExposures: 1, completedExposures: 0,
                 targetStimulus: TAPER_SHARPENING_TARGET_STIMULUS,
                 qualification: TAPER_SHARPENING_QUALIFICATION,

--- a/app/src/engine/periodization.ts
+++ b/app/src/engine/periodization.ts
@@ -1,7 +1,9 @@
 import type {
+    DroppedContributorObjective,
     EventDemandProfile,
     EventPriority,
     GoalCategory,
+    ObjectiveDropReason,
     ObjectiveKey,
     TemplatePhaseEligibility,
     SessionTemplate,
@@ -9,6 +11,10 @@ import type {
     UserGoal,
     WeeklyObjective,
 } from './models';
+// Re-exported for existing importers (e.g. planner.ts, trainingIntent.ts) -- the
+// canonical type definitions live in models.ts (see its own comment) so
+// decisionTrace/RecommendationAudit there can reference them without a circular import.
+export type { DroppedContributorObjective, ObjectiveDropReason };
 import { resolveDemandProfile } from './eventPresets';
 
 export interface PhaseWeights {
@@ -440,19 +446,6 @@ export function goalToUserEvent(goal: UserGoal & { id?: string }): UserEvent | n
  *  enough to shape training" boundary already used for a single governing event. */
 const CONTRIBUTION_WINDOW_DAYS = 35;
 
-export type ObjectiveDropReason = 'inadmissible_during_taper';
-
-export interface DroppedContributorObjective {
-    eventId: string;
-    eventTitle: string;
-    objectiveKey: ObjectiveKey;
-    reason: ObjectiveDropReason;
-    /** Athlete-facing explanation, not just a machine code -- see the plan's own framing:
-     *  "your B-event's threshold session was dropped because it fell in A-event race
-     *  week" is actionable; a quietly reweighted plan teaches the athlete nothing. */
-    message: string;
-}
-
 export interface MultiEventObjectiveResolution {
     objectives: WeeklyObjective[];
     droppedContributorObjectives: DroppedContributorObjective[];
@@ -492,6 +485,9 @@ export function resolveMultiEventObjectives(
 ): MultiEventObjectiveResolution {
     const merged: WeeklyObjective[] = authorityObjectives.map(objective => ({ ...objective }));
     const byKey = new Map<ObjectiveKey, WeeklyObjective>(merged.map(objective => [objective.key, objective]));
+    // Tracks which keys are the authority's own (always wins its fields outright) versus a
+    // previously-merged contributor's (eligible for the union merge below) -- see the loop.
+    const authorityKeys = new Set(authorityObjectives.map(objective => objective.key));
     const droppedContributorObjectives: DroppedContributorObjective[] = [];
 
     const authorityEventId = authorityResult.focusEvent?.id ?? null;
@@ -499,16 +495,31 @@ export function resolveMultiEventObjectives(
         return { objectives: merged, droppedContributorObjectives };
     }
 
-    for (const event of events) {
-        if (event.id === authorityEventId) continue;
-        // Contributors are forward-looking, active commitments only -- a stale/cancelled/
-        // DNS/completed event has nothing live to contribute.
-        if (event.lifecycle !== 'scheduled') continue;
+    // Deterministic contributor order -- mirrors evaluatePeriodizationPhase's own total
+    // order (priority, then proximity, then planning date, then id) so which contributor
+    // "wins" a same-key collision below never depends on the caller-supplied `events`
+    // array order. Without this, two contributors of different modalities producing the
+    // same objective key (e.g. a Running B-event and a Cycling B-event both needing
+    // threshold_quality) could see the winner -- and therefore the merged qualification's
+    // allowedModalities -- flip depending on array order alone.
+    const contributors = events
+        .filter(event => event.id !== authorityEventId && event.lifecycle === 'scheduled')
+        .map(event => {
+            const targetDate = event.timing?.planningDate ?? event.date;
+            return { event, targetDate, daysToEvent: getDaysBetween(currentDateStr, targetDate) };
+        })
+        .filter(({ daysToEvent }) => daysToEvent >= 0 && daysToEvent <= CONTRIBUTION_WINDOW_DAYS)
+        .sort((a, b) => {
+            const prioMap = { A: 1, B: 2, C: 3 };
+            if (prioMap[a.event.priority] !== prioMap[b.event.priority]) {
+                return prioMap[a.event.priority] - prioMap[b.event.priority];
+            }
+            if (a.daysToEvent !== b.daysToEvent) return a.daysToEvent - b.daysToEvent;
+            if (a.targetDate !== b.targetDate) return a.targetDate < b.targetDate ? -1 : 1;
+            return a.event.id < b.event.id ? -1 : a.event.id > b.event.id ? 1 : 0;
+        });
 
-        const targetDate = event.timing?.planningDate ?? event.date;
-        const daysToEvent = getDaysBetween(currentDateStr, targetDate);
-        if (daysToEvent < 0 || daysToEvent > CONTRIBUTION_WINDOW_DAYS) continue;
-
+    for (const { event, daysToEvent } of contributors) {
         const contributorTaperWindowDays = event.priority === 'A' ? 14 : (event.priority === 'B' ? 5 : 0);
         const contributorTaperActive = contributorTaperWindowDays > 0 && daysToEvent <= contributorTaperWindowDays;
         const allowedModalities = modalitiesForEventCategory(event.category);
@@ -547,6 +558,28 @@ export function resolveMultiEventObjectives(
                 // win -- only the required amount is allowed to grow, and only grow.
                 existing.requiredCredit = contributorRequired;
                 existing.targetExposures = Math.max(existing.targetExposures, objective.targetExposures);
+            }
+
+            // Contributor-vs-contributor collisions only (never the authority's own entry,
+            // which always wins its fields outright per the doc comment above): union
+            // compatible modality qualifiers rather than letting the first-processed
+            // contributor's allowedModalities silently exclude a later contributor's
+            // sessions from satisfying the same key. Undefined on either side means "any
+            // modality accepted" -- unioning "any" with anything is still "any", so the
+            // restriction is dropped rather than merged with the other list.
+            if (!authorityKeys.has(objective.key) && existing.qualification) {
+                const existingModalities = existing.qualification.allowedModalities;
+                const contributorModalities = objective.qualification?.allowedModalities;
+                if (existingModalities && contributorModalities) {
+                    existing.qualification = {
+                        ...existing.qualification,
+                        allowedModalities: Array.from(new Set([...existingModalities, ...contributorModalities])),
+                    };
+                } else if (existingModalities || contributorModalities) {
+                    const widened = { ...existing.qualification };
+                    delete widened.allowedModalities;
+                    existing.qualification = widened;
+                }
             }
         }
     }

--- a/app/src/engine/periodization.ts
+++ b/app/src/engine/periodization.ts
@@ -2,10 +2,12 @@ import type {
     EventDemandProfile,
     EventPriority,
     GoalCategory,
+    ObjectiveKey,
     TemplatePhaseEligibility,
     SessionTemplate,
     UserEvent,
     UserGoal,
+    WeeklyObjective,
 } from './models';
 import { resolveDemandProfile } from './eventPresets';
 
@@ -29,6 +31,11 @@ export interface PeriodizationResult {
     staleEvents: UserEvent[];
     /** A DNF focus event gets the normal recovery window, but its load is uncertain. */
     partialEffort: boolean;
+    /** Phase 5.6: two eligible events fully tied on priority, proximity, AND planning
+     *  date -- decidable only by the id-lexicographic determinism backstop. Two A-events
+     *  on the same day is a planning error, not something to blend; this surfaces it
+     *  instead of silently picking one. Empty unless a genuine tie occurred. */
+    governingEventTie: UserEvent[];
 }
 
 /** Modalities that constitute sport-specific exposure for a governing event. This is
@@ -52,6 +59,117 @@ export const DEFAULT_BASE_DEMAND: EventDemandProfile = {
     fatigueResistance: 0.5,
     neuromuscular: 0.4,
 };
+
+/**
+ * Phase 5.7: taper as an explicit contract, not an emergent side effect.
+ *
+ * Before this, a taper day either silently dropped the race_specific_endurance objective
+ * entirely, or -- if reached via the full-volume qualification below -- demanded a bar
+ * (`aerobicEndurance >= 0.6`) a genuine taper session structurally cannot clear. These two
+ * constants give "preserve useful intensity and event-specific freshness" a name and a
+ * real, reachable target -- calibrated against `end_taper_sharpen_01`'s own (deliberately
+ * lower) stimulus profile in templates.ts, matching event-plan.ts's `taper_sharpening`
+ * coverage role, rather than the peak-block `end_race_sim_01`/`end_event_specific_01` bar
+ * `race_specific_endurance` uses everywhere else. Exported so both
+ * `objectivesFromDemand` below and microcycle.ts's plan-derived branch share exactly one
+ * calibration.
+ */
+export const TAPER_SHARPENING_TARGET_STIMULUS: WeeklyObjective['targetStimulus'] = { thresholdPower: 0.5, repeatedSurges: 0.4 };
+export const TAPER_SHARPENING_QUALIFICATION: NonNullable<WeeklyObjective['qualification']> = {
+    minimumStimulus: { thresholdPower: 0.3 },
+    allowedModalities: ['Cycling'],
+    allowedCategories: ['Race-Specific Endurance'],
+};
+
+/** Same rationale as TAPER_SHARPENING_TARGET_STIMULUS above, for event-plan.ts's
+ *  `race_week_strength` role: a taper day's strength_maintenance objective should pull
+ *  toward a short, low-volume primer (strength_race_week_primer_01's own intent) rather
+ *  than the same full-volume target every other phase uses. */
+export const TAPER_STRENGTH_TARGET_STIMULUS: WeeklyObjective['targetStimulus'] = { maxStrength: 0.3, hypertrophy: 0.2 };
+
+/**
+ * Translates one event's demand vector + category into the generic (non-plan-derived)
+ * objective set a day governed by it would want. Pure function of the event's OWN
+ * profile -- never a blended vector -- so it can be reused for both:
+ *   - the taper authority's own objectives (generateWeeklyObjectives's generic branch,
+ *     unchanged behavior from before this function was extracted); and
+ *   - Phase 5.6's per-contributor objectives (resolveMultiEventObjectives below), each
+ *     derived from that contributor's own demand/category/taper state, never a blend
+ *     with the authority's.
+ */
+export function objectivesFromDemand(
+    demand: EventDemandProfile,
+    category: UserEvent['category'] | undefined,
+    taperActive: boolean,
+    isPostEventRecovery: boolean,
+    allowedModalities: SessionTemplate['modality'][]
+): WeeklyObjective[] {
+    const objectives: WeeklyObjective[] = [];
+
+    if (demand.aerobicEndurance >= 0.4) {
+        objectives.push({
+            id: 'obj_z2_aerobic', key: 'zone2_aerobic', title: 'Aerobic Base (Zone 2)',
+            targetExposures: demand.aerobicEndurance >= 0.7 ? 2 : 1,
+            completedExposures: 0,
+            targetStimulus: { aerobicEndurance: 0.8 },
+        });
+    }
+
+    if (demand.thresholdPower >= 0.5 && !taperActive) {
+        objectives.push({
+            id: 'obj_threshold', key: 'threshold_quality', title: 'Threshold Development',
+            targetExposures: 1, completedExposures: 0,
+            targetStimulus: { thresholdPower: 0.9 },
+            qualification: {
+                minimumStimulus: { thresholdPower: 0.6 },
+                ...(allowedModalities.length > 0 ? { allowedModalities } : {}),
+            },
+        });
+    }
+
+    if ((demand.vo2MaxPower >= 0.6 || demand.repeatedSurges >= 0.6) && !isPostEventRecovery) {
+        objectives.push({
+            id: 'obj_surges', key: 'surge_repeatability', title: 'Surge & High-Intensity Repeatability',
+            targetExposures: 1, completedExposures: 0,
+            targetStimulus: { repeatedSurges: 0.9, aerobicEndurance: 0.5 },
+            qualification: {
+                minimumStimulus: { repeatedSurges: 0.6 },
+                ...(allowedModalities.length > 0 ? { allowedModalities } : {}),
+            },
+        });
+    }
+
+    objectives.push({
+        id: 'obj_strength', key: 'strength_maintenance',
+        title: taperActive ? 'Race-Week Strength Primer' : 'Strength & Neuromuscular Maintenance',
+        targetExposures: 1, completedExposures: 0,
+        targetStimulus: taperActive ? TAPER_STRENGTH_TARGET_STIMULUS : { maxStrength: 0.7, hypertrophy: 0.5 },
+    });
+
+    if (category === 'cycling_event' && !isPostEventRecovery) {
+        if (!taperActive && (demand.fatigueResistance >= 0.7 || demand.repeatedSurges >= 0.6)) {
+            objectives.push({
+                id: 'obj_cycling_race_specific', key: 'race_specific_endurance', title: 'Cycling Race-Specific Endurance',
+                targetExposures: 1, completedExposures: 0,
+                targetStimulus: { aerobicEndurance: 0.6, repeatedSurges: 0.6 },
+                qualification: {
+                    minimumStimulus: { aerobicEndurance: 0.6 },
+                    allowedModalities: ['Cycling'],
+                    allowedCategories: ['Race-Specific Endurance'],
+                },
+            });
+        } else if (taperActive) {
+            objectives.push({
+                id: 'obj_taper_sharpening', key: 'race_specific_endurance', title: 'Taper Sharpening (event-specific freshness)',
+                targetExposures: 1, completedExposures: 0,
+                targetStimulus: TAPER_SHARPENING_TARGET_STIMULUS,
+                qualification: TAPER_SHARPENING_QUALIFICATION,
+            });
+        }
+    }
+
+    return objectives;
+}
 
 function getDaysBetween(date1Str: string, date2Str: string): number {
     // These are calendar dates, not instants. Local-midnight timestamps differ by 23
@@ -103,6 +221,7 @@ export function evaluatePeriodizationPhase(
         const targetDate = event.timing?.planningDate ?? event.date;
         return {
             event,
+            targetDate,
             daysToEvent: getDaysBetween(currentDateStr, targetDate),
         };
     });
@@ -128,17 +247,38 @@ export function evaluatePeriodizationPhase(
             daysToEvent: null,
             staleEvents,
             partialEffort: false,
+            governingEventTie: [],
         };
     }
 
-    // Resolve focus event by Priority (A > B > C) and then Proximity.
+    // Resolve the taper authority (Phase 5.6 terminology) by a full total order --
+    // otherwise this is less deterministic than the single-governing-event rule it
+    // replaces. In order: (1) priority A > B > C; (2) proximity, fewer days first;
+    // (3) planning date ascending; (4) event id, lexicographic. (4) is not a real
+    // criterion -- it is a determinism backstop for a genuine tie, commented as such
+    // rather than left to look like a meaningful ranking signal.
     const sortedEvents = [...eligibleEvents].sort((a, b) => {
         const prioMap = { A: 1, B: 2, C: 3 };
         if (prioMap[a.event.priority] !== prioMap[b.event.priority]) {
             return prioMap[a.event.priority] - prioMap[b.event.priority];
         }
-        return a.daysToEvent - b.daysToEvent;
+        if (a.daysToEvent !== b.daysToEvent) {
+            return a.daysToEvent - b.daysToEvent;
+        }
+        if (a.targetDate !== b.targetDate) {
+            return a.targetDate < b.targetDate ? -1 : 1;
+        }
+        return a.event.id < b.event.id ? -1 : a.event.id > b.event.id ? 1 : 0;
     });
+
+    // Two A-events on the same day is a planning error, not something to blend --
+    // surfaced here rather than silently resolved by the id backstop above. Empty
+    // unless 2+ events are genuinely tied through every real criterion.
+    const tiedWithTop = sortedEvents.filter(({ event, daysToEvent, targetDate }) => {
+        const top = sortedEvents[0];
+        return event.priority === top.event.priority && daysToEvent === top.daysToEvent && targetDate === top.targetDate;
+    });
+    const governingEventTie = tiedWithTop.length > 1 ? tiedWithTop.map(({ event }) => event) : [];
 
     const { event: focusEvent, daysToEvent } = sortedEvents[0];
     const partialEffort = focusEvent.lifecycle === 'DNF';
@@ -204,6 +344,7 @@ export function evaluatePeriodizationPhase(
         daysToEvent,
         staleEvents,
         partialEffort,
+        governingEventTie,
     };
 }
 
@@ -282,4 +423,126 @@ export function goalToUserEvent(goal: UserGoal & { id?: string }): UserEvent | n
         // other already-typed UserGoal field this function reads.
         ...(goal.timing ? { timing: goal.timing } : {}),
     };
+}
+
+// --- Phase 5.6: one taper authority, multiple demand contributors ---
+
+/** A contributor event within its own contribution window (see CONTRIBUTION_WINDOW_DAYS
+ *  below), close enough to matter but not the taper authority. Matches
+ *  evaluatePeriodizationPhase's own Specificity-phase threshold -- the same "close
+ *  enough to shape training" boundary already used for a single governing event. */
+const CONTRIBUTION_WINDOW_DAYS = 35;
+
+export type ObjectiveDropReason = 'inadmissible_during_taper';
+
+export interface DroppedContributorObjective {
+    eventId: string;
+    eventTitle: string;
+    objectiveKey: ObjectiveKey;
+    reason: ObjectiveDropReason;
+    /** Athlete-facing explanation, not just a machine code -- see the plan's own framing:
+     *  "your B-event's threshold session was dropped because it fell in A-event race
+     *  week" is actionable; a quietly reweighted plan teaches the athlete nothing. */
+    message: string;
+}
+
+export interface MultiEventObjectiveResolution {
+    objectives: WeeklyObjective[];
+    droppedContributorObjectives: DroppedContributorObjective[];
+}
+
+/** Objective keys a contributor may never inject while the taper authority is tapering --
+ *  a full-volume quality session landing inside the authority's race week is a safety/
+ *  freshness conflict, not a preference to weigh. Extensible: add a key here (with the
+ *  drop message updated below) if another key needs the same protection. */
+const INADMISSIBLE_DURING_AUTHORITY_TAPER: ReadonlySet<ObjectiveKey> = new Set(['threshold_quality']);
+
+/**
+ * Phase 5.6: one taper authority, multiple demand contributors.
+ *
+ * `authorityResult` must be the SAME `PeriodizationResult` used to produce
+ * `authorityObjectives` (e.g. via `generateWeeklyObjectives`) -- its `focusEvent`/`phase`
+ * are the taper authority, already resolved by `evaluatePeriodizationPhase`'s total order.
+ * Only the authority sets `volumeScale`/`intensityScale`; this function never touches
+ * `phase` at all, only the objective list.
+ *
+ * Every OTHER eligible, scheduled event within `CONTRIBUTION_WINDOW_DAYS` contributes
+ * objectives derived from its OWN demand vector, category and OWN taper state via
+ * `objectivesFromDemand` -- never a blended demand vector, which is the point of doing
+ * this after Phase 2's explicit objectives. Where a contributor's objective key collides
+ * with an existing one, the existing (authority-first, then earlier contributors) entry's
+ * fields win on everything except its required amount, which takes
+ * `max(existing, contributor)` -- never summed, or two similar B-events would demand
+ * double the work of one. A contributor objective inadmissible under the authority's
+ * current phase (today: any `threshold_quality` while the authority is tapering) is
+ * dropped with a recorded, athlete-facing reason rather than silently reweighted.
+ */
+export function resolveMultiEventObjectives(
+    events: UserEvent[],
+    currentDateStr: string,
+    authorityResult: PeriodizationResult,
+    authorityObjectives: WeeklyObjective[]
+): MultiEventObjectiveResolution {
+    const merged: WeeklyObjective[] = authorityObjectives.map(objective => ({ ...objective }));
+    const byKey = new Map<ObjectiveKey, WeeklyObjective>(merged.map(objective => [objective.key, objective]));
+    const droppedContributorObjectives: DroppedContributorObjective[] = [];
+
+    const authorityEventId = authorityResult.focusEvent?.id ?? null;
+    if (!authorityEventId) {
+        return { objectives: merged, droppedContributorObjectives };
+    }
+
+    for (const event of events) {
+        if (event.id === authorityEventId) continue;
+        // Contributors are forward-looking, active commitments only -- a stale/cancelled/
+        // DNS/completed event has nothing live to contribute.
+        if (event.lifecycle !== 'scheduled') continue;
+
+        const targetDate = event.timing?.planningDate ?? event.date;
+        const daysToEvent = getDaysBetween(currentDateStr, targetDate);
+        if (daysToEvent < 0 || daysToEvent > CONTRIBUTION_WINDOW_DAYS) continue;
+
+        const contributorTaperWindowDays = event.priority === 'A' ? 14 : (event.priority === 'B' ? 5 : 0);
+        const contributorTaperActive = contributorTaperWindowDays > 0 && daysToEvent <= contributorTaperWindowDays;
+        const allowedModalities = modalitiesForEventCategory(event.category);
+
+        const contributorObjectives = objectivesFromDemand(
+            event.demandProfile,
+            event.category,
+            contributorTaperActive,
+            false, // a forward-looking contributor (daysToEvent >= 0) is never Post-Event Recovery
+            allowedModalities
+        );
+
+        for (const objective of contributorObjectives) {
+            if (authorityResult.phase.taperActive && INADMISSIBLE_DURING_AUTHORITY_TAPER.has(objective.key)) {
+                droppedContributorObjectives.push({
+                    eventId: event.id,
+                    eventTitle: event.title,
+                    objectiveKey: objective.key,
+                    reason: 'inadmissible_during_taper',
+                    message: `${event.title}'s ${objective.title} session was dropped because it fell in ${authorityResult.focusEvent?.title ?? 'the governing event'}'s taper window.`,
+                });
+                continue;
+            }
+
+            const existing = byKey.get(objective.key);
+            if (!existing) {
+                const added = { ...objective };
+                merged.push(added);
+                byKey.set(objective.key, added);
+                continue;
+            }
+            const existingRequired = existing.requiredCredit ?? existing.targetExposures;
+            const contributorRequired = objective.requiredCredit ?? objective.targetExposures;
+            if (contributorRequired > existingRequired) {
+                // The existing entry's other fields (title/qualification/targetStimulus/id)
+                // win -- only the required amount is allowed to grow, and only grow.
+                existing.requiredCredit = contributorRequired;
+                existing.targetExposures = Math.max(existing.targetExposures, objective.targetExposures);
+            }
+        }
+    }
+
+    return { objectives: merged, droppedContributorObjectives };
 }

--- a/app/src/engine/planSchedule.ts
+++ b/app/src/engine/planSchedule.ts
@@ -26,6 +26,12 @@ export interface PlanObjectiveDefinition {
   requiredCredit: number;
   priority: ObjectivePriority; // declared in models.ts
   minGapHoursFrom?: ObjectiveKey[];
+  /** Phase 5.7: the session's role within its block, from the same named vocabulary
+   *  event-plan.ts's coverage keys and templates.ts's phaseEligibility already imply --
+   *  optional so existing plan authoring is unaffected, but generateWeeklyObjectives
+   *  (microcycle.ts) uses a block's `phase === 'taper'` (not this field) to decide
+   *  taper-appropriate calibration; `role` here is the legible label for *why*. */
+  role?: PlanSessionRole;
 }
 
 export interface SequencingRule {
@@ -135,16 +141,29 @@ export function buildSeptemberCyclingEventPlan(event: UserEvent): DataState<Plan
   ];
 
   const objectives: PlanObjectiveDefinition[] = [
-    { key: 'zone2_aerobic', coverageKey: 'easy_aerobic', blockId: 'block_build', requiredCredit: 2, priority: 'must_have' },
-    { key: 'threshold_quality', coverageKey: 'sustained_quality', blockId: 'block_build', requiredCredit: 1, priority: 'must_have' },
-    { key: 'surge_repeatability', coverageKey: 'short_surges', blockId: 'block_build', requiredCredit: 1, priority: 'should_have' },
-    { key: 'strength_maintenance', coverageKey: 'primary_strength', blockId: 'block_build', requiredCredit: 1, priority: 'should_have' },
+    { key: 'zone2_aerobic', coverageKey: 'easy_aerobic', blockId: 'block_build', requiredCredit: 2, priority: 'must_have', role: 'primary_developmental' },
+    { key: 'threshold_quality', coverageKey: 'sustained_quality', blockId: 'block_build', requiredCredit: 1, priority: 'must_have', role: 'primary_developmental' },
+    { key: 'surge_repeatability', coverageKey: 'short_surges', blockId: 'block_build', requiredCredit: 1, priority: 'should_have', role: 'secondary_support' },
+    { key: 'strength_maintenance', coverageKey: 'primary_strength', blockId: 'block_build', requiredCredit: 1, priority: 'should_have', role: 'secondary_support' },
 
-    { key: 'zone2_aerobic', coverageKey: 'easy_aerobic', blockId: 'block_peak', requiredCredit: 1, priority: 'must_have' },
-    { key: 'threshold_quality', coverageKey: 'sustained_quality', blockId: 'block_peak', requiredCredit: 1, priority: 'must_have' },
-    { key: 'race_specific_endurance', coverageKey: 'outdoor_event_specific', blockId: 'block_peak', requiredCredit: 1, priority: 'must_have' },
+    { key: 'zone2_aerobic', coverageKey: 'easy_aerobic', blockId: 'block_peak', requiredCredit: 1, priority: 'must_have', role: 'primary_developmental' },
+    { key: 'threshold_quality', coverageKey: 'sustained_quality', blockId: 'block_peak', requiredCredit: 1, priority: 'must_have', role: 'primary_developmental' },
+    { key: 'race_specific_endurance', coverageKey: 'outdoor_event_specific', blockId: 'block_peak', requiredCredit: 1, priority: 'must_have', role: 'primary_developmental' },
 
-    { key: 'zone2_aerobic', coverageKey: 'easy_aerobic', blockId: 'block_taper', requiredCredit: 1, priority: 'must_have' },
+    // Phase 5.7: the taper block previously only ever authored the generic easy_aerobic
+    // objective, leaving its own declared taper_sharpening/race_week_strength coverage
+    // keys (SEPTEMBER_CYCLING_EVENT_SESSION_COVERAGE above) with no objective demanding
+    // them at all -- exactly the "emergent side effect" the plan describes. These two
+    // additions close that: generateWeeklyObjectives detects blockId -> phase 'taper' and
+    // calibrates both to TAPER_SHARPENING_TARGET_STIMULUS / TAPER_STRENGTH_TARGET_STIMULUS
+    // rather than the peak-block full-volume targets.
+    { key: 'zone2_aerobic', coverageKey: 'easy_aerobic', blockId: 'block_taper', requiredCredit: 1, priority: 'must_have', role: 'primary_developmental' },
+    { key: 'race_specific_endurance', coverageKey: 'taper_sharpening', blockId: 'block_taper', requiredCredit: 1, priority: 'should_have', role: 'taper_sharpening' },
+    // 'secondary_support', not 'taper_sharpening' -- PlanSessionRole's four values are a
+    // generic block-role axis, not a 1:1 restatement of event-plan.ts's four taper
+    // coverage keys; the race-week strength primer is support work that happens to fall
+    // in the taper block, distinct from the endurance-specific sharpening role above.
+    { key: 'strength_maintenance', coverageKey: 'race_week_strength', blockId: 'block_taper', requiredCredit: 1, priority: 'should_have', role: 'secondary_support' },
   ];
 
   return buildPlanDefinition(SEPTEMBER_CYCLING_EVENT_SESSION_COVERAGE, blocks, event, objectives);

--- a/app/src/engine/planner.test.ts
+++ b/app/src/engine/planner.test.ts
@@ -469,7 +469,9 @@ describe('resolveWeeklyAnchors', () => {
         context.trainingSettings = weeklyTrainingSettings({ weekdayMaxMinutes: 60 });
         const event = cyclingEvent('2026-08-27');
         const reservedSunday: FixedActivity = {
-            id: 'family-event', title: 'Fixed commitment', date: '2026-08-09', durationMin: 150, isCompleted: false,
+            id: 'family-event', userId: 'athlete-1', title: 'Fixed commitment', date: '2026-08-09', durationMin: 150,
+            isCompleted: false, fixed: true, environment: 'either', equipment: [],
+            createdAt: '2026-08-01T00:00:00Z', updatedAt: '2026-08-01T00:00:00Z',
         };
 
         const anchors = resolveWeeklyAnchors('2026-08-07', 7, [event], [reservedSunday], context);

--- a/app/src/engine/planner.test.ts
+++ b/app/src/engine/planner.test.ts
@@ -529,3 +529,38 @@ describe('generateWeekAheadPlan weekly-architecture anchoring', () => {
         expect(plan.days).toHaveLength(7);
     });
 });
+
+describe('prepareWeekAheadPlanSeed: multi-event contributor wiring (Phase 5.6)', () => {
+    it('a single-event (or no-event) seed is unaffected by resolveMultiEventObjectives being wired in', () => {
+        const readiness: DailyReadiness = { subjective: neutralSubjective(), objective: quietObjective() };
+        const noEventSeed = prepareWeekAheadPlanSeed(readiness, [], '2026-08-07', []);
+        const singleEventSeed = prepareWeekAheadPlanSeed(readiness, [cyclingEvent('2026-08-27')], '2026-08-07', []);
+
+        // Base-phase objectives (zone2_aerobic/threshold_quality/strength_maintenance)
+        // still generate with no event at all -- unaffected by resolveMultiEventObjectives
+        // being wired in, since there's no eligible authority to run it against.
+        expect(noEventSeed.microcycle.objectives.map(o => o.key).sort()).toEqual(['strength_maintenance', 'threshold_quality', 'zone2_aerobic']);
+        // Same objective set generateWeeklyObjectives alone would produce -- the
+        // multi-event merge is a no-op with only one eligible event.
+        expect(singleEventSeed.microcycle.objectives.length).toBeGreaterThan(0);
+        expect(singleEventSeed.microcycle.objectives.find(o => o.key === 'race_specific_endurance')).toBeDefined();
+    });
+
+    it('a B-event contributor adds its own race-specific objective to the seed built for an A-event authority', () => {
+        const readiness: DailyReadiness = { subjective: neutralSubjective(), objective: quietObjective() };
+        const aEvent = cyclingEvent('2026-10-17'); // ~70 days out from 2026-08-07 -- Build phase, not tapering
+        const bEvent: UserEvent = {
+            id: 'b1', title: 'Local Crit', date: '2026-08-19', priority: 'B', lifecycle: 'scheduled', category: 'cycling_event',
+            demandProfile: { aerobicEndurance: 0.7, thresholdPower: 0.6, vo2MaxPower: 0.5, repeatedSurges: 0.8, sprintPower: 0.4, fatigueResistance: 0.75, neuromuscular: 0.4 },
+        };
+
+        const authorityOnlySeed = prepareWeekAheadPlanSeed(readiness, [aEvent], '2026-08-07', []);
+        const withContributorSeed = prepareWeekAheadPlanSeed(readiness, [aEvent, bEvent], '2026-08-07', []);
+
+        // The A-event authority alone (Build phase, demand thresholds not met for
+        // race_specific_endurance) generates no race-specific objective on its own.
+        expect(authorityOnlySeed.microcycle.objectives.find(o => o.key === 'race_specific_endurance')).toBeUndefined();
+        // The B-event contributor (12 days out, high repeatedSurges) adds one.
+        expect(withContributorSeed.microcycle.objectives.find(o => o.key === 'race_specific_endurance')).toBeDefined();
+    });
+});

--- a/app/src/engine/planner.test.ts
+++ b/app/src/engine/planner.test.ts
@@ -572,4 +572,34 @@ describe('prepareWeekAheadPlanSeed: multi-event contributor wiring (Phase 5.6)',
         // The B-event contributor (12 days out, high repeatedSurges) adds one.
         expect(withContributorSeed.microcycle.objectives.find(o => o.key === 'race_specific_endurance')).toBeDefined();
     });
+
+    it("a dropped contributor objective's reason survives from the resolver through the seed into the final WeekAheadPlan", () => {
+        const context = baseContext();
+        const { readiness, todayRec, tomorrowRec } = buildTodayAndTomorrow(context);
+        const aEvent = cyclingEvent('2026-08-14'); // 7 days out from 2026-08-07 -- inside the 14-day A-taper window
+        const bEvent: UserEvent = {
+            id: 'b-event', title: 'Local Crit', date: '2026-08-25', priority: 'B', lifecycle: 'scheduled', category: 'cycling_event',
+            // thresholdPower >= 0.5 and outside its own 5-day B-taper window (18 days out)
+            // -- objectivesFromDemand would generate threshold_quality on its own, so the
+            // only reason it's absent from the merged seed is the authority-taper drop.
+            demandProfile: { aerobicEndurance: 0.7, thresholdPower: 0.9, vo2MaxPower: 0, repeatedSurges: 0, sprintPower: 0.2, fatigueResistance: 0.6, neuromuscular: 0.3 },
+        };
+        const events = [aEvent, bEvent];
+
+        const seed = prepareWeekAheadPlanSeed(readiness, events, '2026-08-07', []);
+        expect(seed.microcycle.objectives.some(o => o.key === 'threshold_quality')).toBe(false);
+        const seedDropped = seed.droppedContributorObjectives?.find(d => d.objectiveKey === 'threshold_quality');
+        expect(seedDropped).toBeDefined();
+        expect(seedDropped?.eventId).toBe('b-event');
+        expect(seedDropped?.reason).toBe('inadmissible_during_taper');
+        expect(seedDropped?.message).toContain('taper window');
+
+        // The unit-level resolver's result is not enough on its own -- the same drop must
+        // reach the actual WeekAheadPlan the live app renders and persists, not just the
+        // intermediate seed.
+        const plan = generateWeekAheadPlan(readiness, context, null, '2026-08-07', todayRec, tomorrowRec, seed, { days: 7, events });
+        expect(plan.droppedContributorObjectives).toEqual(seed.droppedContributorObjectives);
+        const planDropped = plan.droppedContributorObjectives.find(d => d.objectiveKey === 'threshold_quality');
+        expect(planDropped?.eventId).toBe('b-event');
+    });
 });

--- a/app/src/engine/planner.test.ts
+++ b/app/src/engine/planner.test.ts
@@ -7,6 +7,8 @@ import type { CompletedExposure, TrainingHistoryProvider } from './trainingHisto
 import { rankCandidatesByUtility } from './optimizer';
 import { resolveAvailability } from './schedule';
 import { ENRICHED_TEMPLATES } from './templates';
+import { generateWeeklyObjectives } from './microcycle';
+import { evaluatePeriodizationPhase } from './periodization';
 
 // --- Fixtures (mirrors rules.test.ts's pattern) -----------------------------
 
@@ -534,15 +536,22 @@ describe('prepareWeekAheadPlanSeed: multi-event contributor wiring (Phase 5.6)',
     it('a single-event (or no-event) seed is unaffected by resolveMultiEventObjectives being wired in', () => {
         const readiness: DailyReadiness = { subjective: neutralSubjective(), objective: quietObjective() };
         const noEventSeed = prepareWeekAheadPlanSeed(readiness, [], '2026-08-07', []);
-        const singleEventSeed = prepareWeekAheadPlanSeed(readiness, [cyclingEvent('2026-08-27')], '2026-08-07', []);
+        const event = cyclingEvent('2026-08-27');
+        const singleEventSeed = prepareWeekAheadPlanSeed(readiness, [event], '2026-08-07', []);
 
         // Base-phase objectives (zone2_aerobic/threshold_quality/strength_maintenance)
         // still generate with no event at all -- unaffected by resolveMultiEventObjectives
         // being wired in, since there's no eligible authority to run it against.
         expect(noEventSeed.microcycle.objectives.map(o => o.key).sort()).toEqual(['strength_maintenance', 'threshold_quality', 'zone2_aerobic']);
-        // Same objective set generateWeeklyObjectives alone would produce -- the
-        // multi-event merge is a no-op with only one eligible event.
-        expect(singleEventSeed.microcycle.objectives.length).toBeGreaterThan(0);
+
+        // The single event is its own taper authority with no other contributor in scope,
+        // so resolveMultiEventObjectives (wired into prepareWeekAheadPlanSeed) must be a
+        // true no-op: the exact same key set generateWeeklyObjectives alone would produce
+        // for this event/phase, not merely "non-empty and contains one expected key" (which
+        // wouldn't catch the merge silently adding or mutating objectives).
+        const periodization = evaluatePeriodizationPhase([event], '2026-08-07');
+        const baselineWithoutMerge = generateWeeklyObjectives(periodization.phase, '2026-08-07', periodization.focusEvent);
+        expect(singleEventSeed.microcycle.objectives.map(o => o.key).sort()).toEqual(baselineWithoutMerge.objectives.map(o => o.key).sort());
         expect(singleEventSeed.microcycle.objectives.find(o => o.key === 'race_specific_endurance')).toBeDefined();
     });
 

--- a/app/src/engine/planner.ts
+++ b/app/src/engine/planner.ts
@@ -179,22 +179,25 @@ export function projectFatigueForRankingDate(
  * rest/recovery day. 0.6 remains the modify boundary. */
 export const PROJECTED_FATIGUE_RECOVER_THRESHOLD = 0.65;
 export const PROJECTED_FATIGUE_MODIFY_THRESHOLD = 0.6;
-const PROJECTED_MODIFY_MAX_SYSTEMIC_COST = 0.5;
+// Exported for reuse by sequenceSearch.ts's beam-search prototype (Phase 5.1) -- these
+// three are pure, stable helpers with no state of their own; exporting them keeps one
+// source of truth instead of a second copy of the fatigue-tier gating logic.
+export const PROJECTED_MODIFY_MAX_SYSTEMIC_COST = 0.5;
 
-function maxFatigueDimension(fatigue: DimensionalFatigue): number {
+export function maxFatigueDimension(fatigue: DimensionalFatigue): number {
     return Math.max(
         fatigue.systemic, fatigue.cardiovascular, fatigue.lowerBody,
         fatigue.upperBody, fatigue.impactTissue, fatigue.neuromuscular
     );
 }
 
-function fatigueTierFor(peakFatigue: number): 'train' | 'modify' | 'recover' {
+export function fatigueTierFor(peakFatigue: number): 'train' | 'modify' | 'recover' {
     if (peakFatigue >= PROJECTED_FATIGUE_RECOVER_THRESHOLD) return 'recover';
     if (peakFatigue >= PROJECTED_FATIGUE_MODIFY_THRESHOLD) return 'modify';
     return 'train';
 }
 
-const NEUTRAL_PREFERENCES: UserPreferences = {
+export const NEUTRAL_PREFERENCES: UserPreferences = {
     userId: '',
     preferredRecoveryStyle: 'mixed',
     defaultWeekdayTimeMin: 45,
@@ -211,15 +214,15 @@ const NEUTRAL_PREFERENCES: UserPreferences = {
     updatedAt: '',
 };
 
-function displayModeFromCategory(category: SessionTemplate['category']): 'train' | 'recover' {
+export function displayModeFromCategory(category: SessionTemplate['category']): 'train' | 'recover' {
     return category === 'Rest' || category === 'Mobility/Recovery' ? 'recover' : 'train';
 }
 
-function enrichedCostProfile(templateId: string): WorkoutCostProfile {
+export function enrichedCostProfile(templateId: string): WorkoutCostProfile {
     return ENRICHED_TEMPLATES.find(t => t.id === templateId)?.costProfile ?? ZERO_COST;
 }
 
-function enrichedStimulusProfile(template: SessionTemplate): WorkoutStimulusProfile {
+export function enrichedStimulusProfile(template: SessionTemplate): WorkoutStimulusProfile {
     return template.stimulusProfile ?? ENRICHED_TEMPLATES.find(t => t.id === template.id)?.stimulusProfile ?? ZERO_STIMULUS;
 }
 
@@ -281,7 +284,7 @@ export function applyProjectedObjectiveCredits(
     };
 }
 
-function isAdjacentDate(date: string, anchorDate: string | null): boolean {
+export function isAdjacentDate(date: string, anchorDate: string | null): boolean {
     if (!anchorDate) return false;
     return addDaysToLocalDateString(date, 1) === anchorDate || addDaysToLocalDateString(date, -1) === anchorDate;
 }

--- a/app/src/engine/planner.ts
+++ b/app/src/engine/planner.ts
@@ -26,7 +26,7 @@ export interface PlannedObjectiveCredit {
     earnedCredit: number;
 }
 import { resolveAvailability } from './schedule';
-import { isTemplatePhaseEligible, evaluatePeriodizationPhase, resolveMultiEventObjectives } from './periodization';
+import { isTemplatePhaseEligible, evaluatePeriodizationPhase, resolveMultiEventObjectives, type DroppedContributorObjective } from './periodization';
 import { eligibleTemplates } from './eligibility';
 import { addDaysToLocalDateString, getDayDiff } from '../utils/localDate';
 import {
@@ -84,12 +84,18 @@ export interface WeekAheadPlan {
     days: WeekAheadDay[];
     objectiveCredits: PlannedObjectiveCredit[];
     microcycleObjectives: WeeklyObjective[];
+    /** Phase 5.6 contributor objectives dropped because they fell inadmissible during the
+     *  taper authority's taper window -- see periodization.ts resolveMultiEventObjectives
+     *  and each entry's own athlete-facing `message`. Empty in the overwhelmingly common
+     *  single-or-no-event case. */
+    droppedContributorObjectives: DroppedContributorObjective[];
 }
 
 export interface WeekAheadPlanSeed {
     microcycle: MicrocycleState;
     fatigue: FatigueState;
     trailingHistory?: (RecentHistoryEntry | SessionHistoryEntry)[];
+    droppedContributorObjectives?: DroppedContributorObjective[];
 }
 
 export interface WeekAheadOptions {
@@ -481,10 +487,8 @@ export function prepareWeekAheadPlanSeed(
         // evaluatePeriodizationPhase's total order above), multiple demand contributors.
         // A no-op for the common single-or-no-event case (nothing else in `events` falls
         // in another event's contribution window).
-        microcycle = {
-            ...microcycle,
-            objectives: resolveMultiEventObjectives(events, todayDate, periodization, microcycle.objectives).objectives,
-        };
+        const multiEventResolution = resolveMultiEventObjectives(events, todayDate, periodization, microcycle.objectives);
+        microcycle = { ...microcycle, objectives: multiEventResolution.objectives };
         lightweightHistory.forEach(h => {
             const typeStr = 'type' in h && typeof h.type === 'string' ? h.type : undefined;
             const modality = (h.modality ?? typeStr ?? 'None') as SessionTemplate['modality'];
@@ -503,15 +507,14 @@ export function prepareWeekAheadPlanSeed(
                 todayDate,
             ),
             trailingHistory: projectTrailingHistory(history),
+            droppedContributorObjectives: multiEventResolution.droppedContributorObjectives,
         };
     }
 
     let microcycle = generateWeeklyObjectives(periodization.phase, todayDate, periodization.focusEvent);
     // Phase 5.6: see the completed-history branch above for the same wiring.
-    microcycle = {
-        ...microcycle,
-        objectives: resolveMultiEventObjectives(events, todayDate, periodization, microcycle.objectives).objectives,
-    };
+    const multiEventResolution = resolveMultiEventObjectives(events, todayDate, periodization, microcycle.objectives);
+    microcycle = { ...microcycle, objectives: multiEventResolution.objectives };
     lightweightHistory.forEach(h => {
         const typeStr = 'type' in h && typeof h.type === 'string' ? h.type : undefined;
         const modality = (h.modality ?? typeStr ?? 'None') as SessionTemplate['modality'];
@@ -523,6 +526,7 @@ export function prepareWeekAheadPlanSeed(
         microcycle,
         fatigue,
         trailingHistory: projectTrailingHistory(history),
+        droppedContributorObjectives: multiEventResolution.droppedContributorObjectives,
     };
 }
 
@@ -622,6 +626,19 @@ export function generateWeekAheadPlan(
 
     for (let offset = resultDays.length + 1; offset <= totalDays; offset++) {
         const date = addDaysToLocalDateString(todayDate, offset);
+        // Recomputed per day for template eligibility (isTemplatePhaseEligible below) and
+        // fatigue/anchor logic, but NOT for the objective SET itself: `microcycle.objectives`
+        // (including which Phase 5.6 contributor objectives survived resolveMultiEventObjectives)
+        // was seeded once at todayDate by resolveTrainingIntent/prepareWeekAheadPlanSeed and
+        // is carried unchanged through every day of this loop. A contributor/authority
+        // taper-window transition that falls strictly inside the horizon (e.g. the
+        // authority enters its 14-day taper on day 2 of a 7-day plan, or a contributor
+        // enters its own 35-day contribution window mid-horizon) is therefore not reflected
+        // in which objectives are admissible on days after the transition -- a known,
+        // recorded gap (not silently unnoticed), deliberately not addressed in the same
+        // change that first wired Phase 5.6 into the live path: fixing it requires deciding
+        // how to handle an objective's already-accrued mid-week credit when its
+        // admissibility changes, which is a product question, not just an engineering one.
         const periodization = evaluatePeriodizationPhase(events, date);
         const availability = resolveAvailability(date, null, fixedActivities, context);
 
@@ -764,6 +781,7 @@ export function generateWeekAheadPlan(
         days: resultDays,
         objectiveCredits,
         microcycleObjectives: microcycle.objectives ?? [],
+        droppedContributorObjectives: seed.droppedContributorObjectives ?? [],
     };
 }
 
@@ -792,6 +810,7 @@ export async function generateWeekAheadPlanWithIntent(
             microcycle: intent.microcycle,
             fatigue: intent.fatigue,
             trailingHistory: trailingHistoryFromCompletedExposures(intent.history, todayDate),
+            droppedContributorObjectives: intent.droppedContributorObjectives,
         },
         { ...options, events },
     );

--- a/app/src/engine/planner.ts
+++ b/app/src/engine/planner.ts
@@ -413,6 +413,25 @@ export function projectTrailingHistory(
     });
 }
 
+/** Shared `CompletedExposure[]` -> trailing-history projection for `resolveTrainingIntent`
+ *  callers. Used by both the live greedy entry point (`generateWeekAheadPlanWithIntent`
+ *  below) and the beam-search comparison entry point
+ *  (`sequenceSearch.ts`'s `generateWeekAheadPlanWithIntentBeamSearch`) so ADR-0015's
+ *  comparison stays apples-to-apples -- if this mapping ever drifted between the two call
+ *  sites, the comparison would silently stop being fair. */
+export function trailingHistoryFromCompletedExposures(
+    history: CompletedExposure[],
+    todayDate: string
+): RecentHistoryEntry[] {
+    return history.map(e => ({
+        date: ('completedDate' in e && typeof e.completedDate === 'string' ? e.completedDate : 'date' in e && typeof e.date === 'string' ? e.date : todayDate),
+        modality: e.modality,
+        category: e.category,
+        systemicCost: e.costProfile?.systemic ?? 0,
+        lowerBodyCost: e.costProfile?.lowerBody ?? 0,
+    }));
+}
+
 function isCompletedExposure(entry: RecentHistoryEntry | SessionHistoryEntry): entry is CompletedExposure & (RecentHistoryEntry | SessionHistoryEntry) {
     const record = entry as unknown as Record<string, unknown>;
     return typeof record.date === 'string'
@@ -772,13 +791,7 @@ export async function generateWeekAheadPlanWithIntent(
         {
             microcycle: intent.microcycle,
             fatigue: intent.fatigue,
-            trailingHistory: intent.history.map(e => ({
-                date: ('completedDate' in e && typeof e.completedDate === 'string' ? e.completedDate : 'date' in e && typeof e.date === 'string' ? e.date : todayDate),
-                modality: e.modality,
-                category: e.category,
-                systemicCost: e.costProfile?.systemic ?? 0,
-                lowerBodyCost: e.costProfile?.lowerBody ?? 0,
-            })),
+            trailingHistory: trailingHistoryFromCompletedExposures(intent.history, todayDate),
         },
         { ...options, events },
     );

--- a/app/src/engine/planner.ts
+++ b/app/src/engine/planner.ts
@@ -26,7 +26,7 @@ export interface PlannedObjectiveCredit {
     earnedCredit: number;
 }
 import { resolveAvailability } from './schedule';
-import { isTemplatePhaseEligible, evaluatePeriodizationPhase } from './periodization';
+import { isTemplatePhaseEligible, evaluatePeriodizationPhase, resolveMultiEventObjectives } from './periodization';
 import { eligibleTemplates } from './eligibility';
 import { addDaysToLocalDateString, getDayDiff } from '../utils/localDate';
 import {
@@ -454,6 +454,14 @@ export function prepareWeekAheadPlanSeed(
             completedHistory,
             periodization.focusEvent,
         );
+        // Phase 5.6: one taper authority (periodization.focusEvent, already resolved by
+        // evaluatePeriodizationPhase's total order above), multiple demand contributors.
+        // A no-op for the common single-or-no-event case (nothing else in `events` falls
+        // in another event's contribution window).
+        microcycle = {
+            ...microcycle,
+            objectives: resolveMultiEventObjectives(events, todayDate, periodization, microcycle.objectives).objectives,
+        };
         lightweightHistory.forEach(h => {
             const typeStr = 'type' in h && typeof h.type === 'string' ? h.type : undefined;
             const modality = (h.modality ?? typeStr ?? 'None') as SessionTemplate['modality'];
@@ -476,6 +484,11 @@ export function prepareWeekAheadPlanSeed(
     }
 
     let microcycle = generateWeeklyObjectives(periodization.phase, todayDate, periodization.focusEvent);
+    // Phase 5.6: see the completed-history branch above for the same wiring.
+    microcycle = {
+        ...microcycle,
+        objectives: resolveMultiEventObjectives(events, todayDate, periodization, microcycle.objectives).objectives,
+    };
     lightweightHistory.forEach(h => {
         const typeStr = 'type' in h && typeof h.type === 'string' ? h.type : undefined;
         const modality = (h.modality ?? typeStr ?? 'None') as SessionTemplate['modality'];

--- a/app/src/engine/planner.ts
+++ b/app/src/engine/planner.ts
@@ -51,6 +51,7 @@ import {
     rankCandidates,
 } from './optimizer';
 import { ENRICHED_TEMPLATES } from './templates';
+import { resolveMinimumDaysAfterHardLowerBody } from './planningCandidate';
 import { resolvePlannedDoseForDate, resolveTrainingIntent } from './trainingIntent';
 import { resolvePlanDefinitionForEvent } from './planSchedule';
 import { deriveObjectiveCreditFromProfile } from './stimulus';
@@ -672,7 +673,7 @@ export function generateWeekAheadPlan(
             context,
             effectivePreferences,
             date,
-            { anchorRole, adjacentToAnchor }
+            { anchorRole, adjacentToAnchor, resolveMinimumDaysAfterHardLowerBody }
         );
 
         const rankingResult = rankCandidates(

--- a/app/src/engine/planningCandidate.test.ts
+++ b/app/src/engine/planningCandidate.test.ts
@@ -124,9 +124,13 @@ describe('buildPlanningCandidateIndex (Phase 5.2)', () => {
     it('the real, module-level PLANNING_CANDIDATE_INDEX is built from the actual catalog and template roster', () => {
         expect(PLANNING_CANDIDATE_INDEX.size).toBeGreaterThan(0);
         // Cross-check against a fresh build from the same live data -- guards against the
-        // module-level singleton silently drifting from WORKOUTS/ENRICHED_TEMPLATES.
+        // module-level singleton silently drifting from WORKOUTS/ENRICHED_TEMPLATES. Compare
+        // resolved workout ids per template, not just index size -- two equal-size indexes
+        // could still map the same template id to different workout ids.
         const rebuilt = buildPlanningCandidateIndex(WORKOUTS, ENRICHED_TEMPLATES);
-        expect(PLANNING_CANDIDATE_INDEX.size).toBe(rebuilt.size);
+        const asPairs = (index: typeof rebuilt) =>
+            [...index.entries()].map(([templateId, candidate]) => [templateId, candidate.workoutId]).sort();
+        expect(asPairs(PLANNING_CANDIDATE_INDEX)).toEqual(asPairs(rebuilt));
     });
 
     it('every real active workout with a resolvable engineTemplateIds entry produces a non-null candidate', () => {

--- a/app/src/engine/planningCandidate.test.ts
+++ b/app/src/engine/planningCandidate.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import { buildPlanningCandidateIndex, derivePlanningCandidate, PLANNING_CANDIDATE_INDEX } from './planningCandidate';
+import type { WorkoutDefinition } from '../workouts/models';
+import type { SessionTemplate, WorkoutCostProfile, WorkoutStimulusProfile } from './models';
+import { WORKOUTS } from '../workouts/catalog';
+import { ENRICHED_TEMPLATES } from './templates';
+
+const ZERO_STIMULUS: WorkoutStimulusProfile = {
+    aerobicEndurance: 0, thresholdPower: 0, vo2MaxPower: 0, repeatedSurges: 0,
+    sprintPower: 0, fatigueResistance: 0, maxStrength: 0, hypertrophy: 0,
+};
+const ZERO_COST: WorkoutCostProfile = { systemic: 0, cardiovascular: 0, lowerBody: 0, upperBody: 0, impactTissue: 0, neuromuscular: 0 };
+
+function testTemplate(overrides: Partial<SessionTemplate> = {}): SessionTemplate {
+    return {
+        id: 'tmpl_1', category: 'Hard Endurance', modality: 'Cycling', durationMin: 30, durationMax: 60,
+        title: 'Test Template', description: '', requiredEquipment: [], environment: 'outdoor', safetyTags: [],
+        systemicCost: 0.6, stimulusProfile: { ...ZERO_STIMULUS, thresholdPower: 0.7 }, costProfile: { ...ZERO_COST, lowerBody: 0.7 },
+        ...overrides,
+    };
+}
+
+function testWorkout(overrides: Partial<WorkoutDefinition> = {}): WorkoutDefinition {
+    return {
+        id: 'workout_1', version: 1, status: 'active', name: 'Test Workout', description: '',
+        modality: 'cycling', category: 'threshold', objectives: ['lactate_threshold'],
+        duration: { minimumMin: 20, defaultMin: 40, maximumMin: 60 },
+        loadProfile: { cardiovascular: 4, muscular: 2, mechanical: 2, eccentric: 1, coordination: 2, recoveryHours: 24 },
+        eligibility: {},
+        equipment: ['bike'],
+        contraindicationTags: ['acute_knee_pain'],
+        engineTemplateIds: ['tmpl_1'],
+        blocks: [], variants: [], regressions: [], progressions: [], substitutions: [],
+        garmin: { exportable: true }, tags: [], sourceNotes: [],
+        ...overrides,
+    };
+}
+
+describe('derivePlanningCandidate (Phase 5.2)', () => {
+    it('derives a candidate from a workout linked to a real engine template', () => {
+        const workout = testWorkout();
+        const template = testTemplate();
+        const candidate = derivePlanningCandidate(workout, [template]);
+
+        expect(candidate).not.toBeNull();
+        expect(candidate?.workoutId).toBe('workout_1');
+        expect(candidate?.modality).toBe('Cycling');
+        expect(candidate?.durationRange).toEqual({ min: 20, default: 40, max: 60 });
+        expect(candidate?.stimulus).toEqual(template.stimulusProfile);
+        expect(candidate?.cost).toEqual(template.costProfile);
+        expect(candidate?.recoveryHours).toBe(24);
+        expect(candidate?.equipment).toEqual(['bike']);
+        expect(candidate?.contraindications).toEqual(['acute_knee_pain']);
+    });
+
+    it('returns null when the workout has no engineTemplateIds at all', () => {
+        const workout = testWorkout({ engineTemplateIds: undefined });
+        expect(derivePlanningCandidate(workout, [testTemplate()])).toBeNull();
+    });
+
+    it('returns null when engineTemplateIds points at a template that does not exist in the roster', () => {
+        const workout = testWorkout({ engineTemplateIds: ['nonexistent'] });
+        expect(derivePlanningCandidate(workout, [testTemplate()])).toBeNull();
+    });
+
+    it('carries minimumDaysAfterHardLowerBody through only when the workout declares it', () => {
+        const withValue = derivePlanningCandidate(testWorkout({ eligibility: { minimumDaysAfterHardLowerBody: 3 } }), [testTemplate()]);
+        expect(withValue?.minimumDaysAfterHardLowerBody).toBe(3);
+
+        const without = derivePlanningCandidate(testWorkout({ eligibility: {} }), [testTemplate()]);
+        expect(without?.minimumDaysAfterHardLowerBody).toBeUndefined();
+        expect('minimumDaysAfterHardLowerBody' in (without ?? {})).toBe(false);
+    });
+
+    it('maps WorkoutEnvironment (trainer/field/closed_road/low_traffic_road) onto the coarser engine TrainingEnvironment', () => {
+        const indoor = derivePlanningCandidate(
+            testWorkout({ technicalRequirements: { environment: ['trainer'], supervision: 'none', stopConditions: [] } }),
+            [testTemplate()],
+        );
+        expect(indoor?.environment).toEqual(['indoor']);
+
+        const outdoor = derivePlanningCandidate(
+            testWorkout({ technicalRequirements: { environment: ['field', 'closed_road'], supervision: 'none', stopConditions: [] } }),
+            [testTemplate()],
+        );
+        expect(outdoor?.environment).toEqual(['outdoor']); // deduplicated -- both map to 'outdoor'
+    });
+
+    it('falls back to the matched template\'s own environment when the workout declares no technicalRequirements', () => {
+        const candidate = derivePlanningCandidate(testWorkout(), [testTemplate({ environment: 'either' })]);
+        expect(candidate?.environment).toEqual(['either']);
+    });
+
+    it('classifies sessionRole from the template category, reusing ANCHOR_HISTORY_CATEGORIES (not a second definition)', () => {
+        const anchorCandidate = derivePlanningCandidate(testWorkout(), [testTemplate({ category: 'Hard Endurance' })]);
+        expect(anchorCandidate?.sessionRole).toBe('anchor');
+
+        const recoveryCandidate = derivePlanningCandidate(testWorkout(), [testTemplate({ category: 'Rest', costProfile: ZERO_COST, systemicCost: 0 })]);
+        expect(recoveryCandidate?.sessionRole).toBe('recovery');
+
+        const supportingCandidate = derivePlanningCandidate(testWorkout(), [testTemplate({ category: 'Technical Skill', costProfile: ZERO_COST, systemicCost: 0.1 })]);
+        expect(supportingCandidate?.sessionRole).toBe('supporting');
+    });
+});
+
+describe('buildPlanningCandidateIndex (Phase 5.2)', () => {
+    it('excludes non-active (draft/deprecated) workouts', () => {
+        const draft = testWorkout({ id: 'draft_1', status: 'draft' });
+        const index = buildPlanningCandidateIndex([draft], [testTemplate()]);
+        expect(index.size).toBe(0);
+    });
+
+    it('keeps the higher engineTemplatePriority workout when two workouts implement the same template', () => {
+        const low = testWorkout({ id: 'low_priority', engineTemplatePriority: 1 });
+        const high = testWorkout({ id: 'high_priority', engineTemplatePriority: 5 });
+        const index = buildPlanningCandidateIndex([low, high], [testTemplate()]);
+        expect(index.get('tmpl_1')?.workoutId).toBe('high_priority');
+
+        // Order independence -- same result regardless of catalog array order.
+        const indexReversed = buildPlanningCandidateIndex([high, low], [testTemplate()]);
+        expect(indexReversed.get('tmpl_1')?.workoutId).toBe('high_priority');
+    });
+
+    it('the real, module-level PLANNING_CANDIDATE_INDEX is built from the actual catalog and template roster', () => {
+        expect(PLANNING_CANDIDATE_INDEX.size).toBeGreaterThan(0);
+        // Cross-check against a fresh build from the same live data -- guards against the
+        // module-level singleton silently drifting from WORKOUTS/ENRICHED_TEMPLATES.
+        const rebuilt = buildPlanningCandidateIndex(WORKOUTS, ENRICHED_TEMPLATES);
+        expect(PLANNING_CANDIDATE_INDEX.size).toBe(rebuilt.size);
+    });
+
+    it('every real active workout with a resolvable engineTemplateIds entry produces a non-null candidate', () => {
+        const templateIds = new Set(ENRICHED_TEMPLATES.map(t => t.id));
+        const linkedActiveWorkouts = WORKOUTS.filter(w => w.status === 'active' && w.engineTemplateIds?.some(id => templateIds.has(id)));
+        for (const workout of linkedActiveWorkouts) {
+            expect(derivePlanningCandidate(workout, ENRICHED_TEMPLATES)).not.toBeNull();
+        }
+    });
+});

--- a/app/src/engine/planningCandidate.ts
+++ b/app/src/engine/planningCandidate.ts
@@ -1,0 +1,150 @@
+import type { Equipment, WorkoutDefinition, WorkoutEnvironment } from '../workouts/models';
+import type {
+    Modality,
+    SessionRole,
+    SessionTemplate,
+    TrainingEnvironment,
+    WorkoutCostProfile,
+    WorkoutStimulusProfile,
+} from './models';
+import { WORKOUTS } from '../workouts/catalog';
+import { ENRICHED_TEMPLATES } from './templates';
+import { ANCHOR_HISTORY_CATEGORIES } from './optimizer';
+
+/**
+ * Phase 5.2: moves the planner/workout-library boundary.
+ *
+ * Detailed `WorkoutDefinition`s already carry recovery hours, mechanical/eccentric load,
+ * coordination demand, technical environment, contraindications, and minimum spacing
+ * after hard lower-body work -- but the planner selects a coarse `SessionTemplate` first,
+ * so that metadata arrived only *after* the decision it should have informed (see
+ * `evaluateRecoveryConstraints` in optimizer.ts, whose hard-lower-body spacing rule was a
+ * flat one-day gap with no per-workout data behind it at all). `PlanningCandidate` is
+ * enough semantics to sequence a week without dragging every workout step (blocks,
+ * variants, parameters) into the planner -- prescription generation
+ * (`resolveWorkoutPrescription`) stays downstream and unchanged.
+ *
+ * This type intentionally lives in engine/, not workouts/models.ts as the plan's own
+ * sketch might suggest at first read: workouts/models.ts has zero imports today, and
+ * engine/models.ts already imports from it (`AthletePerformanceProfile`,
+ * `WorkoutPrescription`). Defining a type that references engine types
+ * (`SessionRole`/`Modality`/`WorkoutStimulusProfile`/`WorkoutCostProfile`/
+ * `TrainingEnvironment`) inside workouts/models.ts would make that dependency circular.
+ */
+export interface PlanningCandidate {
+    workoutId: string;
+    sessionRole: SessionRole;
+    modality: Modality;
+    durationRange: { min: number; default: number; max: number };
+    stimulus: WorkoutStimulusProfile;
+    cost: WorkoutCostProfile;
+    recoveryHours: number;
+    minimumDaysAfterHardLowerBody?: number;
+    equipment: Equipment[];
+    environment: TrainingEnvironment[];
+    contraindications: string[];
+}
+
+const ZERO_STIMULUS: WorkoutStimulusProfile = {
+    aerobicEndurance: 0, thresholdPower: 0, vo2MaxPower: 0, repeatedSurges: 0,
+    sprintPower: 0, fatigueResistance: 0, maxStrength: 0, hypertrophy: 0,
+};
+
+const ZERO_COST: WorkoutCostProfile = {
+    systemic: 0, cardiovascular: 0, lowerBody: 0, upperBody: 0, impactTissue: 0, neuromuscular: 0,
+};
+
+/** `WorkoutEnvironment` (catalog-level: trainer/field/closed_road/low_traffic_road) is
+ *  finer-grained than the engine's own `TrainingEnvironment` (indoor/outdoor/either) --
+ *  this is the one, explicit mapping between the two vocabularies. */
+function toTrainingEnvironment(environment: WorkoutEnvironment): TrainingEnvironment {
+    return environment === 'trainer' ? 'indoor' : 'outdoor';
+}
+
+/** Static, date-independent role classification -- reuses optimizer.ts's own
+ *  `ANCHOR_HISTORY_CATEGORIES` rather than inventing a second anchor definition.
+ *  `realizedSessionRole` (planner.ts) is the date/anchor-aware sibling of this; that one
+ *  answers "what did this pick become on this specific day", this one answers "what kind
+ *  of session is this, independent of any day". */
+function staticSessionRole(category: SessionTemplate['category']): SessionRole {
+    if (category === 'Rest' || category === 'Mobility/Recovery') return 'recovery';
+    return ANCHOR_HISTORY_CATEGORIES.includes(category) ? 'anchor' : 'supporting';
+}
+
+/**
+ * Derives one `PlanningCandidate` from a catalog `WorkoutDefinition`, resolved against
+ * its linked engine `SessionTemplate` (`engineTemplateIds[0]` -- a workout with several
+ * linked templates uses the first, same determinism convention as
+ * `engineTemplatePriority`'s own doc comment). Returns `null` for a workout with no
+ * engine-selectable template at all: it exists in the prescription catalog but the
+ * planner itself can never choose it, so it isn't a planning candidate.
+ */
+export function derivePlanningCandidate(
+    workout: WorkoutDefinition,
+    templates: SessionTemplate[]
+): PlanningCandidate | null {
+    const templateId = workout.engineTemplateIds?.[0];
+    const template = templateId ? templates.find(t => t.id === templateId) : undefined;
+    if (!template) return null;
+
+    const environment: TrainingEnvironment[] = workout.technicalRequirements?.environment.length
+        ? Array.from(new Set(workout.technicalRequirements.environment.map(toTrainingEnvironment)))
+        : [template.environment];
+
+    return {
+        workoutId: workout.id,
+        sessionRole: staticSessionRole(template.category),
+        modality: template.modality,
+        durationRange: {
+            min: workout.duration.minimumMin,
+            default: workout.duration.defaultMin,
+            max: workout.duration.maximumMin,
+        },
+        stimulus: template.stimulusProfile ?? ZERO_STIMULUS,
+        cost: template.costProfile ?? ZERO_COST,
+        recoveryHours: workout.loadProfile.recoveryHours,
+        ...(workout.eligibility.minimumDaysAfterHardLowerBody !== undefined
+            ? { minimumDaysAfterHardLowerBody: workout.eligibility.minimumDaysAfterHardLowerBody }
+            : {}),
+        equipment: workout.equipment,
+        environment,
+        contraindications: workout.contraindicationTags,
+    };
+}
+
+/** Every active workout's `PlanningCandidate`, keyed by its resolved engine template id.
+ *  Deprecated/draft workouts are excluded -- the planner can't select them regardless of
+ *  what detail they carry. Built once at module load, same convention as
+ *  `ENRICHED_TEMPLATES` -- the catalog and template roster are both static data. */
+export function buildPlanningCandidateIndex(
+    workouts: WorkoutDefinition[],
+    templates: SessionTemplate[]
+): Map<string, PlanningCandidate> {
+    const index = new Map<string, PlanningCandidate>();
+    for (const workout of workouts) {
+        if (workout.status !== 'active') continue;
+        const candidate = derivePlanningCandidate(workout, templates);
+        if (!candidate) continue;
+        const templateId = workout.engineTemplateIds?.[0];
+        if (!templateId) continue;
+        // A template already indexed keeps whichever workout comes first in the catalog
+        // array unless engineTemplatePriority says otherwise -- same tie-break WorkoutDefinition
+        // itself documents for "several detailed workouts implement one template".
+        const existingWorkout = index.has(templateId)
+            ? workouts.find(w => w.id === index.get(templateId)!.workoutId)
+            : undefined;
+        if (existingWorkout && (existingWorkout.engineTemplatePriority ?? 0) >= (workout.engineTemplatePriority ?? 0)) continue;
+        index.set(templateId, candidate);
+    }
+    return index;
+}
+
+export const PLANNING_CANDIDATE_INDEX: Map<string, PlanningCandidate> = buildPlanningCandidateIndex(WORKOUTS, ENRICHED_TEMPLATES);
+
+/** Convenience resolver matching optimizer.ts's `OptimizationOptions.resolveMinimumDaysAfterHardLowerBody`
+ *  shape -- looks up the per-workout spacing requirement for a given engine template id,
+ *  falling back to `undefined` (the existing flat one-day rule) when no detailed workout
+ *  declares a stricter one. */
+export function resolveMinimumDaysAfterHardLowerBody(templateId: string): number | undefined {
+    return PLANNING_CANDIDATE_INDEX.get(templateId)?.minimumDaysAfterHardLowerBody;
+}

--- a/app/src/engine/policy.ts
+++ b/app/src/engine/policy.ts
@@ -1,11 +1,12 @@
 /** Increment whenever a change can alter a persisted recommendation decision. */
-export const POLICY_VERSION = '2026-08-objective-credit-v2-v2';
+export const POLICY_VERSION = '2026-08-phase5-sequence-planning-v1';
 
 /** Historical versions are intentionally not re-executed by this build. Their compact
  * audits remain readable evidence, but replay is rejected explicitly because the old
  * decision function is not bundled alongside the current policy. */
 export const HISTORICAL_POLICY_VERSIONS = [
     '2026-08-single-ranking-path-v1',
+    '2026-08-objective-credit-v2-v2',
 ] as const;
 
 export function isHistoricalPolicyVersion(version: string): boolean {

--- a/app/src/engine/provenance.test.ts
+++ b/app/src/engine/provenance.test.ts
@@ -22,6 +22,7 @@ describe('recommendation provenance', () => {
             decisionTrace: {
                 policyVersion: POLICY_VERSION,
                 candidateScores: [{ templateId: template.id, utilityScore: 1.25, excludedReasons: [] }],
+                droppedContributorObjectives: [],
             },
         };
         const snapshot = buildTrainingHistorySnapshot(
@@ -46,6 +47,7 @@ describe('recommendation provenance', () => {
             plannedDose: { volume: 0.6, intensity: 1 },
             executionDose: { volume: 0.5, intensity: 1 },
             candidateScores: [{ templateId: template.id, utilityScore: 1.25, excludedReasons: [] }],
+            droppedContributorObjectives: [],
         });
         expect(JSON.stringify(audit)).not.toContain('This should never');
     });
@@ -64,6 +66,7 @@ describe('recommendation provenance', () => {
             decisionTrace: {
                 policyVersion: POLICY_VERSION,
                 candidateScores: [{ templateId: template.id, utilityScore: 1.25, excludedReasons: [] }],
+                droppedContributorObjectives: [],
             },
         };
         const snapshot = buildTrainingHistorySnapshot(

--- a/app/src/engine/provenance.ts
+++ b/app/src/engine/provenance.ts
@@ -33,5 +33,6 @@ export function buildRecommendationAudit(
         ...(recommendation.plannedDose ? { plannedDose: recommendation.plannedDose } : {}),
         ...(recommendation.executionDose ? { executionDose: recommendation.executionDose } : {}),
         candidateScores: trace.candidateScores,
+        droppedContributorObjectives: trace.droppedContributorObjectives,
     };
 }

--- a/app/src/engine/replay.test.ts
+++ b/app/src/engine/replay.test.ts
@@ -13,6 +13,7 @@ function auditedRecommendation(): DailyRecommendation {
             history: { completedEventCount: 1, unmatchedEventCount: 0, sourceStatuses: { activities: 'AVAILABLE', recommendations: 'AVAILABLE', manualTraining: 'MISSING' } },
             envelope: { safetyRestrictedModalityCount: 0, planMaxAllowableTier: 'Easy' },
             candidateScores: [{ templateId: 'easy_01', utilityScore: 1, excludedReasons: [] }, { templateId: 'easy_02', utilityScore: 0.5, excludedReasons: [] }],
+            droppedContributorObjectives: [],
         },
     };
 }

--- a/app/src/engine/rules.ts
+++ b/app/src/engine/rules.ts
@@ -10,6 +10,7 @@ import { resolveTrainingIntent } from './trainingIntent';
 import { POLICY_VERSION } from './policy';
 import { resolveExecutionDose } from './dose';
 import { isTemplatePhaseEligible } from './periodization';
+import { resolveMinimumDaysAfterHardLowerBody } from './planningCandidate';
 
 /**
  * Deterministically pick one template from a filtered set of same-category options,
@@ -472,7 +473,7 @@ export async function evaluateTrainingWithIntent(
         .filter(template => mode !== 'recover' || template.category === 'Rest' || template.category === 'Mobility/Recovery')
         .filter(template => mode !== 'modify' || template.systemicCost <= MODIFY_MAX_SYSTEMIC_COST)
         .filter(template => isTemplatePhaseEligible(template, intent.periodization));
-    const optContext = buildOptimizationContext(intent, context, context.preferences, date);
+    const optContext = buildOptimizationContext(intent, context, context.preferences, date, { resolveMinimumDaysAfterHardLowerBody });
     const rankingResult = rankCandidates(
         candidates,
         optContext.unresolvedObjectives,

--- a/app/src/engine/rules.ts
+++ b/app/src/engine/rules.ts
@@ -511,6 +511,7 @@ export async function evaluateTrainingWithIntent(
                     utilityScore: candidate.utilityScore,
                     excludedReasons: candidate.excludedReasons,
                 })),
+                droppedContributorObjectives: intent.droppedContributorObjectives,
             },
         };
     }
@@ -529,6 +530,7 @@ export async function evaluateTrainingWithIntent(
                 utilityScore: candidate.utilityScore,
                 excludedReasons: candidate.excludedReasons,
             })),
+            droppedContributorObjectives: intent.droppedContributorObjectives,
         },
     };
 }

--- a/app/src/engine/schedule.ts
+++ b/app/src/engine/schedule.ts
@@ -84,8 +84,17 @@ export function resolveAvailability(
 
     // 3. Process Fixed Activities on Target Date
     const daysFixed = fixedActivities.filter(a => a.date === dateStr);
+    // An availabilityOverride caps the whole day's budget outright (e.g. a travel day
+    // where the normal weekday/weekend profile default no longer applies) *before* any
+    // individual activity's own duration is deducted below. Several overrides on the same
+    // day take the most restrictive (min) -- optimistic combination would understate how
+    // constrained the day actually is.
+    const overrides = daysFixed
+        .map(a => a.availabilityOverride)
+        .filter((value): value is number => typeof value === 'number');
+    const overriddenBaseTime = overrides.length > 0 ? Math.min(baseTime, ...overrides) : baseTime;
     const fixedDurationSum = daysFixed.reduce((sum, a) => sum + a.durationMin, 0);
-    const remainingTimeMin = Math.max(0, baseTime - fixedDurationSum);
+    const remainingTimeMin = Math.max(0, overriddenBaseTime - fixedDurationSum);
 
     // 4. Resolve Available Equipment
     const equipmentSet = new Set<string>(resolveOwnedEquipment(userContext?.constraints));

--- a/app/src/engine/schedule.ts
+++ b/app/src/engine/schedule.ts
@@ -83,6 +83,13 @@ export function resolveAvailability(
         : (Number.isFinite(checkinMinutes) ? checkinMinutes : NO_CONTEXT_FALLBACK_MINUTES);
 
     // 3. Process Fixed Activities on Target Date
+    // Deliberately not filtered by `fixed: true/false` -- a movable placeholder still
+    // occupies real time on the date it is currently scheduled for, so it must reduce
+    // availability exactly like an immovable commitment does. `fixed` (movable vs
+    // immovable) is captured on the model but not yet consumed here: it becomes
+    // load-bearing once sequence search (Phase 5.1/5.2) can reason about shifting a
+    // movable placeholder to a different day, at which point *that* code -- not this
+    // availability calculation -- is what should treat movable and immovable differently.
     const daysFixed = fixedActivities.filter(a => a.date === dateStr);
     // An availabilityOverride caps the whole day's budget outright (e.g. a travel day
     // where the normal weekday/weekend profile default no longer applies) *before* any

--- a/app/src/engine/sequenceSearch.test.ts
+++ b/app/src/engine/sequenceSearch.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import { evaluateNextDayPlan, evaluateTraining } from './rules';
+import { generateWeekAheadPlan, prepareWeekAheadPlanSeed } from './planner';
+import { beamSearchWeekAheadPlan } from './sequenceSearch';
+import type { DailyReadiness, EngineObjectiveInput, SubjectiveInput, UserContext, UserEvent } from './models';
+
+function baseContext(overrides: Partial<UserContext['constraints']> = {}): UserContext {
+    return {
+        goals: { shortTerm: '', midTerm: '', longTerm: '' },
+        constraints: {
+            hasCableMachine: false, hasFreeWeights: true, hasTreadmill: false, hasIndoorBike: false,
+            restrictedModalities: [], maxTimeMinutes: 90, ...overrides,
+        },
+        preferences: { avoidedModalities: [], deprioritizedModalities: [], preferredModalities: [], conservativeBias: false },
+    };
+}
+
+function neutralSubjective(overrides: Partial<SubjectiveInput> = {}): SubjectiveInput {
+    return {
+        readiness: 6, sleepQuality: 6, fatigue: 4, soreness: 4, stress: 4, motivation: 6,
+        timeAvailable: 60, painFlag: false, alreadyTrainedToday: false, preferredModalityToday: null,
+        ...overrides,
+    };
+}
+
+function quietObjective(overrides: Partial<EngineObjectiveInput> = {}): EngineObjectiveInput {
+    return {
+        total_steps: 8000, sleep_score: 82, sleep_duration_min: 450, rhr: 50, rhr_7d_avg: 50, rhr_delta: 0,
+        hrv_weekly_avg: 50, hrv_last_night: 50, hrv_delta: 0, respiration: 14, body_battery_wake: 82,
+        last_3_days_hard_sessions_count: 0, yesterday_training: null, today_training: null,
+        sleep_score_delta_7d: 0, rhr_delta_28d: 0, hrv_delta_28d: 0, sleep_score_delta_28d: 0,
+        hrv_stdev_28d: 8.5, rhr_stdev_28d: 3.5, sleep_score_stdev_28d: 7.8,
+        ...overrides,
+    };
+}
+
+function buildTodayAndTomorrow(context: UserContext, date = '2026-08-07') {
+    const readiness: DailyReadiness = { subjective: neutralSubjective(), objective: quietObjective() };
+    const todayRec = evaluateTraining(readiness, context, date);
+    const nextDayPlan = evaluateNextDayPlan(readiness, context, date, todayRec);
+    return {
+        readiness, todayRec,
+        tomorrowRec: nextDayPlan.branches.yellow.recommendation,
+        seed: prepareWeekAheadPlanSeed(readiness, [], date, []),
+    };
+}
+
+const cyclingEvent = (daysOut: string): UserEvent => ({
+    id: 'e1', title: 'Gran Fondo', date: daysOut, priority: 'A', lifecycle: 'scheduled', category: 'cycling_event',
+    demandProfile: { aerobicEndurance: 0.8, thresholdPower: 0.75, vo2MaxPower: 0.7, repeatedSurges: 0.7, sprintPower: 0.3, fatigueResistance: 0.8, neuromuscular: 0.3 },
+});
+
+describe('beamSearchWeekAheadPlan (Phase 5.1 prototype)', () => {
+    it('produces the requested number of days, with today/tomorrow copied verbatim from the greedy inputs', () => {
+        const context = baseContext();
+        const { todayRec, tomorrowRec, seed } = buildTodayAndTomorrow(context);
+        const plan = beamSearchWeekAheadPlan(context, null, '2026-08-07', todayRec, tomorrowRec, seed, { days: 7 });
+
+        expect(plan.days).toHaveLength(7);
+        expect(plan.days[0].confidence).toBe('provisional');
+        expect(plan.days[0].template.id).toBe(tomorrowRec.template.id);
+        expect(plan.days.slice(1).every(d => d.confidence === 'projected')).toBe(true);
+    });
+
+    it('degenerates to exactly the greedy algorithm when beamWidth=1 and candidatesPerDay=1', () => {
+        // The strongest correctness check available: with only ever one branch and one
+        // candidate considered per day, cumulative-score pruning can never diverge from
+        // picking rank-0 each day -- i.e. this must reproduce generateWeekAheadPlan
+        // exactly, proving the reused rankCandidates/fatigue/objective wiring is faithful.
+        const context = baseContext();
+        const event = cyclingEvent('2026-08-27');
+        const { todayRec, tomorrowRec, seed } = buildTodayAndTomorrow(context);
+
+        const greedyPlan = generateWeekAheadPlan(
+            { subjective: neutralSubjective(), objective: quietObjective() }, context, null,
+            '2026-08-07', todayRec, tomorrowRec, seed, { days: 7, events: [event] },
+        );
+        const beamPlan = beamSearchWeekAheadPlan(context, null, '2026-08-07', todayRec, tomorrowRec, seed, { days: 7, events: [event] }, 1, 1);
+
+        expect(beamPlan.days.map(d => d.template.id)).toEqual(greedyPlan.days.map(d => d.template.id));
+        expect(beamPlan.days.map(d => d.date)).toEqual(greedyPlan.days.map(d => d.date));
+    });
+
+    it('a wider beam explores more branch-days than a narrow one (branchDaysScored grows monotonically with beam width)', () => {
+        const context = baseContext();
+        const event = cyclingEvent('2026-08-27');
+        const { todayRec, tomorrowRec, seed } = buildTodayAndTomorrow(context);
+
+        const narrow = beamSearchWeekAheadPlan(context, null, '2026-08-07', todayRec, tomorrowRec, seed, { days: 7, events: [event] }, 1, 1);
+        const wide = beamSearchWeekAheadPlan(context, null, '2026-08-07', todayRec, tomorrowRec, seed, { days: 7, events: [event] }, 15, 5);
+
+        expect(wide.branchDaysScored).toBeGreaterThan(narrow.branchDaysScored);
+        expect(wide.beamWidthUsed).toBe(15);
+        expect(wide.candidatesPerDayUsed).toBe(5);
+    });
+
+    it('the explain trail has one entry per projected day with a non-decreasing cumulative score', () => {
+        const context = baseContext();
+        const { todayRec, tomorrowRec, seed } = buildTodayAndTomorrow(context);
+        const plan = beamSearchWeekAheadPlan(context, null, '2026-08-07', todayRec, tomorrowRec, seed, { days: 7 });
+
+        // 7 total days - 1 provisional (tomorrow) = 6 projected/searched days.
+        expect(plan.explain).toHaveLength(6);
+        for (let i = 1; i < plan.explain.length; i++) {
+            expect(plan.explain[i].cumulativeScoreAfter).toBeGreaterThanOrEqual(plan.explain[i - 1].cumulativeScoreAfter);
+        }
+    });
+
+    it('never selects a template requiring equipment the athlete does not have (hard gate honored)', () => {
+        const context = baseContext({ hasFreeWeights: false, hasCableMachine: false, hasTreadmill: false, hasIndoorBike: false });
+        const { todayRec, tomorrowRec, seed } = buildTodayAndTomorrow(context);
+        const plan = beamSearchWeekAheadPlan(context, null, '2026-08-07', todayRec, tomorrowRec, seed, { days: 7 }, 15, 5);
+
+        // The athlete owns no equipment at all, so every accepted candidate (hard-gated
+        // by MISSING_REQUIRED_EQUIPMENT inside rankCandidates before this prototype ever
+        // sees it) must require none either.
+        plan.days.forEach(day => {
+            expect(day.template.requiredEquipment).toEqual([]);
+        });
+    });
+});

--- a/app/src/engine/sequenceSearch.ts
+++ b/app/src/engine/sequenceSearch.ts
@@ -400,6 +400,7 @@ export async function generateWeekAheadPlanWithIntentBeamSearch(
             microcycle: intent.microcycle,
             fatigue: intent.fatigue,
             trailingHistory: trailingHistoryFromCompletedExposures(intent.history, todayDate),
+            droppedContributorObjectives: intent.droppedContributorObjectives,
         },
         { ...options, events },
         beamWidth,
@@ -410,5 +411,6 @@ export async function generateWeekAheadPlanWithIntentBeamSearch(
         days: result.days,
         objectiveCredits: result.objectiveCredits,
         microcycleObjectives: result.microcycleObjectives,
+        droppedContributorObjectives: intent.droppedContributorObjectives,
     };
 }

--- a/app/src/engine/sequenceSearch.ts
+++ b/app/src/engine/sequenceSearch.ts
@@ -1,0 +1,412 @@
+import type {
+    DailyReadiness,
+    DimensionalFatigue,
+    FatigueState,
+    MicrocycleState,
+    Recommendation,
+    SessionHistoryEntry,
+    SessionTemplate,
+    UserContext,
+    UserEvent,
+    UserPreferences,
+    WeeklyObjective,
+} from './models';
+import type { TrainingHistoryProvider } from './trainingHistory';
+import type { TrainingHistorySnapshot } from './trainingHistorySnapshot';
+import { resolvePlannedDoseForDate, resolveTrainingIntent } from './trainingIntent';
+import { resolveAvailability } from './schedule';
+import { isTemplatePhaseEligible, evaluatePeriodizationPhase, type PeriodizationResult } from './periodization';
+import { eligibleTemplates } from './eligibility';
+import { addDaysToLocalDateString } from '../utils/localDate';
+import { applyCompletedSessionLoad, createEmptyFatigue } from './fatigue';
+import { generateWeeklyObjectives, getUnresolvedObjectives } from './microcycle';
+import { buildOptimizationContext, rankCandidates, type RecentHistoryEntry } from './optimizer';
+import { ENRICHED_TEMPLATES } from './templates';
+import { resolvePlanDefinitionForEvent } from './planSchedule';
+import { deriveObjectiveCreditFromProfile } from './stimulus';
+import { resolveMinimumDaysAfterHardLowerBody } from './planningCandidate';
+import type { PlannedObjectiveCredit, WeekAheadDay, WeekAheadOptions, WeekAheadPlan, WeekAheadPlanSeed } from './planner';
+import {
+    applyProjectedObjectiveCredits,
+    displayModeFromCategory,
+    enrichedCostProfile,
+    enrichedStimulusProfile,
+    fatigueTierFor,
+    isAdjacentDate,
+    maxFatigueDimension,
+    NEUTRAL_PREFERENCES,
+    PROJECTED_FATIGUE_MODIFY_THRESHOLD,
+    PROJECTED_FATIGUE_RECOVER_THRESHOLD,
+    PROJECTED_MODIFY_MAX_SYSTEMIC_COST,
+    projectFatigueForRankingDate,
+    realizedSessionRole,
+    resolveWeeklyAnchors,
+} from './planner';
+
+/**
+ * Phase 5.1: bounded sequence search -- an EXPERIMENT, not a scheduled migration.
+ *
+ * `generateWeekAheadPlan` (planner.ts) walks the "projected" tier one day at a time,
+ * greedily: each day takes `rankCandidates`' rank-0 pick with no visibility into how that
+ * choice constrains the days after it. This module scores the whole partial sequence
+ * across a bounded beam instead, so the planner can prefer
+ *
+ *   Tue threshold / Thu easy aerobic / Sat race-specific
+ *
+ * over
+ *
+ *   Tue threshold / Wed threshold / Thu rest / Fri race-specific
+ *
+ * even when Wednesday's threshold scores higher in isolation -- the class of judgement
+ * the greedy walk structurally cannot make.
+ *
+ * Deliberately maximal reuse, not a parallel engine: per (branch, day) this calls the
+ * exact same `rankCandidates` Phase-3 lexicographic pipeline the greedy loop uses --
+ * hard-gate rejection (`excludedReasons`) already happens *before* `rankCandidates`
+ * returns a score at all, which is this prototype's "reject hard spacing/recovery
+ * violations before scoring" for free, from the prerequisite the plan names. What
+ * changes is which -- and how many -- of `rankCandidates`' accepted results a branch
+ * keeps (top `candidatesPerDay`, not just rank 0), and that pruning after each day is by
+ * *cumulative* sequence score, not that day's score alone.
+ *
+ * Today and tomorrow (the confirmed/provisional tiers) are copied verbatim from the
+ * greedy inputs, unsearched -- this experiment concerns only the "projected" tier's
+ * day-by-day walk, matching the plan's own framing (`Prerequisite: Phase 3's
+ * lexicographic layer`, not a rethink of the confirmed/provisional tiers).
+ *
+ * NOT wired into the live default path. See docs/adr/0015-sequence-planning-and-session-role-model.md
+ * for the recorded adoption decision and the comparison data behind it.
+ */
+
+export const DEFAULT_BEAM_WIDTH = 15;
+export const DEFAULT_CANDIDATES_PER_DAY = 5;
+
+const ZERO_DIMENSIONAL: DimensionalFatigue = {
+    systemic: 0, cardiovascular: 0, lowerBody: 0, upperBody: 0, impactTissue: 0, neuromuscular: 0,
+};
+
+interface SearchBranch {
+    days: WeekAheadDay[];
+    microcycle: MicrocycleState;
+    externalFatigue: FatigueState;
+    objectiveCredits: PlannedObjectiveCredit[];
+    /** Sum of each day's utilityScore across the branch's whole sequence so far -- the
+     *  thing beam pruning actually ranks on, not any single day's score. */
+    cumulativeScore: number;
+}
+
+export interface SequenceExplainEntry {
+    date: string;
+    templateId: string;
+    templateTitle: string;
+    utilityScore: number;
+    runnerUpUtilityScore: number | null;
+    cumulativeScoreAfter: number;
+}
+
+export interface BeamSearchWeekAheadPlan {
+    startDate: string;
+    days: WeekAheadDay[];
+    objectiveCredits: PlannedObjectiveCredit[];
+    microcycleObjectives: WeeklyObjective[];
+    /** The winning branch's own day-by-day trail -- "why is this the best week" in a
+     *  directly answerable form: each day's chosen template, its score, the runner-up's
+     *  score, and the running cumulative total that pruning actually selected on. */
+    explain: SequenceExplainEntry[];
+    beamWidthUsed: number;
+    candidatesPerDayUsed: number;
+    /** Total (branch, candidate) pairs scored across the whole search -- a rough cost
+     *  signal for the "beam search cost" risk the plan calls out. */
+    branchDaysScored: number;
+}
+
+export function beamSearchWeekAheadPlan(
+    context: UserContext,
+    preferences: UserPreferences | null,
+    todayDate: string,
+    todayRec: Recommendation,
+    tomorrowRec: Recommendation | null,
+    seed: WeekAheadPlanSeed,
+    options: WeekAheadOptions = {},
+    beamWidth: number = DEFAULT_BEAM_WIDTH,
+    candidatesPerDay: number = DEFAULT_CANDIDATES_PER_DAY
+): BeamSearchWeekAheadPlan {
+    const totalDays = Math.max(1, options.days ?? 7);
+    const events = options.events ?? [];
+    const fixedActivities = options.fixedActivities ?? [];
+    const effectivePreferences = preferences ?? NEUTRAL_PREFERENCES;
+
+    const periodizationToday = evaluatePeriodizationPhase(events, todayDate);
+    const initialMicrocycle: MicrocycleState = seed.microcycle ?? generateWeeklyObjectives(periodizationToday.phase, todayDate, periodizationToday.focusEvent);
+    const internalStrain: DimensionalFatigue = seed.fatigue?.internalResponseStrain ?? ZERO_DIMENSIONAL;
+    const internalStrainAsOf = todayDate;
+    const initialFatigue: FatigueState = seed.fatigue?.externalLoadFatigue ? seed.fatigue : createEmptyFatigue(todayDate);
+
+    const anchors = resolveWeeklyAnchors(todayDate, totalDays, events, fixedActivities, context, tomorrowRec?.template.category, tomorrowRec?.template.modality);
+
+    const creditingObjectivesFor = (microcycle: MicrocycleState, template: SessionTemplate) => {
+        const stimulus = enrichedStimulusProfile(template);
+        return getUnresolvedObjectives(microcycle, true).flatMap(objective => {
+            const credit = deriveObjectiveCreditFromProfile(objective, stimulus, {}, {
+                modality: template.modality,
+                category: template.category,
+            });
+            return credit.qualifies && credit.earnedCredit > 0
+                ? [{ objective, earnedCredit: credit.earnedCredit }]
+                : [];
+        });
+    };
+
+    const applyPick = (
+        branch: SearchBranch,
+        date: string,
+        template: SessionTemplate,
+        derivedCredits = creditingObjectivesFor(branch.microcycle, template)
+    ): SearchBranch => {
+        const projected = applyProjectedObjectiveCredits(
+            branch.microcycle,
+            derivedCredits.map(item => ({ objectiveId: item.objective.id, earnedCredit: item.earnedCredit })),
+        );
+        const allocationById = new Map(projected.allocations.map(item => [item.objectiveId, item.earnedCredit]));
+        const newCredits: PlannedObjectiveCredit[] = [];
+        derivedCredits.forEach(({ objective }) => {
+            const allocated = allocationById.get(objective.id) ?? 0;
+            if (allocated <= 0) return;
+            newCredits.push({
+                date, objectiveKey: objective.key, objectiveTitle: objective.title,
+                templateId: template.id, templateTitle: template.title, modality: template.modality,
+                earnedCredit: allocated,
+            });
+        });
+        return {
+            ...branch,
+            microcycle: projected.microcycle,
+            externalFatigue: applyCompletedSessionLoad(branch.externalFatigue, date, enrichedCostProfile(template.id)),
+            objectiveCredits: [...branch.objectiveCredits, ...newCredits],
+        };
+    };
+
+    const extendBranch = (
+        branch: SearchBranch,
+        date: string,
+        offset: number,
+        periodization: PeriodizationResult,
+        template: SessionTemplate,
+        utilityScore: number,
+        benefitScore: number,
+        costPenalty: number,
+        peakFatigue: number,
+        runnerUpUtility: number | null,
+        bestBenefitTemplateId: string,
+        bestBenefitScore: number,
+        rationale: string
+    ): SearchBranch => {
+        const pickCredits = creditingObjectivesFor(branch.microcycle, template);
+        const addressed = pickCredits.map(item => item.objective.title);
+        const applied = applyPick(branch, date, template, pickCredits);
+        const day: WeekAheadDay = {
+            date, dayOffset: offset, confidence: 'projected', phaseName: periodization.phase.phaseName,
+            template, mode: displayModeFromCategory(template.category), rationale, addressesObjectives: addressed,
+            diagnostics: {
+                peakFatigue, fatigueTier: fatigueTierFor(peakFatigue), topUtilityScore: utilityScore,
+                runnerUpUtilityScore: runnerUpUtility, selectedBenefitScore: benefitScore, selectedCostPenalty: costPenalty,
+                bestBenefitTemplateId, bestBenefitScore,
+            },
+        };
+        return { ...applied, days: [...branch.days, day], cumulativeScore: branch.cumulativeScore + utilityScore };
+    };
+
+    // Today + tomorrow: copied from the greedy inputs verbatim, unsearched (see module doc).
+    let seedBranch: SearchBranch = {
+        days: [], microcycle: initialMicrocycle, externalFatigue: initialFatigue, objectiveCredits: [], cumulativeScore: 0,
+    };
+    seedBranch = applyPick(seedBranch, todayDate, todayRec.template);
+
+    const confirmedDays: WeekAheadDay[] = [];
+    if (tomorrowRec) {
+        const tomorrowDate = addDaysToLocalDateString(todayDate, 1);
+        const tomorrowPeriodization = evaluatePeriodizationPhase(events, tomorrowDate);
+        const tomorrowCredits = creditingObjectivesFor(seedBranch.microcycle, tomorrowRec.template);
+        const tomorrowDay: WeekAheadDay = {
+            date: tomorrowDate, dayOffset: 1, confidence: 'provisional', phaseName: tomorrowPeriodization.phase.phaseName,
+            template: tomorrowRec.template, mode: tomorrowRec.mode === 'recover' ? 'recover' : 'train',
+            rationale: tomorrowRec.rationale, addressesObjectives: tomorrowCredits.map(item => item.objective.title),
+        };
+        confirmedDays.push(tomorrowDay);
+        seedBranch = applyPick(seedBranch, tomorrowDate, tomorrowRec.template, tomorrowCredits);
+    }
+
+    let beam: SearchBranch[] = [seedBranch];
+    let branchDaysScored = 0;
+    const restFallback = ENRICHED_TEMPLATES.find(t => t.category === 'Rest');
+
+    for (let offset = confirmedDays.length + 1; offset <= totalDays; offset++) {
+        const date = addDaysToLocalDateString(todayDate, offset);
+        const periodization = evaluatePeriodizationPhase(events, date);
+        const availability = resolveAvailability(date, null, fixedActivities, context);
+        const planDefinition = resolvePlanDefinitionForEvent(periodization.focusEvent);
+
+        const nextGeneration: SearchBranch[] = [];
+
+        for (const branch of beam) {
+            const rankingFatigue = projectFatigueForRankingDate(branch.externalFatigue, internalStrain, internalStrainAsOf, date);
+            const unresolved = getUnresolvedObjectives(branch.microcycle, true);
+            const eligible = eligibleTemplates(ENRICHED_TEMPLATES, context, availability.maxTimeMinutes, date)
+                .filter(t => isTemplatePhaseEligible(t, periodization));
+
+            const peakFatigue = maxFatigueDimension(rankingFatigue.combinedFatigue);
+            const fatigueGated = eligible.filter(t => {
+                if (peakFatigue >= PROJECTED_FATIGUE_RECOVER_THRESHOLD) return t.category === 'Rest' || t.category === 'Mobility/Recovery';
+                if (peakFatigue >= PROJECTED_FATIGUE_MODIFY_THRESHOLD) return t.systemicCost <= PROJECTED_MODIFY_MAX_SYSTEMIC_COST;
+                return true;
+            });
+
+            const anchorRole = date === anchors.eventSpecificAnchorDate ? 'event-specific'
+                : date === anchors.qualityAnchorDate ? 'quality' : null;
+            const adjacentToAnchor = isAdjacentDate(date, anchors.eventSpecificAnchorDate)
+                || isAdjacentDate(date, anchors.qualityAnchorDate);
+
+            const projectedHistory: (RecentHistoryEntry | SessionHistoryEntry)[] = [
+                ...(seed.trailingHistory ?? []),
+                {
+                    date: todayDate, templateId: todayRec.template.id, category: todayRec.template.category,
+                    modality: todayRec.template.modality, role: realizedSessionRole(todayDate, todayRec.template, anchors),
+                    systemicCost: todayRec.template.systemicCost, lowerBodyCost: todayRec.template.costProfile?.lowerBody ?? 0,
+                    type: todayRec.template.title,
+                },
+                ...[...confirmedDays, ...branch.days].map(d => ({
+                    date: d.date, templateId: d.template.id, category: d.template.category, modality: d.template.modality,
+                    role: realizedSessionRole(d.date, d.template, anchors), systemicCost: d.template.systemicCost,
+                    lowerBodyCost: d.template.costProfile?.lowerBody ?? 0, type: d.template.title,
+                })),
+            ];
+
+            const optContext = buildOptimizationContext(
+                {
+                    unresolvedObjectives: unresolved,
+                    fatigue: rankingFatigue,
+                    periodization,
+                    history: projectedHistory,
+                    plannedDose: resolvePlannedDoseForDate(periodization.phase, branch.microcycle.objectives, unresolved, planDefinition, date),
+                },
+                context, effectivePreferences, date,
+                { anchorRole, adjacentToAnchor, resolveMinimumDaysAfterHardLowerBody }
+            );
+
+            const rankingResult = rankCandidates(
+                fatigueGated, optContext.unresolvedObjectives, optContext.fatigueState, optContext.availability,
+                optContext.injuryConstraints, optContext.preferences, optContext.options
+            );
+
+            // Hard-constraint rejection already happened inside rankCandidates -- accepted
+            // is the post-rejection, scored candidate set. This is the plan's "reject
+            // before scoring" step, reused rather than reimplemented.
+            const accepted = rankingResult.accepted;
+            branchDaysScored += accepted.length;
+
+            if (accepted.length === 0) {
+                if (restFallback) {
+                    nextGeneration.push(extendBranch(
+                        branch, date, offset, periodization, restFallback,
+                        0, 0, 0, peakFatigue, null, restFallback.id, 0, 'No admissible candidate; fell back to rest.'
+                    ));
+                }
+                continue;
+            }
+
+            const bestBenefit = [...accepted].sort((a, b) => b.benefitScore - a.benefitScore)[0];
+            accepted.slice(0, candidatesPerDay).forEach(candidate => {
+                nextGeneration.push(extendBranch(
+                    branch, date, offset, periodization, candidate.template,
+                    candidate.utilityScore, candidate.benefitScore, candidate.costPenalty,
+                    peakFatigue, accepted[1]?.utilityScore ?? null,
+                    bestBenefit.template.id, bestBenefit.benefitScore, candidate.rationale
+                ));
+            });
+        }
+
+        // Whole-sequence pruning: the beam survives on cumulative score, not the best
+        // single day -- this is what lets the search prefer a slightly weaker day if it
+        // keeps stronger options open for the rest of the week.
+        nextGeneration.sort((a, b) => b.cumulativeScore - a.cumulativeScore);
+        beam = nextGeneration.slice(0, beamWidth);
+        if (beam.length === 0) beam = [seedBranch]; // degenerate case: no branch survived (shouldn't happen given the rest fallback)
+    }
+
+    const winner = beam[0] ?? seedBranch;
+    const explain: SequenceExplainEntry[] = winner.days.map(day => ({
+        date: day.date,
+        templateId: day.template.id,
+        templateTitle: day.template.title,
+        utilityScore: day.diagnostics?.topUtilityScore ?? 0,
+        runnerUpUtilityScore: day.diagnostics?.runnerUpUtilityScore ?? null,
+        cumulativeScoreAfter: winner.days
+            .slice(0, winner.days.indexOf(day) + 1)
+            .reduce((sum, d) => sum + (d.diagnostics?.topUtilityScore ?? 0), 0),
+    }));
+
+    return {
+        startDate: addDaysToLocalDateString(todayDate, 1),
+        days: [...confirmedDays, ...winner.days],
+        objectiveCredits: winner.objectiveCredits,
+        microcycleObjectives: winner.microcycle.objectives ?? [],
+        explain,
+        beamWidthUsed: beamWidth,
+        candidatesPerDayUsed: candidatesPerDay,
+        branchDaysScored,
+    };
+}
+
+/**
+ * Drop-in beam-search analog of `planner.ts`'s `generateWeekAheadPlanWithIntent`, same
+ * arity through `preparedHistorySnapshot` so a comparison harness (see
+ * `simulation/analyze.ts`'s `runScenario` optional `planGenerator` parameter) can swap it
+ * in for the exact same scenario without duplicating history/microcycle/fatigue
+ * resolution. Strips `BeamSearchWeekAheadPlan`'s extra diagnostic fields
+ * (`explain`/`beamWidthUsed`/etc.) down to the plain `WeekAheadPlan` shape the harness
+ * already knows how to score.
+ */
+export async function generateWeekAheadPlanWithIntentBeamSearch(
+    userId: string,
+    todayReadiness: DailyReadiness,
+    context: UserContext,
+    preferences: UserPreferences | null,
+    events: UserEvent[],
+    todayDate: string,
+    todayRec: Recommendation,
+    tomorrowRec: Recommendation | null,
+    options: WeekAheadOptions = {},
+    historyProvider?: TrainingHistoryProvider,
+    preparedHistorySnapshot?: TrainingHistorySnapshot | null,
+    beamWidth: number = DEFAULT_BEAM_WIDTH,
+    candidatesPerDay: number = DEFAULT_CANDIDATES_PER_DAY
+): Promise<WeekAheadPlan> {
+    const intent = await resolveTrainingIntent(userId, events, todayDate, todayReadiness, 7, historyProvider, preparedHistorySnapshot);
+    const result = beamSearchWeekAheadPlan(
+        context,
+        preferences,
+        todayDate,
+        todayRec,
+        tomorrowRec,
+        {
+            microcycle: intent.microcycle,
+            fatigue: intent.fatigue,
+            trailingHistory: intent.history.map(e => ({
+                date: ('completedDate' in e && typeof e.completedDate === 'string' ? e.completedDate : 'date' in e && typeof e.date === 'string' ? e.date : todayDate),
+                modality: e.modality,
+                category: e.category,
+                systemicCost: e.costProfile?.systemic ?? 0,
+                lowerBodyCost: e.costProfile?.lowerBody ?? 0,
+            })),
+        },
+        { ...options, events },
+        beamWidth,
+        candidatesPerDay
+    );
+    return {
+        startDate: result.startDate,
+        days: result.days,
+        objectiveCredits: result.objectiveCredits,
+        microcycleObjectives: result.microcycleObjectives,
+    };
+}

--- a/app/src/engine/sequenceSearch.ts
+++ b/app/src/engine/sequenceSearch.ts
@@ -41,6 +41,7 @@ import {
     projectFatigueForRankingDate,
     realizedSessionRole,
     resolveWeeklyAnchors,
+    trailingHistoryFromCompletedExposures,
 } from './planner';
 
 /**
@@ -329,8 +330,15 @@ export function beamSearchWeekAheadPlan(
         // single day -- this is what lets the search prefer a slightly weaker day if it
         // keeps stronger options open for the rest of the week.
         nextGeneration.sort((a, b) => b.cumulativeScore - a.cumulativeScore);
-        beam = nextGeneration.slice(0, beamWidth);
-        if (beam.length === 0) beam = [seedBranch]; // degenerate case: no branch survived (shouldn't happen given the rest fallback)
+        // Only replace the beam if at least one branch survived this day. Every branch
+        // pushes a rest-fallback extension when `accepted.length === 0`, so an empty
+        // `nextGeneration` should not happen -- but resetting to `[seedBranch]` on it would
+        // discard every previously-planned day while `offset` keeps advancing, producing a
+        // truncated/misnumbered plan. Keeping the current (pre-this-day) beam instead means
+        // the search simply stalls on this day rather than corrupting what came before it.
+        if (nextGeneration.length > 0) {
+            beam = nextGeneration.slice(0, beamWidth);
+        }
     }
 
     const winner = beam[0] ?? seedBranch;
@@ -391,13 +399,7 @@ export async function generateWeekAheadPlanWithIntentBeamSearch(
         {
             microcycle: intent.microcycle,
             fatigue: intent.fatigue,
-            trailingHistory: intent.history.map(e => ({
-                date: ('completedDate' in e && typeof e.completedDate === 'string' ? e.completedDate : 'date' in e && typeof e.date === 'string' ? e.date : todayDate),
-                modality: e.modality,
-                category: e.category,
-                systemicCost: e.costProfile?.systemic ?? 0,
-                lowerBodyCost: e.costProfile?.lowerBody ?? 0,
-            })),
+            trailingHistory: trailingHistoryFromCompletedExposures(intent.history, todayDate),
         },
         { ...options, events },
         beamWidth,

--- a/app/src/engine/simulation/analyze.ts
+++ b/app/src/engine/simulation/analyze.ts
@@ -223,6 +223,12 @@ function computeMetrics(
     };
 }
 
+/** Same shape as `generateWeekAheadPlanWithIntent` (planner.ts) -- the parameter
+ *  `runScenario` below swaps to compare an alternative sequencing strategy (Phase 5.1's
+ *  `generateWeekAheadPlanWithIntentBeamSearch`) against the real production greedy path
+ *  over the exact same scenarios/metrics, with no other part of the harness changing. */
+type WeekAheadPlanGenerator = typeof generateWeekAheadPlanWithIntent;
+
 /**
  * Runs one scenario end to end through the real production code path. Each iteration is
  * one non-overlapping seven-calendar-day block: today's real readiness-driven decision
@@ -231,8 +237,12 @@ function computeMetrics(
  * weekly readiness input was directly evaluated and duplicated that boundary day across
  * consecutive windows. That made the sustained-stress scenario look artificially similar
  * to baseline (its weekly mandated recovery day was never part of the metrics).
+ *
+ * `planGenerator` defaults to the real production greedy path -- pass
+ * `generateWeekAheadPlanWithIntentBeamSearch` (sequenceSearch.ts) to run the identical
+ * scenario through Phase 5.1's beam-search prototype instead, for a direct comparison.
  */
-export async function runScenario(scenario: AthleteScenario): Promise<ScenarioResult> {
+export async function runScenario(scenario: AthleteScenario, planGenerator: WeekAheadPlanGenerator = generateWeekAheadPlanWithIntent): Promise<ScenarioResult> {
     const events = scenario.event ? [scenario.event] : [];
     const accumulatedHistory: CompletedExposure[] = [];
     const historyProvider: TrainingHistoryProvider = {
@@ -258,7 +268,7 @@ export async function runScenario(scenario: AthleteScenario): Promise<ScenarioRe
         const tomorrowRec = nextDayPlan.branches.yellow.recommendation;
 
         // Six future days + today's actual decision = one non-overlapping 7-day block.
-        const plan = await generateWeekAheadPlanWithIntent(
+        const plan = await planGenerator(
             'sim-user', readiness, scenario.context, null, events, currentDate, todayRec, tomorrowRec,
             { days: 6 }, historyProvider,
         );

--- a/app/src/engine/stimulus.test.ts
+++ b/app/src/engine/stimulus.test.ts
@@ -123,6 +123,52 @@ describe('deriveObjectiveCredit', () => {
         const result = deriveObjectiveCredit(sampleObjective, null);
         expect(result).toMatchObject({ earnedCredit: 0, qualifies: false, reason: 'Invalid stimulus profile' });
     });
+
+    // Phase 5.5: confidence discounts earned credit via CONFIDENCE_CREDIT_WEIGHT.
+    describe('confidence weighting', () => {
+        it('defaults to exact (full credit) when confidence is not supplied, unchanged from before this parameter existed', () => {
+            const result = deriveObjectiveCredit(sampleObjective, sampleStimulus, { completionRatio: 1.0 });
+            expect(result.earnedCredit).toBe(0.8);
+        });
+
+        it('discounts credit for inferred confidence', () => {
+            const result = deriveObjectiveCredit(sampleObjective, sampleStimulus, { completionRatio: 1.0 }, undefined, 'inferred');
+            expect(result.earnedCredit).toBe(0.6); // 0.8 * 0.75
+        });
+
+        it('discounts credit further for unknown confidence, but never to zero', () => {
+            const result = deriveObjectiveCredit(sampleObjective, sampleStimulus, { completionRatio: 1.0 }, undefined, 'unknown');
+            expect(result.earnedCredit).toBe(0.32); // 0.8 * 0.4
+            expect(result.earnedCredit).toBeGreaterThan(0);
+            expect(result.qualifies).toBe(true);
+        });
+    });
+
+    // Phase 5.5: a modality/category-scoped objective must fail closed when the evidence
+    // doesn't even know the modality/category, not silently skip the check.
+    describe('fail-closed qualification when context is unknown', () => {
+        it('rejects a modality-scoped objective when context.modality is absent', () => {
+            const restrictedObj: WeeklyObjective = { ...sampleObjective, qualification: { allowedModalities: ['Cycling'] } };
+            const result = deriveObjectiveCredit(restrictedObj, sampleStimulus, { completionRatio: 1.0 });
+            expect(result.qualifies).toBe(false);
+            expect(result.earnedCredit).toBe(0);
+            expect(result.reason).toBe('Modality unknown');
+        });
+
+        it('rejects a category-scoped objective when context.category is absent', () => {
+            const restrictedObj: WeeklyObjective = { ...sampleObjective, qualification: { allowedCategories: ['Race-Specific Endurance'] } };
+            const result = deriveObjectiveCredit(restrictedObj, sampleStimulus, { completionRatio: 1.0 }, { modality: 'Cycling' });
+            expect(result.qualifies).toBe(false);
+            expect(result.earnedCredit).toBe(0);
+            expect(result.reason).toBe('Category unknown');
+        });
+
+        it('still credits an unscoped objective (no qualification at all) with no context supplied', () => {
+            const result = deriveObjectiveCredit(sampleObjective, sampleStimulus, { completionRatio: 1.0 });
+            expect(result.qualifies).toBe(true);
+            expect(result.earnedCredit).toBe(0.8);
+        });
+    });
 });
 
 describe('readStimulusProfile', () => {

--- a/app/src/engine/stimulus.ts
+++ b/app/src/engine/stimulus.ts
@@ -15,6 +15,23 @@ export interface ObjectiveCredit {
     reason?: string;
 }
 
+/** How sure the engine is about a stimulus profile, from strongest to weakest evidence --
+ * see docs/plans/phase-5-sequence-planning.md 5.5 and completedTraining.ts's EvidenceTier,
+ * which produces this value. Absent (the default) means "authored/hypothetical data",
+ * e.g. a catalog template's own stimulusProfile evaluated for a *planned* candidate --
+ * there is nothing to be unsure about there, so it earns full credit exactly as before
+ * this parameter existed. */
+export type StimulusConfidence = 'exact' | 'inferred' | 'unknown';
+
+/** Discounts earned credit by how confident the evidence is, so a genuinely unplanned
+ * session still counts toward adaptation (closing the asymmetry where cost was already
+ * charged but benefit was not) without being trusted as much as a confirmed exact match. */
+export const CONFIDENCE_CREDIT_WEIGHT: Record<StimulusConfidence, number> = {
+    exact: 1.0,
+    inferred: 0.75,
+    unknown: 0.4,
+};
+
 const CANONICAL_AXES = [
     'aerobicEndurance',
     'thresholdPower',
@@ -115,24 +132,40 @@ export function readStimulusProfile(raw: unknown): DataState<WorkoutStimulusProf
 
 /** Calculates credit from an already validated/canonical profile. Use this when one
  * exposure fans out across several objectives so validation and divergence logging happen
- * once at the exposure boundary instead of once per objective. */
+ * once at the exposure boundary instead of once per objective.
+ *
+ * `confidence` (Phase 5.5) discounts earnedCredit via CONFIDENCE_CREDIT_WEIGHT and
+ * defaults to 'exact' -- every pre-existing caller that doesn't pass it keeps today's
+ * full-credit behavior unchanged. */
 export function deriveObjectiveCreditFromProfile(
     objective: WeeklyObjective,
     stimulus: WorkoutStimulusProfile,
     dose: DeliveredDose = {},
     context?: CreditContext,
+    confidence: StimulusConfidence = 'exact',
 ): ObjectiveCredit {
     const completionRatio = clamp01(dose.completionRatio ?? 1.0);
 
     if (objective.qualification) {
         const qual = objective.qualification;
-        if (qual.allowedModalities && qual.allowedModalities.length > 0 && context?.modality) {
+        if (qual.allowedModalities && qual.allowedModalities.length > 0) {
+            // Fail closed: a modality-scoped objective cannot be satisfied by evidence
+            // whose modality isn't even known (e.g. a genuinely unclassified Garmin
+            // activity) -- silently *skipping* this check when context.modality is
+            // absent would let an unknown-source session credit an objective it was
+            // never shown to actually match.
+            if (!context?.modality) {
+                return { objectiveId: objective.id, objectiveKey: objective.key, earnedCredit: 0, qualifies: false, reason: 'Modality unknown' };
+            }
             const allowed = qual.allowedModalities.map(m => m.toLowerCase());
             if (!allowed.includes(context.modality.toLowerCase())) {
                 return { objectiveId: objective.id, objectiveKey: objective.key, earnedCredit: 0, qualifies: false, reason: 'Modality not allowed' };
             }
         }
-        if (qual.allowedCategories && qual.allowedCategories.length > 0 && context?.category) {
+        if (qual.allowedCategories && qual.allowedCategories.length > 0) {
+            if (!context?.category) {
+                return { objectiveId: objective.id, objectiveKey: objective.key, earnedCredit: 0, qualifies: false, reason: 'Category unknown' };
+            }
             const allowed = qual.allowedCategories.map(c => c.toLowerCase());
             if (!allowed.includes(context.category.toLowerCase())) {
                 return { objectiveId: objective.id, objectiveKey: objective.key, earnedCredit: 0, qualifies: false, reason: 'Category not allowed' };
@@ -195,7 +228,8 @@ export function deriveObjectiveCreditFromProfile(
     }
 
     const deliveredDoseRatio = completionRatio * durationRatio;
-    const earnedCredit = Math.round(rawStimulusContribution * deliveredDoseRatio * 100) / 100;
+    const confidenceWeight = CONFIDENCE_CREDIT_WEIGHT[confidence];
+    const earnedCredit = Math.round(rawStimulusContribution * deliveredDoseRatio * confidenceWeight * 100) / 100;
 
     return {
         objectiveId: objective.id,
@@ -213,7 +247,8 @@ export function deriveObjectiveCredit(
     objective: WeeklyObjective,
     rawStimulus: unknown,
     dose: DeliveredDose = {},
-    context?: CreditContext
+    context?: CreditContext,
+    confidence: StimulusConfidence = 'exact',
 ): ObjectiveCredit {
     const stimulusState = readStimulusProfile(rawStimulus);
     if (stimulusState.status !== 'AVAILABLE') {
@@ -225,7 +260,7 @@ export function deriveObjectiveCredit(
             reason: 'Invalid stimulus profile',
         };
     }
-    return deriveObjectiveCreditFromProfile(objective, stimulusState.data, dose, context);
+    return deriveObjectiveCreditFromProfile(objective, stimulusState.data, dose, context, confidence);
 }
 
 /**

--- a/app/src/engine/trainingIntent.ts
+++ b/app/src/engine/trainingIntent.ts
@@ -3,7 +3,7 @@ import { computeInternalResponseStrain, buildFatigueStateFromHistory } from './f
 import { buildMicrocycleState, getUnresolvedObjectives } from './microcycle';
 import type { CompletedExposure, TrainingHistoryProvider } from './trainingHistory';
 import type { TrainingHistorySnapshot } from './trainingHistorySnapshot';
-import { evaluatePeriodizationPhase, type PeriodizationResult } from './periodization';
+import { evaluatePeriodizationPhase, resolveMultiEventObjectives, type DroppedContributorObjective, type PeriodizationResult } from './periodization';
 import { resolvePlanDefinitionForEvent, type PlanDefinition } from './planSchedule';
 import { addDaysToLocalDateString } from '../utils/localDate';
 
@@ -26,6 +26,10 @@ export interface TrainingIntent {
     /** Null only for legacy fixture providers that implement reconstruct() alone. */
     historySnapshot: TrainingHistorySnapshot | null;
     microcycle: MicrocycleState;
+    /** Phase 5.6: a contributor objective dropped because it fell inadmissible during the
+     *  taper authority's taper window (see periodization.ts resolveMultiEventObjectives).
+     *  Empty in the overwhelmingly common single-or-no-event case. */
+    droppedContributorObjectives: DroppedContributorObjective[];
     sessionRole?: 'anchor' | 'supporting' | 'recovery';
     recoveryIntent?: {
         reason: PlannedRecoveryReason;
@@ -112,7 +116,7 @@ export async function resolveTrainingIntent(
     const provider = historyProvider ?? (await import('./firestoreTrainingHistory')).firestoreTrainingHistoryProvider;
     const history = historySnapshot?.exposures ?? await provider.reconstruct(userId, date, windowDays);
     const planDefinition = resolvePlanDefinitionForEvent(periodization.focusEvent);
-    const microcycle = buildMicrocycleState(
+    const builtMicrocycle = buildMicrocycleState(
         periodization.phase,
         addDaysToLocalDateString(date, -windowDays),
         history,
@@ -120,6 +124,15 @@ export async function resolveTrainingIntent(
         planDefinition,
         date,
     );
+    // Phase 5.6: one taper authority (periodization.focusEvent, already resolved by
+    // evaluatePeriodizationPhase's total order above), multiple demand contributors. A
+    // no-op for the common single-or-no-event case (nothing else in `events` falls in
+    // another event's contribution window). This is the single seed-building point shared
+    // by today's decision (evaluateTrainingWithIntent), tomorrow's provisional plan
+    // (evaluateNextDayPlanWithIntent), and the week-ahead strip
+    // (generateWeekAheadPlanWithIntent) -- all three call resolveTrainingIntent.
+    const multiEventResolution = resolveMultiEventObjectives(events, date, periodization, builtMicrocycle.objectives);
+    const microcycle: MicrocycleState = { ...builtMicrocycle, objectives: multiEventResolution.objectives };
     const unresolvedObjectives = getUnresolvedObjectives(microcycle);
     const fatigue = buildFatigueStateFromHistory(history, computeInternalResponseStrain(readiness), date);
     const plannedDose = resolvePlannedDoseForDate(
@@ -129,5 +142,8 @@ export async function resolveTrainingIntent(
         planDefinition,
         date,
     );
-    return { periodization, unresolvedObjectives, plannedDose, fatigue, history, historySnapshot, microcycle };
+    return {
+        periodization, unresolvedObjectives, plannedDose, fatigue, history, historySnapshot, microcycle,
+        droppedContributorObjectives: multiEventResolution.droppedContributorObjectives,
+    };
 }

--- a/app/src/engine/validation.test.ts
+++ b/app/src/engine/validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isValidDate, validateRecommendation, validateAdherenceUpdate, validateGoal } from './validation';
+import { isValidDate, validateRecommendation, validateAdherenceUpdate, validateGoal, validateFixedActivity } from './validation';
 
 describe('isValidDate', () => {
     it('rejects impossible calendar dates rather than normalizing them', () => {
@@ -220,6 +220,90 @@ describe('validateAdherenceUpdate', () => {
         const result = validateAdherenceUpdate({ followed: false, actualModality: '' });
         expect(result.isValid).toBe(true);
         expect(result.data?.actualModality).toBeNull();
+    });
+});
+
+describe('validateFixedActivity', () => {
+    const baseFields = {
+        userId: 'u1',
+        title: 'Evening Football',
+        date: '2026-08-12',
+        durationMin: 90,
+        fixed: true,
+        environment: 'outdoor',
+        isCompleted: false,
+    };
+
+    it('accepts a minimal valid fixed activity', () => {
+        const result = validateFixedActivity({ ...baseFields });
+        expect(result.isValid).toBe(true);
+        expect(result.data?.durationMin).toBe(90);
+        expect(result.data?.fixed).toBe(true);
+    });
+
+    it('accepts expectedStimulus/expectedCost maps within [0, 1]', () => {
+        const result = validateFixedActivity({
+            ...baseFields,
+            expectedStimulus: { aerobicEndurance: 0.6, repeatedSurges: 0.4 },
+            expectedCost: { systemic: 0.8, lowerBody: 0.5 },
+        });
+        expect(result.isValid).toBe(true);
+        expect(result.data?.expectedStimulus).toEqual({ aerobicEndurance: 0.6, repeatedSurges: 0.4 });
+    });
+
+    it('rejects an expectedCost value above 1', () => {
+        const result = validateFixedActivity({ ...baseFields, expectedCost: { systemic: 1.5 } });
+        expect(result.isValid).toBe(false);
+        expect(result.errors.some(e => e.field === 'expectedCost')).toBe(true);
+    });
+
+    it('rejects an expectedStimulus map with an unrecognized axis key', () => {
+        const result = validateFixedActivity({ ...baseFields, expectedStimulus: { notAnAxis: 0.5 } });
+        expect(result.isValid).toBe(false);
+        expect(result.errors.some(e => e.field === 'expectedStimulus')).toBe(true);
+    });
+
+    it('rejects durationMin out of [1, 1440]', () => {
+        expect(validateFixedActivity({ ...baseFields, durationMin: 0 }).isValid).toBe(false);
+        expect(validateFixedActivity({ ...baseFields, durationMin: 1500 }).isValid).toBe(false);
+    });
+
+    it('requires the fixed field (movable vs immovable)', () => {
+        const withoutFixed: Record<string, unknown> = { ...baseFields };
+        delete withoutFixed.fixed;
+        const result = validateFixedActivity(withoutFixed);
+        expect(result.isValid).toBe(false);
+        expect(result.errors.some(e => e.field === 'fixed')).toBe(true);
+    });
+
+    it('rejects an unknown environment', () => {
+        const result = validateFixedActivity({ ...baseFields, environment: 'space' });
+        expect(result.isValid).toBe(false);
+        expect(result.errors.some(e => e.field === 'environment')).toBe(true);
+    });
+
+    it('rejects an oversized equipment list', () => {
+        const result = validateFixedActivity({ ...baseFields, equipment: Array.from({ length: 21 }, (_, i) => `item-${i}`) });
+        expect(result.isValid).toBe(false);
+        expect(result.errors.some(e => e.field === 'equipment')).toBe(true);
+    });
+
+    it('rejects an equipment item that is too long', () => {
+        const result = validateFixedActivity({ ...baseFields, equipment: ['x'.repeat(51)] });
+        expect(result.isValid).toBe(false);
+        expect(result.errors.some(e => e.field === 'equipment')).toBe(true);
+    });
+
+    it('rejects a malformed date', () => {
+        const result = validateFixedActivity({ ...baseFields, date: '08/12/2026' });
+        expect(result.isValid).toBe(false);
+        expect(result.errors.some(e => e.field === 'date')).toBe(true);
+    });
+
+    it('accepts availabilityOverride within [0, 1440] and rejects out-of-range', () => {
+        expect(validateFixedActivity({ ...baseFields, availabilityOverride: 60 }).isValid).toBe(true);
+        expect(validateFixedActivity({ ...baseFields, availabilityOverride: -1 }).isValid).toBe(false);
+        expect(validateFixedActivity({ ...baseFields, availabilityOverride: 1500 }).isValid).toBe(false);
     });
 });
 

--- a/app/src/engine/validation.test.ts
+++ b/app/src/engine/validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isValidDate, validateRecommendation, validateAdherenceUpdate, validateGoal, validateFixedActivity } from './validation';
+import { isValidDate, validateRecommendation, validateAdherenceUpdate, validateGoal, validateFixedActivity, validateCheckin } from './validation';
 
 describe('isValidDate', () => {
     it('rejects impossible calendar dates rather than normalizing them', () => {
@@ -304,6 +304,62 @@ describe('validateFixedActivity', () => {
         expect(validateFixedActivity({ ...baseFields, availabilityOverride: 60 }).isValid).toBe(true);
         expect(validateFixedActivity({ ...baseFields, availabilityOverride: -1 }).isValid).toBe(false);
         expect(validateFixedActivity({ ...baseFields, availabilityOverride: 1500 }).isValid).toBe(false);
+    });
+});
+
+describe('validateCheckin: tissueResponses (Phase 5.4)', () => {
+    const baseFields = {
+        userId: 'u1',
+        date: '2026-08-08',
+        readiness: 7,
+        painOrInjury: true,
+    };
+
+    it('accepts a minimal valid tissue response with just morningState', () => {
+        const result = validateCheckin({ ...baseFields, tissueResponses: { knee: { morningState: 'mild' } } });
+        expect(result.isValid).toBe(true);
+        expect(result.data?.tissueResponses?.knee).toEqual({ region: 'knee', morningState: 'mild' });
+    });
+
+    it('accepts all four signals on a region', () => {
+        const result = validateCheckin({
+            ...baseFields,
+            tissueResponses: {
+                shoulder: { morningState: 'normal', painDuringTraining: 'severe', afterTrainingState: 'moderate', nextMorningReaction: 'mild' },
+            },
+        });
+        expect(result.isValid).toBe(true);
+        expect(result.data?.tissueResponses?.shoulder).toEqual({
+            region: 'shoulder', morningState: 'normal', painDuringTraining: 'severe', afterTrainingState: 'moderate', nextMorningReaction: 'mild',
+        });
+    });
+
+    it('rejects an unrecognized region key', () => {
+        const result = validateCheckin({ ...baseFields, tissueResponses: { notARegion: { morningState: 'mild' } } });
+        expect(result.isValid).toBe(false);
+        expect(result.errors.some(e => e.field === 'tissueResponses')).toBe(true);
+    });
+
+    it('rejects a missing required morningState', () => {
+        const result = validateCheckin({ ...baseFields, tissueResponses: { knee: { painDuringTraining: 'mild' } } });
+        expect(result.isValid).toBe(false);
+        expect(result.errors.some(e => e.field === 'tissueResponses.knee.morningState')).toBe(true);
+    });
+
+    it('rejects an invalid level value', () => {
+        const result = validateCheckin({ ...baseFields, tissueResponses: { knee: { morningState: 'extreme' } } });
+        expect(result.isValid).toBe(false);
+        expect(result.errors.some(e => e.field === 'tissueResponses.knee.morningState')).toBe(true);
+    });
+
+    it('omits the field entirely when absent, and drops it when empty', () => {
+        const absent = validateCheckin({ ...baseFields });
+        expect(absent.isValid).toBe(true);
+        expect(absent.data?.tissueResponses).toBeUndefined();
+
+        const empty = validateCheckin({ ...baseFields, tissueResponses: {} });
+        expect(empty.isValid).toBe(true);
+        expect(empty.data?.tissueResponses).toBeUndefined();
     });
 });
 

--- a/app/src/engine/validation.test.ts
+++ b/app/src/engine/validation.test.ts
@@ -361,6 +361,18 @@ describe('validateCheckin: tissueResponses (Phase 5.4)', () => {
         expect(empty.isValid).toBe(true);
         expect(empty.data?.tissueResponses).toBeUndefined();
     });
+
+    it('rejects an entry whose own region field mismatches its containing map key', () => {
+        const result = validateCheckin({ ...baseFields, tissueResponses: { knee: { region: 'ankle', morningState: 'mild' } } });
+        expect(result.isValid).toBe(false);
+        expect(result.errors.some(e => e.field === 'tissueResponses.knee.region')).toBe(true);
+    });
+
+    it('accepts an entry whose own region field matches its containing map key', () => {
+        const result = validateCheckin({ ...baseFields, tissueResponses: { knee: { region: 'knee', morningState: 'mild' } } });
+        expect(result.isValid).toBe(true);
+        expect(result.data?.tissueResponses?.knee).toEqual({ region: 'knee', morningState: 'mild' });
+    });
 });
 
 describe('validateEventTiming', () => {

--- a/app/src/engine/validation.ts
+++ b/app/src/engine/validation.ts
@@ -28,7 +28,10 @@ import type {
     FixedActivity,
     WorkoutStimulusProfile,
     WorkoutCostProfile,
-    TrainingEnvironment
+    TrainingEnvironment,
+    BodyRegion,
+    RegionTissueResponse,
+    TissueResponseLevel
 } from './models';
 import { validateEventTiming } from './models';
 import { deriveGoalCategory } from './periodization';
@@ -76,6 +79,65 @@ function normalizeEmptyToNull(value: any): any {
 }
 
 // --- Daily Subjective Check-in Validation ---
+
+const BODY_REGIONS: BodyRegion[] = [
+    'knee', 'achilles', 'ankle', 'calf', 'hamstring', 'quadriceps',
+    'adductor_groin', 'hip', 'lower_back', 'shoulder', 'elbow', 'wrist',
+];
+
+const TISSUE_LEVELS: TissueResponseLevel[] = ['normal', 'mild', 'moderate', 'severe'];
+
+function isValidTissueLevel(value: unknown): value is TissueResponseLevel {
+    return typeof value === 'string' && (TISSUE_LEVELS as string[]).includes(value);
+}
+
+/** Validates and rebuilds the optional per-region tissue-response map (Phase 5.4).
+ *  Unknown region keys or malformed entries are reported as errors rather than silently
+ *  dropped -- a client that gets this shape wrong is exactly the case validation exists
+ *  to catch, same as every other field here. */
+function validateTissueResponses(raw: any, errors: ValidationError[]): Partial<Record<BodyRegion, RegionTissueResponse>> | undefined {
+    if (raw === undefined || raw === null) return undefined;
+    if (typeof raw !== 'object' || Array.isArray(raw)) {
+        errors.push({ field: 'tissueResponses', message: 'tissueResponses must be an object keyed by body region' });
+        return undefined;
+    }
+
+    const result: Partial<Record<BodyRegion, RegionTissueResponse>> = {};
+    for (const key of Object.keys(raw)) {
+        if (!(BODY_REGIONS as string[]).includes(key)) {
+            errors.push({ field: 'tissueResponses', message: `tissueResponses has unrecognized region '${key}'` });
+            continue;
+        }
+        const region = key as BodyRegion;
+        const entry = raw[key];
+        if (!entry || typeof entry !== 'object') {
+            errors.push({ field: `tissueResponses.${region}`, message: 'Each region entry must be an object' });
+            continue;
+        }
+        if (!isValidTissueLevel(entry.morningState)) {
+            errors.push({ field: `tissueResponses.${region}.morningState`, message: `morningState must be one of: ${TISSUE_LEVELS.join(', ')}` });
+            continue;
+        }
+        const optionalFields: (keyof RegionTissueResponse)[] = ['painDuringTraining', 'afterTrainingState', 'nextMorningReaction'];
+        let hasInvalidOptional = false;
+        for (const field of optionalFields) {
+            if (entry[field] !== undefined && entry[field] !== null && !isValidTissueLevel(entry[field])) {
+                errors.push({ field: `tissueResponses.${region}.${field}`, message: `${field} must be one of: ${TISSUE_LEVELS.join(', ')}` });
+                hasInvalidOptional = true;
+            }
+        }
+        if (hasInvalidOptional) continue;
+
+        result[region] = {
+            region,
+            morningState: entry.morningState,
+            ...(isValidTissueLevel(entry.painDuringTraining) ? { painDuringTraining: entry.painDuringTraining } : {}),
+            ...(isValidTissueLevel(entry.afterTrainingState) ? { afterTrainingState: entry.afterTrainingState } : {}),
+            ...(isValidTissueLevel(entry.nextMorningReaction) ? { nextMorningReaction: entry.nextMorningReaction } : {}),
+        };
+    }
+    return result;
+}
 
 export function validateCheckin(raw: any): ValidationResult<DailySubjectiveCheckin> {
     const errors: ValidationError[] = [];
@@ -158,6 +220,9 @@ export function validateCheckin(raw: any): ValidationResult<DailySubjectiveCheck
         });
     }
 
+    // Per-region tissue response (Phase 5.4)
+    const tissueResponses = validateTissueResponses(raw.tissueResponses, errors);
+
     if (errors.length > 0) {
         return { isValid: false, errors };
     }
@@ -176,6 +241,7 @@ export function validateCheckin(raw: any): ValidationResult<DailySubjectiveCheck
         illnessSymptoms: raw.illnessSymptoms ?? false,
         unusuallyLimitedTime: raw.unusuallyLimitedTime ?? false,
         alreadyTrainedToday: raw.alreadyTrainedToday ?? false,
+        ...(tissueResponses && Object.keys(tissueResponses).length > 0 ? { tissueResponses } : {}),
         availability: {
             timeAvailableMin: normalizeEmptyToNull(raw.availability?.timeAvailableMin),
             preferredModalityToday: normalizeEmptyToNull(raw.availability?.preferredModalityToday),

--- a/app/src/engine/validation.ts
+++ b/app/src/engine/validation.ts
@@ -33,7 +33,7 @@ import type {
     RegionTissueResponse,
     TissueResponseLevel
 } from './models';
-import { validateEventTiming } from './models';
+import { validateEventTiming, BODY_REGIONS, TISSUE_LEVELS } from './models';
 import { deriveGoalCategory } from './periodization';
 import { EVENT_PRESETS } from './eventPresets';
 import { getLocalDateString } from '../utils/localDate';
@@ -80,15 +80,8 @@ function normalizeEmptyToNull(value: any): any {
 
 // --- Daily Subjective Check-in Validation ---
 
-const BODY_REGIONS: BodyRegion[] = [
-    'knee', 'achilles', 'ankle', 'calf', 'hamstring', 'quadriceps',
-    'adductor_groin', 'hip', 'lower_back', 'shoulder', 'elbow', 'wrist',
-];
-
-const TISSUE_LEVELS: TissueResponseLevel[] = ['normal', 'mild', 'moderate', 'severe'];
-
 function isValidTissueLevel(value: unknown): value is TissueResponseLevel {
-    return typeof value === 'string' && (TISSUE_LEVELS as string[]).includes(value);
+    return typeof value === 'string' && (TISSUE_LEVELS as readonly string[]).includes(value);
 }
 
 /** Validates and rebuilds the optional per-region tissue-response map (Phase 5.4).
@@ -104,7 +97,7 @@ function validateTissueResponses(raw: any, errors: ValidationError[]): Partial<R
 
     const result: Partial<Record<BodyRegion, RegionTissueResponse>> = {};
     for (const key of Object.keys(raw)) {
-        if (!(BODY_REGIONS as string[]).includes(key)) {
+        if (!(BODY_REGIONS as readonly string[]).includes(key)) {
             errors.push({ field: 'tissueResponses', message: `tissueResponses has unrecognized region '${key}'` });
             continue;
         }
@@ -112,6 +105,10 @@ function validateTissueResponses(raw: any, errors: ValidationError[]): Partial<R
         const entry = raw[key];
         if (!entry || typeof entry !== 'object') {
             errors.push({ field: `tissueResponses.${region}`, message: 'Each region entry must be an object' });
+            continue;
+        }
+        if (entry.region !== undefined && entry.region !== region) {
+            errors.push({ field: `tissueResponses.${region}.region`, message: `region must match the containing key '${region}', got '${entry.region}'` });
             continue;
         }
         if (!isValidTissueLevel(entry.morningState)) {
@@ -881,7 +878,7 @@ export function validateFixedActivity(raw: any): ValidationResult<FixedActivity>
     }
 
     if (raw.availabilityOverride !== undefined && raw.availabilityOverride !== null) {
-        if (typeof raw.availabilityOverride !== 'number' || raw.availabilityOverride < 0 || raw.availabilityOverride > 1440) {
+        if (typeof raw.availabilityOverride !== 'number' || !Number.isFinite(raw.availabilityOverride) || raw.availabilityOverride < 0 || raw.availabilityOverride > 1440) {
             errors.push({ field: 'availabilityOverride', message: 'availabilityOverride must be a number of minutes in [0, 1440]' });
         }
     }

--- a/app/src/engine/validation.ts
+++ b/app/src/engine/validation.ts
@@ -24,7 +24,11 @@ import type {
     ConstraintCategory,
     RecoveryStyle,
     TimeOfDay,
-    ExplanationVerbosity
+    ExplanationVerbosity,
+    FixedActivity,
+    WorkoutStimulusProfile,
+    WorkoutCostProfile,
+    TrainingEnvironment
 } from './models';
 import { validateEventTiming } from './models';
 import { deriveGoalCategory } from './periodization';
@@ -718,6 +722,130 @@ export function validatePreferences(raw: any): ValidationResult<UserPreferences>
     };
 
     return { isValid: true, data: preferences, errors: [] };
+}
+
+// --- Fixed Activity Validation ---
+
+const STIMULUS_AXES: (keyof WorkoutStimulusProfile)[] = [
+    'aerobicEndurance', 'thresholdPower', 'vo2MaxPower', 'repeatedSurges',
+    'sprintPower', 'fatigueResistance', 'maxStrength', 'hypertrophy',
+];
+
+const COST_DIMENSIONS: (keyof WorkoutCostProfile)[] = [
+    'systemic', 'cardiovascular', 'lowerBody', 'upperBody', 'impactTissue', 'neuromuscular',
+];
+
+const TRAINING_ENVIRONMENTS: TrainingEnvironment[] = ['indoor', 'outdoor', 'either'];
+
+const MAX_EQUIPMENT_ITEMS = 20;
+const MAX_EQUIPMENT_ITEM_LENGTH = 50;
+
+/** Every key must be a recognized axis and every value a finite 0..1 number -- mirrors
+ *  firestore.rules' hasValidExpectedStimulus/hasValidExpectedCost, which can bound a
+ *  map's keys and size but (per the 5.3 storage contract) cannot iterate a list to type
+ *  check items, so equipment item type/length is enforced here, not just at the rule. */
+function validateProfileMap<K extends string>(
+    raw: any,
+    axes: readonly K[],
+    field: string,
+    errors: ValidationError[]
+): Partial<Record<K, number>> | undefined {
+    if (raw === undefined || raw === null) return undefined;
+    if (typeof raw !== 'object' || Array.isArray(raw)) {
+        errors.push({ field, message: `${field} must be an object` });
+        return undefined;
+    }
+    const keys = Object.keys(raw);
+    const result: Partial<Record<K, number>> = {};
+    for (const key of keys) {
+        if (!(axes as readonly string[]).includes(key)) {
+            errors.push({ field, message: `${field} has unrecognized key '${key}'` });
+            continue;
+        }
+        const value = raw[key];
+        if (typeof value !== 'number' || !Number.isFinite(value) || value < 0 || value > 1) {
+            errors.push({ field, message: `${field}.${key} must be a number in [0, 1]` });
+            continue;
+        }
+        result[key as K] = value;
+    }
+    return result;
+}
+
+export function validateFixedActivity(raw: any): ValidationResult<FixedActivity> {
+    const errors: ValidationError[] = [];
+
+    if (!raw.userId || typeof raw.userId !== 'string') {
+        errors.push({ field: 'userId', message: 'User ID is required' });
+    }
+    if (!raw.title || typeof raw.title !== 'string' || raw.title.trim() === '') {
+        errors.push({ field: 'title', message: 'Title is required' });
+    } else if (raw.title.length > 200) {
+        errors.push({ field: 'title', message: 'Title must be 200 characters or fewer' });
+    }
+    if (!raw.date || typeof raw.date !== 'string' || !isValidDate(raw.date)) {
+        errors.push({ field: 'date', message: 'Date must be a valid date (YYYY-MM-DD)' });
+    }
+    if (!Number.isInteger(raw.durationMin) || raw.durationMin <= 0 || raw.durationMin > 1440) {
+        errors.push({ field: 'durationMin', message: 'Duration must be an integer between 1 and 1440 minutes' });
+    }
+    if (typeof raw.fixed !== 'boolean') {
+        errors.push({ field: 'fixed', message: 'fixed (movable vs immovable) is required' });
+    }
+    if (!raw.environment || !TRAINING_ENVIRONMENTS.includes(raw.environment)) {
+        errors.push({ field: 'environment', message: `Environment must be one of: ${TRAINING_ENVIRONMENTS.join(', ')}` });
+    }
+    if (typeof raw.isCompleted !== 'boolean') {
+        errors.push({ field: 'isCompleted', message: 'isCompleted is required' });
+    }
+
+    let equipment: string[] = [];
+    if (raw.equipment !== undefined) {
+        if (!Array.isArray(raw.equipment) || raw.equipment.length > MAX_EQUIPMENT_ITEMS) {
+            errors.push({ field: 'equipment', message: `equipment must be a list of at most ${MAX_EQUIPMENT_ITEMS} items` });
+        } else if (raw.equipment.some((item: unknown) => typeof item !== 'string' || item.length > MAX_EQUIPMENT_ITEM_LENGTH)) {
+            errors.push({ field: 'equipment', message: `Every equipment item must be a string of at most ${MAX_EQUIPMENT_ITEM_LENGTH} characters` });
+        } else {
+            equipment = raw.equipment;
+        }
+    }
+
+    if (raw.startTime !== undefined && raw.startTime !== null && typeof raw.startTime !== 'string') {
+        errors.push({ field: 'startTime', message: 'startTime must be a string' });
+    }
+
+    if (raw.availabilityOverride !== undefined && raw.availabilityOverride !== null) {
+        if (typeof raw.availabilityOverride !== 'number' || raw.availabilityOverride < 0 || raw.availabilityOverride > 1440) {
+            errors.push({ field: 'availabilityOverride', message: 'availabilityOverride must be a number of minutes in [0, 1440]' });
+        }
+    }
+
+    const expectedStimulus = validateProfileMap(raw.expectedStimulus, STIMULUS_AXES, 'expectedStimulus', errors);
+    const expectedCost = validateProfileMap(raw.expectedCost, COST_DIMENSIONS, 'expectedCost', errors);
+
+    if (errors.length > 0) {
+        return { isValid: false, errors };
+    }
+
+    const activity: FixedActivity = {
+        id: raw.id ?? '',
+        userId: raw.userId,
+        title: raw.title.trim(),
+        date: raw.date,
+        durationMin: raw.durationMin,
+        fixed: raw.fixed,
+        environment: raw.environment,
+        equipment,
+        isCompleted: raw.isCompleted,
+        ...(raw.startTime ? { startTime: raw.startTime } : {}),
+        ...(expectedStimulus && Object.keys(expectedStimulus).length > 0 ? { expectedStimulus } : {}),
+        ...(expectedCost && Object.keys(expectedCost).length > 0 ? { expectedCost } : {}),
+        ...(typeof raw.availabilityOverride === 'number' ? { availabilityOverride: raw.availabilityOverride } : {}),
+        createdAt: raw.createdAt || new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+    };
+
+    return { isValid: true, data: activity, errors: [] };
 }
 
 // --- Daily Recommendation Validation ---

--- a/app/src/services/checkinService.test.ts
+++ b/app/src/services/checkinService.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { DailySubjectiveCheckin } from '../engine/models';
+
+const DELETE_FIELD_SENTINEL = Symbol('deleteField');
+
+const firestore = vi.hoisted(() => {
+    return {
+        collection: vi.fn(),
+        deleteDoc: vi.fn(),
+        deleteField: vi.fn(),
+        doc: vi.fn(),
+        getDoc: vi.fn(),
+        getDocs: vi.fn(),
+        limit: vi.fn(),
+        orderBy: vi.fn(),
+        query: vi.fn(),
+        setDoc: vi.fn(),
+        where: vi.fn(),
+    };
+});
+
+vi.mock('firebase/firestore', () => firestore);
+vi.mock('../firebase', () => ({ getDb: vi.fn(() => ({})) }));
+
+import { CheckinService } from './checkinService';
+
+const baseCheckin: Partial<DailySubjectiveCheckin> = {
+    readiness: 7,
+    sleepQuality: 7,
+    fatigue: 5,
+    soreness: 5,
+    mentalStress: 5,
+    motivation: 7,
+    illnessSymptoms: false,
+    unusuallyLimitedTime: false,
+    alreadyTrainedToday: false,
+};
+
+describe('CheckinService.upsertCheckin tissueResponses clearing', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        firestore.collection.mockReturnValue({ path: 'daily_subjective_checkins' });
+        firestore.doc.mockReturnValue({ path: 'daily_subjective_checkins/2026-08-09' });
+        firestore.setDoc.mockResolvedValue(undefined);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (firestore.deleteField as any).mockReturnValue(DELETE_FIELD_SENTINEL);
+    });
+
+    it('explicitly deletes a previously-persisted tissueResponses field when painOrInjury is false', async () => {
+        const service = new CheckinService();
+        await service.upsertCheckin('u1', {
+            ...baseCheckin,
+            date: '2026-08-09',
+            painOrInjury: false,
+            // No tissueResponses supplied on this write -- this is exactly the case where
+            // an omit-if-empty validator would otherwise leave a stale Firestore value in
+            // place under `merge: true`.
+        });
+
+        expect(firestore.setDoc).toHaveBeenCalledTimes(1);
+        const payload = firestore.setDoc.mock.calls[0][1] as Record<string, unknown>;
+        expect(payload.tissueResponses).toBe(DELETE_FIELD_SENTINEL);
+        const options = firestore.setDoc.mock.calls[0][2] as Record<string, unknown>;
+        expect(options).toEqual({ merge: true });
+    });
+
+    it('persists tissueResponses as-is when painOrInjury is true', async () => {
+        const service = new CheckinService();
+        await service.upsertCheckin('u1', {
+            ...baseCheckin,
+            date: '2026-08-09',
+            painOrInjury: true,
+            tissueResponses: { knee: { region: 'knee', morningState: 'mild' } },
+        });
+
+        expect(firestore.setDoc).toHaveBeenCalledTimes(1);
+        const payload = firestore.setDoc.mock.calls[0][1] as Record<string, unknown>;
+        expect(payload.tissueResponses).toEqual({ knee: { region: 'knee', morningState: 'mild' } });
+    });
+});

--- a/app/src/services/checkinService.ts
+++ b/app/src/services/checkinService.ts
@@ -1,4 +1,4 @@
-import { doc, getDoc, setDoc, deleteDoc, collection, query, where, orderBy, limit, getDocs } from 'firebase/firestore';
+import { doc, getDoc, setDoc, deleteDoc, deleteField, collection, query, where, orderBy, limit, getDocs } from 'firebase/firestore';
 import { getDb } from '../firebase';
 import type { DailySubjectiveCheckin } from '../engine/models';
 import type { DataState } from '../engine/dataState';
@@ -75,10 +75,24 @@ export class CheckinService {
             }
 
             const validatedCheckin = validation.data!;
-            
-            // Save to Firestore
+
+            // Save to Firestore. validateCheckin omits `tissueResponses` from its result
+            // entirely whenever it's absent -- with `merge: true`, an omitted key leaves
+            // whatever was already stored untouched, it does NOT clear it. So a day that
+            // previously had tissueResponses and now reports painOrInjury: false would
+            // otherwise keep the stale region data live in Firestore even though the UI
+            // (DailyCheckin's handleBooleanToggle) already cleared it locally --
+            // mapContextFromGoalsAndTrainingSettings consumes tissueResponses regardless of
+            // painOrInjury, so a stale value would keep restricting the athlete after they
+            // explicitly reported no pain/injury. Explicitly delete the field whenever this
+            // write's own painOrInjury is false, covering every upsert path (including
+            // MinimumSafetyCheckin's partial safety-subset save), not just DailyCheckin's.
+            const payload: Record<string, unknown> = { ...validatedCheckin };
+            if (!validatedCheckin.painOrInjury) {
+                payload.tissueResponses = deleteField();
+            }
             const docRef = doc(getDb(), 'users', userId, this.collectionPath, validatedCheckin.date);
-            await setDoc(docRef, validatedCheckin, { merge: true });
+            await setDoc(docRef, payload, { merge: true });
 
             return validatedCheckin;
         } catch (error) {

--- a/app/src/services/fixedActivityService.test.ts
+++ b/app/src/services/fixedActivityService.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FixedActivity } from '../engine/models';
+
+const firestore = vi.hoisted(() => {
+    return {
+        addDoc: vi.fn(),
+        collection: vi.fn(),
+        deleteDoc: vi.fn(),
+        doc: vi.fn(),
+        getDoc: vi.fn(),
+        getDocs: vi.fn(),
+        query: vi.fn(),
+        setDoc: vi.fn(),
+        where: vi.fn(),
+    };
+});
+
+vi.mock('firebase/firestore', () => firestore);
+vi.mock('../firebase', () => ({ getDb: vi.fn(() => ({})) }));
+
+import { FixedActivityService } from './fixedActivityService';
+
+const validActivity: Omit<FixedActivity, 'id' | 'userId' | 'createdAt' | 'updatedAt'> = {
+    title: 'Evening Football',
+    date: '2026-08-12',
+    durationMin: 90,
+    fixed: true,
+    environment: 'outdoor',
+    equipment: ['cleats'],
+    expectedStimulus: { aerobicEndurance: 0.6, repeatedSurges: 0.4 },
+    expectedCost: { systemic: 0.8, lowerBody: 0.5 },
+    isCompleted: false,
+};
+
+describe('FixedActivityService persistence shape', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        firestore.collection.mockReturnValue({ path: 'fixed_activities' });
+        firestore.doc.mockReturnValue({ path: 'fixed_activities/activity-1' });
+        firestore.addDoc.mockResolvedValue({ id: 'activity-1' });
+        firestore.setDoc.mockResolvedValue(undefined);
+        firestore.getDoc.mockResolvedValue({
+            exists: () => true,
+            data: () => ({ ...validActivity, userId: 'u1', createdAt: '2026-08-01T00:00:00.000Z', updatedAt: '2026-08-01T00:00:00.000Z' }),
+            id: 'activity-1',
+        });
+    });
+
+    it('creates a valid activity and returns it with the generated document id, but without an id field in the stored payload', async () => {
+        const service = new FixedActivityService();
+        const result = await service.createActivity('u1', validActivity);
+
+        expect(result.id).toBe('activity-1');
+        const payload = firestore.addDoc.mock.calls[0][1] as Record<string, unknown>;
+        expect(payload).not.toHaveProperty('id');
+        expect(payload.userId).toBe('u1');
+        expect(payload.fixed).toBe(true);
+        expect(payload.environment).toBe('outdoor');
+    });
+
+    it('rejects creating an activity with an out-of-range expectedCost value', async () => {
+        const service = new FixedActivityService();
+        await expect(service.createActivity('u1', {
+            ...validActivity,
+            expectedCost: { systemic: 1.5 },
+        })).rejects.toThrow(/Validation failed/);
+        expect(firestore.addDoc).not.toHaveBeenCalled();
+    });
+
+    it('rejects creating an activity missing the required fixed field', async () => {
+        const service = new FixedActivityService();
+        const withoutFixed: Record<string, unknown> = { ...validActivity };
+        delete withoutFixed.fixed;
+        await expect(service.createActivity('u1', withoutFixed as typeof validActivity)).rejects.toThrow(/Validation failed/);
+    });
+
+    it('markCompleted merges isCompleted true while preserving createdAt', async () => {
+        const service = new FixedActivityService();
+        await service.markCompleted('u1', 'activity-1');
+
+        const payload = firestore.setDoc.mock.calls[0][1] as Record<string, unknown>;
+        expect(payload.isCompleted).toBe(true);
+        expect(payload.createdAt).toBe('2026-08-01T00:00:00.000Z');
+    });
+
+    it('flags a malformed persisted document as INVALID rather than silently dropping it', async () => {
+        firestore.getDocs.mockResolvedValue({
+            docs: [
+                { id: 'bad-1', data: () => ({ ...validActivity, userId: 'u1', durationMin: -5, createdAt: 'x', updatedAt: 'x' }) },
+            ],
+        });
+        const service = new FixedActivityService();
+        const state = await service.getActivitiesInRangeState('u1', '2026-08-01', '2026-08-31');
+        expect(state.status).toBe('INVALID');
+    });
+
+    it('reads valid activities within range for the correct owner', async () => {
+        firestore.getDocs.mockResolvedValue({
+            docs: [
+                { id: 'activity-1', data: () => ({ ...validActivity, userId: 'u1', createdAt: '2026-08-01T00:00:00.000Z', updatedAt: '2026-08-01T00:00:00.000Z' }) },
+            ],
+        });
+        const service = new FixedActivityService();
+        const state = await service.getActivitiesInRangeState('u1', '2026-08-01', '2026-08-31');
+        expect(state.status).toBe('AVAILABLE');
+        if (state.status === 'AVAILABLE') {
+            expect(state.data).toHaveLength(1);
+            expect(state.data[0].title).toBe('Evening Football');
+        }
+    });
+});

--- a/app/src/services/fixedActivityService.test.ts
+++ b/app/src/services/fixedActivityService.test.ts
@@ -108,4 +108,28 @@ describe('FixedActivityService persistence shape', () => {
             expect(state.data[0].title).toBe('Evening Football');
         }
     });
+
+    it('listAll drops a malformed persisted document rather than surfacing it to UI callers', async () => {
+        firestore.getDocs.mockResolvedValue({
+            docs: [
+                { id: 'good-1', data: () => ({ ...validActivity, userId: 'u1', createdAt: '2026-08-01T00:00:00.000Z', updatedAt: '2026-08-01T00:00:00.000Z' }) },
+                { id: 'bad-1', data: () => ({ ...validActivity, userId: 'u1', durationMin: -5, createdAt: 'x', updatedAt: 'x' }) },
+            ],
+        });
+        const service = new FixedActivityService();
+        const result = await service.listAll('u1');
+        expect(result).toHaveLength(1);
+        expect(result[0].id).toBe('good-1');
+    });
+
+    it('getActivity returns null for a malformed persisted document instead of an unvalidated cast', async () => {
+        firestore.getDoc.mockResolvedValue({
+            exists: () => true,
+            data: () => ({ ...validActivity, userId: 'u1', durationMin: -5, createdAt: 'x', updatedAt: 'x' }),
+            id: 'bad-1',
+        });
+        const service = new FixedActivityService();
+        const result = await service.getActivity('u1', 'bad-1');
+        expect(result).toBeNull();
+    });
 });

--- a/app/src/services/fixedActivityService.test.ts
+++ b/app/src/services/fixedActivityService.test.ts
@@ -132,4 +132,15 @@ describe('FixedActivityService persistence shape', () => {
         const result = await service.getActivity('u1', 'bad-1');
         expect(result).toBeNull();
     });
+
+    it('getActivity returns null for a valid but differently-owned document rather than trusting the doc path alone', async () => {
+        firestore.getDoc.mockResolvedValue({
+            exists: () => true,
+            data: () => ({ ...validActivity, userId: 'someone-else', createdAt: '2026-08-01T00:00:00.000Z', updatedAt: '2026-08-01T00:00:00.000Z' }),
+            id: 'activity-1',
+        });
+        const service = new FixedActivityService();
+        const result = await service.getActivity('u1', 'activity-1');
+        expect(result).toBeNull();
+    });
 });

--- a/app/src/services/fixedActivityService.ts
+++ b/app/src/services/fixedActivityService.ts
@@ -1,0 +1,118 @@
+import { doc, getDoc, setDoc, deleteDoc, collection, query, where, getDocs, addDoc, type DocumentData } from 'firebase/firestore';
+import { getDb } from '../firebase';
+import type { FixedActivity } from '../engine/models';
+import type { DataIssue, DataState } from '../engine/dataState';
+import { validateFixedActivity } from '../engine/validation';
+import { getErrorCode } from '../utils/errors';
+
+type FixedActivityWithId = FixedActivity & { id: string };
+
+/** Builds a document payload containing only stored fields -- `id` is the document key,
+ *  not a stored field, mirroring goalService's storedGoalPayload. */
+function storedActivityPayload(activity: FixedActivity): DocumentData {
+    const payload: DocumentData = { ...activity };
+    delete payload.id;
+    return payload;
+}
+
+/**
+ * Persists `FixedActivity` at `users/{userId}/fixed_activities/{activityId}` (ADR-0002
+ * user-owned path) -- see docs/plans/phase-5-sequence-planning.md 5.3. Every write is
+ * validated client-side against the same shape firestore.rules enforces server-side, so a
+ * malformed document is rejected before the round trip rather than only at the rule.
+ */
+export class FixedActivityService {
+    private readonly collectionPath = 'fixed_activities';
+
+    /** All fixed activities whose `date` falls within [startDate, endDate] inclusive
+     *  (YYYY-MM-DD, Warsaw-local strings compare lexicographically). This is the read the
+     *  planner's week-ahead pipeline uses -- see WeekAheadOptions.fixedActivities. */
+    async getActivitiesInRangeState(userId: string, startDate: string, endDate: string): Promise<DataState<FixedActivityWithId[]>> {
+        try {
+            const collRef = collection(getDb(), 'users', userId, this.collectionPath);
+            const q = query(collRef, where('date', '>=', startDate), where('date', '<=', endDate));
+            const querySnapshot = await getDocs(q);
+            const activities: FixedActivityWithId[] = [];
+            const issues: DataIssue[] = [];
+            const revisions: string[] = [];
+            for (const activityDoc of querySnapshot.docs) {
+                const validation = validateFixedActivity({ ...activityDoc.data(), id: activityDoc.id });
+                if (!validation.isValid || !validation.data || validation.data.userId !== userId) {
+                    issues.push({ code: 'schema-validation-failed', documentPath: `users/${userId}/${this.collectionPath}/${activityDoc.id}` });
+                    continue;
+                }
+                activities.push({ ...validation.data, id: activityDoc.id });
+                if (typeof activityDoc.data().updatedAt === 'string') revisions.push(`${activityDoc.id}:${activityDoc.data().updatedAt}`);
+            }
+            if (issues.length > 0) return { status: 'INVALID', issues };
+            return { status: 'AVAILABLE', data: activities, revision: revisions.sort().join('|') || null };
+        } catch (error: unknown) {
+            return { status: 'UNAVAILABLE', operation: 'read fixed activities', retryable: getErrorCode(error) !== 'permission-denied' };
+        }
+    }
+
+    /** Convenience wrapper for callers that just want the plain list (e.g. UI forms) and
+     *  are fine treating any read failure as "no activities" -- the planner path above
+     *  uses the State-returning variant so it can distinguish absence from failure. */
+    async getActivitiesInRange(userId: string, startDate: string, endDate: string): Promise<FixedActivityWithId[]> {
+        const state = await this.getActivitiesInRangeState(userId, startDate, endDate);
+        return state.status === 'AVAILABLE' ? state.data : [];
+    }
+
+    async listAll(userId: string): Promise<FixedActivityWithId[]> {
+        const collRef = collection(getDb(), 'users', userId, this.collectionPath);
+        const q = query(collRef, where('userId', '==', userId));
+        const querySnapshot = await getDocs(q);
+        return querySnapshot.docs
+            .map(d => ({ ...d.data(), id: d.id } as FixedActivityWithId))
+            .sort((a, b) => a.date.localeCompare(b.date));
+    }
+
+    async getActivity(userId: string, activityId: string): Promise<FixedActivityWithId | null> {
+        const docRef = doc(getDb(), 'users', userId, this.collectionPath, activityId);
+        const docSnap = await getDoc(docRef);
+        if (!docSnap.exists()) return null;
+        return { ...docSnap.data(), id: docSnap.id } as FixedActivityWithId;
+    }
+
+    async createActivity(userId: string, activityData: Omit<FixedActivity, 'id' | 'userId' | 'createdAt' | 'updatedAt'>): Promise<FixedActivity> {
+        const rawData = { userId, ...activityData };
+        const validation = validateFixedActivity(rawData);
+        if (!validation.isValid) {
+            const errorMessages = validation.errors.map(e => `${e.field}: ${e.message}`).join('; ');
+            throw new Error(`Validation failed: ${errorMessages}`);
+        }
+        const validated = validation.data!;
+        const collRef = collection(getDb(), 'users', userId, this.collectionPath);
+        const docRef = await addDoc(collRef, storedActivityPayload(validated));
+        return { ...validated, id: docRef.id };
+    }
+
+    async updateActivity(userId: string, activityId: string, updates: Partial<FixedActivity>): Promise<FixedActivity> {
+        const existing = await this.getActivity(userId, activityId);
+        if (!existing) {
+            throw new Error('Fixed activity not found');
+        }
+        const updatedData = { ...existing, ...updates };
+        const validation = validateFixedActivity(updatedData);
+        if (!validation.isValid) {
+            const errorMessages = validation.errors.map(e => `${e.field}: ${e.message}`).join('; ');
+            throw new Error(`Validation failed: ${errorMessages}`);
+        }
+        const validated = validation.data!;
+        const docRef = doc(getDb(), 'users', userId, this.collectionPath, activityId);
+        await setDoc(docRef, storedActivityPayload(validated), { merge: true });
+        return validated;
+    }
+
+    async markCompleted(userId: string, activityId: string): Promise<FixedActivity> {
+        return this.updateActivity(userId, activityId, { isCompleted: true });
+    }
+
+    async deleteActivity(userId: string, activityId: string): Promise<void> {
+        const docRef = doc(getDb(), 'users', userId, this.collectionPath, activityId);
+        await deleteDoc(docRef);
+    }
+}
+
+export const fixedActivityService = new FixedActivityService();

--- a/app/src/services/fixedActivityService.ts
+++ b/app/src/services/fixedActivityService.ts
@@ -59,12 +59,18 @@ export class FixedActivityService {
         return state.status === 'AVAILABLE' ? state.data : [];
     }
 
+    /** Malformed documents are dropped rather than thrown, same contract as
+     *  `getActivitiesInRangeState` -- these are UI list callers, not the planner path, and
+     *  a validation failure here shouldn't crash the caller. */
     async listAll(userId: string): Promise<FixedActivityWithId[]> {
         const collRef = collection(getDb(), 'users', userId, this.collectionPath);
         const q = query(collRef, where('userId', '==', userId));
         const querySnapshot = await getDocs(q);
         return querySnapshot.docs
-            .map(d => ({ ...d.data(), id: d.id } as FixedActivityWithId))
+            .flatMap(d => {
+                const validation = validateFixedActivity({ ...d.data(), id: d.id });
+                return validation.isValid && validation.data ? [{ ...validation.data, id: d.id }] : [];
+            })
             .sort((a, b) => a.date.localeCompare(b.date));
     }
 
@@ -72,7 +78,9 @@ export class FixedActivityService {
         const docRef = doc(getDb(), 'users', userId, this.collectionPath, activityId);
         const docSnap = await getDoc(docRef);
         if (!docSnap.exists()) return null;
-        return { ...docSnap.data(), id: docSnap.id } as FixedActivityWithId;
+        const validation = validateFixedActivity({ ...docSnap.data(), id: docSnap.id });
+        if (!validation.isValid || !validation.data) return null;
+        return { ...validation.data, id: docSnap.id };
     }
 
     async createActivity(userId: string, activityData: Omit<FixedActivity, 'id' | 'userId' | 'createdAt' | 'updatedAt'>): Promise<FixedActivity> {

--- a/app/src/services/fixedActivityService.ts
+++ b/app/src/services/fixedActivityService.ts
@@ -79,7 +79,11 @@ export class FixedActivityService {
         const docSnap = await getDoc(docRef);
         if (!docSnap.exists()) return null;
         const validation = validateFixedActivity({ ...docSnap.data(), id: docSnap.id });
-        if (!validation.isValid || !validation.data) return null;
+        // The document's own `userId` field must match the requested owner -- unlike
+        // listAll's `where('userId', '==', userId)` query, a direct doc-path read has no
+        // query-level ownership filter, so a stored field that disagrees with the path
+        // (e.g. from a bug or a migration mistake) must not be trusted implicitly.
+        if (!validation.isValid || !validation.data || validation.data.userId !== userId) return null;
         return { ...validation.data, id: docSnap.id };
     }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -63,9 +63,10 @@ Architectural choices, system invariants, and technical trade-offs are documente
 * [**ADR-0010: Decision Provenance, Audit Records & Replay**](./adr/0010-decision-provenance-and-audit-replay.md) — `DataState` read semantics, immutable history revisions, persisted audits, `POLICY_VERSION`, and replay verification.
 * [**ADR-0011: Weekly Architecture — Session Anchors & Ranking Modifiers**](./adr/0011-weekly-architecture-anchors.md) — The anchor pre-pass and optimizer Patches 4–6, including why this composition should not be extended.
 * [**ADR-0014: Objective Credit V2 & Honest Delivered Load**](./adr/0014-objective-credit-v2-and-honest-load.md) — Fractional credit, canonical stimulus axes, delivered cost, and the deferred fatigue-fusion decision.
+* [**ADR-0015: Sequence Planning — Bounded Beam Search Prototype, Adoption Deferred**](./adr/0015-sequence-planning-and-session-role-model.md) — Phase 5.1's beam-search prototype, its comparison data against the production greedy planner, and why adoption is deferred rather than shipped or rejected.
 
 Reserved for work sequenced in [`docs/plans/`](./plans/), written with their phase:
-**0012** plan intent · **0013** structured injury constraints · **0014** objective credit V2 · **0015** sequence planning.
+**0012** plan intent · **0013** structured injury constraints.
 
 ---
 

--- a/docs/adr/0008-week-ahead-planning.md
+++ b/docs/adr/0008-week-ahead-planning.md
@@ -70,8 +70,9 @@ Firestore.
    Periodization is evaluated separately for each date in the strip, including lifecycle
    semantics for stale, completed, and DNF events. Each projected-day optimizer call
    receives that date's focus event and phase rather than reusing today's context.
-   `FixedActivity` still has no Firestore-backed source, so the generic weekly schedule
-   remains the fallback there.
+   `FixedActivity` had no Firestore-backed source at the time this ADR was written; Phase
+   5.3 (docs/plans/phase-5-sequence-planning.md) closed that gap -- see the "Fixed
+   activities" subsection of `docs/architecture/recommendation-engine.md`.
 
 6. **Projected picks become sequence context**: adherence-derived recent sessions seed
    the chain, and each selected today/tomorrow/projected template is appended using its
@@ -107,7 +108,9 @@ Firestore.
 ### Negative
 * Days 2+ are read as "session type", not exact duration/intensity -- the UI must keep
   surfacing that caveat, or the projection will be over-trusted.
-* Fixed activities are still absent from the projection, so the generic weekly schedule
-  can be optimistic on days that already contain an unrecorded commitment.
+* ~~Fixed activities are still absent from the projection, so the generic weekly schedule
+  can be optimistic on days that already contain an unrecorded commitment.~~ Closed by
+  Phase 5.3: `FixedActivity` now persists at `users/{userId}/fixed_activities` and feeds
+  the projection.
 * The sequence policy is intentionally limited to Strength; it does not prescribe a
   universal consecutive-day rule for endurance work.

--- a/docs/adr/0015-sequence-planning-and-session-role-model.md
+++ b/docs/adr/0015-sequence-planning-and-session-role-model.md
@@ -81,7 +81,7 @@ Produced by `npm run compare:sequence-search`
 | Aggregate rest/recovery share (11 scenarios) | 34.5% | 25.1% |
 | Aggregate hard constraint violations | 0 | 0 |
 | Golden week (`cycling_a_event_build_week`) invariant violations | none | none |
-| Wall-clock time, 11 scenarios (multi-week each) | 128ms | 730ms (**5.7x**) |
+| Wall-clock time, 11 scenarios | 128ms | 730ms (**5.7x**) |
 
 Both remain within the Phase 0 aggregate rest-day bound (`[5%, 40%]`, see
 `scripts/simulate-scenarios.mjs`). Per-scenario, beam search **resolved a weekly

--- a/docs/adr/0015-sequence-planning-and-session-role-model.md
+++ b/docs/adr/0015-sequence-planning-and-session-role-model.md
@@ -1,0 +1,150 @@
+# ADR-0015: Sequence Planning — Bounded Beam Search Prototype, Adoption Deferred
+
+* **Status:** Accepted (decision: retain the greedy loop; prototype retained, not wired live)
+* **Date:** 2026-08-08
+* **Deciders:** Core Engineering Team
+
+---
+
+## Context
+
+[`docs/plans/phase-5-sequence-planning.md`](../plans/phase-5-sequence-planning.md) 5.1
+observed that `generateWeekAheadPlan` (`planner.ts`) walks its "projected" tier one day at
+a time, greedily: each day takes `rankCandidates`' rank-0 pick with no visibility into how
+that choice constrains the days that follow. The plan's own example:
+
+```text
+Tue threshold / Thu easy aerobic / Sat race-specific        (whole-week judgement)
+Tue threshold / Wed threshold / Thu rest / Fri race-specific (greedy, myopic)
+```
+
+is a class of judgement the greedy architecture cannot structurally make, even though each
+of its six-plus named ranking policies is individually defensible. The plan proposed
+bounded beam search (width 10-20, 7-day horizon, small per-day candidate set, hard
+constraints rejected before scoring, whole-sequence scoring) as "sufficient" machinery,
+and was explicit that **approving the plan approves building and measuring 5.1, not
+shipping it regardless of outcome** — an explicit adoption decision, recorded here with
+the comparison data, is required either way.
+
+## Decision
+
+**The greedy loop remains the live default.** A working beam-search prototype was built
+(`app/src/engine/sequenceSearch.ts`, `beamSearchWeekAheadPlan` /
+`generateWeekAheadPlanWithIntentBeamSearch`) and benchmarked against production greedy on
+the Phase 0 invariants and the semantic scenario harness. The result is genuinely
+positive on the metrics the harness can score — not a negative result — but two real,
+unresolved costs (compute overhead, and a materially different rest-day frequency this
+harness cannot judge as better or worse on its own) mean adoption is deferred, not
+rejected. This satisfies the plan's completion criterion: *"If it does not measurably
+improve them, the correct outcome is to record that result and keep the greedy loop —
+that is a successful increment, not a failed one."* Here the harness result is positive,
+but the decision to defer is deliberate for reasons the harness doesn't capture — see
+Consequences.
+
+### Implementation approach
+
+Deliberately maximal reuse, not a parallel engine. Per (branch, day), the prototype calls
+the exact same `rankCandidates` Phase-3 lexicographic pipeline the greedy loop uses --
+hard-gate rejection (`excludedReasons`) already happens *before* `rankCandidates` returns
+a score at all, which is the plan's "reject hard spacing/recovery violations before
+scoring" requirement, inherited for free from the Phase 3 prerequisite rather than
+reimplemented. What differs:
+
+* **Candidates per day:** the greedy loop keeps only `rankCandidates`' rank-0 result; the
+  prototype keeps its top `candidatesPerDay` (default 5) accepted results per branch.
+* **Scoring:** each branch accumulates a `cumulativeScore` (sum of each chosen day's
+  `utilityScore`) across the whole sequence. Pruning after each day keeps the top
+  `beamWidth` (default 15) branches by *cumulative* score, not that day's score alone --
+  the mechanism that lets the search prefer a slightly weaker day if it keeps stronger
+  options open for the rest of the week.
+* Today and tomorrow (confirmed/provisional tiers) are copied verbatim from the greedy
+  inputs, unsearched -- this experiment concerns only the "projected" tier's day-by-day
+  walk, matching the plan's own framing.
+
+**Correctness check:** with `beamWidth=1, candidatesPerDay=1` the prototype is
+mathematically forced to reduce to exactly the greedy algorithm (only one branch, only
+one candidate ever considered). `sequenceSearch.test.ts` asserts this produces an
+*identical* day-by-day plan to `generateWeekAheadPlan` for the same inputs -- direct
+evidence the reused fatigue/objective/ranking wiring is faithful, not a subtly different
+reimplementation.
+
+## Comparison data
+
+Produced by `npm run compare:sequence-search`
+(`app/scripts/compare-sequence-search.mjs`), which runs every scenario in
+`src/engine/simulation/scenarios.ts` through both `generateWeekAheadPlanWithIntent`
+(greedy) and `generateWeekAheadPlanWithIntentBeamSearch` (beam, default width 15 /
+5 candidates per day), using the identical `runScenario` harness and metrics for each.
+
+| Metric | Greedy | Beam |
+|---|---|---|
+| Aggregate rest/recovery share (11 scenarios) | 34.5% | 25.1% |
+| Aggregate hard constraint violations | 0 | 0 |
+| Golden week (`cycling_a_event_build_week`) invariant violations | none | none |
+| Wall-clock time, 11 scenarios (multi-week each) | 128ms | 730ms (**5.7x**) |
+
+Both remain within the Phase 0 aggregate rest-day bound (`[5%, 40%]`, see
+`scripts/simulate-scenarios.mjs`). Per-scenario, beam search **resolved a weekly
+objective that greedy left unresolved** in three of eleven scenarios
+(`cycling_gran_fondo_A`, `cycling_criterium_A`, `general_target_generic`), and never left
+unresolved an objective greedy resolved. This is the concrete form of the plan's
+hypothesis: the whole-sequence view sometimes avoids a myopic day-N pick that would have
+blocked a day-(N+2) opportunity, and that shows up as more objectives actually getting
+satisfied within the week, not just a different-looking plan.
+
+Beam search also chose **fewer Mobility/Recovery days and more active training days**
+in nearly every scenario (see `artifacts/sequence-search-comparison/comparison.json`,
+regenerable, gitignored) -- a real, systematic behavioral shift, not incidental noise.
+
+## Consequences
+
+### Positive
+* A genuine, reusable prototype exists (`sequenceSearch.ts`), built on exactly the
+  Phase 3 lexicographic primitives the plan named as prerequisite, with a hard
+  correctness check (`beamWidth=1` degeneracy) against the production algorithm.
+* On every metric the Phase 0 harness can score, beam search is at least as good as
+  greedy and strictly better on objective resolution in several scenarios, with zero new
+  hard-constraint or golden-week violations.
+* The golden-week coaching contract (`goldenWeek.test.ts`) now runs against *both*
+  algorithms permanently, not just as a one-off comparison script -- a durable regression
+  guard for the prototype, and a documented reference point if this decision is revisited.
+
+### Negative / why adoption is deferred, not rejected
+* **~5.7x compute overhead** for the same scenarios. ADR-0008 §3 already flags that the
+  week-ahead strip recomputes on every dashboard load; this multiplier needs profiling
+  against real single-call latency (not just the batch scenario-harness total) and,
+  likely, memoization before it could ship, exactly as the plan's own risk section
+  anticipated ("Measure before shipping; memoise the pre-pass if needed").
+* **A materially different rest-day frequency is a coaching judgement call, not a
+  correctness question.** Both 34.5% and 25.1% satisfy the Phase 0 bound; which is
+  *better* for real athlete outcomes (recovery adequacy, adherence, injury risk) is not
+  something an automated invariant harness can decide, and this repository's stated
+  practice is not to make that call unilaterally in the same session that built the
+  prototype being evaluated.
+* **Depth of blast radius.** `generateWeekAheadPlan` is the live path for every user's
+  week-ahead strip. A first-pass, single-session prototype -- however well it reuses
+  existing primitives -- has not had the review cycles, edge-case testing, or staged
+  rollout the existing greedy loop has accumulated across Phases 0-4.
+
+### Recorded follow-up (not committed to a timeline)
+Before revisiting adoption: (1) profile single-call latency and add memoization if
+needed; (2) get explicit product/coaching sign-off on the rest-day-frequency shift,
+informed by the comparison data above; (3) expand scenario coverage (multi-event,
+injury-constrained, fixed-activity-heavy weeks) before trusting the comparison beyond
+the 11 scenarios exercised here.
+
+## Code References
+
+* [`app/src/engine/sequenceSearch.ts`](../../app/src/engine/sequenceSearch.ts) — the beam-search prototype and its `generateWeekAheadPlanWithIntent`-compatible wrapper.
+* [`app/src/engine/sequenceSearch.test.ts`](../../app/src/engine/sequenceSearch.test.ts) — unit tests, including the `beamWidth=1` greedy-degeneracy correctness check.
+* [`app/src/engine/goldenWeek.test.ts`](../../app/src/engine/goldenWeek.test.ts) — the golden-week coaching contract, run against both algorithms.
+* [`app/scripts/compare-sequence-search.mjs`](../../app/scripts/compare-sequence-search.mjs) — the comparison harness (`npm run compare:sequence-search`).
+* [`app/src/engine/simulation/analyze.ts`](../../app/src/engine/simulation/analyze.ts) — `runScenario`'s `planGenerator` parameter, the seam this comparison is built on.
+* [`app/src/engine/planner.ts`](../../app/src/engine/planner.ts) — the unchanged, live `generateWeekAheadPlan`; several small pure helpers were exported (no behavior change) for `sequenceSearch.ts` to reuse rather than duplicate.
+
+---
+
+## Related decisions
+
+* [ADR-0008: Rolling 7-Day Week-Ahead Planning](./0008-week-ahead-planning.md) — the greedy loop and confidence tiers this experiment measured itself against; §3's live-recompute cost concern is exactly what beam search's 5.7x overhead needs to clear before adoption.
+* [ADR-0007: Adaptive Multi-Sport Engine Architecture](./0007-adaptive-multisport-engine-architecture.md) — the 6-tier engine and lexicographic ranking this prototype reuses rather than reimplements.

--- a/docs/analysis/simulation-baseline.json
+++ b/docs/analysis/simulation-baseline.json
@@ -1107,20 +1107,20 @@
       "totalDays": 28,
       "categoryDistribution": {
         "Moderate Endurance": 5,
-        "Easy Endurance": 7,
-        "Mobility/Recovery": 12,
+        "Easy Endurance": 6,
+        "Mobility/Recovery": 13,
         "Lower-body Strength": 2,
         "Upper-body Strength": 2
       },
       "modalityDistribution": {
-        "Running": 12,
-        "Mobility": 12,
+        "Running": 11,
+        "Mobility": 13,
         "Strength": 4
       },
-      "restOrRecoveryDayCount": 12,
-      "restOrRecoveryDayPct": 42.9,
+      "restOrRecoveryDayCount": 13,
+      "restOrRecoveryDayPct": 46.4,
       "maxConsecutiveSameTemplateStreakWithinCall": 1,
-      "maxConsecutiveSameTemplateStreakAcrossWeeks": 1,
+      "maxConsecutiveSameTemplateStreakAcrossWeeks": 2,
       "objectiveResolution": [
         {
           "key": "zone2_aerobic",
@@ -1214,30 +1214,40 @@
           "date": "2026-08-14",
           "objectiveKey": "strength_maintenance",
           "objectiveTitle": "Strength & Neuromuscular Maintenance",
-          "templateId": "str_upper_01",
-          "templateTitle": "Upper Body Push/Pull",
+          "templateId": "str_lower_01",
+          "templateTitle": "Lower Body Strength & Power",
           "modality": "Strength",
           "earnedCredit": 0.09999999999999998
         },
         {
           "weekIndex": 2,
           "date": "2026-08-21",
-          "objectiveKey": "strength_maintenance",
-          "objectiveTitle": "Strength & Neuromuscular Maintenance",
-          "templateId": "str_lower_01",
-          "templateTitle": "Lower Body Strength & Power",
-          "modality": "Strength",
-          "earnedCredit": 0.19999999999999996
-        },
-        {
-          "weekIndex": 3,
-          "date": "2026-08-28",
           "objectiveKey": "zone2_aerobic",
           "objectiveTitle": "Aerobic Base (Zone 2)",
           "templateId": "end_mod_01",
           "templateTitle": "Steady-State Tempo Run",
           "modality": "Running",
           "earnedCredit": 0.09999999999999987
+        },
+        {
+          "weekIndex": 2,
+          "date": "2026-08-21",
+          "objectiveKey": "threshold_quality",
+          "objectiveTitle": "Threshold Development",
+          "templateId": "end_mod_01",
+          "templateTitle": "Steady-State Tempo Run",
+          "modality": "Running",
+          "earnedCredit": 0.19999999999999996
+        },
+        {
+          "weekIndex": 2,
+          "date": "2026-08-25",
+          "objectiveKey": "strength_maintenance",
+          "objectiveTitle": "Strength & Neuromuscular Maintenance",
+          "templateId": "str_upper_01",
+          "templateTitle": "Upper Body Push/Pull",
+          "modality": "Strength",
+          "earnedCredit": 0.09999999999999998
         },
         {
           "weekIndex": 3,
@@ -1247,11 +1257,21 @@
           "templateId": "end_mod_01",
           "templateTitle": "Steady-State Tempo Run",
           "modality": "Running",
-          "earnedCredit": 0.8
+          "earnedCredit": 0.19999999999999996
+        },
+        {
+          "weekIndex": 3,
+          "date": "2026-09-01",
+          "objectiveKey": "strength_maintenance",
+          "objectiveTitle": "Strength & Neuromuscular Maintenance",
+          "templateId": "str_upper_01",
+          "templateTitle": "Upper Body Push/Pull",
+          "modality": "Strength",
+          "earnedCredit": 0.19999999999999996
         }
       ],
       "utilityDiagnostics": {
-        "fragileSelectionCount": 14,
+        "fragileSelectionCount": 11,
         "lowerBenefitSelectionCount": 0,
         "trainTierRestOrRecoveryCount": 0
       },
@@ -1302,9 +1322,9 @@
       ],
       "anchorScopeNote": "Anchor-day nomination only requires SOME focus event (Race-Specific Endurance templates' phaseEligibility.requiresFocusEvent doesn't check event category), so a nomination can appear even here -- but the optimizer's event-priority penalty for non-matching modalities makes it unlikely to actually win the day's pick. Treat eventSpecificAnchorHit/qualityAnchorHit, not the raw nomination, as the meaningful signal for non-cycling scenarios.",
       "fatigueTierDayCounts": {
-        "train": 4,
+        "train": 3,
         "modify": 4,
-        "recover": 12
+        "recover": 13
       },
       "constraintViolations": []
     },

--- a/docs/architecture/recommendation-engine.md
+++ b/docs/architecture/recommendation-engine.md
@@ -201,6 +201,27 @@ contract is finite `volume ∈ [0,1]`, `intensity ∈ [0,1.2]`.
 
 Recommendation provenance persists both planned and execution dose when available.
 
+### Taper as an explicit contract (Phase 5.7, `microcycle.ts`, `periodization.ts`, `planSchedule.ts`)
+
+Before this, `taperActive`/`volumeScale` reduced volume, but nothing represented "preserve
+useful, event-specific intensity" as its own thing -- `generateWeeklyObjectives` simply
+stopped generating a `race_specific_endurance` objective for the whole taper window
+(`!phaseWeights.taperActive`), so whatever survived `phaseEligibility.requiresTaper`
+gating and utility ranking was accidental, not requested. `event-plan.ts`'s
+`taper_sharpening`/`race_week_strength` coverage roles already named the real intent;
+nothing consumed them as objective targets.
+
+Both `generateWeeklyObjectives` branches (generic days-to-event and plan-derived) now
+generate a taper-calibrated `race_specific_endurance` objective during `taperActive`
+instead of omitting it, and lower the `strength_maintenance` target to a race-week-primer
+level -- calibrated against `end_taper_sharpen_01`'s own (deliberately lower) stimulus
+profile in `templates.ts`, not the full peak-block `end_race_sim_01` bar, which a taper
+session structurally cannot clear. `PlanObjectiveDefinition` (`planSchedule.ts`) gained an
+optional `role: PlanSessionRole` field -- previously declared but never assigned to
+anything -- and the authored September event plan's taper block now actually requests its
+own `taper_sharpening`/`race_week_strength` coverage keys instead of only the generic
+`easy_aerobic` one.
+
 ---
 
 ## Candidate ranking (`optimizer.ts`)

--- a/docs/architecture/recommendation-engine.md
+++ b/docs/architecture/recommendation-engine.md
@@ -388,6 +388,22 @@ shifting a movable placeholder. See
 [docs/plans/phase-5-sequence-planning.md](../plans/phase-5-sequence-planning.md) 5.3 for
 the full storage/validation contract.
 
+### Bounded sequence search prototype (Phase 5.1, `sequenceSearch.ts`) -- not live
+
+The "projected" tier above is a greedy walk: each day takes `rankCandidates`' rank-0 pick
+with no visibility into how that choice constrains later days. `sequenceSearch.ts`'s
+`beamSearchWeekAheadPlan` is a bounded beam-search prototype (width 15, 5 candidates/day
+by default) that scores whole partial sequences instead, reusing `rankCandidates`'
+existing hard-gate-before-scoring separation rather than reimplementing it. Benchmarked
+against greedy on the Phase 0 invariants and semantic scenario harness
+(`npm run compare:sequence-search`): zero new hard-constraint or golden-week violations,
+and strictly better weekly-objective resolution in several scenarios, at a real ~5.7x
+compute cost and a materially lower rest-day frequency the harness can't judge as better
+or worse on its own. **Adoption is deferred, not rejected** -- see
+[ADR-0015](../adr/0015-sequence-planning-and-session-role-model.md) for the full
+comparison data and reasoning. Greedy (`generateWeekAheadPlan`) remains the live default;
+`sequenceSearch.ts` is not imported by any production code path.
+
 ---
 
 ## Verification & audit tooling
@@ -397,6 +413,9 @@ Executed via `cd app && npm run simulate:scenarios`. Runs synthetic athlete scen
 
 ### Recommendation decision replay (`replay:recommendation`)
 Executed via `cd app && npm run replay:recommendation -- <audit.json>`. Accepts a JSON snapshot of a historical recommendation and passes it into `replayRecommendationAudit()` ([`app/src/engine/replay.ts`](../../app/src/engine/replay.ts)). The current policy version can be verified for reproducibility. Known historical policy versions remain auditable but are explicitly rejected as executable replay unless that historical decision function is bundled in a future build.
+
+### Sequence-search comparison (`compare:sequence-search`)
+Executed via `cd app && npm run compare:sequence-search`. Runs every scenario through both the production greedy planner and the Phase 5.1 beam-search prototype ([`app/src/engine/sequenceSearch.ts`](../../app/src/engine/sequenceSearch.ts)) using the identical `runScenario` harness, and reports the comparison (rest-day share, constraint violations, golden-week invariants, per-scenario deltas, timing). Outputs `comparison.json` to `app/artifacts/sequence-search-comparison/` (gitignored, regenerable). See [ADR-0015](../adr/0015-sequence-planning-and-session-role-model.md).
 
 ---
 

--- a/docs/architecture/recommendation-engine.md
+++ b/docs/architecture/recommendation-engine.md
@@ -152,6 +152,36 @@ Keyword matching remains a last-resort compatibility path for old/external recor
 structured stimulus. A match contributes `0.5` credit to the **same** ledger rather than a
 parallel counter, making mixed structured/legacy replay order-independent.
 
+### Evidence hierarchy for completed training (Phase 5.5, `completedTraining.ts`)
+
+Generalises the coarse modality x intensity inference above into a named, ordered
+`EvidenceTier` (strongest to weakest): `exactPrescribedMatch` (adherence confirms a
+catalog template with an authored `stimulusProfile`) → `completedStructuredWorkout` /
+`measuredEffort` (Garmin `activityTrainingLoad` alongside Training Effect -- the closest
+currently-ingested proxy for "completedStructuredWorkout" and per-interval
+power/HR/cadence structure, which nothing ingests yet) → `garminTrainingEffect` →
+`durationIntensity` (an intensity tag alone) → `athleteClassification` (modality guessed
+from free text) → `genericModalityFallback` (nothing known at all).
+`classifyGarminTier`/`stimulusConfidenceForTier` produce `CompletedExposure`'s existing
+`stimulusConfidence` ('exact' | 'inferred' | 'unknown') from this ladder, replacing what
+used to be an ad hoc `exactTemplateMatch`/`hasStimulus`/`modality` check.
+
+`stimulus.ts`'s `CONFIDENCE_CREDIT_WEIGHT` (exact 1.0, inferred 0.75, unknown 0.4) then
+discounts `deriveObjectiveCreditFromProfile`'s earned credit by that confidence -- every
+caller that doesn't pass a confidence defaults to `'exact'` (unchanged full-credit
+behavior, e.g. `planner.ts` scoring an authored candidate template). This closes the
+asymmetry the plan named: `DEFAULT_STIMULUS_BY_MODALITY.Unknown` used to be all-zero even
+though `DEFAULT_COST_BY_MODALITY.Unknown` was not, so an unplanned, unclassifiable session
+was charged fatigue but credited no adaptation at all. It now carries a real, deliberately
+conservative generic profile, discounted rather than zeroed.
+
+A stimulus profile no longer requires a *known* modality to be creditable --
+`genericModalityFallback` still credits a modality-agnostic objective. This is safe only
+because `deriveObjectiveCreditFromProfile` now **fails closed**: a modality- or
+category-scoped objective is rejected (not silently skipped) when the evidence's
+modality/category is unknown, rather than the previous behavior where an absent
+`context.modality`/`context.category` bypassed the restriction entirely.
+
 ---
 
 ## Planned and execution dose authority (`trainingIntent.ts`, `dose.ts`)

--- a/docs/architecture/recommendation-engine.md
+++ b/docs/architecture/recommendation-engine.md
@@ -216,6 +216,29 @@ Preferences rank; they never unlock. An avoided modality is a hard exclude on Pa
 0.2× soft penalty on Path B — a deliberate distinction, since taste must never behave like
 a safety constraint ([ADR-0007](../adr/0007-adaptive-multisport-engine-architecture.md) §6).
 
+### Injury gate sub-ordering (Phase 5.4)
+
+Within the "clinical / safety gates" step above, `injuryPolicy.ts` itself has a total
+order that a single `soreness: 1-10` scalar can't express, because it can't distinguish a
+knee from an Achilles from general DOMS:
+
+```text
+InjuryConstraint (hard, persisted)   TrainingSettings.injuries -- exclude/limit never weakened
+        ↓
+observed tissue response (may tighten)   today's per-region check-in (DailyCheckin.tsx)
+        ↓
+wearable-derived readiness (may tighten) HRV/RHR/body battery -- acts through the separate
+                                          fatigue/mode pipeline, not this gate at all
+```
+
+`resolveEffectiveInjuryConstraints` (called from `adapters.ts`
+`mapContextFromGoalsAndTrainingSettings`) implements the first two steps: it merges a
+day's `RegionTissueResponse[]` into the standing `InjuryConstraint[]`, but only ever
+raises a region's severity for that one read, never lowers it, and never persists the
+result back to `TrainingSettings`. Wearable-derived readiness has no parameter into that
+function at all — a structural guarantee, not just tested behavior, that a good HRV
+reading can't loosen what tissue response or the injury constraint decided.
+
 ---
 
 ## Completed load and fatigue (`completedTraining.ts`, `fatigue.ts`)

--- a/docs/architecture/recommendation-engine.md
+++ b/docs/architecture/recommendation-engine.md
@@ -222,6 +222,33 @@ anything -- and the authored September event plan's taper block now actually req
 own `taper_sharpening`/`race_week_strength` coverage keys instead of only the generic
 `easy_aerobic` one.
 
+### Multi-event: one taper authority, multiple demand contributors (Phase 5.6, `periodization.ts`)
+
+`evaluatePeriodizationPhase` still picks exactly one governing event (the **taper
+authority**) -- but now by a full, commented total order: priority, then proximity, then
+planning date, then event id as a determinism backstop (never a real ranking signal). Two
+events genuinely tied through every real criterion surface via the new
+`governingEventTie` field rather than being silently resolved by the id backstop as if it
+meant something.
+
+Every other eligible, scheduled event within a 35-day window (matching the existing
+Specificity-phase threshold) is a **demand contributor**: `objectivesFromDemand` (shared
+with Phase 5.7's own objective generation) derives objectives from *that event's own*
+demand vector, category, and own taper state -- never a blended vector, which is the
+reason this sits after Phase 2's explicit objectives at all. `resolveMultiEventObjectives`
+unions a contributor's objectives into the authority's own by `ObjectiveKey`: on a
+collision the authority's title/qualification/targetStimulus/id win, and only the
+required amount grows, via `max()` -- two similar B-events never demand double one
+B-event's work by summing. A contributor's `threshold_quality` objective landing inside
+the authority's taper window is dropped, not silently reweighted, with an athlete-facing
+reason recorded (`DroppedContributorObjective.message`).
+
+Only the taper authority ever sets `volumeScale`/`intensityScale` -- contributors supply
+objectives only. Wired into `planner.ts`'s `prepareWeekAheadPlanSeed`, reaching the live
+week-ahead pipeline for any athlete with more than one active dated event; a no-op
+otherwise (`simulate:diff` confirms zero semantic change against the committed baseline).
+The plan-derived path (`PlanDefinition`) is not wired to contributors in this increment.
+
 ---
 
 ## Candidate ranking (`optimizer.ts`)

--- a/docs/architecture/recommendation-engine.md
+++ b/docs/architecture/recommendation-engine.md
@@ -261,6 +261,29 @@ Phase 3 introduced a single, unified ranking path (`rankCandidates`) driven by s
 
 Strength-maintenance benefit takes the stronger of `maxStrength` and `hypertrophy` target/evidence rather than allowing field order to choose which axis counts.
 
+### The planner/workout-library boundary (Phase 5.2, `planningCandidate.ts`)
+
+Detailed `WorkoutDefinition`s (the prescription catalog) already carry recovery hours,
+mechanical/eccentric load, technical environment, contraindications, and per-workout
+minimum spacing after hard lower-body work -- but the planner selects a coarse
+`SessionTemplate` first, so that richer data used to arrive only *after* the decision it
+should have informed. Concretely: `evaluateRecoveryConstraints`'s hard-lower-body spacing
+gate was a flat 2-day rule with no per-workout data behind it at all.
+
+`PlanningCandidate` (`derivePlanningCandidate`, `PLANNING_CANDIDATE_INDEX`) resolves each
+catalog workout against its linked engine template -- enough semantics to sequence a
+week, without dragging blocks/variants/parameters into the planner; prescription
+generation (`resolveWorkoutPrescription`) stays downstream and unchanged. Wired into
+`OptimizationOptions.resolveMinimumDaysAfterHardLowerBody` (optional, defaults to the
+identical flat rule so every caller that doesn't pass it is unaffected): a workout's own
+`eligibility.minimumDaysAfterHardLowerBody` can now tighten *or* correctly loosen that
+gate per workout instead of one generic number for every lower-body session.
+
+Lives in `engine/`, not `workouts/models.ts` as a first read of the type might suggest --
+`engine/models.ts` already imports from `workouts/models.ts`, so a type referencing
+`SessionRole`/`Modality`/`WorkoutStimulusProfile`/`TrainingEnvironment` inside
+`workouts/models.ts` would make that dependency circular.
+
 ---
 
 ## Authority ordering

--- a/docs/architecture/recommendation-engine.md
+++ b/docs/architecture/recommendation-engine.md
@@ -248,6 +248,22 @@ Forecast recommendations never mutate completed credit. They accumulate in
 The planner's `objectiveCredits` display is derived from the same V2 objective-credit
 function used by the live ledger, not the old `stimulusCoverage >= 0.6` model.
 
+### Fixed activities (Phase 5.3)
+
+`FixedActivity` (external commitments -- a booked class, a match, travel) is persisted at
+`users/{userId}/fixed_activities/{activityId}` via `fixedActivityService.ts`, the same
+user-owned/validated-at-the-rule pattern as `goals` (ADR-0002). `Home.tsx` reads the
+current week's activities and passes them into `WeekAheadOptions.fixedActivities`, which
+`resolveWeeklyAnchors`/`resolveAvailability` (`schedule.ts`) already consumed -- the gap
+this closed was the absent Firestore source, not the consuming logic. An
+`availabilityOverride` on an activity caps that day's whole training budget (e.g. a travel
+day) before the activity's own `durationMin` is deducted; several overrides on the same
+day take the most restrictive. `fixed` (movable vs immovable) is captured now but not yet
+consumed -- it becomes load-bearing once sequence search (5.1/5.2) can reason about
+shifting a movable placeholder. See
+[docs/plans/phase-5-sequence-planning.md](../plans/phase-5-sequence-planning.md) 5.3 for
+the full storage/validation contract.
+
 ---
 
 ## Verification & audit tooling

--- a/docs/plans/phase-5-sequence-planning.md
+++ b/docs/plans/phase-5-sequence-planning.md
@@ -16,7 +16,7 @@ Ordered by the increment sequence below, **not** by section number.
 
 | Order | Task | Status | Summary | Primary files |
 |:--:|---|:--:|---|---|
-| 1 | 5.3 | `[ ]` | Persist `FixedActivity` under a user-owned path with rules + emulator tests | `app/firestore.rules`, new `fixedActivityService.ts`, `app/src/engine/schedule.ts`, `planner.ts` |
+| 1 | 5.3 | `[x]` | Persist `FixedActivity` under a user-owned path with rules + emulator tests | `app/firestore.rules`, new `fixedActivityService.ts`, `app/src/engine/schedule.ts`, `planner.ts` |
 | 2 | 5.4 | `[ ]` | Per-region tissue state; may only tighten a Phase-1 injury constraint | `app/src/engine/models.ts`, `components/DailyCheckin.tsx`, `injuryPolicy.ts` |
 | 3 | 5.5 | `[ ]` | Evidence hierarchy for completed training, carrying `stimulusConfidence` | `app/src/engine/completedTraining.ts` |
 | 4 | 5.7 | `[ ]` | Taper as an explicit plan contract rather than an emergent side effect | `app/src/workouts/event-plan.ts`, `app/src/engine/periodization.ts` |
@@ -125,7 +125,7 @@ interface PlanningCandidate {
 
 Prescription generation stays downstream and unchanged.
 
-## `[ ]` 5.3 — Persist fixed activities
+## `[x]` 5.3 — Persist fixed activities
 
 `FixedActivity` exists in the domain and `WeekAheadOptions.fixedActivities` accepts it,
 but there is no Firestore-backed source (ADR-0008 §5 admits this). For a multi-sport

--- a/docs/plans/phase-5-sequence-planning.md
+++ b/docs/plans/phase-5-sequence-planning.md
@@ -18,7 +18,7 @@ Ordered by the increment sequence below, **not** by section number.
 |:--:|---|:--:|---|---|
 | 1 | 5.3 | `[x]` | Persist `FixedActivity` under a user-owned path with rules + emulator tests | `app/firestore.rules`, new `fixedActivityService.ts`, `app/src/engine/schedule.ts`, `planner.ts` |
 | 2 | 5.4 | `[x]` | Per-region tissue state; may only tighten a Phase-1 injury constraint | `app/src/engine/models.ts`, `components/DailyCheckin.tsx`, `injuryPolicy.ts` |
-| 3 | 5.5 | `[ ]` | Evidence hierarchy for completed training, carrying `stimulusConfidence` | `app/src/engine/completedTraining.ts` |
+| 3 | 5.5 | `[x]` | Evidence hierarchy for completed training, carrying `stimulusConfidence` | `app/src/engine/completedTraining.ts` |
 | 4 | 5.7 | `[ ]` | Taper as an explicit plan contract rather than an emergent side effect | `app/src/workouts/event-plan.ts`, `app/src/engine/periodization.ts` |
 | 5 | 5.6 | `[ ]` | Multi-event: one taper authority, multiple demand contributors | `app/src/engine/periodization.ts` |
 | 6 | 5.2 | `[ ]` | `PlanningCandidate` carries spacing/recovery metadata into the decision | `app/src/workouts/models.ts`, `app/src/engine/planner.ts` |
@@ -196,7 +196,7 @@ wearable-derived readiness (may tighten). Test all three pairwise conflicts.
 Fatigue estimates remain guidance; observed local response outranks *wearable* readiness,
 not the injury gate.
 
-## `[ ]` 5.5 — Evidence hierarchy for completed training
+## `[x]` 5.5 — Evidence hierarchy for completed training
 
 Phase 1.2 ships a coarse modality×intensity stimulus inference. This generalises it:
 

--- a/docs/plans/phase-5-sequence-planning.md
+++ b/docs/plans/phase-5-sequence-planning.md
@@ -17,7 +17,7 @@ Ordered by the increment sequence below, **not** by section number.
 | Order | Task | Status | Summary | Primary files |
 |:--:|---|:--:|---|---|
 | 1 | 5.3 | `[x]` | Persist `FixedActivity` under a user-owned path with rules + emulator tests | `app/firestore.rules`, new `fixedActivityService.ts`, `app/src/engine/schedule.ts`, `planner.ts` |
-| 2 | 5.4 | `[ ]` | Per-region tissue state; may only tighten a Phase-1 injury constraint | `app/src/engine/models.ts`, `components/DailyCheckin.tsx`, `injuryPolicy.ts` |
+| 2 | 5.4 | `[x]` | Per-region tissue state; may only tighten a Phase-1 injury constraint | `app/src/engine/models.ts`, `components/DailyCheckin.tsx`, `injuryPolicy.ts` |
 | 3 | 5.5 | `[ ]` | Evidence hierarchy for completed training, carrying `stimulusConfidence` | `app/src/engine/completedTraining.ts` |
 | 4 | 5.7 | `[ ]` | Taper as an explicit plan contract rather than an emergent side effect | `app/src/workouts/event-plan.ts`, `app/src/engine/periodization.ts` |
 | 5 | 5.6 | `[ ]` | Multi-event: one taper authority, multiple demand contributors | `app/src/engine/periodization.ts` |
@@ -174,7 +174,7 @@ Emulator cases beyond the three ownership ones: out-of-range `durationMin`, an
 and a malformed `date`. Each must be **denied** — these are the cases a buggy or
 tampered client actually produces.
 
-## `[ ]` 5.4 — Local tissue state
+## `[x]` 5.4 — Local tissue state
 
 One scalar soreness value cannot distinguish knee from Achilles from calf from adductor
 from general DOMS. Extend the check-in to per-region response (morning state, pain during

--- a/docs/plans/phase-5-sequence-planning.md
+++ b/docs/plans/phase-5-sequence-planning.md
@@ -1,6 +1,9 @@
 # Phase 5 — Sequence planning, real inputs, and the feedback loop
 
-* **Status:** Ready — approved as the destination; increments ordered below. Not the next thing to build.
+* **Status:** Complete — all seven increments landed in the approved order. 5.1's
+  completion is a recorded adoption decision (retain greedy; see
+  [ADR-0015](../adr/0015-sequence-planning-and-session-role-model.md)), not a promotion,
+  per the plan's own definition of done for that increment.
 * **Depends on:** Phases 0–4
 * **Addresses:** the V2 Plan Intent cutover proper
 * **Rough effort:** multi-week; ship as independent increments, not one landing
@@ -22,7 +25,7 @@ Ordered by the increment sequence below, **not** by section number.
 | 4 | 5.7 | `[x]` | Taper as an explicit plan contract rather than an emergent side effect | `app/src/workouts/event-plan.ts`, `app/src/engine/periodization.ts` |
 | 5 | 5.6 | `[x]` | Multi-event: one taper authority, multiple demand contributors | `app/src/engine/periodization.ts` |
 | 6 | 5.2 | `[x]` | `PlanningCandidate` carries spacing/recovery metadata into the decision | `app/src/workouts/models.ts`, `app/src/engine/planner.ts` |
-| 7 | 5.1 | `[ ]` | Bounded sequence search — **build and measure**, adoption conditional (D-BEAM) | `app/src/engine/planner.ts` |
+| 7 | 5.1 | `[x]` | Bounded sequence search — **build and measure**, adoption conditional (D-BEAM) | `app/src/engine/planner.ts` |
 
 **5.1 is an experiment, not a scheduled migration.** Marking it `[x]` requires a recorded
 adoption decision with harness data — retaining the greedy loop is a valid completion.
@@ -60,7 +63,7 @@ increment, not a failed one. Increments 1–6 stand on their own either way.
 
 ---
 
-## `[ ]` 5.1 — Bounded sequence search
+## `[x]` 5.1 — Bounded sequence search
 
 `generateWeekAheadPlan` walks one day at a time, greedily. To compensate, the optimizer
 accumulated six named policies (anti-stacking, post-objective strength suppression,
@@ -96,6 +99,19 @@ judgement the current architecture structurally cannot make.
 
 Prerequisite: Phase 3's lexicographic layer. Search needs hard constraints separated from
 sort keys; it cannot operate on a single blended multiplier.
+
+**Delivered as:** `app/src/engine/sequenceSearch.ts` (`beamSearchWeekAheadPlan`,
+`generateWeekAheadPlanWithIntentBeamSearch`) -- a genuine beam-search prototype built by
+maximal reuse of `rankCandidates`' existing hard-gate-before-scoring separation (the
+Phase 3 prerequisite), not a parallel engine. Benchmarked against greedy via
+`npm run compare:sequence-search` on the Phase 0 invariants and the golden-week semantic
+harness (now run against both algorithms permanently in `goldenWeek.test.ts`). **Decision
+recorded in [ADR-0015](../adr/0015-sequence-planning-and-session-role-model.md): greedy
+retained as the live default.** The comparison itself was genuinely positive (zero new
+constraint/golden-week violations, better objective resolution in several scenarios) --
+adoption is deferred rather than rejected, pending compute-cost profiling and product
+sign-off on a real rest-day-frequency behavior shift the harness cannot judge on its own.
+`sequenceSearch.ts` is not imported by any production code path.
 
 ## `[x]` 5.2 — Move the planner/workout-library boundary
 
@@ -305,18 +321,21 @@ event-specific freshness* rather than arriving as an emergent side effect.
 
 ## Acceptance criteria
 
-- [ ] a sequence-search prototype exists and is benchmarked against greedy on the Phase-0
-      invariants and semantic harness
-- [ ] an explicit adoption decision is recorded in an ADR, with the comparison data —
+- [x] a sequence-search prototype exists and is benchmarked against greedy on the Phase-0
+      invariants and semantic harness (`sequenceSearch.ts`, `compare:sequence-search`)
+- [x] an explicit adoption decision is recorded in an ADR, with the comparison data —
       **either** (a) beam search is promoted, hard constraints reject before scoring, and a
       full week is scored as a sequence and is explainable; **or** (b) greedy is retained
-      and the negative result is recorded. Both satisfy this criterion.
-- [ ] `PlanningCandidate` carries spacing/recovery metadata into the decision
-- [ ] fixed activities persist and affect availability and adjacent days
-- [ ] per-region tissue state constrains mechanical work independently of wearable readiness
-- [ ] inferred stimulus carries confidence and uses the strongest available evidence
-- [ ] taper roles come from the plan, not from weight interactions
-- [ ] Phase 0 invariants hold throughout; each increment's semantic diff explained
+      and the negative result is recorded. Both satisfy this criterion. ([ADR-0015](../adr/0015-sequence-planning-and-session-role-model.md):
+      (b), though the comparison itself was genuinely positive, not negative — adoption is
+      deferred pending compute-cost profiling and product sign-off on a real behavior
+      shift, not rejected on the merits the harness can measure.)
+- [x] `PlanningCandidate` carries spacing/recovery metadata into the decision
+- [x] fixed activities persist and affect availability and adjacent days
+- [x] per-region tissue state constrains mechanical work independently of wearable readiness
+- [x] inferred stimulus carries confidence and uses the strongest available evidence
+- [x] taper roles come from the plan, not from weight interactions
+- [x] Phase 0 invariants hold throughout; each increment's semantic diff explained
 
 ## Risks & rollback
 
@@ -344,6 +363,10 @@ event-specific freshness* rather than arriving as an emergent side effect.
 
 ## Docs to update
 
-* **ADR-0015** (new) — sequence planning and the session-role model
-* **ADR-0008** — superseded in part: the greedy projected loop is replaced
-* `docs/architecture/recommendation-engine.md` — the planner section
+* **ADR-0015** (new, done) — sequence planning: the beam-search prototype, its
+  comparison data, and the recorded adoption decision (defer, not reject).
+* ~~ADR-0008 — superseded in part: the greedy projected loop is replaced~~ Did not
+  happen: the adoption decision (ADR-0015) retained the greedy loop as the live default,
+  so ADR-0008's confidence-tier/greedy-walk description remains accurate as written.
+* `docs/architecture/recommendation-engine.md` (done) — the planner section, plus new
+  subsections for each landed increment (5.3, 5.4, 5.5, 5.6, 5.7, 5.2, 5.1).

--- a/docs/plans/phase-5-sequence-planning.md
+++ b/docs/plans/phase-5-sequence-planning.md
@@ -19,7 +19,7 @@ Ordered by the increment sequence below, **not** by section number.
 | 1 | 5.3 | `[x]` | Persist `FixedActivity` under a user-owned path with rules + emulator tests | `app/firestore.rules`, new `fixedActivityService.ts`, `app/src/engine/schedule.ts`, `planner.ts` |
 | 2 | 5.4 | `[x]` | Per-region tissue state; may only tighten a Phase-1 injury constraint | `app/src/engine/models.ts`, `components/DailyCheckin.tsx`, `injuryPolicy.ts` |
 | 3 | 5.5 | `[x]` | Evidence hierarchy for completed training, carrying `stimulusConfidence` | `app/src/engine/completedTraining.ts` |
-| 4 | 5.7 | `[ ]` | Taper as an explicit plan contract rather than an emergent side effect | `app/src/workouts/event-plan.ts`, `app/src/engine/periodization.ts` |
+| 4 | 5.7 | `[x]` | Taper as an explicit plan contract rather than an emergent side effect | `app/src/workouts/event-plan.ts`, `app/src/engine/periodization.ts` |
 | 5 | 5.6 | `[ ]` | Multi-event: one taper authority, multiple demand contributors | `app/src/engine/periodization.ts` |
 | 6 | 5.2 | `[ ]` | `PlanningCandidate` carries spacing/recovery metadata into the decision | `app/src/workouts/models.ts`, `app/src/engine/planner.ts` |
 | 7 | 5.1 | `[ ]` | Bounded sequence search — **build and measure**, adoption conditional (D-BEAM) | `app/src/engine/planner.ts` |
@@ -263,7 +263,7 @@ Tests before 5.6 is executable: priority tie broken by proximity; proximity tie 
 date then id; two contributors sharing an objective key resolving to `max`, not sum; a
 contributor objective inside race week dropped with its reason present in the audit.
 
-## `[ ]` 5.7 — Taper as an explicit contract
+## `[x]` 5.7 — Taper as an explicit contract
 
 Taper behaviour currently emerges from interactions between `volumeScale`, objective
 generation, template `phaseEligibility` and utility ranking. `event-plan.ts` already names

--- a/docs/plans/phase-5-sequence-planning.md
+++ b/docs/plans/phase-5-sequence-planning.md
@@ -24,8 +24,8 @@ Ordered by the increment sequence below, **not** by section number.
 | 3 | 5.5 | `[x]` | Evidence hierarchy for completed training, carrying `stimulusConfidence` | `app/src/engine/completedTraining.ts` |
 | 4 | 5.7 | `[x]` | Taper as an explicit plan contract rather than an emergent side effect | `app/src/workouts/event-plan.ts`, `app/src/engine/periodization.ts` |
 | 5 | 5.6 | `[x]` | Multi-event: one taper authority, multiple demand contributors | `app/src/engine/periodization.ts` |
-| 6 | 5.2 | `[x]` | `PlanningCandidate` carries spacing/recovery metadata into the decision | `app/src/workouts/models.ts`, `app/src/engine/planner.ts` |
-| 7 | 5.1 | `[x]` | Bounded sequence search — **build and measure**, adoption conditional (D-BEAM) | `app/src/engine/planner.ts` |
+| 6 | 5.2 | `[x]` | `PlanningCandidate` carries spacing/recovery metadata into the decision | `app/src/engine/planningCandidate.ts`, `app/src/engine/optimizer.ts`, `app/src/engine/rules.ts`, `app/src/engine/planner.ts` |
+| 7 | 5.1 | `[x]` | Bounded sequence search — **build and measure**, adoption conditional (D-BEAM) | `app/src/engine/sequenceSearch.ts`, `app/src/engine/planner.ts`, `app/scripts/compare-sequence-search.mjs` |
 
 **5.1 is an experiment, not a scheduled migration.** Marking it `[x]` requires a recorded
 adoption decision with harness data — retaining the greedy loop is a valid completion.
@@ -326,10 +326,11 @@ event-specific freshness* rather than arriving as an emergent side effect.
 - [x] an explicit adoption decision is recorded in an ADR, with the comparison data —
       **either** (a) beam search is promoted, hard constraints reject before scoring, and a
       full week is scored as a sequence and is explainable; **or** (b) greedy is retained
-      and the negative result is recorded. Both satisfy this criterion. ([ADR-0015](../adr/0015-sequence-planning-and-session-role-model.md):
-      (b), though the comparison itself was genuinely positive, not negative — adoption is
-      deferred pending compute-cost profiling and product sign-off on a real behavior
-      shift, not rejected on the merits the harness can measure.)
+      and the measured result and adoption decision are recorded. Both satisfy this
+      criterion. ([ADR-0015](../adr/0015-sequence-planning-and-session-role-model.md): (b) —
+      the comparison itself was genuinely positive, not negative, and is recorded as such;
+      adoption is deferred pending compute-cost profiling and product sign-off on a real
+      behavior shift, not rejected on the merits the harness can measure.)
 - [x] `PlanningCandidate` carries spacing/recovery metadata into the decision
 - [x] fixed activities persist and affect availability and adjacent days
 - [x] per-region tissue state constrains mechanical work independently of wearable readiness

--- a/docs/plans/phase-5-sequence-planning.md
+++ b/docs/plans/phase-5-sequence-planning.md
@@ -21,7 +21,7 @@ Ordered by the increment sequence below, **not** by section number.
 | 3 | 5.5 | `[x]` | Evidence hierarchy for completed training, carrying `stimulusConfidence` | `app/src/engine/completedTraining.ts` |
 | 4 | 5.7 | `[x]` | Taper as an explicit plan contract rather than an emergent side effect | `app/src/workouts/event-plan.ts`, `app/src/engine/periodization.ts` |
 | 5 | 5.6 | `[x]` | Multi-event: one taper authority, multiple demand contributors | `app/src/engine/periodization.ts` |
-| 6 | 5.2 | `[ ]` | `PlanningCandidate` carries spacing/recovery metadata into the decision | `app/src/workouts/models.ts`, `app/src/engine/planner.ts` |
+| 6 | 5.2 | `[x]` | `PlanningCandidate` carries spacing/recovery metadata into the decision | `app/src/workouts/models.ts`, `app/src/engine/planner.ts` |
 | 7 | 5.1 | `[ ]` | Bounded sequence search — **build and measure**, adoption conditional (D-BEAM) | `app/src/engine/planner.ts` |
 
 **5.1 is an experiment, not a scheduled migration.** Marking it `[x]` requires a recorded
@@ -97,7 +97,7 @@ judgement the current architecture structurally cannot make.
 Prerequisite: Phase 3's lexicographic layer. Search needs hard constraints separated from
 sort keys; it cannot operate on a single blended multiplier.
 
-## `[ ]` 5.2 — Move the planner/workout-library boundary
+## `[x]` 5.2 — Move the planner/workout-library boundary
 
 Detailed `WorkoutDefinition`s already carry recovery hours, mechanical and eccentric load,
 coordination demand, technical environment, contraindications, and minimum spacing after
@@ -124,6 +124,20 @@ interface PlanningCandidate {
 ```
 
 Prescription generation stays downstream and unchanged.
+
+**Delivered as:** `app/src/engine/planningCandidate.ts` (not literally
+`workouts/models.ts` -- see the file's own doc comment: `engine/models.ts` already
+imports from `workouts/models.ts`, so a type referencing `SessionRole`/`Modality`/
+`WorkoutStimulusProfile`/`WorkoutCostProfile`/`TrainingEnvironment` living in
+`workouts/models.ts` would make that dependency circular). `derivePlanningCandidate`
+resolves one `WorkoutDefinition` against its linked `SessionTemplate`;
+`PLANNING_CANDIDATE_INDEX` builds the full catalog once, keyed by engine template id.
+Wired into the one concrete gap this closes: `optimizer.ts`'s
+`evaluateRecoveryConstraints` hard-lower-body spacing check was a flat 2-day rule with no
+per-workout data behind it at all -- it now consults
+`resolveMinimumDaysAfterHardLowerBody` (optional, defaults to the identical flat rule)
+so a workout's own `eligibility.minimumDaysAfterHardLowerBody` can tighten *or* loosen
+that gate correctly, wired at both live call sites (`planner.ts`, `rules.ts`).
 
 ## `[x]` 5.3 — Persist fixed activities
 

--- a/docs/plans/phase-5-sequence-planning.md
+++ b/docs/plans/phase-5-sequence-planning.md
@@ -20,7 +20,7 @@ Ordered by the increment sequence below, **not** by section number.
 | 2 | 5.4 | `[x]` | Per-region tissue state; may only tighten a Phase-1 injury constraint | `app/src/engine/models.ts`, `components/DailyCheckin.tsx`, `injuryPolicy.ts` |
 | 3 | 5.5 | `[x]` | Evidence hierarchy for completed training, carrying `stimulusConfidence` | `app/src/engine/completedTraining.ts` |
 | 4 | 5.7 | `[x]` | Taper as an explicit plan contract rather than an emergent side effect | `app/src/workouts/event-plan.ts`, `app/src/engine/periodization.ts` |
-| 5 | 5.6 | `[ ]` | Multi-event: one taper authority, multiple demand contributors | `app/src/engine/periodization.ts` |
+| 5 | 5.6 | `[x]` | Multi-event: one taper authority, multiple demand contributors | `app/src/engine/periodization.ts` |
 | 6 | 5.2 | `[ ]` | `PlanningCandidate` carries spacing/recovery metadata into the decision | `app/src/workouts/models.ts`, `app/src/engine/planner.ts` |
 | 7 | 5.1 | `[ ]` | Bounded sequence search — **build and measure**, adoption conditional (D-BEAM) | `app/src/engine/planner.ts` |
 
@@ -223,7 +223,7 @@ materially better than treating meaningful unplanned training as adaptation-neut
 The asymmetry this closes: today the system sees **cost** from an unplanned hard group
 ride but not **benefit**, so it can prescribe work that was effectively already done.
 
-## `[ ]` 5.6 — Multi-event: separate taper authority from demand contribution
+## `[x]` 5.6 — Multi-event: separate taper authority from demand contribution
 
 `evaluatePeriodizationPhase` picks one governing event by priority then proximity. A more
 realistic model is **one taper authority, multiple demand contributors**: an A-event 70
@@ -262,6 +262,22 @@ teaches them nothing.
 Tests before 5.6 is executable: priority tie broken by proximity; proximity tie broken by
 date then id; two contributors sharing an objective key resolving to `max`, not sum; a
 contributor objective inside race week dropped with its reason present in the audit.
+
+**Delivered as:** `evaluatePeriodizationPhase`'s existing sort gained the two missing
+tie-breakers (planning date, then event id) plus a `governingEventTie` field that
+surfaces — rather than silently resolves — a genuine two-A-events-same-day conflict.
+`objectivesFromDemand` (extracted from Phase 5.7's work, now shared) derives objectives
+from one event's own demand vector; `resolveMultiEventObjectives` (both new, in
+`periodization.ts`) unions the taper authority's objectives with every other eligible
+event's own contribution (within a 35-day window, matching the existing Specificity
+threshold), applying `max(requiredCredit)` on key collisions and dropping — with a
+recorded, athlete-facing reason — any contributor `threshold_quality` objective while the
+authority is tapering. Wired into `planner.ts`'s `prepareWeekAheadPlanSeed` (both the
+completed-history and generic branches), so it reaches the live week-ahead pipeline for
+any athlete with more than one active dated event; a no-op otherwise, confirmed via
+`simulate:diff` against the committed baseline. **Scope boundary:** the plan-derived path
+(`PlanDefinition`/`buildSeptemberCyclingEventPlan`) is not wired to contributors in this
+increment — only the generic days-to-event path is.
 
 ## `[x]` 5.7 — Taper as an explicit contract
 


### PR DESCRIPTION
## What changed

Implements [Phase 5 — Sequence planning, real inputs, and the feedback loop](docs/plans/phase-5-sequence-planning.md) in full: all seven increments, in the approved value-per-risk order, each landed independently.

1. **5.3 — Fixed activities**: `FixedActivity` now persists at `users/{userId}/fixed_activities` (`fixedActivityService.ts`, validated Firestore rules, emulator tests) and actually reaches the planner via `Home.tsx` — previously `WeekAheadOptions.fixedActivities` was never populated from anywhere.
2. **5.4 — Local tissue state**: per-region check-in (`DailyCheckin.tsx`) feeding `injuryPolicy.ts`'s `resolveEffectiveInjuryConstraints`, which can only *tighten* — never weaken — the standing injury gate. All three precedence conflicts (InjuryConstraint vs tissue response, tissue response vs wearable readiness, InjuryConstraint vs wearable readiness) are tested.
3. **5.5 — Evidence hierarchy**: named confidence tiers (`EvidenceTier`) for completed-training stimulus now materially discount objective credit instead of being a write-only label. Fixed a real asymmetry: unclassified sessions charged fatigue but credited zero adaptation.
4. **5.7 — Taper as explicit contract**: taper now generates its own calibrated `race_specific_endurance`/`strength_maintenance` objectives instead of silently omitting them.
5. **5.6 — Multi-event**: one taper authority (full deterministic total order with a documented determinism backstop) + demand contributors (objectives unioned by key, `max()` not sum, inadmissible contributor objectives dropped with a recorded reason).
6. **5.2 — PlanningCandidate**: bridges the workout catalog's per-workout recovery/spacing data into the planner's hard-lower-body spacing gate (previously a flat, workout-blind 2-day rule).
7. **5.1 — Bounded sequence search**: built and benchmarked a real beam-search prototype (`sequenceSearch.ts`) against the production greedy planner. **Adoption deferred, not shipped or rejected** — recorded in [ADR-0015](docs/adr/0015-sequence-planning-and-session-role-model.md), with the comparison data. The prototype is not imported by any production code path.

## Branch history note

This branch was built on top of PR #11 (`gemini-phase4`) per instruction, then re-synced onto `main` after that PR merged. One extra commit (`9cfb606`) corrects a verification-process mistake made mid-session: several earlier per-increment `simulate:diff` checks were run against a self-overwritten baseline (comparing current code to itself), which produced false "no differences" results. Re-verified properly against the actually-committed baseline: exactly one scenario's behavior changed (`running_marathon_A`, driven by 5.7's taper calibration correctly applying to non-cycling events too), root-caused, and the baseline updated to match. See that commit message for the full account.

## Validation

- `npm run build` (typecheck, lint, 473 tests, workout catalog validation, production build) — clean.
- `npm run test:rules` (Firestore emulator security-rules suite) — 25/25 pass.
- `npm run simulate:scenarios` — Phase 0 aggregate bounds gate passes.
- `npm run simulate:diff` — clean against the committed baseline (see note above).
- `npm run compare:sequence-search` — beam-search vs greedy comparison; data recorded in ADR-0015.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added regional tissue-response tracking to daily check-ins for more detailed injury and pain reporting.
  * Added support for saving fixed activities and including them in seven-day planning.
  * Added taper and race-specific objectives, multi-event planning, and workout-specific recovery spacing.
* **Improvements**
  * Recommendations now account for tissue responses and confidence levels in completed training.
  * Fixed-activity availability limits are reflected in daily schedules.
* **Security**
  * Added ownership and validation protections for saved activities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->