### PR TITLE
feat(ui): add expandable workout details in external plan week

### DIFF
--- a/app/src/components/ExternalPlanWeek.css
+++ b/app/src/components/ExternalPlanWeek.css
@@ -83,6 +83,12 @@
   flex: 1;
 }
 
+.external-week-session-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
 .external-week-title {
   font-size: 0.88rem;
   font-weight: 500;
@@ -91,6 +97,29 @@
 .external-week-meta {
   font-size: 0.75rem;
   color: var(--text-secondary);
+}
+
+.external-week-session-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+.external-week-view-btn {
+  background: rgba(56, 189, 248, 0.12);
+  border: 1px solid rgba(56, 189, 248, 0.35);
+  border-radius: 6px;
+  color: #e0f2fe;
+  cursor: pointer;
+  font-size: 0.78rem;
+  font-weight: 500;
+  padding: 0.3rem 0.6rem;
+  white-space: nowrap;
+}
+
+.external-week-view-btn:hover {
+  background: rgba(56, 189, 248, 0.22);
 }
 
 .external-week-missed-btn,
@@ -118,6 +147,75 @@
 .external-week-accept {
   border-color: rgba(52, 211, 153, 0.4);
   color: #6ee7b7;
+}
+
+.external-week-details {
+  margin-top: 0.15rem;
+  padding: 0.75rem 0.85rem;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.external-week-details .external-prescription h5,
+.external-week-details .external-scaling-summary h5,
+.external-week-details .external-fallback h5 {
+  margin: 0.5rem 0 0.3rem;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--text-secondary);
+}
+
+.external-week-details .external-prescription:first-child h5 {
+  margin-top: 0;
+}
+
+.external-week-details .external-prescription-summary {
+  margin: 0;
+  font-size: 0.88rem;
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
+.external-week-details .external-prescription-steps {
+  margin: 0.5rem 0 0;
+  padding-left: 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.external-week-details .external-prescription-steps li {
+  font-size: 0.84rem;
+  line-height: 1.4;
+}
+
+.external-week-details .step-name {
+  font-weight: 600;
+}
+
+.external-week-details .step-target,
+.external-week-details .step-timing,
+.external-week-details .step-notes {
+  display: block;
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+}
+
+.external-week-details .external-scaling-summary p,
+.external-week-details .external-fallback p {
+  margin: 0;
+  font-size: 0.84rem;
+  line-height: 1.45;
+}
+
+.external-week-details .external-fallback {
+  margin-top: 0.6rem;
+  padding: 0.55rem 0.7rem;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px dashed rgba(255, 255, 255, 0.15);
 }
 
 .external-week-finding {

--- a/app/src/components/ExternalPlanWeek.test.ts
+++ b/app/src/components/ExternalPlanWeek.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import React from 'react';
+import { ExternalPlanWeek } from './ExternalPlanWeek';
 import type { PlacedSession } from '../engine/externalPlacement';
 import type { FixedActivity } from '../engine/models';
 
@@ -9,7 +12,14 @@ describe('ExternalPlanWeek occupancy and scheduling contracts', () => {
                 id: 's1', title: 'Threshold', priority: 'key',
                 placement: { week: 1, preferredDay: 'tuesday', flexibility: 'preferred', ifMissed: 'reschedule_within_week' },
                 gating: { modality: 'cycling', intensity: 'hard', durationMin: 60, durationMax: 75, environment: 'either', equipment: ['indoor_bike'] },
-                prescription: { summary: '3x12 at threshold.' },
+                prescription: {
+                    summary: '3x12 at threshold.',
+                    steps: [
+                        { name: 'Warm-up', durationMin: 15, target: 'Zone 2' },
+                        { name: 'Interval', durationMin: 12, sets: 3, setRecoveryMin: 4, target: '95-100% FTP' },
+                    ],
+                },
+                scaling: { reducible: true, reducedSummary: '2x12 at threshold.', fallback: 'Steady 60 min outdoors' },
             },
             date: '2026-08-18',
             status: 'planned',
@@ -57,4 +67,24 @@ describe('ExternalPlanWeek occupancy and scheduling contracts', () => {
         expect(occupied.has('2026-08-17')).toBe(false); // Completed activity does not block
         expect(occupied.has('2026-08-19')).toBe(false); // Free day
     });
+
+    it('renders View workout button for scheduled sessions', () => {
+        const html = renderToStaticMarkup(
+            React.createElement(ExternalPlanWeek, {
+                planTitle: 'Adaptive Peak Plan',
+                weekStartDate: '2026-08-17',
+                placed,
+                critique: null,
+                today: '2026-08-17',
+                onProposeReplacement: () => ({ sessionId: 's1', missedDate: '2026-08-17', outcome: 'unresolved' as const, rationale: '' }),
+                onConfirmReplacement: () => {},
+                onChooseDate: () => {},
+            }),
+        );
+
+        expect(html).toContain('View workout');
+        expect(html).toContain('Threshold');
+        expect(html).toContain('hard · 60–75 min');
+    });
 });
+

--- a/app/src/components/ExternalPlanWeek.tsx
+++ b/app/src/components/ExternalPlanWeek.tsx
@@ -3,6 +3,7 @@ import type { ExternalCritiqueFinding, ExternalWeekCritique } from '../engine/ex
 import type { PlacedSession, ReplacementProposal } from '../engine/externalPlacement';
 import type { FixedActivity } from '../engine/models';
 import { addDaysToLocalDateString } from '../utils/localDate';
+import { stepTiming } from './externalPrescriptionUtils';
 import './ExternalPlanWeek.css';
 
 const WEEKDAY_FORMATTER = new Intl.DateTimeFormat('en-US', { weekday: 'short', timeZone: 'UTC' });
@@ -64,6 +65,19 @@ export function ExternalPlanWeek({
 }: ExternalPlanWeekProps) {
     const [proposal, setProposal] = useState<ReplacementProposal | null>(null);
     const [choosingFor, setChoosingFor] = useState<string | null>(null);
+    const [expandedSessionIds, setExpandedSessionIds] = useState<Set<string>>(() => new Set());
+
+    const toggleExpandSession = (sessionId: string) => {
+        setExpandedSessionIds(prev => {
+            const next = new Set(prev);
+            if (next.has(sessionId)) {
+                next.delete(sessionId);
+            } else {
+                next.add(sessionId);
+            }
+            return next;
+        });
+    };
 
     const days = useMemo(
         () => Array.from({ length: 7 }, (_, offset) => addDaysToLocalDateString(weekStartDate, offset)),
@@ -132,28 +146,78 @@ export function ExternalPlanWeek({
                             </div>
                             <div className="external-week-daybody">
                                 {sessions.length === 0 && <p className="external-week-empty">Nothing placed</p>}
-                                {sessions.map(item => (
-                                    <div key={item.session.id} className={`external-week-session status-${item.status}`}>
-                                        <span className="external-week-icon">{MODALITY_ICON[item.session.gating.modality] ?? '❔'}</span>
-                                        <div className="external-week-sessionbody">
-                                            <span className="external-week-title">{item.session.title}</span>
-                                            <span className="external-week-meta">
-                                                {item.session.gating.intensity} · {item.session.gating.durationMin}–{item.session.gating.durationMax} min
-                                                {' · '}{STATUS_LABEL[item.status]}
-                                                {item.moved && ' (not where your plan first put it)'}
-                                            </span>
+                                {sessions.map(item => {
+                                    const isExpanded = expandedSessionIds.has(item.session.id);
+                                    const steps = item.session.prescription.steps ?? [];
+                                    return (
+                                        <div key={item.session.id} className="external-week-session-item">
+                                            <div className={`external-week-session status-${item.status}`}>
+                                                <span className="external-week-icon">{MODALITY_ICON[item.session.gating.modality] ?? '❔'}</span>
+                                                <div className="external-week-sessionbody">
+                                                    <span className="external-week-title">{item.session.title}</span>
+                                                    <span className="external-week-meta">
+                                                        {item.session.gating.intensity} · {item.session.gating.durationMin}–{item.session.gating.durationMax} min
+                                                        {' · '}{STATUS_LABEL[item.status]}
+                                                        {item.moved && ' (not where your plan first put it)'}
+                                                    </span>
+                                                </div>
+                                                <div className="external-week-session-actions">
+                                                    <button
+                                                        type="button"
+                                                        className="external-week-view-btn"
+                                                        onClick={() => toggleExpandSession(item.session.id)}
+                                                        aria-expanded={isExpanded}
+                                                    >
+                                                        {isExpanded ? 'Hide workout' : 'View workout'}
+                                                    </button>
+                                                    {(item.status === 'planned' || item.status === 'moved') && date <= today && (
+                                                        <button
+                                                            type="button"
+                                                            className="external-week-missed-btn"
+                                                            onClick={() => startProposal(item.session.id, date)}
+                                                        >
+                                                            {date === today ? 'Reschedule' : 'Missed it'}
+                                                        </button>
+                                                    )}
+                                                </div>
+                                            </div>
+                                            {isExpanded && (
+                                                <div className="external-week-details" aria-label={`Workout details for ${item.session.title}`}>
+                                                    <div className="external-prescription">
+                                                        <h5>As your plan wrote it</h5>
+                                                        <p className="external-prescription-summary">
+                                                            {item.session.prescription.summary}
+                                                        </p>
+                                                        {steps.length > 0 && (
+                                                            <ol className="external-prescription-steps">
+                                                                {steps.map((step, index) => (
+                                                                    <li key={`${step.name}-${index}`}>
+                                                                        <span className="step-name">{step.name}</span>
+                                                                        {step.target && <span className="step-target">{step.target}</span>}
+                                                                        {stepTiming(step) && <span className="step-timing">{stepTiming(step)}</span>}
+                                                                        {step.notes && <span className="step-notes">{step.notes}</span>}
+                                                                    </li>
+                                                                ))}
+                                                            </ol>
+                                                        )}
+                                                    </div>
+                                                    {item.session.scaling?.reducedSummary && (
+                                                        <div className="external-scaling-summary">
+                                                            <h5>Reduced version</h5>
+                                                            <p>{item.session.scaling.reducedSummary}</p>
+                                                        </div>
+                                                    )}
+                                                    {item.session.scaling?.fallback && (
+                                                        <aside className="external-fallback" aria-label="Your plan author's note">
+                                                            <h5>Your plan&apos;s note on what to do instead</h5>
+                                                            <p>{item.session.scaling.fallback}</p>
+                                                        </aside>
+                                                    )}
+                                                </div>
+                                            )}
                                         </div>
-                                        {(item.status === 'planned' || item.status === 'moved') && date <= today && (
-                                            <button
-                                                type="button"
-                                                className="external-week-missed-btn"
-                                                onClick={() => startProposal(item.session.id, date)}
-                                            >
-                                                {date === today ? 'Reschedule' : 'Missed it'}
-                                            </button>
-                                        )}
-                                    </div>
-                                ))}
+                                    );
+                                })}
                                 {dayFindings.map((finding, index) => (
                                     <p key={`${finding.rule}-${index}`} className="external-week-finding">
                                         ⚠️ {finding.detail}

--- a/app/src/components/ExternalVerdictBanner.tsx
+++ b/app/src/components/ExternalVerdictBanner.tsx
@@ -1,5 +1,6 @@
 import { describeEligibilityReasons } from '../engine/eligibility';
-import type { ExternalPrescriptionStep, ExternalSessionVerdictSummary, Recommendation } from '../engine/models';
+import type { ExternalSessionVerdictSummary, Recommendation } from '../engine/models';
+import { stepTiming } from './externalPrescriptionUtils';
 import './ExternalVerdictBanner.css';
 
 interface ExternalVerdictBannerProps {
@@ -20,19 +21,6 @@ const DECISION_LABEL: Record<ExternalSessionVerdictSummary['decision'], string> 
 function gateSentence(gateFailures: readonly string[]): string | null {
     if (gateFailures.length === 0) return null;
     return `Excluded because ${describeEligibilityReasons(gateFailures)}.`;
-}
-
-function stepTiming(step: ExternalPrescriptionStep): string | null {
-    const parts: string[] = [];
-    if (step.durationMin !== undefined) parts.push(`${step.durationMin} min`);
-    if (step.durationSec !== undefined) parts.push(`${step.durationSec} s`);
-    if (step.sets !== undefined && step.sets > 1) parts.push(`${step.sets} sets`);
-    if (step.repeat !== undefined && step.repeat > 1) parts.push(`× ${step.repeat}`);
-    if (step.recoveryMin !== undefined) parts.push(`${step.recoveryMin} min recovery`);
-    if (step.recoverySec !== undefined) parts.push(`${step.recoverySec} s recovery`);
-    if (step.setRecoveryMin !== undefined) parts.push(`${step.setRecoveryMin} min between sets`);
-    if (step.setRecoverySec !== undefined) parts.push(`${step.setRecoverySec} s between sets`);
-    return parts.length > 0 ? parts.join(' · ') : null;
 }
 
 /**

--- a/app/src/components/externalPrescriptionUtils.ts
+++ b/app/src/components/externalPrescriptionUtils.ts
@@ -1,0 +1,14 @@
+import type { ExternalPrescriptionStep } from '../engine/models';
+
+export function stepTiming(step: ExternalPrescriptionStep): string | null {
+    const parts: string[] = [];
+    if (step.durationMin !== undefined) parts.push(`${step.durationMin} min`);
+    if (step.durationSec !== undefined) parts.push(`${step.durationSec} s`);
+    if (step.sets !== undefined && step.sets > 1) parts.push(`${step.sets} sets`);
+    if (step.repeat !== undefined && step.repeat > 1) parts.push(`× ${step.repeat}`);
+    if (step.recoveryMin !== undefined) parts.push(`${step.recoveryMin} min recovery`);
+    if (step.recoverySec !== undefined) parts.push(`${step.recoverySec} s recovery`);
+    if (step.setRecoveryMin !== undefined) parts.push(`${step.setRecoveryMin} min between sets`);
+    if (step.setRecoverySec !== undefined) parts.push(`${step.setRecoverySec} s between sets`);
+    return parts.length > 0 ? parts.join(' · ') : null;
+}

--- a/app/tests/visual/capture.pw.ts
+++ b/app/tests/visual/capture.pw.ts
@@ -46,6 +46,8 @@ for (const scenario of VISUAL_SCENARIOS) {
       const viewWorkout = page.getByRole('button', { name: 'View workout' });
       if (await viewWorkout.count()) {
         await viewWorkout.first().click();
+        await expect(viewWorkout.first()).toHaveAttribute('aria-expanded', 'true');
+        await expect(page.getByLabel(/Workout details for /)).toBeVisible();
         await capture(page, scenario, 'workout-expanded', ['Workout steps are available on demand without overwhelming the recommendation.']);
       }
     }

--- a/app/tests/visual/capture.pw.ts
+++ b/app/tests/visual/capture.pw.ts
@@ -45,7 +45,7 @@ for (const scenario of VISUAL_SCENARIOS) {
     if (scenario.id.startsWith('home-') && scenario.id !== 'home-missing-data') {
       const viewWorkout = page.getByRole('button', { name: 'View workout' });
       if (await viewWorkout.count()) {
-        await viewWorkout.click();
+        await viewWorkout.first().click();
         await capture(page, scenario, 'workout-expanded', ['Workout steps are available on demand without overwhelming the recommendation.']);
       }
     }


### PR DESCRIPTION
### Summary

- Adds expandable 'View workout' / 'Hide workout' button to each session row in \ExternalPlanWeek.tsx\.
- Displays structured workout prescription steps (sets, intervals, durations, targets, notes) and author fallback notes.
- Extracts shared step timing formatting logic to \externalPrescriptionUtils.ts\.
- Adds unit tests and updates visual capture test selectors.