### PR TITLE
Fix training-settings schema validation drift

### DIFF
--- a/app/src/engine/composer.ts
+++ b/app/src/engine/composer.ts
@@ -1,5 +1,6 @@
 import type { DailyDecisionInput, DailyRecoverySnapshot, DailySubjectiveCheckin, TrainingIntentProfile, TrainingSettings, UserGoal, UserPreferences } from './models';
 import type { DataState } from './dataState';
+import { isSupportedTrainingSettingsSchemaVersion } from './trainingSettingsSchema';
 import { checkinService } from '../services/checkinService';
 import { goalService } from '../services/goalService';
 import { trainingSettingsService } from '../services/trainingSettingsService';
@@ -269,7 +270,7 @@ export class DecisionComposer {
         });
 
         if (input.trainingSettings.userId !== input.userId) errors.push('Training settings userId mismatch');
-        if (input.trainingSettings.schemaVersion !== 2) errors.push('Unsupported training settings schema');
+        if (!isSupportedTrainingSettingsSchemaVersion(input.trainingSettings.schemaVersion)) errors.push('Unsupported training settings schema');
 
         return {
             isValid: errors.length === 0,

--- a/app/src/engine/composerValidation.test.ts
+++ b/app/src/engine/composerValidation.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import type { DailyDecisionInput } from './models';
+import { DecisionComposer } from './composer';
+import { CURRENT_TRAINING_SETTINGS_SCHEMA_VERSION } from './trainingSettingsSchema';
+import { createDefaultTrainingSettings } from '../services/trainingSettingsService';
+
+function decisionInput(schemaVersion: number): DailyDecisionInput {
+    return {
+        userId: 'athlete',
+        date: '2026-08-15',
+        recoverySnapshot: null,
+        subjectiveCheckin: null,
+        activeGoals: [],
+        trainingSettings: {
+            ...createDefaultTrainingSettings('athlete', '2026-08-15T00:00:00.000Z'),
+            schemaVersion,
+        },
+        preferences: null,
+        trainingIntentProfile: null,
+        dataQuality: {
+            hasRecoverySnapshot: false,
+            hasSubjectiveCheckin: false,
+            subjectiveCheckinComplete: false,
+            profileReady: false,
+        },
+    } as DailyDecisionInput;
+}
+
+describe('DecisionComposer decision-input validation', () => {
+    it('accepts both the current and supported legacy training-settings schemas', async () => {
+        const composer = new DecisionComposer();
+
+        await expect(composer.validateDecisionInput(decisionInput(CURRENT_TRAINING_SETTINGS_SCHEMA_VERSION)))
+            .resolves.toEqual({ isValid: true, errors: [] });
+        await expect(composer.validateDecisionInput(decisionInput(2)))
+            .resolves.toEqual({ isValid: true, errors: [] });
+    });
+
+    it('rejects a training-settings schema outside the shared compatibility set', async () => {
+        const result = await new DecisionComposer().validateDecisionInput(decisionInput(99));
+
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContain('Unsupported training settings schema');
+    });
+});

--- a/app/src/engine/trainingSettingsSchema.ts
+++ b/app/src/engine/trainingSettingsSchema.ts
@@ -1,0 +1,9 @@
+export const CURRENT_TRAINING_SETTINGS_SCHEMA_VERSION = 3 as const;
+export const SUPPORTED_TRAINING_SETTINGS_SCHEMA_VERSIONS = [2, CURRENT_TRAINING_SETTINGS_SCHEMA_VERSION] as const;
+
+export type SupportedTrainingSettingsSchemaVersion = typeof SUPPORTED_TRAINING_SETTINGS_SCHEMA_VERSIONS[number];
+
+export function isSupportedTrainingSettingsSchemaVersion(value: unknown): value is SupportedTrainingSettingsSchemaVersion {
+    return typeof value === 'number'
+        && SUPPORTED_TRAINING_SETTINGS_SCHEMA_VERSIONS.some(version => version === value);
+}

--- a/app/src/services/trainingSettingsService.ts
+++ b/app/src/services/trainingSettingsService.ts
@@ -2,6 +2,7 @@ import { doc, getDoc, setDoc } from 'firebase/firestore';
 import { getDb } from '../firebase';
 import type { BodyRegion, SessionTemplate, TrainingSettings, UserConstraint } from '../engine/models';
 import type { DataState } from '../engine/dataState';
+import { CURRENT_TRAINING_SETTINGS_SCHEMA_VERSION, isSupportedTrainingSettingsSchemaVersion } from '../engine/trainingSettingsSchema';
 import { constraintService } from './constraintService';
 import { getErrorCode } from '../utils/errors';
 import { isValidDate } from '../engine/validation';
@@ -15,7 +16,6 @@ export type TrainingSettingsUpdate = {
     migration?: Partial<TrainingSettings['migration']>;
 };
 
-const SETTINGS_SCHEMA_VERSION = 3 as const;
 const COLLECTION = 'trainingSettings';
 const DOCUMENT = 'profile';
 const equipmentKeys = ['free_weights', 'cable_machine', 'treadmill', 'indoor_bike', 'pullup_bar'] as const;
@@ -30,7 +30,7 @@ function timestamp(): string {
 export function createDefaultTrainingSettings(userId: string, now = timestamp()): TrainingSettings {
     return {
         userId,
-        schemaVersion: SETTINGS_SCHEMA_VERSION,
+        schemaVersion: CURRENT_TRAINING_SETTINGS_SCHEMA_VERSION,
         equipment: { free_weights: false, cable_machine: false, treadmill: false, indoor_bike: false, pullup_bar: false },
         guardrails: { avoid_high_impact: false, avoid_heavy_lower_body: false, avoid_overhead_pressing: false, avoid_heavy_spinal_loading: false },
         injuries: [],
@@ -46,11 +46,11 @@ function isDuration(value: unknown): value is number | null {
     return value === null || (typeof value === 'number' && Number.isInteger(value) && value >= 0 && value <= 1440);
 }
 
-/** Parses storage data defensively so malformed user data never enters the engine. Accepts schema 2 or 3. */
+/** Parses storage data defensively so malformed user data never enters the engine. */
 export function parseTrainingSettings(raw: unknown, userId: string): TrainingSettings | null {
     if (!raw || typeof raw !== 'object') return null;
     const data = raw as Record<string, unknown>;
-    if (data.userId !== userId || (data.schemaVersion !== 2 && data.schemaVersion !== 3)) return null;
+    if (data.userId !== userId || !isSupportedTrainingSettingsSchemaVersion(data.schemaVersion)) return null;
     const equipment = data.equipment as Record<string, unknown> | undefined;
     const guardrails = data.guardrails as Record<string, unknown> | undefined;
     const defaults = data.defaults as Record<string, unknown> | undefined;
@@ -82,7 +82,7 @@ export function parseTrainingSettings(raw: unknown, userId: string): TrainingSet
 
     return {
         ...(data as unknown as TrainingSettings),
-        schemaVersion: SETTINGS_SCHEMA_VERSION,
+        schemaVersion: CURRENT_TRAINING_SETTINGS_SCHEMA_VERSION,
         injuries: (data.injuries as TrainingSettings['injuries']) ?? [],
     };
 }
@@ -109,7 +109,7 @@ export function migrateLegacyConstraints(userId: string, constraints: UserConstr
 function mergeSettings(current: TrainingSettings, update: TrainingSettingsUpdate): TrainingSettings {
     const next: TrainingSettings = {
         ...current,
-        schemaVersion: SETTINGS_SCHEMA_VERSION,
+        schemaVersion: CURRENT_TRAINING_SETTINGS_SCHEMA_VERSION,
         equipment: { ...current.equipment, ...update.equipment },
         guardrails: { ...current.guardrails, ...update.guardrails },
         injuries: update.injuries !== undefined ? update.injuries : current.injuries ?? [],


### PR DESCRIPTION
## Summary

- centralize the current/supported training-settings schema versions in one engine-owned helper
- make both storage parsing/normalization and `DecisionComposer.validateDecisionInput` consume that shared authority
- preserve schema 2 read compatibility while normalizing writes/reads to current schema 3
- add regression coverage proving schema 2 and 3 inputs validate and unknown versions fail

## Validation

- focused Vitest regression added in `composerValidation.test.ts`
- CI is the authoritative full validation for this connector-authored branch

Closes #40