### PR TITLE
🔒 Fix hardcoded API key in GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # Build/test-only configuration. Production configuration remains deployment-owned.
-      VITE_FIREBASE_API_KEY: AIzaSyDUMMYKEYDUMMYKEYDUMMYKEYDUMMYKEY
+      VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY }}
       VITE_FIREBASE_AUTH_DOMAIN: example.firebaseapp.com
       VITE_FIREBASE_PROJECT_ID: example-project
       VITE_FIREBASE_APP_ID: 1:123456789:web:abcdef


### PR DESCRIPTION
🎯 **What:** Removed the hardcoded `VITE_FIREBASE_API_KEY` from the `.github/workflows/ci.yml` workflow.
⚠️ **Risk:** Hardcoding API keys, even ones intended for build/test environments, introduces the risk of leaking sensitive infrastructure credentials if the placeholder is ever replaced with a live key, or if the test environment accesses real resources.
🛡️ **Solution:** Replaced the hardcoded string with a reference to a GitHub Secret (`${{ secrets.VITE_FIREBASE_API_KEY }}`), following security best practices for CI/CD pipelines. This ensures the key is injected securely at runtime without being exposed in the repository's source code.

---
*PR created automatically by Jules for task [16869452900627204413](https://jules.google.com/task/16869452900627204413) started by @Szczepanov*