### PR TITLE
⚡ Bolt: [Performance improvement] Optimize dashboard load with concurrent data fetching

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,6 @@
 ## 2026-08-08 - [Preventing Unnecessary Re-renders via useCallback]
 **Learning:** Even when a component is memoized using `React.memo` (e.g., `AdherencePrompt`, `WeekAheadStrip`), passing down inline functions (like `onResolved={() => setPendingAdherence(null)}`) creates a new function reference on every render of the parent component (`Home.tsx`), breaking the memoization and causing the child to re-render.
 **Action:** Use `useCallback` in the parent component to memoize the function reference passed as a prop, ensuring `React.memo` correctly prevents unnecessary re-renders.
+## 2023-10-27 - [Sequential Promises in React components]
+**Learning:** `loadDashboardData` originally awaited independent backend services sequentially, leading to an unnecessary dashboard load waterfall constraint.
+**Action:** Always scan for uncoupled `await` calls that can be grouped into a single `Promise.all` block. Especially when loading diverse domains of user data (like daily recommendations, fixed activities, and plan blocks) concurrently speeds up hydration without risking correctness.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,6 +5,7 @@
 ## 2026-08-08 - [Preventing Unnecessary Re-renders via useCallback]
 **Learning:** Even when a component is memoized using `React.memo` (e.g., `AdherencePrompt`, `WeekAheadStrip`), passing down inline functions (like `onResolved={() => setPendingAdherence(null)}`) creates a new function reference on every render of the parent component (`Home.tsx`), breaking the memoization and causing the child to re-render.
 **Action:** Use `useCallback` in the parent component to memoize the function reference passed as a prop, ensuring `React.memo` correctly prevents unnecessary re-renders.
-## 2023-10-27 - [Sequential Promises in React components]
+
+## 2026-08-15 - [Sequential Promises in React components]
 **Learning:** `loadDashboardData` originally awaited independent backend services sequentially, leading to an unnecessary dashboard load waterfall constraint.
 **Action:** Always scan for uncoupled `await` calls that can be grouped into a single `Promise.all` block. Especially when loading diverse domains of user data (like daily recommendations, fixed activities, and plan blocks) concurrently speeds up hydration without risking correctness.

--- a/app/src/components/Home.tsx
+++ b/app/src/components/Home.tsx
@@ -175,43 +175,51 @@ export function Home({ userId, onNavigate, onViewData }: HomeProps) {
       }
 
       const yesterday = getPreviousLocalDateString(input.date);
-      const yesterdayRec = await recommendationService.getRecommendation(userId, yesterday).catch(err => {
-        console.warn('Failed to load yesterday\'s recommendation:', err);
-        return null;
-      });
+
+      // ⚡ Bolt Performance Optimization:
+      // Executing independent asynchronous data fetching calls concurrently via Promise.all.
+      // Expected Impact: Reduces sequential blocking during loadDashboardData, saving overall dashboard loading time.
+      const [yesterdayRec, todayAndTomorrowFixedActivities, todayAndTomorrowPlanBlocks] = await Promise.all([
+        recommendationService.getRecommendation(userId, yesterday).catch(err => {
+          console.warn('Failed to load yesterday\'s recommendation:', err);
+          return null;
+        }),
+
+        // Phase 6.2b: today's and tomorrow's own fixed activities must affect the actual
+        // live pick and provisional plan (availability/fatigue/objective credit), not just
+        // the separately-fetched week-ahead forecast strip below. Unlike that forecast read
+        // (which fails closed on a non-AVAILABLE state -- silently treating it as "no
+        // commitments" over a 7-day horizon someone plans around), the live day-0/day-1
+        // decision fails OPEN to an empty list here: this is one day's already-interactive
+        // recommendation, not an unattended multi-day schedule, and a temporary read failure
+        // should not block it entirely -- same tradeoff already made for `yesterdayRec` above.
+        fixedActivityService
+          .getActivitiesInRange(userId, input.date, addDaysToLocalDateString(input.date, 1))
+          .catch(err => {
+            console.warn('Failed to load fixed activities for today/tomorrow:', err);
+            return [];
+          }),
+
+        planBlockService
+          .getBlocksInRangeState(userId, input.date, addDaysToLocalDateString(input.date, 1))
+          .then(state => {
+            if (state.status === 'AVAILABLE') return state.data;
+            console.warn(`Failed to load authored plan blocks for today/tomorrow: ${state.status}`);
+            return [];
+          })
+          .catch(err => {
+            console.warn('Failed to load authored plan blocks for today/tomorrow:', err);
+            return [];
+          })
+      ]);
+
       if (!isCurrent()) return;
+
       setPendingAdherence(
         yesterdayRec && yesterdayRec.adherence.respondedAt === null
           ? { date: yesterday, recommendation: yesterdayRec }
           : null
       );
-
-      // Phase 6.2b: today's and tomorrow's own fixed activities must affect the actual
-      // live pick and provisional plan (availability/fatigue/objective credit), not just
-      // the separately-fetched week-ahead forecast strip below. Unlike that forecast read
-      // (which fails closed on a non-AVAILABLE state -- silently treating it as "no
-      // commitments" over a 7-day horizon someone plans around), the live day-0/day-1
-      // decision fails OPEN to an empty list here: this is one day's already-interactive
-      // recommendation, not an unattended multi-day schedule, and a temporary read failure
-      // should not block it entirely -- same tradeoff already made for `yesterdayRec` above.
-      const todayAndTomorrowFixedActivities = await fixedActivityService
-        .getActivitiesInRange(userId, input.date, addDaysToLocalDateString(input.date, 1))
-        .catch(err => {
-          console.warn('Failed to load fixed activities for today/tomorrow:', err);
-          return [];
-        });
-      const todayAndTomorrowPlanBlocks = await planBlockService
-        .getBlocksInRangeState(userId, input.date, addDaysToLocalDateString(input.date, 1))
-        .then(state => {
-          if (state.status === 'AVAILABLE') return state.data;
-          console.warn(`Failed to load authored plan blocks for today/tomorrow: ${state.status}`);
-          return [];
-        })
-        .catch(err => {
-          console.warn('Failed to load authored plan blocks for today/tomorrow:', err);
-          return [];
-        });
-      if (!isCurrent()) return;
 
       const safetyStatus = getMinimumSafetyCheckinStatus(input.subjectiveCheckin);
       if (input.recoverySnapshot && canGenerateNormalRecommendation(safetyStatus)) {


### PR DESCRIPTION
💡 What: Refactored `loadDashboardData` in `Home.tsx` to use `Promise.all` for fetching independent data (yesterday's recommendation, today's/tomorrow's fixed activities, and authored plan blocks).
🎯 Why: Previously, these requests were awaited sequentially, creating a network waterfall that unnecessarily delayed the dashboard's loading phase.
📊 Impact: Expected to noticeably reduce dashboard loading time by resolving the longest individual request rather than the sum of all requests.
🔬 Measurement: Verify by measuring network request overlap in the DevTools Network tab during a dashboard refresh. All data should still correctly populate or fallback without errors.

---
*PR created automatically by Jules for task [10950748642694294518](https://jules.google.com/task/10950748642694294518) started by @Szczepanov*