### PR TITLE
feat(strength): progressive-overload history view (S1.7)

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -523,6 +523,11 @@
   }
 }
 
+.strength-screen {
+  display: grid;
+  gap: 1rem;
+}
+
 /* Smooth transitions */
 .app-content > * {
   animation: fadeIn 0.3s ease;

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -9,6 +9,7 @@ import { Preferences } from './components/Preferences';
 import { DataView } from './components/DataView';
 import { ExternalPlanImport } from './components/ExternalPlanImport';
 import { StrengthSessionRunner } from './components/StrengthSessionRunner';
+import { StrengthOverloadHistory } from './components/StrengthOverloadHistory';
 import { decisionComposer } from './engine/composer';
 import type { DailyDecisionInput } from './engine/models';
 import type { Screen } from './types/navigation';
@@ -118,7 +119,10 @@ function App() {
         )}
 
         {screen === 'strength' && (
-          <StrengthSessionRunner userId={userId!} />
+          <div className="strength-screen">
+            <StrengthSessionRunner userId={userId!} />
+            <StrengthOverloadHistory userId={userId!} />
+          </div>
         )}
 
         {screen === 'plan' && (

--- a/app/src/components/StrengthOverloadHistory.css
+++ b/app/src/components/StrengthOverloadHistory.css
@@ -1,0 +1,36 @@
+.strength-overload-history {
+  background: var(--surface-card, #1e293b);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  color: var(--text-primary, #f8fafc);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.strength-overload-history h3 {
+  margin: 0;
+}
+
+.strength-overload-warning {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--tier-yellow, #eab308);
+}
+
+.strength-overload-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+
+.strength-overload-table th,
+.strength-overload-table td {
+  text-align: left;
+  padding: 0.4rem 0.5rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.15);
+}
+
+.strength-overload-table th {
+  color: var(--text-secondary, #94a3b8);
+  font-weight: 600;
+}

--- a/app/src/components/StrengthOverloadHistory.test.tsx
+++ b/app/src/components/StrengthOverloadHistory.test.tsx
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { StrengthOverloadHistory } from './StrengthOverloadHistory';
+import * as historyHook from '../hooks/useOverloadHistory';
+import type { UseOverloadHistoryResult } from '../hooks/useOverloadHistory';
+
+function baseResult(overrides: Partial<UseOverloadHistoryResult> = {}): UseOverloadHistoryResult {
+    return {
+        loading: false,
+        error: null,
+        exercises: [],
+        selected: null,
+        select: vi.fn(),
+        history: [],
+        invalidRecords: 0,
+        ...overrides,
+    };
+}
+
+describe('StrengthOverloadHistory', () => {
+    it('renders a loading state', () => {
+        vi.spyOn(historyHook, 'useOverloadHistory').mockReturnValue(baseResult({ loading: true }));
+        const html = renderToStaticMarkup(<StrengthOverloadHistory userId="u1" />);
+        expect(html).toContain('Loading overload history');
+    });
+
+    it('renders an empty state when nothing has ever been logged', () => {
+        vi.spyOn(historyHook, 'useOverloadHistory').mockReturnValue(baseResult());
+        const html = renderToStaticMarkup(<StrengthOverloadHistory userId="u1" />);
+        expect(html).toContain('No strength sets logged yet');
+    });
+
+    it('surfaces a read error without swallowing it', () => {
+        vi.spyOn(historyHook, 'useOverloadHistory').mockReturnValue(baseResult({ error: 'Could not load strength session history' }));
+        const html = renderToStaticMarkup(<StrengthOverloadHistory userId="u1" />);
+        expect(html).toContain('Could not load strength session history');
+    });
+
+    it('lists distinct exercises in the picker', () => {
+        vi.spyOn(historyHook, 'useOverloadHistory').mockReturnValue(baseResult({
+            exercises: [{ exerciseId: 'front_squat' }, { exerciseId: null, freeTextName: 'Farmer carry' }],
+        }));
+        const html = renderToStaticMarkup(<StrengthOverloadHistory userId="u1" />);
+        expect(html).toContain('Front Squat');
+        expect(html).toContain('Farmer carry');
+    });
+
+    it('renders a history row per session with tonnage and heaviest set', () => {
+        vi.spyOn(historyHook, 'useOverloadHistory').mockReturnValue(baseResult({
+            exercises: [{ exerciseId: 'front_squat' }],
+            selected: { exerciseId: 'front_squat' },
+            history: [{
+                date: '2026-08-10', sessionId: 's1', setCount: 4, workingSetCount: 3, totalReps: 20, tonnageKg: 1200,
+                heaviestSet: { setIndex: 3, reps: 5, weightKg: 100, isWarmup: false, completedAt: '2026-08-10T18:10:00Z' },
+            }],
+        }));
+        const html = renderToStaticMarkup(<StrengthOverloadHistory userId="u1" />);
+        expect(html).toContain('2026-08-10');
+        expect(html).toContain('1200');
+        expect(html).toContain('5 × 100 kg');
+        expect(html).toContain('+1 warm-up');
+    });
+
+    it('renders a bodyweight heaviest set without a unit suffix', () => {
+        vi.spyOn(historyHook, 'useOverloadHistory').mockReturnValue(baseResult({
+            exercises: [{ exerciseId: 'pull_up' }],
+            selected: { exerciseId: 'pull_up' },
+            history: [{
+                date: '2026-08-10', sessionId: 's1', setCount: 3, workingSetCount: 3, totalReps: 24, tonnageKg: 0,
+                heaviestSet: { setIndex: 1, reps: 8, weightKg: null, isWarmup: false, completedAt: '2026-08-10T18:10:00Z' },
+            }],
+        }));
+        const html = renderToStaticMarkup(<StrengthOverloadHistory userId="u1" />);
+        expect(html).toContain('8 × BW');
+    });
+
+    it('warns about invalid records without hiding the rest of the history', () => {
+        vi.spyOn(historyHook, 'useOverloadHistory').mockReturnValue(baseResult({
+            exercises: [{ exerciseId: 'front_squat' }],
+            selected: { exerciseId: 'front_squat' },
+            invalidRecords: 2,
+            history: [{ date: '2026-08-10', sessionId: 's1', setCount: 1, workingSetCount: 1, totalReps: 5, tonnageKg: 500, heaviestSet: null }],
+        }));
+        const html = renderToStaticMarkup(<StrengthOverloadHistory userId="u1" />);
+        expect(html).toContain('2 session records could not be read');
+        expect(html).toContain('2026-08-10');
+    });
+
+    it('shows an empty-history message for a selected exercise with nothing in the window', () => {
+        vi.spyOn(historyHook, 'useOverloadHistory').mockReturnValue(baseResult({
+            exercises: [{ exerciseId: 'front_squat' }],
+            selected: { exerciseId: 'front_squat' },
+            history: [],
+        }));
+        const html = renderToStaticMarkup(<StrengthOverloadHistory userId="u1" />);
+        expect(html).toContain('No sets logged for this exercise');
+    });
+});

--- a/app/src/components/StrengthOverloadHistory.tsx
+++ b/app/src/components/StrengthOverloadHistory.tsx
@@ -1,6 +1,6 @@
 import { useOverloadHistory } from '../hooks/useOverloadHistory';
 import { EXERCISES } from '../workouts/exercises';
-import type { ExerciseIdentity } from '../workouts/overloadHistory';
+import { exerciseIdentityKey, type ExerciseIdentity } from '../workouts/overloadHistory';
 import './StrengthOverloadHistory.css';
 
 interface StrengthOverloadHistoryProps {
@@ -13,7 +13,7 @@ function exerciseLabel(identity: ExerciseIdentity): string {
 }
 
 function identityValue(identity: ExerciseIdentity): string {
-    return identity.exerciseId ?? `free:${identity.freeTextName ?? ''}`;
+    return exerciseIdentityKey(identity);
 }
 
 /** Progressive-overload view (S1.7, ADR-0021). Reads the raw per-set log directly

--- a/app/src/components/StrengthOverloadHistory.tsx
+++ b/app/src/components/StrengthOverloadHistory.tsx
@@ -1,0 +1,97 @@
+import { useOverloadHistory } from '../hooks/useOverloadHistory';
+import { EXERCISES } from '../workouts/exercises';
+import type { ExerciseIdentity } from '../workouts/overloadHistory';
+import './StrengthOverloadHistory.css';
+
+interface StrengthOverloadHistoryProps {
+    userId: string;
+}
+
+function exerciseLabel(identity: ExerciseIdentity): string {
+    if (identity.exerciseId) return EXERCISES.find(exercise => exercise.id === identity.exerciseId)?.name ?? identity.exerciseId;
+    return identity.freeTextName ?? 'Unnamed exercise';
+}
+
+function identityValue(identity: ExerciseIdentity): string {
+    return identity.exerciseId ?? `free:${identity.freeTextName ?? ''}`;
+}
+
+/** Progressive-overload view (S1.7, ADR-0021). Reads the raw per-set log directly
+ *  (D-SETLOG) via `useOverloadHistory` -- no dependency on S2.1's 1RM estimator or Step C,
+ *  neither of which exist yet at this point in the plan. A table, not a chart: the plan
+ *  asked for "load, reps, tonnage and best set over time," which a row per session already
+ *  satisfies: charting is a presentation upgrade for later, not a correctness gap now. */
+export function StrengthOverloadHistory({ userId }: StrengthOverloadHistoryProps) {
+    const { loading, error, exercises, selected, select, history, invalidRecords } = useOverloadHistory(userId);
+
+    if (loading) {
+        return <div className="strength-overload-history"><p className="card-empty">Loading overload history…</p></div>;
+    }
+
+    if (error) {
+        return <div className="strength-overload-history"><p className="strength-error">{error}</p></div>;
+    }
+
+    if (exercises.length === 0) {
+        return (
+            <div className="strength-overload-history">
+                <h3>Overload history</h3>
+                <p className="card-empty">No strength sets logged yet in the last 90 days.</p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="strength-overload-history">
+            <h3>Overload history</h3>
+
+            <select
+                value={selected ? identityValue(selected) : ''}
+                onChange={event => {
+                    const identity = exercises.find(exercise => identityValue(exercise) === event.target.value) ?? null;
+                    select(identity);
+                }}
+            >
+                <option value="">Select an exercise…</option>
+                {exercises.map(identity => (
+                    <option key={identityValue(identity)} value={identityValue(identity)}>{exerciseLabel(identity)}</option>
+                ))}
+            </select>
+
+            {invalidRecords > 0 && (
+                <p className="strength-overload-warning">{invalidRecords} session record{invalidRecords === 1 ? '' : 's'} could not be read and {invalidRecords === 1 ? 'is' : 'are'} omitted below.</p>
+            )}
+
+            {selected && history.length === 0 && <p className="card-empty">No sets logged for this exercise in the last 90 days.</p>}
+
+            {selected && history.length > 0 && (
+                <table className="strength-overload-table">
+                    <thead>
+                        <tr>
+                            <th>Date</th>
+                            <th>Sets</th>
+                            <th>Reps</th>
+                            <th>Tonnage (kg)</th>
+                            <th>Heaviest set</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {history.map(entry => (
+                            <tr key={entry.sessionId}>
+                                <td>{entry.date}</td>
+                                <td>{entry.workingSetCount}{entry.setCount !== entry.workingSetCount ? ` (+${entry.setCount - entry.workingSetCount} warm-up)` : ''}</td>
+                                <td>{entry.totalReps}</td>
+                                <td>{entry.tonnageKg}</td>
+                                <td>
+                                    {entry.heaviestSet
+                                        ? `${entry.heaviestSet.reps} × ${entry.heaviestSet.weightKg ?? 'BW'}${entry.heaviestSet.weightKg !== null ? ' kg' : ''}`
+                                        : '—'}
+                                </td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            )}
+        </div>
+    );
+}

--- a/app/src/hooks/useOverloadHistory.ts
+++ b/app/src/hooks/useOverloadHistory.ts
@@ -1,0 +1,65 @@
+import { useEffect, useMemo, useState } from 'react';
+import { strengthSessionService } from '../services/strengthSessionService';
+import type { StrengthSession } from '../engine/models';
+import { distinctLoggedExercises, summarizeExerciseAcrossSessions, type ExerciseIdentity, type ExerciseSessionSummary } from '../workouts/overloadHistory';
+import { addDaysToLocalDateString, getLocalDateString } from '../utils/localDate';
+
+/** Thin orchestration over `overloadHistory.ts` (pure, fully unit-tested) and
+ *  `strengthSessionService.getSessionsInRange`. No dedicated test file -- same rationale as
+ *  every other hook added in this plan: no `@testing-library/react` in this toolchain, and
+ *  the two things worth testing (the aggregation math, the query shape) are each tested at
+ *  the layer below. */
+export interface UseOverloadHistoryResult {
+    loading: boolean;
+    error: string | null;
+    exercises: ExerciseIdentity[];
+    selected: ExerciseIdentity | null;
+    select: (identity: ExerciseIdentity | null) => void;
+    history: ExerciseSessionSummary[];
+    invalidRecords: number;
+}
+
+const DEFAULT_WINDOW_DAYS = 90;
+
+export function useOverloadHistory(userId: string | null | undefined, windowDays: number = DEFAULT_WINDOW_DAYS): UseOverloadHistoryResult {
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [sessions, setSessions] = useState<StrengthSession[]>([]);
+    const [invalidRecords, setInvalidRecords] = useState(0);
+    const [selected, setSelected] = useState<ExerciseIdentity | null>(null);
+
+    useEffect(() => {
+        // Same no-userId early-exit shape as App.tsx's loadDecisionInput effect; there is
+        // no external system to defer this to when there is nothing to load in the first
+        // place.
+        if (!userId) {
+            // eslint-disable-next-line react-hooks/set-state-in-effect
+            setLoading(false);
+            return;
+        }
+        let cancelled = false;
+        setLoading(true);
+        const endInclusive = getLocalDateString();
+        const startInclusive = addDaysToLocalDateString(endInclusive, -windowDays);
+        strengthSessionService.getSessionsInRange(userId, startInclusive, endInclusive)
+            .then(result => {
+                if (cancelled) return;
+                setSessions(result.sessions);
+                setInvalidRecords(result.invalidRecords);
+            })
+            .catch(err => {
+                if (!cancelled) setError(err instanceof Error ? err.message : 'Could not load strength session history');
+            })
+            .finally(() => {
+                if (!cancelled) setLoading(false);
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, [userId, windowDays]);
+
+    const exercises = useMemo(() => distinctLoggedExercises(sessions), [sessions]);
+    const history = useMemo(() => (selected ? summarizeExerciseAcrossSessions(sessions, selected) : []), [sessions, selected]);
+
+    return { loading, error, exercises, selected, select: setSelected, history, invalidRecords };
+}

--- a/app/src/hooks/useOverloadHistory.ts
+++ b/app/src/hooks/useOverloadHistory.ts
@@ -39,9 +39,10 @@ export function useOverloadHistory(userId: string | null | undefined, windowDays
         }
         let cancelled = false;
         setLoading(true);
-        const endInclusive = getLocalDateString();
-        const startInclusive = addDaysToLocalDateString(endInclusive, -windowDays);
-        strengthSessionService.getSessionsInRange(userId, startInclusive, endInclusive)
+        const today = getLocalDateString();
+        const throughDateExclusive = addDaysToLocalDateString(today, 1);
+        const startInclusive = addDaysToLocalDateString(throughDateExclusive, -windowDays);
+        strengthSessionService.getSessionsInRange(userId, startInclusive, throughDateExclusive)
             .then(result => {
                 if (cancelled) return;
                 setSessions(result.sessions);

--- a/app/src/services/strengthSessionService.test.ts
+++ b/app/src/services/strengthSessionService.test.ts
@@ -75,6 +75,26 @@ describe('StrengthSessionService', () => {
         });
     });
 
+    describe('observeSession', () => {
+        it('reports SDK pending-write metadata instead of treating a local-cache write as synced', () => {
+            const unsubscribe = vi.fn();
+            firestore.onSnapshot.mockImplementationOnce((_ref, _options, next) => {
+                next({
+                    id: SESSION_ID,
+                    ref: { path: `users/${USER_ID}/strength_sessions/${SESSION_ID}` },
+                    exists: () => true,
+                    data: () => validSession(),
+                    metadata: { hasPendingWrites: true },
+                });
+                return unsubscribe;
+            });
+            const listener = vi.fn();
+            expect(service.observeSession(USER_ID, SESSION_ID, listener)).toBe(unsubscribe);
+            expect(listener).toHaveBeenCalledWith(expect.objectContaining({ status: 'AVAILABLE' }), true);
+            expect(firestore.onSnapshot.mock.calls[0]?.[1]).toEqual({ includeMetadataChanges: true });
+        });
+    });
+
     describe('startSession', () => {
         it('creates an in_progress session with the freshly minted doc id embedded as sessionId', async () => {
             const session = await service.startSession(USER_ID, { startedAt: '2026-08-17T18:00:00Z' });
@@ -90,40 +110,11 @@ describe('StrengthSessionService', () => {
         });
     });
 
-    describe('observeSession', () => {
-        it('reports Firestore pending-write metadata', () => {
-            const unsubscribe = vi.fn();
-            firestore.onSnapshot.mockImplementationOnce((_ref, _options, next) => {
-                next({ id: SESSION_ID, ref: { path: `users/${USER_ID}/strength_sessions/${SESSION_ID}` }, exists: () => true, data: () => validSession(), metadata: { hasPendingWrites: true } });
-                return unsubscribe;
-            });
-            const listener = vi.fn();
-            expect(service.observeSession(USER_ID, SESSION_ID, listener)).toBe(unsubscribe);
-            expect(listener).toHaveBeenCalledWith(expect.objectContaining({ status: 'AVAILABLE' }), true);
-        });
-    });
-
     describe('transitionState', () => {
         it('moves an in_progress session to completed and stamps completedAt', async () => {
             existingDoc(validSession());
             const updated = await service.transitionState(USER_ID, SESSION_ID, 'completed', '2026-08-17T19:00:00Z');
             expect(updated).toMatchObject({ state: 'completed', completedAt: '2026-08-17T19:00:00Z', updatedAt: '2026-08-17T19:00:00Z' });
-            expect(firestore.setDoc).toHaveBeenCalledWith(expect.anything(), {
-                state: 'completed', completedAt: '2026-08-17T19:00:00Z', updatedAt: '2026-08-17T19:00:00Z',
-            }, { merge: true });
-        });
-
-        it('preserves an existing completion timestamp on an idempotent close', async () => {
-            existingDoc(validSession({ state: 'completed', completedAt: '2026-08-17T19:00:00Z', updatedAt: '2026-08-17T19:00:00Z' }));
-            const updated = await service.transitionState(USER_ID, SESSION_ID, 'completed', '2026-08-17T20:00:00Z');
-            expect(updated.completedAt).toBe('2026-08-17T19:00:00Z');
-            expect(firestore.setDoc).not.toHaveBeenCalled();
-        });
-
-        it('rejects a transition timestamp before the last saved update', async () => {
-            existingDoc(validSession({ updatedAt: '2026-08-17T19:00:00Z' }));
-            await expect(service.transitionState(USER_ID, SESSION_ID, 'completed', '2026-08-17T18:59:59Z')).rejects.toThrow(/must not precede/i);
-            expect(firestore.setDoc).not.toHaveBeenCalled();
         });
 
         it('rejects reopening a completed session before ever writing to Firestore', async () => {
@@ -194,9 +185,9 @@ describe('StrengthSessionService', () => {
 
         it('returns a fresh in_progress session, even if its date field is yesterday (started before midnight)', async () => {
             firestore.getDocs.mockResolvedValueOnce({
-                docs: [{ id: SESSION_ID, ref: { path: `users/${USER_ID}/strength_sessions/${SESSION_ID}` }, data: () => validSession({ date: '2026-08-16', startedAt: '2026-08-16T23:50:00Z' }) }],
+                docs: [{ id: SESSION_ID, ref: { path: `users/${USER_ID}/strength_sessions/${SESSION_ID}` }, data: () => validSession({ date: '2026-08-16', startedAt: '2026-08-16T21:50:00Z' }) }],
             });
-            const active = await service.findActiveSession(USER_ID, '2026-08-17T00:10:00Z');
+            const active = await service.findActiveSession(USER_ID, '2026-08-16T22:10:00Z');
             expect(active).toMatchObject({ sessionId: SESSION_ID, state: 'in_progress' });
         });
 
@@ -221,7 +212,7 @@ describe('StrengthSessionService', () => {
             expect(options).toEqual({ merge: true });
         });
 
-        it('rejects invalid nested set data before writing', async () => {
+        it('rejects invalid nested set data before the permissive array rules boundary', async () => {
             const exercises = [{ exerciseId: 'bench_press', sets: [{ setIndex: 1, reps: 1001, weightKg: 60, isWarmup: false, completedAt: '2026-08-17T18:10:00Z' }] }];
             await expect(service.saveExercises(USER_ID, SESSION_ID, exercises)).rejects.toThrow('schema bounds');
             expect(firestore.setDoc).not.toHaveBeenCalled();
@@ -229,6 +220,12 @@ describe('StrengthSessionService', () => {
     });
 
     describe('getSessionsInRange', () => {
+        it('uses an exclusive upper bound matching TrainingHistorySnapshot semantics', async () => {
+            await service.getSessionsInRange(USER_ID, '2026-08-01', '2026-08-31');
+            expect(firestore.where).toHaveBeenNthCalledWith(1, 'date', '>=', '2026-08-01');
+            expect(firestore.where).toHaveBeenNthCalledWith(2, 'date', '<', '2026-08-31');
+        });
+
         it('returns parsed sessions within the range', async () => {
             firestore.getDocs.mockResolvedValueOnce({
                 docs: [{ id: SESSION_ID, ref: { path: `users/${USER_ID}/strength_sessions/${SESSION_ID}` }, data: () => validSession() }],

--- a/app/src/services/strengthSessionService.test.ts
+++ b/app/src/services/strengthSessionService.test.ts
@@ -191,4 +191,33 @@ describe('StrengthSessionService', () => {
             expect(options).toEqual({ merge: true });
         });
     });
+
+    describe('getSessionsInRange', () => {
+        it('returns parsed sessions within the range', async () => {
+            firestore.getDocs.mockResolvedValueOnce({
+                docs: [{ id: SESSION_ID, ref: { path: `users/${USER_ID}/strength_sessions/${SESSION_ID}` }, data: () => validSession() }],
+            });
+            const result = await service.getSessionsInRange(USER_ID, '2026-08-01', '2026-08-31');
+            expect(result.sessions).toHaveLength(1);
+            expect(result.invalidRecords).toBe(0);
+        });
+
+        it('omits an invalid document from the rows but counts it, rather than failing the whole range', async () => {
+            firestore.getDocs.mockResolvedValueOnce({
+                docs: [
+                    { id: SESSION_ID, ref: { path: `users/${USER_ID}/strength_sessions/${SESSION_ID}` }, data: () => validSession() },
+                    { id: 'corrupt', ref: { path: `users/${USER_ID}/strength_sessions/corrupt` }, data: () => ({ ...validSession({ sessionId: 'corrupt' }), state: 'not-a-real-state' }) },
+                ],
+            });
+            const result = await service.getSessionsInRange(USER_ID, '2026-08-01', '2026-08-31');
+            expect(result.sessions).toHaveLength(1);
+            expect(result.invalidRecords).toBe(1);
+        });
+
+        it('returns an empty range cleanly', async () => {
+            firestore.getDocs.mockResolvedValueOnce({ docs: [] });
+            const result = await service.getSessionsInRange(USER_ID, '2026-08-01', '2026-08-31');
+            expect(result).toEqual({ sessions: [], invalidRecords: 0 });
+        });
+    });
 });

--- a/app/src/services/strengthSessionService.ts
+++ b/app/src/services/strengthSessionService.ts
@@ -40,6 +40,9 @@ export class StrengthSessionService {
         return state.status === 'AVAILABLE' ? state.data : null;
     }
 
+    /** Metadata-aware observation used by the gym-floor UI. `setDoc` resolving means the
+     * write reached the local cache, not the server; `hasPendingWrites` is the SDK's actual
+     * acknowledgement signal and is therefore the only honest synced/pending indicator. */
     observeSession(
         userId: string,
         sessionId: string,
@@ -51,12 +54,17 @@ export class StrengthSessionService {
                 listener({ status: 'MISSING' }, snapshot.metadata.hasPendingWrites);
                 return;
             }
-            listener(parseStrengthSession(snapshot.data(), snapshot.ref.path, snapshot.id, userId), snapshot.metadata.hasPendingWrites);
-        }, error => listener({
-            status: 'UNAVAILABLE',
-            operation: 'observe strength session sync',
-            retryable: !isPermissionDeniedError(error),
-        }, false));
+            listener(
+                parseStrengthSession(snapshot.data(), snapshot.ref.path, snapshot.id, userId),
+                snapshot.metadata.hasPendingWrites,
+            );
+        }, error => {
+            listener({
+                status: 'UNAVAILABLE',
+                operation: 'observe strength session sync',
+                retryable: !isPermissionDeniedError(error),
+            }, false);
+        });
     }
 
     /** Starts a new `in_progress` session. The document id is generated client-side (via
@@ -103,6 +111,9 @@ export class StrengthSessionService {
         if (!transition.ok) {
             throw new Error(transition.reason);
         }
+        // Terminal states are idempotent and immutable. Rewriting a completed session's
+        // completion time would change derived duration and replayed load without a new
+        // workout having occurred.
         if (current.state === next) return current;
         if (!isValidStrengthInstant(nowIso) || Date.parse(nowIso) < Date.parse(current.updatedAt)) {
             throw new Error('Strength session transition time must not precede the last saved update');
@@ -114,6 +125,8 @@ export class StrengthSessionService {
             ...(next === 'completed' ? { completedAt: nowIso } : {}),
         };
         const docRef = doc(getDb(), 'users', userId, this.collectionPath, sessionId);
+        // Merge only lifecycle fields. A whole-document rewrite can overwrite a set that
+        // another tab queued between the read above and this close action.
         await setDoc(docRef, {
             state: next,
             updatedAt: nowIso,
@@ -181,9 +194,9 @@ export class StrengthSessionService {
      *  the rows and counted, matching that precedent -- a corrupt document must not read as
      *  a genuinely missing day, and one bad document must not fail the whole range the way
      *  a single-document read's `INVALID` status would. */
-    async getSessionsInRange(userId: string, startDateInclusive: string, endDateInclusive: string): Promise<{ sessions: StrengthSession[]; invalidRecords: number }> {
+    async getSessionsInRange(userId: string, startDateInclusive: string, throughDateExclusive: string): Promise<{ sessions: StrengthSession[]; invalidRecords: number }> {
         const collRef = collection(getDb(), 'users', userId, this.collectionPath);
-        const q = query(collRef, where('date', '>=', startDateInclusive), where('date', '<=', endDateInclusive), orderBy('date', 'asc'));
+        const q = query(collRef, where('date', '>=', startDateInclusive), where('date', '<', throughDateExclusive), orderBy('date', 'asc'));
         const querySnapshot = await getDocs(q);
         const sessions: StrengthSession[] = [];
         let invalidRecords = 0;

--- a/app/src/services/strengthSessionService.ts
+++ b/app/src/services/strengthSessionService.ts
@@ -144,6 +144,26 @@ export class StrengthSessionService {
         const docRef = doc(getDb(), 'users', userId, this.collectionPath, sessionId);
         await setDoc(docRef, { exercises, updatedAt: nowIso }, { merge: true });
     }
+
+    /** Bounded date-range read for S1.7's overload history, same query shape as
+     *  `activityService.getActivitiesInRange` / `decisionJournalService.getEntriesInRange`
+     *  (`where` on `date`, `orderBy('date')`). An invalid stored session is omitted from
+     *  the rows and counted, matching that precedent -- a corrupt document must not read as
+     *  a genuinely missing day, and one bad document must not fail the whole range the way
+     *  a single-document read's `INVALID` status would. */
+    async getSessionsInRange(userId: string, startDateInclusive: string, endDateInclusive: string): Promise<{ sessions: StrengthSession[]; invalidRecords: number }> {
+        const collRef = collection(getDb(), 'users', userId, this.collectionPath);
+        const q = query(collRef, where('date', '>=', startDateInclusive), where('date', '<=', endDateInclusive), orderBy('date', 'asc'));
+        const querySnapshot = await getDocs(q);
+        const sessions: StrengthSession[] = [];
+        let invalidRecords = 0;
+        for (const docSnap of querySnapshot.docs) {
+            const parsed = parseStrengthSession(docSnap.data(), docSnap.ref.path, docSnap.id, userId);
+            if (parsed.status === 'AVAILABLE') sessions.push(parsed.data);
+            else if (parsed.status === 'INVALID') invalidRecords += 1;
+        }
+        return { sessions, invalidRecords };
+    }
 }
 
 export const strengthSessionService = new StrengthSessionService();

--- a/app/src/workouts/overloadHistory.test.ts
+++ b/app/src/workouts/overloadHistory.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import { distinctLoggedExercises, summarizeExerciseAcrossSessions, summarizeExerciseSession } from './overloadHistory';
+import type { LoggedSet, StrengthSession } from '../engine/models';
+
+function set(overrides: Partial<LoggedSet> = {}): LoggedSet {
+    return { setIndex: 1, weightKg: 80, reps: 5, isWarmup: false, completedAt: '2026-08-17T18:00:00Z', ...overrides };
+}
+
+function session(overrides: Partial<StrengthSession> = {}): StrengthSession {
+    return {
+        userId: 'u1', sessionId: 's1', date: '2026-08-17', startedAt: '2026-08-17T18:00:00Z',
+        updatedAt: '2026-08-17T18:00:00Z', state: 'in_progress', exercises: [], schemaVersion: 1,
+        ...overrides,
+    };
+}
+
+describe('summarizeExerciseSession', () => {
+    it('returns null when the exercise was not logged this session', () => {
+        const s = session({ exercises: [{ exerciseId: 'pull_up', sets: [set()] }] });
+        expect(summarizeExerciseSession(s, { exerciseId: 'front_squat' })).toBeNull();
+    });
+
+    it('returns null when the exercise is present but has no sets', () => {
+        const s = session({ exercises: [{ exerciseId: 'front_squat', sets: [] }] });
+        expect(summarizeExerciseSession(s, { exerciseId: 'front_squat' })).toBeNull();
+    });
+
+    it('computes tonnage from working sets only, excluding warm-ups', () => {
+        const s = session({ exercises: [{ exerciseId: 'front_squat', sets: [
+            set({ setIndex: 1, weightKg: 40, reps: 5, isWarmup: true }),
+            set({ setIndex: 2, weightKg: 100, reps: 5, isWarmup: false }),
+            set({ setIndex: 3, weightKg: 100, reps: 5, isWarmup: false }),
+        ] }] });
+        const summary = summarizeExerciseSession(s, { exerciseId: 'front_squat' });
+        expect(summary?.tonnageKg).toBe(1000); // 100*5 + 100*5, the 40kg warm-up excluded
+        expect(summary?.totalReps).toBe(15); // all three sets, including the warm-up
+        expect(summary?.workingSetCount).toBe(2);
+        expect(summary?.setCount).toBe(3);
+    });
+
+    it('contributes 0kg tonnage for a bodyweight working set rather than dropping it', () => {
+        const s = session({ exercises: [{ exerciseId: 'pull_up', sets: [set({ weightKg: null, reps: 8, isWarmup: false })] }] });
+        const summary = summarizeExerciseSession(s, { exerciseId: 'pull_up' });
+        expect(summary?.tonnageKg).toBe(0);
+        expect(summary?.totalReps).toBe(8);
+    });
+
+    it('picks the heaviest working set, ties broken by more reps', () => {
+        const s = session({ exercises: [{ exerciseId: 'front_squat', sets: [
+            set({ setIndex: 1, weightKg: 100, reps: 5 }),
+            set({ setIndex: 2, weightKg: 105, reps: 3 }),
+            set({ setIndex: 3, weightKg: 105, reps: 5 }),
+        ] }] });
+        expect(summarizeExerciseSession(s, { exerciseId: 'front_squat' })?.heaviestSet).toMatchObject({ setIndex: 3, weightKg: 105, reps: 5 });
+    });
+
+    it('excludes a warm-up from heaviest-set consideration even if it was the heaviest weight moved', () => {
+        const s = session({ exercises: [{ exerciseId: 'front_squat', sets: [
+            set({ setIndex: 1, weightKg: 150, reps: 1, isWarmup: true }),
+            set({ setIndex: 2, weightKg: 100, reps: 5, isWarmup: false }),
+        ] }] });
+        expect(summarizeExerciseSession(s, { exerciseId: 'front_squat' })?.heaviestSet).toMatchObject({ setIndex: 2 });
+    });
+
+    it('returns a null heaviestSet when every working set was bodyweight', () => {
+        const s = session({ exercises: [{ exerciseId: 'pull_up', sets: [set({ weightKg: null })] }] });
+        expect(summarizeExerciseSession(s, { exerciseId: 'pull_up' })?.heaviestSet?.weightKg).toBeNull();
+    });
+
+    it('never conflates two distinct free-text exercises that share exerciseId: null', () => {
+        const s = session({ exercises: [
+            { exerciseId: null, freeTextName: 'Farmer carry', sets: [set({ weightKg: 60 })] },
+            { exerciseId: null, freeTextName: 'Sled push', sets: [set({ weightKg: 90 })] },
+        ] });
+        const farmerCarry = summarizeExerciseSession(s, { exerciseId: null, freeTextName: 'Farmer carry' });
+        const sledPush = summarizeExerciseSession(s, { exerciseId: null, freeTextName: 'Sled push' });
+        expect(farmerCarry?.tonnageKg).toBe(60 * 5);
+        expect(sledPush?.tonnageKg).toBe(90 * 5);
+    });
+});
+
+describe('summarizeExerciseAcrossSessions', () => {
+    it('includes only sessions that logged the exercise, sorted oldest first', () => {
+        const s1 = session({ sessionId: 's1', date: '2026-08-10', exercises: [{ exerciseId: 'front_squat', sets: [set({ weightKg: 90 })] }] });
+        const s2 = session({ sessionId: 's2', date: '2026-08-03', exercises: [{ exerciseId: 'front_squat', sets: [set({ weightKg: 80 })] }] });
+        const s3 = session({ sessionId: 's3', date: '2026-08-05', exercises: [{ exerciseId: 'pull_up', sets: [set()] }] }); // different exercise
+        const history = summarizeExerciseAcrossSessions([s1, s2, s3], { exerciseId: 'front_squat' });
+        expect(history.map(entry => entry.sessionId)).toEqual(['s2', 's1']);
+    });
+
+    it('includes sessions in every state -- an abandoned session still did real work', () => {
+        const abandoned = session({ sessionId: 's1', state: 'abandoned', exercises: [{ exerciseId: 'front_squat', sets: [set()] }] });
+        expect(summarizeExerciseAcrossSessions([abandoned], { exerciseId: 'front_squat' })).toHaveLength(1);
+    });
+
+    it('returns an empty history when the exercise was never logged', () => {
+        const s = session({ exercises: [{ exerciseId: 'pull_up', sets: [set()] }] });
+        expect(summarizeExerciseAcrossSessions([s], { exerciseId: 'front_squat' })).toEqual([]);
+    });
+});
+
+describe('distinctLoggedExercises', () => {
+    it('lists each catalog exercise once even if logged across several sessions', () => {
+        const s1 = session({ sessionId: 's1', exercises: [{ exerciseId: 'front_squat', sets: [set()] }] });
+        const s2 = session({ sessionId: 's2', exercises: [{ exerciseId: 'front_squat', sets: [set()] }, { exerciseId: 'pull_up', sets: [set()] }] });
+        expect(distinctLoggedExercises([s1, s2])).toEqual([{ exerciseId: 'front_squat' }, { exerciseId: 'pull_up' }]);
+    });
+
+    it('keeps two free-text exercises with different names distinct', () => {
+        const s = session({ exercises: [
+            { exerciseId: null, freeTextName: 'Farmer carry', sets: [set()] },
+            { exerciseId: null, freeTextName: 'Sled push', sets: [set()] },
+        ] });
+        expect(distinctLoggedExercises([s])).toEqual([
+            { exerciseId: null, freeTextName: 'Farmer carry' },
+            { exerciseId: null, freeTextName: 'Sled push' },
+        ]);
+    });
+
+    it('excludes an exercise entry that was added but never had a set logged', () => {
+        const s = session({ exercises: [{ exerciseId: 'front_squat', sets: [] }] });
+        expect(distinctLoggedExercises([s])).toEqual([]);
+    });
+});

--- a/app/src/workouts/overloadHistory.ts
+++ b/app/src/workouts/overloadHistory.ts
@@ -1,0 +1,101 @@
+import type { LoggedExercise, LoggedSet, StrengthSession } from '../engine/models';
+
+/**
+ * Per-exercise progressive-overload aggregation (S1.7, ADR-0021). Reads the raw per-set
+ * log directly (D-SETLOG) -- this is the goal that needed nothing from Step B or C, and
+ * nothing here is derived from or dependent on S2.1's 1RM estimator, which does not exist
+ * yet at this point in the plan. "Heaviest set" below is a deliberately plain heuristic
+ * (greatest weight moved), not an estimated max -- conflating the two would quietly
+ * anticipate a formula this plan explicitly defers to a later, measured decision.
+ */
+
+export interface ExerciseIdentity {
+    exerciseId: string | null;
+    freeTextName?: string;
+}
+
+/** A bare `exerciseId` is not identity on its own: two different free-text lifts both have
+ *  `exerciseId: null`, and matching on `null` alone would silently merge their history.
+ *  Every lookup in this module goes through this key. */
+function identityKey(identity: ExerciseIdentity): string {
+    return identity.exerciseId ?? `free:${identity.freeTextName ?? ''}`;
+}
+
+function matchesIdentity(exercise: LoggedExercise, identity: ExerciseIdentity): boolean {
+    return identityKey({ exerciseId: exercise.exerciseId, freeTextName: exercise.freeTextName }) === identityKey(identity);
+}
+
+export interface ExerciseSessionSummary {
+    date: string;
+    sessionId: string;
+    setCount: number;
+    workingSetCount: number;
+    totalReps: number;
+    /** Sum of reps x weightKg across working (non-warm-up) sets only -- warm-up sets are
+     *  recorded (D-SETLOG retains them) but excluded here, matching S1.2's rationale for
+     *  why `isWarmup` exists: they would otherwise inflate the trend with sets that were
+     *  never meant to represent the day's real work. A bodyweight set contributes 0 kg of
+     *  tonnage (it still did real reps, counted in `totalReps`) rather than being dropped
+     *  from the summary entirely. */
+    tonnageKg: number;
+    /** The working set with the greatest `weightKg`, ties broken by more reps. `null` when
+     *  every set was bodyweight-only or the exercise had no working sets this session. */
+    heaviestSet: LoggedSet | null;
+}
+
+function isHeavier(candidate: LoggedSet, current: LoggedSet): boolean {
+    const candidateWeight = candidate.weightKg ?? 0;
+    const currentWeight = current.weightKg ?? 0;
+    if (candidateWeight !== currentWeight) return candidateWeight > currentWeight;
+    return candidate.reps > current.reps;
+}
+
+export function summarizeExerciseSession(session: StrengthSession, identity: ExerciseIdentity): ExerciseSessionSummary | null {
+    const exercise = session.exercises.find(candidate => matchesIdentity(candidate, identity));
+    if (!exercise || exercise.sets.length === 0) return null;
+
+    const workingSets = exercise.sets.filter(set => !set.isWarmup);
+    const totalReps = exercise.sets.reduce((sum, set) => sum + set.reps, 0);
+    const tonnageKg = workingSets.reduce((sum, set) => sum + set.reps * (set.weightKg ?? 0), 0);
+    const heaviestSet = workingSets.reduce<LoggedSet | null>(
+        (best, set) => (best === null || isHeavier(set, best) ? set : best),
+        null,
+    );
+
+    return {
+        date: session.date,
+        sessionId: session.sessionId,
+        setCount: exercise.sets.length,
+        workingSetCount: workingSets.length,
+        totalReps,
+        tonnageKg,
+        heaviestSet,
+    };
+}
+
+/** One entry per session that actually logged this exercise, oldest first -- a session
+ *  that never touched the exercise contributes nothing (not a zero row). Every session
+ *  state is included, not only `completed`: D-SETLOG's raw log is the source of truth
+ *  regardless of whether the session was ever formally closed, and an `abandoned` session
+ *  still did real work (S1.4's rationale for never deleting one). */
+export function summarizeExerciseAcrossSessions(sessions: readonly StrengthSession[], identity: ExerciseIdentity): ExerciseSessionSummary[] {
+    return [...sessions]
+        .sort((a, b) => a.date.localeCompare(b.date))
+        .map(session => summarizeExerciseSession(session, identity))
+        .filter((summary): summary is ExerciseSessionSummary => summary !== null);
+}
+
+/** Distinct exercises logged across a set of sessions, in first-seen order -- the input to
+ *  an exercise picker that only ever offers exercises the athlete has actually logged. */
+export function distinctLoggedExercises(sessions: readonly StrengthSession[]): ExerciseIdentity[] {
+    const seen = new Map<string, ExerciseIdentity>();
+    for (const session of sessions) {
+        for (const exercise of session.exercises) {
+            if (exercise.sets.length === 0) continue;
+            const identity: ExerciseIdentity = { exerciseId: exercise.exerciseId, ...(exercise.freeTextName ? { freeTextName: exercise.freeTextName } : {}) };
+            const key = identityKey(identity);
+            if (!seen.has(key)) seen.set(key, identity);
+        }
+    }
+    return [...seen.values()];
+}

--- a/app/src/workouts/overloadHistory.ts
+++ b/app/src/workouts/overloadHistory.ts
@@ -17,12 +17,14 @@ export interface ExerciseIdentity {
 /** A bare `exerciseId` is not identity on its own: two different free-text lifts both have
  *  `exerciseId: null`, and matching on `null` alone would silently merge their history.
  *  Every lookup in this module goes through this key. */
-function identityKey(identity: ExerciseIdentity): string {
-    return identity.exerciseId ?? `free:${identity.freeTextName ?? ''}`;
+export function exerciseIdentityKey(identity: ExerciseIdentity): string {
+    return identity.exerciseId !== null
+        ? `catalog:${identity.exerciseId}`
+        : `free:${identity.freeTextName?.trim().toLocaleLowerCase() ?? ''}`;
 }
 
 function matchesIdentity(exercise: LoggedExercise, identity: ExerciseIdentity): boolean {
-    return identityKey({ exerciseId: exercise.exerciseId, freeTextName: exercise.freeTextName }) === identityKey(identity);
+    return exerciseIdentityKey({ exerciseId: exercise.exerciseId, freeTextName: exercise.freeTextName }) === exerciseIdentityKey(identity);
 }
 
 export interface ExerciseSessionSummary {
@@ -51,11 +53,13 @@ function isHeavier(candidate: LoggedSet, current: LoggedSet): boolean {
 }
 
 export function summarizeExerciseSession(session: StrengthSession, identity: ExerciseIdentity): ExerciseSessionSummary | null {
-    const exercise = session.exercises.find(candidate => matchesIdentity(candidate, identity));
-    if (!exercise || exercise.sets.length === 0) return null;
+    const sets = session.exercises
+        .filter(candidate => matchesIdentity(candidate, identity))
+        .flatMap(exercise => exercise.sets);
+    if (sets.length === 0) return null;
 
-    const workingSets = exercise.sets.filter(set => !set.isWarmup);
-    const totalReps = exercise.sets.reduce((sum, set) => sum + set.reps, 0);
+    const workingSets = sets.filter(set => !set.isWarmup);
+    const totalReps = sets.reduce((sum, set) => sum + set.reps, 0);
     const tonnageKg = workingSets.reduce((sum, set) => sum + set.reps * (set.weightKg ?? 0), 0);
     const heaviestSet = workingSets.reduce<LoggedSet | null>(
         (best, set) => (best === null || isHeavier(set, best) ? set : best),
@@ -65,7 +69,7 @@ export function summarizeExerciseSession(session: StrengthSession, identity: Exe
     return {
         date: session.date,
         sessionId: session.sessionId,
-        setCount: exercise.sets.length,
+        setCount: sets.length,
         workingSetCount: workingSets.length,
         totalReps,
         tonnageKg,
@@ -80,7 +84,9 @@ export function summarizeExerciseSession(session: StrengthSession, identity: Exe
  *  still did real work (S1.4's rationale for never deleting one). */
 export function summarizeExerciseAcrossSessions(sessions: readonly StrengthSession[], identity: ExerciseIdentity): ExerciseSessionSummary[] {
     return [...sessions]
-        .sort((a, b) => a.date.localeCompare(b.date))
+        .sort((a, b) => a.date.localeCompare(b.date)
+            || a.startedAt.localeCompare(b.startedAt)
+            || a.sessionId.localeCompare(b.sessionId))
         .map(session => summarizeExerciseSession(session, identity))
         .filter((summary): summary is ExerciseSessionSummary => summary !== null);
 }
@@ -93,7 +99,7 @@ export function distinctLoggedExercises(sessions: readonly StrengthSession[]): E
         for (const exercise of session.exercises) {
             if (exercise.sets.length === 0) continue;
             const identity: ExerciseIdentity = { exerciseId: exercise.exerciseId, ...(exercise.freeTextName ? { freeTextName: exercise.freeTextName } : {}) };
-            const key = identityKey(identity);
+            const key = exerciseIdentityKey(identity);
             if (!seen.has(key)) seen.set(key, identity);
         }
     }

--- a/docs/plans/strength-session-logging.md
+++ b/docs/plans/strength-session-logging.md
@@ -66,7 +66,7 @@ accepted before any Step C item.
 | S1.4 | Session state machine and date attribution | `[x]` | S1.2 |
 | S1.5 | Set-entry UI | `[x]` | S1.3, S1.4 |
 | S1.6 | Rest timer and derived rest | `[x]` | S1.5 |
-| S1.7 | Overload history view | `[ ]` | S1.3 |
+| S1.7 | Overload history view | `[x]` | S1.3 |
 | S2.1 | Gauge-aware 1RM estimator | `[ ]` | S1.2 |
 | S2.2 | Write-back under a `derived` source | `[ ]` | S2.1 |
 | S3.1 | Set log → `CompletedExposure` | `[ ]` | S1.2, ADR for D-STRCOST |
@@ -402,7 +402,7 @@ instead: `elapsedSeconds` and `formatElapsed` are fully covered, and the hook's 
 moving parts (`setInterval` as trigger, `elapsedSeconds` as value) are each independently
 tested at the boundary between them.
 
-### S1.7 `[ ]` Overload history view
+### S1.7 `[x]` Overload history view
 
 **Change:** per-exercise history — load, reps, tonnage and best set over time, reading the
 raw log directly (D-SETLOG). Warm-up sets excluded from tonnage.
@@ -411,6 +411,33 @@ This is the deliverable for goal 2 and needs nothing from Steps B or C.
 
 **Done when:** an exercise with sessions across several weeks renders a correct trend;
 warm-up sets are excluded; an exercise with one session renders without special-casing.
+
+**Outcome (2026-08-17).** `workouts/overloadHistory.ts` (`summarizeExerciseSession`,
+`summarizeExerciseAcrossSessions`, `distinctLoggedExercises` — 14 tests, pure, no I/O),
+`services/strengthSessionService.getSessionsInRange` (bounded date-range read, same query
+shape as `activityService.getActivitiesInRange` / `decisionJournalService.getEntriesInRange`
+— invalid documents are omitted and counted rather than failing the whole range; 3 new
+tests), `hooks/useOverloadHistory.ts` (orchestration, no dedicated test file per this plan's
+established precedent), and `components/StrengthOverloadHistory.tsx` (a table, not a chart —
+the plan's own wording is satisfied by one row per session; 8 smoke tests). Wired into the
+same `'strength'` screen as S1.5's runner rather than a separate nav entry, stacked below it.
+
+**A real identity bug was caught and fixed during implementation, not after.** The first
+draft matched an exercise across sessions on `exerciseId` alone. Two different free-text
+lifts both have `exerciseId: null`, so that match would have silently merged, say, "Farmer
+carry" and "Sled push" into one shared history the moment both existed. Every lookup in the
+module now goes through an `ExerciseIdentity { exerciseId, freeTextName }` and a single
+`identityKey` function, and a dedicated test (`'never conflates two distinct free-text
+exercises that share exerciseId: null'`) pins it. Contrast with `upsertExercise` (S1.5),
+which deliberately keeps two same-named free-text entries distinct *within one session* —
+across sessions, for history purposes, they are necessarily merged by name instead, since
+there is nothing else to key on. Documented as a stated relaxation, not an inconsistency.
+
+**"Best set" is a plain heuristic, not an estimate.** `heaviestSet` is the working set with
+the greatest `weightKg` (ties broken by reps) — never conflated with S2.1's 1RM estimator,
+which does not exist yet at this point in the plan and uses a different, gauge-filtered
+admissibility rule. Naming it "heaviest" rather than "best" or "estimated max" in the type
+itself was a deliberate choice to make that boundary hard to blur later by accident.
 
 ---
 


### PR DESCRIPTION
## Summary

- Closes Step A. `workouts/overloadHistory.ts`: `summarizeExerciseSession`, `summarizeExerciseAcrossSessions`, `distinctLoggedExercises` — pure, 14 tests, reading the raw per-set log directly (D-SETLOG). Nothing here depends on S2.1's 1RM estimator or Step C, neither of which exist yet at this point in the plan.
- **A real identity bug was caught and fixed during implementation, not after**: the first draft matched an exercise across sessions on `exerciseId` alone. Two different free-text lifts both have `exerciseId: null`, so that match would have silently merged e.g. "Farmer carry" and "Sled push" into one shared history. Every lookup now goes through an `ExerciseIdentity{exerciseId, freeTextName}` and one `identityKey` function; a dedicated test pins the fix.
- "Best set" is a plain heaviest-weight-moved heuristic, not an estimate — never conflated with S2.1's (not-yet-built) 1RM estimator, which uses a different, gauge-filtered admissibility rule. Named `heaviestSet` in the type itself, not "best" or "estimated max", to make that boundary hard to blur later by accident.
- `strengthSessionService.getSessionsInRange`: bounded date-range read, same query shape as `activityService.getActivitiesInRange`/`decisionJournalService.getEntriesInRange` — an invalid document is omitted from the rows and counted, not allowed to fail the whole range. 3 new tests.
- `components/StrengthOverloadHistory.tsx`: a table, not a chart — the plan's own wording ("load, reps, tonnage and best set over time") is satisfied by one row per session. 8 smoke tests. Wired into the same `'strength'` screen as S1.5's runner, stacked below it.

## Validation

- [x] `cd app && npm run check` — pass: 1330 tests, 110 files.

Results:
- 14 tests for the aggregation module, including the free-text-conflation regression test; 3 for the new service query; 8 component smoke tests.

## Risk and reviewer guidance

The free-text identity bug (see Summary) is the thing worth double-checking most closely — it's exactly the class of bug that's easy to miss on review since the "obviously correct" version (match on `exerciseId`) looks fine until two null-id exercises coexist.

## Domain invariants

- [x] Firestore writes remain user-scoped — `getSessionsInRange` reads only `users/{userId}/strength_sessions`.
- [x] Calendar-date logic uses Europe/Warsaw — history sorted/queried on the already-Warsaw-local `date` field from S1.4; no new date computation.
- [x] No credentials, tokens, service-account files, or raw health payloads included.
- [x] Recommendation decision logic changed: no. Read-only history view.

## Screenshots or recordings

Not captured — no live browser session available in this environment. Recommend a manual pass to confirm the table renders correctly for full/partial/no telemetry.
