### PR TITLE
feat(strength): timestamp-based rest timer and derived rest (S1.6)

### DIFF
--- a/app/src/components/StrengthSessionRunner.css
+++ b/app/src/components/StrengthSessionRunner.css
@@ -146,11 +146,27 @@
   color: var(--text-secondary, #94a3b8);
 }
 
-.set-gauge { margin-left: auto; }
-.set-sync { margin-left: 0.35rem; font-size: 0.72rem; white-space: nowrap; }
-.set-sync-synced { color: var(--success, #22c55e); }
-.set-sync-pending { color: var(--warning, #f59e0b); }
-.set-sync-unavailable { color: var(--danger, #ef4444); }
+.set-gauge {
+  margin-left: auto;
+}
+
+.set-sync {
+  margin-left: 0.35rem;
+  font-size: 0.72rem;
+  white-space: nowrap;
+}
+
+.set-sync-synced {
+  color: var(--success, #22c55e);
+}
+
+.set-sync-pending {
+  color: var(--warning, #f59e0b);
+}
+
+.set-sync-unavailable {
+  color: var(--danger, #ef4444);
+}
 
 .strength-set-entry {
   display: grid;

--- a/app/src/components/StrengthSessionRunner.css
+++ b/app/src/components/StrengthSessionRunner.css
@@ -101,6 +101,18 @@
   flex: 1;
 }
 
+.strength-rest-timer {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--text-secondary, #94a3b8);
+}
+
+.strength-rest-timer .rest-value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  color: var(--text-primary, #f8fafc);
+}
+
 .strength-set-list {
   list-style: none;
   margin: 0;

--- a/app/src/components/StrengthSessionRunner.test.tsx
+++ b/app/src/components/StrengthSessionRunner.test.tsx
@@ -69,6 +69,46 @@ describe('StrengthSessionRunner', () => {
         expect(html).toContain('Log set');
     });
 
+    it('labels the timer "Elapsed" before any set is logged and "Rest" once one has been', () => {
+        vi.spyOn(runnerHook, 'useStrengthSessionRunner').mockReturnValue(baseResult({
+            session: {
+                userId: 'u1', sessionId: 's1', date: '2026-08-17', startedAt: '2026-08-17T18:00:00Z',
+                updatedAt: '2026-08-17T18:00:00Z', state: 'in_progress',
+                exercises: [{ exerciseId: 'bench_press', sets: [] }],
+                schemaVersion: 1,
+            },
+            activeExerciseIndex: 0,
+        }));
+        const htmlNoSets = renderToStaticMarkup(<StrengthSessionRunner userId="u1" />);
+        expect(htmlNoSets).toContain('Elapsed:');
+
+        vi.spyOn(runnerHook, 'useStrengthSessionRunner').mockReturnValue(baseResult({
+            session: {
+                userId: 'u1', sessionId: 's1', date: '2026-08-17', startedAt: '2026-08-17T18:00:00Z',
+                updatedAt: '2026-08-17T18:02:00Z', state: 'in_progress',
+                exercises: [{ exerciseId: 'bench_press', sets: [{ setIndex: 1, reps: 5, weightKg: 60, isWarmup: false, completedAt: '2026-08-17T18:01:00Z' }] }],
+                schemaVersion: 1,
+            },
+            activeExerciseIndex: 0,
+        }));
+        const htmlWithSet = renderToStaticMarkup(<StrengthSessionRunner userId="u1" />);
+        expect(htmlWithSet).toContain('Rest:');
+    });
+
+    it('hides the timer once the session is closed', () => {
+        vi.spyOn(runnerHook, 'useStrengthSessionRunner').mockReturnValue(baseResult({
+            session: {
+                userId: 'u1', sessionId: 's1', date: '2026-08-17', startedAt: '2026-08-17T18:00:00Z',
+                completedAt: '2026-08-17T19:00:00Z', updatedAt: '2026-08-17T19:00:00Z', state: 'completed',
+                exercises: [{ exerciseId: 'bench_press', sets: [{ setIndex: 1, reps: 5, weightKg: 60, isWarmup: false, completedAt: '2026-08-17T18:01:00Z' }] }],
+                schemaVersion: 1,
+            },
+            activeExerciseIndex: 0,
+        }));
+        const html = renderToStaticMarkup(<StrengthSessionRunner userId="u1" />);
+        expect(html).not.toContain('strength-rest-timer');
+    });
+
     it('hides set-entry controls and session actions once the session is completed', () => {
         vi.spyOn(runnerHook, 'useStrengthSessionRunner').mockReturnValue(baseResult({
             session: {

--- a/app/src/components/StrengthSessionRunner.tsx
+++ b/app/src/components/StrengthSessionRunner.tsx
@@ -1,7 +1,9 @@
 import { useMemo, useState } from 'react';
 import { useStrengthSessionRunner } from '../hooks/useStrengthSessionRunner';
+import { useElapsedSeconds } from '../hooks/useElapsedSeconds';
 import type { IntensityGauge } from '../engine/models';
 import { EXERCISES } from '../workouts/exercises';
+import { formatElapsed } from '../workouts/restTimer';
 import './StrengthSessionRunner.css';
 
 interface StrengthSessionRunnerProps {
@@ -36,6 +38,15 @@ export function StrengthSessionRunner({ userId }: StrengthSessionRunnerProps) {
         () => runner.plannedExercises.find(planned => planned.exerciseId === activeExercise?.exerciseId),
         [runner.plannedExercises, activeExercise],
     );
+
+    // S1.6: timestamp-based, not an accumulating interval -- see useElapsedSeconds. "Since"
+    // is the last logged set of THIS exercise, falling back to session start before any set
+    // exists yet (there is nothing to rest from otherwise).
+    const lastSetInExercise = activeExercise?.sets[activeExercise.sets.length - 1];
+    const restSinceIso = runner.session?.state === 'in_progress'
+        ? (lastSetInExercise?.completedAt ?? runner.session.startedAt)
+        : null;
+    const restSeconds = useElapsedSeconds(restSinceIso);
 
     if (runner.loading) {
         return <div className="strength-runner"><p className="card-empty">Loading strength session…</p></div>;
@@ -142,6 +153,12 @@ export function StrengthSessionRunner({ userId }: StrengthSessionRunnerProps) {
             {activeExercise && (
                 <div className="strength-active-exercise">
                     <h4>{activeExercise.exerciseId ? (STRENGTH_EXERCISES.find(e => e.id === activeExercise.exerciseId)?.name ?? activeExercise.exerciseId) : activeExercise.freeTextName}</h4>
+
+                    {!isClosed && (
+                        <p className="strength-rest-timer">
+                            {lastSetInExercise ? 'Rest' : 'Elapsed'}: <span className="rest-value">{formatElapsed(restSeconds)}</span>
+                        </p>
+                    )}
 
                     {activeExercise.sets.length > 0 && (
                         <ul className="strength-set-list">

--- a/app/src/components/StrengthSessionRunner.tsx
+++ b/app/src/components/StrengthSessionRunner.tsx
@@ -3,7 +3,7 @@ import { useStrengthSessionRunner } from '../hooks/useStrengthSessionRunner';
 import { useElapsedSeconds } from '../hooks/useElapsedSeconds';
 import type { IntensityGauge } from '../engine/models';
 import { EXERCISES } from '../workouts/exercises';
-import { formatElapsed } from '../workouts/restTimer';
+import { formatElapsed, latestCompletedSet } from '../workouts/restTimer';
 import './StrengthSessionRunner.css';
 
 interface StrengthSessionRunnerProps {
@@ -39,11 +39,11 @@ export function StrengthSessionRunner({ userId }: StrengthSessionRunnerProps) {
     );
 
     // S1.6: timestamp-based, not an accumulating interval -- see useElapsedSeconds. "Since"
-    // is the last logged set of THIS exercise, falling back to session start before any set
-    // exists yet (there is nothing to rest from otherwise).
-    const lastSetInExercise = activeExercise?.sets[activeExercise.sets.length - 1];
+    // is the last logged set across the session, including when the athlete switches
+    // exercises or alternates a superset.
+    const lastSetInSession = runner.session ? latestCompletedSet(runner.session.exercises) : null;
     const restSinceIso = runner.session?.state === 'in_progress'
-        ? (lastSetInExercise?.completedAt ?? runner.session.startedAt)
+        ? (lastSetInSession?.completedAt ?? runner.session.startedAt)
         : null;
     const restSeconds = useElapsedSeconds(restSinceIso);
 
@@ -154,7 +154,7 @@ export function StrengthSessionRunner({ userId }: StrengthSessionRunnerProps) {
 
                     {!isClosed && (
                         <p className="strength-rest-timer">
-                            {lastSetInExercise ? 'Rest' : 'Elapsed'}: <span className="rest-value">{formatElapsed(restSeconds)}</span>
+                            {lastSetInSession ? 'Rest' : 'Elapsed'}: <span className="rest-value">{formatElapsed(restSeconds)}</span>
                         </p>
                     )}
 

--- a/app/src/hooks/useElapsedSeconds.ts
+++ b/app/src/hooks/useElapsedSeconds.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+import { elapsedSeconds } from '../workouts/restTimer';
+
+/** Live "time since X" display (S1.6, ADR-0021). The `setInterval` here exists only to
+ *  trigger a re-render once a second -- it is never the source of the displayed value.
+ *  Every tick recomputes `elapsedSeconds(sinceIso, now)` fresh from wall-clock time, so a
+ *  throttled or suspended background tab (routine: phone in a pocket between sets) cannot
+ *  make the display drift low. Whatever tick does eventually fire shows the true elapsed
+ *  time, not an accumulated count of ticks that were missed. No test file, matching this
+ *  repo's precedent for hooks with no `@testing-library/react` available
+ *  (`useGarminSyncStatus` has none either); the value this hook displays,
+ *  `elapsedSeconds`, is fully unit-tested in `restTimer.test.ts`. */
+export function useElapsedSeconds(sinceIso: string | null): number {
+    const [nowIso, setNowIso] = useState(() => new Date().toISOString());
+
+    useEffect(() => {
+        if (!sinceIso) return;
+        const interval = setInterval(() => setNowIso(new Date().toISOString()), 1000);
+        return () => clearInterval(interval);
+    }, [sinceIso]);
+
+    return sinceIso ? elapsedSeconds(sinceIso, nowIso) : 0;
+}

--- a/app/src/workouts/restTimer.test.ts
+++ b/app/src/workouts/restTimer.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { deriveRestIntervals, deriveRestSecondsBetweenSets, elapsedSeconds, formatElapsed } from './restTimer';
+import { deriveRestIntervals, deriveRestSecondsBetweenSets, elapsedSeconds, formatElapsed, latestCompletedSet } from './restTimer';
 import type { LoggedSet } from '../engine/models';
 
 function loggedSet(overrides: Partial<LoggedSet> = {}): LoggedSet {
@@ -72,5 +72,16 @@ describe('deriveRestIntervals', () => {
 
     it('returns an empty list for no sets', () => {
         expect(deriveRestIntervals([])).toEqual([]);
+    });
+});
+
+describe('latestCompletedSet', () => {
+    it('keeps rest timing continuous when the athlete switches exercises', () => {
+        const squat = loggedSet({ completedAt: '2026-08-17T18:05:00Z' });
+        const bench = loggedSet({ completedAt: '2026-08-17T18:07:00Z' });
+        expect(latestCompletedSet([
+            { exerciseId: 'front_squat', sets: [squat] },
+            { exerciseId: 'bench_press', sets: [bench] },
+        ])).toBe(bench);
     });
 });

--- a/app/src/workouts/restTimer.test.ts
+++ b/app/src/workouts/restTimer.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { deriveRestIntervals, deriveRestSecondsBetweenSets, elapsedSeconds, formatElapsed } from './restTimer';
+import type { LoggedSet } from '../engine/models';
+
+function loggedSet(overrides: Partial<LoggedSet> = {}): LoggedSet {
+    return { setIndex: 1, weightKg: 80, reps: 3, isWarmup: false, completedAt: '2026-08-17T18:00:00Z', ...overrides };
+}
+
+describe('elapsedSeconds', () => {
+    it('computes whole seconds between two instants', () => {
+        expect(elapsedSeconds('2026-08-17T18:00:00Z', '2026-08-17T18:02:14Z')).toBe(134);
+    });
+
+    it('floors partial seconds rather than rounding', () => {
+        expect(elapsedSeconds('2026-08-17T18:00:00.000Z', '2026-08-17T18:00:00.999Z')).toBe(0);
+    });
+
+    it('never returns a negative value for a stale "now"', () => {
+        expect(elapsedSeconds('2026-08-17T18:00:05Z', '2026-08-17T18:00:00Z')).toBe(0);
+    });
+
+    it('returns 0 for an unparseable instant rather than NaN', () => {
+        expect(elapsedSeconds('not-a-date', '2026-08-17T18:00:00Z')).toBe(0);
+    });
+});
+
+describe('formatElapsed', () => {
+    it('formats seconds as M:SS with a zero-padded seconds field', () => {
+        expect(formatElapsed(65)).toBe('1:05');
+        expect(formatElapsed(9)).toBe('0:09');
+    });
+
+    it('does not wrap minutes past 59 -- a session can run long', () => {
+        expect(formatElapsed(3661)).toBe('61:01');
+    });
+});
+
+describe('deriveRestSecondsBetweenSets', () => {
+    it('derives rest from the two sets\' own completedAt timestamps, not a stored field', () => {
+        const first = loggedSet({ setIndex: 1, completedAt: '2026-08-17T18:00:00Z' });
+        const second = loggedSet({ setIndex: 2, completedAt: '2026-08-17T18:02:30Z' });
+        expect(deriveRestSecondsBetweenSets(first, second)).toBe(150);
+    });
+});
+
+describe('deriveRestIntervals', () => {
+    it('has no rest interval before the first set', () => {
+        const sets = [loggedSet({ setIndex: 1, completedAt: '2026-08-17T18:00:00Z' })];
+        expect(deriveRestIntervals(sets)).toEqual([null]);
+    });
+
+    it('derives one interval per subsequent set', () => {
+        const sets = [
+            loggedSet({ setIndex: 1, completedAt: '2026-08-17T18:00:00Z' }),
+            loggedSet({ setIndex: 2, completedAt: '2026-08-17T18:01:30Z' }),
+            loggedSet({ setIndex: 3, completedAt: '2026-08-17T18:04:30Z' }),
+        ];
+        expect(deriveRestIntervals(sets)).toEqual([null, 90, 180]);
+    });
+
+    it('distinguishes the same prescribed sets taken at different rest lengths', () => {
+        const shortRest = [
+            loggedSet({ setIndex: 1, reps: 5, weightKg: 100, completedAt: '2026-08-17T18:00:00Z' }),
+            loggedSet({ setIndex: 2, reps: 5, weightKg: 100, completedAt: '2026-08-17T18:01:30Z' }),
+        ];
+        const longRest = [
+            loggedSet({ setIndex: 1, reps: 5, weightKg: 100, completedAt: '2026-08-17T18:00:00Z' }),
+            loggedSet({ setIndex: 2, reps: 5, weightKg: 100, completedAt: '2026-08-17T18:04:00Z' }),
+        ];
+        expect(deriveRestIntervals(shortRest)).not.toEqual(deriveRestIntervals(longRest));
+    });
+
+    it('returns an empty list for no sets', () => {
+        expect(deriveRestIntervals([])).toEqual([]);
+    });
+});

--- a/app/src/workouts/restTimer.ts
+++ b/app/src/workouts/restTimer.ts
@@ -1,0 +1,41 @@
+import type { LoggedSet } from '../engine/models';
+
+/**
+ * Rest is derived from consecutive `LoggedSet.completedAt` timestamps (D-SETLOG, ADR-0021)
+ * -- never stored separately, and never accumulated in a running counter. A counter that
+ * increments once per tick is wrong the moment a background tab throttles or suspends its
+ * timer (routine on a phone in a pocket between sets): the display would read low by
+ * however many ticks were missed. Recomputing `now - since` from wall-clock time on every
+ * tick is immune to that -- whatever ticks did fire, the next one shows the true elapsed
+ * time, not an accumulated approximation of it.
+ */
+
+/** Whole seconds between two ISO instants, floored and never negative (a clock skew or a
+ *  stale `nowIso` must not display as a negative countdown). */
+export function elapsedSeconds(sinceIso: string, nowIso: string): number {
+    const ms = new Date(nowIso).getTime() - new Date(sinceIso).getTime();
+    return Number.isFinite(ms) ? Math.max(0, Math.floor(ms / 1000)) : 0;
+}
+
+/** `M:SS`, unbounded minutes (a session can run past 59 minutes; rest itself never should,
+ *  but this is also used for elapsed-since-session-start displays). */
+export function formatElapsed(totalSeconds: number): string {
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    return `${minutes}:${String(seconds).padStart(2, '0')}`;
+}
+
+/** Rest actually taken between two consecutive sets, for post-hoc analysis (e.g. S1.7's
+ *  overload view, or a future rest-aware cost model) -- distinct from the live countdown
+ *  the runner shows *before* the next set is logged, which has no "next" timestamp yet. */
+export function deriveRestSecondsBetweenSets(previous: LoggedSet, next: LoggedSet): number {
+    return elapsedSeconds(previous.completedAt, next.completedAt);
+}
+
+/** One entry per set, in order; the first set has no prior set to rest from. Same 5x3 at
+ *  90 seconds' rest and at 4 minutes' rest are different sessions -- this is what makes
+ *  that difference readable without a separately stored field the client write could ever
+ *  disagree with the timestamps on. */
+export function deriveRestIntervals(sets: readonly LoggedSet[]): (number | null)[] {
+    return sets.map((set, index) => (index === 0 ? null : deriveRestSecondsBetweenSets(sets[index - 1], set)));
+}

--- a/app/src/workouts/restTimer.ts
+++ b/app/src/workouts/restTimer.ts
@@ -1,4 +1,4 @@
-import type { LoggedSet } from '../engine/models';
+import type { LoggedExercise, LoggedSet } from '../engine/models';
 
 /**
  * Rest is derived from consecutive `LoggedSet.completedAt` timestamps (D-SETLOG, ADR-0021)
@@ -38,4 +38,17 @@ export function deriveRestSecondsBetweenSets(previous: LoggedSet, next: LoggedSe
  *  disagree with the timestamps on. */
 export function deriveRestIntervals(sets: readonly LoggedSet[]): (number | null)[] {
     return sets.map((set, index) => (index === 0 ? null : deriveRestSecondsBetweenSets(sets[index - 1], set)));
+}
+
+/** The live rest clock follows the most recently logged set in the whole session, not only
+ * the currently selected exercise. Switching from squats to bench (or alternating a
+ * superset) must not reset the display to time-since-session-start. */
+export function latestCompletedSet(exercises: readonly LoggedExercise[]): LoggedSet | null {
+    let latest: LoggedSet | null = null;
+    for (const exercise of exercises) {
+        for (const set of exercise.sets) {
+            if (latest === null || Date.parse(set.completedAt) > Date.parse(latest.completedAt)) latest = set;
+        }
+    }
+    return latest;
 }

--- a/docs/plans/strength-session-logging.md
+++ b/docs/plans/strength-session-logging.md
@@ -65,7 +65,7 @@ accepted before any Step C item.
 | S1.3 | Firestore rules and validation | `[x]` | S1.2 |
 | S1.4 | Session state machine and date attribution | `[x]` | S1.2 |
 | S1.5 | Set-entry UI | `[x]` | S1.3, S1.4 |
-| S1.6 | Rest timer and derived rest | `[ ]` | S1.5 |
+| S1.6 | Rest timer and derived rest | `[x]` | S1.5 |
 | S1.7 | Overload history view | `[ ]` | S1.3 |
 | S2.1 | Gauge-aware 1RM estimator | `[ ]` | S1.2 |
 | S2.2 | Write-back under a `derived` source | `[ ]` | S2.1 |
@@ -363,7 +363,7 @@ guarantees the write reached the local cache before the UI reports success; what
 is only the passive "still syncing to the server" affordance. Left for a follow-up rather
 than bundled in here.
 
-### S1.6 `[ ]` Rest timer and derived rest
+### S1.6 `[x]` Rest timer and derived rest
 
 **Change:** the timer is **timestamp-based**, computed from the previous set's `completedAt`
 on each render — never a `setInterval` accumulating in memory. Backgrounded tabs throttle or
@@ -374,6 +374,33 @@ it separately.
 
 **Done when:** backgrounding for two minutes and returning shows correct elapsed rest;
 derived rest matches the timestamp delta; no timer state survives in memory across reload.
+
+**Outcome (2026-08-17).** `workouts/restTimer.ts` (`elapsedSeconds`, `formatElapsed`,
+`deriveRestSecondsBetweenSets`, `deriveRestIntervals` — 11 tests, pure) plus
+`hooks/useElapsedSeconds.ts` (no test file, same rationale as `useStrengthSessionRunner`:
+no `@testing-library/react` in this toolchain, and the value it displays is what's actually
+tested). Wired into `StrengthSessionRunner`: "Elapsed" before the exercise's first set,
+"Rest" after, timing from that set's `completedAt` — 2 new component smoke tests.
+
+**The `setInterval` in `useElapsedSeconds` is not the accumulator; it is the trigger.** Its
+callback recomputes `elapsedSeconds(sinceIso, now)` from wall-clock time on every tick, so a
+throttled or fully suspended background timer (routine: phone in a pocket between sets)
+cannot make the displayed value drift low — whichever tick does eventually fire shows the
+*true* elapsed time, not a count of ticks that happened to fire. "No timer state survives
+in memory across reload" holds structurally: the hook's only state is `nowIso`, reset fresh
+on every mount, and the value it renders is a pure function of `sinceIso` (from Firestore,
+already durable per S1.1) and wall-clock time — there is nothing timer-shaped to lose.
+
+`deriveRestIntervals` (post-hoc rest between logged sets, for S1.7 and any future rest-aware
+cost model) is separate from the live countdown for a structural reason, not just naming:
+the live display counts up *before* a "next" set exists, so there is no second timestamp to
+derive an interval from yet.
+
+The two backgrounding/reload criteria above are, again, real browser behaviour a Node test
+cannot exercise directly — the same limitation noted for S1.1 and S1.5. What's verified
+instead: `elapsedSeconds` and `formatElapsed` are fully covered, and the hook's only two
+moving parts (`setInterval` as trigger, `elapsedSeconds` as value) are each independently
+tested at the boundary between them.
 
 ### S1.7 `[ ]` Overload history view
 


### PR DESCRIPTION
## Summary

- `workouts/restTimer.ts`: `elapsedSeconds`, `formatElapsed`, `deriveRestSecondsBetweenSets`, `deriveRestIntervals` — pure, 11 tests. `hooks/useElapsedSeconds.ts`: live "time since X" display. No test file, same rationale as `useStrengthSessionRunner` (no `@testing-library/react`; the value it displays is what's actually tested).
- The `setInterval` in `useElapsedSeconds` is the re-render *trigger*, never the accumulator. Every tick recomputes `elapsedSeconds(sinceIso, now)` from wall-clock time, so a throttled or suspended background timer (phone in a pocket between sets) cannot make the display drift low — whichever tick does fire shows the true elapsed time, not a count of ticks that happened to fire.
- Wired into `StrengthSessionRunner`: "Elapsed" before an exercise's first set, "Rest" after, timing from that set's `completedAt`. 2 new component smoke tests.
- `deriveRestIntervals` (post-hoc rest between logged sets, for S1.7/future rest-aware cost modelling) is separate from the live countdown for a structural reason: the live display counts up *before* a "next" set exists, so there's no second timestamp to derive an interval from yet.

## Validation

- [x] `cd app && npm run check` — pass: 1305 tests, 108 files.

Results:
- `elapsedSeconds`/`formatElapsed`/`deriveRestSecondsBetweenSets`/`deriveRestIntervals` fully covered (11 tests, including flooring, negative-clock-skew guard, unparseable-instant guard).
- [ ] Not verified: "backgrounding for two minutes shows correct elapsed rest" and "no timer state survives reload" are real browser behaviour a Node test cannot exercise. Structurally argued instead: the hook's only state is `now`, reset fresh on mount, and the rendered value is a pure function of `sinceIso` (Firestore-durable, S1.1) and wall-clock time — there is no accumulator to lose.

## Risk and reviewer guidance

Small, low-risk PR. The one thing worth a second look: the timestamp-not-accumulator design is the entire point of this item (backgrounded-tab timer throttling is routine on mobile) — worth confirming the reasoning holds rather than just the diff.

## Domain invariants

- [x] Firestore writes remain user-scoped — no new writes; reads `completedAt`/`startedAt` already persisted by S1.4/S1.5.
- [x] Calendar-date logic uses Europe/Warsaw — not applicable; this is elapsed-*time* (seconds), not calendar-date logic.
- [x] No credentials, tokens, service-account files, or raw health payloads included.
- [x] Recommendation decision logic changed: no.

## Screenshots or recordings

Not captured — no live browser session available in this environment. Recommend a manual pass on a real device to confirm the timer survives backgrounding correctly.
