### PR TITLE
⚡ Bolt: Add React.memo to DetailedTodayPlan

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-08-08 - [Preventing Unnecessary Re-renders]
+**Learning:** In a complex React dashboard component (`Home.tsx`) with multiple independent interactive sections (e.g., Week Ahead Strip, Detailed Plan, Adherence Prompts), state updates in one section (like changing `selectedNextDayTier` or toggling `showWorkoutDetails`) cause the entire dashboard to re-render, including expensive sub-components like `DetailedTodayPlan`.
+**Action:** Use `React.memo` for pure presentation components that receive complex props but shouldn't re-render unless those specific props change. This isolates rendering costs in data-heavy views.

--- a/app/src/components/Home.tsx
+++ b/app/src/components/Home.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef, memo } from 'react';
 import { decisionComposer } from '../engine/composer';
 import { evaluateTrainingWithIntent, evaluateNextDayPlanWithIntent, adjustSessionRecommendation } from '../engine/rules';
 import { mapSnapshotToEngineInput, mapCheckinToSubjectiveInput, mapContextFromGoalsAndTrainingSettings, mapGoalsToUserEvents } from '../engine/adapters';
@@ -44,7 +44,7 @@ function formatEventTiming(daysToEvent: number | null): string {
   return daysToEvent > 0 ? `In ${daysToEvent} days` : `${Math.abs(daysToEvent)} days ago`;
 }
 
-function DetailedTodayPlan({ prescription }: { prescription: WorkoutPrescription }) {
+const DetailedTodayPlan = memo(function DetailedTodayPlan({ prescription }: { prescription: WorkoutPrescription }) {
   return (
     <section className="detailed-plan" aria-label="Detailed training plan">
       <div className="detailed-plan-header">
@@ -104,7 +104,7 @@ function DetailedTodayPlan({ prescription }: { prescription: WorkoutPrescription
       <p className="plan-legend">{getPrescriptionLegend()}</p>
     </section>
   );
-}
+});
 
 export function Home({ userId, onNavigate, onViewData }: HomeProps) {
   const [decisionInput, setDecisionInput] = useState<DailyDecisionInput | null>(null);


### PR DESCRIPTION
💡 What: Wrapped `DetailedTodayPlan` inside `Home.tsx` with `React.memo()`.

🎯 Why: The `Home` dashboard contains multiple states (e.g., `selectedNextDayTier`, `adjustmentDirection`, `showWorkoutDetails`) that trigger re-renders. `DetailedTodayPlan` is a visually complex but pure presentation component that takes a `WorkoutPrescription` object. By memoizing it, we prevent it from pointlessly re-rendering and re-evaluating when unrelated dashboard state changes.

📊 Impact: Reduces computational overhead and DOM diffing by preventing unnecessary re-renders of the detailed workout section when interacting with other parts of the dashboard (like the week-ahead strip).

🔬 Measurement: Can be verified using React DevTools Profiler by toggling the `selectedNextDayTier` or other isolated state in `Home` and observing that `DetailedTodayPlan` skips rendering. Tested the application correctness using `npm run check`.

---
*PR created automatically by Jules for task [3304968218090079941](https://jules.google.com/task/3304968218090079941) started by @Szczepanov*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved dashboard responsiveness by preventing unnecessary re-renders of the detailed daily plan when its data has not changed.

* **Documentation**
  * Added guidance on reducing unnecessary React component re-renders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->