### PR TITLE
🧪 Add unauthenticated test for get_sleep_data

### DIFF
--- a/tests/test_garmin_client.py
+++ b/tests/test_garmin_client.py
@@ -74,3 +74,9 @@ def test_login_credential_mode_requires_email_and_password(tmp_path):
 
     with pytest.raises(RuntimeError, match="GARMIN_EMAIL"):
         wrapper.login_with_tokens_or_credentials(token_file)
+
+
+def test_get_sleep_data_unauthenticated():
+    wrapper = GarminClientWrapper(allow_credential_login=False)
+    with pytest.raises(RuntimeError, match="Garmin client is not authenticated. Call login first."):
+        wrapper.get_sleep_data("2023-10-10")


### PR DESCRIPTION
🎯 **What:** Added a unit test to verify that `get_sleep_data` raises a `RuntimeError` when called without authenticating the Garmin client.
📊 **Coverage:** Tests the `self.api is None` edge case for `get_sleep_data` method in `GarminClientWrapper`.
✨ **Result:** Increased test coverage for error conditions and prevents regressions when modifying authentication state in `GarminClientWrapper`.

---
*PR created automatically by Jules for task [3873143776305439073](https://jules.google.com/task/3873143776305439073) started by @Szczepanov*