### PR TITLE
🧪 Add tests for CLI commands

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,238 @@
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from garmin_sync.cli import (
+    main,
+    run_audit_cmd,
+    run_backfill,
+    run_daily_sync,
+    run_rebuild_cmd,
+)
+
+
+from typing import Any, Generator
+
+
+@pytest.fixture
+def mock_settings() -> Generator[Any, None, None]:
+    with patch("garmin_sync.cli.load_settings") as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_service() -> Generator[Any, None, None]:
+    with patch("garmin_sync.cli.GarminSyncService") as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_run_audit() -> Generator[Any, None, None]:
+    with patch("garmin_sync.cli.run_audit") as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_format_report() -> Generator[Any, None, None]:
+    with patch("garmin_sync.cli.format_report") as mock:
+        yield mock
+
+
+def test_run_daily_sync_success(mock_settings: Any, mock_service: Any) -> None:
+    mock_service_instance = mock_service.return_value
+    mock_service_instance.sync_daily.return_value = True
+
+    args = ["--date", "2023-10-27", "--force", "--resync-days", "2"]
+    exit_code = run_daily_sync(args)
+
+    assert exit_code == 0
+    mock_settings.assert_called_once()
+    mock_service.assert_called_once_with(mock_settings.return_value)
+    mock_service_instance.sync_daily.assert_called_once_with(
+        target_date_str="2023-10-27",
+        force=True,
+        resync_lookback_days=2,
+    )
+
+
+def test_run_daily_sync_failure(mock_settings: Any, mock_service: Any) -> None:
+    mock_service_instance = mock_service.return_value
+    mock_service_instance.sync_daily.return_value = False
+
+    exit_code = run_daily_sync([])
+
+    assert exit_code == 1
+    mock_service_instance.sync_daily.assert_called_once_with(
+        target_date_str=None,
+        force=False,
+        resync_lookback_days=None,
+    )
+
+
+def test_run_daily_sync_exception(mock_settings: Any, mock_service: Any) -> None:
+    mock_service_instance = mock_service.return_value
+    mock_service_instance.sync_daily.side_effect = Exception("Test Error")
+
+    exit_code = run_daily_sync([])
+
+    assert exit_code == 1
+
+
+def test_run_backfill_success(mock_settings: Any, mock_service: Any) -> None:
+    mock_service_instance = mock_service.return_value
+    mock_service_instance.backfill.return_value = True
+
+    args = ["--days", "30", "--start-date", "2023-09-01", "--end-date", "2023-10-01", "--force"]
+    exit_code = run_backfill(args)
+
+    assert exit_code == 0
+    mock_settings.assert_called_once()
+    mock_service.assert_called_once_with(mock_settings.return_value)
+    mock_service_instance.backfill.assert_called_once_with(
+        days=30,
+        start_date_str="2023-09-01",
+        end_date_str="2023-10-01",
+        force=True,
+    )
+
+
+def test_run_backfill_failure(mock_settings: Any, mock_service: Any) -> None:
+    mock_service_instance = mock_service.return_value
+    mock_service_instance.backfill.return_value = False
+
+    exit_code = run_backfill([])
+
+    assert exit_code == 1
+    mock_service_instance.backfill.assert_called_once_with(
+        days=56,
+        start_date_str=None,
+        end_date_str=None,
+        force=False,
+    )
+
+
+def test_run_backfill_exception(mock_settings: Any, mock_service: Any) -> None:
+    mock_service_instance = mock_service.return_value
+    mock_service_instance.backfill.side_effect = Exception("Test Error")
+
+    exit_code = run_backfill([])
+
+    assert exit_code == 1
+
+
+def test_run_audit_cmd_success(mock_settings: Any, mock_service: Any, mock_run_audit: Any, mock_format_report: Any) -> None:
+    mock_service_instance = mock_service.return_value
+    mock_run_audit.return_value = "report_data"
+    mock_format_report.return_value = "Formatted Report"
+
+    args = ["--days", "60", "--end-date", "2023-10-27"]
+    exit_code = run_audit_cmd(args)
+
+    assert exit_code == 0
+    mock_settings.assert_called_once()
+    mock_service.assert_called_once_with(mock_settings.return_value)
+    mock_run_audit.assert_called_once_with(
+        mock_settings.return_value,
+        mock_service_instance.repository,
+        mock_service_instance.archive_store,
+        days=60,
+        end_date_str="2023-10-27",
+    )
+    mock_format_report.assert_called_once_with("report_data")
+
+
+def test_run_audit_cmd_exception(mock_settings: Any, mock_service: Any, mock_run_audit: Any) -> None:
+    mock_run_audit.side_effect = Exception("Test Error")
+
+    exit_code = run_audit_cmd([])
+
+    assert exit_code == 1
+
+
+def test_run_rebuild_cmd_success(mock_settings: Any, mock_service: Any) -> None:
+    mock_service_instance = mock_service.return_value
+    mock_service_instance.rebuild.return_value = True
+
+    args = ["--start-date", "2023-10-01", "--end-date", "2023-10-31"]
+    exit_code = run_rebuild_cmd(args)
+
+    assert exit_code == 0
+    mock_settings.assert_called_once()
+    mock_service.assert_called_once_with(mock_settings.return_value)
+    mock_service_instance.rebuild.assert_called_once_with("2023-10-01", "2023-10-31")
+
+
+def test_run_rebuild_cmd_missing_args() -> None:
+    with pytest.raises(SystemExit):
+        run_rebuild_cmd([])
+
+
+def test_run_rebuild_cmd_failure(mock_settings: Any, mock_service: Any) -> None:
+    mock_service_instance = mock_service.return_value
+    mock_service_instance.rebuild.return_value = False
+
+    args = ["--start-date", "2023-10-01", "--end-date", "2023-10-31"]
+    exit_code = run_rebuild_cmd(args)
+
+    assert exit_code == 1
+
+
+def test_run_rebuild_cmd_exception(mock_settings: Any, mock_service: Any) -> None:
+    mock_service_instance = mock_service.return_value
+    mock_service_instance.rebuild.side_effect = Exception("Test Error")
+
+    args = ["--start-date", "2023-10-01", "--end-date", "2023-10-31"]
+    exit_code = run_rebuild_cmd(args)
+
+    assert exit_code == 1
+
+
+@patch("garmin_sync.cli.run_daily_sync")
+def test_main_sync(mock_run_daily_sync: Any) -> None:
+    mock_run_daily_sync.return_value = 0
+
+    with patch.object(sys, "argv", ["garmin_sync", "sync", "--date", "2023-10-27"]):
+        exit_code = main()
+
+    assert exit_code == 0
+    mock_run_daily_sync.assert_called_once_with(["--date", "2023-10-27"])
+
+
+@patch("garmin_sync.cli.run_backfill")
+def test_main_backfill(mock_run_backfill: Any) -> None:
+    mock_run_backfill.return_value = 0
+
+    with patch.object(sys, "argv", ["garmin_sync", "backfill", "--days", "10"]):
+        exit_code = main()
+
+    assert exit_code == 0
+    mock_run_backfill.assert_called_once_with(["--days", "10"])
+
+
+@patch("garmin_sync.cli.run_audit_cmd")
+def test_main_audit(mock_run_audit_cmd: Any) -> None:
+    mock_run_audit_cmd.return_value = 0
+
+    with patch.object(sys, "argv", ["garmin_sync", "audit"]):
+        exit_code = main()
+
+    assert exit_code == 0
+    mock_run_audit_cmd.assert_called_once_with([])
+
+
+@patch("garmin_sync.cli.run_rebuild_cmd")
+def test_main_rebuild(mock_run_rebuild_cmd: Any) -> None:
+    mock_run_rebuild_cmd.return_value = 0
+
+    with patch.object(sys, "argv", ["garmin_sync", "rebuild", "--start-date", "2023-10-01", "--end-date", "2023-10-31"]):
+        exit_code = main()
+
+    assert exit_code == 0
+    mock_run_rebuild_cmd.assert_called_once_with(["--start-date", "2023-10-01", "--end-date", "2023-10-31"])
+
+
+def test_main_missing_command() -> None:
+    with patch.object(sys, "argv", ["garmin_sync"]):
+        with pytest.raises(SystemExit):
+            main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import sys
+from typing import Any, Generator
 from unittest.mock import patch
 
 import pytest
@@ -10,9 +11,6 @@ from garmin_sync.cli import (
     run_daily_sync,
     run_rebuild_cmd,
 )
-
-
-from typing import Any, Generator
 
 
 @pytest.fixture


### PR DESCRIPTION
🎯 **What:** The `garmin_sync.cli.py` lacked tests. This change introduces `tests/test_cli.py` to ensure all command line operations and dispatch logic works properly.
📊 **Coverage:** Covered all standard CLI commands (`sync`, `backfill`, `audit`, `rebuild`) mapping to `run_daily_sync`, `run_backfill`, `run_audit_cmd`, and `run_rebuild_cmd`, including the `main()` argparse execution path. Handled happy paths, returned failures, raised exceptions, and missing command-line arguments. 
✨ **Result:** Provides a complete test suite for the CLI entry point, allowing more robust updates or refactoring in the future.

---
*PR created automatically by Jules for task [8284886617226979430](https://jules.google.com/task/8284886617226979430) started by @Szczepanov*