### PR TITLE
docs: shadow-mode analysis and Phase 9.0 plan

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -85,6 +85,7 @@ Point-in-time assessments of the system as built, including gaps between documen
 * [**2026-08-10 Training-intent & periodization architecture analysis**](./analysis/2026-08-10-training-intent-periodization-architecture.md) — Evidence for Phase 7A/7B mode, preference-ownership, capacity, and stateful-allocation proposals.
 * [**2026-08-11 Phase 6 & 7 compliance review**](./analysis/2026-08-11-phase-6-7-compliance-review.md) — Code, test, simulation, deployment, and plan-status review of the delivered Phase 6 and Phase 7 work.
 * [**2026-08-15 Externally-authored plan feasibility**](./analysis/2026-08-15-externally-authored-plan-feasibility.md) — Structural assessment of importing an externally-authored training plan and narrowing the engine to per-session adjudication.
+* [**2026-08-16 Manual AI loop vs app adjudication**](./analysis/2026-08-16-manual-loop-vs-app-adjudication.md) — Whether the athlete's manual daily AI loop should be replaced by the app now that Phase 8 has landed. Verdict: shadow both for one block first; the subjective input is the one unmeasured path.
 
 ---
 
@@ -101,6 +102,7 @@ How agreed changes get made. Mutable, status-tracked, and expected to go stale �
 * [**Phase 7A: Weekly allocation & safe role reservations**](./plans/phase-7-weekly-allocation-and-role-reservations.md) — The PR #17 follow-up: reserve eligible required roles, protect them from support work, and report safety-forced misses.
 * [**Phase 7B: Training intent, capacity & planning modes**](./plans/phase-7-training-intent-and-planning-modes.md) — Evergreen evidence-to-dose-to-capacity planning proposal.
 * [**Phase 8: Externally-planned mode**](./plans/phase-8-externally-planned-mode.md) — *Implemented.* Import an externally-authored plan, adjudicate its sessions against daily readiness, and repoint the weekly machinery to critique.
+* [**Phase 9.0: Shadow mode and the decision journal**](./plans/phase-9-0-shadow-mode-and-decision-journal.md) — *Draft.* Run the app and the athlete's AI side by side for one block and record where they disagree; produces the real subjective corpus Phase 9 needs.
 * [**Phase 9: Subjective baselines in readiness mode**](./plans/phase-9-subjective-baselines.md) — *Draft.* Build the tighten-only subjective drift term behind a default-off selector, give the corpus real subjective variance, then decide from evidence whether it ships.
 
 ---

--- a/docs/analysis/2026-08-16-manual-loop-vs-app-adjudication.md
+++ b/docs/analysis/2026-08-16-manual-loop-vs-app-adjudication.md
@@ -1,0 +1,179 @@
+# Should the manual AI loop be replaced by the app? (2026-08-16)
+
+**Question asked.** The athlete's current workflow is manual: each morning they report
+subjective and objective recovery scores to a general-purpose AI as a prompt, and the AI
+returns today's session plus actions for the coming days. Every week or two they reassess
+the block with the same AI. With Phase 8 built, should they switch to this app?
+
+**Verdict: not yet — but not because the app is too weak.** Run both in parallel for one
+training block first. Switching now would discard the only evidence that can answer the
+question, and the cost of collecting that evidence is roughly one screen plus the habit of
+using the app daily, which is a prerequisite of switching anyway.
+
+Verified against `origin/main` at `f63b145`, which is PR #50 (Phase 8) merged.
+
+---
+
+## 1. Phase 8 changed what is actually being asked
+
+The original question was "is this engine a better coach than the athlete's AI?" The
+answer was no, and
+[the feasibility analysis](./2026-08-15-externally-authored-plan-feasibility.md) accepted
+that as a premise rather than arguing with it. ADR-0019 then split the engine's two jobs
+and gave one of them away:
+
+| Job | Owner after Phase 8 |
+|---|---|
+| **Selection** — which session, and the macro/meso structure around it | The athlete's AI |
+| **Adjudication** — is today the day, at what dose, does it violate a hard constraint | This engine |
+
+That split is not a compromise; it lines up with where each system is actually strong.
+
+**What a fresh AI chat structurally cannot do.** It holds no state between mornings. It
+knows the athlete has done three hard sessions in six days only if they remember to say
+so, and it cannot decay yesterday's load into today's. The app's `fatigue.ts` accumulates
+and decays six dimensions across days from Garmin data plus adherence, and
+`microcycle.ts` carries an objective ledger the same way. This is not a modelling
+preference — it is memory the conversational loop does not have.
+
+**What the engine structurally cannot do.** It cannot hear "my knee twinged on the last
+interval" unless that maps to a check-in field. Free-text nuance reaches the AI and
+reaches the engine only as a checkbox.
+
+So the live question is narrower than it was: **is the engine's daily go/no-go trustworthy
+enough to replace the daily AI prompt?** Gatekeeping is exactly where deterministic rules
+beat a language model, so the prior should be favourable. The rest of this document is
+about the one place it is not.
+
+---
+
+## 2. What is genuinely ready
+
+- **Ingestion.** `src/garmin_sync/` is a complete daily sync with backfill, a completeness
+  audit, an immutable raw-payload archive (ADR-0005), and a documented Cloud Run + Cloud
+  Scheduler deployment (`docs/ops/cloud-run-deployment.md`). Objective scores stop being
+  something the athlete transcribes into a prompt.
+- **Cross-day state.** Fatigue, objective credit, and completed-training reconciliation all
+  persist and replay. `completedTraining.ts` upgrades an adherence-confirmed session's
+  evidence tier, so answering the daily adherence prompt measurably improves the next day's
+  inputs.
+- **Hard gates.** Equipment, environment, time budget, guardrails and injury restrictions
+  are enforced in one resolver (`eligibility.ts`), emulator-tested, and cannot be forgotten
+  mid-conversation the way a constraint mentioned three prompts ago can be.
+- **Auditability.** Every decision persists a compact `RecommendationAudit`, and after
+  Phase 8 an external decision names the exact plan revision bytes it was made from and
+  fails replay loudly if those bytes changed (ADR-0019 D-IMMUT).
+
+None of that is available in the manual loop at any price.
+
+---
+
+## 3. The gap that should stop an outright switch
+
+**The input the athlete personally supplies every morning is the least-validated thing in
+the system.**
+
+Two facts, both checkable:
+
+1. **Nothing baselines subjective scores on the decision path.**
+   `mapCheckinToSubjectiveInput` maps one day's check-in to `SubjectiveInput`, and that is
+   all any decision sees. `contextBrief.ts` does read check-in history and already computes
+   7-day/28-day subjective drift with a coverage gate — but it renders a brief for the
+   athlete's AI; nothing feeds it back into `rules.ts`. A reported fatigue of 6/10 is
+   therefore treated identically whether the athlete's normal is 2 or 6. This is
+   precisely what [ADR-0020](../adr/0020-subjective-baselines-in-readiness-mode.md) exists
+   to address, and [Phase 9](../plans/phase-9-subjective-baselines.md) is still `Draft`.
+2. **The corpus that would measure it cannot.** `simulation/scenarios.ts` builds nearly
+   every scenario from `stableReadiness()`, which returns a constant subjective vector. The
+   synthetic athletes have **zero subjective variance**. A calibration run today would
+   report "no effect" for a structural reason, not an empirical one — Phase 9's own plan
+   flags this and makes 9.5 a hard precondition of 9.6.
+
+The existing calibration evidence is honest about its own boundary
+([Phase 6.4](./2026-08-10-phase-6-calibration-corpus.md)):
+
+> This is deterministic policy-regression evidence, not physiological or clinical
+> calibration. A frequently activated rule is a review signal, not a recommendation to
+> change a threshold.
+
+So: the objective half of readiness is baselined against the athlete's own 7-day and 28-day
+history (`metricStrain` in `rules.ts` z-scores it). The subjective half is not baselined at
+all. The AI, whatever else it does badly, reads a 6/10 with the memory of what the athlete
+usually reports.
+
+**This is the single largest behavioural difference between the two loops**, and it sits on
+the input the athlete cares most about.
+
+---
+
+## 4. What is missing that is not a code gap
+
+Nothing in this repository has ever compared an engine verdict to the athlete's own verdict
+on the same day. There is no disagreement log, no outcome measurement, and no record of a
+day where the two loops would have diverged. Every piece of evidence the project holds is
+deterministic self-consistency: does the engine reproduce itself, does a change move a
+synthetic baseline.
+
+That is the right kind of evidence for refactoring. It is the wrong kind for deciding
+whether to hand over the daily decision.
+
+**A switch made now would be made on taste, and would also destroy the counterfactual** —
+once the AI is out of the loop there is nothing to compare against.
+
+---
+
+## 5. Recommendation
+
+**Shadow, don't switch.** For one block (4–6 weeks):
+
+1. Use the app daily — check-in, read the verdict, answer the adherence prompt.
+2. Keep prompting the AI as today.
+3. Record all three each day: the engine's verdict, the AI's verdict, and what was actually
+   done.
+
+This yields three things at once:
+
+- **The disagreement log**, which is the actual answer to the question asked.
+- **A real subjective corpus** — 4–6 weeks of the athlete's own check-ins, with real
+  variance. This is a by-product of using the app at all; the check-ins already persist to
+  `users/{uid}/daily_subjective_checkins/{date}`.
+- **The habit**, which any switch requires regardless of the outcome.
+
+The corpus is the part worth emphasising. Phase 9.5 currently reads "give the scenario
+corpus realistic subjective variance," which today means *inventing* it. After a shadow
+block it means *sampling the one athlete who matters*. That converts Phase 9 from
+"measure a term we invented, on fixtures we also invented" into "measure it on the person
+who will use it" — and largely dissolves the chicken-and-egg the plan opens by describing.
+
+**Sequenced:**
+
+| Step | Why it is first |
+|---|---|
+| Deploy the sync unattended, plus a 56-day backfill | Shadowing against data gaps measures the ingestion, not the engine |
+| [Phase 9.0 — shadow mode and decision journal](../plans/phase-9-0-shadow-mode-and-decision-journal.md) | Produces the disagreement log and the real corpus |
+| Run the block | The gate is data volume, not code |
+| [Phase 9](../plans/phase-9-subjective-baselines.md), re-scoped | 9.5 now samples real check-ins instead of inventing variance |
+| Decide | From the log, not from taste |
+
+### Explicitly not next
+
+- **More engine features.** Phases 2–7 are implemented and Phase 8 is in review. The
+  binding constraint is evidence, not capability.
+- **Threshold tuning.** Any tuning done before the shadow block is tuning against synthetic
+  athletes with a constant subjective vector.
+- **An in-app model call.** ADR-0019 D-NOPARSE excluded it deliberately, and the paste
+  workflow already round-tripped a real 21-session plan with no hand-editing.
+
+---
+
+## 6. Answering the question directly
+
+**Is it good enough?** For the daily go/no-go, close — because Phase 8 narrowed the job to
+gatekeeping, and the gates are real, tested and stateful in a way the manual loop is not.
+The reservation is not the engine's architecture; it is that the athlete's own subjective
+scores enter it unnormalised and unmeasured.
+
+**Should the athlete switch?** Not in one step, and not yet. Run both for a block. If the
+disagreement log shows the engine and the AI mostly agreeing, the switch is safe and the
+evidence to make it will exist. If they disagree often, that log is worth more than any
+further engine work — it will say exactly where.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -73,6 +73,7 @@ all-`Ready` table became unusable.
 | 7A | [Weekly allocation & safe role reservations](./phase-7-weekly-allocation-and-role-reservations.md) | **Implemented** | none | none | resolves PR #17's healthy/fresh cycling role-coverage failure without recalibrating recovery |
 | 7B | [Training intent, capacity & planning modes](./phase-7-training-intent-and-planning-modes.md) | **Implemented** | none | none | evidence-derived Evergreen dose packed into real capacity, while preserving structured and demand-derived event planning — not an original review finding |
 | 8 | [Externally-planned mode](./phase-8-externally-planned-mode.md) | **Implemented** | — | — | imports an externally-authored plan and narrows the engine to per-session adjudication plus weekly critique — not an original review finding |
+| 9.0 | [Shadow mode & decision journal](./phase-9-0-shadow-mode-and-decision-journal.md) | **Draft** | 9.0.1, 9.0.2 | — | runs the app against the athlete's existing AI loop for one block and records the disagreements — the first evidence in this repository from a real athlete rather than a synthetic corpus |
 | 9 | [Subjective baselines in readiness mode](./phase-9-subjective-baselines.md) | **Draft** | 9.5 only | ADR-0020 acceptance | self-normalises subjective scores as a tighten-only drift term, measured behind a default-off selector before any ship decision — not an original review finding |
 
 Phases 0–6 are implemented. Phase 6 delivered explicit scenario evidence, calibration

--- a/docs/plans/phase-9-0-shadow-mode-and-decision-journal.md
+++ b/docs/plans/phase-9-0-shadow-mode-and-decision-journal.md
@@ -1,0 +1,314 @@
+# Phase 9.0: Shadow mode and the decision journal
+
+* **Status:** Draft
+* **Blocked by:** nothing in code. 9.0.1 (unattended ingestion) is an operational precondition.
+* **Unlocks:** a decision on whether to retire the manual AI daily loop, and a real
+  subjective corpus for [Phase 9](./phase-9-subjective-baselines.md) 9.5
+* **Source analysis:** [2026-08-16 manual loop vs app adjudication](../analysis/2026-08-16-manual-loop-vs-app-adjudication.md)
+* **Decisions:** none new. See "Why this needs no ADR" below.
+
+## Goal
+
+Run the app and the athlete's existing AI loop side by side for one training block, and
+record where they disagree.
+
+The deliverable is **evidence, not a feature**: a per-day log of the engine's verdict, the
+AI's verdict, and what actually happened. Everything built here exists to collect that log
+honestly and to get it back out for analysis.
+
+## Why this comes before Phase 9
+
+Phase 9 opens by describing a chicken-and-egg: the coefficients come from calibration, but
+calibration needs an implementation. It resolves that with a default-off selector. It does
+**not** resolve a second one, which 9.5 states plainly — the corpus has no subjective
+variance to measure, because `simulation/scenarios.ts` builds nearly every scenario from
+`stableReadiness()`, a constant.
+
+So 9.5 as written means *inventing* variance. After a shadow block it means *sampling the
+athlete's own check-ins*. Same work item, categorically better input, and it arrives as a
+by-product of using the app rather than as extra work.
+
+The disagreement log is the larger prize. Nothing in this repository has ever compared an
+engine verdict to a human verdict on the same day.
+
+## Why this needs no ADR
+
+Every decision here is about evidence collection, and nothing built can change a
+recommendation. The closest precedent is
+[Phase 6.4's calibration corpus](../analysis/2026-08-10-phase-6-calibration-corpus.md),
+which shipped with a dated analysis and no ADR for the same reason. The two design
+commitments that would otherwise deserve one — the journal is invisible to the engine, and
+anchoring is measured rather than assumed away — are stated here and enforced by tests.
+
+If the readout at 9.0.8 leads to changing engine policy, *that* needs an ADR.
+
+---
+
+## Preconditions
+
+* **9.0.1 must be complete before the block starts.** Shadowing against ingestion gaps
+  measures the sync, not the engine.
+* The athlete keeps prompting their AI exactly as today. Changing the manual loop mid-block
+  invalidates the comparison.
+
+---
+
+## Work items
+
+### 9.0.1 Unattended ingestion `[ ]`
+
+**Current behaviour.** `docs/ops/cloud-run-deployment.md` documents a Cloud Run Job plus
+Cloud Scheduler trigger. It is written, not necessarily running.
+
+**Change.** Operational, not code:
+
+1. Deploy the job and schedule it daily, early enough that the snapshot exists before the
+   morning check-in.
+2. `uv run python -m garmin_sync backfill --days 56` so the 28-day objective baselines are
+   mature on day 1 rather than maturing during the measurement.
+3. `uv run python -m garmin_sync audit` over the block window; record the coverage result.
+
+**Done when.** Seven consecutive days land unattended, and the audit reports no gap in the
+backfilled window. A gap discovered mid-block is a confound, not a data point.
+
+---
+
+### 9.0.2 Decision journal model, validation and storage `[ ]`
+
+**Current behaviour.** The engine's verdict already persists —
+`users/{uid}/daily_recommendations/{date}` carries `mode`, `templateId`, `adherence` and
+the compact `recommendationAudit`, and after ADR-0019 an external decision also carries
+`externalPlan` provenance. The athlete's *own* verdict is recorded nowhere.
+
+**Change.** Add `users/{uid}/decision_journal/{date}`, one document per day:
+
+```ts
+export type ShadowVerdict = 'proceed' | 'scale' | 'defer' | 'skip' | 'advisory';
+
+export interface DecisionJournalEntry {
+    userId: string;
+    date: string;                        // Warsaw-local, matches the recommendation doc id
+    /** What the athlete's own planner said to do today. */
+    externalVerdict: ShadowVerdict;
+    /** Free text, the athlete's own words. Never parsed. */
+    externalNote?: string;
+    /** Which the athlete saw first. The honest way to handle anchoring: measure it. */
+    sawEngineVerdictFirst: boolean;
+    /** What they actually did, in the same vocabulary. */
+    actualVerdict?: ShadowVerdict;
+    recordedAt: string;
+    schemaVersion: 1;
+}
+```
+
+`ShadowVerdict` deliberately reuses `ExternalSessionDecision`'s exact five values. The
+comparison is only meaningful if both sides speak one vocabulary, and these five already
+cover what a conversational planner says: do it, do it easier, move it, skip it, your call.
+
+Validation in `engine/validation.ts` (closed key set, as every other stored shape).
+Firestore rules owner-scoped, with `hasValidDecisionJournalEntry`, mirroring the
+`daily_subjective_checkins` block. Emulator tests including cross-user denial.
+
+**Done when.** A well-formed entry is accepted, a malformed or foreign-owned one is
+rejected, and the rules tests prove both.
+
+---
+
+### 9.0.3 Journal entry UI `[ ]`
+
+**Change.** A card on Home, beside the adherence prompt, that records today's entry.
+
+Two ordering rules, both about not corrupting the evidence:
+
+* The entry form is reachable **without** expanding the recommendation, so an athlete who
+  wants to record the AI's verdict blind can.
+* Whichever order they choose, `sawEngineVerdictFirst` records it. The field is set from
+  observed interaction, not from asking the athlete to self-report their own bias.
+
+The card shows the engine's verdict for the day only after an entry exists or the athlete
+explicitly reveals it.
+
+**Done when.** An entry can be recorded before the engine's verdict is visible; recording
+after reveal is possible and flagged; and the flag reflects what actually happened rather
+than a checkbox the athlete ticks.
+
+---
+
+### 9.0.4 Agreement classification `[ ]`
+
+**Change.** Add `engine/shadowAgreement.ts`, pure:
+
+```ts
+export type AgreementClass =
+    | 'agree'
+    | 'engine_more_conservative'
+    | 'engine_less_conservative'
+    | 'incomparable';
+
+export function classifyAgreement(engine: ShadowVerdict, external: ShadowVerdict): AgreementClass;
+```
+
+Ordering on the conservatism ladder: `proceed` > `scale` > `defer` ≈ `skip`. `defer` and
+`skip` are equally conservative *about today* — they differ in what happens to the session
+afterwards, which is a placement question, not a load question. `advisory` sits outside the
+ladder entirely (D-EVENT makes it a non-instruction), so any pair involving it is
+`incomparable` rather than being forced onto a scale it was never on.
+
+Classifying in code rather than in a spreadsheet is the point: the readout at 9.0.8 must not
+depend on how the reviewer eyeballed the table.
+
+**Done when.** Every ordered pair of the five verdicts has an asserted class, and the
+`advisory` rows assert `incomparable` in both directions.
+
+---
+
+### 9.0.5 Export `[ ]`
+
+**Change.** Add `engine/shadowLog.ts` (pure renderer) and a service read, following the
+`contextBrief.ts` / `contextBriefService.ts` split exactly.
+
+One row per day, joining what already exists with what 9.0.2 adds:
+
+| Column | Source |
+|---|---|
+| `date` | — |
+| `engineVerdict`, `engineMode` | `daily_recommendations/{date}` |
+| `externalVerdict`, `externalNote`, `sawEngineVerdictFirst` | `decision_journal/{date}` |
+| `actualVerdict`, `adherence.followed`, `actualDurationMin` | journal + recommendation |
+| `agreement` | 9.0.4 |
+| subjective vector | `daily_subjective_checkins/{date}` |
+| objective vector, 7d/28d deltas | `daily_recovery_snapshots/{date}` |
+| `policyVersion`, `externalPlan.contentHash` | `recommendationAudit` |
+
+Two consumers, one file: the 9.0.8 readout, and Phase 9.5's corpus.
+
+Rows are emitted for days with **any** of the three, not only complete ones — a day the
+athlete skipped the check-in is itself a finding, and silently dropping it would bias the
+log toward days that went well. That is the same missingness argument `contextBrief.ts`
+already makes about its coverage gate.
+
+**Done when.** A fixture of partial days round-trips with the gaps visible as gaps, and no
+identifier or raw wearable payload appears in the output.
+
+---
+
+### 9.0.6 The journal cannot reach the engine `[ ]`
+
+**Change.** Extend the runtime-import-graph guard added for ADR-0019
+(`engine/externalArchitecture.test.ts`, or a sibling) so that no module reachable from
+`rules.ts`, `optimizer.ts`, `planner.ts` or `trainingIntent.ts` can reach
+`decisionJournalService.ts` or `shadowLog.ts`.
+
+**Why this is load-bearing.** A journal the engine reads is evidence contaminated by its own
+effect. This is the same one-way boundary D-CRITIQUE draws for the weekly critique, for the
+same reason, and it is worth enforcing structurally rather than by intention — the existing
+guard already carries a positive control so a passing result means absence rather than a
+broken scan.
+
+**Done when.** The guard fails if a planted import is added, and passes otherwise.
+
+---
+
+### 9.0.7 Run the block `[ ]`
+
+Not a code task. 4–6 weeks of: check-in, record the AI's verdict, read the engine's verdict,
+answer the adherence prompt.
+
+**Done when** the export contains:
+
+* **≥ 28 days** with an engine verdict and an external verdict both present;
+* **≥ 21 days** with a complete subjective check-in — the same 21-of-28 coverage floor
+  `contextBrief.ts` already applies before it will show a subjective baseline at all;
+* **≥ 7 days** where `sawEngineVerdictFirst` is false, so anchoring can be estimated rather
+  than merely acknowledged.
+
+If the third gate is not met, the log is still useful for Phase 9's corpus but the
+agreement rate must be reported as anchored. Say so rather than quietly reporting it as if
+it were independent.
+
+---
+
+### 9.0.8 Readout and decision `[ ]`
+
+**Change.** A dated analysis in `docs/analysis/` reporting:
+
+* agreement rate overall, and split by `sawEngineVerdictFirst`;
+* the disagreement rows in full, with the athlete's note — the sample is small enough to
+  read every one, and the interesting content is in the prose;
+* directional bias: is the engine systematically more or less conservative;
+* whether disagreements concentrate on days where the subjective scores diverge from the
+  athlete's own trailing average, which is the specific hypothesis
+  [ADR-0020](../adr/0020-subjective-baselines-in-readiness-mode.md) predicts.
+
+Then one of:
+
+1. **Switch.** Agreement is high and disagreements are defensible. The manual daily prompt
+   retires; the AI keeps the block planning it is better at.
+2. **Switch with a named fix.** Disagreements concentrate somewhere specific — most likely
+   subjective normalisation, which is Phase 9. Do that first, then switch.
+3. **Do not switch, and record why.** The most valuable outcome if it is the true one, and
+   the reason it is worth building the log rather than deciding on taste.
+
+**Done when.** The analysis is written and Phase 9's 9.5 is re-scoped to sample the block's
+check-ins instead of inventing variance.
+
+---
+
+## Acceptance criteria
+
+- [ ] `cd app && npm run check` and `npm run test:rules` pass.
+- [ ] `npm run simulate:diff` reports no changed pre-existing baseline scenario. Nothing in
+      this phase touches a decision path, so a change here is a bug in this phase.
+- [ ] `POLICY_VERSION` is **unchanged**. If it needs a bump, something in this phase reached
+      the decision path and 9.0.6 failed to catch it.
+- [ ] A planted import from `rules.ts` to the journal fails 9.0.6's guard.
+- [ ] The export contains no identifiers, raw wearable payloads, or free-text check-in notes
+      beyond the athlete's own journal note.
+- [ ] The block's volume gates in 9.0.7 are met, or the shortfall is stated in the readout.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Anchoring: the athlete reads the engine's verdict, then "remembers" the AI agreeing. | Cannot be eliminated without hiding the app. Recorded per day (9.0.3) and reported split (9.0.8); a minimum of unanchored days is a volume gate. |
+| The athlete stops recording after two weeks. | The entry is one tap on a card already on Home. If it lapses anyway, that is itself the answer about daily-use viability, and should be reported rather than retried silently. |
+| The log becomes a feature and starts influencing decisions. | 9.0.6 makes that a test failure, not a judgement call. |
+| Comparing a five-value verdict flattens real nuance. | Accepted, and why `externalNote` is free text and every disagreement row is read individually rather than only aggregated. |
+| One athlete, one block, no control. | Accepted and stated. This is decision evidence for one person's workflow, not a study. It is still strictly more than the zero real-athlete evidence held today. |
+
+## Out of scope
+
+* Any change to `rules.ts`, thresholds, or the strain formula. That is Phase 9, and doing it
+  during the block would invalidate the block.
+* Automating capture of the AI's verdict. Parsing a chat transcript at the persistence
+  boundary is the same non-determinism ADR-0019 D-NOPARSE refused.
+* Surfacing agreement statistics to the athlete during the block — it would feed back into
+  the behaviour being measured.
+* Backfilling the journal. It cannot be reconstructed.
+
+## Docs to update
+
+- [ ] `docs/README.md` — index row.
+- [ ] `plans/README.md` — plan table row.
+- [ ] `AGENTS.md` — `engine/` map gains `shadowAgreement.ts` and `shadowLog.ts`.
+- [ ] `phase-9-subjective-baselines.md` — 9.5 re-scoped to sample the block's check-ins.
+- [ ] `architecture/recommendation-engine.md` — only if 9.0.8 leads to a policy change.
+
+---
+
+## Task board
+
+| # | Task | Status | Blocked by |
+|---|---|:--:|---|
+| 9.0.1 | Unattended ingestion | `[ ]` | — |
+| 9.0.2 | Journal model, validation, storage | `[ ]` | — |
+| 9.0.3 | Journal entry UI | `[ ]` | 9.0.2 |
+| 9.0.4 | Agreement classification | `[ ]` | 9.0.2 |
+| 9.0.5 | Export | `[ ]` | 9.0.2, 9.0.4 |
+| 9.0.6 | Journal-cannot-reach-engine guard | `[ ]` | 9.0.2 |
+| 9.0.7 | Run the block | `[ ]` | 9.0.1, 9.0.3, 9.0.6 |
+| 9.0.8 | Readout and decision | `[ ]` | 9.0.7 |
+
+9.0.1 and 9.0.2 are startable immediately and in parallel — one is operational, the other is
+a storage shape with no dependency on it. 9.0.1 is on the critical path for the block, so it
+should start first even though it is not code.

--- a/docs/plans/phase-9-0-shadow-mode-and-decision-journal.md
+++ b/docs/plans/phase-9-0-shadow-mode-and-decision-journal.md
@@ -62,8 +62,8 @@ Cloud Scheduler trigger. It is written, not necessarily running.
 
 **Change.** Operational, not code:
 
-1. Deploy the job and schedule it daily, early enough that the snapshot exists before the
-   morning check-in.
+1. Deploy the job and schedule it daily at `05:00 Europe/Warsaw` (`0 5 * * *`), early enough
+   that the snapshot exists before the morning check-in.
 2. `uv run python -m garmin_sync backfill --days 56` so the 28-day objective baselines are
    mature on day 1 rather than maturing during the measurement.
 3. `uv run python -m garmin_sync audit` over the block window; record the coverage result.
@@ -96,7 +96,8 @@ export interface DecisionJournalEntry {
     sawEngineVerdictFirst: boolean;
     /** What they actually did, in the same vocabulary. */
     actualVerdict?: ShadowVerdict;
-    recordedAt: string;
+    createdAt: string;
+    updatedAt: string;
     schemaVersion: 1;
 }
 ```
@@ -105,9 +106,19 @@ export interface DecisionJournalEntry {
 comparison is only meaningful if both sides speak one vocabulary, and these five already
 cover what a conversational planner says: do it, do it easier, move it, skip it, your call.
 
+**Mutation lifecycle:**
+- **Morning write (creation):** Records `externalVerdict`, optional `externalNote`, and
+  locks `sawEngineVerdictFirst` (determined from whether the athlete revealed the engine
+  recommendation prior to submission).
+- **Evening write (update):** Records or updates `actualVerdict` (or syncs from daily
+  adherence) and sets `updatedAt`.
+- **Immutability rule:** `sawEngineVerdictFirst` and `createdAt` cannot be modified on
+  update, preventing post-hoc rewriting of anchoring telemetry.
+
 Validation in `engine/validation.ts` (closed key set, as every other stored shape).
 Firestore rules owner-scoped, with `hasValidDecisionJournalEntry`, mirroring the
-`daily_subjective_checkins` block. Emulator tests including cross-user denial.
+`daily_subjective_checkins` block and enforcing immutable `sawEngineVerdictFirst` / `createdAt`
+on update. Emulator tests including cross-user denial and update-tampering rejection.
 
 **Done when.** A well-formed entry is accepted, a malformed or foreign-owned one is
 rejected, and the rules tests prove both.
@@ -127,6 +138,11 @@ Two ordering rules, both about not corrupting the evidence:
 
 The card shows the engine's verdict for the day only after an entry exists or the athlete
 explicitly reveals it.
+
+**Adherence alignment:** When the athlete answers the existing `AdherencePrompt.tsx`
+(`followed === true`), `actualVerdict` defaults naturally to the executed recommendation's
+verdict rather than forcing the athlete through redundant double-entry, while still
+permitting an explicit override on the journal card if execution diverged from both.
 
 **Done when.** An entry can be recorded before the engine's verdict is visible; recording
 after reveal is possible and flagged; and the flag reflects what actually happened rather

--- a/docs/plans/phase-9-subjective-baselines.md
+++ b/docs/plans/phase-9-subjective-baselines.md
@@ -2,6 +2,7 @@
 
 * **Status:** Draft
 * **Blocked by:** [ADR-0020](../adr/0020-subjective-baselines-in-readiness-mode.md) acceptance
+* **Strongly preceded by:** [Phase 9.0](./phase-9-0-shadow-mode-and-decision-journal.md) — its shadow block turns 9.5 from inventing subjective variance into sampling the athlete's own
 * **Unlocks:** a decision on whether self-normalised subjective drift belongs in the mode gate at all
 * **Decisions:** ADR-0020 (D-SUBJDRIFT, D-SUBJADD, D-SUBJFLOOR, D-SUBJCOV, D-SUBJSD, D-SUBJPURE, D-SUBJANCHOR, D-SUBJCAL, D-SUBJAUDIT)
 
@@ -34,6 +35,10 @@ until a separate, evidence-backed decision flips it.
 * ADR-0020 accepted.
 * **9.5 must land before 9.6 is run.** Reading a comparison against the current corpus
   would produce a confidently wrong answer — see the work item for why.
+* **Phase 9.0's block should precede 9.5** where scheduling allows. It is not a hard
+  blocker — 9.5's invented profiles are still better than a constant — but a real 4–6 week
+  check-in record makes the profiles observed rather than assumed, and the calibration is
+  only as good as the variance it is measured against.
 
 ---
 
@@ -169,7 +174,20 @@ artefact of the fixtures, not evidence about the idea. It would close ADR-0020 a
 `Rejected` for entirely the wrong reason.
 
 **Change.** Extend the corpus with per-athlete *subjective scale profiles* — the personal
-scale-use differences the whole ADR exists to correct:
+scale-use differences the whole ADR exists to correct.
+
+**Preferred source: the Phase 9.0 block.** If
+[Phase 9.0](./phase-9-0-shadow-mode-and-decision-journal.md) has run, its export carries
+4–6 weeks of the athlete's real check-ins. Derive the profiles' *parameters* — baseline
+level per metric, day-to-day standard deviation, and the shape of any real drift — from
+that record instead of choosing them. The fixtures stay synthetic and deterministic, since
+the corpus must remain reproducible; what changes is that their numbers are observed rather
+than invented, and at least one of them is the athlete who will actually use the result.
+
+Without 9.0, the table below stands as written, and the limitation in the risk table
+("synthetic profiles measure fixtures rather than people") applies at full strength.
+
+The profiles to build either way:
 
 | Fixture | Shape | What it must prove |
 |---|---|---|
@@ -274,7 +292,7 @@ code is not what closes this task.
 | Risk | Mitigation |
 |---|---|
 | Calibrating against a zero-variance corpus produces a false "no signal". | 9.5 is a hard precondition of 9.6 and an acceptance criterion in its own right. |
-| Synthetic subjective profiles are invented, so the calibration measures fixtures rather than people. | Acknowledged and unavoidable: this is policy-regression evidence, not clinical validation — the same limitation `simulate:calibrate` already states about itself. The fixtures bound the *shape* of the effect, not its real-world magnitude. |
+| Synthetic subjective profiles are invented, so the calibration measures fixtures rather than people. | Narrowed, not removed, by running [Phase 9.0](./phase-9-0-shadow-mode-and-decision-journal.md) first: its block supplies observed parameters for the profiles. Beyond that it is unavoidable — this is policy-regression evidence, not clinical validation, the same limitation `simulate:calibrate` already states about itself. The fixtures bound the *shape* of the effect, not its real-world magnitude. |
 | The term tightens too readily and raises recovery share without benefit. | Exactly what 9.6 measures; that outcome is 9.8 option 3, and it is the same reason `max` was retained over additive fusion. |
 | Ordinal data treated as interval. | Recorded in ADR-0020 as an accepted compromise; bounded by the stdev floor and the ±2.0 cap. |
 
@@ -317,4 +335,6 @@ are additive and optional.
 
 9.5 is startable immediately and independently of the ADR — a corpus with realistic
 subjective variance is worth having whether or not the drift term ever ships, because
-every readiness-related scenario currently exercises a constant.
+every readiness-related scenario currently exercises a constant. Starting it *after*
+Phase 9.0's block is nonetheless better: the same work, with observed parameters instead of
+chosen ones.


### PR DESCRIPTION
Answers a direct question -- should the manual daily AI loop be replaced by the app now that Phase 8 has landed -- and plans the work that would answer it with evidence instead of taste.

The analysis argues: not yet, and not because the app is too weak. Phase 8 narrowed the engine's job to adjudication, which is where deterministic rules beat a language model, and the cross-day state the app holds is something a fresh chat structurally cannot have. The reservation is narrower than the old one: the athlete's own subjective scores enter the decision path unnormalised, and the corpus that would measure that has zero subjective variance by construction (scenarios.ts builds nearly every case from a constant), so a calibration run today would report "no effect" for a structural reason.

Phase 9.0 is the plan that fixes the evidence gap rather than the engine: run both loops for one block and record where they disagree. It yields the disagreement log, and -- as a by-product of simply using the app -- the real subjective corpus Phase 9's own 9.5 currently has to invent.

Two design commitments are enforced rather than intended: the journal cannot be reached from any decision module (an import-graph guard, the same one-way boundary D-CRITIQUE draws for the weekly critique), because a journal the engine reads is evidence contaminated by its own effect; and anchoring is recorded per-day and reported split rather than assumed away.

Phase 9's 9.5 is re-scoped accordingly: after a shadow block its profiles are parameterised from observed check-ins rather than chosen. Not a hard blocker -- invented variance still beats a constant -- but stated as the better ordering.

No code touched; POLICY_VERSION unchanged. 963 app tests pass on this base.

## Summary

<!--
What changed? Name the behavior, module, or artifact—not just the files.
Why now? State the defect, requirement, or decision that motivated it.
What is the user or operational impact? Say "No user-visible change" when applicable.
Keep this to 2–5 bullets. Link the issue, ADR, plan, or analysis document when relevant.
-->

## Validation

<!--
For every applicable check, replace the checkbox with [x] and record the exact outcome below.
For any skipped applicable check, leave it unchecked and explain why. Do not claim CI will validate it.
Include focused manual verification when an automated check cannot prove the change.

Results:
- `command`: pass/fail; what it covered
- Manual check: scenario and observed result
-->

- [ ] `uv run pytest` (backend changes)
- [ ] `uv run ruff check .` and `uv run mypy src/garmin_sync` (backend changes)
- [ ] `cd app && npm run check` (frontend changes)
- [ ] `cd app && npm run test:rules` (Firestore rules changes)
- [ ] `cd app && npm run simulate:scenarios` (recommendation-engine changes)
- [ ] `cd app && npm run visual:refresh` (material UI changes)

## Risk and reviewer guidance

<!--
What should a reviewer inspect most closely, and why?
What could regress? Include data migration, deployment, compatibility, or rollback notes.
Say "Low risk: ..." only with a concrete reason. Link relevant ADRs, architecture docs, or issues.
-->

## Domain invariants

<!--
For each invariant touched by this change, replace [ ] with [x] and state how it was checked.
If none apply, delete the checklist and write "Not applicable — [reason]."
-->

- [ ] Firestore writes remain user-scoped under `users/{APP_USER_ID}/...`; no `default_user` or top-level recovery snapshots were introduced.
- [ ] Calendar-date logic uses `Europe/Warsaw`; completed `totalSteps` still means the previous calendar day (`D - 1`).
- [ ] No credentials, tokens, service-account files, or raw health payloads are included.
- [ ] Recommendation decision logic changed: `POLICY_VERSION` was evaluated and relevant architecture/ADR documentation was updated.

## Screenshots or recordings

<!--
For user-visible changes, attach before/after evidence for the affected desktop and mobile states.
For non-UI changes, write "Not applicable — [reason]."
-->
