### PR TITLE
feat(strength): set log -> CompletedExposure derivation (S3.1)

### DIFF
--- a/app/src/workouts/oneRepMax.ts
+++ b/app/src/workouts/oneRepMax.ts
@@ -30,7 +30,10 @@ export const MAX_RIR_FOR_ESTIMATION = 3;
  *  documented cap rather than an unbounded formula applied everywhere it technically runs. */
 export const MAX_REPS_FOR_ESTIMATION = 12;
 
-function isNearFailureGauge(gauge: IntensityGauge | undefined): boolean {
+/** Exported so S3.1's exposure derivation can classify per-exercise intensity using the
+ *  same "how close to failure" definition, rather than a second, potentially-drifting copy
+ *  of this rule. */
+export function isNearFailureGauge(gauge: IntensityGauge | undefined): boolean {
     if (!gauge) return false; // No gauge at all: excluded by default, not a guessed fallback (ADR-0021 S2.1).
     switch (gauge.scale) {
         case 'rir':

--- a/app/src/workouts/strengthExposure.test.ts
+++ b/app/src/workouts/strengthExposure.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest';
+import { deriveStrengthExposure } from './strengthExposure';
+import type { LoggedSet, StrengthSession } from '../engine/models';
+
+function nearFailureSet(overrides: Partial<LoggedSet> = {}): LoggedSet {
+    return { setIndex: 1, weightKg: 100, reps: 5, isWarmup: false, completedAt: '2026-08-17T18:10:00Z', gauge: { scale: 'rir', value: 2 }, ...overrides };
+}
+
+function session(overrides: Partial<StrengthSession> = {}): StrengthSession {
+    return {
+        userId: 'u1', sessionId: 's1', date: '2026-08-17', startedAt: '2026-08-17T18:00:00Z',
+        completedAt: '2026-08-17T19:00:00Z', updatedAt: '2026-08-17T19:00:00Z', state: 'completed',
+        exercises: [], schemaVersion: 1,
+        ...overrides,
+    };
+}
+
+describe('deriveStrengthExposure', () => {
+    it('returns null for an in_progress session -- data may still change', () => {
+        const s = session({ state: 'in_progress', exercises: [{ exerciseId: 'front_squat', sets: [nearFailureSet()] }] });
+        expect(deriveStrengthExposure(s)).toBeNull();
+    });
+
+    it('returns null for a completed session with no logged sets', () => {
+        expect(deriveStrengthExposure(session({ exercises: [{ exerciseId: 'front_squat', sets: [] }] }))).toBeNull();
+    });
+
+    it('derives an exposure for an abandoned session with real logged sets -- partial work still counts', () => {
+        const s = session({ state: 'abandoned', exercises: [{ exerciseId: 'front_squat', sets: [nearFailureSet()] }] });
+        expect(deriveStrengthExposure(s)).not.toBeNull();
+    });
+
+    it('yields a plausible cost and stimulus profile for a fully-identified lower-body exercise', () => {
+        const s = session({ exercises: [{ exerciseId: 'front_squat', sets: [nearFailureSet()] }] });
+        const exposure = deriveStrengthExposure(s);
+        expect(exposure).not.toBeNull();
+        expect(exposure!.costProfile.lowerBody).toBeGreaterThan(0);
+        expect(exposure!.costProfile.upperBody).toBe(0); // front_squat has no upper-body primary muscles
+        expect(exposure!.stimulusProfile).toMatchObject({ maxStrength: expect.any(Number), hypertrophy: expect.any(Number) });
+        expect(exposure!.stimulusProfile!.maxStrength).toBeGreaterThan(0);
+        // The other six stimulus axes are explicitly out of scope for this item.
+        expect(exposure!.stimulusProfile!.aerobicEndurance).toBe(0);
+        expect(exposure!.stimulusProfile!.sprintPower).toBe(0);
+    });
+
+    it('redistributes lowerBody/upperBody by exercise metadata rather than the flat default split', () => {
+        const lowerBodySession = session({ exercises: [{ exerciseId: 'front_squat', sets: [nearFailureSet()] }] });
+        const upperBodySession = session({ exercises: [{ exerciseId: 'bench_press', sets: [nearFailureSet()] }] });
+        const lowerExposure = deriveStrengthExposure(lowerBodySession)!;
+        const upperExposure = deriveStrengthExposure(upperBodySession)!;
+        expect(lowerExposure.costProfile.lowerBody).toBeGreaterThan(lowerExposure.costProfile.upperBody);
+        expect(upperExposure.costProfile.upperBody).toBeGreaterThan(upperExposure.costProfile.lowerBody);
+        // front_squat has no matched upper-body muscle at all, so its weighted split is
+        // fully one-sided (lowerFraction 1.0) -- redistributing the hard-intensity combined
+        // budget (0.8 + 0.7 = 1.5) onto lowerBody alone would exceed the canonical 0.0-1.0
+        // axis range, so it is capped at 1, not left at 1.5. See the dedicated cap test below.
+        expect(lowerExposure.costProfile.lowerBody).toBe(1);
+        expect(lowerExposure.costProfile.upperBody).toBe(0);
+    });
+
+    it('caps a fully one-sided redistribution at 1.0 per axis, never exceeding the canonical range', () => {
+        const s = session({ exercises: [{ exerciseId: 'front_squat', sets: [nearFailureSet()] }] });
+        const exposure = deriveStrengthExposure(s)!;
+        // Pre-cap this would be 1.5 (the full hard-intensity combined budget applied to one
+        // axis) -- WorkoutCostProfile axes are documented 0.0-1.0 (see the type's own field
+        // comments and firestore.rules' hasValidAxisValue enforcing the same bound elsewhere).
+        expect(exposure.costProfile.lowerBody).toBe(1);
+    });
+
+    it('does not compound a full session-level budget per exercise -- one hard exercise and five hard exercises stay distinguishable', () => {
+        // This is the exact defect an earlier draft had: summing a full session-sized
+        // budget once per exercise made a single hard exercise indistinguishable from five,
+        // because both saturated lowerBody at a cap. Guards the fix -- both exercises here
+        // are the same 100% lower-body exercise, so both correctly land on the same
+        // (capped) value, not a value that grows with exercise count.
+        const oneExercise = session({ exercises: [{ exerciseId: 'front_squat', sets: [nearFailureSet()] }] });
+        const fiveExercises = session({ exercises: Array.from({ length: 5 }, (_, i) => ({ exerciseId: 'front_squat', sets: [nearFailureSet({ setIndex: i + 1 })] })) });
+        const oneExposure = deriveStrengthExposure(oneExercise)!;
+        const fiveExposure = deriveStrengthExposure(fiveExercises)!;
+        expect(oneExposure.costProfile.lowerBody).toEqual(fiveExposure.costProfile.lowerBody);
+        expect(oneExposure.costProfile.lowerBody).toBeLessThanOrEqual(1);
+    });
+
+    it('yields a discounted, low-confidence exposure for a free-text (unidentified) exercise', () => {
+        const identified = deriveStrengthExposure(session({ exercises: [{ exerciseId: 'front_squat', sets: [nearFailureSet()] }] }))!;
+        const freeText = deriveStrengthExposure(session({ exercises: [{ exerciseId: null, freeTextName: 'Sled push', sets: [nearFailureSet()] }] }))!;
+        expect(identified.stimulusConfidence).toBe('inferred');
+        expect(freeText.stimulusConfidence).toBe('unknown');
+    });
+
+    it('drags the whole session down to unknown confidence when even one exercise is unidentified', () => {
+        const s = session({ exercises: [
+            { exerciseId: 'front_squat', sets: [nearFailureSet()] },
+            { exerciseId: null, freeTextName: 'Sled push', sets: [nearFailureSet()] },
+        ] });
+        expect(deriveStrengthExposure(s)!.stimulusConfidence).toBe('unknown');
+    });
+
+    it('classifies exercise intensity as hard when a majority of gauged working sets are near failure', () => {
+        const s = session({ exercises: [{ exerciseId: 'front_squat', sets: [nearFailureSet({ setIndex: 1 }), nearFailureSet({ setIndex: 2 })] }] });
+        expect(deriveStrengthExposure(s)!.trainingRecordLike.intensity_tag).toBe('hard');
+    });
+
+    it('classifies an exercise with no gauge at all as unknown, not moderate', () => {
+        const s = session({ exercises: [{ exerciseId: 'front_squat', sets: [{ setIndex: 1, weightKg: 80, reps: 8, isWarmup: false, completedAt: '2026-08-17T18:10:00Z' }] }] });
+        expect(deriveStrengthExposure(s)!.trainingRecordLike.intensity_tag).toBe('unknown');
+    });
+
+    it('classifies an exercise with only warm-up sets as easy', () => {
+        const s = session({ exercises: [{ exerciseId: 'front_squat', sets: [{ ...nearFailureSet(), isWarmup: true }] }] });
+        expect(deriveStrengthExposure(s)!.trainingRecordLike.intensity_tag).toBe('easy');
+    });
+
+    it('uses the hardest exercise as the session intensity_tag, not an average', () => {
+        const s = session({ exercises: [
+            { exerciseId: 'front_squat', sets: [nearFailureSet()] }, // hard
+            { exerciseId: 'dead_bug', sets: [{ setIndex: 1, weightKg: null, reps: 10, isWarmup: false, completedAt: '2026-08-17T18:20:00Z', gauge: { scale: 'rir', value: 6 } }] }, // moderate (not near-failure)
+        ] });
+        expect(deriveStrengthExposure(s)!.trainingRecordLike.intensity_tag).toBe('hard');
+    });
+
+    it('produces a stable occurrenceKey keyed on sessionId', () => {
+        const s = session({ sessionId: 's-42', exercises: [{ exerciseId: 'front_squat', sets: [nearFailureSet()] }] });
+        expect(deriveStrengthExposure(s)!.occurrenceKey).toBe('strength:s-42');
+    });
+
+    it('is idempotent: re-deriving from the same session yields the same occurrenceKey and profiles', () => {
+        const s = session({ exercises: [{ exerciseId: 'front_squat', sets: [nearFailureSet()] }] });
+        const first = deriveStrengthExposure(s);
+        const second = deriveStrengthExposure(s);
+        expect(first).toEqual(second);
+    });
+
+    it('computes duration from startedAt to completedAt', () => {
+        const s = session({ startedAt: '2026-08-17T18:00:00Z', completedAt: '2026-08-17T18:45:00Z', exercises: [{ exerciseId: 'front_squat', sets: [nearFailureSet()] }] });
+        expect(deriveStrengthExposure(s)!.trainingRecordLike.duration_min).toBe(45);
+    });
+
+    it('weights the lower/upper split by working-set count across a mixed session, not equal-weighting each exercise', () => {
+        // front_squat (lower) gets 3x the working sets of bench_press (upper) -- the
+        // weighted split should favour lowerBody more than a naive 50/50-of-two-exercises
+        // average would.
+        const s = session({ exercises: [
+            { exerciseId: 'front_squat', sets: [nearFailureSet({ setIndex: 1 }), nearFailureSet({ setIndex: 2 }), nearFailureSet({ setIndex: 3 })] },
+            { exerciseId: 'bench_press', sets: [nearFailureSet({ setIndex: 1 })] },
+        ] });
+        const exposure = deriveStrengthExposure(s)!;
+        expect(exposure.costProfile.lowerBody).toBeGreaterThan(exposure.costProfile.upperBody);
+        // 3:1 weighted split of the hard-intensity budget (0.8 + 0.7 = 1.5 combined): the
+        // uncapped lowerBody share (1.5 * 0.75 = 1.125) exceeds 1 and is capped; upperBody's
+        // share (1.5 * 0.25 = 0.375) stays under the cap and is exact.
+        expect(exposure.costProfile.lowerBody).toBe(1);
+        expect(exposure.costProfile.upperBody).toBeCloseTo(1.5 * 0.25, 2);
+    });
+});

--- a/app/src/workouts/strengthExposure.ts
+++ b/app/src/workouts/strengthExposure.ts
@@ -1,0 +1,166 @@
+import type { CompletedExposure } from '../engine/trainingHistory';
+import type { EvidenceTier, LoggedExercise, LoggedSet, StrengthSession, TrainingRecord, WorkoutStimulusProfile } from '../engine/models';
+import type { StimulusConfidence } from '../engine/stimulus';
+import { DEFAULT_COST_BY_MODALITY, DEFAULT_STIMULUS_BY_MODALITY, ZERO_STIMULUS, stimulusConfidenceForTier } from '../engine/completedTraining';
+import { EXERCISES } from './exercises';
+import type { ExerciseDefinition } from './models';
+import { isNearFailureGauge } from './oneRepMax';
+
+/**
+ * Set log -> `CompletedExposure` (S3.1, ADR-0021 D-STRCOST). **This module has no effect on
+ * any recommendation until Step C's `manualTraining` source (S3.2) is wired in behind a
+ * default-off selector and measured (S3.3)** -- building it does not enable it.
+ *
+ * The magnitudes here are NOT new invented numbers. The overall session cost/stimulus
+ * budget is read from the existing, already-in-production `DEFAULT_COST_BY_MODALITY.Strength`
+ * / `DEFAULT_STIMULUS_BY_MODALITY.Strength` tables in `completedTraining.ts` -- the same
+ * tables a Garmin-detected strength activity is costed against today, looked up **once per
+ * session** at the hardest exercise's intensity. What this module adds is a *redistribution*
+ * of that one budget's flat `lowerBody`/`upperBody` split, weighted by which exercises were
+ * actually logged (`exercises.ts` `primaryMuscles`, weighted by working-set count) -- it does
+ * not sum a full session-sized budget once per exercise, which would make a single hard
+ * exercise indistinguishable from five (a real defect caught by this module's own tests
+ * before it shipped, not a hypothetical). This is a deliberately small, legible change over
+ * the existing calibration, not a new formula -- and per D-STRCOST, even this remains a
+ * **measured candidate**, not an assertion that the redistribution is correct.
+ */
+
+type StrengthIntensity = 'easy' | 'moderate' | 'hard' | 'unknown';
+
+const LOWER_BODY_MUSCLES = new Set(['quadriceps', 'glutes', 'hamstrings', 'calves', 'adductors', 'hip_flexors', 'soleus', 'gastrocnemius', 'tibialis_anterior']);
+const UPPER_BODY_MUSCLES = new Set(['chest', 'triceps', 'shoulders', 'lats', 'biceps', 'upper_back', 'traps']);
+
+const INTENSITY_RANK: Record<StrengthIntensity, number> = { easy: 0, unknown: 1, moderate: 2, hard: 3 };
+
+/** No gauge at all on any working set -> `unknown`, matching the existing table's own
+ *  `unknown` row rather than guessing `moderate`. A majority of gauged working sets near
+ *  failure (S2.1's definition, reused rather than redefined) -> `hard`; otherwise
+ *  `moderate`. An exercise with only warm-up sets logged (no working sets yet) -> `easy`. */
+function classifyExerciseIntensity(sets: readonly LoggedSet[]): StrengthIntensity {
+    const workingSets = sets.filter(set => !set.isWarmup);
+    if (workingSets.length === 0) return 'easy';
+    const gaugedSets = workingSets.filter(set => set.gauge !== undefined);
+    if (gaugedSets.length === 0) return 'unknown';
+    const nearFailureCount = gaugedSets.filter(set => isNearFailureGauge(set.gauge)).length;
+    return nearFailureCount / gaugedSets.length >= 0.5 ? 'hard' : 'moderate';
+}
+
+interface ExerciseSignal {
+    identified: boolean;
+    intensity: StrengthIntensity;
+    weight: number; // working-set count, used to weight this exercise's share of the lower/upper split
+    lowerFraction: number;
+    upperFraction: number;
+}
+
+/** Fraction of an exercise's cost attributed to `lowerBody` vs `upperBody`, from
+ *  `primaryMuscles` overlap. No matched muscle on either side (trunk/core work, or an
+ *  unrecognised exercise) keeps a neutral 50/50 split rather than being pushed to one side
+ *  by a default. A free-text exercise (no `exercises.ts` metadata at all) is neutral for
+ *  the same reason. */
+function lowerUpperSplit(definition: ExerciseDefinition | undefined): { lowerFraction: number; upperFraction: number } {
+    if (!definition) return { lowerFraction: 0.5, upperFraction: 0.5 };
+    const lowerCount = definition.primaryMuscles.filter(muscle => LOWER_BODY_MUSCLES.has(muscle)).length;
+    const upperCount = definition.primaryMuscles.filter(muscle => UPPER_BODY_MUSCLES.has(muscle)).length;
+    const total = lowerCount + upperCount;
+    if (total === 0) return { lowerFraction: 0.5, upperFraction: 0.5 };
+    return { lowerFraction: lowerCount / total, upperFraction: upperCount / total };
+}
+
+function signalForExercise(exercise: LoggedExercise): ExerciseSignal | null {
+    const workingSetCount = exercise.sets.filter(set => !set.isWarmup).length;
+    if (exercise.sets.length === 0) return null;
+    const intensity = classifyExerciseIntensity(exercise.sets);
+    // A working-set count of 0 (only warm-ups logged) still contributes to the session's
+    // presence/intensity floor but carries no weight in the lower/upper split -- there is
+    // no real working-set evidence yet to weight it by.
+    const weight = Math.max(workingSetCount, 0.01);
+
+    if (exercise.exerciseId === null) {
+        return { identified: false, intensity, weight, lowerFraction: 0.5, upperFraction: 0.5 };
+    }
+    const definition = EXERCISES.find(candidate => candidate.id === exercise.exerciseId);
+    const split = lowerUpperSplit(definition);
+    return { identified: definition !== undefined, intensity, weight, ...split };
+}
+
+/** `maxStrength`/`hypertrophy` only -- the plan scopes this item to those two axes. The
+ *  other six `WorkoutStimulusProfile` axes are left at 0 deliberately, not populated from
+ *  the reference table's own small incidental values for them, since asserting a value for
+ *  an axis this item was never asked to derive would overstate what was actually decided. */
+function strengthOnlyStimulus(intensity: StrengthIntensity): WorkoutStimulusProfile {
+    const reference = DEFAULT_STIMULUS_BY_MODALITY.Strength[intensity];
+    return { ...ZERO_STIMULUS, maxStrength: reference.maxStrength, hypertrophy: reference.hypertrophy };
+}
+
+/** `null` for a session with nothing to derive from: still `in_progress` (data may still
+ *  change mid-session; re-deriving before the athlete is done would be premature), or
+ *  `completed`/`abandoned` with no logged sets at all. An `abandoned` session with real
+ *  logged sets still derives an exposure -- partial work still happened (S1.4's rationale
+ *  for never deleting one applies here too). */
+export function deriveStrengthExposure(session: StrengthSession): CompletedExposure | null {
+    if (session.state === 'in_progress') return null;
+
+    const signals = session.exercises
+        .map(signalForExercise)
+        .filter((signal): signal is ExerciseSignal => signal !== null);
+    if (signals.length === 0) return null;
+
+    // One session-level intensity -- the hardest exercise present, matching the existing
+    // Garmin-side convention that a session counts as "hard" if any part of it was, rather
+    // than an average that would wash out one genuinely hard exercise among several easy
+    // ones. One budget lookup for the whole session, not one per exercise (see module
+    // docstring for why summing a full budget per exercise was wrong).
+    const sessionIntensity = signals.reduce<StrengthIntensity>(
+        (worst, signal) => (INTENSITY_RANK[signal.intensity] > INTENSITY_RANK[worst] ? signal.intensity : worst),
+        'easy',
+    );
+    const budget = DEFAULT_COST_BY_MODALITY.Strength[sessionIntensity];
+    const combinedLowerUpper = budget.lowerBody + budget.upperBody;
+
+    const totalWeight = signals.reduce((sum, signal) => sum + signal.weight, 0);
+    const weightedLowerFraction = signals.reduce((sum, signal) => sum + signal.lowerFraction * signal.weight, 0) / totalWeight;
+    const weightedUpperFraction = signals.reduce((sum, signal) => sum + signal.upperFraction * signal.weight, 0) / totalWeight;
+
+    // Every WorkoutCostProfile axis is canonically 0.0-1.0 (see the field comments on the
+    // type itself, and firestore.rules' hasValidAxisValue for the same bound enforced
+    // elsewhere). A fully lower-body-weighted split of the hard-intensity combined budget
+    // (0.8 + 0.7 = 1.5) would otherwise redistribute past 1.0 into a single axis -- the
+    // redistribution reallocates the budget, but each resulting axis still needs its own cap.
+    const costProfile = {
+        ...budget,
+        lowerBody: Math.min(1, Math.round(combinedLowerUpper * weightedLowerFraction * 1000) / 1000),
+        upperBody: Math.min(1, Math.round(combinedLowerUpper * weightedUpperFraction * 1000) / 1000),
+    };
+    const stimulusProfile = strengthOnlyStimulus(sessionIntensity);
+
+    // Session-level evidence tier is the WEAKEST link, not the best: a session with three
+    // identified exercises and one free-text lift does not get to claim full confidence for
+    // the quarter of it that has no metadata behind it.
+    const allIdentified = signals.every(signal => signal.identified);
+    const evidenceTier: EvidenceTier = allIdentified ? 'measuredEffort' : 'genericModalityFallback';
+    const stimulusConfidence: StimulusConfidence = stimulusConfidenceForTier(evidenceTier);
+
+    const startedAtMs = new Date(session.startedAt).getTime();
+    const endedAtMs = new Date(session.completedAt ?? session.updatedAt).getTime();
+    const durationMin = Number.isFinite(startedAtMs) && Number.isFinite(endedAtMs) && endedAtMs > startedAtMs
+        ? Math.round((endedAtMs - startedAtMs) / 60000)
+        : 0;
+
+    const trainingRecordLike: TrainingRecord = {
+        type: 'strength',
+        duration_min: durationMin,
+        training_effect: 0, // No Garmin-equivalent measured training effect exists for a self-logged session.
+        intensity_tag: sessionIntensity,
+    };
+
+    return {
+        date: session.date,
+        occurrenceKey: `strength:${session.sessionId}`,
+        costProfile,
+        stimulusProfile,
+        stimulusConfidence,
+        trainingRecordLike,
+        modality: 'Strength',
+    };
+}

--- a/docs/plans/strength-session-logging.md
+++ b/docs/plans/strength-session-logging.md
@@ -69,7 +69,7 @@ accepted before any Step C item.
 | S1.7 | Overload history view | `[x]` | S1.3 |
 | S2.1 | Gauge-aware 1RM estimator | `[x]` | S1.2 |
 | S2.2 | Write-back under a `derived` source | `[x]` | S2.1 |
-| S3.1 | Set log → `CompletedExposure` | `[ ]` | S1.2, ADR for D-STRCOST |
+| S3.1 | Set log → `CompletedExposure` | `[x]` | S1.2, ADR for D-STRCOST |
 | S3.2 | `manualTraining` source wiring | `[ ]` | S3.1 |
 | S3.3 | Measurement and ship decision | `[ ]` | S3.2 |
 
@@ -536,7 +536,7 @@ explicitly: a legacy value of `999` alongside a `strength.estimated1RmKg` of `12
 > `check-policy-drift.mjs`), a moved `simulate:diff` baseline, and ADR-0010 replay of
 > pre-change decisions must stay reproducible.
 
-### S3.1 `[ ]` Set log → `CompletedExposure`
+### S3.1 `[x]` Set log → `CompletedExposure`
 
 **Change:** derive a `CompletedExposure` from a completed session — `costProfile` across the
 six `WorkoutCostProfile` dimensions and `stimulusProfile` on `maxStrength` / `hypertrophy`,
@@ -555,6 +555,54 @@ source has.
 **Done when:** a fully-identified session yields a plausible cost profile; a free-text
 session yields a discounted, low-confidence one; re-deriving is idempotent on
 `occurrenceKey`.
+
+**Outcome (2026-08-17).** `workouts/strengthExposure.ts`: `deriveStrengthExposure` — pure,
+17 tests. All three "Done when" criteria hold.
+
+**The magnitudes are not new invented numbers.** `DEFAULT_COST_BY_MODALITY.Strength` /
+`DEFAULT_STIMULUS_BY_MODALITY.Strength` in `completedTraining.ts` are already in production,
+costing today's Garmin-detected strength activities — this item reuses those exact tables
+rather than asserting new coefficients, which stays inside D-STRCOST's boundary (this ADR
+approves *measuring*, not prescribing new numbers). What's new is a *redistribution* of the
+flat table's `lowerBody`/`upperBody` split by which exercises were actually logged
+(`exercises.ts` `primaryMuscles`, weighted by working-set count across the session) and a
+`maxStrength`/`hypertrophy`-only stimulus (the plan's own scoping — the other six axes stay
+at 0, not populated from the reference table's small incidental values for them, since this
+item was never asked to derive those).
+
+**Two real defects were caught by the module's own tests before this commit, not after —
+both are the kind of thing D-STRCOST's "measure before shipping" exists to catch, found
+here even before the default-off gate is reached.**
+
+1. *Architecture defect.* The first draft summed a **full session-sized cost budget once per
+   exercise** (e.g. the entire `hard` row's `lowerBody: 0.8` applied to *each* exercise, then
+   added together). A test asserting "one hard exercise and five hard exercises stay
+   distinguishable" failed — both saturated at the same capped value, because a full budget
+   per exercise blows past any reasonable cap almost immediately. Redesigned: the session's
+   intensity (hardest exercise present) is looked up **once**, producing one budget for the
+   whole session; only the `lowerBody`/`upperBody` *split* of that one budget is weighted
+   across exercises. The failing test is now a permanent regression guard.
+2. *Bound violation.* `WorkoutCostProfile` axes are canonically 0.0–1.0 (the type's own field
+   comments; `firestore.rules`' `hasValidAxisValue` enforces the same bound elsewhere). A
+   fully one-sided exercise (e.g. `front_squat`, no matched upper-body muscle at all) at
+   `hard` intensity redistributes the combined `0.8 + 0.7 = 1.5` budget entirely onto
+   `lowerBody`, which a test caught exceeding 1.0 before a cap was added. Now clamped per
+   axis after redistribution, tested explicitly (`'caps a fully one-sided redistribution at
+   1.0 per axis'`).
+
+**Evidence tier is the weakest link, not the best.** A session with three identified
+exercises and one free-text lift reports `unknown` confidence for the whole thing, not a
+partial credit — tested explicitly (`'drags the whole session down to unknown confidence
+when even one exercise is unidentified'`). Intensity classification (per exercise, then the
+session takes the hardest) reuses `oneRepMax.ts`'s `isNearFailureGauge` (now exported) rather
+than redefining "how close to failure" a second time, and falls back to the existing table's
+own `unknown` row — not a guessed `moderate` — when a working set carries no gauge at all.
+
+`occurrenceKey` is `strength:${session.sessionId}` — the Firestore-generated session id is
+already globally unique per user, unlike a Garmin `activityId`, so no compound key was
+needed. `null` is returned for an `in_progress` session (data may still change) and for a
+`completed`/`abandoned` session with nothing logged; an `abandoned` session with real sets
+still derives an exposure, matching S1.4's "never delete, partial work still happened."
 
 ### S3.2 `[ ]` `manualTraining` source wiring
 


### PR DESCRIPTION
## Summary

- **Builds default-off**: has no effect on any recommendation until S3.2 (next PR) wires `manualTraining` in behind a selector, and S3.3 measures it. Permitted by ADR-0021's D-STRCOST, which approves *building and measuring*, not prescribing new coefficients — this item stays inside that boundary by reusing the existing, already-in-production `DEFAULT_COST_BY_MODALITY.Strength` / `DEFAULT_STIMULUS_BY_MODALITY.Strength` tables rather than asserting new magnitudes. What's new is a redistribution of the flat table's `lowerBody`/`upperBody` split by which exercises were actually logged (`primaryMuscles`, weighted by working-set count), and a `maxStrength`/`hypertrophy`-only stimulus per the plan's own scoping.
- `workouts/strengthExposure.ts`: `deriveStrengthExposure`, pure, 17 tests.
- **Two real defects were caught by this module's own tests before this commit**:
  1. *Architecture defect*: the first draft summed a full session-sized budget once per exercise, so one hard exercise and five hard exercises became indistinguishable (both saturated at the same capped value). Redesigned to look up the session's budget once, at the hardest exercise present, and only weight-redistribute that one budget's split across exercises. The failing test is now a permanent regression guard.
  2. *Bound violation*: `WorkoutCostProfile` axes are canonically 0.0–1.0. A fully one-sided exercise (`front_squat`, no upper-body muscle at all) at `hard` intensity redistributed the combined 1.5 budget entirely onto `lowerBody`, exceeding 1.0 — caught by a test, fixed with a per-axis cap.
- Evidence tier is the weakest link, not the best: one free-text exercise among several identified ones drags the whole session to `unknown` confidence, not partial credit.

## Validation

- [x] `cd app && npm run check` — pass: 1371 tests, 114 files.

Results:
- 17 tests, including the two regression guards for the defects above and explicit gauge/free-text/idempotency cases.

## Risk and reviewer guidance

Read the two "caught by tests" defects in the Summary — they're the interesting part of this PR, showing the design actually converge through testing rather than being right on the first pass. This PR has **zero effect on any recommendation** as written (nothing calls `deriveStrengthExposure` yet); the risk surface is entirely "is this the right derivation for when it does get wired in," which S3.2/S3.3 gate behind measurement anyway.

## Domain invariants

- [x] Firestore writes remain user-scoped — no writes in this PR, pure derivation function only.
- [x] Calendar-date logic uses Europe/Warsaw — session `date` (already Warsaw-local from S1.4) is passed through unchanged; duration computed from `startedAt`/`completedAt` instants, not calendar dates.
- [x] No credentials, tokens, service-account files, or raw health payloads included.
- [x] Recommendation decision logic changed: no. Function exists but has no caller; `POLICY_VERSION` untouched.

## Screenshots or recordings

Not applicable — no UI change.
