### PR TITLE
🧪 [testing improvement] Add missing error test for unauthenticated get_stats

### DIFF
--- a/tests/test_garmin_client.py
+++ b/tests/test_garmin_client.py
@@ -80,3 +80,9 @@ def test_get_sleep_data_unauthenticated():
     wrapper = GarminClientWrapper(allow_credential_login=False)
     with pytest.raises(RuntimeError, match="Garmin client is not authenticated. Call login first."):
         wrapper.get_sleep_data("2023-10-10")
+
+
+def test_get_stats_unauthenticated():
+    wrapper = GarminClientWrapper(allow_credential_login=False)
+    with pytest.raises(RuntimeError, match="Garmin client is not authenticated. Call login first."):
+        wrapper.get_stats("2023-10-10")


### PR DESCRIPTION
🎯 **What:** Added a missing error test `test_get_stats_unauthenticated` for the unauthenticated `get_stats` method of `GarminClientWrapper` in `src/garmin_sync/garmin_client.py:99`.
📊 **Coverage:** The test ensures that calling `get_stats` on an unauthenticated client correctly raises a `RuntimeError` with a clear message, covering this previously untested edge case.
✨ **Result:** Improved test coverage by verifying the expected behavior of `get_stats` when no valid login session is active, increasing reliability and confidence for future refactoring.

---
*PR created automatically by Jules for task [2144811635405239167](https://jules.google.com/task/2144811635405239167) started by @Szczepanov*