### PR TITLE
Enforce planning-mode derivation authority

### DIFF
--- a/app/src/engine/planningModeArchitecture.test.ts
+++ b/app/src/engine/planningModeArchitecture.test.ts
@@ -91,9 +91,14 @@ describe('planning-mode architecture authority', () => {
 
                 // A focus-event null/existence test must never be used outside the authority
                 // module to choose one of the effective planning-mode literals.
+                const focusCondition = ts.isIfStatement(node)
+                    ? node.expression
+                    : ts.isConditionalExpression(node)
+                        ? node.condition
+                        : null;
                 if (fileName !== 'planningMode.ts'
-                    && (ts.isIfStatement(node) || ts.isConditionalExpression(node))
-                    && subtreeContains(node.expression, isFocusEventAccess)
+                    && focusCondition
+                    && subtreeContains(focusCondition, isFocusEventAccess)
                     && containsModeLiteral(node)) {
                     violations.push(`${fileName}:${lineOf(source, node)} derives planning mode from focusEvent`);
                 }

--- a/app/src/engine/planningModeArchitecture.test.ts
+++ b/app/src/engine/planningModeArchitecture.test.ts
@@ -5,7 +5,6 @@ import * as ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 
 const ENGINE_DIR = dirname(fileURLToPath(import.meta.url));
-const MODE_LITERALS = new Set(['evergreen', 'event_directed']);
 const DIRECT_PROFILE_BRANCH_ALLOWLIST = new Set(['planningMode.ts', 'validation.ts']);
 
 function productionEngineFiles(directory = ENGINE_DIR): string[] {
@@ -34,6 +33,38 @@ function subtreeContains(node: ts.Node, predicate: (candidate: ts.Node) => boole
     return found;
 }
 
+function planningModeLiterals(): Set<string> {
+    const modelsPath = join(ENGINE_DIR, 'models.ts');
+    const source = ts.createSourceFile(
+        'models.ts',
+        readFileSync(modelsPath, 'utf8'),
+        ts.ScriptTarget.Latest,
+        true,
+        ts.ScriptKind.TS,
+    );
+    const modes = new Set<string>();
+
+    const visit = (node: ts.Node): void => {
+        if (ts.isTypeAliasDeclaration(node) && node.name.text === 'PlanningMode') {
+            const collectLiteral = (candidate: ts.Node): void => {
+                if (ts.isLiteralTypeNode(candidate) && ts.isStringLiteral(candidate.literal)) {
+                    modes.add(candidate.literal.text);
+                }
+                candidate.forEachChild(collectLiteral);
+            };
+            collectLiteral(node.type);
+            return;
+        }
+        node.forEachChild(visit);
+    };
+    visit(source);
+
+    if (modes.size === 0) {
+        throw new Error('Architecture guard could not resolve PlanningMode literals from engine/models.ts');
+    }
+    return modes;
+}
+
 function isPlanningModeAccess(node: ts.Node): boolean {
     return (ts.isPropertyAccessExpression(node) && node.name.text === 'planningMode')
         || (ts.isElementAccessExpression(node)
@@ -48,8 +79,8 @@ function isFocusEventAccess(node: ts.Node): boolean {
             && node.argumentExpression.text === 'focusEvent');
 }
 
-function containsModeLiteral(node: ts.Node): boolean {
-    return subtreeContains(node, candidate => ts.isStringLiteral(candidate) && MODE_LITERALS.has(candidate.text));
+function containsModeLiteral(node: ts.Node, modeLiterals: ReadonlySet<string>): boolean {
+    return subtreeContains(node, candidate => ts.isStringLiteral(candidate) && modeLiterals.has(candidate.text));
 }
 
 function branchCondition(node: ts.Node): ts.Expression | null {
@@ -66,6 +97,7 @@ function lineOf(source: ts.SourceFile, node: ts.Node): number {
 describe('planning-mode architecture authority', () => {
     it('keeps effective planning-mode derivation inside planningMode.ts', () => {
         const violations: string[] = [];
+        const modeLiterals = planningModeLiterals();
 
         for (const absolutePath of productionEngineFiles()) {
             const fileName = relative(ENGINE_DIR, absolutePath).replaceAll('\\', '/');
@@ -76,11 +108,13 @@ describe('planning-mode architecture authority', () => {
             const visit = (node: ts.Node): void => {
                 // PlanningContext mode literals are authority output. Production code outside
                 // planningMode.ts may consume the resolved value, but must not construct it.
+                // Derive the literal set from PlanningMode itself so a future third mode is
+                // guarded automatically when the union widens.
                 if (baseName !== 'planningMode.ts'
                     && ts.isPropertyAssignment(node)
                     && propertyName(node.name) === 'mode'
                     && ts.isStringLiteral(node.initializer)
-                    && MODE_LITERALS.has(node.initializer.text)) {
+                    && modeLiterals.has(node.initializer.text)) {
                     violations.push(`${fileName}:${lineOf(source, node)} constructs effective mode '${node.initializer.text}'`);
                 }
 
@@ -103,7 +137,7 @@ describe('planning-mode architecture authority', () => {
                 if (baseName !== 'planningMode.ts'
                     && focusCondition
                     && subtreeContains(focusCondition, isFocusEventAccess)
-                    && containsModeLiteral(node)) {
+                    && containsModeLiteral(node, modeLiterals)) {
                     violations.push(`${fileName}:${lineOf(source, node)} derives planning mode from focusEvent`);
                 }
 

--- a/app/src/engine/planningModeArchitecture.test.ts
+++ b/app/src/engine/planningModeArchitecture.test.ts
@@ -5,7 +5,7 @@ import * as ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 
 const ENGINE_DIR = dirname(fileURLToPath(import.meta.url));
-const DIRECT_PROFILE_BRANCH_ALLOWLIST = new Set(['planningMode.ts', 'validation.ts']);
+const DIRECT_PROFILE_ACCESS_ALLOWLIST = new Set(['planningMode.ts', 'validation.ts']);
 
 function productionEngineFiles(directory = ENGINE_DIR): string[] {
     return readdirSync(directory, { withFileTypes: true })
@@ -83,13 +83,6 @@ function containsModeLiteral(node: ts.Node, modeLiterals: ReadonlySet<string>): 
     return subtreeContains(node, candidate => ts.isStringLiteral(candidate) && modeLiterals.has(candidate.text));
 }
 
-function branchCondition(node: ts.Node): ts.Expression | null {
-    if (ts.isIfStatement(node) || ts.isWhileStatement(node) || ts.isDoStatement(node)) return node.expression;
-    if (ts.isConditionalExpression(node)) return node.condition;
-    if (ts.isSwitchStatement(node)) return node.expression;
-    return null;
-}
-
 function lineOf(source: ts.SourceFile, node: ts.Node): number {
     return source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1;
 }
@@ -118,13 +111,12 @@ describe('planning-mode architecture authority', () => {
                     violations.push(`${fileName}:${lineOf(source, node)} constructs effective mode '${node.initializer.text}'`);
                 }
 
-                // Persisted profile validation may inspect planningMode for schema validity;
-                // all behavioral branching on that field belongs to planningMode.ts.
-                if (!DIRECT_PROFILE_BRANCH_ALLOWLIST.has(baseName)) {
-                    const condition = branchCondition(node);
-                    if (condition && subtreeContains(condition, isPlanningModeAccess)) {
-                        violations.push(`${fileName}:${lineOf(source, node)} branches directly on TrainingIntentProfile.planningMode`);
-                    }
+                // No engine module may even read the persisted profile's mode to make its own
+                // decision. validation.ts is the only non-authority exception because it checks
+                // the persisted schema rather than deriving runtime behavior. This also catches
+                // aliasing such as `const mode = profile.planningMode` before a later branch.
+                if (!DIRECT_PROFILE_ACCESS_ALLOWLIST.has(baseName) && isPlanningModeAccess(node)) {
+                    violations.push(`${fileName}:${lineOf(source, node)} reads TrainingIntentProfile.planningMode outside the authority`);
                 }
 
                 // A focus-event null/existence test must never be used outside the authority

--- a/app/src/engine/planningModeArchitecture.test.ts
+++ b/app/src/engine/planningModeArchitecture.test.ts
@@ -1,5 +1,5 @@
 import { readdirSync, readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { dirname, join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import * as ts from 'typescript';
 import { describe, expect, it } from 'vitest';
@@ -8,12 +8,14 @@ const ENGINE_DIR = dirname(fileURLToPath(import.meta.url));
 const MODE_LITERALS = new Set(['evergreen', 'event_directed']);
 const DIRECT_PROFILE_BRANCH_ALLOWLIST = new Set(['planningMode.ts', 'validation.ts']);
 
-function productionEngineFiles(): string[] {
-    return readdirSync(ENGINE_DIR, { withFileTypes: true })
-        .filter(entry => entry.isFile()
-            && entry.name.endsWith('.ts')
-            && !entry.name.endsWith('.test.ts'))
-        .map(entry => entry.name)
+function productionEngineFiles(directory = ENGINE_DIR): string[] {
+    return readdirSync(directory, { withFileTypes: true })
+        .flatMap(entry => {
+            const absolutePath = join(directory, entry.name);
+            if (entry.isDirectory()) return productionEngineFiles(absolutePath);
+            if (!entry.isFile() || !entry.name.endsWith('.ts') || entry.name.endsWith('.test.ts')) return [];
+            return [absolutePath];
+        })
         .sort();
 }
 
@@ -65,14 +67,16 @@ describe('planning-mode architecture authority', () => {
     it('keeps effective planning-mode derivation inside planningMode.ts', () => {
         const violations: string[] = [];
 
-        for (const fileName of productionEngineFiles()) {
-            const sourceText = readFileSync(join(ENGINE_DIR, fileName), 'utf8');
+        for (const absolutePath of productionEngineFiles()) {
+            const fileName = relative(ENGINE_DIR, absolutePath).replaceAll('\\', '/');
+            const baseName = fileName.split('/').at(-1) ?? fileName;
+            const sourceText = readFileSync(absolutePath, 'utf8');
             const source = ts.createSourceFile(fileName, sourceText, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
 
             const visit = (node: ts.Node): void => {
                 // PlanningContext mode literals are authority output. Production code outside
                 // planningMode.ts may consume the resolved value, but must not construct it.
-                if (fileName !== 'planningMode.ts'
+                if (baseName !== 'planningMode.ts'
                     && ts.isPropertyAssignment(node)
                     && propertyName(node.name) === 'mode'
                     && ts.isStringLiteral(node.initializer)
@@ -82,7 +86,7 @@ describe('planning-mode architecture authority', () => {
 
                 // Persisted profile validation may inspect planningMode for schema validity;
                 // all behavioral branching on that field belongs to planningMode.ts.
-                if (!DIRECT_PROFILE_BRANCH_ALLOWLIST.has(fileName)) {
+                if (!DIRECT_PROFILE_BRANCH_ALLOWLIST.has(baseName)) {
                     const condition = branchCondition(node);
                     if (condition && subtreeContains(condition, isPlanningModeAccess)) {
                         violations.push(`${fileName}:${lineOf(source, node)} branches directly on TrainingIntentProfile.planningMode`);
@@ -96,7 +100,7 @@ describe('planning-mode architecture authority', () => {
                     : ts.isConditionalExpression(node)
                         ? node.condition
                         : null;
-                if (fileName !== 'planningMode.ts'
+                if (baseName !== 'planningMode.ts'
                     && focusCondition
                     && subtreeContains(focusCondition, isFocusEventAccess)
                     && containsModeLiteral(node)) {

--- a/app/src/engine/planningModeArchitecture.test.ts
+++ b/app/src/engine/planningModeArchitecture.test.ts
@@ -50,6 +50,13 @@ function containsModeLiteral(node: ts.Node): boolean {
     return subtreeContains(node, candidate => ts.isStringLiteral(candidate) && MODE_LITERALS.has(candidate.text));
 }
 
+function branchCondition(node: ts.Node): ts.Expression | null {
+    if (ts.isIfStatement(node) || ts.isWhileStatement(node) || ts.isDoStatement(node)) return node.expression;
+    if (ts.isConditionalExpression(node)) return node.condition;
+    if (ts.isSwitchStatement(node)) return node.expression;
+    return null;
+}
+
 function lineOf(source: ts.SourceFile, node: ts.Node): number {
     return source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1;
 }
@@ -76,11 +83,7 @@ describe('planning-mode architecture authority', () => {
                 // Persisted profile validation may inspect planningMode for schema validity;
                 // all behavioral branching on that field belongs to planningMode.ts.
                 if (!DIRECT_PROFILE_BRANCH_ALLOWLIST.has(fileName)) {
-                    const condition = ts.isIfStatement(node) || ts.isWhileStatement(node) || ts.isDoStatement(node)
-                        ? node.expression
-                        : ts.isConditionalExpression(node) || ts.isSwitchStatement(node)
-                            ? node.condition ?? node.expression
-                            : null;
+                    const condition = branchCondition(node);
                     if (condition && subtreeContains(condition, isPlanningModeAccess)) {
                         violations.push(`${fileName}:${lineOf(source, node)} branches directly on TrainingIntentProfile.planningMode`);
                     }

--- a/app/src/engine/planningModeArchitecture.test.ts
+++ b/app/src/engine/planningModeArchitecture.test.ts
@@ -1,0 +1,108 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import * as ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+const ENGINE_DIR = dirname(fileURLToPath(import.meta.url));
+const MODE_LITERALS = new Set(['evergreen', 'event_directed']);
+const DIRECT_PROFILE_BRANCH_ALLOWLIST = new Set(['planningMode.ts', 'validation.ts']);
+
+function productionEngineFiles(): string[] {
+    return readdirSync(ENGINE_DIR, { withFileTypes: true })
+        .filter(entry => entry.isFile()
+            && entry.name.endsWith('.ts')
+            && !entry.name.endsWith('.test.ts'))
+        .map(entry => entry.name)
+        .sort();
+}
+
+function propertyName(node: ts.Node): string | null {
+    if (ts.isIdentifier(node)) return node.text;
+    if (ts.isStringLiteral(node)) return node.text;
+    return null;
+}
+
+function subtreeContains(node: ts.Node, predicate: (candidate: ts.Node) => boolean): boolean {
+    if (predicate(node)) return true;
+    let found = false;
+    node.forEachChild(child => {
+        if (!found && subtreeContains(child, predicate)) found = true;
+    });
+    return found;
+}
+
+function isPlanningModeAccess(node: ts.Node): boolean {
+    return (ts.isPropertyAccessExpression(node) && node.name.text === 'planningMode')
+        || (ts.isElementAccessExpression(node)
+            && ts.isStringLiteral(node.argumentExpression)
+            && node.argumentExpression.text === 'planningMode');
+}
+
+function isFocusEventAccess(node: ts.Node): boolean {
+    return (ts.isPropertyAccessExpression(node) && node.name.text === 'focusEvent')
+        || (ts.isElementAccessExpression(node)
+            && ts.isStringLiteral(node.argumentExpression)
+            && node.argumentExpression.text === 'focusEvent');
+}
+
+function containsModeLiteral(node: ts.Node): boolean {
+    return subtreeContains(node, candidate => ts.isStringLiteral(candidate) && MODE_LITERALS.has(candidate.text));
+}
+
+function lineOf(source: ts.SourceFile, node: ts.Node): number {
+    return source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1;
+}
+
+describe('planning-mode architecture authority', () => {
+    it('keeps effective planning-mode derivation inside planningMode.ts', () => {
+        const violations: string[] = [];
+
+        for (const fileName of productionEngineFiles()) {
+            const sourceText = readFileSync(join(ENGINE_DIR, fileName), 'utf8');
+            const source = ts.createSourceFile(fileName, sourceText, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+
+            const visit = (node: ts.Node): void => {
+                // PlanningContext mode literals are authority output. Production code outside
+                // planningMode.ts may consume the resolved value, but must not construct it.
+                if (fileName !== 'planningMode.ts'
+                    && ts.isPropertyAssignment(node)
+                    && propertyName(node.name) === 'mode'
+                    && ts.isStringLiteral(node.initializer)
+                    && MODE_LITERALS.has(node.initializer.text)) {
+                    violations.push(`${fileName}:${lineOf(source, node)} constructs effective mode '${node.initializer.text}'`);
+                }
+
+                // Persisted profile validation may inspect planningMode for schema validity;
+                // all behavioral branching on that field belongs to planningMode.ts.
+                if (!DIRECT_PROFILE_BRANCH_ALLOWLIST.has(fileName)) {
+                    const condition = ts.isIfStatement(node) || ts.isWhileStatement(node) || ts.isDoStatement(node)
+                        ? node.expression
+                        : ts.isConditionalExpression(node) || ts.isSwitchStatement(node)
+                            ? node.condition ?? node.expression
+                            : null;
+                    if (condition && subtreeContains(condition, isPlanningModeAccess)) {
+                        violations.push(`${fileName}:${lineOf(source, node)} branches directly on TrainingIntentProfile.planningMode`);
+                    }
+                }
+
+                // A focus-event null/existence test must never be used outside the authority
+                // module to choose one of the effective planning-mode literals.
+                if (fileName !== 'planningMode.ts'
+                    && (ts.isIfStatement(node) || ts.isConditionalExpression(node))
+                    && subtreeContains(node.expression, isFocusEventAccess)
+                    && containsModeLiteral(node)) {
+                    violations.push(`${fileName}:${lineOf(source, node)} derives planning mode from focusEvent`);
+                }
+
+                node.forEachChild(visit);
+            };
+            visit(source);
+        }
+
+        expect(
+            violations,
+            'ADR-0017 requires planningMode.ts to be the sole authority that derives effective planning mode. Consume PlanningContext.mode downstream instead of re-deriving it.',
+        ).toEqual([]);
+    });
+});

--- a/app/src/engine/simulation/analyze.ts
+++ b/app/src/engine/simulation/analyze.ts
@@ -3,6 +3,7 @@ import { evaluateNextDayPlanWithIntent, evaluateTrainingWithIntent } from '../ru
 import { generateWeekAheadPlanWithIntent, resolveWeeklyAnchors, type WeekAheadDay } from '../planner';
 import type { CompletedExposure, TrainingHistoryProvider } from '../trainingHistory';
 import { evaluatePeriodizationPhase } from '../periodization';
+import { resolvePlanningContext } from '../planningMode';
 import { addDaysToLocalDateString } from '../../utils/localDate';
 import { workoutForTemplate } from '../../workouts/prescription';
 import type { AthleteScenario } from './scenarios';
@@ -259,7 +260,12 @@ function computeMetrics(
     const objectiveResolution = Array.from(objectiveTallies.values());
     const qualityWarnings: string[] = [];
     const missedObjectives = objectiveResolution.filter(o => o.timesResolved < o.timesGenerated);
-    const isEvergreen = scenario.trainingIntentProfile?.planningMode === 'evergreen';
+    const effectivePlanningMode = resolvePlanningContext(
+        scenario.trainingIntentProfile ?? null,
+        evaluatePeriodizationPhase(scenarioEvents, scenario.startDate),
+        scenario.startDate,
+    ).mode;
+    const isEvergreen = effectivePlanningMode === 'evergreen';
     // Evergreen packing reports safe partial-dose and target shortfalls in its weekly
     // budget. Those are athlete-facing feasibility facts, not a planner-quality failure.
     // Event-directed objectives remain strict calibration contracts.

--- a/app/src/engine/simulation/analyze.ts
+++ b/app/src/engine/simulation/analyze.ts
@@ -251,7 +251,7 @@ function computeMetrics(
         });
         return { weekIndex, fatigueTierDayCounts: weekFatigueTiers, restOrRecoveryDayCount: weekRestOrRecoveryDays };
     });
-    const scenarioEvents = scenario.events ?? (scenario.event ? [scenario.event] : []);
+    const scenarioEvents = [...(scenario.events ?? (scenario.event ? [scenario.event] : []))];
     const primaryEvent = scenarioEvents[0] ?? null;
     const isCyclingRelevantEvent = primaryEvent?.category === 'cycling_event' || primaryEvent?.category === 'triathlon';
     const anchorScopeNote = isCyclingRelevantEvent ? null :


### PR DESCRIPTION
## Summary

- add an AST-aware architecture regression that keeps effective planning-mode derivation in `planningMode.ts`
- recursively scan production modules under `app/src/engine`, not only today's top-level layout
- prohibit persisted `TrainingIntentProfile.planningMode` reads outside `planningMode.ts` and schema validation, so alias-then-branch re-derivations are caught too
- derive the guarded mode literals from the `PlanningMode` type itself, so a future `externally_planned` mode is covered automatically when the union widens
- reject `focusEvent`-based construction of an effective mode elsewhere and report file/line diagnostics with the ADR-0017 authority contract
- fix a real inconsistency exposed by the guard: simulator quality-warning classification now asks `resolvePlanningContext` for the effective mode instead of reading the persisted profile directly, so an `event_directed` profile with no eligible event is analyzed as Evergreen just like the engine

## Validation

- the test parses production engine TypeScript with the repository's existing `typescript` dev dependency
- CI is the authoritative full validation for this connector-authored branch

Closes #42