### PR TITLE
feat(strength): strength_sessions schema and read-side parser (S1.2)

### DIFF
--- a/app/src/engine/models.ts
+++ b/app/src/engine/models.ts
@@ -1255,6 +1255,67 @@ export interface DailyRecommendation {
     };
 }
 
+/** Discriminated intensity gauge for one logged strength set (ADR-0021 D-GAUGE). `rir` and
+ *  `rpe_rts` measure the same failure-proximity construct in different vocabulary and are
+ *  mutually convertible -- but only at READ time; the persisted value is always exactly
+ *  what the athlete entered. `velocity_loss` and `technical` measure output quality, not
+ *  proximity to failure, and are never convertible to or from the other two. Consumers
+ *  that need "how close to failure" (S2.1's 1RM estimator) must branch on `scale`, not
+ *  assume every gauge answers that question. */
+export type IntensityGauge =
+    | { scale: 'rir'; value: number }
+    | { scale: 'rpe_rts'; value: number }
+    | { scale: 'velocity_loss'; percent: number }
+    | { scale: 'technical'; met: boolean; note?: string };
+
+/** One logged set (ADR-0021 D-SETLOG: this is the raw source of truth, never derived
+ *  data written back). `completedAt` is what makes rest duration free -- consecutive
+ *  sets' timestamps are the rest interval; no separate rest field is stored. */
+export interface LoggedSet {
+    setIndex: number;
+    weightKg: number | null;
+    reps: number;
+    gauge?: IntensityGauge;
+    isWarmup: boolean;
+    completedAt: string;
+    notes?: string;
+}
+
+/** `exerciseId` is a soft reference into workouts/exercises.ts, not an enforced foreign
+ *  key -- an unrecognised or null id (free-text lift) is still loggable for overload
+ *  tracking; it only loses the dimensional-cost derivation in S3.1, where it degrades to a
+ *  discounted evidence tier rather than a rejected write. */
+export interface LoggedExercise {
+    exerciseId: string | null;
+    freeTextName?: string;
+    sets: LoggedSet[];
+}
+
+export type StrengthSessionState = 'in_progress' | 'completed' | 'abandoned';
+
+/** Persisted at users/{uid}/strength_sessions/{sessionId} (ADR-0021). `date` is the
+ *  Warsaw-local calendar date of session START, fixed at creation and never recomputed --
+ *  a session crossing midnight belongs to its start date. `updatedAt` stamps every write
+ *  (the schema block in the strength-session-logging plan omitted it; added here because a
+ *  document rewritten on every set, per D-SETLOG's per-set persistence requirement, needs a
+ *  monotonic field for read-layer revision tracking -- the same role `syncedAt` plays for
+ *  NormalizedGarminActivity). `sessionRpe` is whole-session Borg CR-10 and is never an
+ *  `IntensityGauge` -- a different construct from any set-level gauge. */
+export interface StrengthSession {
+    userId: string;
+    sessionId: string;
+    date: string;
+    startedAt: string;
+    completedAt?: string;
+    updatedAt: string;
+    state: StrengthSessionState;
+    sourceRecommendationDate?: string;
+    exercises: LoggedExercise[];
+    sessionRpe?: number;
+    notes?: string;
+    schemaVersion: 1;
+}
+
 /** Backend-normalized Garmin activity stored at users/{uid}/activities/{activityId}. */
 export interface NormalizedGarminActivity {
     activityId: string;

--- a/app/src/engine/strengthSessionValidation.ts
+++ b/app/src/engine/strengthSessionValidation.ts
@@ -1,0 +1,59 @@
+import type { IntensityGauge, LoggedExercise, LoggedSet } from './models';
+
+/** Shared persisted/UI bounds for ADR-0021 strength-session data. Keeping these in the
+ * engine layer prevents the form, parser, and estimators from accepting different values. */
+export const MAX_STRENGTH_EXERCISES = 30;
+export const MAX_SETS_PER_EXERCISE = 50;
+export const MAX_REPS_PER_SET = 1000;
+export const MAX_WEIGHT_KG = 1000;
+export const MAX_RIR = 10;
+export const MIN_RPE_RTS = 1;
+export const MAX_RPE_RTS = 10;
+export const MAX_VELOCITY_LOSS_PERCENT = 100;
+
+export function isValidIntensityGauge(gauge: IntensityGauge): boolean {
+    switch (gauge.scale) {
+        case 'rir':
+            return Number.isFinite(gauge.value) && gauge.value >= 0 && gauge.value <= MAX_RIR;
+        case 'rpe_rts':
+            return Number.isFinite(gauge.value) && gauge.value >= MIN_RPE_RTS && gauge.value <= MAX_RPE_RTS;
+        case 'velocity_loss':
+            return Number.isFinite(gauge.percent)
+                && gauge.percent >= 0
+                && gauge.percent <= MAX_VELOCITY_LOSS_PERCENT;
+        case 'technical':
+            return typeof gauge.met === 'boolean'
+                && (gauge.note === undefined || (gauge.note.length > 0 && gauge.note.length <= 2000));
+    }
+}
+
+export function isValidStrengthInstant(value: string): boolean {
+    return value.trim() !== '' && Number.isFinite(Date.parse(value));
+}
+
+export function isValidLoggedSet(set: LoggedSet): boolean {
+    return Number.isInteger(set.setIndex)
+        && set.setIndex >= 1
+        && set.setIndex <= MAX_SETS_PER_EXERCISE
+        && Number.isInteger(set.reps)
+        && set.reps >= 1
+        && set.reps <= MAX_REPS_PER_SET
+        && (set.weightKg === null || (Number.isFinite(set.weightKg) && set.weightKg >= 0 && set.weightKg <= MAX_WEIGHT_KG))
+        && isValidStrengthInstant(set.completedAt)
+        && (set.gauge === undefined || isValidIntensityGauge(set.gauge))
+        && (set.notes === undefined || (set.notes.length > 0 && set.notes.length <= 2000));
+}
+
+export function areValidLoggedExercises(exercises: readonly LoggedExercise[]): boolean {
+    if (exercises.length > MAX_STRENGTH_EXERCISES) return false;
+    return exercises.every(exercise => {
+        if (exercise.sets.length > MAX_SETS_PER_EXERCISE) return false;
+        if (exercise.freeTextName !== undefined && (exercise.freeTextName.length === 0 || exercise.freeTextName.length > 200)) return false;
+        const indices = new Set<number>();
+        return exercise.sets.every(set => {
+            if (!isValidLoggedSet(set) || indices.has(set.setIndex)) return false;
+            indices.add(set.setIndex);
+            return true;
+        });
+    });
+}

--- a/app/src/persistence/parsers/strengthSession.test.ts
+++ b/app/src/persistence/parsers/strengthSession.test.ts
@@ -21,11 +21,16 @@ describe('parseStrengthSession', () => {
         });
     });
 
-    it('falls back to the document id when sessionId is absent', () => {
+    it('rejects a missing sessionId instead of weakening the rules path binding', () => {
         const rest: Record<string, unknown> = { ...session };
         delete rest.sessionId;
         const parsed = parseStrengthSession(rest, 'users/u1/strength_sessions/s-1', 's-1', 'u1');
-        expect(parsed).toMatchObject({ status: 'AVAILABLE', data: { sessionId: 's-1' } });
+        expect(parsed).toMatchObject({ status: 'INVALID', issues: [{ code: 'session-id-mismatch', field: 'sessionId' }] });
+    });
+
+    it('rejects a stored sessionId that disagrees with the document path', () => {
+        const parsed = parseStrengthSession({ ...session, sessionId: 'other' }, 'p', 's-1', 'u1');
+        expect(parsed).toMatchObject({ status: 'INVALID', issues: [{ code: 'session-id-mismatch', field: 'sessionId' }] });
     });
 
     it('rejects a document whose stored userId does not match the expected owner', () => {
@@ -50,6 +55,16 @@ describe('parseStrengthSession', () => {
     it('rejects a session with no startedAt instant', () => {
         const parsed = parseStrengthSession({ ...session, startedAt: 'not-a-timestamp' }, 'p', 's-1', 'u1');
         expect(parsed).toMatchObject({ status: 'INVALID', issues: [{ code: 'invalid-type', field: 'startedAt' }] });
+    });
+
+    it('rejects a valid date that is not the Warsaw-local date of startedAt', () => {
+        const parsed = parseStrengthSession({
+            ...session,
+            date: '2026-08-17',
+            startedAt: '2026-08-17T23:30:00Z',
+            updatedAt: '2026-08-17T23:35:00Z',
+        }, 'p', 's-1', 'u1');
+        expect(parsed).toMatchObject({ status: 'INVALID', issues: [{ code: 'date-start-mismatch', field: 'date' }] });
     });
 
     it('rejects an unrecognised state', () => {
@@ -93,6 +108,62 @@ describe('parseStrengthSession', () => {
             exercises: [{ exerciseId: 'pull_up', sets: [{ ...validSet, weightKg: 'eighty' }] }],
         }, 'p', 's-1', 'u1');
         expect(parsed).toMatchObject({ status: 'AVAILABLE', data: { exercises: [{ sets: [] }] } });
+    });
+
+    it('requires completedAt exactly for completed sessions', () => {
+        expect(parseStrengthSession({ ...session, state: 'completed' }, 'p', 's-1', 'u1'))
+            .toMatchObject({ status: 'INVALID', issues: [{ code: 'invalid-lifecycle', field: 'completedAt' }] });
+        expect(parseStrengthSession({ ...session, completedAt: '2026-08-17T19:00:00Z' }, 'p', 's-1', 'u1'))
+            .toMatchObject({ status: 'INVALID', issues: [{ code: 'invalid-lifecycle', field: 'completedAt' }] });
+    });
+
+    it('rejects lifecycle timestamps that run backwards', () => {
+        expect(parseStrengthSession({ ...session, updatedAt: '2026-08-17T17:00:00Z' }, 'p', 's-1', 'u1'))
+            .toMatchObject({ status: 'INVALID', issues: [{ code: 'invalid-order', field: 'updatedAt' }] });
+        expect(parseStrengthSession({
+            ...session,
+            state: 'completed',
+            completedAt: '2026-08-17T19:00:00Z',
+            updatedAt: '2026-08-17T18:30:00Z',
+        }, 'p', 's-1', 'u1')).toMatchObject({ status: 'INVALID', issues: [{ code: 'invalid-order', field: 'completedAt' }] });
+    });
+
+    it('drops fractional/out-of-range reps and weights at the persistence boundary', () => {
+        const parsed = parseStrengthSession({
+            ...session,
+            exercises: [{
+                exerciseId: 'pull_up',
+                sets: [
+                    { ...validSet, setIndex: 1.5 },
+                    { ...validSet, setIndex: 2, reps: 1001 },
+                    { ...validSet, setIndex: 3, weightKg: 1001 },
+                ],
+            }],
+        }, 'p', 's-1', 'u1');
+        expect(parsed).toMatchObject({ status: 'AVAILABLE', data: { exercises: [{ sets: [] }] } });
+    });
+
+    it('keeps only the first set when corrupt data repeats a set index', () => {
+        const parsed = parseStrengthSession({
+            ...session,
+            exercises: [{ exerciseId: 'pull_up', sets: [validSet, { ...validSet, reps: 99 }] }],
+        }, 'p', 's-1', 'u1');
+        expect(parsed).toMatchObject({ status: 'AVAILABLE', data: { exercises: [{ sets: [{ reps: 3 }] }] } });
+    });
+
+    it('degrades out-of-range gauge values to absent', () => {
+        for (const gauge of [
+            { scale: 'rir', value: -1 },
+            { scale: 'rpe_rts', value: 11 },
+            { scale: 'velocity_loss', percent: 101 },
+        ]) {
+            const parsed = parseStrengthSession({
+                ...session,
+                exercises: [{ exerciseId: 'hang_power_clean', sets: [{ ...validSet, gauge }] }],
+            }, 'p', 's-1', 'u1');
+            const data = parsed.status === 'AVAILABLE' ? parsed.data : undefined;
+            expect(data?.exercises[0]?.sets[0]?.gauge).toBeUndefined();
+        }
     });
 
     it('degrades a malformed gauge to absent without dropping the set', () => {

--- a/app/src/persistence/parsers/strengthSession.test.ts
+++ b/app/src/persistence/parsers/strengthSession.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'vitest';
+import { parseStrengthSession } from './strengthSession';
+
+const validSet = {
+    setIndex: 1, weightKg: 80, reps: 3, isWarmup: false,
+    completedAt: '2026-08-17T18:02:00Z', gauge: { scale: 'rir', value: 3 },
+};
+
+const session = {
+    userId: 'u1', sessionId: 's-1', date: '2026-08-17', startedAt: '2026-08-17T18:00:00Z',
+    updatedAt: '2026-08-17T18:05:00Z', state: 'in_progress', schemaVersion: 1,
+    exercises: [{ exerciseId: 'hang_power_clean', sets: [validSet] }],
+};
+
+describe('parseStrengthSession', () => {
+    it('accepts a well-formed session', () => {
+        const parsed = parseStrengthSession(session, 'users/u1/strength_sessions/s-1', 's-1', 'u1');
+        expect(parsed).toMatchObject({
+            status: 'AVAILABLE',
+            data: { sessionId: 's-1', state: 'in_progress', exercises: [{ exerciseId: 'hang_power_clean', sets: [{ reps: 3, weightKg: 80 }] }] },
+        });
+    });
+
+    it('falls back to the document id when sessionId is absent', () => {
+        const rest: Record<string, unknown> = { ...session };
+        delete rest.sessionId;
+        const parsed = parseStrengthSession(rest, 'users/u1/strength_sessions/s-1', 's-1', 'u1');
+        expect(parsed).toMatchObject({ status: 'AVAILABLE', data: { sessionId: 's-1' } });
+    });
+
+    it('rejects a document whose stored userId does not match the expected owner', () => {
+        const parsed = parseStrengthSession(session, 'p', 's-1', 'someone-else');
+        expect(parsed).toMatchObject({ status: 'INVALID', issues: [{ code: 'user-id-mismatch', field: 'userId' }] });
+    });
+
+    it('rejects a non-object payload', () => {
+        expect(parseStrengthSession('nope', 'p', 's-1', 'u1')).toMatchObject({ status: 'INVALID', issues: [{ code: 'not-an-object' }] });
+    });
+
+    it('rejects an unsupported schema version', () => {
+        const parsed = parseStrengthSession({ ...session, schemaVersion: 2 }, 'p', 's-1', 'u1');
+        expect(parsed).toMatchObject({ status: 'INVALID', issues: [{ code: 'unsupported-schema-version', schemaVersion: 2, field: 'schemaVersion' }] });
+    });
+
+    it('rejects a malformed calendar date instead of normalizing it', () => {
+        const parsed = parseStrengthSession({ ...session, date: '2026-02-30' }, 'p', 's-1', 'u1');
+        expect(parsed).toMatchObject({ status: 'INVALID', issues: [{ code: 'invalid-date', field: 'date' }] });
+    });
+
+    it('rejects a session with no startedAt instant', () => {
+        const parsed = parseStrengthSession({ ...session, startedAt: 'not-a-timestamp' }, 'p', 's-1', 'u1');
+        expect(parsed).toMatchObject({ status: 'INVALID', issues: [{ code: 'invalid-type', field: 'startedAt' }] });
+    });
+
+    it('rejects an unrecognised state', () => {
+        const parsed = parseStrengthSession({ ...session, state: 'paused' }, 'p', 's-1', 'u1');
+        expect(parsed).toMatchObject({ status: 'INVALID', issues: [{ code: 'invalid-type', field: 'state' }] });
+    });
+
+    it('rejects a non-array exercises field', () => {
+        const parsed = parseStrengthSession({ ...session, exercises: 'none' }, 'p', 's-1', 'u1');
+        expect(parsed).toMatchObject({ status: 'INVALID', issues: [{ code: 'invalid-type', field: 'exercises' }] });
+    });
+
+    it('drops a malformed set but keeps the rest of the session AVAILABLE (D-SETLOG)', () => {
+        const corruptSet = { setIndex: 'two', reps: 3, isWarmup: false, completedAt: '2026-08-17T18:04:00Z' };
+        const parsed = parseStrengthSession({
+            ...session,
+            exercises: [{ exerciseId: 'hang_power_clean', sets: [validSet, corruptSet] }],
+        }, 'p', 's-1', 'u1');
+        expect(parsed).toMatchObject({ status: 'AVAILABLE', data: { exercises: [{ sets: [{ setIndex: 1 }] }] } });
+    });
+
+    it('drops a malformed exercise but keeps the rest of the session AVAILABLE', () => {
+        const parsed = parseStrengthSession({
+            ...session,
+            exercises: [{ exerciseId: 'hang_power_clean', sets: [validSet] }, { exerciseId: 42, sets: [] }],
+        }, 'p', 's-1', 'u1');
+        expect(parsed).toMatchObject({ status: 'AVAILABLE', data: { exercises: [{ exerciseId: 'hang_power_clean' }] } });
+    });
+
+    it('accepts explicit null weightKg as bodyweight', () => {
+        const parsed = parseStrengthSession({
+            ...session,
+            exercises: [{ exerciseId: 'pull_up', sets: [{ ...validSet, weightKg: null, gauge: undefined }] }],
+        }, 'p', 's-1', 'u1');
+        expect(parsed).toMatchObject({ status: 'AVAILABLE', data: { exercises: [{ sets: [{ weightKg: null }] }] } });
+    });
+
+    it('drops a set with a corrupt (non-null, non-numeric) weight rather than coercing it to bodyweight', () => {
+        const parsed = parseStrengthSession({
+            ...session,
+            exercises: [{ exerciseId: 'pull_up', sets: [{ ...validSet, weightKg: 'eighty' }] }],
+        }, 'p', 's-1', 'u1');
+        expect(parsed).toMatchObject({ status: 'AVAILABLE', data: { exercises: [{ sets: [] }] } });
+    });
+
+    it('degrades a malformed gauge to absent without dropping the set', () => {
+        const parsed = parseStrengthSession({
+            ...session,
+            exercises: [{ exerciseId: 'hang_power_clean', sets: [{ ...validSet, gauge: { scale: 'rir', value: 'a lot' } }] }],
+        }, 'p', 's-1', 'u1');
+        expect(parsed).toMatchObject({ status: 'AVAILABLE', data: { exercises: [{ sets: [{ setIndex: 1 }] }] } });
+        const parsedData = parsed.status === 'AVAILABLE' ? parsed.data : undefined;
+        expect(parsedData?.exercises[0]?.sets[0]?.gauge).toBeUndefined();
+    });
+
+    it('accepts each intensity gauge scale, tagged and unconverted', () => {
+        const scales = [
+            { scale: 'rir', value: 2 },
+            { scale: 'rpe_rts', value: 8 },
+            { scale: 'velocity_loss', percent: 15 },
+            { scale: 'technical', met: true },
+        ] as const;
+        for (const gauge of scales) {
+            const parsed = parseStrengthSession({
+                ...session,
+                exercises: [{ exerciseId: 'hang_power_clean', sets: [{ ...validSet, gauge }] }],
+            }, 'p', 's-1', 'u1');
+            expect(parsed.status).toBe('AVAILABLE');
+            const data = parsed.status === 'AVAILABLE' ? parsed.data : undefined;
+            expect(data?.exercises[0]?.sets[0]?.gauge).toEqual(gauge);
+        }
+    });
+
+    it('never treats rir and rpe_rts as interchangeable at parse time', () => {
+        const parsed = parseStrengthSession({
+            ...session,
+            exercises: [{ exerciseId: 'hang_power_clean', sets: [{ ...validSet, gauge: { scale: 'rpe_rts', value: 8 } }] }],
+        }, 'p', 's-1', 'u1');
+        const data = parsed.status === 'AVAILABLE' ? parsed.data : undefined;
+        expect(data?.exercises[0]?.sets[0]?.gauge).toEqual({ scale: 'rpe_rts', value: 8 });
+    });
+
+    it('accepts a null exerciseId (free-text lift) without requiring freeTextName', () => {
+        const parsed = parseStrengthSession({
+            ...session,
+            exercises: [{ exerciseId: null, sets: [validSet] }],
+        }, 'p', 's-1', 'u1');
+        expect(parsed).toMatchObject({ status: 'AVAILABLE', data: { exercises: [{ exerciseId: null }] } });
+    });
+
+    it('ignores unrecognised top-level keys', () => {
+        const parsed = parseStrengthSession({ ...session, somethingFuture: true }, 'p', 's-1', 'u1');
+        expect(parsed.status).toBe('AVAILABLE');
+    });
+
+    it('rejects session RPE outside the Borg CR-10 range rather than clamping it', () => {
+        const parsed = parseStrengthSession({ ...session, sessionRpe: 15 }, 'p', 's-1', 'u1');
+        const data = parsed.status === 'AVAILABLE' ? parsed.data : undefined;
+        expect(data?.sessionRpe).toBeUndefined();
+    });
+
+    it('uses updatedAt as the read-layer revision', () => {
+        const parsed = parseStrengthSession(session, 'p', 's-1', 'u1');
+        expect(parsed).toMatchObject({ revision: '2026-08-17T18:05:00Z' });
+    });
+});

--- a/app/src/persistence/parsers/strengthSession.ts
+++ b/app/src/persistence/parsers/strengthSession.ts
@@ -1,0 +1,159 @@
+import type { DataIssue, DataState } from '../../engine/dataState';
+import type { IntensityGauge, LoggedExercise, LoggedSet, StrengthSession, StrengthSessionState } from '../../engine/models';
+import { isValidDate } from '../../engine/validation';
+
+/** Parses users/{uid}/strength_sessions/{sessionId} (ADR-0021). House style matches
+ *  trainingHistory.ts's parseNormalizedGarminActivity: unrecognised keys are ignored, and
+ *  a malformed field degrades rather than invalidating the whole read -- but the *scope* of
+ *  that degradation differs by nesting level. A malformed top-level field (date, state,
+ *  schemaVersion) invalidates the document, matching every other parser in this directory.
+ *  A malformed set or exercise is instead dropped from its parent array and the rest of the
+ *  session still parses AVAILABLE: D-SETLOG's raw log should survive one bad entry from a
+ *  flaky offline write, not vanish along with every other set in the session. */
+
+const STRENGTH_SESSION_STATES: readonly StrengthSessionState[] = ['in_progress', 'completed', 'abandoned'];
+const NOTE_MAX_LENGTH = 2000;
+const FREE_TEXT_NAME_MAX_LENGTH = 200;
+
+type RawDocument = Record<string, unknown>;
+
+function invalid(documentPath: string, code: string, field?: string, schemaVersion?: number): DataState<never> {
+    const issue: DataIssue = { code, documentPath, ...(field ? { field } : {}), ...(schemaVersion !== undefined ? { schemaVersion } : {}) };
+    return { status: 'INVALID', issues: [issue] };
+}
+
+function isObject(value: unknown): value is RawDocument {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isValidInstant(value: unknown): value is string {
+    return typeof value === 'string' && value.trim() !== '' && Number.isFinite(Date.parse(value));
+}
+
+function boundedString(value: unknown, maxLength: number): string | undefined {
+    return typeof value === 'string' && value.length > 0 && value.length <= maxLength ? value : undefined;
+}
+
+function finiteNumber(value: unknown): value is number {
+    return typeof value === 'number' && Number.isFinite(value);
+}
+
+/** Explicit `null` is bodyweight and is accepted. Anything else that isn't a valid
+ *  non-negative number is treated as malformed -- silently coercing a corrupt numeric
+ *  value to `null` would misreport a real loaded set as bodyweight, which is worse than
+ *  dropping the set. */
+function parseWeightKg(raw: unknown): { ok: true; value: number | null } | { ok: false } {
+    if (raw === null) return { ok: true, value: null };
+    if (finiteNumber(raw) && raw >= 0) return { ok: true, value: raw };
+    return { ok: false };
+}
+
+function parseGauge(raw: unknown): IntensityGauge | undefined {
+    if (!isObject(raw) || typeof raw.scale !== 'string') return undefined;
+    switch (raw.scale) {
+        case 'rir':
+        case 'rpe_rts':
+            return finiteNumber(raw.value) ? { scale: raw.scale, value: raw.value } : undefined;
+        case 'velocity_loss':
+            return finiteNumber(raw.percent) && raw.percent >= 0 ? { scale: 'velocity_loss', percent: raw.percent } : undefined;
+        case 'technical': {
+            if (typeof raw.met !== 'boolean') return undefined;
+            const note = boundedString(raw.note, NOTE_MAX_LENGTH);
+            return { scale: 'technical', met: raw.met, ...(note !== undefined ? { note } : {}) };
+        }
+        default:
+            return undefined;
+    }
+}
+
+/** Required fields (setIndex, reps, isWarmup, completedAt) missing or malformed drop the
+ *  whole set rather than invalidating the session -- see module docstring. Optional fields
+ *  degrade individually. */
+function parseSet(raw: unknown): LoggedSet | undefined {
+    if (!isObject(raw)) return undefined;
+    if (!finiteNumber(raw.setIndex) || raw.setIndex < 1) return undefined;
+    if (!finiteNumber(raw.reps) || raw.reps <= 0) return undefined;
+    if (typeof raw.isWarmup !== 'boolean') return undefined;
+    if (!isValidInstant(raw.completedAt)) return undefined;
+
+    const weightKg = parseWeightKg(raw.weightKg);
+    if (!weightKg.ok) return undefined;
+
+    const gauge = parseGauge(raw.gauge);
+    const notes = boundedString(raw.notes, NOTE_MAX_LENGTH);
+
+    return {
+        setIndex: raw.setIndex,
+        weightKg: weightKg.value,
+        reps: raw.reps,
+        isWarmup: raw.isWarmup,
+        completedAt: raw.completedAt,
+        ...(gauge !== undefined ? { gauge } : {}),
+        ...(notes !== undefined ? { notes } : {}),
+    };
+}
+
+/** Required fields (exerciseId, sets) missing or malformed drop the whole exercise. A null
+ *  exerciseId with no freeTextName is still accepted -- unlabeled is recoverable, losing
+ *  the sets is not. */
+function parseExercise(raw: unknown): LoggedExercise | undefined {
+    if (!isObject(raw)) return undefined;
+    if (raw.exerciseId !== null && typeof raw.exerciseId !== 'string') return undefined;
+    if (!Array.isArray(raw.sets)) return undefined;
+
+    const sets = raw.sets.map(parseSet).filter((set): set is LoggedSet => set !== undefined);
+    const freeTextName = boundedString(raw.freeTextName, FREE_TEXT_NAME_MAX_LENGTH);
+
+    return {
+        exerciseId: raw.exerciseId,
+        sets,
+        ...(freeTextName !== undefined ? { freeTextName } : {}),
+    };
+}
+
+export function parseStrengthSession(raw: unknown, documentPath: string, documentId: string, userId: string): DataState<StrengthSession> {
+    if (!isObject(raw)) return invalid(documentPath, 'not-an-object');
+
+    // Matches decisionInputs.ts's parseDecisionJournalEntry: this collection is
+    // client-writable, so the document's own userId is checked against the caller's
+    // expected owner as defense in depth alongside the Firestore rules path binding.
+    if (raw.userId !== userId) return invalid(documentPath, 'user-id-mismatch', 'userId');
+
+    if (raw.schemaVersion !== 1) {
+        return invalid(documentPath, 'unsupported-schema-version', 'schemaVersion', typeof raw.schemaVersion === 'number' ? raw.schemaVersion : undefined);
+    }
+    if (typeof raw.date !== 'string' || !isValidDate(raw.date)) return invalid(documentPath, 'invalid-date', 'date');
+    if (!isValidInstant(raw.startedAt)) return invalid(documentPath, 'invalid-type', 'startedAt');
+    if (!isValidInstant(raw.updatedAt)) return invalid(documentPath, 'invalid-type', 'updatedAt');
+    if (typeof raw.state !== 'string' || !STRENGTH_SESSION_STATES.includes(raw.state as StrengthSessionState)) {
+        return invalid(documentPath, 'invalid-type', 'state');
+    }
+    if (!Array.isArray(raw.exercises)) return invalid(documentPath, 'invalid-type', 'exercises');
+
+    const sessionId = typeof raw.sessionId === 'string' && raw.sessionId.trim() !== '' ? raw.sessionId : documentId;
+    const exercises = raw.exercises.map(parseExercise).filter((exercise): exercise is LoggedExercise => exercise !== undefined);
+
+    const completedAt = isValidInstant(raw.completedAt) ? raw.completedAt : undefined;
+    const sourceRecommendationDate = typeof raw.sourceRecommendationDate === 'string' && isValidDate(raw.sourceRecommendationDate) ? raw.sourceRecommendationDate : undefined;
+    const sessionRpe = finiteNumber(raw.sessionRpe) && raw.sessionRpe >= 0 && raw.sessionRpe <= 10 ? raw.sessionRpe : undefined;
+    const notes = boundedString(raw.notes, NOTE_MAX_LENGTH);
+
+    return {
+        status: 'AVAILABLE',
+        data: {
+            userId,
+            sessionId,
+            date: raw.date,
+            startedAt: raw.startedAt,
+            updatedAt: raw.updatedAt,
+            state: raw.state as StrengthSessionState,
+            exercises,
+            schemaVersion: 1,
+            ...(completedAt !== undefined ? { completedAt } : {}),
+            ...(sourceRecommendationDate !== undefined ? { sourceRecommendationDate } : {}),
+            ...(sessionRpe !== undefined ? { sessionRpe } : {}),
+            ...(notes !== undefined ? { notes } : {}),
+        },
+        revision: raw.updatedAt,
+    };
+}

--- a/app/src/persistence/parsers/strengthSession.ts
+++ b/app/src/persistence/parsers/strengthSession.ts
@@ -1,6 +1,18 @@
 import type { DataIssue, DataState } from '../../engine/dataState';
 import type { IntensityGauge, LoggedExercise, LoggedSet, StrengthSession, StrengthSessionState } from '../../engine/models';
+import {
+    MAX_REPS_PER_SET,
+    MAX_RIR,
+    MAX_RPE_RTS,
+    MAX_SETS_PER_EXERCISE,
+    MAX_STRENGTH_EXERCISES,
+    MAX_VELOCITY_LOSS_PERCENT,
+    MAX_WEIGHT_KG,
+    MIN_RPE_RTS,
+    isValidStrengthInstant,
+} from '../../engine/strengthSessionValidation';
 import { isValidDate } from '../../engine/validation';
+import { getLocalDateString } from '../../utils/localDate';
 
 /** Parses users/{uid}/strength_sessions/{sessionId} (ADR-0021). House style matches
  *  trainingHistory.ts's parseNormalizedGarminActivity: unrecognised keys are ignored, and
@@ -27,7 +39,7 @@ function isObject(value: unknown): value is RawDocument {
 }
 
 function isValidInstant(value: unknown): value is string {
-    return typeof value === 'string' && value.trim() !== '' && Number.isFinite(Date.parse(value));
+    return typeof value === 'string' && isValidStrengthInstant(value);
 }
 
 function boundedString(value: unknown, maxLength: number): string | undefined {
@@ -44,7 +56,7 @@ function finiteNumber(value: unknown): value is number {
  *  dropping the set. */
 function parseWeightKg(raw: unknown): { ok: true; value: number | null } | { ok: false } {
     if (raw === null) return { ok: true, value: null };
-    if (finiteNumber(raw) && raw >= 0) return { ok: true, value: raw };
+    if (finiteNumber(raw) && raw >= 0 && raw <= MAX_WEIGHT_KG) return { ok: true, value: raw };
     return { ok: false };
 }
 
@@ -52,10 +64,17 @@ function parseGauge(raw: unknown): IntensityGauge | undefined {
     if (!isObject(raw) || typeof raw.scale !== 'string') return undefined;
     switch (raw.scale) {
         case 'rir':
+            return finiteNumber(raw.value) && raw.value >= 0 && raw.value <= MAX_RIR
+                ? { scale: 'rir', value: raw.value }
+                : undefined;
         case 'rpe_rts':
-            return finiteNumber(raw.value) ? { scale: raw.scale, value: raw.value } : undefined;
+            return finiteNumber(raw.value) && raw.value >= MIN_RPE_RTS && raw.value <= MAX_RPE_RTS
+                ? { scale: 'rpe_rts', value: raw.value }
+                : undefined;
         case 'velocity_loss':
-            return finiteNumber(raw.percent) && raw.percent >= 0 ? { scale: 'velocity_loss', percent: raw.percent } : undefined;
+            return finiteNumber(raw.percent) && raw.percent >= 0 && raw.percent <= MAX_VELOCITY_LOSS_PERCENT
+                ? { scale: 'velocity_loss', percent: raw.percent }
+                : undefined;
         case 'technical': {
             if (typeof raw.met !== 'boolean') return undefined;
             const note = boundedString(raw.note, NOTE_MAX_LENGTH);
@@ -71,8 +90,8 @@ function parseGauge(raw: unknown): IntensityGauge | undefined {
  *  degrade individually. */
 function parseSet(raw: unknown): LoggedSet | undefined {
     if (!isObject(raw)) return undefined;
-    if (!finiteNumber(raw.setIndex) || raw.setIndex < 1) return undefined;
-    if (!finiteNumber(raw.reps) || raw.reps <= 0) return undefined;
+    if (!finiteNumber(raw.setIndex) || !Number.isInteger(raw.setIndex) || raw.setIndex < 1 || raw.setIndex > MAX_SETS_PER_EXERCISE) return undefined;
+    if (!finiteNumber(raw.reps) || !Number.isInteger(raw.reps) || raw.reps <= 0 || raw.reps > MAX_REPS_PER_SET) return undefined;
     if (typeof raw.isWarmup !== 'boolean') return undefined;
     if (!isValidInstant(raw.completedAt)) return undefined;
 
@@ -100,8 +119,14 @@ function parseExercise(raw: unknown): LoggedExercise | undefined {
     if (!isObject(raw)) return undefined;
     if (raw.exerciseId !== null && typeof raw.exerciseId !== 'string') return undefined;
     if (!Array.isArray(raw.sets)) return undefined;
+    if (raw.sets.length > MAX_SETS_PER_EXERCISE) return undefined;
 
-    const sets = raw.sets.map(parseSet).filter((set): set is LoggedSet => set !== undefined);
+    const seenSetIndices = new Set<number>();
+    const sets = raw.sets.map(parseSet).filter((set): set is LoggedSet => {
+        if (!set || seenSetIndices.has(set.setIndex)) return false;
+        seenSetIndices.add(set.setIndex);
+        return true;
+    });
     const freeTextName = boundedString(raw.freeTextName, FREE_TEXT_NAME_MAX_LENGTH);
 
     return {
@@ -125,15 +150,27 @@ export function parseStrengthSession(raw: unknown, documentPath: string, documen
     if (typeof raw.date !== 'string' || !isValidDate(raw.date)) return invalid(documentPath, 'invalid-date', 'date');
     if (!isValidInstant(raw.startedAt)) return invalid(documentPath, 'invalid-type', 'startedAt');
     if (!isValidInstant(raw.updatedAt)) return invalid(documentPath, 'invalid-type', 'updatedAt');
+    if (Date.parse(raw.updatedAt) < Date.parse(raw.startedAt)) return invalid(documentPath, 'invalid-order', 'updatedAt');
     if (typeof raw.state !== 'string' || !STRENGTH_SESSION_STATES.includes(raw.state as StrengthSessionState)) {
         return invalid(documentPath, 'invalid-type', 'state');
     }
     if (!Array.isArray(raw.exercises)) return invalid(documentPath, 'invalid-type', 'exercises');
+    if (raw.exercises.length > MAX_STRENGTH_EXERCISES) return invalid(documentPath, 'out-of-range', 'exercises');
 
-    const sessionId = typeof raw.sessionId === 'string' && raw.sessionId.trim() !== '' ? raw.sessionId : documentId;
+    if (raw.sessionId !== documentId) return invalid(documentPath, 'session-id-mismatch', 'sessionId');
+    if (raw.date !== getLocalDateString(new Date(raw.startedAt))) {
+        return invalid(documentPath, 'date-start-mismatch', 'date');
+    }
+
     const exercises = raw.exercises.map(parseExercise).filter((exercise): exercise is LoggedExercise => exercise !== undefined);
 
     const completedAt = isValidInstant(raw.completedAt) ? raw.completedAt : undefined;
+    if ((raw.state === 'completed') !== (completedAt !== undefined)) {
+        return invalid(documentPath, 'invalid-lifecycle', 'completedAt');
+    }
+    if (completedAt && (Date.parse(completedAt) < Date.parse(raw.startedAt) || Date.parse(completedAt) > Date.parse(raw.updatedAt))) {
+        return invalid(documentPath, 'invalid-order', 'completedAt');
+    }
     const sourceRecommendationDate = typeof raw.sourceRecommendationDate === 'string' && isValidDate(raw.sourceRecommendationDate) ? raw.sourceRecommendationDate : undefined;
     const sessionRpe = finiteNumber(raw.sessionRpe) && raw.sessionRpe >= 0 && raw.sessionRpe <= 10 ? raw.sessionRpe : undefined;
     const notes = boundedString(raw.notes, NOTE_MAX_LENGTH);
@@ -142,7 +179,7 @@ export function parseStrengthSession(raw: unknown, documentPath: string, documen
         status: 'AVAILABLE',
         data: {
             userId,
-            sessionId,
+            sessionId: documentId,
             date: raw.date,
             startedAt: raw.startedAt,
             updatedAt: raw.updatedAt,

--- a/docs/plans/strength-session-logging.md
+++ b/docs/plans/strength-session-logging.md
@@ -61,7 +61,7 @@ accepted before any Step C item.
 | Item | Title | Status | Blocked by |
 |---|---|---|---|
 | S1.1 | Offline persistence | `[x]` | — |
-| S1.2 | `strength_sessions` schema and types | `[ ]` | D-GAUGE |
+| S1.2 | `strength_sessions` schema and types | `[x]` | D-GAUGE |
 | S1.3 | Firestore rules and validation | `[ ]` | S1.2 |
 | S1.4 | Session state machine and date attribution | `[ ]` | S1.2 |
 | S1.5 | Set-entry UI | `[ ]` | S1.3, S1.4 |
@@ -116,7 +116,7 @@ reconnect" is a real-browser behaviour. The unit tests prove the cache is *confi
 that IndexedDB round-trips. Confirm by hand (DevTools → Network → Offline, write, reload,
 reconnect) before S1.5 depends on it.
 
-### S1.2 `[ ]` `strength_sessions` schema and types — **implements D-GAUGE, D-SETLOG**
+### S1.2 `[x]` `strength_sessions` schema and types — **implements D-GAUGE, D-SETLOG**
 
 **Change:** define the persisted shape at `users/{userId}/strength_sessions/{sessionId}`.
 
@@ -144,10 +144,12 @@ interface LoggedExercise {
 }
 
 interface StrengthSession {
+    userId: string;                // added during implementation, see outcome note
     sessionId: string;
     date: string;                  // Warsaw-local, from session START (S1.4)
     startedAt: string;
     completedAt?: string;
+    updatedAt: string;             // added during implementation, see outcome note
     state: 'in_progress' | 'completed' | 'abandoned';
     sourceRecommendationDate?: string;   // set when started from a prescription
     exercises: LoggedExercise[];
@@ -173,6 +175,30 @@ Notes that are not optional:
 **Done when:** types exist, a parser mirrors the `parseNormalizedGarminActivity` house
 style (unknown keys ignored, malformed optional fields degrade rather than invalidate), and
 `npm run check` passes.
+
+**Outcome (2026-08-17).** Implemented in `engine/models.ts` (types) and a new
+`persistence/parsers/strengthSession.ts`, with 20 tests. Two fields were added beyond this
+block, both required by S1.3's already-planned rules shape rather than optional polish:
+
+* **`userId`.** Every other client-writable collection (`decision_journal`, `goals`,
+  `daily_recommendations`) duplicates `userId` in the document so `hasOwnedUserId` /
+  `keepsOwnership` can validate it; this schema block omitted it. The parser now takes
+  `userId` as a caller-supplied parameter and checks it against the stored value before
+  anything else, mirroring `parseDecisionJournalEntry` — a mismatch is `user-id-mismatch`,
+  not silently trusted.
+* **`updatedAt`.** D-SETLOG requires per-set persistence (every logged set is its own
+  write), so the document needs a monotonic field for read-layer revision tracking. Used as
+  the parser's `DataState` revision, the same role `syncedAt` plays for
+  `NormalizedGarminActivity`.
+
+Degradation policy is two-tier and was tested explicitly: a malformed **top-level** field
+(date, state, schemaVersion, startedAt, updatedAt, userId mismatch) invalidates the whole
+document. A malformed **set or exercise** is dropped from its parent array and the rest of
+the session still parses `AVAILABLE` — D-SETLOG's raw log should survive one bad entry from
+a flaky offline write, not vanish along with every other set in the session. `weightKg`
+parsing is deliberately asymmetric: explicit `null` is accepted as bodyweight, but a
+non-null, non-numeric value drops the set rather than being coerced to `null` — coercion
+would misreport a real loaded set as bodyweight.
 
 ### S1.3 `[ ]` Firestore rules and validation
 


### PR DESCRIPTION
## Summary

- Implements D-GAUGE and D-SETLOG (ADR-0021). Adds `IntensityGauge`, `LoggedSet`, `LoggedExercise`, `StrengthSessionState` and `StrengthSession` to `engine/models.ts`, and `parseStrengthSession` to a new `persistence/parsers/strengthSession.ts` mirroring `parseNormalizedGarminActivity`'s house style.
- Two fields added beyond the plan's illustrative schema block: `userId` (every other client-writable collection duplicates it for `hasOwnedUserId`/`keepsOwnership`) and `updatedAt` (D-SETLOG requires per-set persistence, so the document needs a monotonic revision field — the role `syncedAt` plays for `NormalizedGarminActivity`).
- Degradation policy is two-tier: a malformed top-level field (date, state, schemaVersion, startedAt, updatedAt, userId mismatch) invalidates the whole document; a malformed *set or exercise* is dropped from its parent array and the rest of the session still parses `AVAILABLE` — the raw log should survive one bad entry from a flaky offline write, not vanish along with every other set.
- `parseWeightKg` is deliberately asymmetric: explicit `null` is bodyweight and accepted; a non-null, non-numeric weight drops the set rather than being coerced to `null`, since that coercion would misreport a real loaded set. No conversion between `rir`/`rpe_rts` happens at parse time, per D-GAUGE.

## Validation

- [x] `cd app && npm run check` — pass: 1232 tests (20 new in `strengthSession.test.ts`).

Results:
- Explicit tests: degradation policy (dropped-set, dropped-exercise cases), all four gauge scales round-trip untouched, `userId` mismatch rejected, `schemaVersion !== 1` rejected.

## Risk and reviewer guidance

Please double-check the two additions beyond the plan's schema (`userId`, `updatedAt`) against S1.3 (Firestore rules, next PR in this stack) — they were added specifically because S1.3's rules design requires them. No engine/recommendation code path reads this collection yet, so this PR has zero effect on any decision.

## Domain invariants

- [x] Firestore writes remain user-scoped — `strengthSession.ts` requires `userId` in the parsed document and checks it against the caller-supplied owner (`user-id-mismatch` otherwise), matching `decisionInputs.ts`'s `parseDecisionJournalEntry` precedent.
- [x] Calendar-date logic uses Europe/Warsaw — `date` validated via the existing `isValidDate`; date *computation* lands in S1.4 (next-next PR).
- [x] No credentials, tokens, service-account files, or raw health payloads included.
- [x] Recommendation decision logic changed: no. New types and a parser only; nothing reads this collection into the engine yet.

## Screenshots or recordings

Not applicable — no UI change.
