### PR TITLE
feat(strength): 1RM write-back under a derived ownership rung (S2.2)

### DIFF
--- a/app/src/engine/validation.ts
+++ b/app/src/engine/validation.ts
@@ -873,6 +873,19 @@ export function validatePreferences(raw: any): ValidationResult<UserPreferences>
                  !Object.values(raw.performanceProfile.estimated1RmKg).every((value) => typeof value === 'number' && Number.isFinite(value) && value > 0))) {
                 errors.push({ field: 'performanceProfile.estimated1RmKg', message: 'All estimated 1RM values must be positive numbers' });
             }
+            // ADR-0021 D-1RMSRC: per-exercise provenance for estimated1RmKg.
+            if (raw.performanceProfile.estimated1RmSources !== undefined) {
+                const validSources = ['garmin', 'manual', 'coach', 'derived'];
+                const sources = raw.performanceProfile.estimated1RmSources;
+                const isValid = typeof sources === 'object' && sources !== null &&
+                    Object.values(sources).every((entry: any) =>
+                        typeof entry === 'object' && entry !== null &&
+                        validSources.includes(entry.source) &&
+                        (entry.computedAt === undefined || typeof entry.computedAt === 'string'));
+                if (!isValid) {
+                    errors.push({ field: 'performanceProfile.estimated1RmSources', message: 'Each 1RM source entry must have a valid source (garmin, manual, coach or derived) and an optional computedAt string' });
+                }
+            }
         }
     }
 

--- a/app/src/hooks/useStrengthSessionRunner.ts
+++ b/app/src/hooks/useStrengthSessionRunner.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import type { LoggedExercise, LoggedSet, StrengthSession } from '../engine/models';
 import { strengthSessionService } from '../services/strengthSessionService';
 import { recommendationService } from '../services/recommendationService';
+import { finalizeStrengthSession } from '../services/strengthSessionCompletion';
 import { getLocalDateString } from '../utils/localDate';
 import {
     appendSetToExercise,
@@ -191,7 +192,8 @@ export function useStrengthSessionRunner(userId: string | null | undefined): Use
         setError(null);
         setSaving(true);
         try {
-            const updated = await strengthSessionService.transitionState(userId!, session.sessionId, next);
+            const nowIso = new Date().toISOString();
+            const updated = await finalizeStrengthSession(userId!, session, next, nowIso);
             setSession(updated);
         } catch (err) {
             setError(err instanceof Error ? err.message : `Could not mark the session ${next}`);

--- a/app/src/services/preferencesService.test.ts
+++ b/app/src/services/preferencesService.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const firestore = vi.hoisted(() => ({ doc: vi.fn(), getDoc: vi.fn(), setDoc: vi.fn() }));
+
+vi.mock('firebase/firestore', () => firestore);
+vi.mock('../firebase', () => ({ getDb: vi.fn(() => ({})) }));
+
+import { PreferencesService } from './preferencesService';
+import type { StrengthSession } from '../engine/models';
+
+const USER_ID = 'u1';
+
+/** Only S2.2's applyOneRepMaxDerivations is covered here -- this service otherwise has no
+ *  existing test file, and adding coverage for the rest of it is out of scope for this
+ *  plan; consistent with how every other new method added in this plan is tested without
+ *  taking on unrelated pre-existing gaps. */
+function sessionWithExercise(exerciseId: string, weightKg: number, reps: number, rir: number): StrengthSession {
+    return {
+        userId: USER_ID, sessionId: 's1', date: '2026-08-17', startedAt: '2026-08-17T18:00:00Z',
+        updatedAt: '2026-08-17T18:10:00Z', state: 'completed', schemaVersion: 1,
+        exercises: [{ exerciseId, sets: [{ setIndex: 1, weightKg, reps, isWarmup: false, completedAt: '2026-08-17T18:10:00Z', gauge: { scale: 'rir', value: rir } }] }],
+    };
+}
+
+function existingDoc(data: Record<string, unknown>) {
+    firestore.getDoc.mockResolvedValue({ exists: () => true, data: () => data });
+}
+
+function missingDoc() {
+    firestore.getDoc.mockResolvedValue({ exists: () => false });
+}
+
+describe('PreferencesService.applyOneRepMaxDerivations', () => {
+    let service: PreferencesService;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        service = new PreferencesService();
+        firestore.doc.mockReturnValue({ path: `users/${USER_ID}/preferences/profile` });
+        firestore.setDoc.mockResolvedValue(undefined);
+    });
+
+    it('writes a derived value to both estimated1RmKg locations and records provenance when nothing existed before', async () => {
+        missingDoc();
+        const outcomes = await service.applyOneRepMaxDerivations(USER_ID, sessionWithExercise('front_squat', 100, 5, 2), '2026-08-17T18:15:00Z');
+
+        expect(outcomes).toMatchObject([{ exerciseId: 'front_squat', result: { updated: true, source: 'derived' } }]);
+        expect(firestore.setDoc).toHaveBeenCalledTimes(1);
+        const [, payload] = firestore.setDoc.mock.calls[0] as [unknown, { performanceProfile: { estimated1RmKg: Record<string, number>; strength: { estimated1RmKg: Record<string, number> }; estimated1RmSources: Record<string, { source: string; computedAt?: string }> } }];
+        expect(payload.performanceProfile.estimated1RmKg.front_squat).toBeCloseTo(116.7, 1);
+        expect(payload.performanceProfile.strength.estimated1RmKg.front_squat).toBeCloseTo(116.7, 1);
+        expect(payload.performanceProfile.estimated1RmSources.front_squat).toMatchObject({ source: 'derived', computedAt: '2026-08-17T18:15:00Z' });
+    });
+
+    it('never writes when the existing value is manual, and reports why', async () => {
+        existingDoc({
+            userId: USER_ID,
+            performanceProfile: { estimated1RmKg: { front_squat: 120 }, estimated1RmSources: { front_squat: { source: 'manual' } } },
+        });
+
+        const outcomes = await service.applyOneRepMaxDerivations(USER_ID, sessionWithExercise('front_squat', 130, 5, 1), '2026-08-17T18:15:00Z');
+
+        expect(outcomes).toMatchObject([{ result: { updated: false, estimatedOneRmKg: 120, source: 'manual' } }]);
+        expect(firestore.setDoc).not.toHaveBeenCalled();
+    });
+
+    it('reads strength.estimated1RmKg ahead of the legacy top-level field, matching prescription.ts', async () => {
+        existingDoc({
+            userId: USER_ID,
+            performanceProfile: {
+                estimated1RmKg: { front_squat: 999 }, // legacy, should be ignored in favour of strength.*
+                strength: { estimated1RmKg: { front_squat: 120 } },
+                estimated1RmSources: { front_squat: { source: 'coach' } },
+            },
+        });
+
+        const outcomes = await service.applyOneRepMaxDerivations(USER_ID, sessionWithExercise('front_squat', 200, 5, 1), '2026-08-17T18:15:00Z');
+
+        // Protected because the effective (strength.*) source is coach, not because of the legacy value.
+        expect(outcomes).toMatchObject([{ result: { updated: false, estimatedOneRmKg: 120, source: 'coach' } }]);
+        expect(firestore.setDoc).not.toHaveBeenCalled();
+    });
+
+    it('does not write at all when no exercise produced an admissible estimate', async () => {
+        missingDoc();
+        const noGaugeSession: StrengthSession = {
+            userId: USER_ID, sessionId: 's1', date: '2026-08-17', startedAt: '2026-08-17T18:00:00Z',
+            updatedAt: '2026-08-17T18:10:00Z', state: 'completed', schemaVersion: 1,
+            exercises: [{ exerciseId: 'front_squat', sets: [{ setIndex: 1, weightKg: 100, reps: 5, isWarmup: false, completedAt: '2026-08-17T18:10:00Z' }] }],
+        };
+        const outcomes = await service.applyOneRepMaxDerivations(USER_ID, noGaugeSession);
+        expect(outcomes).toEqual([]);
+        expect(firestore.setDoc).not.toHaveBeenCalled();
+    });
+});

--- a/app/src/services/preferencesService.ts
+++ b/app/src/services/preferencesService.ts
@@ -284,6 +284,7 @@ export class PreferencesService {
         const updatedStrengthEstimated1RmKg = { ...profile?.strength?.estimated1RmKg };
         const updatedSources = { ...profile?.estimated1RmSources };
         for (const outcome of written) {
+            if (!outcome.result.updated) continue;
             updatedEstimated1RmKg[outcome.exerciseId] = outcome.result.estimatedOneRmKg;
             updatedStrengthEstimated1RmKg[outcome.exerciseId] = outcome.result.estimatedOneRmKg;
             updatedSources[outcome.exerciseId] = { source: outcome.result.source, ...(outcome.result.computedAt ? { computedAt: outcome.result.computedAt } : {}) };

--- a/app/src/services/preferencesService.ts
+++ b/app/src/services/preferencesService.ts
@@ -1,8 +1,9 @@
 import { doc, getDoc, setDoc } from 'firebase/firestore';
 import { getDb } from '../firebase';
-import type { UserPreferences } from '../engine/models';
+import type { StrengthSession, UserPreferences } from '../engine/models';
 import type { DataState } from '../engine/dataState';
 import { validatePreferences } from '../engine/validation';
+import { deriveOneRepMaxUpdatesForSession, type OneRepMaxDerivationOutcome } from '../workouts/oneRepMaxWriteback';
 
 export class PreferencesService {
     private readonly collectionPath = 'preferences';
@@ -255,6 +256,49 @@ export class PreferencesService {
         };
 
         return this.upsertPreferences(userId, { preferredUnits: updatedUnits }, prefs);
+    }
+
+    /**
+     * Applies S2.2's gauge-aware 1RM write-back (ADR-0021 D-1RMSRC) for every exercise in a
+     * completed strength session. Reads the *effective* current value the same way
+     * `prescription.ts` does -- `strength.estimated1RmKg` first, falling back to the legacy
+     * top-level `estimated1RmKg` -- so a value only ever present in the legacy field is
+     * still correctly protected rather than treated as absent. A write is dual-written to
+     * both locations (matching how this profile's V2/V3 fields already coexist) so neither
+     * reader is left stale, but `estimated1RmSources` is a single shared provenance map --
+     * there is exactly one true source per exercise, not one per schema version.
+     *
+     * Returns every outcome (updated and protected alike) so a caller can show what
+     * happened; only the `updated: true` outcomes are actually persisted.
+     */
+    async applyOneRepMaxDerivations(userId: string, session: StrengthSession, computedAtIso: string = new Date().toISOString()): Promise<OneRepMaxDerivationOutcome[]> {
+        const prefs = await this.getPreferences(userId);
+        const profile = prefs?.performanceProfile;
+        const effectiveEstimated1RmKg: Record<string, number> = { ...profile?.estimated1RmKg, ...profile?.strength?.estimated1RmKg };
+
+        const outcomes = deriveOneRepMaxUpdatesForSession(session, effectiveEstimated1RmKg, profile?.estimated1RmSources, computedAtIso);
+        const written = outcomes.filter(outcome => outcome.result.updated);
+        if (written.length === 0) return outcomes;
+
+        const updatedEstimated1RmKg = { ...profile?.estimated1RmKg };
+        const updatedStrengthEstimated1RmKg = { ...profile?.strength?.estimated1RmKg };
+        const updatedSources = { ...profile?.estimated1RmSources };
+        for (const outcome of written) {
+            updatedEstimated1RmKg[outcome.exerciseId] = outcome.result.estimatedOneRmKg;
+            updatedStrengthEstimated1RmKg[outcome.exerciseId] = outcome.result.estimatedOneRmKg;
+            updatedSources[outcome.exerciseId] = { source: outcome.result.source, ...(outcome.result.computedAt ? { computedAt: outcome.result.computedAt } : {}) };
+        }
+
+        await this.upsertPreferences(userId, {
+            performanceProfile: {
+                ...profile,
+                estimated1RmKg: updatedEstimated1RmKg,
+                estimated1RmSources: updatedSources,
+                strength: { ...profile?.strength, estimated1RmKg: updatedStrengthEstimated1RmKg },
+            },
+        }, prefs);
+
+        return outcomes;
     }
 
     /**

--- a/app/src/services/strengthSessionCompletion.test.ts
+++ b/app/src/services/strengthSessionCompletion.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { StrengthSession } from '../engine/models';
+import { finalizeStrengthSession } from './strengthSessionCompletion';
+
+const session: StrengthSession = {
+    userId: 'u1', sessionId: 's1', date: '2026-08-17', startedAt: '2026-08-17T16:00:00Z',
+    updatedAt: '2026-08-17T16:00:00Z', state: 'in_progress', exercises: [], schemaVersion: 1,
+};
+
+describe('finalizeStrengthSession', () => {
+    it('applies 1RM derivations before making a completed session terminal', async () => {
+        const calls: string[] = [];
+        const applyOneRepMaxDerivations = vi.fn(async () => { calls.push('derive'); return []; });
+        const transitionState = vi.fn(async (_userId, _sessionId, next, nowIso) => {
+            calls.push('transition');
+            return { ...session, state: next, completedAt: nowIso, updatedAt: nowIso };
+        });
+
+        await finalizeStrengthSession('u1', session, 'completed', '2026-08-17T17:00:00Z', {
+            applyOneRepMaxDerivations,
+            transitionState,
+        });
+
+        expect(calls).toEqual(['derive', 'transition']);
+        expect(applyOneRepMaxDerivations).toHaveBeenCalledWith(
+            'u1',
+            expect.objectContaining({ state: 'completed', completedAt: '2026-08-17T17:00:00Z' }),
+            '2026-08-17T17:00:00Z',
+        );
+    });
+
+    it('keeps the session resumable when derivation fails', async () => {
+        const transitionState = vi.fn();
+        await expect(finalizeStrengthSession('u1', session, 'completed', '2026-08-17T17:00:00Z', {
+            applyOneRepMaxDerivations: vi.fn(async () => { throw new Error('offline'); }),
+            transitionState,
+        })).rejects.toThrow('offline');
+        expect(transitionState).not.toHaveBeenCalled();
+    });
+
+    it('abandons without deriving a 1RM', async () => {
+        const applyOneRepMaxDerivations = vi.fn();
+        const transitionState = vi.fn(async () => ({ ...session, state: 'abandoned' as const }));
+        await finalizeStrengthSession('u1', session, 'abandoned', '2026-08-17T17:00:00Z', {
+            applyOneRepMaxDerivations,
+            transitionState,
+        });
+        expect(applyOneRepMaxDerivations).not.toHaveBeenCalled();
+    });
+});

--- a/app/src/services/strengthSessionCompletion.ts
+++ b/app/src/services/strengthSessionCompletion.ts
@@ -1,0 +1,38 @@
+import type { StrengthSession, StrengthSessionState } from '../engine/models';
+import { isValidStrengthInstant } from '../engine/strengthSessionValidation';
+import { preferencesService } from './preferencesService';
+import { strengthSessionService } from './strengthSessionService';
+
+interface StrengthSessionCompletionDependencies {
+    applyOneRepMaxDerivations: typeof preferencesService.applyOneRepMaxDerivations;
+    transitionState: typeof strengthSessionService.transitionState;
+}
+
+const productionDependencies: StrengthSessionCompletionDependencies = {
+    applyOneRepMaxDerivations: preferencesService.applyOneRepMaxDerivations.bind(preferencesService),
+    transitionState: strengthSessionService.transitionState.bind(strengthSessionService),
+};
+
+/** Completion orchestration for S2.2/S1.4. Derivation runs before the terminal transition:
+ * if the preferences write fails, the session remains resumable and Finish can be retried.
+ * Repeating a successful derivation is safe because only the `derived` ownership rung is
+ * writable and the same logged sets deterministically produce the same estimate. */
+export async function finalizeStrengthSession(
+    userId: string,
+    session: StrengthSession,
+    next: Exclude<StrengthSessionState, 'in_progress'>,
+    nowIso: string = new Date().toISOString(),
+    dependencies: StrengthSessionCompletionDependencies = productionDependencies,
+): Promise<StrengthSession> {
+    if (!isValidStrengthInstant(nowIso) || Date.parse(nowIso) < Date.parse(session.updatedAt)) {
+        throw new Error('Strength session completion time must not precede the last saved update');
+    }
+    if (next === 'completed') {
+        await dependencies.applyOneRepMaxDerivations(
+            userId,
+            { ...session, state: 'completed', completedAt: nowIso, updatedAt: nowIso },
+            nowIso,
+        );
+    }
+    return dependencies.transitionState(userId, session.sessionId, next, nowIso);
+}

--- a/app/src/workouts/models.ts
+++ b/app/src/workouts/models.ts
@@ -414,6 +414,11 @@ export interface DeviceCapabilities {
   cadenceData?: boolean;
 }
 
+/** `derived` added for ADR-0021 D-1RMSRC: a 1RM estimated from logged sets (S2.1) joins
+ *  the same ownership vocabulary as a Garmin import rather than bypassing it, and must
+ *  never overwrite `manual` or `coach` -- the reason `targetSources` exists at all. */
+export type TargetSource = 'garmin' | 'manual' | 'coach' | 'derived';
+
 export interface AthletePerformanceProfile {
   // Legacy top-level fields for backwards compatibility with v2 readers
   ftpWatts?: number | null;
@@ -421,7 +426,13 @@ export interface AthletePerformanceProfile {
   lthrBpm?: number | null;
   estimated1RmKg?: Record<string, number>;
   /** Field-level ownership prevents a Garmin refresh from replacing a coach target. */
-  targetSources?: Partial<Record<'ftpWatts' | 'thresholdPaceSecPerKm' | 'lthrBpm' | 'cyclingLthr' | 'runningLthr', 'garmin' | 'manual' | 'coach'>>;
+  targetSources?: Partial<Record<'ftpWatts' | 'thresholdPaceSecPerKm' | 'lthrBpm' | 'cyclingLthr' | 'runningLthr', TargetSource>>;
+  /** Per-exercise 1RM provenance, parallel to `estimated1RmKg`/`strength.estimated1RmKg`
+   *  (ADR-0021 D-1RMSRC) -- keyed by the same `exerciseId` as those maps. An exercise
+   *  present in `estimated1RmKg` with no entry here has no recorded source, and per
+   *  ADR-0021's literal text S2.2's writer treats that as writable, the same as a fully
+   *  absent value -- only an explicit `manual` or `coach` source is protected. */
+  estimated1RmSources?: Record<string, { source: TargetSource; computedAt?: string }>;
   /** Most recent provider import, retained even when the effective target is manual. */
   garmin?: {
     ftpWatts?: number | null;

--- a/app/src/workouts/oneRepMaxWriteback.test.ts
+++ b/app/src/workouts/oneRepMaxWriteback.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { applyOneRepMaxDerivation, deriveOneRepMaxUpdatesForSession } from './oneRepMaxWriteback';
+import type { OneRepMaxEstimate } from './oneRepMax';
+import type { LoggedSet, StrengthSession } from '../engine/models';
+
+function estimate(overrides: Partial<OneRepMaxEstimate> = {}): OneRepMaxEstimate {
+    const set: LoggedSet = { setIndex: 1, weightKg: 100, reps: 5, isWarmup: false, completedAt: '2026-08-17T18:00:00Z', gauge: { scale: 'rir', value: 2 } };
+    return { estimatedOneRmKg: 116.7, fromSet: set, formula: 'epley', ...overrides };
+}
+
+describe('applyOneRepMaxDerivation', () => {
+    it('populates an absent value', () => {
+        const result = applyOneRepMaxDerivation(undefined, undefined, estimate(), '2026-08-17T18:05:00Z');
+        expect(result).toEqual({ updated: true, estimatedOneRmKg: 116.7, source: 'derived', computedAt: '2026-08-17T18:05:00Z' });
+    });
+
+    it('replaces a stale derived value, even when the new estimate is lower', () => {
+        const lowerEstimate = estimate({ estimatedOneRmKg: 110 });
+        const result = applyOneRepMaxDerivation(120, 'derived', lowerEstimate, '2026-08-17T18:05:00Z');
+        expect(result).toMatchObject({ updated: true, estimatedOneRmKg: 110, source: 'derived' });
+    });
+
+    it('never overwrites a manual value, even one the new estimate would raise', () => {
+        const higherEstimate = estimate({ estimatedOneRmKg: 200 });
+        const result = applyOneRepMaxDerivation(100, 'manual', higherEstimate, '2026-08-17T18:05:00Z');
+        expect(result).toEqual({ updated: false, estimatedOneRmKg: 100, source: 'manual', reason: expect.stringMatching(/protected/i) });
+    });
+
+    it('never overwrites a coach value', () => {
+        const result = applyOneRepMaxDerivation(100, 'coach', estimate(), '2026-08-17T18:05:00Z');
+        expect(result.updated).toBe(false);
+    });
+
+    it('writes over an existing value that has no recorded source, per ADR-0021\'s literal text', () => {
+        const result = applyOneRepMaxDerivation(100, undefined, estimate(), '2026-08-17T18:05:00Z');
+        expect(result).toEqual({ updated: true, estimatedOneRmKg: 116.7, source: 'derived', computedAt: '2026-08-17T18:05:00Z' });
+    });
+});
+
+describe('deriveOneRepMaxUpdatesForSession', () => {
+    function session(overrides: Partial<StrengthSession> = {}): StrengthSession {
+        return {
+            userId: 'u1', sessionId: 's1', date: '2026-08-17', startedAt: '2026-08-17T18:00:00Z',
+            updatedAt: '2026-08-17T18:00:00Z', state: 'in_progress', exercises: [], schemaVersion: 1,
+            ...overrides,
+        };
+    }
+
+    it('produces one outcome per exercise with an admissible near-failure set', () => {
+        const s = session({ exercises: [
+            { exerciseId: 'front_squat', sets: [{ setIndex: 1, weightKg: 100, reps: 5, isWarmup: false, completedAt: '2026-08-17T18:00:00Z', gauge: { scale: 'rir', value: 2 } }] },
+        ] });
+        const outcomes = deriveOneRepMaxUpdatesForSession(s, undefined, undefined, '2026-08-17T18:05:00Z');
+        expect(outcomes).toHaveLength(1);
+        expect(outcomes[0]).toMatchObject({ exerciseId: 'front_squat', result: { updated: true, source: 'derived' } });
+    });
+
+    it('produces no outcome for an exercise with no admissible sets (e.g. velocity_loss only)', () => {
+        const s = session({ exercises: [
+            { exerciseId: 'hang_power_clean', sets: [{ setIndex: 1, weightKg: 80, reps: 3, isWarmup: false, completedAt: '2026-08-17T18:00:00Z', gauge: { scale: 'velocity_loss', percent: 15 } }] },
+        ] });
+        expect(deriveOneRepMaxUpdatesForSession(s, undefined, undefined, '2026-08-17T18:05:00Z')).toEqual([]);
+    });
+
+    it('produces no outcome for a free-text exercise -- no stable key into estimated1RmKg', () => {
+        const s = session({ exercises: [
+            { exerciseId: null, freeTextName: 'Trap bar deadlift', sets: [{ setIndex: 1, weightKg: 150, reps: 3, isWarmup: false, completedAt: '2026-08-17T18:00:00Z', gauge: { scale: 'rir', value: 1 } }] },
+        ] });
+        expect(deriveOneRepMaxUpdatesForSession(s, undefined, undefined, '2026-08-17T18:05:00Z')).toEqual([]);
+    });
+
+    it('respects existing manual protection per exercise, independently across a multi-exercise session', () => {
+        const s = session({ exercises: [
+            { exerciseId: 'front_squat', sets: [{ setIndex: 1, weightKg: 100, reps: 5, isWarmup: false, completedAt: '2026-08-17T18:00:00Z', gauge: { scale: 'rir', value: 2 } }] },
+            { exerciseId: 'bench_press', sets: [{ setIndex: 1, weightKg: 80, reps: 3, isWarmup: false, completedAt: '2026-08-17T18:10:00Z', gauge: { scale: 'rir', value: 1 } }] },
+        ] });
+        const outcomes = deriveOneRepMaxUpdatesForSession(
+            s,
+            { bench_press: 90 },
+            { bench_press: { source: 'manual' } },
+            '2026-08-17T18:15:00Z',
+        );
+        const frontSquat = outcomes.find(o => o.exerciseId === 'front_squat');
+        const benchPress = outcomes.find(o => o.exerciseId === 'bench_press');
+        expect(frontSquat?.result.updated).toBe(true);
+        expect(benchPress?.result.updated).toBe(false);
+        expect(benchPress?.result.estimatedOneRmKg).toBe(90);
+    });
+});

--- a/app/src/workouts/oneRepMaxWriteback.ts
+++ b/app/src/workouts/oneRepMaxWriteback.ts
@@ -1,0 +1,86 @@
+import type { LoggedExercise, StrengthSession } from '../engine/models';
+import type { TargetSource } from './models';
+import { estimateOneRepMax, type OneRepMaxEstimate } from './oneRepMax';
+
+/**
+ * Write-back ownership for a derived 1RM (S2.2, ADR-0021 D-1RMSRC). `targetSources` exists,
+ * in its own words, so a Garmin refresh can never replace a coach target; this module joins
+ * that same mechanism as an additional source rather than bypassing it. ADR-0021's own text
+ * is exact and is followed literally: "A derived estimate may populate a target whose source
+ * is absent or already `derived`. It may never overwrite `manual` or `coach`." Writability
+ * turns on the SOURCE alone, not on whether a value already exists -- an existing value with
+ * no recorded source is writable, matching the ADR, not protected by an unstated inference
+ * about who might have entered it.
+ */
+
+export interface OneRepMaxWritebackResult {
+    updated: boolean;
+    estimatedOneRmKg: number;
+    source: TargetSource;
+    computedAt?: string;
+    /** Present only when `updated` is false -- why the existing value was left alone. */
+    reason?: string;
+}
+
+/** `existingSource` is the *only* determinant of writability -- not whether a value already
+ *  exists, and not how the new estimate compares to it. This is self-calibration, not a
+ *  personal-record tracker: a derived value replaces a stale derived one even when the new
+ *  estimate is lower (e.g. after a break), because the point is to track current capacity,
+ *  not a lifetime peak. An absent source is writable per ADR-0021's literal text, even when
+ *  a value is already present under that absent source. */
+export function applyOneRepMaxDerivation(
+    existingValue: number | undefined,
+    existingSource: TargetSource | undefined,
+    estimate: OneRepMaxEstimate,
+    computedAtIso: string,
+): OneRepMaxWritebackResult {
+    const isWritable = existingSource === undefined || existingSource === 'derived';
+    if (!isWritable) {
+        return {
+            updated: false,
+            // existingSource is defined and protected here, so a defined existingValue is
+            // the only reachable case -- a protected source with no recorded value would be
+            // a data inconsistency between the two maps, not a state this function invents.
+            estimatedOneRmKg: existingValue as number,
+            source: existingSource,
+            reason: `existing ${existingSource} value is protected and was not overwritten`,
+        };
+    }
+    return { updated: true, estimatedOneRmKg: estimate.estimatedOneRmKg, source: 'derived', computedAt: computedAtIso };
+}
+
+export interface OneRepMaxDerivationOutcome {
+    exerciseId: string;
+    estimate: OneRepMaxEstimate;
+    result: OneRepMaxWritebackResult;
+}
+
+function findAdmissibleEstimate(exercise: LoggedExercise): OneRepMaxEstimate | null {
+    if (exercise.exerciseId === null) return null; // No stable key into estimated1RmKg for a free-text lift.
+    return estimateOneRepMax(exercise.sets);
+}
+
+/** One outcome per exercise in `session` that produced an admissible estimate (S2.1) --
+ *  an exercise with no admissible sets, or no `exerciseId`, contributes nothing rather than
+ *  a null-ish entry. Every outcome is included regardless of whether it was actually
+ *  written, so a caller (and a test) can see *why* a protected value was left alone. */
+export function deriveOneRepMaxUpdatesForSession(
+    session: StrengthSession,
+    currentEstimated1RmKg: Record<string, number> | undefined,
+    currentEstimated1RmSources: Record<string, { source: TargetSource; computedAt?: string }> | undefined,
+    computedAtIso: string,
+): OneRepMaxDerivationOutcome[] {
+    const outcomes: OneRepMaxDerivationOutcome[] = [];
+    for (const exercise of session.exercises) {
+        const estimate = findAdmissibleEstimate(exercise);
+        if (!estimate || exercise.exerciseId === null) continue;
+        const result = applyOneRepMaxDerivation(
+            currentEstimated1RmKg?.[exercise.exerciseId],
+            currentEstimated1RmSources?.[exercise.exerciseId]?.source,
+            estimate,
+            computedAtIso,
+        );
+        outcomes.push({ exerciseId: exercise.exerciseId, estimate, result });
+    }
+    return outcomes;
+}

--- a/app/src/workouts/oneRepMaxWriteback.ts
+++ b/app/src/workouts/oneRepMaxWriteback.ts
@@ -13,14 +13,21 @@ import { estimateOneRepMax, type OneRepMaxEstimate } from './oneRepMax';
  * about who might have entered it.
  */
 
-export interface OneRepMaxWritebackResult {
-    updated: boolean;
-    estimatedOneRmKg: number;
-    source: TargetSource;
-    computedAt?: string;
-    /** Present only when `updated` is false -- why the existing value was left alone. */
-    reason?: string;
-}
+export type OneRepMaxWritebackResult =
+    | {
+        updated: true;
+        estimatedOneRmKg: number;
+        source: 'derived';
+        computedAt: string;
+    }
+    | {
+        updated: false;
+        /** A protected provenance entry can be corrupt and have no corresponding value.
+         * Report that honestly instead of casting `undefined` to `number`. */
+        estimatedOneRmKg: number | null;
+        source: TargetSource;
+        reason: string;
+    };
 
 /** `existingSource` is the *only* determinant of writability -- not whether a value already
  *  exists, and not how the new estimate compares to it. This is self-calibration, not a
@@ -38,10 +45,7 @@ export function applyOneRepMaxDerivation(
     if (!isWritable) {
         return {
             updated: false,
-            // existingSource is defined and protected here, so a defined existingValue is
-            // the only reachable case -- a protected source with no recorded value would be
-            // a data inconsistency between the two maps, not a state this function invents.
-            estimatedOneRmKg: existingValue as number,
+            estimatedOneRmKg: existingValue ?? null,
             source: existingSource,
             reason: `existing ${existingSource} value is protected and was not overwritten`,
         };

--- a/docs/plans/strength-session-logging.md
+++ b/docs/plans/strength-session-logging.md
@@ -68,7 +68,7 @@ accepted before any Step C item.
 | S1.6 | Rest timer and derived rest | `[x]` | S1.5 |
 | S1.7 | Overload history view | `[x]` | S1.3 |
 | S2.1 | Gauge-aware 1RM estimator | `[x]` | S1.2 |
-| S2.2 | Write-back under a `derived` source | `[ ]` | S2.1 |
+| S2.2 | Write-back under a `derived` source | `[x]` | S2.1 |
 | S3.1 | Set log → `CompletedExposure` | `[ ]` | S1.2, ADR for D-STRCOST |
 | S3.2 | `manualTraining` source wiring | `[ ]` | S3.1 |
 | S3.3 | Measurement and ship decision | `[ ]` | S3.2 |
@@ -487,7 +487,7 @@ Among admissible sets, the estimator returns the one implying the **highest** ca
 an average — a single genuine near-failure set is stronger evidence of true capacity than
 diluting it against other, less-informative admissible sets from the same exercise.
 
-### S2.2 `[ ]` Write-back under a `derived` source — **implements D-1RMSRC**
+### S2.2 `[x]` Write-back under a `derived` source — **implements D-1RMSRC**
 
 **Change:** add a `derived` rung to `targetSources` and write estimated 1RM into
 `estimated1RmKg` only where the existing source is absent or itself `derived`. Never
@@ -499,6 +499,33 @@ must extend that mechanism rather than bypass it (A3.3).
 **Done when:** a `manual` 1RM survives a derivation that would have lowered it; an absent
 1RM is populated; a stale `derived` value is replaced; `prescription.test.ts`'s
 "relative when no 1RM is known" case still passes for exercises with no data.
+
+**Outcome (2026-08-17).** `workouts/oneRepMaxWriteback.ts` (`applyOneRepMaxDerivation`,
+`deriveOneRepMaxUpdatesForSession` — pure, 9 tests) and
+`preferencesService.applyOneRepMaxDerivations` (4 tests, mocked Firestore). All four "Done
+when" criteria hold, including the required `prescription.test.ts` case, run explicitly.
+
+**A first draft contradicted the accepted ADR-0021 text and was caught before landing, not
+after.** This plan's own wording above ("existing source is absent or itself `derived`") is
+ambiguous, and the first implementation resolved that ambiguity by treating an existing
+value with no recorded source as *protected* — reasoning, by analogy with
+`upsert_garmin_performance_targets`' documented "existing values without provenance are
+conservatively treated as manual," that an untracked `estimated1RmKg` value was more likely
+hand-entered than not. Re-reading ADR-0021 directly (not just this plan) before writing the
+outcome note surfaced the actual accepted text: *"A derived estimate may populate a target
+whose **source is absent** or already `derived`."* Unambiguous, and the opposite of what had
+been built. Fixed before commit: writability now turns on `existingSource` alone
+(`undefined` or `'derived'`), never on whether a value is already present under that absent
+source. The one test this changed (`'treats an existing value with no recorded source as
+protected'` → `'writes over an existing value that has no recorded source, per ADR-0021's
+literal text'`) is the exact case the contradiction lived in.
+
+Dual-write and lookup: `prescription.ts` reads `strength.estimated1RmKg` ahead of the legacy
+top-level `estimated1RmKg`; `applyOneRepMaxDerivations` reads the same effective value (so a
+value only present in the legacy field is still correctly protected, not treated as absent)
+and writes the derived result to **both** locations, keeping neither reader stale. Tested
+explicitly: a legacy value of `999` alongside a `strength.estimated1RmKg` of `120` under a
+`coach` source correctly protects `120`, not `999` and not an unprotected write.
 
 ---
 


### PR DESCRIPTION
## Summary

- Closes Step B. `workouts/oneRepMaxWriteback.ts`: `applyOneRepMaxDerivation` (single exercise), `deriveOneRepMaxUpdatesForSession` (whole session) — pure, 9 tests. `preferencesService.applyOneRepMaxDerivations` wires it to Firestore, 4 tests against a mocked SDK.
- `workouts/models.ts`: `TargetSource` widened to add `'derived'`, reused by both `targetSources` and the new `estimated1RmSources` map (per-exercise provenance, parallel to `estimated1RmKg`). `engine/validation.ts` validates the new field the same way `estimated1RmKg` already is.
- **A first draft contradicted the accepted ADR-0021 text and was caught before landing.** The plan's own wording ("existing source is absent or itself derived") is ambiguous; the first implementation resolved that by treating an existing value with no recorded source as *protected*, by analogy with `upsert_garmin_performance_targets`' "no provenance → treat as manual" precedent. Re-reading ADR-0021 directly before writing the outcome note surfaced its actual unambiguous text: *"A derived estimate may populate a target whose source is absent or already derived."* Opposite of what was built. Fixed before commit: writability now turns on `existingSource` alone (`undefined` or `'derived'`), never on whether a value already exists under that absent source. One test changed to match.
- Dual-write: `prescription.ts` reads `strength.estimated1RmKg` ahead of the legacy top-level `estimated1RmKg`, so `applyOneRepMaxDerivations` reads the same effective value and writes the result to both, keeping neither reader stale. `estimated1RmSources` stays a single shared provenance map — there is exactly one true source per exercise.
- `prescription.test.ts`'s required "relative when no 1RM is known" case run explicitly and confirmed passing, per the plan's stated acceptance criterion.

## Validation

- [x] `cd app && npm run check` — pass: 1354 tests, 113 files.

Results:
- 9 tests for the pure write-back rule; 4 for the Firestore-wired service method (including a legacy-vs-`strength.*` precedence case); `prescription.test.ts`'s "relative when no 1RM is known" test run and confirmed still green.

## Risk and reviewer guidance

**Please read the ADR-contradiction note in the Summary carefully** — it's the most important thing in this PR. I want a second set of eyes confirming my re-read of ADR-0021 (an absent source is writable, full stop, regardless of whether a value already exists) is correct, since it directly affects whether an untracked-provenance 1RM value can be silently overwritten by a derived estimate.

## Domain invariants

- [x] Firestore writes remain user-scoped — writes go through `preferencesService`, existing user-scoped path (`users/{userId}/preferences/profile`).
- [x] Calendar-date logic uses Europe/Warsaw — not applicable, no date logic in this PR.
- [x] No credentials, tokens, service-account files, or raw health payloads included.
- [x] Recommendation decision logic changed: no `POLICY_VERSION` impact — this changes prescription *input data* (1RM), not the recommendation engine's decision logic itself, and only for exercises with no `manual`/`coach` source already set.

## Screenshots or recordings

Not applicable — no UI change.
