### PR TITLE
🧪 [testing improvement] Add unit tests for DataState module

### DIFF
--- a/app/src/engine/dataState.test.ts
+++ b/app/src/engine/dataState.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { summarizeDataState, DataState } from './dataState';
+
+describe('summarizeDataState', () => {
+    it('should summarize an AVAILABLE state by returning only status and revision', () => {
+        const state: DataState<string> = {
+            status: 'AVAILABLE',
+            data: 'test data',
+            revision: '1',
+            issues: [{ code: 'TEST', documentPath: 'doc/1' }]
+        };
+        const result = summarizeDataState(state);
+        expect(result).toEqual({ status: 'AVAILABLE', revision: '1' });
+    });
+
+    it('should summarize an AVAILABLE state with null revision', () => {
+        const state: DataState<number> = {
+            status: 'AVAILABLE',
+            data: 42,
+            revision: null
+        };
+        const result = summarizeDataState(state);
+        expect(result).toEqual({ status: 'AVAILABLE', revision: null });
+    });
+
+    it('should return MISSING state identically', () => {
+        const state: DataState<string> = { status: 'MISSING' };
+        const result = summarizeDataState(state);
+        expect(result).toEqual({ status: 'MISSING' });
+    });
+
+    it('should return INVALID state identically with its issues', () => {
+        const state: DataState<string> = {
+            status: 'INVALID',
+            issues: [
+                { code: 'ERR1', documentPath: 'doc/1', field: 'fieldA' },
+                { code: 'ERR2', documentPath: 'doc/2', schemaVersion: 2 }
+            ]
+        };
+        const result = summarizeDataState(state);
+        expect(result).toEqual({
+            status: 'INVALID',
+            issues: [
+                { code: 'ERR1', documentPath: 'doc/1', field: 'fieldA' },
+                { code: 'ERR2', documentPath: 'doc/2', schemaVersion: 2 }
+            ]
+        });
+    });
+
+    it('should return UNAVAILABLE state identically with operation and retryable flags', () => {
+        const state: DataState<string> = {
+            status: 'UNAVAILABLE',
+            operation: 'fetchDoc',
+            retryable: true
+        };
+        const result = summarizeDataState(state);
+        expect(result).toEqual({
+            status: 'UNAVAILABLE',
+            operation: 'fetchDoc',
+            retryable: true
+        });
+    });
+});

--- a/app/src/engine/dataState.test.ts
+++ b/app/src/engine/dataState.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { summarizeDataState, DataState } from './dataState';
+import { summarizeDataState, type DataState } from './dataState';
 
 describe('summarizeDataState', () => {
     it('should summarize an AVAILABLE state by returning only status and revision', () => {


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was a missing test file for the `DataState` module (`app/src/engine/dataState.ts`), specifically the `summarizeDataState` function.
📊 **Coverage:** The scenarios now tested include handling of all `DataState` variations:
- `AVAILABLE` (correctly strips payload data and issue details to only return the status and revision).
- `MISSING` (returns state identically).
- `INVALID` (returns state identically, keeping issue arrays intact).
- `UNAVAILABLE` (returns state identically, keeping operational retry metadata).
- Missing/Null revision scenarios in `AVAILABLE` state are also covered.
✨ **Result:** Test coverage for `app/src/engine/dataState.ts` is now comprehensive and regressions can be caught securely by the `vitest` suite.

---
*PR created automatically by Jules for task [1948093801553546867](https://jules.google.com/task/1948093801553546867) started by @Szczepanov*