### PR TITLE
feat(strength): gauge-aware 1RM estimator (S2.1)

### DIFF
--- a/app/src/workouts/oneRepMax.test.ts
+++ b/app/src/workouts/oneRepMax.test.ts
@@ -37,6 +37,11 @@ describe('estimateOneRepMax', () => {
         expect(estimateOneRepMax([set({ gauge: undefined })])).toBeNull();
     });
 
+    it('excludes an out-of-range gauge rather than treating it as evidence', () => {
+        expect(estimateOneRepMax([set({ gauge: { scale: 'rir', value: -1 } })])).toBeNull();
+        expect(estimateOneRepMax([set({ gauge: { scale: 'rpe_rts', value: 11 } })])).toBeNull();
+    });
+
     it(`excludes a set beyond MAX_RIR_FOR_ESTIMATION (${MAX_RIR_FOR_ESTIMATION}) reps in reserve`, () => {
         expect(estimateOneRepMax([set({ gauge: { scale: 'rir', value: MAX_RIR_FOR_ESTIMATION + 1 } })])).toBeNull();
         expect(estimateOneRepMax([set({ gauge: { scale: 'rir', value: MAX_RIR_FOR_ESTIMATION } })])).not.toBeNull();

--- a/app/src/workouts/oneRepMax.test.ts
+++ b/app/src/workouts/oneRepMax.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { MAX_REPS_FOR_ESTIMATION, MAX_RIR_FOR_ESTIMATION, estimateOneRepMax } from './oneRepMax';
+import type { LoggedSet } from '../engine/models';
+
+function set(overrides: Partial<LoggedSet> = {}): LoggedSet {
+    return { setIndex: 1, weightKg: 100, reps: 5, isWarmup: false, completedAt: '2026-08-17T18:00:00Z', ...overrides };
+}
+
+describe('estimateOneRepMax', () => {
+    it('produces a plausible Epley estimate from a near-failure set of 5 at 2 RIR', () => {
+        const estimate = estimateOneRepMax([set({ weightKg: 100, reps: 5, gauge: { scale: 'rir', value: 2 } })]);
+        expect(estimate).toMatchObject({ estimatedOneRmKg: 116.7, formula: 'epley' }); // 100 * (1 + 5/30)
+    });
+
+    it('produces no estimate for a power-snatch session gauged by velocity loss', () => {
+        const sets = [
+            set({ weightKg: 80, reps: 3, gauge: { scale: 'velocity_loss', percent: 15 } }),
+            set({ weightKg: 85, reps: 3, gauge: { scale: 'velocity_loss', percent: 18 } }),
+        ];
+        expect(estimateOneRepMax(sets)).toBeNull();
+    });
+
+    it('produces no estimate for a technical-quality gauged session, regardless of met/missed', () => {
+        expect(estimateOneRepMax([set({ gauge: { scale: 'technical', met: true } })])).toBeNull();
+        expect(estimateOneRepMax([set({ gauge: { scale: 'technical', met: false } })])).toBeNull();
+    });
+
+    it('never lets warm-up sets influence the result', () => {
+        const withWarmup = estimateOneRepMax([
+            set({ setIndex: 1, weightKg: 150, reps: 1, isWarmup: true, gauge: { scale: 'rir', value: 0 } }), // heavier but a warm-up
+            set({ setIndex: 2, weightKg: 100, reps: 5, isWarmup: false, gauge: { scale: 'rir', value: 2 } }),
+        ]);
+        expect(withWarmup?.fromSet.setIndex).toBe(2);
+    });
+
+    it('excludes an ungauged set rather than guessing it was near failure', () => {
+        expect(estimateOneRepMax([set({ gauge: undefined })])).toBeNull();
+    });
+
+    it(`excludes a set beyond MAX_RIR_FOR_ESTIMATION (${MAX_RIR_FOR_ESTIMATION}) reps in reserve`, () => {
+        expect(estimateOneRepMax([set({ gauge: { scale: 'rir', value: MAX_RIR_FOR_ESTIMATION + 1 } })])).toBeNull();
+        expect(estimateOneRepMax([set({ gauge: { scale: 'rir', value: MAX_RIR_FOR_ESTIMATION } })])).not.toBeNull();
+    });
+
+    it('excludes an RPE below the equivalent admissibility threshold', () => {
+        const admissibleRpe = 10 - MAX_RIR_FOR_ESTIMATION;
+        expect(estimateOneRepMax([set({ gauge: { scale: 'rpe_rts', value: admissibleRpe - 1 } })])).toBeNull();
+        expect(estimateOneRepMax([set({ gauge: { scale: 'rpe_rts', value: admissibleRpe } })])).not.toBeNull();
+    });
+
+    it(`excludes a set beyond MAX_REPS_FOR_ESTIMATION (${MAX_REPS_FOR_ESTIMATION}) reps even if gauged near failure`, () => {
+        expect(estimateOneRepMax([set({ reps: MAX_REPS_FOR_ESTIMATION + 1, gauge: { scale: 'rir', value: 1 } })])).toBeNull();
+    });
+
+    it('excludes a bodyweight set -- there is no external load to estimate a loaded max from', () => {
+        expect(estimateOneRepMax([set({ weightKg: null, gauge: { scale: 'rir', value: 1 } })])).toBeNull();
+    });
+
+    it('picks the admissible set implying the highest capacity, not an average across sets', () => {
+        const estimate = estimateOneRepMax([
+            set({ setIndex: 1, weightKg: 90, reps: 5, gauge: { scale: 'rir', value: 1 } }), // Epley ~105
+            set({ setIndex: 2, weightKg: 100, reps: 3, gauge: { scale: 'rir', value: 1 } }), // Epley 110
+        ]);
+        expect(estimate?.fromSet.setIndex).toBe(2);
+    });
+
+    it('returns null for an empty set list', () => {
+        expect(estimateOneRepMax([])).toBeNull();
+    });
+});

--- a/app/src/workouts/oneRepMax.ts
+++ b/app/src/workouts/oneRepMax.ts
@@ -1,0 +1,87 @@
+import type { IntensityGauge, LoggedSet } from '../engine/models';
+
+/**
+ * Gauge-aware 1RM estimation (S2.1, ADR-0021). The gauge filter is the entire point of
+ * this module, not an afterthought on top of it -- estimation is only valid on sets taken
+ * near failure (ADR-0021's Context section, and the source analysis's finding A4.1). Feeding
+ * a deliberately fast, submaximal power triple into a 1RM formula returns a number with no
+ * physiological meaning, and that number then corrupts every prescription derived from it
+ * via `estimated_1rm_percent`.
+ *
+ * Formula: Epley (1985), `1RM = weight x (1 + reps / 30)`. Chosen for simplicity and being
+ * the more commonly implemented default in this space, not a claim that it out-performs
+ * Brzycki's `weight x 36 / (37 - reps)` -- this repo does not have evidence either way, and
+ * per D-SUBJEST's precedent (ADR-0020: estimator details are versioned policy, not
+ * invariants), the formula itself may change without this module's admissibility rules
+ * needing to.
+ */
+
+export const ONE_RM_FORMULA = 'epley' as const;
+
+/** Sets more than this many reps in reserve are self-estimates too far from failure to
+ *  trust -- the source analysis's finding A4 on `primer_rir`'s default of 6 (range 4-8):
+ *  at that distance the value functions as a coaching instruction ("stay fast, stay
+ *  fresh"), not a measurement. RPE admissibility is the same bound restated on the
+ *  inverted scale (RPE 10 = 0 RIR, so admissible RPE is 10 - MAX_RIR_FOR_ESTIMATION). */
+export const MAX_RIR_FOR_ESTIMATION = 3;
+
+/** Epley's error grows with rep count; a set logged at 15+ reps is not a reliable proxy
+ *  for a 1-5 rep max regardless of how close to failure it was taken. Conservative,
+ *  documented cap rather than an unbounded formula applied everywhere it technically runs. */
+export const MAX_REPS_FOR_ESTIMATION = 12;
+
+function isNearFailureGauge(gauge: IntensityGauge | undefined): boolean {
+    if (!gauge) return false; // No gauge at all: excluded by default, not a guessed fallback (ADR-0021 S2.1).
+    switch (gauge.scale) {
+        case 'rir':
+            return gauge.value <= MAX_RIR_FOR_ESTIMATION;
+        case 'rpe_rts':
+            return gauge.value >= 10 - MAX_RIR_FOR_ESTIMATION;
+        case 'velocity_loss':
+        case 'technical':
+            // Quality-limited, not failure-limited, by design (D-GAUGE) -- never admissible
+            // for 1RM estimation regardless of the recorded value. A power snatch at any
+            // velocity-loss percentage says nothing about how close the athlete was to a
+            // true maximum, because that was never the intent of the set.
+            return false;
+    }
+}
+
+function isAdmissibleForEstimation(set: LoggedSet): boolean {
+    if (set.isWarmup) return false;
+    if (set.weightKg === null || set.weightKg <= 0) return false; // No external load to estimate a loaded 1RM from.
+    if (set.reps <= 0 || set.reps > MAX_REPS_FOR_ESTIMATION) return false;
+    return isNearFailureGauge(set.gauge);
+}
+
+function epleyOneRepMax(weightKg: number, reps: number): number {
+    return weightKg * (1 + reps / 30);
+}
+
+export interface OneRepMaxEstimate {
+    estimatedOneRmKg: number;
+    fromSet: LoggedSet;
+    formula: typeof ONE_RM_FORMULA;
+}
+
+/** Estimates a 1RM from whichever admissible set implies the highest true capacity --
+ *  the best evidence available from that set of sets, not an average across them (a
+ *  single near-failure single is stronger evidence than several sets diluted together).
+ *  Returns `null` when nothing in `sets` is admissible: a power/velocity session, an
+ *  all-warm-up exercise, or an all-bodyweight exercise all correctly produce no estimate
+ *  rather than a fabricated one. */
+export function estimateOneRepMax(sets: readonly LoggedSet[]): OneRepMaxEstimate | null {
+    let best: OneRepMaxEstimate | null = null;
+    for (const set of sets) {
+        // Re-checking weightKg here (rather than trusting isAdmissibleForEstimation's
+        // identical check) is what lets TypeScript narrow it to `number` without an
+        // assertion -- the two checks must stay in sync; MAX_REPS_FOR_ESTIMATION and the
+        // gauge rule remain the single source of truth in isAdmissibleForEstimation.
+        if (!isAdmissibleForEstimation(set) || set.weightKg === null) continue;
+        const estimatedOneRmKg = Math.round(epleyOneRepMax(set.weightKg, set.reps) * 10) / 10;
+        if (best === null || estimatedOneRmKg > best.estimatedOneRmKg) {
+            best = { estimatedOneRmKg, fromSet: set, formula: ONE_RM_FORMULA };
+        }
+    }
+    return best;
+}

--- a/app/src/workouts/oneRepMax.ts
+++ b/app/src/workouts/oneRepMax.ts
@@ -1,4 +1,5 @@
 import type { IntensityGauge, LoggedSet } from '../engine/models';
+import { isValidIntensityGauge } from '../engine/strengthSessionValidation';
 
 /**
  * Gauge-aware 1RM estimation (S2.1, ADR-0021). The gauge filter is the entire point of
@@ -31,7 +32,7 @@ export const MAX_RIR_FOR_ESTIMATION = 3;
 export const MAX_REPS_FOR_ESTIMATION = 12;
 
 function isNearFailureGauge(gauge: IntensityGauge | undefined): boolean {
-    if (!gauge) return false; // No gauge at all: excluded by default, not a guessed fallback (ADR-0021 S2.1).
+    if (!gauge || !isValidIntensityGauge(gauge)) return false; // Invalid/absent gauges never become evidence.
     switch (gauge.scale) {
         case 'rir':
             return gauge.value <= MAX_RIR_FOR_ESTIMATION;

--- a/docs/plans/strength-session-logging.md
+++ b/docs/plans/strength-session-logging.md
@@ -67,7 +67,7 @@ accepted before any Step C item.
 | S1.5 | Set-entry UI | `[x]` | S1.3, S1.4 |
 | S1.6 | Rest timer and derived rest | `[x]` | S1.5 |
 | S1.7 | Overload history view | `[x]` | S1.3 |
-| S2.1 | Gauge-aware 1RM estimator | `[ ]` | S1.2 |
+| S2.1 | Gauge-aware 1RM estimator | `[x]` | S1.2 |
 | S2.2 | Write-back under a `derived` source | `[ ]` | S2.1 |
 | S3.1 | Set log → `CompletedExposure` | `[ ]` | S1.2, ADR for D-STRCOST |
 | S3.2 | `manualTraining` source wiring | `[ ]` | S3.1 |
@@ -443,7 +443,7 @@ itself was a deliberate choice to make that boundary hard to blur later by accid
 
 ## Step B — 1RM self-calibration
 
-### S2.1 `[ ]` Gauge-aware 1RM estimator
+### S2.1 `[x]` Gauge-aware 1RM estimator
 
 **Change:** estimate 1RM per exercise from logged working sets (Epley or Brzycki — state
 which and why in the module docstring).
@@ -462,6 +462,30 @@ then corrupts every prescription derived from it.
 
 **Done when:** a power-snatch session at `velocity_loss` produces **no** 1RM estimate; a
 near-failure set of 5 produces a plausible one; warm-ups never influence the result.
+
+**Outcome (2026-08-17).** `workouts/oneRepMax.ts`: `estimateOneRepMax` — pure, 11 tests, no
+I/O. Formula is Epley (1985), stated in the module docstring alongside why: simplicity and
+being the more commonly implemented default, explicitly **not** a claim that it outperforms
+Brzycki — this repo has no evidence either way, and per D-SUBJEST's precedent (ADR-0020),
+the formula is versioned policy, not an invariant this module should assert authority over.
+
+Admissibility, each independently tested: `isWarmup` excluded; a `null` `weightKg`
+(bodyweight) excluded, since there is no external load to estimate a *loaded* max from; reps
+beyond `MAX_REPS_FOR_ESTIMATION = 12` excluded even when gauged near failure, because
+Epley's error compounds with rep count regardless of proximity to failure; `velocity_loss`
+and `technical` gauges excluded unconditionally, any value — the plan called these
+quality-limited, not failure-limited, and this is where that distinction actually bites: no
+percentage or met/missed outcome on a power set implies anything about a true maximum, so
+there is no threshold to tune here, only exclusion; an **absent gauge is excluded by
+default**, the explicit deliberate choice the plan asked for rather than an unstated
+assumption; and `rir`/`rpe_rts` are admissible only within `MAX_RIR_FOR_ESTIMATION = 3`
+(RPE ≥ 7 on the inverted scale) — the source analysis's own finding on `primer_rir`'s
+default of 6: past that distance a self-estimate is a coaching instruction, not a
+measurement.
+
+Among admissible sets, the estimator returns the one implying the **highest** capacity, not
+an average — a single genuine near-failure set is stronger evidence of true capacity than
+diluting it against other, less-informative admissible sets from the same exercise.
 
 ### S2.2 `[ ]` Write-back under a `derived` source — **implements D-1RMSRC**
 


### PR DESCRIPTION
## Summary

- `workouts/oneRepMax.ts`: `estimateOneRepMax`, pure, no I/O, 11 tests. Epley (1985) formula, stated with why in the module docstring: simplicity and being the more common default, explicitly **not** a claim it outperforms Brzycki — no evidence either way here, and per D-SUBJEST's precedent (ADR-0020) the formula is versioned policy, not an invariant this module asserts authority over.
- The gauge filter is the point of this module, each rule independently tested: `isWarmup` excluded; `null` `weightKg` (bodyweight) excluded, no external load to estimate a loaded max from; reps beyond `MAX_REPS_FOR_ESTIMATION` (12) excluded even near failure, since Epley's error compounds with rep count regardless; `velocity_loss`/`technical` gauges excluded unconditionally at any value — quality-limited sets imply nothing about a true maximum; an absent gauge excluded by default, the explicit deliberate choice the plan asked for; `rir`/`rpe_rts` admissible only within `MAX_RIR_FOR_ESTIMATION` (3), i.e. RPE ≥ 7 — the source analysis's own finding on `primer_rir`'s default of 6, where a self-estimate that far out is a coaching instruction, not a measurement.
- Among admissible sets, returns whichever implies the highest capacity, not an average — one genuine near-failure set is stronger evidence than diluting it against other admissible sets.

## Validation

- [x] `cd app && npm run check` — pass: 1341 tests, 111 files.

Results:
- 11 tests covering every admissibility rule independently (warm-up, bodyweight, rep cap, each gauge scale, RIR/RPE thresholds, empty input, highest-capacity selection).

## Risk and reviewer guidance

The admissibility thresholds (`MAX_RIR_FOR_ESTIMATION = 3`, `MAX_REPS_FOR_ESTIMATION = 12`) are this implementation's own documented choices, not derived from a cited source — worth a second opinion if you have a stronger reference for either.

## Domain invariants

- [x] Firestore writes remain user-scoped — no writes in this PR; pure estimation function only (write-back is S2.2, next PR).
- [x] Calendar-date logic uses Europe/Warsaw — not applicable, no date logic here.
- [x] No credentials, tokens, service-account files, or raw health payloads included.
- [x] Recommendation decision logic changed: no. Estimator has no caller yet; nothing consumes its output until S2.2.

## Screenshots or recordings

Not applicable — no UI change.
