### PR TITLE
feat(firebase): enable persistent offline cache for gym-floor writes (S1.1)

### DIFF
--- a/app/src/firebase.test.ts
+++ b/app/src/firebase.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/** S1.1 pins the offline-durability contract in `getDb()`. Every service test mocks
+ *  `../firebase` wholesale, so without this file nothing exercises the real
+ *  initialization path and the persistent cache could be dropped without a single test
+ *  turning red -- on a feature whose entire purpose is surviving a gym with no signal. */
+
+const initializeFirestore = vi.fn<(app: unknown, settings: Record<string, unknown>) => { tag: string }>(
+    () => ({ tag: 'persistent-db' }),
+);
+const getFirestore = vi.fn(() => ({ tag: 'fallback-db' }));
+const persistentLocalCache = vi.fn((settings: unknown) => ({ kind: 'persistent', settings }));
+const persistentMultipleTabManager = vi.fn(() => ({ kind: 'multi-tab' }));
+
+vi.mock('firebase/app', () => ({ initializeApp: vi.fn(() => ({ name: 'test-app' })) }));
+vi.mock('firebase/auth', () => ({ getAuth: vi.fn(() => ({ tag: 'auth' })) }));
+vi.mock('firebase/firestore', () => ({
+    initializeFirestore,
+    getFirestore,
+    persistentLocalCache,
+    persistentMultipleTabManager,
+}));
+
+async function loadFirebaseModule() {
+    vi.resetModules();
+    return import('./firebase');
+}
+
+describe('getDb offline durability contract (S1.1)', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        initializeFirestore.mockReturnValue({ tag: 'persistent-db' });
+    });
+
+    it('configures a persistent local cache so offline writes survive a reload', async () => {
+        const { getDb } = await loadFirebaseModule();
+        getDb();
+
+        expect(initializeFirestore).toHaveBeenCalledTimes(1);
+        const settings = initializeFirestore.mock.calls[0][1];
+        expect(settings.localCache).toEqual({ kind: 'persistent', settings: { tabManager: { kind: 'multi-tab' } } });
+        expect(persistentLocalCache).toHaveBeenCalledTimes(1);
+    });
+
+    it('uses the multi-tab manager, since the app may be open more than once', async () => {
+        const { getDb } = await loadFirebaseModule();
+        getDb();
+
+        expect(persistentMultipleTabManager).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps ignoreUndefinedProperties, which every service write already relies on', async () => {
+        const { getDb } = await loadFirebaseModule();
+        getDb();
+
+        const settings = initializeFirestore.mock.calls[0][1];
+        expect(settings.ignoreUndefinedProperties).toBe(true);
+    });
+
+    it('memoizes, so a second caller never re-initializes Firestore', async () => {
+        const { getDb } = await loadFirebaseModule();
+        const first = getDb();
+        const second = getDb();
+
+        expect(first).toBe(second);
+        expect(initializeFirestore).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls back to getFirestore when initialization is rejected', async () => {
+        initializeFirestore.mockImplementation(() => {
+            throw new Error('Firestore has already been started');
+        });
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const { getDb } = await loadFirebaseModule();
+        expect(getDb()).toEqual({ tag: 'fallback-db' });
+        expect(getFirestore).toHaveBeenCalledTimes(1);
+
+        warn.mockRestore();
+    });
+
+    it('warns on fallback rather than dropping durability silently', async () => {
+        initializeFirestore.mockImplementation(() => {
+            throw new Error('cache unavailable');
+        });
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const { getDb } = await loadFirebaseModule();
+        getDb();
+
+        expect(warn).toHaveBeenCalledTimes(1);
+        expect(String(warn.mock.calls[0][0])).toMatch(/offline durability/i);
+
+        warn.mockRestore();
+    });
+});

--- a/app/src/firebase.ts
+++ b/app/src/firebase.ts
@@ -1,5 +1,11 @@
 import { initializeApp, type FirebaseApp } from 'firebase/app';
-import { initializeFirestore, getFirestore, type Firestore } from 'firebase/firestore';
+import {
+  initializeFirestore,
+  getFirestore,
+  persistentLocalCache,
+  persistentMultipleTabManager,
+  type Firestore,
+} from 'firebase/firestore';
 import { getAuth, type Auth } from 'firebase/auth';
 
 const firebaseConfig = {
@@ -21,8 +27,24 @@ let _db: Firestore | undefined;
 export function getDb(): Firestore {
   if (!_db) {
     try {
-      _db = initializeFirestore(getApp(), { ignoreUndefinedProperties: true });
-    } catch {
+      // Persistent local cache (S1.1) is a durability requirement, not a performance
+      // tweak: strength set logging writes from a gym floor, frequently with no signal,
+      // and a write lost mid-session is the failure that makes a logger get abandoned.
+      // Writes land in IndexedDB immediately and flush when connectivity returns.
+      // Multi-tab manager because the app may legitimately be open more than once.
+      _db = initializeFirestore(getApp(), {
+        ignoreUndefinedProperties: true,
+        localCache: persistentLocalCache({ tabManager: persistentMultipleTabManager() }),
+      });
+    } catch (error: unknown) {
+      // Reached when Firestore was already initialized for this app, and as a last
+      // resort if the cache configuration is rejected outright. The fallback instance
+      // has no offline durability, so say so rather than degrading silently -- the
+      // whole point of the branch above is the guarantee this one cannot make.
+      console.warn(
+        'Firestore persistent cache unavailable; continuing without offline durability. Writes made while offline may not survive a reload.',
+        error,
+      );
       _db = getFirestore(getApp());
     }
   }

--- a/docs/plans/strength-session-logging.md
+++ b/docs/plans/strength-session-logging.md
@@ -34,7 +34,7 @@ Three goals, delivered one per step, cheapest risk first:
 | P2 | Prescription emits per-step sets/reps/RIR/technical targets | ✅ `StepTarget`, `IntensityTarget` |
 | P3 | A declared `manualTraining` history source | ✅ declared in `trainingHistorySnapshot.ts`, hardcoded `MISSING` (A2.1) |
 | P4 | A 1RM store with field-level ownership | ✅ `estimated1RmKg` + `targetSources` — **no writer exists** (A2.2) |
-| P5 | Offline write durability | ❌ **S1.1 — no `localCache` configured; blocks all gym-floor use** |
+| P5 | Offline write durability | ✅ **S1.1 done** — `persistentLocalCache` with multi-tab manager in `firebase.ts` |
 | P6 | A decision on the intensity-gauge schema | ❌ **D-GAUGE — blocks S1.2** |
 | P7 | A decision on set-log → dimensional cost | ❌ **D-STRCOST — blocks Step C only** |
 
@@ -60,7 +60,7 @@ accepted before any Step C item.
 
 | Item | Title | Status | Blocked by |
 |---|---|---|---|
-| S1.1 | Offline persistence | `[ ]` | — |
+| S1.1 | Offline persistence | `[x]` | — |
 | S1.2 | `strength_sessions` schema and types | `[ ]` | D-GAUGE |
 | S1.3 | Firestore rules and validation | `[ ]` | S1.2 |
 | S1.4 | Session state machine and date attribution | `[ ]` | S1.2 |
@@ -77,7 +77,7 @@ accepted before any Step C item.
 
 ## Step A — Logging
 
-### S1.1 `[ ]` Offline persistence
+### S1.1 `[x]` Offline persistence
 
 **Current:** `firebase.ts` calls `initializeFirestore(getApp(), { ignoreUndefinedProperties: true })`
 with no local cache. Every write requires live connectivity.
@@ -95,6 +95,26 @@ reconnect; `npm run check` passes.
 
 > Verify no existing test asserts on cold-cache behaviour before enabling — persistence
 > changes read timing, and this touches every collection, not just the new one.
+
+**Outcome (2026-08-17).** The cold-cache caveat was checked and is a non-issue: every
+service test mocks `../firebase` wholesale (`getDb: vi.fn(() => ({}))`), and the emulator
+suite initializes through `@firebase/rules-unit-testing`'s `initializeTestEnvironment`, so
+no test reaches `src/firebase.ts` at all. `npm run check` passes (1212 tests) and
+`npm run build` succeeds.
+
+Two things were added beyond the literal change:
+
+* `firebase.test.ts` now pins the durability contract. Because every service test mocks the
+  module, nothing previously exercised `getDb()` — the persistent cache could have been
+  deleted without a single test failing, on the one item whose entire purpose is durability.
+* The pre-existing bare `catch {}` now warns before falling back to `getFirestore`. That
+  fallback yields an instance with no offline durability, and silently degrading the exact
+  guarantee this item exists to provide is not an acceptable failure mode.
+
+**Not verified here:** "a write issued while offline is visibly queued and flushes on
+reconnect" is a real-browser behaviour. The unit tests prove the cache is *configured*, not
+that IndexedDB round-trips. Confirm by hand (DevTools → Network → Offline, write, reload,
+reconnect) before S1.5 depends on it.
 
 ### S1.2 `[ ]` `strength_sessions` schema and types — **implements D-GAUGE, D-SETLOG**
 


### PR DESCRIPTION
## Summary

- `getDb()` had no local cache configured — every Firestore write required live connectivity. Fine for existing desk-chair writes (check-ins, preferences); wrong for strength set logging, which happens on a gym floor with no signal (ADR-0021 / strength-session-logging plan, S1.1).
- Configures `persistentLocalCache` with the multi-tab manager, preserving `ignoreUndefinedProperties`. Writes now land in IndexedDB immediately and flush on reconnect.
- Added beyond the literal change: `firebase.test.ts` (new) pins the durability contract — every existing service test mocks `../firebase` wholesale, so nothing previously exercised `getDb()` at all; the persistent cache could have been silently removed without a single test failing. The pre-existing bare `catch {}` fallback now warns before dropping to `getFirestore()` (no offline durability) instead of degrading silently.
- No user-visible change beyond durability; this is the first item in a 12-item stacked strength-logging plan (`docs/plans/strength-session-logging.md`).

## Validation

- [x] `cd app && npm run check` — pass: 1212 tests, includes new `firebase.test.ts` (6 tests).
- Manual check: cold-cache caveat verified by inspection — every service test mocks `../firebase`; emulator suite (`firestoreRules.emulator.test.ts`) initializes via `@firebase/rules-unit-testing`, never touching `src/firebase.ts`. No test asserts on cold-cache behaviour, so none needed updating.
- [ ] Not verified: "a write issued while offline is visibly queued and flushes on reconnect" is real-browser/IndexedDB behaviour a Node test can't exercise. Recorded as an open manual-verification item in the plan (DevTools → Offline → write → reload → reconnect) rather than claimed.

## Risk and reviewer guidance

Low risk, one call-site change (`initializeFirestore`'s options object). The property to check: enabling persistence changes read timing for every collection in the app, not just a new one — verified no existing test depends on cold-cache timing (see Validation). Rollback is trivial: revert one options object.

## Domain invariants

- [x] Firestore writes remain user-scoped — unchanged, this only touches client-side cache configuration.
- [x] Calendar-date logic uses Europe/Warsaw — not touched by this PR.
- [x] No credentials, tokens, service-account files, or raw health payloads included.
- [x] Recommendation decision logic changed: no. Pure infrastructure change, no `POLICY_VERSION` impact.

## Screenshots or recordings

Not applicable — no UI change.
