### PR TITLE
Reconcile Phase 7 plan status and acceptance evidence

### DIFF
--- a/docs/plans/phase-7-training-intent-and-planning-modes.md
+++ b/docs/plans/phase-7-training-intent-and-planning-modes.md
@@ -525,28 +525,34 @@ architecture doc's description matches `planningMode.ts` and `evergreenStrategy.
 
 ## Acceptance criteria
 
-- [ ] An athlete with no events and no profile receives a coherent week from documented
+Acceptance was rechecked against the 2026-08-11 Phase 6/7 compliance review and current
+source before closing the bookkeeping gap. These checks record the point-in-time delivered
+behaviour. The direct future-regression guards requested in issues #42 and #43 strengthen
+two of these contracts; their absence at the audit commit did not mean the inspected
+behaviour itself failed the criterion.
+
+- [x] An athlete with no events and no profile receives a coherent week from documented
       defaults — no crash, no empty candidate set, no fabricated event.
-- [ ] An eventless athlete's dose requirement is derived before packing; identical session
+- [x] An eventless athlete's dose requirement is derived before packing; identical session
       counts with materially different usable minutes can produce different shortfalls.
-- [ ] `coverageNeedTierForTemplate` is no longer a constant `3` for eventless athletes.
-- [ ] `taperActive` is false on every eventless day and on every dated `general_target`
+- [x] `coverageNeedTierForTemplate` is no longer a constant `3` for eventless athletes.
+- [x] `taperActive` is false on every eventless day and on every dated `general_target`
       goal without an explicit `EventTaperSpec.startDate`.
-- [ ] `simulate:diff` shows **zero** change on all pre-existing event-directed scenarios.
-- [ ] `SEPTEMBER_CYCLING_EVENT_SESSION_COVERAGE` is byte-identical.
-- [ ] `TrainingIntentProfile` and `UserPreferences` each have one documented field
+- [x] `simulate:diff` shows **zero** change on all pre-existing event-directed scenarios.
+- [x] `SEPTEMBER_CYCLING_EVENT_SESSION_COVERAGE` is byte-identical.
+- [x] `TrainingIntentProfile` and `UserPreferences` each have one documented field
       ownership; no composer merge can create conflicting live preferences.
-- [ ] Required occurrences fit real minutes/windows and declared minimum packing capacity,
+- [x] Required occurrences fit real minutes/windows and declared minimum packing capacity,
       or yield semantics-preserving `below_guideline_range`,
       `guideline_target_shortfall`, `goal_requirement_shortfall`, or
       `minimum_dose_shortfall`; no fictional cross-role credit is created.
-- [ ] A public-health guideline lower bound is never rendered as a biological no-benefit
+- [x] A public-health guideline lower bound is never rendered as a biological no-benefit
       threshold; safe partial dose and its dose-response trade-off remain visible.
-- [ ] Every evidence-authoritative dose rule has source, population, outcome, confidence,
+- [x] Every evidence-authoritative dose rule has source, population, outcome, confidence,
       applicability, authority class, policy version, and review date; product packing
       heuristics are distinguishable from those rules.
-- [ ] `npm run check` and `npm run test:rules` green; policy-drift guard passes.
-- [ ] No engine module outside `planningMode.ts` derives planning mode from
+- [x] `npm run check` and `npm run test:rules` green; policy-drift guard passes.
+- [x] No engine module outside `planningMode.ts` derives planning mode from
       `focusEvent === null`.
 
 ---

--- a/docs/plans/phase-7-weekly-allocation-and-role-reservations.md
+++ b/docs/plans/phase-7-weekly-allocation-and-role-reservations.md
@@ -1,8 +1,7 @@
 # Phase 7A — Weekly allocation and safe role reservations
 
 * **Status:** `Implemented`
-* **Blocked by:** Baseline review remains blocked until this plan's acceptance criteria
-  pass; PR #17's current semantic baseline remains unchanged.
+* **Blocked by:** none; reviewed semantic-baseline acceptance is complete.
 * **Unlocks:** reviewed semantic-baseline acceptance for healthy/fresh cycling scenarios;
   explicit explanation of safety-forced weekly-role misses.
 * **Decision:** [ADR-0018](../adr/0018-weekly-allocation-and-role-reservations.md)

--- a/docs/plans/phase-7-weekly-allocation-and-role-reservations.md
+++ b/docs/plans/phase-7-weekly-allocation-and-role-reservations.md
@@ -1,6 +1,6 @@
 # Phase 7A — Weekly allocation and safe role reservations
 
-* **Status:** `Approved`
+* **Status:** `Implemented`
 * **Blocked by:** Baseline review remains blocked until this plan's acceptance criteria
   pass; PR #17's current semantic baseline remains unchanged.
 * **Unlocks:** reviewed semantic-baseline acceptance for healthy/fresh cycling scenarios;


### PR DESCRIPTION
## Summary

- mark Phase 7A `Implemented` so its plan header matches its completed task board, acceptance criteria, plan index, and compliance review
- re-check Phase 7B's twelve acceptance claims against the Phase 6/7 compliance review and current source, then mark the delivered criteria complete
- record the audit qualification explicitly: #42 and #43 add missing future-regression guards, but the inspected point-in-time behavior already satisfies the corresponding acceptance claims
- preserve the existing `Implemented` Phase 7B lifecycle status rather than using unchecked bookkeeping to imply work was not delivered

## Validation

- documentation-only governance reconciliation
- evidence basis: `docs/analysis/2026-08-11-phase-6-7-compliance-review.md`
- #42 and #43 remain separate PRs as requested, so this PR does not bundle their regression guards

Closes #41