### PR TITLE
Phase 9.7b: persist and validate compact subjective-drift audit

### DIFF
--- a/app/firestore.rules
+++ b/app/firestore.rules
@@ -49,9 +49,35 @@ service cloud.firestore {
         && dose.intensity is number && dose.intensity >= 0 && dose.intensity <= 1.2;
     }
 
+    function hasValidSubjectiveDriftMetricMap(m) {
+      return m is map
+        && m.keys().hasOnly(['readiness', 'sleepQuality', 'fatigue', 'soreness', 'mentalStress', 'motivation'])
+        && m.keys().hasAll(['readiness', 'sleepQuality', 'fatigue', 'soreness', 'mentalStress', 'motivation'])
+        && m.readiness is number && m.readiness >= 0 && m.readiness <= 20
+        && m.sleepQuality is number && m.sleepQuality >= 0 && m.sleepQuality <= 20
+        && m.fatigue is number && m.fatigue >= 0 && m.fatigue <= 20
+        && m.soreness is number && m.soreness >= 0 && m.soreness <= 20
+        && m.mentalStress is number && m.mentalStress >= 0 && m.mentalStress <= 20
+        && m.motivation is number && m.motivation >= 0 && m.motivation <= 20;
+    }
+
+    function hasValidSubjectiveDriftAudit(drift) {
+      return drift is map
+        && drift.keys().hasOnly(['estimatorId', 'historyThroughDateExclusive', 'recentRecordedDays', 'longRecordedDays', 'contribution', 'perMetricContributions', 'decisionRelevant'])
+        && drift.keys().hasAll(['estimatorId', 'historyThroughDateExclusive', 'recentRecordedDays', 'longRecordedDays', 'contribution', 'perMetricContributions', 'decisionRelevant'])
+        && drift.estimatorId is string && drift.estimatorId.size() > 0 && drift.estimatorId.size() <= 120
+        && drift.historyThroughDateExclusive is string
+        && drift.historyThroughDateExclusive.matches('^[0-9]{4}-[0-9]{2}-[0-9]{2}$')
+        && drift.recentRecordedDays is int && drift.recentRecordedDays >= 0 && drift.recentRecordedDays <= 366
+        && drift.longRecordedDays is int && drift.longRecordedDays >= drift.recentRecordedDays && drift.longRecordedDays <= 366
+        && drift.contribution is number && drift.contribution >= 0 && drift.contribution <= 120
+        && hasValidSubjectiveDriftMetricMap(drift.perMetricContributions)
+        && drift.decisionRelevant is bool;
+    }
+
     function hasValidRecommendationAudit(audit) {
       return audit is map
-        && audit.keys().hasOnly(['policyVersion', 'evaluatedAt', 'decisionContextRevision', 'safetyStatus', 'history', 'envelope', 'plannedDose', 'executionDose', 'candidateScores', 'droppedContributorObjectives', 'externalPlan'])
+        && audit.keys().hasOnly(['policyVersion', 'evaluatedAt', 'decisionContextRevision', 'safetyStatus', 'history', 'envelope', 'plannedDose', 'executionDose', 'candidateScores', 'droppedContributorObjectives', 'externalPlan', 'subjectiveDrift'])
         && audit.keys().hasAll(['policyVersion', 'evaluatedAt', 'decisionContextRevision', 'safetyStatus', 'history', 'envelope', 'candidateScores'])
         && audit.policyVersion is string
         && audit.evaluatedAt is string
@@ -77,6 +103,7 @@ service cloud.firestore {
         && (!('executionDose' in audit) || hasValidDose(audit.executionDose))
         && audit.candidateScores is list && audit.candidateScores.size() <= 64
         && (!('droppedContributorObjectives' in audit) || (audit.droppedContributorObjectives is list && audit.droppedContributorObjectives.size() <= 64))
+        && (!('subjectiveDrift' in audit) || hasValidSubjectiveDriftAudit(audit.subjectiveDrift))
         && (!('externalPlan' in audit) || (
           audit.externalPlan is map
           && audit.externalPlan.keys().hasOnly(['planId', 'revision', 'sessionId', 'contentHash'])
@@ -159,7 +186,6 @@ service cloud.firestore {
       allow delete: if isOwner(userId);
     }
 
-    // --- Decision journal (Phase 9.0): immutable morning evidence plus an evening actual outcome.
     function hasValidDecisionJournalEntry(userId, date) {
       return hasOwnedUserId(userId)
         && isDateDocument(date)

--- a/app/package.json
+++ b/app/package.json
@@ -22,7 +22,7 @@
     "preview": "vite preview",
     "test": "vitest run",
     "test:rules": "firebase --project demo-adaptive-training emulators:exec --only firestore \"npm run test:rules:emulator\"",
-    "test:rules:emulator": "vitest run src/emulator/firestoreRules.emulator.test.ts",
+    "test:rules:emulator": "vitest run src/emulator/*.emulator.test.ts",
     "firestore:rules:drift": "node scripts/check-firestore-rules-drift.mjs --project adaptive-training-recommender",
     "firestore:rules:deploy": "node scripts/deploy-firestore-rules.mjs --project adaptive-training-recommender",
     "firestore:rules:rollback": "node scripts/rollback-firestore-rules.mjs --project adaptive-training-recommender",

--- a/app/src/emulator/subjectiveDriftAuditRules.emulator.test.ts
+++ b/app/src/emulator/subjectiveDriftAuditRules.emulator.test.ts
@@ -1,0 +1,129 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { readFileSync } from 'node:fs';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { assertFails, assertSucceeds, initializeTestEnvironment, type RulesTestEnvironment } from '@firebase/rules-unit-testing';
+import { doc, setDoc } from 'firebase/firestore';
+
+const emulatorDescribe = process.env.FIRESTORE_EMULATOR_HOST ? describe : describe.skip;
+let env: RulesTestEnvironment;
+const userId = 'drift-audit-athlete';
+const path = `users/${userId}/daily_recommendations/2026-08-16`;
+
+function driftAudit() {
+    return {
+        estimatorId: 'subjective-baseline-v1-mean-stdev-7-28',
+        historyThroughDateExclusive: '2026-08-16',
+        recentRecordedDays: 7,
+        longRecordedDays: 28,
+        contribution: 1.2,
+        perMetricContributions: {
+            readiness: 0.2,
+            sleepQuality: 0.2,
+            fatigue: 0.2,
+            soreness: 0.2,
+            mentalStress: 0.2,
+            motivation: 0.2,
+        },
+        decisionRelevant: true,
+    };
+}
+
+function recommendation() {
+    return {
+        userId,
+        date: '2026-08-16',
+        templateId: 'easy_01',
+        templateTitle: 'Easy Ride',
+        category: 'Easy Endurance',
+        modality: 'Cycling',
+        mode: 'modify',
+        rationale: 'Compact rationale.',
+        schemaVersion: 3,
+        createdAt: '2026-08-16T06:00:00Z',
+        updatedAt: '2026-08-16T06:00:00Z',
+        adherence: {
+            respondedAt: null,
+            followed: null,
+            actualModality: null,
+            actualDurationMin: null,
+            skipped: false,
+            notes: null,
+        },
+        recommendationAudit: {
+            policyVersion: '2026-08-external-plan-provenance-v1',
+            evaluatedAt: '2026-08-16T06:00:00Z',
+            decisionContextRevision: 'history-v1:2026-08-16:7:none:none',
+            safetyStatus: 'complete',
+            history: {
+                completedEventCount: 0,
+                unmatchedEventCount: 0,
+                sourceStatuses: { activities: 'AVAILABLE', recommendations: 'AVAILABLE', manualTraining: 'MISSING' },
+            },
+            envelope: { safetyRestrictedModalityCount: 0, planMaxAllowableTier: 'Easy' },
+            candidateScores: [],
+            subjectiveDrift: driftAudit(),
+        },
+    };
+}
+
+emulatorDescribe('Phase 9.7 subjective drift recommendation audit rules', () => {
+    beforeAll(async () => {
+        env = await initializeTestEnvironment({
+            projectId: 'demo-adaptive-training-subjective-drift',
+            firestore: { rules: readFileSync('firestore.rules', 'utf8') },
+        });
+    });
+    afterEach(async () => env.clearFirestore());
+    afterAll(async () => env.cleanup());
+
+    it('accepts the compact normalized subjective drift audit shape', async () => {
+        const db = env.authenticatedContext(userId).firestore();
+        await expect(assertSucceeds(setDoc(doc(db, path), recommendation()))).resolves.toBeUndefined();
+    });
+
+    it('rejects raw history or any unknown field inside subjectiveDrift', async () => {
+        const db = env.authenticatedContext(userId).firestore();
+        const value = recommendation();
+        (value.recommendationAudit.subjectiveDrift as any).rawHistory = [{ readiness: 3 }];
+        await assertFails(setDoc(doc(db, path), value));
+    });
+
+    it('rejects incomplete, negative, or unbounded per-metric maps', async () => {
+        const db = env.authenticatedContext(userId).firestore();
+        for (const mutation of [
+            (d: any) => { delete d.perMetricContributions.motivation; },
+            (d: any) => { d.perMetricContributions.fatigue = -0.1; },
+            (d: any) => { d.perMetricContributions.soreness = 21; },
+            (d: any) => { d.perMetricContributions.extra = 0; },
+        ]) {
+            const value = recommendation();
+            mutation(value.recommendationAudit.subjectiveDrift);
+            await assertFails(setDoc(doc(db, path), value));
+        }
+    });
+
+    it('rejects impossible coverage, malformed history boundary, and an unbounded total', async () => {
+        const db = env.authenticatedContext(userId).firestore();
+        for (const patch of [
+            { recentRecordedDays: 29, longRecordedDays: 28 },
+            { recentRecordedDays: -1 },
+            { longRecordedDays: 367 },
+            { historyThroughDateExclusive: '16-08-2026' },
+            { contribution: -1 },
+            { contribution: 121 },
+        ]) {
+            const value = recommendation();
+            Object.assign(value.recommendationAudit.subjectiveDrift, patch);
+            await assertFails(setDoc(doc(db, path), value));
+        }
+    });
+
+    it('keeps the audit write-once when decision fields are unchanged', async () => {
+        const db = env.authenticatedContext(userId).firestore();
+        await assertSucceeds(setDoc(doc(db, path), recommendation()));
+        const mutated = recommendation();
+        mutated.recommendationAudit.subjectiveDrift.contribution = 1.3;
+        mutated.recommendationAudit.subjectiveDrift.perMetricContributions.readiness = 0.3;
+        await assertFails(setDoc(doc(db, path), mutated));
+    });
+});

--- a/app/src/engine/subjectiveDriftAudit.ts
+++ b/app/src/engine/subjectiveDriftAudit.ts
@@ -12,14 +12,21 @@ export interface SubjectiveDriftAudit {
     decisionRelevant: boolean;
 }
 
+/** Persisted RecommendationAudit is declared in the central models module. Augment it here
+ * rather than making foundational models import this audit helper; this file is already
+ * part of provenance/replay, and the optional field preserves the legacy v3 shape when
+ * subjective drift is absent. */
+declare module './models' {
+    interface RecommendationAudit {
+        subjectiveDrift?: SubjectiveDriftAudit;
+    }
+}
+
 /** Measurement code may carry additional counterfactual fields, but persistence strips
- * them by projecting onto SubjectiveDriftAudit. Keeping this structural type here lets
- * provenance remain independent of simulation modules. */
+ * them by projecting onto SubjectiveDriftAudit. */
 export type SubjectiveDriftAuditSource = SubjectiveDriftAudit & Record<string, unknown>;
 
-export function compactSubjectiveDriftAudit(
-    evidence: SubjectiveDriftAuditSource | null,
-): SubjectiveDriftAudit | null {
+export function compactSubjectiveDriftAudit(evidence: SubjectiveDriftAuditSource | null): SubjectiveDriftAudit | null {
     if (!evidence) return null;
     return {
         estimatorId: evidence.estimatorId,
@@ -32,39 +39,24 @@ export function compactSubjectiveDriftAudit(
     };
 }
 
-/**
- * Replay-side structural verification for normalized drift provenance. This deliberately
- * does not reconstruct an estimator from raw health data, because those data are
- * intentionally absent from the recommendation audit. Reproducible invariants are the
- * exclusive decision-date boundary, coverage sanity, canonical metric set,
- * finite/non-negative values, and component-total reconciliation.
- */
-export function subjectiveDriftAuditReplayErrors(
-    audit: unknown,
-    decisionDate: string,
-): string[] {
+/** Replay-side structural verification for normalized drift provenance. Raw health history
+ * is intentionally absent, so reproducible invariants are date boundary, coverage sanity,
+ * canonical metric set, finite/non-negative values, and arithmetic reconciliation. */
+export function subjectiveDriftAuditReplayErrors(audit: unknown, decisionDate: string): string[] {
     if (audit === undefined || audit === null) return [];
     if (typeof audit !== 'object' || Array.isArray(audit)) return ['Subjective drift audit is not an object.'];
 
     const errors: string[] = [];
     const record = audit as Record<string, unknown>;
-    if (typeof record.estimatorId !== 'string' || record.estimatorId.trim() === '') {
-        errors.push('Subjective drift audit estimatorId is invalid.');
-    }
-    if (record.historyThroughDateExclusive !== decisionDate) {
-        errors.push(`Subjective drift audit history boundary ${String(record.historyThroughDateExclusive)} does not equal decision date ${decisionDate}.`);
-    }
+    if (typeof record.estimatorId !== 'string' || record.estimatorId.trim() === '') errors.push('Subjective drift audit estimatorId is invalid.');
+    if (record.historyThroughDateExclusive !== decisionDate) errors.push(`Subjective drift audit history boundary ${String(record.historyThroughDateExclusive)} does not equal decision date ${decisionDate}.`);
     const recent = record.recentRecordedDays;
     const long = record.longRecordedDays;
     if (!Number.isInteger(recent) || (recent as number) < 0) errors.push('Subjective drift recent coverage is invalid.');
     if (!Number.isInteger(long) || (long as number) < 0) errors.push('Subjective drift long coverage is invalid.');
-    if (Number.isInteger(recent) && Number.isInteger(long) && (recent as number) > (long as number)) {
-        errors.push('Subjective drift recent coverage exceeds long coverage.');
-    }
+    if (Number.isInteger(recent) && Number.isInteger(long) && (recent as number) > (long as number)) errors.push('Subjective drift recent coverage exceeds long coverage.');
     if (typeof record.decisionRelevant !== 'boolean') errors.push('Subjective drift decisionRelevant is invalid.');
-    if (typeof record.contribution !== 'number' || !Number.isFinite(record.contribution) || record.contribution < 0) {
-        errors.push('Subjective drift total contribution is invalid.');
-    }
+    if (typeof record.contribution !== 'number' || !Number.isFinite(record.contribution) || record.contribution < 0) errors.push('Subjective drift total contribution is invalid.');
 
     const perMetric = record.perMetricContributions;
     if (!perMetric || typeof perMetric !== 'object' || Array.isArray(perMetric)) {
@@ -82,14 +74,10 @@ export function subjectiveDriftAuditReplayErrors(
     let sum = 0;
     for (const metric of SUBJECTIVE_BASELINE_METRICS) {
         const value = metricRecord[metric];
-        if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
-            errors.push(`Subjective drift contribution for ${metric} is invalid.`);
-        } else {
-            sum += value;
-        }
+        if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) errors.push(`Subjective drift contribution for ${metric} is invalid.`);
+        else sum += value;
     }
-    if (typeof record.contribution === 'number' && Number.isFinite(record.contribution)
-        && Math.abs(sum - record.contribution) > 1e-6) {
+    if (typeof record.contribution === 'number' && Number.isFinite(record.contribution) && Math.abs(sum - record.contribution) > 1e-6) {
         errors.push(`Subjective drift component sum ${sum} does not reconcile to total ${record.contribution}.`);
     }
     return errors;


### PR DESCRIPTION
## Summary

Logically stacked on **#60 / #59**. Implements the **storage-contract half of Phase 9.7** while the production subjective-drift selector remains `off`.

- Augments persisted `RecommendationAudit` with optional compact `subjectiveDrift` provenance.
- Extends the closed Firestore v3 audit schema to allow exactly:
  - estimator id;
  - exclusive history date boundary;
  - recent/long coverage counts;
  - bounded total contribution;
  - exact six-key bounded per-metric contribution map;
  - decision-relevant boolean.
- Raw subjective history, notes, unknown fields/metrics, impossible coverage and negative/unbounded contributions are rejected by security rules.
- Existing `auditWriteOnce()` semantics apply unchanged: same-decision/adherence updates cannot rewrite drift evidence after persistence.
- Adds a dedicated emulator contract suite and changes `test:rules:emulator` to run all `*.emulator.test.ts` rule suites.

## Validation

Head `1a04a6e43fb6071c9f36bcdbab75a6613c68bea6` passed **CI Pipeline #463** completely while temporarily based on `main`, including the new Firestore emulator suite, frontend tests/coverage/build, policy guard, simulations/diff, Node audit, Python and Docker.

The PR is now retargeted to its logical stacked base `chatgpt/phase-9-7`.

## Evidence/privacy boundary

Firestore validates shape/type/size/range; arithmetic component-total reconciliation remains in `replayRecommendationAudit`, where float-tolerance validation is appropriate. Firestore does not receive raw subjective history.

This does **not** activate subjective drift or bump `POLICY_VERSION`. Final deciding-path telemetry/rationale/audit attachment remains coupled to the full planner-policy threading work.