### PR TITLE
feat(engine): integrate rolling step baselines and acute surge fatigue protection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ This document outlines repository rules, code conventions, testing instructions,
 1. **User Isolation**: NEVER write recovery documents to `daily_recovery_snapshot/{date}` or with `"default_user"`. Always write to `users/{APP_USER_ID}/daily_recovery_snapshots/{YYYY-MM-DD}`.
 2. **Timezone Semantics**: Always use `Europe/Warsaw` for local date calculations (`local_today()` in Python, `getLocalDateString()` in TypeScript). Do not use UTC `toISOString().split('T')[0]` for calendar dates.
 3. **No Credential Leaks**: Never commit `.env`, `.garth`, Firebase service account files, or raw health JSONs.
-4. **Step Count Semantics**: `totalSteps` in recovery snapshots represents the completed previous calendar day (`D - 1`).
+4. **Step Count Semantics**: `totalSteps` in recovery snapshots represents the completed previous calendar day (`D - 1`). Rolling 7d/28d baselines normalize ambient step surges, and estimated activity steps (runs, field sports, walks) are deducted in `fatigue.ts` to prevent double-counting structured training.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ Quick guide for building, testing, and working on `adaptive-training-recommender
 ## Core Guidelines & Architectural Rules
 - **User Scoping**: Ingestion output path MUST be `users/{APP_USER_ID}/daily_recovery_snapshots/{YYYY-MM-DD}`. Never write `"default_user"` documents.
 - **Timezone**: Dates MUST be computed in `Europe/Warsaw` timezone (`local_today()` in Python, `getLocalDateString()` in TS). Avoid UTC `.toISOString().split('T')[0]` for calendar dates.
-- **Step Semantics**: `totalSteps` represents previous completed day (`D - 1`).
+- **Step Semantics**: `totalSteps` represents previous completed day (`D - 1`). Baselines and activity-deducted ambient surges feed `fatigue.ts`.
 - **Security**: Never commit credentials, `.garth` token directories, `.env` files, or raw health JSON logs.
 
 ## Essential Development Commands

--- a/app/src/components/DataView.tsx
+++ b/app/src/components/DataView.tsx
@@ -183,6 +183,18 @@ export function DataView({ decisionInput, userId, initialTab = 'recovery' }: Dat
             <span className="data-label">Sleep Score 28d Stdev:</span>
             <span className="data-value">{decisionInput.recoverySnapshot?.derived.sleepScore28dStdev ?? 'N/A'}</span>
           </div>
+          <div className="data-item">
+            <span className="data-label">Steps 7d Avg:</span>
+            <span className="data-value">{decisionInput.recoverySnapshot?.derived.steps7dAvg ?? 'N/A'}</span>
+          </div>
+          <div className="data-item">
+            <span className="data-label">Steps 28d Avg:</span>
+            <span className="data-value">{decisionInput.recoverySnapshot?.derived.steps28dAvg ?? 'N/A'}</span>
+          </div>
+          <div className="data-item">
+            <span className="data-label">Steps 28d Stdev:</span>
+            <span className="data-value">{decisionInput.recoverySnapshot?.derived.steps28dStdev ?? 'N/A'}</span>
+          </div>
         </div>
 
         <div className="data-group">
@@ -190,7 +202,7 @@ export function DataView({ decisionInput, userId, initialTab = 'recovery' }: Dat
           <div className="data-item">
             <span className="data-label">Sleep Score vs 7d:</span>
             <span className="data-value">
-              {decisionInput.recoverySnapshot?.derived.deltas.sleepScoreVs7d !== null
+              {decisionInput.recoverySnapshot?.derived.deltas.sleepScoreVs7d !== null && decisionInput.recoverySnapshot?.derived.deltas.sleepScoreVs7d !== undefined
                 ? `${decisionInput.recoverySnapshot!.derived.deltas.sleepScoreVs7d > 0 ? '+' : ''}${decisionInput.recoverySnapshot!.derived.deltas.sleepScoreVs7d}`
                 : 'N/A'
               }
@@ -199,7 +211,7 @@ export function DataView({ decisionInput, userId, initialTab = 'recovery' }: Dat
           <div className="data-item">
             <span className="data-label">Sleep Score vs 28d:</span>
             <span className="data-value">
-              {decisionInput.recoverySnapshot?.derived.deltas.sleepScoreVs28d !== null
+              {decisionInput.recoverySnapshot?.derived.deltas.sleepScoreVs28d !== null && decisionInput.recoverySnapshot?.derived.deltas.sleepScoreVs28d !== undefined
                 ? `${decisionInput.recoverySnapshot!.derived.deltas.sleepScoreVs28d > 0 ? '+' : ''}${decisionInput.recoverySnapshot!.derived.deltas.sleepScoreVs28d}`
                 : 'N/A'
               }
@@ -208,7 +220,7 @@ export function DataView({ decisionInput, userId, initialTab = 'recovery' }: Dat
           <div className="data-item">
             <span className="data-label">Resting HR vs 7d:</span>
             <span className="data-value">
-              {decisionInput.recoverySnapshot?.derived.deltas.restingHrVs7d !== null
+              {decisionInput.recoverySnapshot?.derived.deltas.restingHrVs7d !== null && decisionInput.recoverySnapshot?.derived.deltas.restingHrVs7d !== undefined
                 ? `${decisionInput.recoverySnapshot!.derived.deltas.restingHrVs7d > 0 ? '+' : ''}${decisionInput.recoverySnapshot!.derived.deltas.restingHrVs7d}`
                 : 'N/A'
               }
@@ -217,7 +229,7 @@ export function DataView({ decisionInput, userId, initialTab = 'recovery' }: Dat
           <div className="data-item">
             <span className="data-label">Resting HR vs 28d:</span>
             <span className="data-value">
-              {decisionInput.recoverySnapshot?.derived.deltas.restingHrVs28d !== null
+              {decisionInput.recoverySnapshot?.derived.deltas.restingHrVs28d !== null && decisionInput.recoverySnapshot?.derived.deltas.restingHrVs28d !== undefined
                 ? `${decisionInput.recoverySnapshot!.derived.deltas.restingHrVs28d > 0 ? '+' : ''}${decisionInput.recoverySnapshot!.derived.deltas.restingHrVs28d}`
                 : 'N/A'
               }
@@ -226,7 +238,7 @@ export function DataView({ decisionInput, userId, initialTab = 'recovery' }: Dat
           <div className="data-item">
             <span className="data-label">HRV vs 7d:</span>
             <span className="data-value">
-              {decisionInput.recoverySnapshot?.derived.deltas.hrvVs7d !== null
+              {decisionInput.recoverySnapshot?.derived.deltas.hrvVs7d !== null && decisionInput.recoverySnapshot?.derived.deltas.hrvVs7d !== undefined
                 ? `${decisionInput.recoverySnapshot!.derived.deltas.hrvVs7d > 0 ? '+' : ''}${decisionInput.recoverySnapshot!.derived.deltas.hrvVs7d}`
                 : 'N/A'
               }
@@ -235,8 +247,26 @@ export function DataView({ decisionInput, userId, initialTab = 'recovery' }: Dat
           <div className="data-item">
             <span className="data-label">HRV vs 28d:</span>
             <span className="data-value">
-              {decisionInput.recoverySnapshot?.derived.deltas.hrvVs28d !== null
+              {decisionInput.recoverySnapshot?.derived.deltas.hrvVs28d !== null && decisionInput.recoverySnapshot?.derived.deltas.hrvVs28d !== undefined
                 ? `${decisionInput.recoverySnapshot!.derived.deltas.hrvVs28d > 0 ? '+' : ''}${decisionInput.recoverySnapshot!.derived.deltas.hrvVs28d}`
+                : 'N/A'
+              }
+            </span>
+          </div>
+          <div className="data-item">
+            <span className="data-label">Steps vs 7d:</span>
+            <span className="data-value">
+              {decisionInput.recoverySnapshot?.derived.deltas.stepsVs7d !== null && decisionInput.recoverySnapshot?.derived.deltas.stepsVs7d !== undefined
+                ? `${decisionInput.recoverySnapshot!.derived.deltas.stepsVs7d > 0 ? '+' : ''}${decisionInput.recoverySnapshot!.derived.deltas.stepsVs7d}`
+                : 'N/A'
+              }
+            </span>
+          </div>
+          <div className="data-item">
+            <span className="data-label">Steps vs 28d:</span>
+            <span className="data-value">
+              {decisionInput.recoverySnapshot?.derived.deltas.stepsVs28d !== null && decisionInput.recoverySnapshot?.derived.deltas.stepsVs28d !== undefined
+                ? `${decisionInput.recoverySnapshot!.derived.deltas.stepsVs28d > 0 ? '+' : ''}${decisionInput.recoverySnapshot!.derived.deltas.stepsVs28d}`
                 : 'N/A'
               }
             </span>

--- a/app/src/engine/adapters.ts
+++ b/app/src/engine/adapters.ts
@@ -62,11 +62,16 @@ export function mapSnapshotToEngineInput(snapshot: DailyRecoverySnapshot): Engin
         rhr_delta_28d: snapshot.derived.deltas.restingHrVs28d,
         hrv_delta_28d: snapshot.derived.deltas.hrvVs28d,
         sleep_score_delta_28d: snapshot.derived.deltas.sleepScoreVs28d,
+        steps_7d_avg: snapshot.derived.steps7dAvg ?? null,
+        steps_28d_avg: snapshot.derived.steps28dAvg ?? null,
+        steps_delta_7d: snapshot.derived.deltas.stepsVs7d ?? null,
+        steps_delta_28d: snapshot.derived.deltas.stepsVs28d ?? null,
         // ?? null normalizes documents written before baselineComputationVersion 2,
         // where these fields are absent (undefined) rather than explicitly null.
         hrv_stdev_28d: snapshot.derived.hrv28dStdev ?? null,
         rhr_stdev_28d: snapshot.derived.restingHr28dStdev ?? null,
         sleep_score_stdev_28d: snapshot.derived.sleepScore28dStdev ?? null,
+        steps_stdev_28d: snapshot.derived.steps28dStdev ?? null,
     };
 }
 

--- a/app/src/engine/contextBrief.ts
+++ b/app/src/engine/contextBrief.ts
@@ -176,6 +176,9 @@ function renderObjective(snapshots: readonly DailyRecoverySnapshot[], windowDays
     lines.push(metricLine('HRV (overnight avg)', 'ms', raw.hrvOvernightAvg, derived.hrv7dAvg, derived.hrv28dAvg, derived.deltas.hrvVs7d, derived.deltas.hrvVs28d));
     lines.push(metricLine('Resting HR', 'bpm', raw.restingHr, derived.restingHr7dAvg, derived.restingHr28dAvg, derived.deltas.restingHrVs7d, derived.deltas.restingHrVs28d));
     lines.push(metricLine('Sleep score', 'pts', raw.sleepScore, derived.sleepScore7dAvg, derived.sleepScore28dAvg, derived.deltas.sleepScoreVs7d, derived.deltas.sleepScoreVs28d));
+    if (raw.totalSteps !== null) {
+        lines.push(metricLine('Steps (yesterday D-1)', 'steps', raw.totalSteps, derived.steps7dAvg ?? null, derived.steps28dAvg ?? null, derived.deltas.stepsVs7d ?? null, derived.deltas.stepsVs28d ?? null));
+    }
     if (raw.bodyBatteryWake !== null) lines.push(`- Body battery on waking: ${raw.bodyBatteryWake}`);
     if (raw.hrvStatus) lines.push(`- HRV status (device): ${raw.hrvStatus}`);
     if (raw.trainingReadiness?.score != null) {

--- a/app/src/engine/fatigue.ts
+++ b/app/src/engine/fatigue.ts
@@ -81,6 +81,26 @@ export function decayFatigue(
 }
 
 /**
+ * Estimates the step contribution from a logged Garmin activity so structured sessions
+ * (runs, soccer, hikes) are not double-counted as unlogged ambient walking surge.
+ */
+export function estimateActivitySteps(training: { type?: string; duration_min?: number } | null | undefined): number {
+    if (!training || !training.duration_min || training.duration_min <= 0) return 0;
+    const type = (training.type || '').toLowerCase();
+
+    // Running and high-cadence field sports: ~155 steps/min
+    if (type.includes('run') || type.includes('soccer') || type.includes('football') || type.includes('trail')) {
+        return Math.round(training.duration_min * 155);
+    }
+    // Dedicated walking or hiking activities: ~110 steps/min
+    if (type.includes('walk') || type.includes('hike')) {
+        return Math.round(training.duration_min * 110);
+    }
+    // Other sports (cycling, swimming, gym strength) do not produce primary ambulatory impact steps
+    return 0;
+}
+
+/**
  * Computes internal response strain vector from subjective check-in and objective Garmin deltas.
  */
 export function computeInternalResponseStrain(readiness: DailyReadiness): DimensionalFatigue {
@@ -96,7 +116,8 @@ export function computeInternalResponseStrain(readiness: DailyReadiness): Dimens
     const sleepDeficit = objective.sleep_score !== null && objective.sleep_score < 75 ? (75 - objective.sleep_score) / 50 : 0;
 
     // Acute ambulatory surge (unlogged high-volume walking/hiking)
-    // Triggers when yesterday's step count is >= 1.8x the 7-day average AND >= +6,000 steps above baseline.
+    // Evaluates net ambient steps (totalSteps - estimatedActivitySteps) against the 7-day baseline.
+    // Triggers when ambient steps >= 1.8x baseline AND excess >= +6,000 steps above baseline.
     let ambulatoryTissueStrain = 0;
     const steps7dAvg = objective.steps_7d_avg;
     const totalSteps = objective.total_steps;
@@ -107,15 +128,17 @@ export function computeInternalResponseStrain(readiness: DailyReadiness): Dimens
         steps7dAvg !== undefined &&
         steps7dAvg > 0
     ) {
-        const excessSteps = totalSteps - steps7dAvg;
-        const surgeRatio = totalSteps / steps7dAvg;
-        if (surgeRatio >= 1.8 && excessSteps >= 6000) {
-            // Scale smoothly up to a 0.4 dampening cap for a +15,000 excess step surge
-            ambulatoryTissueStrain = Math.min(0.4, (excessSteps / 15000) * 0.4);
+        const activitySteps = estimateActivitySteps(objective.yesterday_training);
+        const ambientSteps = Math.max(0, totalSteps - activitySteps);
+        const excessAmbientSteps = ambientSteps - steps7dAvg;
+        const surgeRatio = ambientSteps / steps7dAvg;
+        if (surgeRatio >= 1.8 && excessAmbientSteps >= 6000) {
+            // Scale smoothly up to a 0.4 dampening cap for a +15,000 excess ambient step surge
+            ambulatoryTissueStrain = Math.min(0.4, (excessAmbientSteps / 15000) * 0.4);
         }
     }
 
-    const systemic = Math.min(1, 0.4 * subFatigue + 0.3 * hrvDrop + 0.3 * sleepDeficit + 0.5 * ambulatoryTissueStrain);
+    const systemic = Math.min(1, 0.4 * subFatigue + 0.3 * hrvDrop + 0.3 * sleepDeficit);
     const cardiovascular = Math.min(1, 0.5 * rhrElevated + 0.5 * hrvDrop);
     const lowerBody = Math.min(1, subSoreness + ambulatoryTissueStrain);
     const upperBody = subSoreness * 0.7; // default soreness split

--- a/app/src/engine/fatigue.ts
+++ b/app/src/engine/fatigue.ts
@@ -95,11 +95,31 @@ export function computeInternalResponseStrain(readiness: DailyReadiness): Dimens
     const rhrElevated = objective.rhr_delta !== null && objective.rhr_delta > 0 ? Math.min(1, objective.rhr_delta / 10) : 0;
     const sleepDeficit = objective.sleep_score !== null && objective.sleep_score < 75 ? (75 - objective.sleep_score) / 50 : 0;
 
-    const systemic = Math.min(1, 0.4 * subFatigue + 0.3 * hrvDrop + 0.3 * sleepDeficit);
+    // Acute ambulatory surge (unlogged high-volume walking/hiking)
+    // Triggers when yesterday's step count is >= 1.8x the 7-day average AND >= +6,000 steps above baseline.
+    let ambulatoryTissueStrain = 0;
+    const steps7dAvg = objective.steps_7d_avg;
+    const totalSteps = objective.total_steps;
+    if (
+        totalSteps !== null &&
+        totalSteps !== undefined &&
+        steps7dAvg !== null &&
+        steps7dAvg !== undefined &&
+        steps7dAvg > 0
+    ) {
+        const excessSteps = totalSteps - steps7dAvg;
+        const surgeRatio = totalSteps / steps7dAvg;
+        if (surgeRatio >= 1.8 && excessSteps >= 6000) {
+            // Scale smoothly up to a 0.4 dampening cap for a +15,000 excess step surge
+            ambulatoryTissueStrain = Math.min(0.4, (excessSteps / 15000) * 0.4);
+        }
+    }
+
+    const systemic = Math.min(1, 0.4 * subFatigue + 0.3 * hrvDrop + 0.3 * sleepDeficit + 0.5 * ambulatoryTissueStrain);
     const cardiovascular = Math.min(1, 0.5 * rhrElevated + 0.5 * hrvDrop);
-    const lowerBody = subSoreness;
+    const lowerBody = Math.min(1, subSoreness + ambulatoryTissueStrain);
     const upperBody = subSoreness * 0.7; // default soreness split
-    const impactTissue = subSoreness;
+    const impactTissue = Math.min(1, subSoreness + ambulatoryTissueStrain);
     const neuromuscular = Math.min(1, 0.5 * subFatigue + 0.5 * (1 - (subjective.motivation / 10)));
 
     return {

--- a/app/src/engine/fatigueClearing.test.ts
+++ b/app/src/engine/fatigueClearing.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { DimensionalFatigue, FatigueState, UserPreferences } from './models';
 import type { ResolvedAvailability } from './schedule';
-import { combineFatigue, decayFatigue } from './fatigue';
+import { combineFatigue, computeInternalResponseStrain, decayFatigue } from './fatigue';
 import { ENRICHED_TEMPLATES } from './templates';
 import { rankCandidates } from './optimizer';
 import { workoutForTemplate } from '../workouts/prescription';
@@ -70,5 +70,40 @@ describe('macrocycle v5 recovery and strength contracts', () => {
         expect(reduced.systemicCost).toBeLessThanOrEqual(0.5);
         expect(reduced.costProfile?.systemic).toBeLessThanOrEqual(0.5);
         expect(workoutForTemplate(reduced.id)?.id).toBe('strength_full_body_maintenance_01');
+    });
+
+    it('injects tissue-specific fatigue dampening when an acute step surge is detected', () => {
+        const baseReadiness = {
+            subjective: {
+                readiness: 8, sleepQuality: 8, fatigue: 2, soreness: 1, stress: 2, motivation: 8,
+                timeAvailable: 90, painFlag: false, alreadyTrainedToday: false, preferredModalityToday: null,
+            },
+            objective: {
+                total_steps: 20000, sleep_score: 85, sleep_duration_min: 480, rhr: 50, rhr_7d_avg: 50, rhr_delta: 0,
+                hrv_weekly_avg: 50, hrv_last_night: 50, hrv_delta: 0, respiration: 14, body_battery_wake: 90,
+                last_3_days_hard_sessions_count: 0, yesterday_training: null, today_training: null,
+                sleep_score_delta_7d: 0, rhr_delta_28d: 0, hrv_delta_28d: 0, sleep_score_delta_28d: 0,
+                hrv_stdev_28d: 8, rhr_stdev_28d: 3, sleep_score_stdev_28d: 7,
+                steps_7d_avg: 5000, steps_28d_avg: 5500, steps_delta_7d: 15000, steps_delta_28d: 14500, steps_stdev_28d: 800,
+            },
+        };
+
+        const normalReadiness = {
+            ...baseReadiness,
+            objective: {
+                ...baseReadiness.objective,
+                total_steps: 5000,
+                steps_delta_7d: 0,
+            },
+        };
+
+        const normalStrain = computeInternalResponseStrain(normalReadiness);
+        const surgeStrain = computeInternalResponseStrain(baseReadiness);
+
+        expect(normalStrain.impactTissue).toBe(0);
+        expect(normalStrain.lowerBody).toBe(0);
+        expect(surgeStrain.impactTissue).toBeGreaterThan(0.35);
+        expect(surgeStrain.lowerBody).toBeGreaterThan(0.35);
+        expect(surgeStrain.systemic).toBeGreaterThan(normalStrain.systemic);
     });
 });

--- a/app/src/engine/fatigueClearing.test.ts
+++ b/app/src/engine/fatigueClearing.test.ts
@@ -72,7 +72,7 @@ describe('macrocycle v5 recovery and strength contracts', () => {
         expect(workoutForTemplate(reduced.id)?.id).toBe('strength_full_body_maintenance_01');
     });
 
-    it('injects tissue-specific fatigue dampening when an acute step surge is detected', () => {
+    it('injects tissue-specific fatigue dampening when an acute unlogged step surge is detected', () => {
         const baseReadiness = {
             subjective: {
                 readiness: 8, sleepQuality: 8, fatigue: 2, soreness: 1, stress: 2, motivation: 8,
@@ -104,6 +104,34 @@ describe('macrocycle v5 recovery and strength contracts', () => {
         expect(normalStrain.lowerBody).toBe(0);
         expect(surgeStrain.impactTissue).toBeGreaterThan(0.35);
         expect(surgeStrain.lowerBody).toBeGreaterThan(0.35);
-        expect(surgeStrain.systemic).toBeGreaterThan(normalStrain.systemic);
+    });
+
+    it('does not trigger an ambient surge when high step volume is explained by a logged running activity', () => {
+        const loggedRunReadiness = {
+            subjective: {
+                readiness: 8, sleepQuality: 8, fatigue: 2, soreness: 1, stress: 2, motivation: 8,
+                timeAvailable: 90, painFlag: false, alreadyTrainedToday: false, preferredModalityToday: null,
+            },
+            objective: {
+                total_steps: 20000, sleep_score: 85, sleep_duration_min: 480, rhr: 50, rhr_7d_avg: 50, rhr_delta: 0,
+                hrv_weekly_avg: 50, hrv_last_night: 50, hrv_delta: 0, respiration: 14, body_battery_wake: 90,
+                last_3_days_hard_sessions_count: 1,
+                yesterday_training: {
+                    type: 'running',
+                    duration_min: 90, // 90 min * 155 steps/min = ~13,950 steps -> ambient = 6,050 vs 5,000 baseline
+                    training_effect: 3.5,
+                    intensity_tag: 'hard',
+                },
+                today_training: null,
+                sleep_score_delta_7d: 0, rhr_delta_28d: 0, hrv_delta_28d: 0, sleep_score_delta_28d: 0,
+                hrv_stdev_28d: 8, rhr_stdev_28d: 3, sleep_score_stdev_28d: 7,
+                steps_7d_avg: 5000, steps_28d_avg: 5500, steps_delta_7d: 15000, steps_delta_28d: 14500, steps_stdev_28d: 800,
+            },
+        };
+
+        const strain = computeInternalResponseStrain(loggedRunReadiness);
+        // Because the run accounts for ~14k steps, net ambient steps (6,050) is only +1,050 above baseline -> no ambient surge
+        expect(strain.impactTissue).toBe(0);
+        expect(strain.lowerBody).toBe(0);
     });
 });

--- a/app/src/engine/models.ts
+++ b/app/src/engine/models.ts
@@ -58,6 +58,10 @@ export interface EngineObjectiveInput {
     rhr_delta_28d: number | null;
     hrv_delta_28d: number | null;
     sleep_score_delta_28d: number | null;
+    steps_7d_avg?: number | null;
+    steps_28d_avg?: number | null;
+    steps_delta_7d?: number | null;
+    steps_delta_28d?: number | null;
     /** This person's own trailing 28-day population stdev per metric -- normalizes a
      *  raw delta into "how unusual is this for *this* person" instead of comparing
      *  everyone against the same fixed absolute number. Null until 14+ days of history
@@ -65,6 +69,7 @@ export interface EngineObjectiveInput {
     hrv_stdev_28d: number | null;
     rhr_stdev_28d: number | null;
     sleep_score_stdev_28d: number | null;
+    steps_stdev_28d?: number | null;
 }
 
 export interface DailyReadiness {
@@ -880,6 +885,9 @@ export interface DailyRecoverySnapshot {
         hrv28dStdev?: number | null;
         restingHr28dStdev?: number | null;
         sleepScore28dStdev?: number | null;
+        steps7dAvg?: number | null;
+        steps28dAvg?: number | null;
+        steps28dStdev?: number | null;
         deltas: {
             sleepScoreVs7d: number | null;
             sleepScoreVs28d: number | null;
@@ -889,6 +897,8 @@ export interface DailyRecoverySnapshot {
             hrvVs28d: number | null;
             respirationVs7d: number | null;
             respirationVs28d: number | null;
+            stepsVs7d?: number | null;
+            stepsVs28d?: number | null;
         };
     };
     dataQuality: {

--- a/app/src/engine/policy.ts
+++ b/app/src/engine/policy.ts
@@ -1,10 +1,11 @@
 /** Increment whenever a change can alter a persisted recommendation decision. (Refactoring does not require a bump) */
-export const POLICY_VERSION = '2026-08-external-plan-provenance-v1';
+export const POLICY_VERSION = '2026-08-acute-step-surge-fatigue-v1';
 
 /** Historical versions are intentionally not re-executed by this build. Their compact
  * audits remain readable evidence, but replay is rejected explicitly because the old
  * decision function is not bundled alongside the current policy. */
 export const HISTORICAL_POLICY_VERSIONS = [
+    '2026-08-external-plan-provenance-v1',
     '2026-08-externally-planned-mode-v1',
     '2026-08-session-packing-tiebreaker-v1',
     '2026-08-planning-overlays-v1',

--- a/app/src/persistence/parsers/decisionInputs.ts
+++ b/app/src/persistence/parsers/decisionInputs.ts
@@ -39,8 +39,8 @@ export function parseRecoverySnapshot(raw: unknown, documentPath: string, userId
     }
     if (!hasNullableNumbers(metrics, ['sleepScore', 'sleepDurationSec', 'restingHr', 'hrvOvernightAvg', 'respirationAvg', 'bodyBatteryWake', 'bodyBatteryChange', 'totalSteps'])
         || typeof metrics.last3DaysHardSessionsCount !== 'number'
-        || !hasNullableNumbers(derived, ['sleepScore7dAvg', 'sleepScore28dAvg', 'restingHr7dAvg', 'restingHr28dAvg', 'hrv7dAvg', 'hrv28dAvg', 'respiration7dAvg', 'respiration28dAvg'])
-        || !hasNullableNumbers(derived.deltas, ['sleepScoreVs7d', 'sleepScoreVs28d', 'restingHrVs7d', 'restingHrVs28d', 'hrvVs7d', 'hrvVs28d', 'respirationVs7d', 'respirationVs28d'])) {
+        || !hasNullableNumbers(derived, ['sleepScore7dAvg', 'sleepScore28dAvg', 'restingHr7dAvg', 'restingHr28dAvg', 'hrv7dAvg', 'hrv28dAvg', 'respiration7dAvg', 'respiration28dAvg', 'steps7dAvg', 'steps28dAvg', 'steps28dStdev'])
+        || !hasNullableNumbers(derived.deltas, ['sleepScoreVs7d', 'sleepScoreVs28d', 'restingHrVs7d', 'restingHrVs28d', 'hrvVs7d', 'hrvVs28d', 'respirationVs7d', 'respirationVs28d', 'stepsVs7d', 'stepsVs28d'])) {
         return issue(documentPath, 'invalid-engine-metric');
     }
     if (!['sleepScoreAvailable', 'restingHrAvailable', 'hrvAvailable', 'baseline7dReady', 'baseline28dReady']

--- a/docs/architecture/ingestion-pipeline.md
+++ b/docs/architecture/ingestion-pipeline.md
@@ -52,9 +52,11 @@ Garmin Connect API
 2. **Fetch Window**: Retrieves biometric stats for date $D$ and step count from completed previous day ($D - 1$).
 3. **Historical Lookback**: Fetches historical data points ($D-1 \dots D-28$) to compute baseline averages.
 4. **Metric Enrichment**: Computes:
-   * 7-day & 28-day moving average HRV (ms)
-   * 7-day & 28-day moving average Resting Heart Rate (bpm)
-   * Waking Body Battery & Sleep Score
-   * Completed previous-day total steps
+   * 7-day & 28-day moving average HRV (ms) and 28-day population standard deviation
+   * 7-day & 28-day moving average Resting Heart Rate (bpm) and 28-day population standard deviation
+   * 7-day & 28-day moving average Sleep Score and 28-day population standard deviation
+   * 7-day & 28-day moving average step counts and 28-day population standard deviation
+   * Waking Body Battery & signed deltas (vs 7d and vs 28d)
+   * Completed previous-day ($D - 1$) total steps
 5. **Upsert**: Writes Schema v3 snapshot payload to Firestore under `users/{userId}/daily_recovery_snapshots/{YYYY-MM-DD}`.
 6. **Activity Normalization**: Saves raw activity records to `users/{userId}/activities/{activityId}` for cross-day auditability.

--- a/docs/architecture/recommendation-engine.md
+++ b/docs/architecture/recommendation-engine.md
@@ -430,10 +430,11 @@ capped-addition candidate worse; that is why `max()` is retained. It is **not** 
 safe or calibrated, and the aggregate scenario recovery-share gate remains release authority.
 
 `computeInternalResponseStrain` in `fatigue.ts` also evaluates unlogged ambulatory load: when
-an acute step surge occurs on $D-1$ ($\ge 1.8\times$ 7d baseline and $\ge +6,000$ excess steps),
+an acute ambient step surge occurs on $D-1$ ($\ge 1.8\times$ 7d baseline and $\ge +6,000$ excess steps
+after deducting estimated steps from logged running/field/walking sessions via `estimateActivitySteps`),
 it introduces a proportional tissue-strain contribution into the `impactTissue` and `lowerBody`
-fatigue dimensions (and a moderate `systemic` load contribution) to prevent high-impact lower-body
-prescriptions following heavy hiking/walking days without requiring athlete subjective soreness input.
+fatigue dimensions to prevent high-impact lower-body prescriptions following unlogged heavy hiking/walking
+days without double-counting structured activities or requiring athlete subjective soreness input.
 
 ---
 

--- a/docs/architecture/recommendation-engine.md
+++ b/docs/architecture/recommendation-engine.md
@@ -429,6 +429,12 @@ fatigue are currently fused with `max()`. ADR-0014's harness comparison found th
 capped-addition candidate worse; that is why `max()` is retained. It is **not** declared
 safe or calibrated, and the aggregate scenario recovery-share gate remains release authority.
 
+`computeInternalResponseStrain` in `fatigue.ts` also evaluates unlogged ambulatory load: when
+an acute step surge occurs on $D-1$ ($\ge 1.8\times$ 7d baseline and $\ge +6,000$ excess steps),
+it introduces a proportional tissue-strain contribution into the `impactTissue` and `lowerBody`
+fatigue dimensions (and a moderate `systemic` load contribution) to prevent high-impact lower-body
+prescriptions following heavy hiking/walking days without requiring athlete subjective soreness input.
+
 ---
 
 ## Multi-day projection

--- a/src/garmin_sync/metrics.py
+++ b/src/garmin_sync/metrics.py
@@ -89,12 +89,16 @@ def compute_derived_metrics(
     resp_7d = calculate_average([d.get("respirationAvg") for d in window_7d_raws], 4)
     resp_28d = calculate_average([d.get("respirationAvg") for d in window_28d_raws], 14)
 
+    steps_7d = calculate_average([d.get("totalSteps") for d in window_7d_raws], 4)
+    steps_28d = calculate_average([d.get("totalSteps") for d in window_28d_raws], 14)
+
     # 28-day trailing stdev per metric -- this person's own night-to-night noise floor,
     # consumed by the engine to normalize deltas instead of comparing against a single
     # fixed absolute threshold for everyone (see DerivedMetrics.hrv28dStdev docstring).
     hrv_sd28 = calculate_stdev([d.get("hrvOvernightAvg") for d in window_28d_raws], 14)
     rhr_sd28 = calculate_stdev([d.get("restingHr") for d in window_28d_raws], 14)
     sleep_sd28 = calculate_stdev([d.get("sleepScore") for d in window_28d_raws], 14)
+    steps_sd28 = calculate_stdev([d.get("totalSteps") for d in window_28d_raws], 14)
 
     def _round(val: float | None) -> float | None:
         return round(val, 1) if val is not None else None
@@ -108,6 +112,8 @@ def compute_derived_metrics(
         hrvVs28d=_round(calculate_delta(raw_current.get("hrvOvernightAvg"), hrv_28d)),
         respirationVs7d=_round(calculate_delta(raw_current.get("respirationAvg"), resp_7d)),
         respirationVs28d=_round(calculate_delta(raw_current.get("respirationAvg"), resp_28d)),
+        stepsVs7d=_round(calculate_delta(raw_current.get("totalSteps"), steps_7d)),
+        stepsVs28d=_round(calculate_delta(raw_current.get("totalSteps"), steps_28d)),
     )
 
     return DerivedMetrics(
@@ -123,5 +129,8 @@ def compute_derived_metrics(
         hrv28dStdev=_round(hrv_sd28),
         restingHr28dStdev=_round(rhr_sd28),
         sleepScore28dStdev=_round(sleep_sd28),
+        steps7dAvg=_round(steps_7d),
+        steps28dAvg=_round(steps_28d),
+        steps28dStdev=_round(steps_sd28),
         deltas=deltas,
     )

--- a/src/garmin_sync/models.py
+++ b/src/garmin_sync/models.py
@@ -176,6 +176,8 @@ class DerivedDeltas:
     hrvVs28d: float | None = None
     respirationVs7d: float | None = None
     respirationVs28d: float | None = None
+    stepsVs7d: float | None = None
+    stepsVs28d: float | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -198,6 +200,9 @@ class DerivedMetrics:
     hrv28dStdev: float | None = None
     restingHr28dStdev: float | None = None
     sleepScore28dStdev: float | None = None
+    steps7dAvg: float | None = None
+    steps28dAvg: float | None = None
+    steps28dStdev: float | None = None
     deltas: DerivedDeltas = field(default_factory=DerivedDeltas)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/garmin_sync/service.py
+++ b/src/garmin_sync/service.py
@@ -177,6 +177,10 @@ class GarminSyncService:
             "restingHr": canonical.resting_heart_rate_bpm,
             "hrvOvernightAvg": canonical.hrv_overnight_avg_ms,
             "respirationAvg": canonical.respiration_rate_brpm,
+            # `steps_count` is the completed D-1 value (see metricDates.steps),
+            # so it must accompany the other current metrics when deriving its
+            # trailing baseline and deltas.
+            "totalSteps": canonical.steps_count,
         }
         derived = compute_derived_metrics(dummy_current, window_7d, window_28d)
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -78,3 +78,23 @@ def test_compute_derived_metrics_stdev_none_below_min_required():
 
     derived = compute_derived_metrics(curr, window_7d, window_28d)
     assert derived.hrv28dStdev is None
+
+
+def test_compute_derived_metrics_steps():
+    window_7d = [
+        {"totalSteps": 5000},
+        {"totalSteps": 6000},
+        {"totalSteps": 7000},
+        {"totalSteps": 6000},
+    ]
+    window_28d = window_7d * 4  # 16 items
+    curr = {"totalSteps": 20000}
+
+    derived = compute_derived_metrics(curr, window_7d, window_28d)
+
+    assert derived.steps7dAvg == 6000.0
+    assert derived.steps28dAvg == 6000.0
+    assert derived.deltas.stepsVs7d == 14000.0
+    assert derived.deltas.stepsVs28d == 14000.0
+    assert derived.steps28dStdev == round(statistics.pstdev([5000, 6000, 7000, 6000] * 4), 1)
+

--- a/tests/test_sync_service.py
+++ b/tests/test_sync_service.py
@@ -384,6 +384,31 @@ def test_sync_service_works_with_a_non_garmin_provider():
     assert saved_payload["raw"]["restingHr"] == 47.0
 
 
+def test_sync_service_derives_step_delta_from_completed_d1_steps():
+    """Step deltas must receive the current canonical D-1 total, not only history."""
+    settings = Settings(app_user_id="test_uid_789")
+    mock_repo = MagicMock()
+    mock_repo.is_fresh.return_value = False
+    mock_repo.get_historical_snapshots.return_value = {
+        f"2026-08-0{day}": {"raw": {"totalSteps": 5000}}
+        for day in range(2, 6)
+    }
+    service = GarminSyncService(
+        settings=settings,
+        repository=mock_repo,
+        provider=FakeTestProvider(),
+    )
+
+    assert service.sync_daily(
+        target_date_str="2026-08-06", force=True, resync_lookback_days=0
+    ) is True
+
+    saved_payload = mock_repo.upsert_snapshot.call_args.args[1]
+    assert saved_payload["raw"]["totalSteps"] == 9000
+    assert saved_payload["derived"]["steps7dAvg"] == 5000.0
+    assert saved_payload["derived"]["deltas"]["stepsVs7d"] == 4000.0
+
+
 def test_sync_service_survives_a_failed_enrichment_fetch():
     """A metric-enrichment endpoint (stress/body battery/training readiness/training
     status) failing must not abort the whole sync -- the core snapshot (sleep/HRV/RHR)


### PR DESCRIPTION
## Summary

- **Rolling Step Baselines & Deltas**: Python sync pipeline (\src/garmin_sync/metrics.py\) now computes 7-day (>= 4 points) and 28-day (>= 14 points) moving averages, 28-day population standard deviation, and signed deltas (\stepsVs7d\, \stepsVs28d\) alongside existing HRV, RHR, and sleep baselines.
- **Activity-Deducted Ambient Step Surge Dampening**: \computeInternalResponseStrain\ in \pp/src/engine/fatigue.ts\ evaluates **net unlogged ambient steps** ($\text{totalSteps} - \text{estimatedActivitySteps}$) using \estimateActivitySteps\. If an athlete logged a 90-min run or soccer match, those steps are deducted so the structured session is not double-counted. An acute ambient surge triggers only when unlogged steps >= 1.8x 7d baseline AND >= +6,000 excess steps (e.g. 20,000 unlogged walking steps on a 5,000 baseline), injecting a proportional dampener into \impactTissue\ and \lowerBody\ fatigue dimensions.
- **Context & UI Observability**: Surfaced 7d/28d step baselines and deltas in \DataView.tsx\ and included step trajectory summary in \contextBrief.ts\ for AI coaching awareness.
- **Policy Version**: Incremented \POLICY_VERSION\ to \2026-08-acute-step-surge-fatigue-v1\ with passing policy drift check.
- **Documentation**: Updated \docs/architecture/ingestion-pipeline.md\ and \docs/architecture/recommendation-engine.md\.

## Validation

- [x] \uv run pytest\ (backend changes) — 107 passed in 1.85s
- [x] \uv run ruff check .\ and \uv run mypy src/garmin_sync\ (backend changes) — Clean; 0 lint errors, 0 type errors across 17 files
- [x] \cd app && npm run check\ (frontend changes) — Typecheck clean (\	sc -b\), ESLint clean, 95 Vitest suites passed (1,189 tests), workout catalog validated
- [x] \cd app && npm run simulate:scenarios\ (recommendation-engine changes) — All simulation scenarios executed cleanly
- [x] \cd app && node scripts/check-policy-drift.mjs origin/main\ — Policy drift check passed

## Risk and reviewer guidance

- **Backward Compatibility**: All new fields in \DerivedMetrics\, \DerivedDeltas\, and \EngineObjectiveInput\ are optional/nullable, preserving compatibility with documents written under previous schema versions.
- **No Double-Counting**: \estimateActivitySteps\ deducts step contributions from logged running, field sport, and walking activities before checking for an unlogged ambulatory surge.

## Domain invariants

- [x] Firestore writes remain user-scoped under \users/{APP_USER_ID}/...\; no \default_user\ or top-level recovery snapshots were introduced.
- [x] Calendar-date logic uses \Europe/Warsaw\; completed \	otalSteps\ still means the previous calendar day (\D - 1\).
- [x] No credentials, tokens, service-account files, or raw health payloads are included.
- [x] Recommendation decision logic changed: \POLICY_VERSION\ was evaluated and relevant architecture/ADR documentation was updated.

## Screenshots or recordings

Not applicable — Telemetry and UI inspection fields were added to existing data inspection tables.