### PR TITLE
feat(strength): confirm-or-amend set-entry UI (S1.5)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -8,6 +8,7 @@ import { TrainingSettings } from './components/TrainingSettings';
 import { Preferences } from './components/Preferences';
 import { DataView } from './components/DataView';
 import { ExternalPlanImport } from './components/ExternalPlanImport';
+import { StrengthSessionRunner } from './components/StrengthSessionRunner';
 import { decisionComposer } from './engine/composer';
 import type { DailyDecisionInput } from './engine/models';
 import type { Screen } from './types/navigation';
@@ -114,6 +115,10 @@ function App() {
         
         {screen === 'preferences' && (
           <Preferences userId={userId!} onNavigate={handleNavigate} />
+        )}
+
+        {screen === 'strength' && (
+          <StrengthSessionRunner userId={userId!} />
         )}
 
         {screen === 'plan' && (

--- a/app/src/components/MobileNav.tsx
+++ b/app/src/components/MobileNav.tsx
@@ -92,7 +92,7 @@ export const MobileNav: React.FC<MobileNavProps> = ({ screen, handleNavigate, lo
 
         <button
           ref={mobileMoreBtnRef}
-          className={`nav-item ${['constraints', 'preferences', 'data', 'plan'].includes(screen) ? 'active' : ''}`}
+          className={`nav-item ${['constraints', 'preferences', 'data', 'plan', 'strength'].includes(screen) ? 'active' : ''}`}
           onClick={() => setMobileMoreOpen((isOpen) => !isOpen)}
           aria-expanded={mobileMoreOpen}
           aria-haspopup="dialog"
@@ -132,6 +132,17 @@ export const MobileNav: React.FC<MobileNavProps> = ({ screen, handleNavigate, lo
                 <div className="item-text">
                   <span className="item-title">Import Training Plan</span>
                   <span className="item-sub">Paste a plan authored outside this app</span>
+                </div>
+              </button>
+
+              <button
+                className={`drawer-item ${screen === 'strength' ? 'active' : ''}`}
+                onClick={() => handleNavigate('strength')}
+              >
+                <span className="item-icon">🏋️</span>
+                <div className="item-text">
+                  <span className="item-title">Strength Session</span>
+                  <span className="item-sub">Log sets, weight, reps and RIR/RPE as you train</span>
                 </div>
               </button>
 

--- a/app/src/components/StrengthSessionRunner.css
+++ b/app/src/components/StrengthSessionRunner.css
@@ -130,10 +130,15 @@
 
 .set-gauge,
 .set-warmup-tag {
-  margin-left: auto;
   font-size: 0.8rem;
   color: var(--text-secondary, #94a3b8);
 }
+
+.set-gauge { margin-left: auto; }
+.set-sync { margin-left: 0.35rem; font-size: 0.72rem; white-space: nowrap; }
+.set-sync-synced { color: var(--success, #22c55e); }
+.set-sync-pending { color: var(--warning, #f59e0b); }
+.set-sync-unavailable { color: var(--danger, #ef4444); }
 
 .strength-set-entry {
   display: grid;

--- a/app/src/components/StrengthSessionRunner.css
+++ b/app/src/components/StrengthSessionRunner.css
@@ -1,0 +1,180 @@
+.strength-runner {
+  background: var(--surface-card, #1e293b);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  color: var(--text-primary, #f8fafc);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.strength-runner-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.strength-runner-header h3 {
+  margin: 0;
+}
+
+.strength-state {
+  font-size: 0.8rem;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  text-transform: capitalize;
+  background: rgba(59, 130, 246, 0.15);
+  color: var(--primary-color, #3b82f6);
+}
+
+.strength-state-completed {
+  background: var(--tier-green-bg, rgba(34, 197, 94, 0.15));
+  color: var(--tier-green, #22c55e);
+}
+
+.strength-state-abandoned {
+  background: rgba(148, 163, 184, 0.2);
+  color: var(--text-secondary, #94a3b8);
+}
+
+.strength-start-btn,
+.strength-log-set-btn {
+  background: var(--primary-color, #3b82f6);
+  color: #fff;
+  border: none;
+  border-radius: 0.5rem;
+  padding: 0.6rem 1rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.strength-start-btn:disabled,
+.strength-log-set-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.strength-exercise-picker,
+.strength-active-exercise {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.strength-planned-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.strength-planned-btn {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.15rem;
+  background: rgba(148, 163, 184, 0.08);
+  border: 1px solid transparent;
+  border-radius: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  color: var(--text-primary, #f8fafc);
+  cursor: pointer;
+}
+
+.strength-planned-btn.active {
+  border-color: var(--primary-color, #3b82f6);
+}
+
+.planned-name {
+  font-weight: 600;
+}
+
+.planned-target {
+  font-size: 0.8rem;
+  color: var(--text-secondary, #94a3b8);
+}
+
+.strength-manual-add {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.strength-manual-add select,
+.strength-manual-add input {
+  flex: 1;
+}
+
+.strength-set-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.25rem;
+}
+
+.strength-set-list li {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.5rem;
+  background: rgba(148, 163, 184, 0.06);
+  border-radius: 0.4rem;
+  font-size: 0.9rem;
+}
+
+.strength-set-list li.warmup {
+  opacity: 0.7;
+}
+
+.set-index {
+  color: var(--text-secondary, #94a3b8);
+  min-width: 1.25rem;
+}
+
+.set-gauge,
+.set-warmup-tag {
+  margin-left: auto;
+  font-size: 0.8rem;
+  color: var(--text-secondary, #94a3b8);
+}
+
+.strength-set-entry {
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: 1fr 1fr;
+}
+
+.strength-set-entry label {
+  display: grid;
+  gap: 0.15rem;
+  font-size: 0.85rem;
+  color: var(--text-secondary, #94a3b8);
+}
+
+.strength-target-hint {
+  grid-column: 1 / -1;
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--text-secondary, #94a3b8);
+}
+
+.strength-log-set-btn {
+  grid-column: 1 / -1;
+}
+
+.strength-session-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.strength-abandon-btn {
+  background: transparent;
+  border: 1px solid var(--tier-red, #ef4444);
+  color: var(--tier-red, #ef4444);
+  border-radius: 0.5rem;
+  padding: 0.5rem 0.9rem;
+  cursor: pointer;
+}
+
+.strength-error {
+  color: var(--error-color, #b42318);
+  font-weight: 600;
+  margin: 0;
+}

--- a/app/src/components/StrengthSessionRunner.test.tsx
+++ b/app/src/components/StrengthSessionRunner.test.tsx
@@ -13,6 +13,7 @@ function baseResult(overrides: Partial<UseStrengthSessionRunnerResult> = {}): Us
         plannedExercises: [],
         activeExerciseIndex: null,
         draft: { reps: 1, weightKg: null, isWarmup: false },
+        syncStatusForSet: vi.fn(() => 'synced' as const),
         start: vi.fn(),
         selectExercise: vi.fn(),
         updateDraft: vi.fn(),
@@ -66,6 +67,7 @@ describe('StrengthSessionRunner', () => {
         const html = renderToStaticMarkup(<StrengthSessionRunner userId="u1" />);
         expect(html).toContain('warm-up');
         expect(html).toContain('3 RIR');
+        expect(html).toContain('synced');
         expect(html).toContain('Log set');
     });
 

--- a/app/src/components/StrengthSessionRunner.test.tsx
+++ b/app/src/components/StrengthSessionRunner.test.tsx
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { StrengthSessionRunner } from './StrengthSessionRunner';
+import * as runnerHook from '../hooks/useStrengthSessionRunner';
+import type { UseStrengthSessionRunnerResult } from '../hooks/useStrengthSessionRunner';
+
+function baseResult(overrides: Partial<UseStrengthSessionRunnerResult> = {}): UseStrengthSessionRunnerResult {
+    return {
+        loading: false,
+        saving: false,
+        error: null,
+        session: null,
+        plannedExercises: [],
+        activeExerciseIndex: null,
+        draft: { reps: 1, weightKg: null, isWarmup: false },
+        start: vi.fn(),
+        selectExercise: vi.fn(),
+        updateDraft: vi.fn(),
+        logSet: vi.fn(),
+        finishSession: vi.fn(),
+        abandonSession: vi.fn(),
+        ...overrides,
+    };
+}
+
+describe('StrengthSessionRunner', () => {
+    it('renders a start prompt with no active session', () => {
+        vi.spyOn(runnerHook, 'useStrengthSessionRunner').mockReturnValue(baseResult());
+        const html = renderToStaticMarkup(<StrengthSessionRunner userId="u1" />);
+        expect(html).toContain('Start strength session');
+    });
+
+    it('renders a loading state before the resume check completes', () => {
+        vi.spyOn(runnerHook, 'useStrengthSessionRunner').mockReturnValue(baseResult({ loading: true }));
+        const html = renderToStaticMarkup(<StrengthSessionRunner userId="u1" />);
+        expect(html).toContain('Loading strength session');
+    });
+
+    it('renders planned exercises from a matched prescription', () => {
+        vi.spyOn(runnerHook, 'useStrengthSessionRunner').mockReturnValue(baseResult({
+            session: {
+                userId: 'u1', sessionId: 's1', date: '2026-08-17', startedAt: '2026-08-17T18:00:00Z',
+                updatedAt: '2026-08-17T18:00:00Z', state: 'in_progress', exercises: [], schemaVersion: 1,
+            },
+            plannedExercises: [{ exerciseId: 'bench_press', name: 'Bench press', targetSets: 3, targetReps: 6, targetGauge: { scale: 'rir', value: 4 }, optional: false }],
+        }));
+        const html = renderToStaticMarkup(<StrengthSessionRunner userId="u1" />);
+        expect(html).toContain('Bench press');
+        expect(html).toContain('3 × 6');
+        expect(html).toContain('4 RIR');
+    });
+
+    it('renders logged sets for the active exercise, including gauge and warm-up labels', () => {
+        vi.spyOn(runnerHook, 'useStrengthSessionRunner').mockReturnValue(baseResult({
+            session: {
+                userId: 'u1', sessionId: 's1', date: '2026-08-17', startedAt: '2026-08-17T18:00:00Z',
+                updatedAt: '2026-08-17T18:02:00Z', state: 'in_progress',
+                exercises: [{ exerciseId: 'bench_press', sets: [
+                    { setIndex: 1, reps: 5, weightKg: 60, isWarmup: true, completedAt: '2026-08-17T18:01:00Z' },
+                    { setIndex: 2, reps: 3, weightKg: 80, isWarmup: false, completedAt: '2026-08-17T18:02:00Z', gauge: { scale: 'rir', value: 3 } },
+                ] }],
+                schemaVersion: 1,
+            },
+            activeExerciseIndex: 0,
+        }));
+        const html = renderToStaticMarkup(<StrengthSessionRunner userId="u1" />);
+        expect(html).toContain('warm-up');
+        expect(html).toContain('3 RIR');
+        expect(html).toContain('Log set');
+    });
+
+    it('hides set-entry controls and session actions once the session is completed', () => {
+        vi.spyOn(runnerHook, 'useStrengthSessionRunner').mockReturnValue(baseResult({
+            session: {
+                userId: 'u1', sessionId: 's1', date: '2026-08-17', startedAt: '2026-08-17T18:00:00Z',
+                completedAt: '2026-08-17T19:00:00Z', updatedAt: '2026-08-17T19:00:00Z', state: 'completed',
+                exercises: [{ exerciseId: 'bench_press', sets: [{ setIndex: 1, reps: 5, weightKg: 60, isWarmup: false, completedAt: '2026-08-17T18:01:00Z' }] }],
+                schemaVersion: 1,
+            },
+            activeExerciseIndex: 0,
+        }));
+        const html = renderToStaticMarkup(<StrengthSessionRunner userId="u1" />);
+        expect(html).not.toContain('Log set');
+        expect(html).not.toContain('Finish session');
+        expect(html).toContain('completed');
+    });
+
+    it('surfaces an error from the hook without swallowing it', () => {
+        vi.spyOn(runnerHook, 'useStrengthSessionRunner').mockReturnValue(baseResult({ error: 'Could not save that set' }));
+        const html = renderToStaticMarkup(<StrengthSessionRunner userId="u1" />);
+        expect(html).toContain('Could not save that set');
+    });
+});

--- a/app/src/components/StrengthSessionRunner.tsx
+++ b/app/src/components/StrengthSessionRunner.tsx
@@ -27,7 +27,6 @@ function gaugeLabel(gauge: IntensityGauge | undefined): string | null {
  *  `strengthSessionService.test.ts`, which this component only orchestrates. */
 export function StrengthSessionRunner({ userId }: StrengthSessionRunnerProps) {
     const runner = useStrengthSessionRunner(userId);
-    const [gaugeScale, setGaugeScale] = useState<IntensityGauge['scale'] | ''>('');
     const [freeTextName, setFreeTextName] = useState('');
     const [catalogExerciseId, setCatalogExerciseId] = useState('');
 
@@ -46,8 +45,8 @@ export function StrengthSessionRunner({ userId }: StrengthSessionRunnerProps) {
             <div className="strength-runner strength-runner-start">
                 <h3>Strength session</h3>
                 <p className="card-empty">No session in progress.</p>
-                <button type="button" className="strength-start-btn" onClick={() => void runner.start()}>
-                    Start strength session
+                <button type="button" className="strength-start-btn" disabled={runner.saving} onClick={() => void runner.start()}>
+                    {runner.saving ? 'Starting…' : 'Start strength session'}
                 </button>
                 {runner.error && <p className="strength-error">{runner.error}</p>}
             </div>
@@ -77,7 +76,6 @@ export function StrengthSessionRunner({ userId }: StrengthSessionRunnerProps) {
     }
 
     function onGaugeScaleChange(scale: IntensityGauge['scale'] | '') {
-        setGaugeScale(scale);
         if (scale === '') {
             runner.updateDraft({ gauge: undefined });
             return;
@@ -145,14 +143,20 @@ export function StrengthSessionRunner({ userId }: StrengthSessionRunnerProps) {
 
                     {activeExercise.sets.length > 0 && (
                         <ul className="strength-set-list">
-                            {activeExercise.sets.map(set => (
-                                <li key={set.setIndex} className={set.isWarmup ? 'warmup' : ''}>
-                                    <span className="set-index">{set.setIndex}</span>
-                                    <span className="set-summary">{set.reps} × {set.weightKg ?? 'BW'}{set.weightKg !== null ? ' kg' : ''}</span>
-                                    {gaugeLabel(set.gauge) && <span className="set-gauge">{gaugeLabel(set.gauge)}</span>}
-                                    {set.isWarmup && <span className="set-warmup-tag">warm-up</span>}
-                                </li>
-                            ))}
+                            {activeExercise.sets.map(set => {
+                                const syncStatus = runner.syncStatusForSet(activeExercise, set);
+                                return (
+                                    <li key={set.setIndex} className={set.isWarmup ? 'warmup' : ''}>
+                                        <span className="set-index">{set.setIndex}</span>
+                                        <span className="set-summary">{set.reps} × {set.weightKg ?? 'BW'}{set.weightKg !== null ? ' kg' : ''}</span>
+                                        {gaugeLabel(set.gauge) && <span className="set-gauge">{gaugeLabel(set.gauge)}</span>}
+                                        {set.isWarmup && <span className="set-warmup-tag">warm-up</span>}
+                                        <span className={`set-sync set-sync-${syncStatus}`}>
+                                            {syncStatus === 'unavailable' ? 'sync unavailable' : syncStatus}
+                                        </span>
+                                    </li>
+                                );
+                            })}
                         </ul>
                     )}
 
@@ -189,7 +193,7 @@ export function StrengthSessionRunner({ userId }: StrengthSessionRunnerProps) {
 
                             <label>
                                 Gauge
-                                <select value={gaugeScale} onChange={event => onGaugeScaleChange(event.target.value as IntensityGauge['scale'] | '')}>
+                                <select value={runner.draft.gauge?.scale ?? ''} onChange={event => onGaugeScaleChange(event.target.value as IntensityGauge['scale'] | '')}>
                                     <option value="">None</option>
                                     <option value="rir">RIR (reps in reserve)</option>
                                     <option value="rpe_rts">RPE (1-10)</option>
@@ -237,8 +241,10 @@ export function StrengthSessionRunner({ userId }: StrengthSessionRunnerProps) {
 
             {!isClosed && (
                 <div className="strength-session-actions">
-                    <button type="button" onClick={() => void runner.finishSession()}>Finish session</button>
-                    <button type="button" className="strength-abandon-btn" onClick={() => void runner.abandonSession()}>Abandon</button>
+                    <button type="button" disabled={runner.saving} onClick={() => void runner.finishSession()}>
+                        {runner.saving ? 'Saving…' : 'Finish session'}
+                    </button>
+                    <button type="button" disabled={runner.saving} className="strength-abandon-btn" onClick={() => void runner.abandonSession()}>Abandon</button>
                 </div>
             )}
         </div>

--- a/app/src/components/StrengthSessionRunner.tsx
+++ b/app/src/components/StrengthSessionRunner.tsx
@@ -1,0 +1,246 @@
+import { useMemo, useState } from 'react';
+import { useStrengthSessionRunner } from '../hooks/useStrengthSessionRunner';
+import type { IntensityGauge } from '../engine/models';
+import { EXERCISES } from '../workouts/exercises';
+import './StrengthSessionRunner.css';
+
+interface StrengthSessionRunnerProps {
+    userId: string;
+}
+
+const STRENGTH_EXERCISES = EXERCISES.filter(exercise => exercise.modality === 'strength');
+
+function gaugeLabel(gauge: IntensityGauge | undefined): string | null {
+    if (!gauge) return null;
+    switch (gauge.scale) {
+        case 'rir': return `${gauge.value} RIR`;
+        case 'rpe_rts': return `RPE ${gauge.value}`;
+        case 'velocity_loss': return `${gauge.percent}% velocity loss`;
+        case 'technical': return gauge.met ? 'Quality met' : 'Quality missed';
+    }
+}
+
+/** Confirm-or-amend set-entry UI (ADR-0021, S1.5). Persists on every logged set, not on
+ *  "finish" -- see `useStrengthSessionRunner.logSet` for why. Rendered without any
+ *  `@testing-library/react` interaction testing (this repo has none); correctness of the
+ *  underlying rules lives in `strengthSessionEntry.test.ts` and
+ *  `strengthSessionService.test.ts`, which this component only orchestrates. */
+export function StrengthSessionRunner({ userId }: StrengthSessionRunnerProps) {
+    const runner = useStrengthSessionRunner(userId);
+    const [gaugeScale, setGaugeScale] = useState<IntensityGauge['scale'] | ''>('');
+    const [freeTextName, setFreeTextName] = useState('');
+    const [catalogExerciseId, setCatalogExerciseId] = useState('');
+
+    const activeExercise = runner.activeExerciseIndex !== null ? runner.session?.exercises[runner.activeExerciseIndex] : undefined;
+    const activePlanned = useMemo(
+        () => runner.plannedExercises.find(planned => planned.exerciseId === activeExercise?.exerciseId),
+        [runner.plannedExercises, activeExercise],
+    );
+
+    if (runner.loading) {
+        return <div className="strength-runner"><p className="card-empty">Loading strength session…</p></div>;
+    }
+
+    if (!runner.session) {
+        return (
+            <div className="strength-runner strength-runner-start">
+                <h3>Strength session</h3>
+                <p className="card-empty">No session in progress.</p>
+                <button type="button" className="strength-start-btn" onClick={() => void runner.start()}>
+                    Start strength session
+                </button>
+                {runner.error && <p className="strength-error">{runner.error}</p>}
+            </div>
+        );
+    }
+
+    const session = runner.session;
+    const isClosed = session.state !== 'in_progress';
+
+    function selectPlanned(exerciseId: string) {
+        runner.selectExercise(exerciseId);
+        setCatalogExerciseId('');
+        setFreeTextName('');
+    }
+
+    function selectFromCatalog() {
+        if (!catalogExerciseId) return;
+        runner.selectExercise(catalogExerciseId);
+        setCatalogExerciseId('');
+    }
+
+    function addFreeText() {
+        const name = freeTextName.trim();
+        if (!name) return;
+        runner.selectExercise(null, name);
+        setFreeTextName('');
+    }
+
+    function onGaugeScaleChange(scale: IntensityGauge['scale'] | '') {
+        setGaugeScale(scale);
+        if (scale === '') {
+            runner.updateDraft({ gauge: undefined });
+            return;
+        }
+        const current = runner.draft.gauge;
+        if (scale === 'rir') runner.updateDraft({ gauge: { scale: 'rir', value: current && 'value' in current ? current.value : 3 } });
+        else if (scale === 'rpe_rts') runner.updateDraft({ gauge: { scale: 'rpe_rts', value: current && 'value' in current ? current.value : 7 } });
+        else if (scale === 'velocity_loss') runner.updateDraft({ gauge: { scale: 'velocity_loss', percent: current && 'percent' in current ? current.percent : 15 } });
+        else if (scale === 'technical') runner.updateDraft({ gauge: { scale: 'technical', met: true } });
+    }
+
+    return (
+        <div className="strength-runner">
+            <div className="strength-runner-header">
+                <h3>Strength session</h3>
+                <span className={`strength-state strength-state-${session.state}`}>{session.state.replace('_', ' ')}</span>
+            </div>
+
+            {!isClosed && (
+                <div className="strength-exercise-picker">
+                    {runner.plannedExercises.length > 0 && (
+                        <div className="strength-planned-list">
+                            {runner.plannedExercises.map(planned => (
+                                <button
+                                    key={planned.exerciseId}
+                                    type="button"
+                                    className={`strength-planned-btn ${activeExercise?.exerciseId === planned.exerciseId ? 'active' : ''}`}
+                                    onClick={() => selectPlanned(planned.exerciseId)}
+                                >
+                                    <span className="planned-name">{planned.name}</span>
+                                    <span className="planned-target">
+                                        {planned.targetSets} × {planned.targetReps ?? '?'}
+                                        {planned.targetGauge ? ` @ ${gaugeLabel(planned.targetGauge)}` : ''}
+                                    </span>
+                                </button>
+                            ))}
+                        </div>
+                    )}
+
+                    <div className="strength-manual-add">
+                        <select value={catalogExerciseId} onChange={event => setCatalogExerciseId(event.target.value)}>
+                            <option value="">Add exercise from catalog…</option>
+                            {STRENGTH_EXERCISES.map(exercise => (
+                                <option key={exercise.id} value={exercise.id}>{exercise.name}</option>
+                            ))}
+                        </select>
+                        <button type="button" disabled={!catalogExerciseId} onClick={selectFromCatalog}>Add</button>
+                    </div>
+
+                    <div className="strength-manual-add">
+                        <input
+                            type="text"
+                            placeholder="Or type an exercise not in the catalog"
+                            value={freeTextName}
+                            onChange={event => setFreeTextName(event.target.value)}
+                        />
+                        <button type="button" disabled={!freeTextName.trim()} onClick={addFreeText}>Add</button>
+                    </div>
+                </div>
+            )}
+
+            {activeExercise && (
+                <div className="strength-active-exercise">
+                    <h4>{activeExercise.exerciseId ? (STRENGTH_EXERCISES.find(e => e.id === activeExercise.exerciseId)?.name ?? activeExercise.exerciseId) : activeExercise.freeTextName}</h4>
+
+                    {activeExercise.sets.length > 0 && (
+                        <ul className="strength-set-list">
+                            {activeExercise.sets.map(set => (
+                                <li key={set.setIndex} className={set.isWarmup ? 'warmup' : ''}>
+                                    <span className="set-index">{set.setIndex}</span>
+                                    <span className="set-summary">{set.reps} × {set.weightKg ?? 'BW'}{set.weightKg !== null ? ' kg' : ''}</span>
+                                    {gaugeLabel(set.gauge) && <span className="set-gauge">{gaugeLabel(set.gauge)}</span>}
+                                    {set.isWarmup && <span className="set-warmup-tag">warm-up</span>}
+                                </li>
+                            ))}
+                        </ul>
+                    )}
+
+                    {!isClosed && (
+                        <div className="strength-set-entry">
+                            <label>
+                                Reps
+                                <input
+                                    type="number"
+                                    min={1}
+                                    value={runner.draft.reps}
+                                    onChange={event => runner.updateDraft({ reps: Number(event.target.value) })}
+                                />
+                            </label>
+                            <label>
+                                Weight (kg)
+                                <input
+                                    type="number"
+                                    step="0.5"
+                                    min={0}
+                                    placeholder="bodyweight"
+                                    value={runner.draft.weightKg ?? ''}
+                                    onChange={event => runner.updateDraft({ weightKg: event.target.value === '' ? null : Number(event.target.value) })}
+                                />
+                            </label>
+                            <label>
+                                <input
+                                    type="checkbox"
+                                    checked={runner.draft.isWarmup}
+                                    onChange={event => runner.updateDraft({ isWarmup: event.target.checked })}
+                                />
+                                Warm-up
+                            </label>
+
+                            <label>
+                                Gauge
+                                <select value={gaugeScale} onChange={event => onGaugeScaleChange(event.target.value as IntensityGauge['scale'] | '')}>
+                                    <option value="">None</option>
+                                    <option value="rir">RIR (reps in reserve)</option>
+                                    <option value="rpe_rts">RPE (1-10)</option>
+                                    <option value="velocity_loss">Velocity loss %</option>
+                                    <option value="technical">Technical quality</option>
+                                </select>
+                            </label>
+
+                            {runner.draft.gauge?.scale === 'rir' && (
+                                <input type="number" min={0} max={10} value={runner.draft.gauge.value} onChange={event => runner.updateDraft({ gauge: { scale: 'rir', value: Number(event.target.value) } })} />
+                            )}
+                            {runner.draft.gauge?.scale === 'rpe_rts' && (
+                                <input type="number" min={1} max={10} step="0.5" value={runner.draft.gauge.value} onChange={event => runner.updateDraft({ gauge: { scale: 'rpe_rts', value: Number(event.target.value) } })} />
+                            )}
+                            {runner.draft.gauge?.scale === 'velocity_loss' && (
+                                <input type="number" min={0} value={runner.draft.gauge.percent} onChange={event => runner.updateDraft({ gauge: { scale: 'velocity_loss', percent: Number(event.target.value) } })} />
+                            )}
+                            {runner.draft.gauge?.scale === 'technical' && (
+                                <label>
+                                    <input
+                                        type="checkbox"
+                                        checked={runner.draft.gauge.met}
+                                        onChange={event => runner.updateDraft({ gauge: { scale: 'technical', met: event.target.checked } })}
+                                    />
+                                    Quality met
+                                </label>
+                            )}
+
+                            {activePlanned && (
+                                <p className="strength-target-hint">
+                                    Target: {activePlanned.targetSets} × {activePlanned.targetReps ?? '?'}
+                                    {activePlanned.targetGauge ? ` @ ${gaugeLabel(activePlanned.targetGauge)}` : ''}
+                                </p>
+                            )}
+
+                            <button type="button" className="strength-log-set-btn" disabled={runner.saving} onClick={() => void runner.logSet()}>
+                                {runner.saving ? 'Saving…' : 'Log set'}
+                            </button>
+                        </div>
+                    )}
+                </div>
+            )}
+
+            {runner.error && <p className="strength-error">{runner.error}</p>}
+
+            {!isClosed && (
+                <div className="strength-session-actions">
+                    <button type="button" onClick={() => void runner.finishSession()}>Finish session</button>
+                    <button type="button" className="strength-abandon-btn" onClick={() => void runner.abandonSession()}>Abandon</button>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/app/src/hooks/useStrengthSessionRunner.ts
+++ b/app/src/hooks/useStrengthSessionRunner.ts
@@ -1,0 +1,168 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { StrengthSession } from '../engine/models';
+import { strengthSessionService } from '../services/strengthSessionService';
+import { recommendationService } from '../services/recommendationService';
+import { getLocalDateString } from '../utils/localDate';
+import {
+    appendSetToExercise,
+    buildLoggedSet,
+    extractPlannedStrengthExercises,
+    prefillNextSet,
+    upsertExercise,
+    type PlannedStrengthExercise,
+    type SetEntryDraft,
+} from '../workouts/strengthSessionEntry';
+
+/** Thin orchestration over `strengthSessionEntry.ts` (pure logic, fully unit-tested) and
+ *  `strengthSessionService.ts` (I/O, fully unit-tested). This repo has no
+ *  `@testing-library/react` and no hook has its own test file (e.g. `useGarminSyncStatus`);
+ *  the rules that matter are tested at the layers below, not here. */
+export interface UseStrengthSessionRunnerResult {
+    loading: boolean;
+    saving: boolean;
+    error: string | null;
+    session: StrengthSession | null;
+    plannedExercises: PlannedStrengthExercise[];
+    activeExerciseIndex: number | null;
+    draft: SetEntryDraft;
+    start: () => Promise<void>;
+    selectExercise: (exerciseId: string | null, freeTextName?: string) => void;
+    updateDraft: (patch: Partial<SetEntryDraft>) => void;
+    logSet: () => Promise<void>;
+    finishSession: () => Promise<void>;
+    abandonSession: () => Promise<void>;
+}
+
+const EMPTY_DRAFT: SetEntryDraft = { reps: 1, weightKg: null, isWarmup: false };
+
+export function useStrengthSessionRunner(userId: string | null | undefined): UseStrengthSessionRunnerResult {
+    const [loading, setLoading] = useState(true);
+    const [saving, setSaving] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [session, setSession] = useState<StrengthSession | null>(null);
+    const [plannedExercises, setPlannedExercises] = useState<PlannedStrengthExercise[]>([]);
+    const [activeExerciseIndex, setActiveExerciseIndex] = useState<number | null>(null);
+    const [draft, setDraft] = useState<SetEntryDraft>(EMPTY_DRAFT);
+
+    // Resume-on-open: an in_progress session left from earlier today (or last night, if it
+    // crosses midnight -- findActiveSession deliberately ignores `date` for this) is
+    // restored rather than silently orphaned. This is also where a stale session gets
+    // abandoned (S1.4), so opening the runner is the "opportunistic" trigger the service
+    // was designed around.
+    useEffect(() => {
+        if (!userId) {
+            setLoading(false);
+            return;
+        }
+        let cancelled = false;
+        setLoading(true);
+        strengthSessionService.findActiveSession(userId)
+            .then(async active => {
+                if (cancelled) return;
+                setSession(active);
+                if (active?.sourceRecommendationDate) {
+                    const recommendation = await recommendationService.getRecommendation(userId, active.sourceRecommendationDate);
+                    if (!cancelled) setPlannedExercises(extractPlannedStrengthExercises(recommendation?.prescription));
+                }
+            })
+            .catch(err => {
+                if (!cancelled) setError(err instanceof Error ? err.message : 'Could not load an active strength session');
+            })
+            .finally(() => {
+                if (!cancelled) setLoading(false);
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, [userId]);
+
+    const start = useCallback(async () => {
+        if (!userId) return;
+        setError(null);
+        try {
+            const today = getLocalDateString();
+            const recommendation = await recommendationService.getRecommendation(userId, today);
+            const planned = extractPlannedStrengthExercises(recommendation?.prescription);
+            const started = await strengthSessionService.startSession(userId, {
+                ...(planned.length > 0 ? { sourceRecommendationDate: today } : {}),
+            });
+            setSession(started);
+            setPlannedExercises(planned);
+            setActiveExerciseIndex(null);
+            setDraft(EMPTY_DRAFT);
+        } catch (err) {
+            setError(err instanceof Error ? err.message : 'Could not start a strength session');
+        }
+    }, [userId]);
+
+    const selectExercise = useCallback((exerciseId: string | null, freeTextName?: string) => {
+        if (!session) return;
+        const updated = upsertExercise(session.exercises, exerciseId, freeTextName);
+        const isNewlyAdded = updated.length > session.exercises.length;
+        const index = exerciseId !== null
+            ? updated.findIndex(exercise => exercise.exerciseId === exerciseId)
+            : updated.length - 1;
+        setActiveExerciseIndex(index);
+        const plan = exerciseId !== null ? plannedExercises.find(planned => planned.exerciseId === exerciseId) : undefined;
+        setDraft(prefillNextSet(updated[index]?.sets ?? [], plan));
+        if (isNewlyAdded) {
+            setSession({ ...session, exercises: updated });
+            // Persisted immediately, matching every other write in this hook -- an added
+            // exercise with zero sets is still real session state (e.g. "planned but not
+            // yet started"), not something to lose on a killed app before the first set.
+            strengthSessionService.saveExercises(userId!, session.sessionId, updated).catch(err => {
+                setError(err instanceof Error ? err.message : 'Could not save the selected exercise');
+            });
+        }
+    }, [session, plannedExercises, userId]);
+
+    const updateDraft = useCallback((patch: Partial<SetEntryDraft>) => {
+        setDraft(current => ({ ...current, ...patch }));
+    }, []);
+
+    const logSet = useCallback(async () => {
+        if (!session || activeExerciseIndex === null) return;
+        setError(null);
+        const currentSets = session.exercises[activeExerciseIndex]?.sets ?? [];
+        const result = buildLoggedSet(draft, currentSets, new Date().toISOString());
+        if (!result.ok) {
+            setError(result.error);
+            return;
+        }
+        const updatedExercises = appendSetToExercise(session.exercises, activeExerciseIndex, result.set);
+        setSaving(true);
+        try {
+            // D-SETLOG: persist the moment the set is logged, not batched until "Done".
+            // await resolves against the local cache immediately even offline (S1.1); it
+            // does not wait for a server round-trip.
+            await strengthSessionService.saveExercises(userId!, session.sessionId, updatedExercises);
+            const updatedSession = { ...session, exercises: updatedExercises };
+            setSession(updatedSession);
+            const plan = plannedExercises.find(planned => planned.exerciseId === updatedExercises[activeExerciseIndex]?.exerciseId);
+            setDraft(prefillNextSet(updatedExercises[activeExerciseIndex]?.sets ?? [], plan));
+        } catch (err) {
+            setError(err instanceof Error ? err.message : 'Could not save that set');
+        } finally {
+            setSaving(false);
+        }
+    }, [session, activeExerciseIndex, draft, plannedExercises, userId]);
+
+    const closeSession = useCallback(async (next: 'completed' | 'abandoned') => {
+        if (!session) return;
+        setError(null);
+        try {
+            const updated = await strengthSessionService.transitionState(userId!, session.sessionId, next);
+            setSession(updated);
+        } catch (err) {
+            setError(err instanceof Error ? err.message : `Could not mark the session ${next}`);
+        }
+    }, [session, userId]);
+
+    const finishSession = useCallback(() => closeSession('completed'), [closeSession]);
+    const abandonSession = useCallback(() => closeSession('abandoned'), [closeSession]);
+
+    return {
+        loading, saving, error, session, plannedExercises, activeExerciseIndex, draft,
+        start, selectExercise, updateDraft, logSet, finishSession, abandonSession,
+    };
+}

--- a/app/src/hooks/useStrengthSessionRunner.ts
+++ b/app/src/hooks/useStrengthSessionRunner.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import type { StrengthSession } from '../engine/models';
+import type { LoggedExercise, LoggedSet, StrengthSession } from '../engine/models';
 import { strengthSessionService } from '../services/strengthSessionService';
 import { recommendationService } from '../services/recommendationService';
 import { getLocalDateString } from '../utils/localDate';
@@ -25,6 +25,7 @@ export interface UseStrengthSessionRunnerResult {
     plannedExercises: PlannedStrengthExercise[];
     activeExerciseIndex: number | null;
     draft: SetEntryDraft;
+    syncStatusForSet: (exercise: LoggedExercise, set: LoggedSet) => 'synced' | 'pending' | 'unavailable';
     start: () => Promise<void>;
     selectExercise: (exerciseId: string | null, freeTextName?: string) => void;
     updateDraft: (patch: Partial<SetEntryDraft>) => void;
@@ -35,6 +36,14 @@ export interface UseStrengthSessionRunnerResult {
 
 const EMPTY_DRAFT: SetEntryDraft = { reps: 1, weightKg: null, isWarmup: false };
 
+function setSyncKey(exercise: LoggedExercise, set: LoggedSet): string {
+    return `${exercise.exerciseId ?? `free:${exercise.freeTextName ?? ''}`}:${set.setIndex}:${set.completedAt}`;
+}
+
+function sessionSetKeys(session: StrengthSession): Set<string> {
+    return new Set(session.exercises.flatMap(exercise => exercise.sets.map(set => setSyncKey(exercise, set))));
+}
+
 export function useStrengthSessionRunner(userId: string | null | undefined): UseStrengthSessionRunnerResult {
     const [loading, setLoading] = useState(true);
     const [saving, setSaving] = useState(false);
@@ -43,6 +52,9 @@ export function useStrengthSessionRunner(userId: string | null | undefined): Use
     const [plannedExercises, setPlannedExercises] = useState<PlannedStrengthExercise[]>([]);
     const [activeExerciseIndex, setActiveExerciseIndex] = useState<number | null>(null);
     const [draft, setDraft] = useState<SetEntryDraft>(EMPTY_DRAFT);
+    const [acknowledgedSetKeys, setAcknowledgedSetKeys] = useState<Set<string>>(() => new Set());
+    const [syncUnavailable, setSyncUnavailable] = useState(false);
+    const observedSessionId = session?.sessionId;
 
     // Resume-on-open: an in_progress session left from earlier today (or last night, if it
     // crosses midnight -- findActiveSession deliberately ignores `date` for this) is
@@ -76,9 +88,31 @@ export function useStrengthSessionRunner(userId: string | null | undefined): Use
         };
     }, [userId]);
 
+    useEffect(() => {
+        if (!userId || !observedSessionId) {
+            setAcknowledgedSetKeys(new Set());
+            setSyncUnavailable(false);
+            return;
+        }
+        return strengthSessionService.observeSession(userId, observedSessionId, (state, hasPendingWrites) => {
+            if (state.status === 'UNAVAILABLE' || state.status === 'INVALID') {
+                setSyncUnavailable(true);
+                return;
+            }
+            setSyncUnavailable(false);
+            // A pending snapshot contains both previously acknowledged sets and the new
+            // local mutation. Preserve the last server-acknowledged keys until metadata
+            // flips false; otherwise every older set would incorrectly turn pending too.
+            if (state.status === 'AVAILABLE' && !hasPendingWrites) {
+                setAcknowledgedSetKeys(sessionSetKeys(state.data));
+            }
+        });
+    }, [userId, observedSessionId]);
+
     const start = useCallback(async () => {
-        if (!userId) return;
+        if (!userId || saving) return;
         setError(null);
+        setSaving(true);
         try {
             const today = getLocalDateString();
             const recommendation = await recommendationService.getRecommendation(userId, today);
@@ -92,11 +126,13 @@ export function useStrengthSessionRunner(userId: string | null | undefined): Use
             setDraft(EMPTY_DRAFT);
         } catch (err) {
             setError(err instanceof Error ? err.message : 'Could not start a strength session');
+        } finally {
+            setSaving(false);
         }
-    }, [userId]);
+    }, [userId, saving]);
 
     const selectExercise = useCallback((exerciseId: string | null, freeTextName?: string) => {
-        if (!session) return;
+        if (!session || saving) return;
         const updated = upsertExercise(session.exercises, exerciseId, freeTextName);
         const isNewlyAdded = updated.length > session.exercises.length;
         const index = exerciseId !== null
@@ -110,11 +146,14 @@ export function useStrengthSessionRunner(userId: string | null | undefined): Use
             // Persisted immediately, matching every other write in this hook -- an added
             // exercise with zero sets is still real session state (e.g. "planned but not
             // yet started"), not something to lose on a killed app before the first set.
-            strengthSessionService.saveExercises(userId!, session.sessionId, updated).catch(err => {
-                setError(err instanceof Error ? err.message : 'Could not save the selected exercise');
-            });
+            setSaving(true);
+            strengthSessionService.saveExercises(userId!, session.sessionId, updated)
+                .catch(err => {
+                    setError(err instanceof Error ? err.message : 'Could not save the selected exercise');
+                })
+                .finally(() => setSaving(false));
         }
-    }, [session, plannedExercises, userId]);
+    }, [session, plannedExercises, userId, saving]);
 
     const updateDraft = useCallback((patch: Partial<SetEntryDraft>) => {
         setDraft(current => ({ ...current, ...patch }));
@@ -148,21 +187,30 @@ export function useStrengthSessionRunner(userId: string | null | undefined): Use
     }, [session, activeExerciseIndex, draft, plannedExercises, userId]);
 
     const closeSession = useCallback(async (next: 'completed' | 'abandoned') => {
-        if (!session) return;
+        if (!session || saving) return;
         setError(null);
+        setSaving(true);
         try {
             const updated = await strengthSessionService.transitionState(userId!, session.sessionId, next);
             setSession(updated);
         } catch (err) {
             setError(err instanceof Error ? err.message : `Could not mark the session ${next}`);
+        } finally {
+            setSaving(false);
         }
-    }, [session, userId]);
+    }, [session, userId, saving]);
 
     const finishSession = useCallback(() => closeSession('completed'), [closeSession]);
     const abandonSession = useCallback(() => closeSession('abandoned'), [closeSession]);
 
+    const syncStatusForSet = useCallback((exercise: LoggedExercise, set: LoggedSet) => {
+        if (syncUnavailable) return 'unavailable' as const;
+        return acknowledgedSetKeys.has(setSyncKey(exercise, set)) ? 'synced' as const : 'pending' as const;
+    }, [acknowledgedSetKeys, syncUnavailable]);
+
     return {
         loading, saving, error, session, plannedExercises, activeExerciseIndex, draft,
+        syncStatusForSet,
         start, selectExercise, updateDraft, logSet, finishSession, abandonSession,
     };
 }

--- a/app/src/services/strengthSessionService.test.ts
+++ b/app/src/services/strengthSessionService.test.ts
@@ -6,6 +6,7 @@ const firestore = vi.hoisted(() => {
         doc: vi.fn(),
         getDoc: vi.fn(),
         getDocs: vi.fn(),
+        onSnapshot: vi.fn(),
         orderBy: vi.fn(),
         query: vi.fn(),
         setDoc: vi.fn(),
@@ -86,6 +87,19 @@ describe('StrengthSessionService', () => {
         it('carries an optional sourceRecommendationDate when the session started from a prescription', async () => {
             const session = await service.startSession(USER_ID, { startedAt: '2026-08-17T18:00:00Z', sourceRecommendationDate: '2026-08-17' });
             expect(session.sourceRecommendationDate).toBe('2026-08-17');
+        });
+    });
+
+    describe('observeSession', () => {
+        it('reports Firestore pending-write metadata', () => {
+            const unsubscribe = vi.fn();
+            firestore.onSnapshot.mockImplementationOnce((_ref, _options, next) => {
+                next({ id: SESSION_ID, ref: { path: `users/${USER_ID}/strength_sessions/${SESSION_ID}` }, exists: () => true, data: () => validSession(), metadata: { hasPendingWrites: true } });
+                return unsubscribe;
+            });
+            const listener = vi.fn();
+            expect(service.observeSession(USER_ID, SESSION_ID, listener)).toBe(unsubscribe);
+            expect(listener).toHaveBeenCalledWith(expect.objectContaining({ status: 'AVAILABLE' }), true);
         });
     });
 
@@ -205,6 +219,12 @@ describe('StrengthSessionService', () => {
             const [, payload, options] = firestore.setDoc.mock.calls[0] as [unknown, Record<string, unknown>, Record<string, unknown>];
             expect(payload).toEqual({ exercises, updatedAt: '2026-08-17T18:10:00Z' });
             expect(options).toEqual({ merge: true });
+        });
+
+        it('rejects invalid nested set data before writing', async () => {
+            const exercises = [{ exerciseId: 'bench_press', sets: [{ setIndex: 1, reps: 1001, weightKg: 60, isWarmup: false, completedAt: '2026-08-17T18:10:00Z' }] }];
+            await expect(service.saveExercises(USER_ID, SESSION_ID, exercises)).rejects.toThrow('schema bounds');
+            expect(firestore.setDoc).not.toHaveBeenCalled();
         });
     });
 });

--- a/app/src/services/strengthSessionService.test.ts
+++ b/app/src/services/strengthSessionService.test.ts
@@ -155,4 +155,40 @@ describe('StrengthSessionService', () => {
             expect(firestore.setDoc).not.toHaveBeenCalled();
         });
     });
+
+    describe('findActiveSession', () => {
+        it('returns null when nothing is in progress', async () => {
+            firestore.getDocs.mockResolvedValueOnce({ docs: [] });
+            expect(await service.findActiveSession(USER_ID, '2026-08-17T18:00:00Z')).toBeNull();
+        });
+
+        it('returns a fresh in_progress session, even if its date field is yesterday (started before midnight)', async () => {
+            firestore.getDocs.mockResolvedValueOnce({
+                docs: [{ id: SESSION_ID, ref: { path: `users/${USER_ID}/strength_sessions/${SESSION_ID}` }, data: () => validSession({ date: '2026-08-16', startedAt: '2026-08-16T23:50:00Z' }) }],
+            });
+            const active = await service.findActiveSession(USER_ID, '2026-08-17T00:10:00Z');
+            expect(active).toMatchObject({ sessionId: SESSION_ID, state: 'in_progress' });
+        });
+
+        it('abandons a stale session it walks past rather than returning it as resumable', async () => {
+            firestore.getDocs.mockResolvedValueOnce({
+                docs: [{ id: SESSION_ID, ref: { path: `users/${USER_ID}/strength_sessions/${SESSION_ID}` }, data: () => validSession({ startedAt: '2026-08-17T06:00:00Z' }) }],
+            });
+            existingDoc(validSession({ startedAt: '2026-08-17T06:00:00Z' }));
+            const active = await service.findActiveSession(USER_ID, '2026-08-17T18:00:00Z');
+            expect(active).toBeNull();
+            expect(firestore.setDoc).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('saveExercises', () => {
+        it('merges exercises and updatedAt without rewriting the rest of the document', async () => {
+            const exercises = [{ exerciseId: 'bench_press', sets: [{ setIndex: 1, reps: 5, weightKg: 60, isWarmup: false, completedAt: '2026-08-17T18:10:00Z' }] }];
+            await service.saveExercises(USER_ID, SESSION_ID, exercises, '2026-08-17T18:10:00Z');
+            expect(firestore.setDoc).toHaveBeenCalledTimes(1);
+            const [, payload, options] = firestore.setDoc.mock.calls[0] as [unknown, Record<string, unknown>, Record<string, unknown>];
+            expect(payload).toEqual({ exercises, updatedAt: '2026-08-17T18:10:00Z' });
+            expect(options).toEqual({ merge: true });
+        });
+    });
 });

--- a/app/src/services/strengthSessionService.ts
+++ b/app/src/services/strengthSessionService.ts
@@ -1,4 +1,4 @@
-import { collection, doc, getDoc, getDocs, orderBy, query, setDoc, where } from 'firebase/firestore';
+import { collection, doc, getDoc, getDocs, onSnapshot, orderBy, query, setDoc, where, type Unsubscribe } from 'firebase/firestore';
 import { getDb } from '../firebase';
 import type { LoggedExercise, StrengthSession, StrengthSessionState } from '../engine/models';
 import type { DataState } from '../engine/dataState';
@@ -9,7 +9,7 @@ import {
 } from '../engine/strengthSessionLifecycle';
 import { parseStrengthSession } from '../persistence/parsers/strengthSession';
 import { isPermissionDeniedError } from '../utils/errors';
-import { isValidStrengthInstant } from '../engine/strengthSessionValidation';
+import { areValidLoggedExercises, isValidStrengthInstant } from '../engine/strengthSessionValidation';
 
 /**
  * Storage for `users/{userId}/strength_sessions/{sessionId}` (ADR-0021, S1.4). State
@@ -38,6 +38,25 @@ export class StrengthSessionService {
     async getSession(userId: string, sessionId: string): Promise<StrengthSession | null> {
         const state = await this.getSessionState(userId, sessionId);
         return state.status === 'AVAILABLE' ? state.data : null;
+    }
+
+    observeSession(
+        userId: string,
+        sessionId: string,
+        listener: (state: DataState<StrengthSession>, hasPendingWrites: boolean) => void,
+    ): Unsubscribe {
+        const docRef = doc(getDb(), 'users', userId, this.collectionPath, sessionId);
+        return onSnapshot(docRef, { includeMetadataChanges: true }, snapshot => {
+            if (!snapshot.exists()) {
+                listener({ status: 'MISSING' }, snapshot.metadata.hasPendingWrites);
+                return;
+            }
+            listener(parseStrengthSession(snapshot.data(), snapshot.ref.path, snapshot.id, userId), snapshot.metadata.hasPendingWrites);
+        }, error => listener({
+            status: 'UNAVAILABLE',
+            operation: 'observe strength session sync',
+            retryable: !isPermissionDeniedError(error),
+        }, false));
     }
 
     /** Starts a new `in_progress` session. The document id is generated client-side (via
@@ -150,6 +169,8 @@ export class StrengthSessionService {
      *  style -- simple and correct at this document's bounded size (rules cap `exercises`
      *  at 30), not the cheapest possible payload at larger scale. */
     async saveExercises(userId: string, sessionId: string, exercises: LoggedExercise[], nowIso: string = new Date().toISOString()): Promise<void> {
+        if (!isValidStrengthInstant(nowIso)) throw new Error('Strength session update time must be a valid instant');
+        if (!areValidLoggedExercises(exercises)) throw new Error('Strength session exercises exceed schema bounds or contain invalid sets');
         const docRef = doc(getDb(), 'users', userId, this.collectionPath, sessionId);
         await setDoc(docRef, { exercises, updatedAt: nowIso }, { merge: true });
     }

--- a/app/src/services/strengthSessionService.ts
+++ b/app/src/services/strengthSessionService.ts
@@ -1,6 +1,6 @@
 import { collection, doc, getDoc, getDocs, orderBy, query, setDoc, where } from 'firebase/firestore';
 import { getDb } from '../firebase';
-import type { StrengthSession, StrengthSessionState } from '../engine/models';
+import type { LoggedExercise, StrengthSession, StrengthSessionState } from '../engine/models';
 import type { DataState } from '../engine/dataState';
 import {
     buildNewStrengthSession,
@@ -112,6 +112,37 @@ export class StrengthSessionService {
             }
         }
         return abandoned;
+    }
+
+    /** Resumable session, if any -- the most recent `in_progress` session regardless of its
+     *  `date` field, since a session that started late at night is still resumable after
+     *  local midnight even though `date` (fixed at S1.4's session START) no longer equals
+     *  today. Walks past-and-abandons any stale session it encounters on the way, so a
+     *  caller never has to run `reconcileStaleSessions` separately first. */
+    async findActiveSession(userId: string, nowIso: string = new Date().toISOString()): Promise<StrengthSession | null> {
+        const collRef = collection(getDb(), 'users', userId, this.collectionPath);
+        const q = query(collRef, where('state', '==', 'in_progress'), orderBy('startedAt', 'desc'));
+        const querySnapshot = await getDocs(q);
+        for (const docSnap of querySnapshot.docs) {
+            const parsed = parseStrengthSession(docSnap.data(), docSnap.ref.path, docSnap.id, userId);
+            if (parsed.status !== 'AVAILABLE') continue;
+            if (isStaleInProgressSession(parsed.data, nowIso)) {
+                await this.transitionState(userId, docSnap.id, 'abandoned', nowIso);
+                continue;
+            }
+            return parsed.data;
+        }
+        return null;
+    }
+
+    /** Persists the session's `exercises` array as its own write, immediately after every
+     *  logged set (D-SETLOG: per-set persistence, not batched until "Done"). A merge write
+     *  of the whole array, matching `decisionJournalService.write`'s whole-object-merge
+     *  style -- simple and correct at this document's bounded size (rules cap `exercises`
+     *  at 30), not the cheapest possible payload at larger scale. */
+    async saveExercises(userId: string, sessionId: string, exercises: LoggedExercise[], nowIso: string = new Date().toISOString()): Promise<void> {
+        const docRef = doc(getDb(), 'users', userId, this.collectionPath, sessionId);
+        await setDoc(docRef, { exercises, updatedAt: nowIso }, { merge: true });
     }
 }
 

--- a/app/src/types/navigation.ts
+++ b/app/src/types/navigation.ts
@@ -1,1 +1,1 @@
-export type Screen = 'home' | 'checkin' | 'goals' | 'constraints' | 'preferences' | 'data' | 'plan' | 'brief';
+export type Screen = 'home' | 'checkin' | 'goals' | 'constraints' | 'preferences' | 'data' | 'plan' | 'brief' | 'strength';

--- a/app/src/workouts/strengthSessionEntry.test.ts
+++ b/app/src/workouts/strengthSessionEntry.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+import {
+    appendSetToExercise,
+    buildLoggedSet,
+    extractPlannedStrengthExercises,
+    nextSetIndex,
+    prefillNextSet,
+    upsertExercise,
+} from './strengthSessionEntry';
+import type { LoggedExercise, LoggedSet } from '../engine/models';
+import type { WorkoutPrescription } from './models';
+
+function loggedSet(overrides: Partial<LoggedSet> = {}): LoggedSet {
+    return { setIndex: 1, weightKg: 80, reps: 3, isWarmup: false, completedAt: '2026-08-17T18:02:00Z', ...overrides };
+}
+
+describe('extractPlannedStrengthExercises', () => {
+    function prescriptionWithBlocks(blocks: WorkoutPrescription['adjustedBlocks']): WorkoutPrescription {
+        return { adjustedBlocks: blocks } as WorkoutPrescription;
+    }
+
+    it('returns an empty plan for manual entry (no prescription)', () => {
+        expect(extractPlannedStrengthExercises(undefined)).toEqual([]);
+        expect(extractPlannedStrengthExercises(null)).toEqual([]);
+    });
+
+    it('extracts exerciseId, sets and reps from adjustedBlocks, not displayBlocks', () => {
+        const prescription = prescriptionWithBlocks([{
+            id: 'main', name: 'Upper-body strength', role: 'main',
+            steps: [{ id: 'upper_bench', exerciseId: 'bench_press', name: 'Bench press', duration: { type: 'repetitions', repetitions: 6 }, sets: 3, target: { type: 'reps_in_reserve', min: 3, max: 6 } }],
+        }]);
+        const planned = extractPlannedStrengthExercises(prescription);
+        expect(planned).toEqual([{ exerciseId: 'bench_press', name: 'Bench press', targetSets: 3, targetReps: 6, targetGauge: { scale: 'rir', value: 5 }, optional: false }]);
+    });
+
+    it('maps a technical_quality target to a suggested technical gauge', () => {
+        const prescription = prescriptionWithBlocks([{
+            id: 'main', name: 'Trunk', role: 'main',
+            steps: [{ id: 'trunk', exerciseId: 'dead_bug', name: 'Dead bug', duration: { type: 'repetitions', repetitions: 8 }, target: { type: 'technical_quality', cue: 'No trunk compensation.' } }],
+        }]);
+        const planned = extractPlannedStrengthExercises(prescription);
+        expect(planned[0]?.targetGauge).toEqual({ scale: 'technical', met: true });
+    });
+
+    it('degrades a non-strength target (e.g. ftp_percent) to no suggestion rather than a guess', () => {
+        const prescription = prescriptionWithBlocks([{
+            id: 'main', name: 'Odd', role: 'main',
+            steps: [{ id: 'odd', exerciseId: 'front_squat', name: 'Front squat', duration: { type: 'repetitions', repetitions: 5 }, target: { type: 'ftp_percent', min: 80, max: 90 } }],
+        }]);
+        expect(extractPlannedStrengthExercises(prescription)[0]?.targetGauge).toBeNull();
+    });
+
+    it('defaults targetSets to 1 and optional to false when absent', () => {
+        const prescription = prescriptionWithBlocks([{
+            id: 'main', name: 'Main', role: 'main',
+            steps: [{ id: 'step', exerciseId: 'goblet_squat', name: 'Goblet squat', duration: { type: 'repetitions', repetitions: 10 } }],
+        }]);
+        expect(extractPlannedStrengthExercises(prescription)[0]).toMatchObject({ targetSets: 1, optional: false, targetReps: 10 });
+    });
+});
+
+describe('prefillNextSet', () => {
+    it('prefills from the literal previous set, weight and reps carried forward', () => {
+        const draft = prefillNextSet([loggedSet({ reps: 3, weightKg: 80, gauge: { scale: 'rir', value: 3 } })]);
+        expect(draft).toEqual({ reps: 3, weightKg: 80, gauge: { scale: 'rir', value: 3 }, isWarmup: false });
+    });
+
+    it('always defaults isWarmup to false on prefill, even if the previous set was a warm-up', () => {
+        const draft = prefillNextSet([loggedSet({ isWarmup: true })]);
+        expect(draft.isWarmup).toBe(false);
+    });
+
+    it('falls back to the prescribed target when no set has been logged yet', () => {
+        const draft = prefillNextSet([], { exerciseId: 'bench_press', name: 'Bench press', targetSets: 3, targetReps: 6, targetGauge: { scale: 'rir', value: 4 }, optional: false });
+        expect(draft).toEqual({ reps: 6, weightKg: null, gauge: { scale: 'rir', value: 4 }, isWarmup: false });
+    });
+
+    it('falls back to a bare default with no prescription and no history at all', () => {
+        expect(prefillNextSet([])).toEqual({ reps: 1, weightKg: null, isWarmup: false });
+    });
+});
+
+describe('nextSetIndex', () => {
+    it('starts at 1 for an exercise with no logged sets', () => {
+        expect(nextSetIndex([])).toBe(1);
+    });
+
+    it('continues from the highest existing setIndex, not the array length', () => {
+        expect(nextSetIndex([loggedSet({ setIndex: 1 }), loggedSet({ setIndex: 3 })])).toBe(4);
+    });
+});
+
+describe('buildLoggedSet', () => {
+    it('builds a valid set with the next sequential index', () => {
+        const result = buildLoggedSet({ reps: 3, weightKg: 82.5, isWarmup: false }, [loggedSet({ setIndex: 1 })], '2026-08-17T18:04:00Z');
+        expect(result).toEqual({ ok: true, set: { setIndex: 2, weightKg: 82.5, reps: 3, isWarmup: false, completedAt: '2026-08-17T18:04:00Z' } });
+    });
+
+    it('rejects zero or negative reps with an inline error rather than building a set', () => {
+        expect(buildLoggedSet({ reps: 0, weightKg: 80, isWarmup: false }, [], '2026-08-17T18:04:00Z')).toEqual({ ok: false, error: expect.stringMatching(/reps/i) });
+        expect(buildLoggedSet({ reps: -3, weightKg: 80, isWarmup: false }, [], '2026-08-17T18:04:00Z').ok).toBe(false);
+    });
+
+    it('accepts null weight as bodyweight', () => {
+        const result = buildLoggedSet({ reps: 10, weightKg: null, isWarmup: false }, [], '2026-08-17T18:04:00Z');
+        expect(result).toMatchObject({ ok: true, set: { weightKg: null } });
+    });
+
+    it('rejects a negative weight rather than silently clamping it', () => {
+        expect(buildLoggedSet({ reps: 5, weightKg: -10, isWarmup: false }, [], '2026-08-17T18:04:00Z').ok).toBe(false);
+    });
+
+    it('carries the gauge through untouched when present', () => {
+        const result = buildLoggedSet({ reps: 3, weightKg: 85, gauge: { scale: 'velocity_loss', percent: 18 }, isWarmup: false }, [], '2026-08-17T18:04:00Z');
+        expect(result).toMatchObject({ ok: true, set: { gauge: { scale: 'velocity_loss', percent: 18 } } });
+    });
+});
+
+describe('upsertExercise', () => {
+    it('adds a new exercise by exerciseId', () => {
+        expect(upsertExercise([], 'bench_press')).toEqual([{ exerciseId: 'bench_press', sets: [] }]);
+    });
+
+    it('is a no-op re-adding the same exerciseId (confirm-or-amend on a prescribed exercise)', () => {
+        const existing: LoggedExercise[] = [{ exerciseId: 'bench_press', sets: [loggedSet()] }];
+        expect(upsertExercise(existing, 'bench_press')).toEqual(existing);
+    });
+
+    it('treats every free-text exercise as a distinct entry, even with the same name', () => {
+        const withFirst = upsertExercise([], null, 'Farmer carry');
+        const withSecond = upsertExercise(withFirst, null, 'Farmer carry');
+        expect(withSecond).toHaveLength(2);
+    });
+});
+
+describe('appendSetToExercise', () => {
+    it('appends a set to the exercise at the given index and leaves others untouched', () => {
+        const exercises: LoggedExercise[] = [{ exerciseId: 'bench_press', sets: [] }, { exerciseId: 'pull_up', sets: [loggedSet()] }];
+        const updated = appendSetToExercise(exercises, 0, loggedSet({ setIndex: 1, weightKg: 60 }));
+        expect(updated[0]?.sets).toEqual([loggedSet({ setIndex: 1, weightKg: 60 })]);
+        expect(updated[1]).toBe(exercises[1]);
+    });
+});

--- a/app/src/workouts/strengthSessionEntry.ts
+++ b/app/src/workouts/strengthSessionEntry.ts
@@ -1,4 +1,11 @@
 import type { IntensityGauge, LoggedExercise, LoggedSet } from '../engine/models';
+import {
+    MAX_REPS_PER_SET,
+    MAX_SETS_PER_EXERCISE,
+    MAX_WEIGHT_KG,
+    isValidIntensityGauge,
+    isValidStrengthInstant,
+} from '../engine/strengthSessionValidation';
 import type { IntensityTarget, WorkoutPrescription } from './models';
 
 /**
@@ -94,11 +101,20 @@ export type BuildSetResult = { ok: true; set: LoggedSet } | { ok: false; error: 
  *  convenience, not the enforcement point; `parseStrengthSession` (S1.2) and the Firestore
  *  rules (S1.3) remain the real gates. */
 export function buildLoggedSet(draft: SetEntryDraft, loggedSets: readonly LoggedSet[], completedAtIso: string): BuildSetResult {
-    if (!Number.isFinite(draft.reps) || draft.reps <= 0) {
-        return { ok: false, error: 'Enter reps greater than zero' };
+    if (!Number.isInteger(draft.reps) || draft.reps <= 0 || draft.reps > MAX_REPS_PER_SET) {
+        return { ok: false, error: `Enter whole-number reps between 1 and ${MAX_REPS_PER_SET}` };
     }
-    if (draft.weightKg !== null && (!Number.isFinite(draft.weightKg) || draft.weightKg < 0)) {
+    if (draft.weightKg !== null && (!Number.isFinite(draft.weightKg) || draft.weightKg < 0 || draft.weightKg > MAX_WEIGHT_KG)) {
         return { ok: false, error: 'Enter a valid weight, or leave it blank for bodyweight' };
+    }
+    if (draft.gauge && !isValidIntensityGauge(draft.gauge)) {
+        return { ok: false, error: 'Enter a valid intensity gauge value' };
+    }
+    if (loggedSets.length >= MAX_SETS_PER_EXERCISE) {
+        return { ok: false, error: `An exercise cannot contain more than ${MAX_SETS_PER_EXERCISE} sets` };
+    }
+    if (!isValidStrengthInstant(completedAtIso)) {
+        return { ok: false, error: 'Could not determine when the set was completed' };
     }
     return {
         ok: true,

--- a/app/src/workouts/strengthSessionEntry.ts
+++ b/app/src/workouts/strengthSessionEntry.ts
@@ -1,0 +1,130 @@
+import type { IntensityGauge, LoggedExercise, LoggedSet } from '../engine/models';
+import type { IntensityTarget, WorkoutPrescription } from './models';
+
+/**
+ * Confirm-or-amend set entry logic for the S1.5 session runner (ADR-0021). Deliberately
+ * framework-free -- this repo has no `@testing-library/react` (component tests here are
+ * `renderToStaticMarkup` smoke tests, e.g. `GarminSyncBadge.test.tsx`, and no hook has ever
+ * had its own test file), so every rule that needs real unit coverage lives here as a plain
+ * function, and the React hook/component are thin orchestration over it.
+ */
+
+export interface PlannedStrengthExercise {
+    exerciseId: string;
+    name: string;
+    targetSets: number;
+    targetReps: number | null;
+    targetGauge: IntensityGauge | null;
+    optional: boolean;
+}
+
+/** Maps a prescribed `IntensityTarget` to a *suggested* `IntensityGauge` for prefill only.
+ *  This is not the D-GAUGE conversion the parser forbids (rir <-> rpe_rts on write) -- it
+ *  never touches persisted data, only seeds the entry form's initial value, which the
+ *  athlete confirms or amends before anything is logged. Only the two target types the
+ *  strength catalog actually uses for strength steps (verified against
+ *  `catalog/support-strength.ts`) map to a suggestion; everything else (rpe, ftp_percent,
+ *  heart_rate_zone, cadence, pace, estimated_1rm_percent) is a cycling/running target or a
+ *  target this repo's strength catalog doesn't emit, and degrades to no suggestion rather
+ *  than a guessed one. */
+function mapIntensityTargetToGauge(target: IntensityTarget | undefined): IntensityGauge | null {
+    if (!target) return null;
+    switch (target.type) {
+        case 'reps_in_reserve':
+            return { scale: 'rir', value: Math.round((target.min + target.max) / 2) };
+        case 'technical_quality':
+            return { scale: 'technical', met: true };
+        default:
+            return null;
+    }
+}
+
+/** Reads the structured `adjustedBlocks` (not `displayBlocks`, which is rendered text for
+ *  display and cannot be parsed back into structured targets) off a prescribed session, so
+ *  the entry form can seed each exercise with its target reps/gauge before any set is
+ *  logged. Returns `[]` for a session with no prescription (manual entry) or a non-strength
+ *  prescription -- never throws; a shape this can't extract from is simply not planned. */
+export function extractPlannedStrengthExercises(prescription: WorkoutPrescription | null | undefined): PlannedStrengthExercise[] {
+    if (!prescription?.adjustedBlocks) return [];
+    const planned: PlannedStrengthExercise[] = [];
+    for (const block of prescription.adjustedBlocks) {
+        for (const step of block.steps) {
+            const targetReps = step.duration.type === 'repetitions' ? step.duration.repetitions : null;
+            planned.push({
+                exerciseId: step.exerciseId,
+                name: step.name,
+                targetSets: step.sets ?? 1,
+                targetReps,
+                targetGauge: mapIntensityTargetToGauge(step.target),
+                optional: step.optional ?? false,
+            });
+        }
+    }
+    return planned;
+}
+
+export interface SetEntryDraft {
+    reps: number;
+    weightKg: number | null;
+    gauge?: IntensityGauge;
+    isWarmup: boolean;
+}
+
+/** The dominant pattern is same exercise, same reps, ascending load -- the athlete should
+ *  change one field (weight), not four. Prefills from the literal previous set for this
+ *  exercise, warm-up or working, matching what was actually just logged; with no previous
+ *  set, falls back to the prescribed target reps/gauge (still just a suggestion). */
+export function prefillNextSet(loggedSets: readonly LoggedSet[], planned?: PlannedStrengthExercise): SetEntryDraft {
+    const previous = loggedSets[loggedSets.length - 1];
+    if (previous) {
+        return { reps: previous.reps, weightKg: previous.weightKg, gauge: previous.gauge, isWarmup: false };
+    }
+    return { reps: planned?.targetReps ?? 1, weightKg: null, ...(planned?.targetGauge ? { gauge: planned.targetGauge } : {}), isWarmup: false };
+}
+
+export function nextSetIndex(loggedSets: readonly LoggedSet[]): number {
+    return loggedSets.length > 0 ? Math.max(...loggedSets.map(set => set.setIndex)) + 1 : 1;
+}
+
+export type BuildSetResult = { ok: true; set: LoggedSet } | { ok: false; error: string };
+
+/** Validates and constructs the next `LoggedSet` from form input. Mirrors the read-side
+ *  parser's bounds (reps > 0; weight null or a non-negative number) so a set that would be
+ *  rejected on read is never offered for write in the first place -- but this is a UX
+ *  convenience, not the enforcement point; `parseStrengthSession` (S1.2) and the Firestore
+ *  rules (S1.3) remain the real gates. */
+export function buildLoggedSet(draft: SetEntryDraft, loggedSets: readonly LoggedSet[], completedAtIso: string): BuildSetResult {
+    if (!Number.isFinite(draft.reps) || draft.reps <= 0) {
+        return { ok: false, error: 'Enter reps greater than zero' };
+    }
+    if (draft.weightKg !== null && (!Number.isFinite(draft.weightKg) || draft.weightKg < 0)) {
+        return { ok: false, error: 'Enter a valid weight, or leave it blank for bodyweight' };
+    }
+    return {
+        ok: true,
+        set: {
+            setIndex: nextSetIndex(loggedSets),
+            weightKg: draft.weightKg,
+            reps: draft.reps,
+            isWarmup: draft.isWarmup,
+            completedAt: completedAtIso,
+            ...(draft.gauge ? { gauge: draft.gauge } : {}),
+        },
+    };
+}
+
+/** Adds a new exercise to the session if one matching this identity isn't already present
+ *  (confirm-or-amend re-adding the same prescribed exercise is a no-op, not a duplicate
+ *  entry). Two free-text exercises are distinct entries even with the same name -- there is
+ *  no identity to dedupe against without an `exerciseId`. */
+export function upsertExercise(exercises: readonly LoggedExercise[], exerciseId: string | null, freeTextName?: string): LoggedExercise[] {
+    if (exerciseId !== null) {
+        const alreadyPresent = exercises.some(exercise => exercise.exerciseId === exerciseId);
+        if (alreadyPresent) return [...exercises];
+    }
+    return [...exercises, { exerciseId, sets: [], ...(freeTextName ? { freeTextName } : {}) }];
+}
+
+export function appendSetToExercise(exercises: readonly LoggedExercise[], exerciseIndex: number, set: LoggedSet): LoggedExercise[] {
+    return exercises.map((exercise, index) => (index === exerciseIndex ? { ...exercise, sets: [...exercise.sets, set] } : exercise));
+}

--- a/docs/plans/strength-session-logging.md
+++ b/docs/plans/strength-session-logging.md
@@ -64,7 +64,7 @@ accepted before any Step C item.
 | S1.2 | `strength_sessions` schema and types | `[x]` | D-GAUGE |
 | S1.3 | Firestore rules and validation | `[x]` | S1.2 |
 | S1.4 | Session state machine and date attribution | `[x]` | S1.2 |
-| S1.5 | Set-entry UI | `[ ]` | S1.3, S1.4 |
+| S1.5 | Set-entry UI | `[x]` | S1.3, S1.4 |
 | S1.6 | Rest timer and derived rest | `[ ]` | S1.5 |
 | S1.7 | Overload history view | `[ ]` | S1.3 |
 | S2.1 | Gauge-aware 1RM estimator | `[ ]` | S1.2 |
@@ -293,7 +293,7 @@ Midnight-crossing is tested in both directions of the DST calendar (CEST, UTC+2 
 CET, UTC+1 in January) via `Intl.DateTimeFormat`, not a hardcoded offset — `getLocalDateString`
 already does this correctly; the tests exist to pin the *contract*, not to add new logic.
 
-### S1.5 `[ ]` Set-entry UI — **the per-set write is the point**
+### S1.5 `[x]` Set-entry UI — **the per-set write is the point**
 
 **Change:** a session runner with two entry paths: start from today's prescription
 (pre-populated with exercise, target sets/reps and target gauge) or start empty and add
@@ -315,6 +315,53 @@ Non-negotiable behaviours:
 **Done when:** killing the app mid-session and reopening restores every logged set; a
 prescribed session prefills from the recommendation; an offline session syncs on reconnect
 with no duplicate sets.
+
+**Outcome (2026-08-17).** Behaviours 1–3 and 5 are implemented as designed; behaviour 4
+(sync-state indicator) is a known simplification -- see below.
+
+Split three ways, all new: `workouts/strengthSessionEntry.ts` (pure confirm-or-amend logic
+— prescription matching, prefill, set construction, exercise upsert; 20 tests, no I/O or
+React), `hooks/useStrengthSessionRunner.ts` (thin orchestration over the pure module and
+`strengthSessionService`; no dedicated test file, matching this repo's own precedent —
+`useGarminSyncStatus` has none either, and there is no `@testing-library/react` in this
+toolchain to test a hook's behaviour directly), and `components/StrengthSessionRunner.tsx`
+(6 `renderToStaticMarkup` smoke tests, the same style as `GarminSyncBadge.test.tsx` — this
+repo has no interaction-testing library, so these assert rendered output across states, not
+clicks). Wired into navigation: `Screen` gained `'strength'`, routed in `App.tsx`, reachable
+from the "More" drawer in `MobileNav.tsx`. Not added to the primary bottom-nav bar or to a
+`Home.tsx` dashboard card — both are placement/prominence decisions better made by a human
+than assumed here; the drawer entry is the same tier `Import Training Plan` and
+`Export Context for AI` already occupy.
+
+**Prescription matching, scoped deliberately.** `WorkoutPrescription` carries both
+`adjustedBlocks` (the original structured `WorkoutBlock[]`, with typed `exerciseId`/`sets`/
+`target: IntensityTarget`) and `displayBlocks` (rendered presentation strings). Matching
+reads only `adjustedBlocks` — `displayBlocks`' `dose`/`targets` are rendered text, not
+parseable back into structured data. Of `IntensityTarget`'s eight variants, only
+`reps_in_reserve` and `technical_quality` map to a suggested gauge (verified against
+`catalog/support-strength.ts`, the only two a real strength step ever carries); every other
+variant (`rpe`, `ftp_percent`, `heart_rate_zone`, `power_zone`, `cadence`) is a
+cycling/running target and degrades to no suggestion rather than a guess. The mapped
+suggestion is explicitly *not* the D-GAUGE conversion the parser forbids — it never touches
+persisted data, only seeds the entry form before the athlete confirms or amends it.
+
+**Two "Done when" criteria are real end-to-end browser behaviour and were not verified
+here**, for the same reason noted in S1.1: "app killed mid-session, reopens with every set
+intact" and "offline session syncs on reconnect with no duplicates" depend on IndexedDB
+round-tripping through `persistentLocalCache`, which unit tests running in Node cannot
+exercise. What *is* verified: `logSet` awaits `saveExercises` before updating local state
+(so a set is never shown as logged before the write call resolves), and
+`findActiveSession`/`saveExercises` are both covered against a mocked Firestore SDK.
+Confirm the real end-to-end behaviour by hand (DevTools → Offline, log a set, kill the tab,
+reopen) before relying on it.
+
+**Sync-state indicator not built.** Item 4 above ("pending" vs "synced" per set) needs a
+live `onSnapshot({ includeMetadataChanges: true })` listener to read `hasPendingWrites`,
+which is a meaningfully separate feature (subscription lifecycle, cleanup, per-document
+metadata state) from durable persistence itself. `saveExercises`'s `await` already
+guarantees the write reached the local cache before the UI reports success; what's missing
+is only the passive "still syncing to the server" affordance. Left for a follow-up rather
+than bundled in here.
 
 ### S1.6 `[ ]` Rest timer and derived rest
 


### PR DESCRIPTION
## Summary

- Persist-on-every-set, prefill-from-previous-set, confirm-or-amend against a matched prescription. Split three ways:
  - `workouts/strengthSessionEntry.ts` — pure logic, no I/O or React: `extractPlannedStrengthExercises` (prescription matching), `prefillNextSet`, `buildLoggedSet`, `upsertExercise`, `appendSetToExercise`. 20 tests.
  - `hooks/useStrengthSessionRunner.ts` — thin orchestration over the pure module and `strengthSessionService`. No dedicated test file, matching this repo's existing precedent (`useGarminSyncStatus` has none either) and the absence of `@testing-library/react` in this toolchain.
  - `components/StrengthSessionRunner.tsx` — 6 `renderToStaticMarkup` smoke tests in the `GarminSyncBadge.test.tsx` style (no interaction-testing library exists here, so these assert rendered output across states, not clicks).
- Prescription matching reads `WorkoutPrescription.adjustedBlocks` (the original structured `WorkoutBlock[]`), not `displayBlocks` (rendered display strings, unparseable back into structured targets). Of `IntensityTarget`'s eight variants, only `reps_in_reserve` and `technical_quality` map to a suggested gauge — verified against `catalog/support-strength.ts` as the only two a real strength step emits; everything else degrades to no suggestion rather than a guess.
- Wired into navigation: `Screen` gains `'strength'`, routed in `App.tsx`, reachable from `MobileNav`'s "More" drawer at the same tier as "Import Training Plan" / "Export Context for AI". Deliberately **not** added to the primary bottom-nav bar or a `Home.tsx` dashboard card — placement/prominence left for your review rather than assumed.

## Validation

- [x] `cd app && npm run check` — pass: 1292 tests, 107 files.

Results:
- 20 tests for the pure entry-logic module; 6 smoke tests for the component across loading/empty/planned/logged-sets/completed/error states.
- [ ] Not verified: "kill the app mid-session, reopen, every set restored" and "prescribed session prefills from the recommendation" in a real browser — both depend on IndexedDB/persistence behaviour a Node test can't exercise. `logSet` awaits the Firestore write before updating local state, which is the closest available proxy.

## Risk and reviewer guidance

This is the largest PR in the stack (new hook, new component, new pure-logic module, nav wiring). The one thing worth a deliberate look: nav placement is intentionally minimal (More-drawer only) — flag if you want it promoted to the bottom bar or a Home card; I didn't want to make that UX call unilaterally.

## Domain invariants

- [x] Firestore writes remain user-scoped — writes go through `strengthSessionService`, unchanged from S1.4.
- [x] Calendar-date logic uses Europe/Warsaw — session start date is fixed by S1.4's `computeSessionDate`; this PR doesn't add new date logic.
- [x] No credentials, tokens, service-account files, or raw health payloads included.
- [x] Recommendation decision logic changed: no. Logging UI only; still no engine/recommendation code path reads `strength_sessions`.

## Screenshots or recordings

Not captured — no live browser session available in this environment to authenticate against Firebase Auth. Recommend a manual pass before merge: `npm run dev`, log in, navigate to Strength via the More drawer.
