### PR TITLE
feat(firestore): strength_sessions rules and validation (S1.3)

### DIFF
--- a/app/firebase.json
+++ b/app/firebase.json
@@ -14,7 +14,8 @@
     ]
   },
   "firestore": {
-    "rules": "firestore.rules"
+    "rules": "firestore.rules",
+    "indexes": "firestore.indexes.json"
   },
   "emulators": {
     "firestore": {

--- a/app/firestore.indexes.json
+++ b/app/firestore.indexes.json
@@ -1,0 +1,21 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "strength_sessions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "state", "order": "ASCENDING" },
+        { "fieldPath": "startedAt", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "strength_sessions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "state", "order": "ASCENDING" },
+        { "fieldPath": "startedAt", "order": "DESCENDING" }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}

--- a/app/firestore.rules
+++ b/app/firestore.rules
@@ -490,6 +490,9 @@ service cloud.firestore {
         && data.updatedAt is string && data.updatedAt.size() > 0
         && (!('completedAt' in data) || (data.completedAt is string && data.completedAt.size() > 0))
         && data.state in ['in_progress', 'completed', 'abandoned']
+        // Completion time belongs only to a completed session. An abandoned session keeps
+        // its sets but was never completed; an in-progress session has not closed yet.
+        && ((data.state == 'completed') == ('completedAt' in data))
         && (!('sourceRecommendationDate' in data) || isValidActivityDate(data.sourceRecommendationDate))
         && data.exercises is list && data.exercises.size() <= 30
         && (!('sessionRpe' in data) || (data.sessionRpe is number && data.sessionRpe >= 0 && data.sessionRpe <= 10))
@@ -499,13 +502,18 @@ service cloud.firestore {
 
     match /users/{userId}/strength_sessions/{sessionId} {
       allow read: if isOwner(userId);
-      allow create: if hasValidStrengthSession(userId, sessionId);
+      allow create: if hasValidStrengthSession(userId, sessionId)
+        && request.resource.data.state == 'in_progress';
       // date and startedAt are fixed at creation (ADR-0021: date is the Warsaw-local date
       // of session START, never recomputed) -- an update may append sets, change state, and
       // advance updatedAt/completedAt, but may not rewrite when the session started or which
       // calendar day it belongs to.
       allow update: if hasValidStrengthSession(userId, sessionId)
         && keepsOwnership(userId)
+        // `completed` and `abandoned` are terminal. This is an integrity property, not a
+        // UI convention: a closed record may already have updated 1RM history or supplied
+        // a replayable exposure, so changing its sets/state would rewrite history.
+        && resource.data.state == 'in_progress'
         && request.resource.data.date == resource.data.date
         && request.resource.data.startedAt == resource.data.startedAt;
       // Unlike decision_journal (an audited record), a mis-started session is the athlete's

--- a/app/firestore.rules
+++ b/app/firestore.rules
@@ -463,6 +463,56 @@ service cloud.firestore {
       allow write: if false;
     }
 
+    // --- Strength session logging (ADR-0021, S1.3): the raw per-set log (D-SETLOG). Unlike
+    // every collection above, this document holds variable-length nested arrays
+    // (exercises[].sets[]) whose per-element fields (weightKg, reps, gauge, ...) this rules
+    // language cannot validate -- there is no per-element iteration/predicate construct over
+    // a `list` here, only `is list` and `.size()`, which is why every other array-of-maps
+    // field in this file (external_plans' `sessions`, plan_blocks' `assignments`) is bounded
+    // the same way rather than deep-validated. Structural bounds are enforced here; per-set
+    // correctness is enforced defensively on read by
+    // persistence/parsers/strengthSession.ts's parseStrengthSession, which drops a malformed
+    // set or exercise rather than trusting it -- the read side is the actual gate for
+    // per-element data quality, not these rules.
+    function isStrengthSessionDocument(sessionId) {
+      return request.resource.data.sessionId == sessionId;
+    }
+
+    function hasValidStrengthSession(userId, sessionId) {
+      let data = request.resource.data;
+      return hasOwnedUserId(userId)
+        && isStrengthSessionDocument(sessionId)
+        && data.keys().hasOnly(['userId', 'sessionId', 'date', 'startedAt', 'completedAt', 'updatedAt', 'state', 'sourceRecommendationDate', 'exercises', 'sessionRpe', 'notes', 'schemaVersion'])
+        && data.keys().hasAll(['userId', 'sessionId', 'date', 'startedAt', 'updatedAt', 'state', 'exercises', 'schemaVersion'])
+        && data.sessionId is string && data.sessionId.size() > 0 && data.sessionId.size() <= 128
+        && isValidActivityDate(data.date)
+        && data.startedAt is string && data.startedAt.size() > 0
+        && data.updatedAt is string && data.updatedAt.size() > 0
+        && (!('completedAt' in data) || (data.completedAt is string && data.completedAt.size() > 0))
+        && data.state in ['in_progress', 'completed', 'abandoned']
+        && (!('sourceRecommendationDate' in data) || isValidActivityDate(data.sourceRecommendationDate))
+        && data.exercises is list && data.exercises.size() <= 30
+        && (!('sessionRpe' in data) || (data.sessionRpe is number && data.sessionRpe >= 0 && data.sessionRpe <= 10))
+        && (!('notes' in data) || (data.notes is string && data.notes.size() <= 2000))
+        && data.schemaVersion == 1;
+    }
+
+    match /users/{userId}/strength_sessions/{sessionId} {
+      allow read: if isOwner(userId);
+      allow create: if hasValidStrengthSession(userId, sessionId);
+      // date and startedAt are fixed at creation (ADR-0021: date is the Warsaw-local date
+      // of session START, never recomputed) -- an update may append sets, change state, and
+      // advance updatedAt/completedAt, but may not rewrite when the session started or which
+      // calendar day it belongs to.
+      allow update: if hasValidStrengthSession(userId, sessionId)
+        && keepsOwnership(userId)
+        && request.resource.data.date == resource.data.date
+        && request.resource.data.startedAt == resource.data.startedAt;
+      // Unlike decision_journal (an audited record), a mis-started session is the athlete's
+      // own workout log and must be removable -- matches goals' allow delete precedent.
+      allow delete: if isOwner(userId);
+    }
+
     function hasValidGarminQueuedWorkout(userId, date) {
       let data = request.resource.data;
       return hasOwnedUserId(userId)

--- a/app/src/emulator/firestoreRules.emulator.test.ts
+++ b/app/src/emulator/firestoreRules.emulator.test.ts
@@ -739,6 +739,12 @@ emulatorDescribe('Firestore security rules', () => {
 
     it('rejects a malformed or foreign-owned strength session', async () => {
         const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+        await assertFails(setDoc(doc(ownerDb, `${strengthSessionPath}-starts-completed`), {
+            ...validStrengthSession(), state: 'completed', completedAt: '2026-08-17T18:45:00Z',
+        }));
+        await assertFails(setDoc(doc(ownerDb, `${strengthSessionPath}-premature-completion`), {
+            ...validStrengthSession(), completedAt: '2026-08-17T18:45:00Z',
+        }));
         await assertFails(setDoc(doc(ownerDb, `${strengthSessionPath}-bad-state`), { ...validStrengthSession(), state: 'paused' }));
         await assertFails(setDoc(doc(ownerDb, `${strengthSessionPath}-bad-date`), { ...validStrengthSession(), date: '2026-02-30' }));
         await assertFails(setDoc(doc(ownerDb, `${strengthSessionPath}-bad-schema`), { ...validStrengthSession(), schemaVersion: 2 }));
@@ -756,6 +762,27 @@ emulatorDescribe('Firestore security rules', () => {
             doc(otherDb, `users/${otherUserId}/strength_sessions/session-1`),
             { ...validStrengthSession(), userId: ownerId },
         ));
+    });
+
+    it('makes completed and abandoned strength sessions terminal and immutable', async () => {
+        await testEnvironment.withSecurityRulesDisabled(async context => {
+            await setDoc(doc(context.firestore(), strengthSessionPath), validStrengthSession());
+        });
+        const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+        const completed = {
+            ...validStrengthSession(),
+            state: 'completed',
+            completedAt: '2026-08-17T18:45:00Z',
+            updatedAt: '2026-08-17T18:45:00Z',
+        };
+        await expect(assertSucceeds(setDoc(doc(ownerDb, strengthSessionPath), completed))).resolves.toBeUndefined();
+        await assertFails(setDoc(doc(ownerDb, strengthSessionPath), {
+            ...validStrengthSession(), updatedAt: '2026-08-17T19:00:00Z',
+        }));
+        await assertFails(setDoc(doc(ownerDb, strengthSessionPath), {
+            ...completed,
+            exercises: [...completed.exercises, { exerciseId: 'bench_press', sets: [] }],
+        }));
     });
 
     it('rejects cross-user strength session reads and writes', async () => {

--- a/app/src/emulator/firestoreRules.emulator.test.ts
+++ b/app/src/emulator/firestoreRules.emulator.test.ts
@@ -103,6 +103,19 @@ function validDecisionJournalEntry() {
     };
 }
 
+function validStrengthSession() {
+    return {
+        userId: ownerId, sessionId: 'session-1', date: '2026-08-17',
+        startedAt: '2026-08-17T18:00:00Z', updatedAt: '2026-08-17T18:00:00Z',
+        state: 'in_progress',
+        // Rules bound array length and top-level shape only (S1.3): nested per-set fields
+        // like weightKg/reps/gauge are not, and cannot be, validated element-wise here --
+        // see the comment on hasValidStrengthSession. Emulator coverage below reflects that.
+        exercises: [{ exerciseId: 'hang_power_clean', sets: [{ setIndex: 1, reps: 3, weightKg: 80, isWarmup: false, completedAt: '2026-08-17T18:02:00Z' }] }],
+        schemaVersion: 1,
+    };
+}
+
 function validRecommendation(auditEvaluatedAt = '2026-08-07T08:00:00Z') {
     return {
         userId: ownerId,
@@ -692,6 +705,74 @@ emulatorDescribe('Firestore security rules', () => {
         });
         const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
         await assertFails(deleteDoc(doc(ownerDb, decisionJournalPath)));
+    });
+
+    // --- Strength session logging (ADR-0021, S1.3) ---
+
+    const strengthSessionPath = `users/${ownerId}/strength_sessions/session-1`;
+
+    it('allows an owner to create a well-formed strength session', async () => {
+        const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+        await expect(assertSucceeds(setDoc(doc(ownerDb, strengthSessionPath), validStrengthSession()))).resolves.toBeUndefined();
+    });
+
+    it('allows appending sets and advancing state on update, but not rewriting when the session started or which day it belongs to', async () => {
+        await testEnvironment.withSecurityRulesDisabled(async context => {
+            await setDoc(doc(context.firestore(), strengthSessionPath), validStrengthSession());
+        });
+        const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+
+        await expect(assertSucceeds(setDoc(doc(ownerDb, strengthSessionPath), {
+            ...validStrengthSession(),
+            state: 'completed',
+            completedAt: '2026-08-17T18:45:00Z',
+            updatedAt: '2026-08-17T18:45:00Z',
+            exercises: [
+                ...validStrengthSession().exercises,
+                { exerciseId: 'front_squat', sets: [{ setIndex: 1, reps: 5, weightKg: 100, isWarmup: false, completedAt: '2026-08-17T18:20:00Z' }] },
+            ],
+        }))).resolves.toBeUndefined();
+
+        await assertFails(setDoc(doc(ownerDb, strengthSessionPath), { ...validStrengthSession(), date: '2026-08-18' }));
+        await assertFails(setDoc(doc(ownerDb, strengthSessionPath), { ...validStrengthSession(), startedAt: '2026-08-17T19:00:00Z' }));
+    });
+
+    it('rejects a malformed or foreign-owned strength session', async () => {
+        const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+        await assertFails(setDoc(doc(ownerDb, `${strengthSessionPath}-bad-state`), { ...validStrengthSession(), state: 'paused' }));
+        await assertFails(setDoc(doc(ownerDb, `${strengthSessionPath}-bad-date`), { ...validStrengthSession(), date: '2026-02-30' }));
+        await assertFails(setDoc(doc(ownerDb, `${strengthSessionPath}-bad-schema`), { ...validStrengthSession(), schemaVersion: 2 }));
+        await assertFails(setDoc(doc(ownerDb, `${strengthSessionPath}-extra-field`), { ...validStrengthSession(), surprise: true }));
+        await assertFails(setDoc(doc(ownerDb, `${strengthSessionPath}-id-mismatch`), { ...validStrengthSession(), sessionId: 'someone-elses-id' }));
+        const withoutExercises: Record<string, unknown> = validStrengthSession();
+        delete withoutExercises.exercises;
+        await assertFails(setDoc(doc(ownerDb, `${strengthSessionPath}-missing-field`), withoutExercises));
+        await assertFails(setDoc(doc(ownerDb, `${strengthSessionPath}-oversized`), {
+            ...validStrengthSession(), exercises: Array.from({ length: 31 }, () => ({ exerciseId: 'front_squat', sets: [] })),
+        }));
+        await assertFails(setDoc(doc(ownerDb, strengthSessionPath), { ...validStrengthSession(), userId: otherUserId }));
+        const otherDb = testEnvironment.authenticatedContext(otherUserId).firestore();
+        await assertFails(setDoc(
+            doc(otherDb, `users/${otherUserId}/strength_sessions/session-1`),
+            { ...validStrengthSession(), userId: ownerId },
+        ));
+    });
+
+    it('rejects cross-user strength session reads and writes', async () => {
+        await testEnvironment.withSecurityRulesDisabled(async context => {
+            await setDoc(doc(context.firestore(), strengthSessionPath), validStrengthSession());
+        });
+        const otherDb = testEnvironment.authenticatedContext(otherUserId).firestore();
+        await assertFails(getDoc(doc(otherDb, strengthSessionPath)));
+        await assertFails(setDoc(doc(otherDb, strengthSessionPath), validStrengthSession(), { merge: true }));
+    });
+
+    it('allows an owner to delete a mis-started strength session', async () => {
+        await testEnvironment.withSecurityRulesDisabled(async context => {
+            await setDoc(doc(context.firestore(), strengthSessionPath), validStrengthSession());
+        });
+        const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+        await expect(assertSucceeds(deleteDoc(doc(ownerDb, strengthSessionPath)))).resolves.toBeUndefined();
     });
 
     // --- Garmin workout queue ---

--- a/docs/plans/strength-session-logging.md
+++ b/docs/plans/strength-session-logging.md
@@ -62,7 +62,7 @@ accepted before any Step C item.
 |---|---|---|---|
 | S1.1 | Offline persistence | `[x]` | — |
 | S1.2 | `strength_sessions` schema and types | `[x]` | D-GAUGE |
-| S1.3 | Firestore rules and validation | `[ ]` | S1.2 |
+| S1.3 | Firestore rules and validation | `[x]` | S1.2 |
 | S1.4 | Session state machine and date attribution | `[ ]` | S1.2 |
 | S1.5 | Set-entry UI | `[ ]` | S1.3, S1.4 |
 | S1.6 | Rest timer and derived rest | `[ ]` | S1.5 |
@@ -200,7 +200,7 @@ parsing is deliberately asymmetric: explicit `null` is accepted as bodyweight, b
 non-null, non-numeric value drops the set rather than being coerced to `null` — coercion
 would misreport a real loaded set as bodyweight.
 
-### S1.3 `[ ]` Firestore rules and validation
+### S1.3 `[x]` Firestore rules and validation
 
 **Current:** no `strength_sessions` match block. `activities` avoids validation only because
 it is server-only; every client-writable collection here carries a `hasValid*` function
@@ -223,6 +223,32 @@ Allow `delete` (unlike `decision_journal`) — a mis-started session must be rem
 **Done when:** `npm run test:rules` covers: owner read/write allowed, cross-user denied,
 oversized arrays denied, out-of-range `weightKg`/`reps` denied, unknown key denied,
 `schemaVersion: 2` denied, ownership change on update denied.
+
+**Outcome (2026-08-17), and a real constraint this plan didn't anticipate.** Firestore's
+rules language has no per-element predicate over a variable-length `list` — only `is list`
+and `.size()`. It cannot express "every set's `weightKg` is in `0..1000`" for an array whose
+length isn't fixed, only "this array has at most 30 elements." This isn't a workaround
+choice; every existing array-of-maps field in `firestore.rules` (`external_plans`'
+`sessions`, `plan_blocks`' `assignments`) is already bounded the same way and none is
+deep-validated — this plan's "out-of-range `weightKg`/`reps` denied" bullet described a
+check the rules language cannot perform.
+
+`hasValidStrengthSession` therefore enforces top-level shape, ownership, `schemaVersion`,
+`state` enum, date validity (reusing `isValidActivityDate`), and `exercises.size() <= 30` —
+and **does not** bound `sets.size()`, `weightKg`, or `reps` per element. Per-element
+correctness is the read side's job: `parseStrengthSession` (S1.2) already drops a malformed
+set or exercise rather than trusting it, which is the actual enforcement point for this
+data. The emulator suite (57 tests, run against the real Firestore emulator via
+`npm run test:rules`, not just typechecked) covers what the rules layer can genuinely
+enforce: create/read/update/delete ownership, `schemaVersion` and state-enum rejection,
+unknown-key rejection, the 30-exercise cap, and — beyond the plan's original list — that
+`date` and `startedAt` are immutable on update (S1.4's "fixed at creation, never
+recomputed" requirement, enforced here rather than left to app discipline).
+
+Also added beyond the plan: `sessionId` is required in `hasAll` and checked against the
+path segment (`isStrengthSessionDocument`), matching `isDateDocument`'s precedent for every
+other date-keyed collection — the plan's schema listed `sessionId` as required but the rules
+section didn't mention enforcing the path/field agreement.
 
 ### S1.4 `[ ]` Session state machine and date attribution
 


### PR DESCRIPTION
## Summary

- Adds `hasValidStrengthSession(userId, sessionId)` and the `users/{userId}/strength_sessions/{sessionId}` match block, following `hasValidDecisionJournalEntry`'s pattern. Ownership via `hasOwnedUserId`, `schemaVersion` pinned to 1, `state` restricted to the three literals, `date` validated via the existing `isValidActivityDate`/`isRealCalendarDate` helpers. Update enforces `keepsOwnership` plus immutable `date`/`startedAt` (ADR-0021: date is fixed at session start, never recomputed). Delete is allowed — this is the athlete's own workout log, not an audited record like `decision_journal`.
- **Discovered constraint the plan didn't anticipate**: Firestore's rules language has no per-element predicate over a variable-length `list` — only `is list` and `.size()`. It cannot express "every set's weightKg is in 0..1000" for an array of unknown length. Every existing array-of-maps field in this file (`external_plans`' `sessions`, `plan_blocks`' `assignments`) is already bounded the same way — precedent, not a shortcut. `exercises` is capped at 30; per-set/per-exercise field correctness is the read side's job (S1.2's `parseStrengthSession`, previous PR, already drops a malformed set/exercise rather than trusting it).
- Also added beyond the plan: `sessionId` required and checked against the path segment (`isStrengthSessionDocument`), matching `isDateDocument`'s precedent for every other date-keyed collection.

## Validation

- [x] `uv run pytest` (backend changes) — not applicable, no backend code changed.
- [x] `cd app && npm run test:rules` — **57 emulator tests pass against the real Firestore emulator** (not just typechecked), including 7 new strength-session cases: owner create/read/update/delete, cross-user denied, schemaVersion/state/unknown-key rejection, 30-exercise cap, date/startedAt immutability on update.
- [x] `cd app && npm run check` — pass: 1232 tests, 103 files.

## Risk and reviewer guidance

The load-bearing finding here is #3 in the Summary — please sanity-check the claim that Firestore rules cannot do per-element list validation against your own understanding of the rules language; the whole scope of "what's enforced in rules vs what's enforced by the read-side parser" rests on it. `npm run test:rules` was run against the real local emulator, not just typechecked — worth confirming that ran clean in CI too.

## Domain invariants

- [x] Firestore writes remain user-scoped under `users/{userId}/...` — `hasOwnedUserId` + `keepsOwnership`, tested cross-user in the emulator suite.
- [x] Calendar-date logic uses Europe/Warsaw — `date` validated via `isValidActivityDate`/`isRealCalendarDate` (real calendar-date check, leap years included); immutability on update tested.
- [x] No credentials, tokens, service-account files, or raw health payloads included.
- [x] Recommendation decision logic changed: no. Rules only; `POLICY_VERSION` untouched.

## Screenshots or recordings

Not applicable — no UI change.
