### PR TITLE
feat(export): add workout export and Garmin Connect sync suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,6 +212,7 @@ firebase-service-account.json
 .garmin_tokens/
 garmin_tokens.json
 .garmin_archive/
+cloud-run-job.env.yaml
 sleep_daily_sample.json
 hrv_range_sample.json
 *.cache*

--- a/app/src/components/ExternalPlanWeek.css
+++ b/app/src/components/ExternalPlanWeek.css
@@ -157,6 +157,12 @@
   border: 1px solid rgba(255, 255, 255, 0.08);
 }
 
+.external-week-details-header {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 0.5rem;
+}
+
 .external-week-details .external-prescription h5,
 .external-week-details .external-scaling-summary h5,
 .external-week-details .external-fallback h5 {

--- a/app/src/components/ExternalPlanWeek.css
+++ b/app/src/components/ExternalPlanWeek.css
@@ -83,6 +83,12 @@
   flex: 1;
 }
 
+.external-week-session-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
 .external-week-title {
   font-size: 0.88rem;
   font-weight: 500;
@@ -91,6 +97,29 @@
 .external-week-meta {
   font-size: 0.75rem;
   color: var(--text-secondary);
+}
+
+.external-week-session-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+.external-week-view-btn {
+  background: rgba(56, 189, 248, 0.12);
+  border: 1px solid rgba(56, 189, 248, 0.35);
+  border-radius: 6px;
+  color: #e0f2fe;
+  cursor: pointer;
+  font-size: 0.78rem;
+  font-weight: 500;
+  padding: 0.3rem 0.6rem;
+  white-space: nowrap;
+}
+
+.external-week-view-btn:hover {
+  background: rgba(56, 189, 248, 0.22);
 }
 
 .external-week-missed-btn,
@@ -118,6 +147,75 @@
 .external-week-accept {
   border-color: rgba(52, 211, 153, 0.4);
   color: #6ee7b7;
+}
+
+.external-week-details {
+  margin-top: 0.15rem;
+  padding: 0.75rem 0.85rem;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.external-week-details .external-prescription h5,
+.external-week-details .external-scaling-summary h5,
+.external-week-details .external-fallback h5 {
+  margin: 0.5rem 0 0.3rem;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--text-secondary);
+}
+
+.external-week-details .external-prescription:first-child h5 {
+  margin-top: 0;
+}
+
+.external-week-details .external-prescription-summary {
+  margin: 0;
+  font-size: 0.88rem;
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
+.external-week-details .external-prescription-steps {
+  margin: 0.5rem 0 0;
+  padding-left: 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.external-week-details .external-prescription-steps li {
+  font-size: 0.84rem;
+  line-height: 1.4;
+}
+
+.external-week-details .step-name {
+  font-weight: 600;
+}
+
+.external-week-details .step-target,
+.external-week-details .step-timing,
+.external-week-details .step-notes {
+  display: block;
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+}
+
+.external-week-details .external-scaling-summary p,
+.external-week-details .external-fallback p {
+  margin: 0;
+  font-size: 0.84rem;
+  line-height: 1.45;
+}
+
+.external-week-details .external-fallback {
+  margin-top: 0.6rem;
+  padding: 0.55rem 0.7rem;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px dashed rgba(255, 255, 255, 0.15);
 }
 
 .external-week-finding {

--- a/app/src/components/ExternalPlanWeek.test.ts
+++ b/app/src/components/ExternalPlanWeek.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import React from 'react';
+import { ExternalPlanWeek } from './ExternalPlanWeek';
 import type { PlacedSession } from '../engine/externalPlacement';
 import type { FixedActivity } from '../engine/models';
 
@@ -9,7 +12,14 @@ describe('ExternalPlanWeek occupancy and scheduling contracts', () => {
                 id: 's1', title: 'Threshold', priority: 'key',
                 placement: { week: 1, preferredDay: 'tuesday', flexibility: 'preferred', ifMissed: 'reschedule_within_week' },
                 gating: { modality: 'cycling', intensity: 'hard', durationMin: 60, durationMax: 75, environment: 'either', equipment: ['indoor_bike'] },
-                prescription: { summary: '3x12 at threshold.' },
+                prescription: {
+                    summary: '3x12 at threshold.',
+                    steps: [
+                        { name: 'Warm-up', durationMin: 15, target: 'Zone 2' },
+                        { name: 'Interval', durationMin: 12, sets: 3, setRecoveryMin: 4, target: '95-100% FTP' },
+                    ],
+                },
+                scaling: { reducible: true, reducedSummary: '2x12 at threshold.', fallback: 'Steady 60 min outdoors' },
             },
             date: '2026-08-18',
             status: 'planned',
@@ -57,4 +67,24 @@ describe('ExternalPlanWeek occupancy and scheduling contracts', () => {
         expect(occupied.has('2026-08-17')).toBe(false); // Completed activity does not block
         expect(occupied.has('2026-08-19')).toBe(false); // Free day
     });
+
+    it('renders View workout button for scheduled sessions', () => {
+        const html = renderToStaticMarkup(
+            React.createElement(ExternalPlanWeek, {
+                planTitle: 'Adaptive Peak Plan',
+                weekStartDate: '2026-08-17',
+                placed,
+                critique: null,
+                today: '2026-08-17',
+                onProposeReplacement: () => ({ sessionId: 's1', missedDate: '2026-08-17', outcome: 'unresolved' as const, rationale: '' }),
+                onConfirmReplacement: () => {},
+                onChooseDate: () => {},
+            }),
+        );
+
+        expect(html).toContain('View workout');
+        expect(html).toContain('Threshold');
+        expect(html).toContain('hard · 60–75 min');
+    });
 });
+

--- a/app/src/components/ExternalPlanWeek.test.ts
+++ b/app/src/components/ExternalPlanWeek.test.ts
@@ -71,6 +71,7 @@ describe('ExternalPlanWeek occupancy and scheduling contracts', () => {
     it('renders View workout button for scheduled sessions', () => {
         const html = renderToStaticMarkup(
             React.createElement(ExternalPlanWeek, {
+                userId: 'user-1',
                 planTitle: 'Adaptive Peak Plan',
                 weekStartDate: '2026-08-17',
                 placed,

--- a/app/src/components/ExternalPlanWeek.tsx
+++ b/app/src/components/ExternalPlanWeek.tsx
@@ -26,7 +26,7 @@ const MODALITY_ICON: Record<string, string> = {
 };
 
 export interface ExternalPlanWeekProps {
-    userId?: string;
+    userId: string;
     planTitle: string;
     weekStartDate: string;
     placed: readonly PlacedSession[];
@@ -62,7 +62,7 @@ function weekLevelFindings(critique: ExternalWeekCritique | null): ExternalCriti
  * this screen moves a session on its own.
  */
 export function ExternalPlanWeek({
-    userId = 'current-user',
+    userId,
     planTitle, weekStartDate, placed, critique, today, fixedActivities,
     onProposeReplacement, onConfirmReplacement, onChooseDate, writeError = null,
 }: ExternalPlanWeekProps) {

--- a/app/src/components/ExternalPlanWeek.tsx
+++ b/app/src/components/ExternalPlanWeek.tsx
@@ -3,6 +3,7 @@ import type { ExternalCritiqueFinding, ExternalWeekCritique } from '../engine/ex
 import type { PlacedSession, ReplacementProposal } from '../engine/externalPlacement';
 import type { FixedActivity } from '../engine/models';
 import { addDaysToLocalDateString } from '../utils/localDate';
+import { stepTiming } from './externalPrescriptionUtils';
 import './ExternalPlanWeek.css';
 
 const WEEKDAY_FORMATTER = new Intl.DateTimeFormat('en-US', { weekday: 'short', timeZone: 'UTC' });
@@ -64,6 +65,19 @@ export function ExternalPlanWeek({
 }: ExternalPlanWeekProps) {
     const [proposal, setProposal] = useState<ReplacementProposal | null>(null);
     const [choosingFor, setChoosingFor] = useState<string | null>(null);
+    const [expandedSessionIds, setExpandedSessionIds] = useState<Set<string>>(() => new Set());
+
+    const toggleExpandSession = (sessionId: string) => {
+        setExpandedSessionIds(prev => {
+            const next = new Set(prev);
+            if (next.has(sessionId)) {
+                next.delete(sessionId);
+            } else {
+                next.add(sessionId);
+            }
+            return next;
+        });
+    };
 
     const days = useMemo(
         () => Array.from({ length: 7 }, (_, offset) => addDaysToLocalDateString(weekStartDate, offset)),
@@ -132,28 +146,78 @@ export function ExternalPlanWeek({
                             </div>
                             <div className="external-week-daybody">
                                 {sessions.length === 0 && <p className="external-week-empty">Nothing placed</p>}
-                                {sessions.map(item => (
-                                    <div key={item.session.id} className={`external-week-session status-${item.status}`}>
-                                        <span className="external-week-icon">{MODALITY_ICON[item.session.gating.modality] ?? '❔'}</span>
-                                        <div className="external-week-sessionbody">
-                                            <span className="external-week-title">{item.session.title}</span>
-                                            <span className="external-week-meta">
-                                                {item.session.gating.intensity} · {item.session.gating.durationMin}–{item.session.gating.durationMax} min
-                                                {' · '}{STATUS_LABEL[item.status]}
-                                                {item.moved && ' (not where your plan first put it)'}
-                                            </span>
+                                {sessions.map(item => {
+                                    const isExpanded = expandedSessionIds.has(item.session.id);
+                                    const steps = item.session.prescription.steps ?? [];
+                                    return (
+                                        <div key={item.session.id} className="external-week-session-item">
+                                            <div className={`external-week-session status-${item.status}`}>
+                                                <span className="external-week-icon">{MODALITY_ICON[item.session.gating.modality] ?? '❔'}</span>
+                                                <div className="external-week-sessionbody">
+                                                    <span className="external-week-title">{item.session.title}</span>
+                                                    <span className="external-week-meta">
+                                                        {item.session.gating.intensity} · {item.session.gating.durationMin}–{item.session.gating.durationMax} min
+                                                        {' · '}{STATUS_LABEL[item.status]}
+                                                        {item.moved && ' (not where your plan first put it)'}
+                                                    </span>
+                                                </div>
+                                                <div className="external-week-session-actions">
+                                                    <button
+                                                        type="button"
+                                                        className="external-week-view-btn"
+                                                        onClick={() => toggleExpandSession(item.session.id)}
+                                                        aria-expanded={isExpanded}
+                                                    >
+                                                        {isExpanded ? 'Hide workout' : 'View workout'}
+                                                    </button>
+                                                    {(item.status === 'planned' || item.status === 'moved') && date <= today && (
+                                                        <button
+                                                            type="button"
+                                                            className="external-week-missed-btn"
+                                                            onClick={() => startProposal(item.session.id, date)}
+                                                        >
+                                                            {date === today ? 'Reschedule' : 'Missed it'}
+                                                        </button>
+                                                    )}
+                                                </div>
+                                            </div>
+                                            {isExpanded && (
+                                                <div className="external-week-details" aria-label={`Workout details for ${item.session.title}`}>
+                                                    <div className="external-prescription">
+                                                        <h5>As your plan wrote it</h5>
+                                                        <p className="external-prescription-summary">
+                                                            {item.session.prescription.summary}
+                                                        </p>
+                                                        {steps.length > 0 && (
+                                                            <ol className="external-prescription-steps">
+                                                                {steps.map((step, index) => (
+                                                                    <li key={`${step.name}-${index}`}>
+                                                                        <span className="step-name">{step.name}</span>
+                                                                        {step.target && <span className="step-target">{step.target}</span>}
+                                                                        {stepTiming(step) && <span className="step-timing">{stepTiming(step)}</span>}
+                                                                        {step.notes && <span className="step-notes">{step.notes}</span>}
+                                                                    </li>
+                                                                ))}
+                                                            </ol>
+                                                        )}
+                                                    </div>
+                                                    {item.session.scaling?.reducedSummary && (
+                                                        <div className="external-scaling-summary">
+                                                            <h5>Reduced version</h5>
+                                                            <p>{item.session.scaling.reducedSummary}</p>
+                                                        </div>
+                                                    )}
+                                                    {item.session.scaling?.fallback && (
+                                                        <aside className="external-fallback" aria-label="Your plan author's note">
+                                                            <h5>Your plan&apos;s note on what to do instead</h5>
+                                                            <p>{item.session.scaling.fallback}</p>
+                                                        </aside>
+                                                    )}
+                                                </div>
+                                            )}
                                         </div>
-                                        {(item.status === 'planned' || item.status === 'moved') && date <= today && (
-                                            <button
-                                                type="button"
-                                                className="external-week-missed-btn"
-                                                onClick={() => startProposal(item.session.id, date)}
-                                            >
-                                                {date === today ? 'Reschedule' : 'Missed it'}
-                                            </button>
-                                        )}
-                                    </div>
-                                ))}
+                                    );
+                                })}
                                 {dayFindings.map((finding, index) => (
                                     <p key={`${finding.rule}-${index}`} className="external-week-finding">
                                         ⚠️ {finding.detail}

--- a/app/src/components/ExternalPlanWeek.tsx
+++ b/app/src/components/ExternalPlanWeek.tsx
@@ -4,6 +4,7 @@ import type { PlacedSession, ReplacementProposal } from '../engine/externalPlace
 import type { FixedActivity } from '../engine/models';
 import { addDaysToLocalDateString } from '../utils/localDate';
 import { stepTiming } from './externalPrescriptionUtils';
+import { WorkoutExportMenu } from './WorkoutExportMenu';
 import './ExternalPlanWeek.css';
 
 const WEEKDAY_FORMATTER = new Intl.DateTimeFormat('en-US', { weekday: 'short', timeZone: 'UTC' });
@@ -25,6 +26,7 @@ const MODALITY_ICON: Record<string, string> = {
 };
 
 export interface ExternalPlanWeekProps {
+    userId?: string;
     planTitle: string;
     weekStartDate: string;
     placed: readonly PlacedSession[];
@@ -60,6 +62,7 @@ function weekLevelFindings(critique: ExternalWeekCritique | null): ExternalCriti
  * this screen moves a session on its own.
  */
 export function ExternalPlanWeek({
+    userId = 'current-user',
     planTitle, weekStartDate, placed, critique, today, fixedActivities,
     onProposeReplacement, onConfirmReplacement, onChooseDate, writeError = null,
 }: ExternalPlanWeekProps) {
@@ -183,6 +186,15 @@ export function ExternalPlanWeek({
                                             </div>
                                             {isExpanded && (
                                                 <div className="external-week-details" aria-label={`Workout details for ${item.session.title}`}>
+                                                    <div className="external-week-details-header">
+                                                        <WorkoutExportMenu
+                                                            userId={userId}
+                                                            date={date}
+                                                            title={item.session.title}
+                                                            modality={item.session.gating.modality}
+                                                            externalSession={item.session}
+                                                        />
+                                                    </div>
                                                     <div className="external-prescription">
                                                         <h5>As your plan wrote it</h5>
                                                         <p className="external-prescription-summary">

--- a/app/src/components/ExternalVerdictBanner.tsx
+++ b/app/src/components/ExternalVerdictBanner.tsx
@@ -1,5 +1,6 @@
 import { describeEligibilityReasons } from '../engine/eligibility';
-import type { ExternalPrescriptionStep, ExternalSessionVerdictSummary, Recommendation } from '../engine/models';
+import type { ExternalSessionVerdictSummary, Recommendation } from '../engine/models';
+import { stepTiming } from './externalPrescriptionUtils';
 import './ExternalVerdictBanner.css';
 
 interface ExternalVerdictBannerProps {
@@ -20,19 +21,6 @@ const DECISION_LABEL: Record<ExternalSessionVerdictSummary['decision'], string> 
 function gateSentence(gateFailures: readonly string[]): string | null {
     if (gateFailures.length === 0) return null;
     return `Excluded because ${describeEligibilityReasons(gateFailures)}.`;
-}
-
-function stepTiming(step: ExternalPrescriptionStep): string | null {
-    const parts: string[] = [];
-    if (step.durationMin !== undefined) parts.push(`${step.durationMin} min`);
-    if (step.durationSec !== undefined) parts.push(`${step.durationSec} s`);
-    if (step.sets !== undefined && step.sets > 1) parts.push(`${step.sets} sets`);
-    if (step.repeat !== undefined && step.repeat > 1) parts.push(`× ${step.repeat}`);
-    if (step.recoveryMin !== undefined) parts.push(`${step.recoveryMin} min recovery`);
-    if (step.recoverySec !== undefined) parts.push(`${step.recoverySec} s recovery`);
-    if (step.setRecoveryMin !== undefined) parts.push(`${step.setRecoveryMin} min between sets`);
-    if (step.setRecoverySec !== undefined) parts.push(`${step.setRecoverySec} s between sets`);
-    return parts.length > 0 ? parts.join(' · ') : null;
 }
 
 /**

--- a/app/src/components/Home.tsx
+++ b/app/src/components/Home.tsx
@@ -31,6 +31,7 @@ import {
 import { externalPlanService } from '../services/externalPlanService';
 import { ExternalVerdictBanner } from './ExternalVerdictBanner';
 import { ExternalPlanWeek } from './ExternalPlanWeek';
+import { WorkoutExportMenu } from './WorkoutExportMenu';
 import { AdherencePrompt, type AdherenceAnswer } from './AdherencePrompt';
 import { DecisionJournalCard } from './DecisionJournalCard';
 import { MinimumSafetyCheckin } from './MinimumSafetyCheckin';
@@ -67,12 +68,33 @@ function formatEventTiming(daysToEvent: number | null): string {
   return daysToEvent > 0 ? `In ${daysToEvent} days` : `${Math.abs(daysToEvent)} days ago`;
 }
 
-const DetailedTodayPlan = memo(function DetailedTodayPlan({ prescription }: { prescription: WorkoutPrescription }) {
+const DetailedTodayPlan = memo(function DetailedTodayPlan({
+  prescription,
+  userId,
+  date,
+  title,
+  modality,
+}: {
+  prescription: WorkoutPrescription;
+  userId: string;
+  date: string;
+  title: string;
+  modality: string;
+}) {
   return (
     <section className="detailed-plan" aria-label="Detailed training plan">
       <div className="detailed-plan-header">
-        <h5>Today&apos;s Plan</h5>
-        <span>{prescription.targetDurationMin} min target</span>
+        <div>
+          <h5>Today&apos;s Plan</h5>
+          <span>{prescription.targetDurationMin} min target</span>
+        </div>
+        <WorkoutExportMenu
+          userId={userId}
+          date={date}
+          title={title}
+          modality={modality}
+          prescription={prescription}
+        />
       </div>
       {prescription.displayBlocks.map((block) => (
         <section className={`plan-block plan-block-${block.role}`} key={block.id}>
@@ -693,7 +715,15 @@ export function Home({ userId, onNavigate, onViewData }: HomeProps) {
                     >
                       {showWorkoutDetails ? 'Hide workout' : 'View workout'}
                     </button>
-                    {showWorkoutDetails && <DetailedTodayPlan prescription={activeRec.prescription} />}
+                    {showWorkoutDetails && (
+                      <DetailedTodayPlan
+                        prescription={activeRec.prescription}
+                        userId={userId}
+                        date={decisionInput?.date ?? ''}
+                        title={activeRec.template.title}
+                        modality={activeRec.template.modality}
+                      />
+                    )}
                   </>
                 )}
 
@@ -761,6 +791,7 @@ export function Home({ userId, onNavigate, onViewData }: HomeProps) {
 
           {activeExternalPlan && decisionInput && (
             <ExternalPlanWeek
+              userId={userId}
               planTitle={activeExternalPlan.plan.title}
               weekStartDate={mondayOf(decisionInput.date)}
               placed={activeExternalPlan.placed}

--- a/app/src/components/WorkoutExportMenu.css
+++ b/app/src/components/WorkoutExportMenu.css
@@ -1,0 +1,90 @@
+.workout-export-container {
+  position: relative;
+  display: inline-block;
+}
+
+.workout-export-trigger-btn {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 6px;
+  color: #e0f2fe;
+  cursor: pointer;
+  font-size: 0.78rem;
+  font-weight: 500;
+  padding: 0.3rem 0.65rem;
+  white-space: nowrap;
+  transition: all 0.15s ease;
+}
+
+.workout-export-trigger-btn:hover {
+  background: rgba(56, 189, 248, 0.15);
+  border-color: rgba(56, 189, 248, 0.4);
+}
+
+.workout-export-dropdown {
+  position: absolute;
+  top: calc(100% + 0.35rem);
+  right: 0;
+  z-index: 50;
+  width: 17.5rem;
+  background: #0f172a;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 8px;
+  box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.6), 0 8px 10px -6px rgba(0, 0, 0, 0.4);
+  padding: 0.35rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.workout-export-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.65rem;
+  padding: 0.5rem 0.6rem;
+  border-radius: 6px;
+  background: transparent;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.15s ease;
+  width: 100%;
+}
+
+.workout-export-item:hover {
+  background: rgba(255, 255, 255, 0.07);
+}
+
+.workout-export-item.primary-action {
+  background: rgba(56, 189, 248, 0.08);
+  border: 1px solid rgba(56, 189, 248, 0.2);
+}
+
+.workout-export-item.primary-action:hover {
+  background: rgba(56, 189, 248, 0.18);
+}
+
+.export-icon {
+  font-size: 1.1rem;
+  line-height: 1;
+  margin-top: 0.1rem;
+}
+
+.export-text {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.export-text strong {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: #f1f5f9;
+}
+
+.export-text span {
+  font-size: 0.72rem;
+  color: var(--text-secondary, #94a3b8);
+  margin-top: 0.1rem;
+}

--- a/app/src/components/WorkoutExportMenu.test.ts
+++ b/app/src/components/WorkoutExportMenu.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import React from 'react';
+import { WorkoutExportMenu } from './WorkoutExportMenu';
+
+vi.mock('firebase/firestore', () => ({
+    doc: vi.fn(),
+    setDoc: vi.fn(),
+    getDoc: vi.fn(),
+}));
+
+vi.mock('../firebase', () => ({
+    getDb: vi.fn(() => ({})),
+}));
+
+describe('WorkoutExportMenu', () => {
+    it('renders export trigger button', () => {
+        const html = renderToStaticMarkup(
+            React.createElement(WorkoutExportMenu, {
+                userId: 'user-1',
+                date: '2026-08-17',
+                title: 'Threshold 3x12',
+                modality: 'cycling',
+            }),
+        );
+
+        expect(html).toContain('Export / Sync');
+    });
+});

--- a/app/src/components/WorkoutExportMenu.tsx
+++ b/app/src/components/WorkoutExportMenu.tsx
@@ -1,0 +1,189 @@
+import { useState, useCallback, useRef, useEffect } from 'react';
+import type { WorkoutPrescription } from '../workouts/models';
+import type { ExternalPlanSession } from '../engine/models';
+import { generateZwiftFromPrescription, generateZwiftFromExternalSession, downloadZwiftFile } from '../utils/zwiftExport';
+import { exportWorkoutPrescriptionToJson, exportExternalSessionToJson, downloadJsonFile, copyJsonToClipboard, type CanonicalWorkoutExport } from '../utils/workoutJsonExport';
+import { garminWorkoutQueueService } from '../services/garminWorkoutQueueService';
+import './WorkoutExportMenu.css';
+
+export interface WorkoutExportMenuProps {
+    userId: string;
+    date: string;
+    title: string;
+    modality: string;
+    prescription?: WorkoutPrescription;
+    externalSession?: ExternalPlanSession;
+    onSyncQueued?: () => void;
+}
+
+export function WorkoutExportMenu({
+    userId,
+    date,
+    title,
+    modality,
+    prescription,
+    externalSession,
+    onSyncQueued,
+}: WorkoutExportMenuProps) {
+    const [isOpen, setIsOpen] = useState(false);
+    const [syncState, setSyncState] = useState<'idle' | 'queuing' | 'queued' | 'error'>('idle');
+    const [copied, setCopied] = useState(false);
+    const menuRef = useRef<HTMLDivElement>(null);
+
+    const isCycling = modality.toLowerCase() === 'cycling' || modality.toLowerCase() === 'bike';
+
+    const getCanonicalExport = useCallback((): CanonicalWorkoutExport => {
+        if (prescription) {
+            return exportWorkoutPrescriptionToJson(prescription, modality);
+        }
+        if (externalSession) {
+            return exportExternalSessionToJson(externalSession);
+        }
+        return {
+            schemaVersion: 'canonical_workout_v1',
+            title,
+            workoutId: title.toLowerCase().replace(/\s+/g, '_'),
+            modality,
+            targetDurationMin: 60,
+            blocks: [],
+            exportedAt: new Date().toISOString(),
+        };
+    }, [prescription, externalSession, title, modality]);
+
+    const handleDownloadZwift = () => {
+        let xml = '';
+        if (prescription) {
+            xml = generateZwiftFromPrescription(prescription);
+        } else if (externalSession) {
+            xml = generateZwiftFromExternalSession(externalSession);
+        }
+        if (xml) {
+            const cleanName = title.replace(/[^a-zA-Z0-9_-]/g, '_');
+            downloadZwiftFile(`${cleanName}_${date}`, xml);
+        }
+        setIsOpen(false);
+    };
+
+    const handleDownloadJson = () => {
+        const payload = getCanonicalExport();
+        const cleanName = title.replace(/[^a-zA-Z0-9_-]/g, '_');
+        downloadJsonFile(`${cleanName}_${date}`, payload);
+        setIsOpen(false);
+    };
+
+    const handleCopyJson = async () => {
+        const payload = getCanonicalExport();
+        await copyJsonToClipboard(payload);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+    };
+
+    const handleQueueGarminSync = async () => {
+        setSyncState('queuing');
+        try {
+            const payload = getCanonicalExport();
+            await garminWorkoutQueueService.queueWorkout(userId, date, payload);
+            setSyncState('queued');
+            onSyncQueued?.();
+            setTimeout(() => {
+                setSyncState('idle');
+                setIsOpen(false);
+            }, 2500);
+        } catch (err) {
+            console.error('Failed to queue Garmin workout sync:', err);
+            setSyncState('error');
+            setTimeout(() => setSyncState('idle'), 3000);
+        }
+    };
+
+    // Close dropdown on outside click
+    useEffect(() => {
+        if (!isOpen) return;
+        const handleOutsideClick = (e: MouseEvent) => {
+            if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+                setIsOpen(false);
+            }
+        };
+        document.addEventListener('mousedown', handleOutsideClick);
+        return () => document.removeEventListener('mousedown', handleOutsideClick);
+    }, [isOpen]);
+
+    return (
+        <div className="workout-export-container" ref={menuRef}>
+            <button
+                type="button"
+                className="workout-export-trigger-btn"
+                onClick={() => setIsOpen(prev => !prev)}
+                aria-expanded={isOpen}
+                aria-haspopup="menu"
+                title="Export or sync structured workout"
+            >
+                ⬇️ Export / Sync ▾
+            </button>
+
+            {isOpen && (
+                <div className="workout-export-dropdown" role="menu">
+                    <button
+                        type="button"
+                        className="workout-export-item primary-action"
+                        role="menuitem"
+                        onClick={handleQueueGarminSync}
+                        disabled={syncState === 'queuing'}
+                    >
+                        <span className="export-icon">⚡</span>
+                        <div className="export-text">
+                            <strong>Sync to Garmin Connect</strong>
+                            <span>
+                                {syncState === 'queuing' ? 'Queuing sync...' :
+                                 syncState === 'queued' ? '✓ Queued for Garmin push!' :
+                                 syncState === 'error' ? 'Failed to queue sync' :
+                                 'Upload & schedule to your Garmin calendar'}
+                            </span>
+                        </div>
+                    </button>
+
+                    {isCycling && (
+                        <button
+                            type="button"
+                            className="workout-export-item"
+                            role="menuitem"
+                            onClick={handleDownloadZwift}
+                        >
+                            <span className="export-icon">🚴</span>
+                            <div className="export-text">
+                                <strong>Download Zwift (.zwo)</strong>
+                                <span>For Zwift, TrainerRoad, & Edge head units</span>
+                            </div>
+                        </button>
+                    )}
+
+                    <button
+                        type="button"
+                        className="workout-export-item"
+                        role="menuitem"
+                        onClick={handleDownloadJson}
+                    >
+                        <span className="export-icon">📦</span>
+                        <div className="export-text">
+                            <strong>Download Workout Data (.json)</strong>
+                            <span>Full sets, reps, weight, RPE, & targets</span>
+                        </div>
+                    </button>
+
+                    <button
+                        type="button"
+                        className="workout-export-item"
+                        role="menuitem"
+                        onClick={handleCopyJson}
+                    >
+                        <span className="export-icon">📋</span>
+                        <div className="export-text">
+                            <strong>{copied ? '✓ Copied JSON!' : 'Copy Workout JSON'}</strong>
+                            <span>Copy raw schema to clipboard</span>
+                        </div>
+                    </button>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/app/src/components/externalPrescriptionUtils.ts
+++ b/app/src/components/externalPrescriptionUtils.ts
@@ -1,0 +1,14 @@
+import type { ExternalPrescriptionStep } from '../engine/models';
+
+export function stepTiming(step: ExternalPrescriptionStep): string | null {
+    const parts: string[] = [];
+    if (step.durationMin !== undefined) parts.push(`${step.durationMin} min`);
+    if (step.durationSec !== undefined) parts.push(`${step.durationSec} s`);
+    if (step.sets !== undefined && step.sets > 1) parts.push(`${step.sets} sets`);
+    if (step.repeat !== undefined && step.repeat > 1) parts.push(`× ${step.repeat}`);
+    if (step.recoveryMin !== undefined) parts.push(`${step.recoveryMin} min recovery`);
+    if (step.recoverySec !== undefined) parts.push(`${step.recoverySec} s recovery`);
+    if (step.setRecoveryMin !== undefined) parts.push(`${step.setRecoveryMin} min between sets`);
+    if (step.setRecoverySec !== undefined) parts.push(`${step.setRecoverySec} s between sets`);
+    return parts.length > 0 ? parts.join(' · ') : null;
+}

--- a/app/src/services/garminWorkoutQueueService.test.ts
+++ b/app/src/services/garminWorkoutQueueService.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest';
+import { GarminWorkoutQueueService } from './garminWorkoutQueueService';
+import type { CanonicalWorkoutExport } from '../utils/workoutJsonExport';
+
+vi.mock('firebase/firestore', () => ({
+    doc: vi.fn((_db, path) => ({ path })),
+    setDoc: vi.fn(async () => {}),
+    getDoc: vi.fn(async () => ({ exists: () => false })),
+}));
+
+vi.mock('../firebase', () => ({
+    getDb: vi.fn(() => ({})),
+}));
+
+describe('GarminWorkoutQueueService', () => {
+    it('queues a workout in users/{userId}/garmin_workout_queue/{date}', async () => {
+        const service = new GarminWorkoutQueueService();
+        const payload: CanonicalWorkoutExport = {
+            schemaVersion: 'canonical_workout_v1',
+            title: 'Threshold 3x12',
+            workoutId: 's1',
+            modality: 'cycling',
+            targetDurationMin: 75,
+            blocks: [],
+            exportedAt: '2026-08-17T08:00:00Z',
+        };
+
+        await expect(service.queueWorkout('user-1', '2026-08-17', payload)).resolves.not.toThrow();
+    });
+});

--- a/app/src/services/garminWorkoutQueueService.ts
+++ b/app/src/services/garminWorkoutQueueService.ts
@@ -1,0 +1,44 @@
+import { doc, getDoc, setDoc } from 'firebase/firestore';
+import { getDb } from '../firebase';
+import type { CanonicalWorkoutExport } from '../utils/workoutJsonExport';
+
+export interface GarminQueuedWorkout {
+    userId: string;
+    date: string;
+    workoutTitle: string;
+    modality: string;
+    status: 'pending' | 'synced' | 'failed';
+    queuedAt: string;
+    syncedAt?: string | null;
+    error?: string | null;
+    payload: CanonicalWorkoutExport;
+}
+
+export class GarminWorkoutQueueService {
+    async queueWorkout(userId: string, date: string, payload: CanonicalWorkoutExport): Promise<void> {
+        const db = getDb();
+        const ref = doc(db, `users/${userId}/garmin_workout_queue/${date}`);
+        const data: GarminQueuedWorkout = {
+            userId,
+            date,
+            workoutTitle: payload.title,
+            modality: payload.modality,
+            status: 'pending',
+            queuedAt: new Date().toISOString(),
+            syncedAt: null,
+            error: null,
+            payload,
+        };
+        await setDoc(ref, data);
+    }
+
+    async getQueueItem(userId: string, date: string): Promise<GarminQueuedWorkout | null> {
+        const db = getDb();
+        const ref = doc(db, `users/${userId}/garmin_workout_queue/${date}`);
+        const snap = await getDoc(ref);
+        if (!snap.exists()) return null;
+        return snap.data() as GarminQueuedWorkout;
+    }
+}
+
+export const garminWorkoutQueueService = new GarminWorkoutQueueService();

--- a/app/src/utils/workoutJsonExport.test.ts
+++ b/app/src/utils/workoutJsonExport.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { exportWorkoutPrescriptionToJson, exportExternalSessionToJson } from './workoutJsonExport';
+import type { WorkoutPrescription } from '../workouts/models';
+import type { ExternalPlanSession } from '../engine/models';
+
+describe('workoutJsonExport', () => {
+    it('exports a strength workout prescription with parsed sets, reps, and cues', () => {
+        const prescription: WorkoutPrescription = {
+            id: 'p1',
+            userId: 'user-1',
+            date: '2026-08-17',
+            workoutId: 'full_body_strength_a',
+            workoutVersion: 1,
+            variantId: 'full',
+            targetDurationMin: 60,
+            adjustedBlocks: [],
+            displayBlocks: [
+                {
+                    id: 'b1',
+                    name: 'Main Strength',
+                    role: 'main',
+                    steps: [
+                        {
+                            id: 's1',
+                            name: 'Barbell Back Squat',
+                            dose: '4 x 6 @ RPE 8',
+                            rest: '2.5 min',
+                            targets: ['RPE 8', 'Controlled eccentric'],
+                            cues: ['Chest tall', 'Drive mid-foot'],
+                            stopConditions: ['Knee valgus collapse'],
+                        },
+                    ],
+                },
+            ],
+            rationale: [],
+            adjustmentReasons: [],
+            source: { recommendationEngineVersion: '1.0.0' },
+            status: 'recommended',
+        };
+
+        const json = exportWorkoutPrescriptionToJson(prescription, 'strength', 'full_body_strength');
+        expect(json.schemaVersion).toBe('canonical_workout_v1');
+        expect(json.modality).toBe('strength');
+        expect(json.blocks[0].steps[0].name).toBe('Barbell Back Squat');
+        expect(json.blocks[0].steps[0].sets).toBe(4);
+        expect(json.blocks[0].steps[0].repetitions).toBe(6);
+        expect(json.blocks[0].steps[0].targetRpe).toBe(8);
+        expect(json.blocks[0].steps[0].restAfterSec).toBe(150);
+        expect(json.blocks[0].steps[0].cues).toEqual(['Chest tall', 'Drive mid-foot']);
+        expect(json.blocks[0].steps[0].stopConditions).toEqual(['Knee valgus collapse']);
+    });
+
+    it('exports an external session with step intervals and recoveries', () => {
+        const session: ExternalPlanSession = {
+            id: 'ext-ride',
+            title: 'Tempo 2x20',
+            priority: 'key',
+            placement: { week: 1, preferredDay: 'wednesday', flexibility: 'preferred', ifMissed: 'drop' },
+            gating: { modality: 'cycling', intensity: 'hard', durationMin: 70, durationMax: 85, environment: 'outdoor', equipment: [] },
+            prescription: {
+                summary: '2x20 min tempo.',
+                steps: [
+                    { name: 'Warm-up', durationMin: 15 },
+                    { name: 'Tempo block', durationMin: 20, repeat: 2, recoveryMin: 5, target: '85% FTP' },
+                ],
+            },
+        };
+
+        const json = exportExternalSessionToJson(session);
+        expect(json.schemaVersion).toBe('canonical_workout_v1');
+        expect(json.modality).toBe('cycling');
+        expect(json.blocks[0].steps).toHaveLength(2);
+        expect(json.blocks[0].steps[1].repetitions).toBe(2);
+        expect(json.blocks[0].steps[1].durationSeconds).toBe(1200);
+        expect(json.blocks[0].steps[1].restAfterSec).toBe(300);
+    });
+});

--- a/app/src/utils/workoutJsonExport.ts
+++ b/app/src/utils/workoutJsonExport.ts
@@ -1,0 +1,170 @@
+import type { WorkoutPrescription, DisplayTarget, TechnicalRequirements } from '../workouts/models';
+import type { ExternalPlanSession } from '../engine/models';
+
+export interface CanonicalExportStep {
+    id?: string;
+    name: string;
+    exerciseId?: string;
+    dose?: string;
+    durationSeconds?: number;
+    sets?: number;
+    repetitions?: number;
+    targetRpe?: number;
+    weightKg?: number;
+    weightPercent1Rm?: number;
+    restAfterSec?: number;
+    targets?: string[];
+    structuredTargets?: DisplayTarget[];
+    cues?: string[];
+    stopConditions?: string[];
+    optional?: boolean;
+    notes?: string;
+}
+
+export interface CanonicalExportBlock {
+    id?: string;
+    name: string;
+    role: string;
+    steps: CanonicalExportStep[];
+}
+
+export interface CanonicalWorkoutExport {
+    schemaVersion: 'canonical_workout_v1';
+    title: string;
+    workoutId: string;
+    modality: string;
+    targetDurationMin: number;
+    category?: string;
+    summary?: string;
+    blocks: CanonicalExportBlock[];
+    technicalRequirements?: TechnicalRequirements;
+    exportedAt: string;
+}
+
+function parseDoseToMetrics(dose: string): { durationSeconds?: number; sets?: number; repetitions?: number; rpe?: number } {
+    const res: { durationSeconds?: number; sets?: number; repetitions?: number; rpe?: number } = {};
+    const minMatch = dose.match(/(\d+(?:\.\d+)?)\s*(?:min|m\b)/i);
+    if (minMatch) res.durationSeconds = Math.round(parseFloat(minMatch[1]) * 60);
+
+    const repsMatch = dose.match(/(\d+)\s*(?:reps|r\b)/i);
+    if (repsMatch) res.repetitions = parseInt(repsMatch[1], 10);
+
+    const setsRepsMatch = dose.match(/(\d+)\s*[x×]\s*(\d+)/i);
+    if (setsRepsMatch) {
+        res.sets = parseInt(setsRepsMatch[1], 10);
+        res.repetitions = parseInt(setsRepsMatch[2], 10);
+    }
+
+    const rpeMatch = dose.match(/RPE\s*(\d+(?:\.\d+)?)/i);
+    if (rpeMatch) res.rpe = parseFloat(rpeMatch[1]);
+
+    return res;
+}
+
+function parseRestToSeconds(rest: string | undefined): number | undefined {
+    if (!rest) return undefined;
+    const minMatch = rest.match(/(\d+(?:\.\d+)?)\s*(?:min|m\b)/i);
+    if (minMatch) return Math.round(parseFloat(minMatch[1]) * 60);
+    const secMatch = rest.match(/(\d+)\s*(?:sec|s\b)/i);
+    if (secMatch) return parseInt(secMatch[1], 10);
+    return undefined;
+}
+
+export function exportWorkoutPrescriptionToJson(
+    prescription: WorkoutPrescription,
+    modality: string = 'cycling',
+    category?: string,
+): CanonicalWorkoutExport {
+    const blocks: CanonicalExportBlock[] = prescription.displayBlocks.map(block => ({
+        id: block.id,
+        name: block.name,
+        role: block.role,
+        steps: block.steps.map(step => {
+            const parsed = parseDoseToMetrics(step.dose);
+            return {
+                id: step.id,
+                name: step.name,
+                dose: step.dose,
+                durationSeconds: parsed.durationSeconds,
+                sets: parsed.sets,
+                repetitions: parsed.repetitions,
+                targetRpe: parsed.rpe,
+                restAfterSec: parseRestToSeconds(step.rest),
+                targets: step.targets,
+                structuredTargets: step.structuredTargets,
+                cues: step.cues,
+                stopConditions: step.stopConditions,
+                optional: step.optional,
+            };
+        }),
+    }));
+
+    return {
+        schemaVersion: 'canonical_workout_v1',
+        title: prescription.workoutId.replaceAll('_', ' '),
+        workoutId: prescription.workoutId,
+        modality,
+        targetDurationMin: prescription.targetDurationMin,
+        category,
+        blocks,
+        exportedAt: new Date().toISOString(),
+    };
+}
+
+export function exportExternalSessionToJson(
+    session: ExternalPlanSession,
+): CanonicalWorkoutExport {
+    const steps: CanonicalExportStep[] = (session.prescription.steps ?? []).map(step => ({
+        name: step.name,
+        durationSeconds: (step.durationMin ? step.durationMin * 60 : 0) + (step.durationSec ?? 0) || undefined,
+        sets: step.sets,
+        repetitions: step.repeat,
+        targets: step.target ? [step.target] : undefined,
+        restAfterSec: (step.recoveryMin ? step.recoveryMin * 60 : 0) + (step.recoverySec ?? 0)
+            || (step.setRecoveryMin ? step.setRecoveryMin * 60 : 0) + (step.setRecoverySec ?? 0)
+            || undefined,
+        notes: step.notes,
+    }));
+
+    const blocks: CanonicalExportBlock[] = [
+        {
+            id: 'main-block',
+            name: 'Workout Steps',
+            role: 'main',
+            steps: steps.length > 0 ? steps : [{
+                name: session.title,
+                durationSeconds: (session.gating.durationMin || 60) * 60,
+                notes: session.prescription.summary,
+            }],
+        },
+    ];
+
+    return {
+        schemaVersion: 'canonical_workout_v1',
+        title: session.title,
+        workoutId: session.id,
+        modality: session.gating.modality,
+        targetDurationMin: session.gating.durationMin,
+        summary: session.prescription.summary,
+        blocks,
+        exportedAt: new Date().toISOString(),
+    };
+}
+
+export function downloadJsonFile(filename: string, data: unknown): void {
+    const jsonStr = JSON.stringify(data, null, 2);
+    const blob = new Blob([jsonStr], { type: 'application/json;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename.endsWith('.json') ? filename : `${filename}.json`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+}
+
+export async function copyJsonToClipboard(data: unknown): Promise<void> {
+    const jsonStr = JSON.stringify(data, null, 2);
+    await navigator.clipboard.writeText(jsonStr);
+}

--- a/app/src/utils/zwiftExport.test.ts
+++ b/app/src/utils/zwiftExport.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import { generateZwiftFromPrescription, generateZwiftFromExternalSession } from './zwiftExport';
+import type { WorkoutPrescription } from '../workouts/models';
+import type { ExternalPlanSession } from '../engine/models';
+
+describe('zwiftExport', () => {
+    it('generates valid Zwift XML from a cycling workout prescription', () => {
+        const prescription: WorkoutPrescription = {
+            id: 'p1',
+            userId: 'user-1',
+            date: '2026-08-17',
+            workoutId: 'aerobic_engine_3x15',
+            workoutVersion: 1,
+            variantId: 'full',
+            targetDurationMin: 90,
+            adjustedBlocks: [],
+            displayBlocks: [
+                {
+                    id: 'b1',
+                    name: 'Warm-up',
+                    role: 'warmup',
+                    steps: [
+                        { id: 's1', name: 'Spin up', dose: '15 min', targets: ['Zone 2 building'], cues: [] },
+                    ],
+                },
+                {
+                    id: 'b2',
+                    name: 'Main Work',
+                    role: 'main',
+                    steps: [
+                        {
+                            id: 's2',
+                            name: 'Threshold Intervals',
+                            dose: '3 x 15 min',
+                            rest: '5 min easy',
+                            targets: ['90-95% FTP'],
+                            structuredTargets: [{ role: 'primary', label: 'Power', metric: 'ftp_percent', valueText: '90–95% FTP' }],
+                            cues: [],
+                        },
+                    ],
+                },
+                {
+                    id: 'b3',
+                    name: 'Cool-down',
+                    role: 'cooldown',
+                    steps: [
+                        { id: 's3', name: 'Easy spin', dose: '10 min', targets: ['Zone 1'], cues: [] },
+                    ],
+                },
+            ],
+            rationale: [],
+            adjustmentReasons: [],
+            source: { recommendationEngineVersion: '1.0.0' },
+            status: 'recommended',
+        };
+
+        const xml = generateZwiftFromPrescription(prescription);
+        expect(xml).toContain('<workout_file>');
+        expect(xml).toContain('<sportType>bike</sportType>');
+        expect(xml).toContain('<Warmup Duration="900"');
+        expect(xml).toContain('<Intervals Repeat="3" OnDuration="900" OffDuration="300"');
+        expect(xml).toContain('<Cooldown Duration="600"');
+        expect(xml).toContain('</workout_file>');
+    });
+
+    it('generates valid Zwift XML from an external plan session', () => {
+        const session: ExternalPlanSession = {
+            id: 'ext-s1',
+            title: 'Threshold 3x12',
+            priority: 'key',
+            placement: { week: 1, preferredDay: 'tuesday', flexibility: 'preferred', ifMissed: 'carry_forward' },
+            gating: { modality: 'cycling', intensity: 'hard', durationMin: 75, durationMax: 90, environment: 'either', equipment: [] },
+            prescription: {
+                summary: '3x12 at threshold.',
+                steps: [
+                    { name: 'Warm-up', durationMin: 15, target: 'Zone 2' },
+                    { name: 'Interval', durationMin: 12, repeat: 3, recoveryMin: 4, target: '95-100% FTP' },
+                    { name: 'Cool-down', durationMin: 10, target: 'Zone 1' },
+                ],
+            },
+        };
+
+        const xml = generateZwiftFromExternalSession(session);
+        expect(xml).toContain('<workout_file>');
+        expect(xml).toContain('<name>Threshold 3x12</name>');
+        expect(xml).toContain('<Warmup Duration="900"');
+        expect(xml).toContain('<Intervals Repeat="3" OnDuration="720" OffDuration="240"');
+        expect(xml).toContain('<Cooldown Duration="600"');
+    });
+});

--- a/app/src/utils/zwiftExport.ts
+++ b/app/src/utils/zwiftExport.ts
@@ -1,0 +1,166 @@
+import type { WorkoutPrescription } from '../workouts/models';
+import type { ExternalPlanSession } from '../engine/models';
+
+export interface ZwiftExportOptions {
+    ftpWatts?: number | null;
+    author?: string;
+}
+
+function escapeXml(unsafe: string): string {
+    return unsafe
+        .replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;')
+        .replaceAll('"', '&quot;')
+        .replaceAll("'", '&apos;');
+}
+
+function parseFractionFtpFromTargetText(targetText: string | undefined): number | null {
+    if (!targetText) return null;
+    const ftpMatch = targetText.match(/(\d+)(?:\s*[-–]\s*(\d+))?\s*%\s*FTP/i);
+    if (ftpMatch) {
+        const min = parseInt(ftpMatch[1], 10);
+        const max = ftpMatch[2] ? parseInt(ftpMatch[2], 10) : min;
+        return ((min + max) / 2) / 100;
+    }
+    if (/zone\s*1|recovery/i.test(targetText)) return 0.50;
+    if (/zone\s*2|endurance|aerobic/i.test(targetText)) return 0.65;
+    if (/zone\s*3|tempo|sweet\s*spot/i.test(targetText)) return 0.82;
+    if (/zone\s*4|threshold/i.test(targetText)) return 0.96;
+    if (/zone\s*5|vo2/i.test(targetText)) return 1.12;
+    if (/zone\s*6|anaerobic/i.test(targetText)) return 1.30;
+    return null;
+}
+
+function parseDurationSeconds(dose: string): number {
+    const minMatch = dose.match(/(\d+(?:\.\d+)?)\s*(?:min|m\b)/i);
+    if (minMatch) return Math.round(parseFloat(minMatch[1]) * 60);
+    const secMatch = dose.match(/(\d+)\s*(?:sec|s\b)/i);
+    if (secMatch) return parseInt(secMatch[1], 10);
+    return 300;
+}
+
+export function generateZwiftFromPrescription(
+    prescription: WorkoutPrescription,
+    options: ZwiftExportOptions = {},
+): string {
+    const author = options.author ?? 'Adaptive Training Recommender';
+    const lines: string[] = [
+        '<workout_file>',
+        `    <author>${escapeXml(author)}</author>`,
+        `    <name>${escapeXml(prescription.workoutId.replaceAll('_', ' '))}</name>`,
+        `    <description>${escapeXml(`Target duration: ${prescription.targetDurationMin} min`)}</description>`,
+        '    <sportType>bike</sportType>',
+        '    <workout>',
+    ];
+
+    for (const block of prescription.displayBlocks) {
+        for (const step of block.steps) {
+            const isWarmup = block.role === 'warmup' || /warm-?up/i.test(step.name);
+            const isCooldown = block.role === 'cooldown' || /cool-?down/i.test(step.name);
+
+            let powerFraction = 0.70;
+            const targetText = step.structuredTargets?.map(t => t.valueText).join(' ') ?? step.targets.join(' ');
+            const parsedPower = parseFractionFtpFromTargetText(targetText);
+            if (parsedPower !== null) {
+                powerFraction = parsedPower;
+            } else if (isWarmup) {
+                powerFraction = 0.60;
+            } else if (isCooldown) {
+                powerFraction = 0.50;
+            }
+
+            const durationSec = parseDurationSeconds(step.dose);
+            const repeatMatch = step.dose.match(/(\d+)\s*[x×]/i);
+            const repeats = repeatMatch ? parseInt(repeatMatch[1], 10) : 1;
+
+            if (repeats > 1) {
+                const restSec = step.rest ? parseDurationSeconds(step.rest) : 120;
+                lines.push(
+                    `        <Intervals Repeat="${repeats}" OnDuration="${durationSec}" OffDuration="${restSec}" OnPower="${powerFraction.toFixed(2)}" OffPower="0.50"/>`,
+                );
+            } else if (isWarmup) {
+                lines.push(
+                    `        <Warmup Duration="${durationSec}" PowerLow="0.50" PowerHigh="${powerFraction.toFixed(2)}"/>`,
+                );
+            } else if (isCooldown) {
+                lines.push(
+                    `        <Cooldown Duration="${durationSec}" PowerLow="${powerFraction.toFixed(2)}" PowerHigh="0.45"/>`,
+                );
+            } else {
+                lines.push(
+                    `        <SteadyState Duration="${durationSec}" Power="${powerFraction.toFixed(2)}"/>`,
+                );
+            }
+        }
+    }
+
+    lines.push('    </workout>', '</workout_file>');
+    return lines.join('\n');
+}
+
+export function generateZwiftFromExternalSession(
+    session: ExternalPlanSession,
+    options: ZwiftExportOptions = {},
+): string {
+    const author = options.author ?? 'Adaptive Training Recommender';
+    const lines: string[] = [
+        '<workout_file>',
+        `    <author>${escapeXml(author)}</author>`,
+        `    <name>${escapeXml(session.title)}</name>`,
+        `    <description>${escapeXml(session.prescription.summary)}</description>`,
+        '    <sportType>bike</sportType>',
+        '    <workout>',
+    ];
+
+    const steps = session.prescription.steps ?? [];
+    if (steps.length === 0) {
+        const durationSec = (session.gating.durationMin || 60) * 60;
+        const power = session.gating.intensity === 'hard' ? 0.90 : session.gating.intensity === 'recovery' ? 0.55 : 0.70;
+        lines.push(`        <SteadyState Duration="${durationSec}" Power="${power.toFixed(2)}"/>`);
+    } else {
+        for (const step of steps) {
+            const stepDurationSec = (step.durationMin ? step.durationMin * 60 : 0) + (step.durationSec ?? 0) || 300;
+            const isWarmup = /warm-?up/i.test(step.name);
+            const isCooldown = /cool-?down/i.test(step.name);
+            const power = parseFractionFtpFromTargetText(step.target) ?? (isWarmup ? 0.60 : isCooldown ? 0.50 : 0.80);
+            const repeats = (step.repeat ?? 1) * (step.sets ?? 1);
+
+            if (repeats > 1) {
+                const restSec = (step.recoveryMin ? step.recoveryMin * 60 : 0) + (step.recoverySec ?? 0)
+                    || (step.setRecoveryMin ? step.setRecoveryMin * 60 : 0) + (step.setRecoverySec ?? 0)
+                    || 120;
+                lines.push(
+                    `        <Intervals Repeat="${repeats}" OnDuration="${stepDurationSec}" OffDuration="${restSec}" OnPower="${power.toFixed(2)}" OffPower="0.50"/>`,
+                );
+            } else if (isWarmup) {
+                lines.push(
+                    `        <Warmup Duration="${stepDurationSec}" PowerLow="0.50" PowerHigh="${power.toFixed(2)}"/>`,
+                );
+            } else if (isCooldown) {
+                lines.push(
+                    `        <Cooldown Duration="${stepDurationSec}" PowerLow="${power.toFixed(2)}" PowerHigh="0.45"/>`,
+                );
+            } else {
+                lines.push(
+                    `        <SteadyState Duration="${stepDurationSec}" Power="${power.toFixed(2)}"/>`,
+                );
+            }
+        }
+    }
+
+    lines.push('    </workout>', '</workout_file>');
+    return lines.join('\n');
+}
+
+export function downloadZwiftFile(filename: string, content: string): void {
+    const blob = new Blob([content], { type: 'application/xml;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename.endsWith('.zwo') ? filename : `${filename}.zwo`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+}

--- a/app/tests/visual/capture.pw.ts
+++ b/app/tests/visual/capture.pw.ts
@@ -45,7 +45,7 @@ for (const scenario of VISUAL_SCENARIOS) {
     if (scenario.id.startsWith('home-') && scenario.id !== 'home-missing-data') {
       const viewWorkout = page.getByRole('button', { name: 'View workout' });
       if (await viewWorkout.count()) {
-        await viewWorkout.click();
+        await viewWorkout.first().click();
         await capture(page, scenario, 'workout-expanded', ['Workout steps are available on demand without overwhelming the recommendation.']);
       }
     }

--- a/docs/ops/cloud-run-deployment.md
+++ b/docs/ops/cloud-run-deployment.md
@@ -60,6 +60,39 @@ Set up a Google Cloud Scheduler job to trigger the Cloud Run Job daily:
 
 ---
 
+---
+
+## ⚡ 4. Automating Garmin Workout Sync (Queue Polling)
+
+Clicking "Sync to Garmin" in the web app only writes a `pending` doc to
+`users/{userId}/garmin_workout_queue/{date}` (see `garminWorkoutQueueService.ts`) --
+direct browser-to-Garmin uploads are blocked by Garmin's CORS policy, so something
+server-side has to pick that doc up and push it. `push_pending_workouts` closes that
+loop: it polls the queue for every `status == 'pending'` item and uploads/schedules
+each one via `push_workout`'s shared `_upload_and_schedule` path, then marks it
+`synced`.
+
+Wire it up as a **second** Cloud Scheduler job hitting the same Cloud Run Job image
+you already deploy for `sync` -- no new IAM, no new container:
+
+* **Command override**: `python -m garmin_sync push-pending-workouts`
+* **Frequency**: every 2-5 minutes, e.g. `*/3 * * * *`
+* **Timezone**: `Europe/Warsaw`
+* **Target**: same `projects.locations.jobs.run` endpoint as the daily sync job, with
+  a `containerOverrides.args` override of `["push-pending-workouts"]`
+* **Auth**: same OAuth Token / Cloud Run Invoker role as the daily sync scheduler
+
+This is a deliberate poll (not an instant Firestore-triggered function): it reuses
+100% of the existing Job/Scheduler infra instead of adding Eventarc + a separate
+Cloud Function + its own IAM surface, at the cost of a couple minutes of latency
+between the click and the Garmin push. `push_workout`'s status check makes repeated
+polls (and any overlap with a manual `push-workout` run) idempotent -- an
+already-`synced` item is skipped, never re-uploaded. Queue items older than
+`--max-age-days` (default 14) are left pending rather than pushed, so an abandoned
+entry doesn't resurface on Garmin weeks later.
+
+---
+
 ## 🔑 Initial Token Bootstrap
 
 Because Cloud Run cannot handle interactive Garmin MFA or password logins (`GARMIN_ALLOW_CREDENTIAL_LOGIN=false`), initialize the OAuth token locally first:

--- a/docs/ops/cloud-run-deployment.md
+++ b/docs/ops/cloud-run-deployment.md
@@ -1,103 +1,210 @@
 # GCP Cloud Run & Cloud Scheduler Deployment Guide
 
-This guide describes how to containerize, deploy, and schedule the Python Garmin ingestion job on Google Cloud Platform (GCP).
+This guide containerizes the Python Garmin ingestion/sync package and schedules two
+recurring jobs on Google Cloud Platform (GCP):
+
+* **`garmin-sync`** -- daily recovery-metrics ingestion (`python -m garmin_sync sync`)
+* **`garmin-push-pending-workouts`** -- polls the Firestore workout queue every few
+  minutes and pushes anything queued by "Sync to Garmin" in the web app
+  (`python -m garmin_sync push-pending-workouts`)
+
+Both share one container image and one runtime service account; only their
+`--args` differ. Run the sections below in order.
 
 ---
 
-## 🐳 1. Building and Pushing Container Image
+## 0. Prerequisites
 
-From the workspace root, build the Docker container image:
+* [`gcloud` CLI](https://cloud.google.com/sdk/docs/install) installed and logged in
+  (`gcloud auth login`).
+* Your existing **Firebase project** is the GCP project to use -- Firebase projects
+  *are* GCP projects, same project ID, same Firestore instance the web app already
+  writes to. Find it in the Firebase console or `app/.firebaserc`.
+* A Garmin Connect account (email + password) for the one-time token bootstrap.
+* No local Docker required -- `gcloud builds submit` builds remotely.
 
 ```bash
-# Define target GCP project and image tag
 export GCP_PROJECT="your-gcp-project-id"
-export IMAGE_TAG="gcr.io/${GCP_PROJECT}/garmin-sync:latest"
-
-# Build container
-docker build -t ${IMAGE_TAG} .
-
-# Push to Container Registry / Artifact Registry
-docker push ${IMAGE_TAG}
+export REGION="europe-central2"  # Warsaw
+gcloud config set project ${GCP_PROJECT}
 ```
 
 ---
 
-## ☁️ 2. Cloud Run Job Configuration
-
-Create a Cloud Run Job executing `python -m garmin_sync sync`:
-
-* **Execution Mode**: Cloud Run Job (One-off task trigger)
-* **Tasks**: 1 task per execution
-* **Service Account**: GCP IAM service account with roles:
-  * `roles/datastore.user` (Firestore Write access)
-  * `roles/storage.objectAdmin` (GCS Token & Archive bucket access)
-
-### Required Environment Variables
-
-| Variable | Recommended Cloud Run Setting | Notes |
-|---|---|---|
-| `APP_USER_ID` | `<TARGET_FIREBASE_UID>` | Firebase Auth UID for user snapshot paths |
-| `APP_TIMEZONE` | `Europe/Warsaw` | Application timezone |
-| `GARMIN_TOKEN_STORE` | `gcs` | Enforces stateless GCS token persistence |
-| `GARMIN_TOKEN_BUCKET` | `<YOUR_PRIVATE_TOKEN_BUCKET>` | Dedicated GCS bucket storing token file |
-| `GARMIN_TOKEN_OBJECT` | `garmin/garmin_tokens.json` | GCS object path for Garmin OAuth token |
-| `GARMIN_ALLOW_CREDENTIAL_LOGIN` | `false` | Cloud runs MUST set `false` (token-only authentication) |
-| `GARMIN_ARCHIVE_ENABLED` | `true` (optional) | Opt-in raw payload archiving in GCS |
-
----
-
-## ⏰ 3. Cloud Scheduler Setup
-
-Set up a Google Cloud Scheduler job to trigger the Cloud Run Job daily:
-
-* **Frequency**: `0 6 * * *` (06:00 AM every day) or `15 6 * * *` (06:15 AM)
-* **Timezone**: `Europe/Warsaw`
-* **Target**: HTTP target calling Cloud Run Job Execution API endpoint:
-  ```text
-  POST https://run.googleapis.com/v1/projects/{PROJECT}/locations/{REGION}/jobs/{JOB_NAME}:run
-  ```
-* **Auth**: OAuth Token with Cloud Run Invoker role.
-
----
-
----
-
-## ⚡ 4. Automating Garmin Workout Sync (Queue Polling)
-
-Clicking "Sync to Garmin" in the web app only writes a `pending` doc to
-`users/{userId}/garmin_workout_queue/{date}` (see `garminWorkoutQueueService.ts`) --
-direct browser-to-Garmin uploads are blocked by Garmin's CORS policy, so something
-server-side has to pick that doc up and push it. `push_pending_workouts` closes that
-loop: it polls the queue for every `status == 'pending'` item and uploads/schedules
-each one via `push_workout`'s shared `_upload_and_schedule` path, then marks it
-`synced`.
-
-Wire it up as a **second** Cloud Scheduler job hitting the same Cloud Run Job image
-you already deploy for `sync` -- no new IAM, no new container:
-
-* **Command override**: `python -m garmin_sync push-pending-workouts`
-* **Frequency**: every 2-5 minutes, e.g. `*/3 * * * *`
-* **Timezone**: `Europe/Warsaw`
-* **Target**: same `projects.locations.jobs.run` endpoint as the daily sync job, with
-  a `containerOverrides.args` override of `["push-pending-workouts"]`
-* **Auth**: same OAuth Token / Cloud Run Invoker role as the daily sync scheduler
-
-This is a deliberate poll (not an instant Firestore-triggered function): it reuses
-100% of the existing Job/Scheduler infra instead of adding Eventarc + a separate
-Cloud Function + its own IAM surface, at the cost of a couple minutes of latency
-between the click and the Garmin push. `push_workout`'s status check makes repeated
-polls (and any overlap with a manual `push-workout` run) idempotent -- an
-already-`synced` item is skipped, never re-uploaded. Queue items older than
-`--max-age-days` (default 14) are left pending rather than pushed, so an abandoned
-entry doesn't resurface on Garmin weeks later.
-
----
-
-## 🔑 Initial Token Bootstrap
-
-Because Cloud Run cannot handle interactive Garmin MFA or password logins (`GARMIN_ALLOW_CREDENTIAL_LOGIN=false`), initialize the OAuth token locally first:
+## 1. Enable required APIs
 
 ```bash
-# Run local token bootstrap script
-uv run python scripts/bootstrap_garmin_tokens.py --bucket <YOUR_PRIVATE_TOKEN_BUCKET>
+gcloud services enable run.googleapis.com cloudscheduler.googleapis.com \
+  artifactregistry.googleapis.com cloudbuild.googleapis.com \
+  firestore.googleapis.com storage.googleapis.com
 ```
+
+---
+
+## 2. Create the token bucket and service accounts
+
+A private GCS bucket holds the Garmin OAuth token JSON (`GARMIN_TOKEN_STORE=gcs`
+keeps Cloud Run stateless -- no local disk between runs). Two service accounts:
+one the Jobs run as, one Cloud Scheduler uses to invoke them (least privilege --
+the scheduler identity never touches Firestore or GCS directly).
+
+```bash
+gcloud storage buckets create gs://${GCP_PROJECT}-garmin-tokens \
+  --location=${REGION} --uniform-bucket-level-access
+```
+
+```bash
+gcloud iam service-accounts create garmin-sync-job \
+  --display-name="Garmin sync Cloud Run Job runtime identity"
+```
+
+```bash
+export JOB_SA_EMAIL="garmin-sync-job@${GCP_PROJECT}.iam.gserviceaccount.com"
+
+gcloud projects add-iam-policy-binding ${GCP_PROJECT} \
+  --member="serviceAccount:${JOB_SA_EMAIL}" --role="roles/datastore.user"
+
+gcloud storage buckets add-iam-policy-binding gs://${GCP_PROJECT}-garmin-tokens \
+  --member="serviceAccount:${JOB_SA_EMAIL}" --role="roles/storage.objectAdmin"
+```
+
+```bash
+gcloud iam service-accounts create garmin-scheduler-invoker \
+  --display-name="Cloud Scheduler -> Cloud Run Jobs invoker"
+
+export SCHEDULER_SA_EMAIL="garmin-scheduler-invoker@${GCP_PROJECT}.iam.gserviceaccount.com"
+```
+(`SCHEDULER_SA_EMAIL` is granted `roles/run.invoker` per-Job in step 4, after the
+Jobs exist.)
+
+---
+
+## 3. Build and push the container image
+
+Container Registry (`gcr.io`) is retired -- this uses Artifact Registry.
+
+```bash
+gcloud artifacts repositories create garmin-sync \
+  --repository-format=docker --location=${REGION}
+
+export IMAGE_TAG="${REGION}-docker.pkg.dev/${GCP_PROJECT}/garmin-sync/garmin-sync:latest"
+
+gcloud builds submit --tag ${IMAGE_TAG}
+```
+
+---
+
+## 4. Bootstrap the Garmin OAuth token
+
+Cloud Run can't handle interactive Garmin MFA/password prompts
+(`GARMIN_ALLOW_CREDENTIAL_LOGIN=false` in production), so the first token is
+created locally, once, and uploaded to the bucket from step 2. Run from the
+workspace root with your own GCP user credentials (needs write access to the
+bucket -- project Owner/Editor has this by default):
+
+```bash
+uv sync
+```
+
+```bash
+GARMIN_EMAIL="you@example.com" GARMIN_PASSWORD="your_password" \
+  uv run python scripts/bootstrap_garmin_tokens.py \
+  --bucket ${GCP_PROJECT}-garmin-tokens
+```
+
+It prompts for an MFA code interactively if your Garmin account has 2FA enabled.
+
+---
+
+## 5. Create the two Cloud Run Jobs
+
+Copy `docs/ops/cloud-run-job.env.yaml.example` to `cloud-run-job.env.yaml`
+(gitignored) and fill in `APP_USER_ID` (your Firebase Auth UID),
+`GARMIN_TOKEN_BUCKET` (`${GCP_PROJECT}-garmin-tokens`), and `GCP_PROJECT_ID`.
+
+```bash
+gcloud run jobs create garmin-sync \
+  --image=${IMAGE_TAG} --region=${REGION} \
+  --service-account=${JOB_SA_EMAIL} \
+  --env-vars-file=cloud-run-job.env.yaml \
+  --args=sync \
+  --max-retries=0
+```
+
+```bash
+gcloud run jobs create garmin-push-pending-workouts \
+  --image=${IMAGE_TAG} --region=${REGION} \
+  --service-account=${JOB_SA_EMAIL} \
+  --env-vars-file=cloud-run-job.env.yaml \
+  --args=push-pending-workouts \
+  --max-retries=0
+```
+
+Grant the scheduler identity permission to run each Job:
+
+```bash
+gcloud run jobs add-iam-policy-binding garmin-sync \
+  --region=${REGION} --member="serviceAccount:${SCHEDULER_SA_EMAIL}" \
+  --role="roles/run.invoker"
+
+gcloud run jobs add-iam-policy-binding garmin-push-pending-workouts \
+  --region=${REGION} --member="serviceAccount:${SCHEDULER_SA_EMAIL}" \
+  --role="roles/run.invoker"
+```
+
+Smoke-test before scheduling anything:
+
+```bash
+gcloud run jobs execute garmin-sync --region=${REGION} --wait
+```
+
+```bash
+gcloud logging read \
+  "resource.type=cloud_run_job AND resource.labels.job_name=garmin-sync" \
+  --limit=50 --format="value(textPayload)"
+```
+
+---
+
+## 6. Create the two Cloud Scheduler jobs
+
+```bash
+gcloud scheduler jobs create http garmin-sync-daily \
+  --location=${REGION} \
+  --schedule="15 6 * * *" \
+  --time-zone="Europe/Warsaw" \
+  --uri="https://run.googleapis.com/v2/projects/${GCP_PROJECT}/locations/${REGION}/jobs/garmin-sync:run" \
+  --http-method=POST \
+  --oauth-service-account-email=${SCHEDULER_SA_EMAIL}
+```
+
+```bash
+gcloud scheduler jobs create http garmin-push-pending-workouts-poll \
+  --location=${REGION} \
+  --schedule="*/3 * * * *" \
+  --time-zone="Europe/Warsaw" \
+  --uri="https://run.googleapis.com/v2/projects/${GCP_PROJECT}/locations/${REGION}/jobs/garmin-push-pending-workouts:run" \
+  --http-method=POST \
+  --oauth-service-account-email=${SCHEDULER_SA_EMAIL}
+```
+
+Both fit inside Cloud Scheduler's free tier (3 jobs/project/month); Cloud Run Jobs
+bill per second of actual execution, which for this workload is pennies a month.
+
+---
+
+## 7. End-to-end check
+
+1. In the web app, open a workout and click **Sync to Garmin Connect** -- this
+   writes `status: 'pending'` to `users/{uid}/garmin_workout_queue/{date}`.
+2. Either wait up to 3 minutes for the next poll, or trigger it immediately:
+   `gcloud scheduler jobs run garmin-push-pending-workouts-poll --location=${REGION}`.
+3. Confirm the queue doc flips to `status: 'synced'` with a `garminWorkoutId`, and
+   the workout shows up on your Garmin Connect calendar for that date.
+
+`push_workout`'s status check (see `src/garmin_sync/service.py`) makes repeated
+polls -- and any overlap with a manual `push-workout` run -- idempotent: an
+already-`synced` item is skipped, never re-uploaded. Queue items older than
+`--max-age-days` (default 14, configurable on `push-pending-workouts`) are left
+pending rather than pushed, so an abandoned entry doesn't resurface on Garmin
+weeks later.

--- a/docs/ops/cloud-run-job.env.yaml.example
+++ b/docs/ops/cloud-run-job.env.yaml.example
@@ -1,0 +1,12 @@
+# Env vars for both Cloud Run Jobs (garmin-sync and garmin-push-pending-workouts).
+# Copy to cloud-run-job.env.yaml (gitignored), fill in the placeholders, and pass it to
+# `gcloud run jobs create/update` via --env-vars-file=cloud-run-job.env.yaml.
+# Do NOT commit the filled-in copy -- it's deploy-time config, not source.
+
+APP_USER_ID: "your_firebase_uid_here"
+APP_TIMEZONE: "Europe/Warsaw"
+GARMIN_TOKEN_STORE: "gcs"
+GARMIN_TOKEN_BUCKET: "your-garmin-private-bucket"
+GARMIN_TOKEN_OBJECT: "garmin/garmin_tokens.json"
+GARMIN_ALLOW_CREDENTIAL_LOGIN: "false"
+GCP_PROJECT_ID: "your-gcp-project-id"

--- a/src/garmin_sync/cli.py
+++ b/src/garmin_sync/cli.py
@@ -141,6 +141,28 @@ def run_push_workout_cmd(args: list[str] | None = None) -> int:
         return 1
 
 
+def run_push_pending_workouts_cmd(args: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Poll the Firestore workout queue and push every pending item to Garmin Connect."
+    )
+    parser.add_argument(
+        "--max-age-days",
+        type=int,
+        default=14,
+        help="Leave (don't push) queue items older than this many days pending (default 14)",
+    )
+    parsed_args = parser.parse_args(args)
+
+    try:
+        settings = load_settings()
+        service = GarminSyncService(settings)
+        success = service.push_pending_workouts(max_age_days=parsed_args.max_age_days)
+        return 0 if success else 1
+    except Exception as e:
+        logger.error(f"Push pending workouts execution error: {type(e).__name__}: {e}")
+        return 1
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Garmin Sync Pipeline CLI")
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -191,6 +213,18 @@ def main() -> int:
         "--date", type=str, default=None, help="Target date YYYY-MM-DD (default local today)"
     )
 
+    # Push-pending-workouts subcommand
+    push_pending_parser = subparsers.add_parser(
+        "push-pending-workouts",
+        help="Poll the Firestore workout queue and push every pending item to Garmin Connect",
+    )
+    push_pending_parser.add_argument(
+        "--max-age-days",
+        type=int,
+        default=14,
+        help="Leave (don't push) queue items older than this many days pending (default 14)",
+    )
+
     args = parser.parse_args()
 
     if args.command == "sync":
@@ -203,6 +237,8 @@ def main() -> int:
         return run_rebuild_cmd(sys.argv[2:])
     elif args.command == "push-workout":
         return run_push_workout_cmd(sys.argv[2:])
+    elif args.command == "push-pending-workouts":
+        return run_push_pending_workouts_cmd(sys.argv[2:])
     return 1
 
 

--- a/src/garmin_sync/cli.py
+++ b/src/garmin_sync/cli.py
@@ -119,6 +119,28 @@ def run_rebuild_cmd(args: list[str] | None = None) -> int:
         return 1
 
 
+def run_push_workout_cmd(args: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Upload and schedule a queued structured workout to Garmin Connect."
+    )
+    parser.add_argument(
+        "--date",
+        type=str,
+        default=None,
+        help="Target date YYYY-MM-DD (default local today in Warsaw)",
+    )
+    parsed_args = parser.parse_args(args)
+
+    try:
+        settings = load_settings()
+        service = GarminSyncService(settings)
+        success = service.push_workout(date_str=parsed_args.date)
+        return 0 if success else 1
+    except Exception as e:
+        logger.error(f"Push workout execution error: {type(e).__name__}: {e}")
+        return 1
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Garmin Sync Pipeline CLI")
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -161,6 +183,14 @@ def main() -> int:
     )
     rebuild_parser.add_argument("--end-date", type=str, required=True, help="End date YYYY-MM-DD")
 
+    # Push-workout subcommand
+    push_workout_parser = subparsers.add_parser(
+        "push-workout", help="Upload and schedule a queued structured workout to Garmin Connect"
+    )
+    push_workout_parser.add_argument(
+        "--date", type=str, default=None, help="Target date YYYY-MM-DD (default local today)"
+    )
+
     args = parser.parse_args()
 
     if args.command == "sync":
@@ -171,6 +201,8 @@ def main() -> int:
         return run_audit_cmd(sys.argv[2:])
     elif args.command == "rebuild":
         return run_rebuild_cmd(sys.argv[2:])
+    elif args.command == "push-workout":
+        return run_push_workout_cmd(sys.argv[2:])
     return 1
 
 

--- a/src/garmin_sync/garmin_client.py
+++ b/src/garmin_sync/garmin_client.py
@@ -26,6 +26,8 @@ class GarminDataClient(Protocol):
     def get_heart_rate_zones(self) -> list[dict[str, Any]]: ...
     def get_cycling_ftp(self) -> dict[str, Any] | list[dict[str, Any]]: ...
     def get_lactate_threshold(self) -> dict[str, Any]: ...
+    def upload_workout(self, workout_json: dict[str, Any]) -> dict[str, Any]: ...
+    def schedule_workout(self, workout_id: str, date_iso: str) -> dict[str, Any]: ...
 
 
 class GarminClientWrapper:
@@ -181,3 +183,14 @@ class GarminClientWrapper:
             if start_date_iso <= act.get("startTimeLocal", "")[:10] <= end_date_iso
         ]
         return window_acts
+
+    def upload_workout(self, workout_json: dict[str, Any]) -> dict[str, Any]:
+        if not self.api:
+            raise RuntimeError("Garmin client is not authenticated. Call login first.")
+        return self.api.upload_workout(workout_json) or {}
+
+    def schedule_workout(self, workout_id: str, date_iso: str) -> dict[str, Any]:
+        if not self.api:
+            raise RuntimeError("Garmin client is not authenticated. Call login first.")
+        return self.api.schedule_workout(workout_id, date_iso) or {}
+

--- a/src/garmin_sync/service.py
+++ b/src/garmin_sync/service.py
@@ -596,3 +596,64 @@ class GarminSyncService:
         if skipped_dates:
             logger.warning(f"Skipped dates: {skipped_dates}")
         return len(rebuilt_dates) > 0
+
+    def push_workout(
+        self,
+        date_str: str | None = None,
+        workout_payload: dict[str, Any] | None = None,
+    ) -> bool:
+        """Upload and schedule a structured workout to Garmin Connect."""
+        target_date = str(date_str or local_today())
+        client = self._init_garmin_client()
+
+        payload = workout_payload
+        if not payload:
+            if not self.repository.db:
+                logger.warning("Firestore DB not initialized; cannot read queue.")
+                return False
+            queue_doc = (
+                self.repository.db.collection("users")
+                .document(self.settings.app_user_id)
+                .collection("garmin_workout_queue")
+                .document(target_date)
+                .get()
+            )
+            if queue_doc.exists:
+                data = queue_doc.to_dict() or {}
+                payload = data.get("payload")
+
+        if not payload:
+            logger.warning(f"No workout payload found for {target_date} in Firestore queue.")
+            return False
+
+        from .workout_export import canonical_workout_to_garmin_payload
+
+        garmin_payload = canonical_workout_to_garmin_payload(payload)
+        logger.info(
+            f"Uploading workout '{garmin_payload.get('workoutName')}' to Garmin Connect for {target_date}..."
+        )
+        res = client.upload_workout(garmin_payload)
+        workout_id = str(res.get("workoutId") or res.get("workout_id") or "")
+
+        if workout_id:
+            logger.info(f"Scheduling workout {workout_id} on {target_date}...")
+            client.schedule_workout(workout_id, target_date)
+            if self.repository.db:
+                self.repository.db.collection("users").document(
+                    self.settings.app_user_id
+                ).collection("garmin_workout_queue").document(target_date).set(
+                    {
+                        "status": "synced",
+                        "syncedAt": str(local_today()),
+                        "garminWorkoutId": workout_id,
+                    },
+                    merge=True,
+                )
+            logger.info(
+                f"Successfully uploaded and scheduled workout {workout_id} for {target_date}."
+            )
+            return True
+        else:
+            logger.warning(f"Workout uploaded, but no workoutId returned: {res}")
+            return True
+

--- a/src/garmin_sync/service.py
+++ b/src/garmin_sync/service.py
@@ -603,8 +603,11 @@ class GarminSyncService:
         workout_payload: dict[str, Any] | None = None,
     ) -> bool:
         """Upload and schedule a structured workout to Garmin Connect."""
-        target_date = str(date_str or local_today())
-        client = self._init_garmin_client()
+        target_date = (
+            get_date_string(parse_date_string(date_str))
+            if date_str
+            else get_date_string(local_today(self.settings.app_timezone))
+        )
 
         payload = workout_payload
         if not payload:
@@ -626,6 +629,7 @@ class GarminSyncService:
             logger.warning(f"No workout payload found for {target_date} in Firestore queue.")
             return False
 
+        client = self._init_garmin_client()
         from .workout_export import canonical_workout_to_garmin_payload
 
         garmin_payload = canonical_workout_to_garmin_payload(payload)
@@ -653,7 +657,6 @@ class GarminSyncService:
                 f"Successfully uploaded and scheduled workout {workout_id} for {target_date}."
             )
             return True
-        else:
-            logger.warning(f"Workout uploaded, but no workoutId returned: {res}")
-            return True
+        logger.error(f"Workout upload returned no workoutId; leaving queue pending: {res}")
+        return False
 

--- a/src/garmin_sync/service.py
+++ b/src/garmin_sync/service.py
@@ -602,7 +602,14 @@ class GarminSyncService:
         date_str: str | None = None,
         workout_payload: dict[str, Any] | None = None,
     ) -> bool:
-        """Upload and schedule a structured workout to Garmin Connect."""
+        """Upload and schedule a structured workout to Garmin Connect.
+
+        When `workout_payload` is omitted, the queue item's own `status` gates the
+        push: anything other than 'pending' (i.e. already 'synced', or 'failed' and
+        not yet requeued) is treated as an idempotent no-op rather than re-uploaded.
+        This is what lets `push_pending_workouts` (and any retried caller) poll/re-poll
+        the queue safely without ever creating duplicate Garmin workouts.
+        """
         target_date = (
             get_date_string(parse_date_string(date_str))
             if date_str
@@ -623,12 +630,88 @@ class GarminSyncService:
             )
             if queue_doc.exists:
                 data = queue_doc.to_dict() or {}
+                status = data.get("status")
+                if status and status != "pending":
+                    logger.info(
+                        f"[{target_date}] Queue item already '{status}'; skipping (idempotent no-op)."
+                    )
+                    return True
                 payload = data.get("payload")
 
         if not payload:
             logger.warning(f"No workout payload found for {target_date} in Firestore queue.")
             return False
 
+        return self._upload_and_schedule(target_date, payload)
+
+    def push_pending_workouts(self, max_age_days: int = 14) -> bool:
+        """Poll the Firestore workout queue for every 'pending' item and push each to
+        Garmin Connect. Meant to run frequently (e.g. every few minutes via Cloud
+        Scheduler) so a "Sync to Garmin" click in the web app reaches Garmin without a
+        human ever running `push-workout` by hand for that date.
+
+        Queue items older than `max_age_days` are left pending, not pushed -- an
+        abandoned/forgotten entry shouldn't resurface on Garmin days or weeks later.
+        Relies on push_workout's own status check for idempotency, so a retried poll
+        (or one that overlaps a manual `push-workout` run) can never double-upload.
+        """
+        if not self.repository.db:
+            logger.warning("Firestore DB not initialized; cannot poll queue.")
+            return False
+
+        from google.cloud.firestore_v1.base_query import FieldFilter
+
+        queue_collection = (
+            self.repository.db.collection("users")
+            .document(self.settings.app_user_id)
+            .collection("garmin_workout_queue")
+        )
+        pending_docs = list(
+            queue_collection.where(filter=FieldFilter("status", "==", "pending")).stream()
+        )
+
+        if not pending_docs:
+            logger.info("No pending Garmin workout queue items found.")
+            return True
+
+        oldest_allowed_iso = get_date_string(
+            n_days_ago(local_today(self.settings.app_timezone), max_age_days)
+        )
+
+        ok = True
+        pushed = 0
+        for doc in pending_docs:
+            data = doc.to_dict() or {}
+            target_date = data.get("date") or doc.id
+            payload = data.get("payload")
+
+            if target_date < oldest_allowed_iso:
+                logger.warning(
+                    f"[{target_date}] Pending queue item is older than {max_age_days}d; "
+                    "leaving pending, not pushing."
+                )
+                continue
+            if not payload:
+                logger.warning(f"[{target_date}] Pending queue item has no payload; skipping.")
+                continue
+
+            try:
+                if self._upload_and_schedule(target_date, payload):
+                    pushed += 1
+                else:
+                    ok = False
+            except Exception as e:
+                logger.error(f"[{target_date}] Failed to push queued workout: {e}")
+                ok = False
+
+        logger.info(
+            f"push_pending_workouts finished: {pushed}/{len(pending_docs)} pending item(s) pushed."
+        )
+        return ok
+
+    def _upload_and_schedule(self, target_date: str, payload: dict[str, Any]) -> bool:
+        """Shared upload -> schedule -> mark-synced pipeline used by both push_workout
+        (single date) and push_pending_workouts (bulk poll), so they can't drift."""
         client = self._init_garmin_client()
         from .workout_export import canonical_workout_to_garmin_payload
 

--- a/src/garmin_sync/workout_export.py
+++ b/src/garmin_sync/workout_export.py
@@ -1,0 +1,130 @@
+"""Workout transformation into Garmin Connect API payload schema."""
+
+from typing import Any
+
+SPORT_TYPE_MAP: dict[str, dict[str, Any]] = {
+    "cycling": {"sportTypeId": 2, "sportTypeKey": "cycling"},
+    "bike": {"sportTypeId": 2, "sportTypeKey": "cycling"},
+    "running": {"sportTypeId": 1, "sportTypeKey": "running"},
+    "run": {"sportTypeId": 1, "sportTypeKey": "running"},
+    "strength": {"sportTypeId": 3, "sportTypeKey": "strength_training"},
+    "mobility": {"sportTypeId": 3, "sportTypeKey": "fitness_equipment"},
+    "cross_training": {"sportTypeId": 4, "sportTypeKey": "cross_country_skiing"},
+}
+
+STEP_TYPE_MAP: dict[str, dict[str, Any]] = {
+    "warmup": {"stepTypeId": 1, "stepTypeKey": "warmup"},
+    "cooldown": {"stepTypeId": 2, "stepTypeKey": "cooldown"},
+    "interval": {"stepTypeId": 3, "stepTypeKey": "interval"},
+    "recovery": {"stepTypeId": 4, "stepTypeKey": "recovery"},
+    "rest": {"stepTypeId": 5, "stepTypeKey": "rest"},
+}
+
+END_CONDITION_MAP: dict[str, dict[str, Any]] = {
+    "time": {"conditionTypeId": 2, "conditionTypeKey": "time"},
+    "distance": {"conditionTypeId": 3, "conditionTypeKey": "distance"},
+    "reps": {"conditionTypeId": 4, "conditionTypeKey": "reps"},
+    "lap_button": {"conditionTypeId": 1, "conditionTypeKey": "lap.button"},
+}
+
+
+def canonical_workout_to_garmin_payload(workout: dict[str, Any]) -> dict[str, Any]:
+    """Convert canonical workout JSON into Garmin Connect's workout payload structure."""
+    modality = str(workout.get("modality", "cycling")).lower()
+    sport = SPORT_TYPE_MAP.get(modality, SPORT_TYPE_MAP["cycling"])
+    title = str(workout.get("title", "Adaptive Workout"))
+    blocks = workout.get("blocks", [])
+
+    workout_steps: list[dict[str, Any]] = []
+    step_order = 1
+
+    for block in blocks:
+        block_role = str(block.get("role", "main")).lower()
+        default_step_type = (
+            STEP_TYPE_MAP["warmup"]
+            if block_role == "warmup"
+            else STEP_TYPE_MAP["cooldown"]
+            if block_role == "cooldown"
+            else STEP_TYPE_MAP["interval"]
+        )
+
+        for step in block.get("steps", []):
+            duration_sec = step.get("durationSeconds") or 300
+            reps = step.get("repetitions") or step.get("sets")
+
+            step_type = default_step_type
+            step_name = str(step.get("name", "")).lower()
+            if "warm" in step_name:
+                step_type = STEP_TYPE_MAP["warmup"]
+            elif "cool" in step_name:
+                step_type = STEP_TYPE_MAP["cooldown"]
+            elif "rest" in step_name or "recovery" in step_name:
+                step_type = STEP_TYPE_MAP["recovery"]
+
+            if reps and modality == "strength":
+                end_condition = END_CONDITION_MAP["reps"]
+                end_condition_value = reps
+            else:
+                end_condition = END_CONDITION_MAP["time"]
+                end_condition_value = duration_sec
+
+            garmin_step: dict[str, Any] = {
+                "type": "ExecutableStepDTO",
+                "stepId": None,
+                "stepOrder": step_order,
+                "stepType": step_type,
+                "childStepId": None,
+                "description": step.get("name", "") or None,
+                "endCondition": end_condition,
+                "endConditionValue": end_condition_value,
+                "targetType": {"workoutTargetTypeId": 1, "workoutTargetTypeKey": "no.target"},
+            }
+
+            workout_steps.append(garmin_step)
+            step_order += 1
+
+            # If there is a rest interval after this step, add a recovery step
+            rest_sec = step.get("restAfterSec")
+            if rest_sec and rest_sec > 0:
+                workout_steps.append(
+                    {
+                        "type": "ExecutableStepDTO",
+                        "stepId": None,
+                        "stepOrder": step_order,
+                        "stepType": STEP_TYPE_MAP["recovery"],
+                        "childStepId": None,
+                        "description": "Rest interval",
+                        "endCondition": END_CONDITION_MAP["time"],
+                        "endConditionValue": rest_sec,
+                        "targetType": {"workoutTargetTypeId": 1, "workoutTargetTypeKey": "no.target"},
+                    }
+                )
+                step_order += 1
+
+    if not workout_steps:
+        workout_steps.append(
+            {
+                "type": "ExecutableStepDTO",
+                "stepId": None,
+                "stepOrder": 1,
+                "stepType": STEP_TYPE_MAP["interval"],
+                "childStepId": None,
+                "description": title,
+                "endCondition": END_CONDITION_MAP["time"],
+                "endConditionValue": (workout.get("targetDurationMin") or 60) * 60,
+                "targetType": {"workoutTargetTypeId": 1, "workoutTargetTypeKey": "no.target"},
+            }
+        )
+
+    return {
+        "workoutName": title,
+        "description": workout.get("summary") or f"Adaptive {modality} session",
+        "sportType": sport,
+        "workoutSegments": [
+            {
+                "segmentOrder": 1,
+                "sportType": sport,
+                "workoutSteps": workout_steps,
+            }
+        ],
+    }

--- a/src/garmin_sync/workout_export.py
+++ b/src/garmin_sync/workout_export.py
@@ -7,9 +7,11 @@ SPORT_TYPE_MAP: dict[str, dict[str, Any]] = {
     "bike": {"sportTypeId": 2, "sportTypeKey": "cycling"},
     "running": {"sportTypeId": 1, "sportTypeKey": "running"},
     "run": {"sportTypeId": 1, "sportTypeKey": "running"},
-    "strength": {"sportTypeId": 3, "sportTypeKey": "strength_training"},
-    "mobility": {"sportTypeId": 3, "sportTypeKey": "fitness_equipment"},
-    "cross_training": {"sportTypeId": 4, "sportTypeKey": "cross_country_skiing"},
+    "strength": {"sportTypeId": 5, "sportTypeKey": "strength_training"},
+    "mobility": {"sportTypeId": 11, "sportTypeKey": "mobility"},
+    # The app's cross-training bucket is deliberately vendor-neutral; Garmin's
+    # generic "other" type is safer than labelling every session as skiing.
+    "cross_training": {"sportTypeId": 3, "sportTypeKey": "other"},
 }
 
 STEP_TYPE_MAP: dict[str, dict[str, Any]] = {
@@ -23,7 +25,7 @@ STEP_TYPE_MAP: dict[str, dict[str, Any]] = {
 END_CONDITION_MAP: dict[str, dict[str, Any]] = {
     "time": {"conditionTypeId": 2, "conditionTypeKey": "time"},
     "distance": {"conditionTypeId": 3, "conditionTypeKey": "distance"},
-    "reps": {"conditionTypeId": 4, "conditionTypeKey": "reps"},
+    "reps": {"conditionTypeId": 10, "conditionTypeKey": "reps"},
     "lap_button": {"conditionTypeId": 1, "conditionTypeKey": "lap.button"},
 }
 

--- a/tests/test_sync_service.py
+++ b/tests/test_sync_service.py
@@ -66,6 +66,36 @@ class TargetAwareFakeProvider(FakeTestProvider):
         )
 
 
+def test_push_workout_fails_when_garmin_does_not_return_a_workout_id():
+    settings = Settings(app_user_id="test_uid_789")
+    client = MagicMock()
+    client.upload_workout.return_value = {}
+    service = GarminSyncService(
+        settings=settings,
+        repository=MagicMock(db=None),
+        garmin_client=client,
+    )
+
+    result = service.push_workout(
+        date_str="2026-08-17",
+        workout_payload={"title": "Easy ride", "modality": "cycling", "blocks": []},
+    )
+
+    assert result is False
+    client.schedule_workout.assert_not_called()
+
+
+def test_push_workout_does_not_authenticate_when_the_queue_is_empty():
+    settings = Settings(app_user_id="test_uid_789")
+    service = GarminSyncService(settings=settings, repository=MagicMock(db=None))
+    service._init_garmin_client = MagicMock()
+
+    result = service.push_workout(date_str="2026-08-17")
+
+    assert result is False
+    service._init_garmin_client.assert_not_called()
+
+
 class DateAwareFakeProvider:
     """Like FakeTestProvider, but returns a per-date restingHr so a test can tell which
     date's fetch produced which stored value -- needed to prove the lookback resync's

--- a/tests/test_sync_service.py
+++ b/tests/test_sync_service.py
@@ -96,6 +96,128 @@ def test_push_workout_does_not_authenticate_when_the_queue_is_empty():
     service._init_garmin_client.assert_not_called()
 
 
+def test_push_workout_skips_already_synced_queue_item():
+    """The idempotency guard that makes polling safe: a queue item that already made
+    it to Garmin must not be re-uploaded just because push_workout runs again."""
+    settings = Settings(app_user_id="test_uid_789")
+    mock_repo = MagicMock()
+    doc_snap = MagicMock()
+    doc_snap.exists = True
+    doc_snap.to_dict.return_value = {
+        "status": "synced",
+        "garminWorkoutId": "999",
+        "payload": {"title": "Easy ride", "modality": "cycling", "blocks": []},
+    }
+    mock_repo.db.collection.return_value.document.return_value.collection.return_value.document.return_value.get.return_value = (
+        doc_snap
+    )
+    client = MagicMock()
+    service = GarminSyncService(settings=settings, repository=mock_repo, garmin_client=client)
+
+    result = service.push_workout(date_str="2026-08-17")
+
+    assert result is True
+    client.upload_workout.assert_not_called()
+
+
+class _FakeQueueDoc:
+    """Minimal stand-in for a Firestore QueryResult document snapshot."""
+
+    def __init__(self, doc_id: str, data: dict):
+        self.id = doc_id
+        self._data = data
+
+    def to_dict(self) -> dict:
+        return self._data
+
+
+def test_push_pending_workouts_pushes_each_pending_item_and_marks_synced():
+    settings = Settings(app_user_id="test_uid_789")
+    mock_repo = MagicMock()
+    docs = [
+        _FakeQueueDoc(
+            "2026-08-17",
+            {
+                "date": "2026-08-17",
+                "status": "pending",
+                "payload": {"title": "Ride A", "modality": "cycling", "blocks": []},
+            },
+        ),
+        _FakeQueueDoc(
+            "2026-08-18",
+            {
+                "date": "2026-08-18",
+                "status": "pending",
+                "payload": {"title": "Ride B", "modality": "cycling", "blocks": []},
+            },
+        ),
+    ]
+    queue_collection = mock_repo.db.collection.return_value.document.return_value.collection.return_value
+    queue_collection.where.return_value.stream.return_value = docs
+
+    client = MagicMock()
+    client.upload_workout.side_effect = [{"workoutId": "111"}, {"workoutId": "222"}]
+    service = GarminSyncService(settings=settings, repository=mock_repo, garmin_client=client)
+
+    result = service.push_pending_workouts()
+
+    assert result is True
+    assert client.upload_workout.call_count == 2
+    assert client.schedule_workout.call_count == 2
+    set_calls = queue_collection.document.return_value.set.call_args_list
+    assert len(set_calls) == 2
+    for call in set_calls:
+        assert call.args[0]["status"] == "synced"
+
+
+def test_push_pending_workouts_leaves_stale_items_pending():
+    settings = Settings(app_user_id="test_uid_789")
+    mock_repo = MagicMock()
+    docs = [
+        _FakeQueueDoc(
+            "2025-01-01",
+            {
+                "date": "2025-01-01",
+                "status": "pending",
+                "payload": {"title": "Old ride", "modality": "cycling", "blocks": []},
+            },
+        ),
+    ]
+    queue_collection = mock_repo.db.collection.return_value.document.return_value.collection.return_value
+    queue_collection.where.return_value.stream.return_value = docs
+
+    client = MagicMock()
+    service = GarminSyncService(settings=settings, repository=mock_repo, garmin_client=client)
+
+    result = service.push_pending_workouts()
+
+    assert result is True
+    client.upload_workout.assert_not_called()
+
+
+def test_push_pending_workouts_returns_true_for_empty_queue():
+    settings = Settings(app_user_id="test_uid_789")
+    mock_repo = MagicMock()
+    queue_collection = mock_repo.db.collection.return_value.document.return_value.collection.return_value
+    queue_collection.where.return_value.stream.return_value = []
+    service = GarminSyncService(settings=settings, repository=mock_repo)
+    service._init_garmin_client = MagicMock()
+
+    result = service.push_pending_workouts()
+
+    assert result is True
+    service._init_garmin_client.assert_not_called()
+
+
+def test_push_pending_workouts_fails_without_firestore_db():
+    settings = Settings(app_user_id="test_uid_789")
+    service = GarminSyncService(settings=settings, repository=MagicMock(db=None))
+
+    result = service.push_pending_workouts()
+
+    assert result is False
+
+
 class DateAwareFakeProvider:
     """Like FakeTestProvider, but returns a per-date restingHr so a test can tell which
     date's fetch produced which stored value -- needed to prove the lookback resync's

--- a/tests/test_workout_export.py
+++ b/tests/test_workout_export.py
@@ -1,0 +1,37 @@
+from garmin_sync.workout_export import canonical_workout_to_garmin_payload
+
+
+def test_canonical_workout_to_garmin_payload():
+    workout = {
+        "schemaVersion": "canonical_workout_v1",
+        "title": "Threshold 3x12",
+        "workoutId": "threshold_3x12",
+        "modality": "cycling",
+        "targetDurationMin": 75,
+        "blocks": [
+            {
+                "name": "Warmup",
+                "role": "warmup",
+                "steps": [{"name": "Spin", "durationSeconds": 900}],
+            },
+            {
+                "name": "Main",
+                "role": "main",
+                "steps": [
+                    {
+                        "name": "Interval 1",
+                        "durationSeconds": 720,
+                        "restAfterSec": 240,
+                    }
+                ],
+            },
+        ],
+    }
+
+    payload = canonical_workout_to_garmin_payload(workout)
+    assert payload["workoutName"] == "Threshold 3x12"
+    assert payload["sportType"]["sportTypeKey"] == "cycling"
+    assert len(payload["workoutSegments"][0]["workoutSteps"]) == 3
+    assert payload["workoutSegments"][0]["workoutSteps"][0]["stepType"]["stepTypeKey"] == "warmup"
+    assert payload["workoutSegments"][0]["workoutSteps"][1]["stepType"]["stepTypeKey"] == "interval"
+    assert payload["workoutSegments"][0]["workoutSteps"][2]["stepType"]["stepTypeKey"] == "recovery"

--- a/tests/test_workout_export.py
+++ b/tests/test_workout_export.py
@@ -35,3 +35,23 @@ def test_canonical_workout_to_garmin_payload():
     assert payload["workoutSegments"][0]["workoutSteps"][0]["stepType"]["stepTypeKey"] == "warmup"
     assert payload["workoutSegments"][0]["workoutSteps"][1]["stepType"]["stepTypeKey"] == "interval"
     assert payload["workoutSegments"][0]["workoutSteps"][2]["stepType"]["stepTypeKey"] == "recovery"
+
+
+def test_strength_workout_uses_garmin_strength_and_repetition_ids():
+    payload = canonical_workout_to_garmin_payload(
+        {
+            "title": "Squats",
+            "modality": "strength",
+            "blocks": [
+                {
+                    "steps": [
+                        {"name": "Back squat", "repetitions": 5},
+                    ]
+                }
+            ],
+        }
+    )
+
+    step = payload["workoutSegments"][0]["workoutSteps"][0]
+    assert payload["sportType"] == {"sportTypeId": 5, "sportTypeKey": "strength_training"}
+    assert step["endCondition"] == {"conditionTypeId": 10, "conditionTypeKey": "reps"}


### PR DESCRIPTION
### Summary

- **Garmin Connect Sync**: Adds queueing in Firestore (\users/{userId}/garmin_workout_queue/{date}\) and automated upload/schedule via Python backend (\src/garmin_sync/workout_export.py\, \garmin_client.py\, and CLI \push-workout\).
- **Zwift Workout (.zwo)**: Client-side export module generating structured XML with power targets (% FTP), warm-ups, cooldowns, and interval repeats.
- **Canonical Workout Data (.json)**: Structured schema capturing exercises, sets, reps, weight targets, RPE, rest timers, stop conditions, and cues. Supports direct file download and clipboard copying.
- **UI Menu**: Adds \WorkoutExportMenu\ dropdown in Today's recommendation (\Home.tsx\) and in external plan week session details (\ExternalPlanWeek.tsx\).
- **Testing**: Added full unit test suites for Zwift XML generation, Canonical JSON serialization, Firestore queue service, UI dropdown, and Python Garmin payload transformation.