### PR TITLE
fix(sync): preserve Firestore history on skipped dates during rebuild

### DIFF
--- a/src/garmin_sync/service.py
+++ b/src/garmin_sync/service.py
@@ -532,6 +532,11 @@ class GarminSyncService:
                     f"hrv={raw_hrv is not None}, activities={raw_activities is not None}). Skipping."
                 )
                 skipped_dates.append(target_iso)
+                # Keep history continuous: load existing Firestore raw snapshot if present
+                # so downstream dates in the rebuild range still have full 7d/28d baselines.
+                existing = self.repository.get_snapshot(target_iso)
+                if existing and existing.get("raw"):
+                    raw_memory_store[target_iso] = existing["raw"]
                 continue
 
             stats_fallback = self.archive_store.load("stats", yesterday_iso)

--- a/tests/test_rebuild_and_audit.py
+++ b/tests/test_rebuild_and_audit.py
@@ -74,6 +74,44 @@ def test_rebuild_skips_date_missing_archived_payload(tmp_path):
     assert mock_client.mock_calls == []
 
 
+def test_rebuild_preserves_existing_firestore_history_on_skipped_dates(tmp_path):
+    archive_store = LocalRawArchiveStore(base_dir=tmp_path)
+    # Day 2 is fully archived
+    archive_store.archive("stats", "2026-08-07", {"restingHeartRate": 50}, "run-1", "0.3.8")
+    archive_store.archive("sleep", "2026-08-07", {"sleepScores": {"overallScore": {"value": 80}}}, "run-1", "0.3.8")
+    archive_store.archive("hrv", "2026-08-07", {"hrvSummary": {"weeklyAvg": 55, "lastNightAvg": 55}}, "run-1", "0.3.8")
+    archive_store.archive("activities", "2026-08-07", [], "run-1", "0.3.8")
+
+    settings = Settings(app_user_id="test_uid_789")
+    mock_repo = MagicMock()
+    mock_repo.get_historical_snapshots.return_value = {
+        f"2026-07-{d:02d}": {"raw": {"sleepScore": 80, "restingHr": 50, "hrvOvernightAvg": 55, "respirationAvg": 14, "totalSteps": 6000}}
+        for d in range(10, 32)
+    }
+    # Day 1 is missing from archive but present in Firestore
+    mock_repo.get_snapshot.return_value = {
+        "raw": {"sleepScore": 80, "restingHr": 50, "hrvOvernightAvg": 55, "respirationAvg": 14, "totalSteps": 6000}
+    }
+    mock_client = MagicMock()
+
+    service = GarminSyncService(
+        settings=settings,
+        repository=mock_repo,
+        garmin_client=mock_client,
+        archive_store=archive_store,
+    )
+
+    result = service.rebuild("2026-08-06", "2026-08-07")
+
+    assert result is True
+    # Day 2 should have been upserted with 28d baseline because Day 1's raw snapshot was preserved in memory
+    assert mock_repo.upsert_snapshot.call_count == 1
+    call_args = mock_repo.upsert_snapshot.call_args_list[0]
+    date_iso, snapshot_dict = call_args[0]
+    assert date_iso == "2026-08-07"
+    assert snapshot_dict["derived"]["steps28dAvg"] == 6000.0
+
+
 def test_audit_reports_missing_snapshots_and_availability():
     settings = Settings(app_user_id="test_uid_789")
     mock_repo = MagicMock()


### PR DESCRIPTION
## Summary

- **Problem**: When running \ebuild\ over a date range where earlier dates lacked raw archive payloads (e.g. July 1 – Aug 5), \ebuild\ skipped those dates without loading their existing Firestore raw snapshots into in-memory prehistory. As a result, when rebuilding later dates (Aug 6 – Aug 17), only 11 days of data were in memory, which is < 14 points, causing 28-day baselines (\steps28dAvg\, \hrv28dAvg\, \sleepScore28dAvg\) to be set to \None\.
- **Fix**: Updated \ebuild_from_archive\ in \src/garmin_sync/service.py\ to load existing Firestore raw snapshots into \aw_memory_store\ on skipped dates so that downstream dates always retain contiguous 28-day baseline history.
- **Tests**: Added \	est_rebuild_preserves_existing_firestore_history_on_skipped_dates\ in \	ests/test_rebuild_and_audit.py\.

## Validation
- [x] \uv run pytest\ — 109 passed in 2.10s
- [x] \uv run ruff check .\ and \uv run mypy src/garmin_sync\ — 0 errors