### PR TITLE
feat(engine): manualTraining source wiring behind a default-off selector (S3.2)

### DIFF
--- a/app/src/engine/firestoreTrainingHistory.test.ts
+++ b/app/src/engine/firestoreTrainingHistory.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { StrengthSession } from './models';
+
+const { activityService, recommendationService, strengthSessionService } = vi.hoisted(() => ({
+    activityService: { getActivitiesInRange: vi.fn(async () => ({ status: 'AVAILABLE', revision: 'a', data: [] })) },
+    recommendationService: { getRecommendationsInRange: vi.fn(async () => ({ status: 'AVAILABLE', revision: 'r', data: [] })) },
+    strengthSessionService: { getSessionsInRange: vi.fn(async (): Promise<{ sessions: StrengthSession[]; invalidRecords: number }> => ({ sessions: [], invalidRecords: 0 })) },
+}));
+
+vi.mock('../services/activityService', () => ({ activityService }));
+vi.mock('../services/recommendationService', () => ({ recommendationService }));
+vi.mock('../services/strengthSessionService', () => ({ strengthSessionService }));
+
+import { firestoreTrainingHistoryProvider, toManualTrainingDataState } from './firestoreTrainingHistory';
+
+const session: StrengthSession = {
+    userId: 'u1', sessionId: 's1', date: '2026-08-06', startedAt: '2026-08-06T18:00:00Z',
+    updatedAt: '2026-08-06T18:45:00Z', state: 'completed', exercises: [], schemaVersion: 1,
+};
+
+describe('toManualTrainingDataState (S3.2)', () => {
+    it('is AVAILABLE with usable sessions', () => {
+        expect(toManualTrainingDataState('u1', { sessions: [session], invalidRecords: 0 })).toMatchObject({ status: 'AVAILABLE', data: [session] });
+    });
+
+    it('is MISSING when there are genuinely zero sessions and zero invalid records', () => {
+        expect(toManualTrainingDataState('u1', { sessions: [], invalidRecords: 0 })).toEqual({ status: 'MISSING' });
+    });
+
+    it('is INVALID, not MISSING, when every record present was corrupt -- the exact conflation the failure contract forbids', () => {
+        const state = toManualTrainingDataState('u1', { sessions: [], invalidRecords: 3 });
+        expect(state.status).toBe('INVALID');
+        expect(state).not.toEqual({ status: 'MISSING' });
+    });
+
+    it('prefers AVAILABLE over INVALID when some sessions are usable despite other corrupt records', () => {
+        const state = toManualTrainingDataState('u1', { sessions: [session], invalidRecords: 2 });
+        expect(state.status).toBe('AVAILABLE');
+    });
+});
+
+describe('firestoreTrainingHistoryProvider.getSnapshot (S3.2)', () => {
+    it('fetches strength sessions in the same parallel batch as activities and recommendations', async () => {
+        await firestoreTrainingHistoryProvider.getSnapshot!('u1', '2026-08-07', 7);
+        expect(strengthSessionService.getSessionsInRange).toHaveBeenCalledWith('u1', '2026-07-31', '2026-08-07');
+    });
+
+    it('has the selector off: the fetch happens but the returned snapshot is unaffected by real strength data', async () => {
+        strengthSessionService.getSessionsInRange.mockResolvedValueOnce({ sessions: [session], invalidRecords: 0 });
+        const snapshot = await firestoreTrainingHistoryProvider.getSnapshot!('u1', '2026-08-07', 7);
+        expect(snapshot.sourceStates.manualTraining).toEqual({ status: 'MISSING' });
+        expect(snapshot.exposures).toEqual([]);
+    });
+});

--- a/app/src/engine/firestoreTrainingHistory.test.ts
+++ b/app/src/engine/firestoreTrainingHistory.test.ts
@@ -1,9 +1,9 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { StrengthSession } from './models';
 
 const { activityService, recommendationService, strengthSessionService } = vi.hoisted(() => ({
-    activityService: { getActivitiesInRange: vi.fn(async () => ({ status: 'AVAILABLE', revision: 'a', data: [] })) },
-    recommendationService: { getRecommendationsInRange: vi.fn(async () => ({ status: 'AVAILABLE', revision: 'r', data: [] })) },
+    activityService: { getActivitiesInRange: vi.fn(async () => ({ status: 'AVAILABLE' as const, revision: 'a', data: [] })) },
+    recommendationService: { getRecommendationsInRange: vi.fn(async () => ({ status: 'AVAILABLE' as const, revision: 'r', data: [] })) },
     strengthSessionService: { getSessionsInRange: vi.fn(async (): Promise<{ sessions: StrengthSession[]; invalidRecords: number }> => ({ sessions: [], invalidRecords: 0 })) },
 }));
 
@@ -11,44 +11,52 @@ vi.mock('../services/activityService', () => ({ activityService }));
 vi.mock('../services/recommendationService', () => ({ recommendationService }));
 vi.mock('../services/strengthSessionService', () => ({ strengthSessionService }));
 
-import { firestoreTrainingHistoryProvider, toManualTrainingDataState } from './firestoreTrainingHistory';
+import {
+    firestoreTrainingHistoryProvider,
+    getFirestoreTrainingHistorySnapshot,
+    toManualTrainingDataState,
+} from './firestoreTrainingHistory';
 
 const session: StrengthSession = {
     userId: 'u1', sessionId: 's1', date: '2026-08-06', startedAt: '2026-08-06T18:00:00Z',
-    updatedAt: '2026-08-06T18:45:00Z', state: 'completed', exercises: [], schemaVersion: 1,
+    completedAt: '2026-08-06T18:45:00Z', updatedAt: '2026-08-06T18:45:00Z', state: 'completed',
+    exercises: [{ exerciseId: 'front_squat', sets: [{ setIndex: 1, weightKg: 80, reps: 5, isWarmup: false, completedAt: '2026-08-06T18:15:00Z', gauge: { scale: 'rir', value: 2 } }] }],
+    schemaVersion: 1,
 };
 
-describe('toManualTrainingDataState (S3.2)', () => {
-    it('is AVAILABLE with usable sessions', () => {
-        expect(toManualTrainingDataState('u1', { sessions: [session], invalidRecords: 0 })).toMatchObject({ status: 'AVAILABLE', data: [session] });
+describe('manual training DataState', () => {
+    it('uses stable session identity as well as timestamps in the revision', () => {
+        expect(toManualTrainingDataState('u1', { sessions: [session], invalidRecords: 0 })).toMatchObject({
+            status: 'AVAILABLE', revision: 's1:2026-08-06T18:45:00Z', data: [session],
+        });
     });
 
-    it('is MISSING when there are genuinely zero sessions and zero invalid records', () => {
+    it('distinguishes genuine absence from any corrupt record', () => {
         expect(toManualTrainingDataState('u1', { sessions: [], invalidRecords: 0 })).toEqual({ status: 'MISSING' });
-    });
-
-    it('is INVALID, not MISSING, when every record present was corrupt -- the exact conflation the failure contract forbids', () => {
-        const state = toManualTrainingDataState('u1', { sessions: [], invalidRecords: 3 });
-        expect(state.status).toBe('INVALID');
-        expect(state).not.toEqual({ status: 'MISSING' });
-    });
-
-    it('prefers AVAILABLE over INVALID when some sessions are usable despite other corrupt records', () => {
-        const state = toManualTrainingDataState('u1', { sessions: [session], invalidRecords: 2 });
-        expect(state.status).toBe('AVAILABLE');
+        expect(toManualTrainingDataState('u1', { sessions: [session], invalidRecords: 1 })).toMatchObject({ status: 'INVALID' });
     });
 });
 
-describe('firestoreTrainingHistoryProvider.getSnapshot (S3.2)', () => {
-    it('fetches strength sessions in the same parallel batch as activities and recommendations', async () => {
-        await firestoreTrainingHistoryProvider.getSnapshot!('u1', '2026-08-07', 7);
-        expect(strengthSessionService.getSessionsInRange).toHaveBeenCalledWith('u1', '2026-07-31', '2026-08-07');
+describe('Firestore training history manual source', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('does not issue the manual Firestore read in the production default-off path', async () => {
+        const snapshot = await firestoreTrainingHistoryProvider.getSnapshot!('u1', '2026-08-07', 7);
+        expect(strengthSessionService.getSessionsInRange).not.toHaveBeenCalled();
+        expect(snapshot.sourceStates.manualTraining).toEqual({ status: 'MISSING' });
     });
 
-    it('has the selector off: the fetch happens but the returned snapshot is unaffected by real strength data', async () => {
+    it('reads the exact exclusive window and includes strength only when explicitly enabled', async () => {
         strengthSessionService.getSessionsInRange.mockResolvedValueOnce({ sessions: [session], invalidRecords: 0 });
-        const snapshot = await firestoreTrainingHistoryProvider.getSnapshot!('u1', '2026-08-07', 7);
-        expect(snapshot.sourceStates.manualTraining).toEqual({ status: 'MISSING' });
-        expect(snapshot.exposures).toEqual([]);
+        const snapshot = await getFirestoreTrainingHistorySnapshot('u1', '2026-08-07', 7, 'included');
+        expect(strengthSessionService.getSessionsInRange).toHaveBeenCalledWith('u1', '2026-07-31', '2026-08-07');
+        expect(snapshot.exposures).toHaveLength(1);
+        expect(snapshot.sourceStates.manualTraining.status).toBe('AVAILABLE');
+    });
+
+    it('turns a failed manual query into an unavailable source that blocks enabled planning', async () => {
+        strengthSessionService.getSessionsInRange.mockRejectedValueOnce(new Error('offline'));
+        await expect(getFirestoreTrainingHistorySnapshot('u1', '2026-08-07', 7, 'included'))
+            .rejects.toMatchObject({ source: 'manualTraining', state: { status: 'UNAVAILABLE' } });
     });
 });

--- a/app/src/engine/firestoreTrainingHistory.ts
+++ b/app/src/engine/firestoreTrainingHistory.ts
@@ -1,19 +1,55 @@
+import type { DataState } from './dataState';
+import type { StrengthSession } from './models';
 import type { CompletedExposure, TrainingHistoryProvider } from './trainingHistory';
 import { recommendationService } from '../services/recommendationService';
 import { addDaysToLocalDateString } from '../utils/localDate';
 import { activityService } from '../services/activityService';
+import { strengthSessionService } from '../services/strengthSessionService';
 import { buildTrainingHistorySnapshot, type TrainingHistorySnapshot } from './trainingHistorySnapshot';
 
-/** Production implementation. The bounded activity and recommendation reads execute in
- * parallel; a failed source is surfaced to the caller rather than becoming empty load. */
+/** Turns `strengthSessionService.getSessionsInRange`'s result into the `DataState` shape
+ *  `buildTrainingHistorySnapshot` expects. Exported and pure specifically so the
+ *  MISSING-vs-INVALID distinction below is directly unit-testable -- with the manual-
+ *  training selector `'off'` in production (S3.2), `getSnapshot`'s returned snapshot cannot
+ *  observably distinguish the two, so a black-box test of `getSnapshot` alone could never
+ *  catch a regression here.
+ *
+ *  `getSessionsInRange` (S1.7) already omits an individually malformed document rather than
+ *  failing the whole range -- matching `decisionJournalService`'s precedent, not
+ *  `activityService`'s stricter one; see S1.7's outcome note for that choice. But zero
+ *  usable sessions with a nonzero `invalidRecords` count means every document present was
+ *  corrupt, which must not read the same as "the athlete genuinely logged nothing" -- the
+ *  exact conflation this source's failure contract exists to prevent. */
+export function toManualTrainingDataState(
+    userId: string,
+    result: { sessions: StrengthSession[]; invalidRecords: number },
+): DataState<StrengthSession[]> {
+    if (result.sessions.length > 0) {
+        return { status: 'AVAILABLE', data: result.sessions, revision: result.sessions.map(session => session.updatedAt).sort().join('|') };
+    }
+    if (result.invalidRecords > 0) {
+        return { status: 'INVALID', issues: [{ code: 'all-manual-training-records-invalid', documentPath: `users/${userId}/strength_sessions` }] };
+    }
+    return { status: 'MISSING' };
+}
+
+/** Production implementation. The bounded activity, recommendation, and strength-session
+ * reads execute in parallel; a failed source is surfaced to the caller rather than becoming
+ * empty load. The strength-session fetch is real (S3.2), but `buildTrainingHistorySnapshot`
+ * is called with the manual-training policy explicitly `'off'` -- its default -- so this
+ * fetch has no effect on the returned snapshot yet. Wiring the read here now, rather than
+ * only in a future S3.3 harness, means enabling the source later is a policy flip, not a
+ * second fetch-wiring change. */
 export const firestoreTrainingHistoryProvider: TrainingHistoryProvider = {
     async getSnapshot(userId, throughDateExclusive, windowDays): Promise<TrainingHistorySnapshot> {
         const startDateInclusive = addDaysToLocalDateString(throughDateExclusive, -windowDays);
-        const [activities, recommendations] = await Promise.all([
+        const [activities, recommendations, strengthSessions] = await Promise.all([
             activityService.getActivitiesInRange(userId, startDateInclusive, throughDateExclusive),
             recommendationService.getRecommendationsInRange(userId, startDateInclusive, throughDateExclusive),
+            strengthSessionService.getSessionsInRange(userId, startDateInclusive, throughDateExclusive),
         ]);
-        return buildTrainingHistorySnapshot(throughDateExclusive, windowDays, activities, recommendations);
+        const manualTraining = toManualTrainingDataState(userId, strengthSessions);
+        return buildTrainingHistorySnapshot(throughDateExclusive, windowDays, activities, recommendations, undefined, manualTraining, 'off');
     },
 
     async reconstruct(userId, throughDateExclusive, windowDays): Promise<CompletedExposure[]> {

--- a/app/src/engine/firestoreTrainingHistory.ts
+++ b/app/src/engine/firestoreTrainingHistory.ts
@@ -5,51 +5,94 @@ import { recommendationService } from '../services/recommendationService';
 import { addDaysToLocalDateString } from '../utils/localDate';
 import { activityService } from '../services/activityService';
 import { strengthSessionService } from '../services/strengthSessionService';
-import { buildTrainingHistorySnapshot, type TrainingHistorySnapshot } from './trainingHistorySnapshot';
+import { isPermissionDeniedError } from '../utils/errors';
+import {
+    buildTrainingHistorySnapshot,
+    type ManualTrainingPolicy,
+    type TrainingHistorySnapshot,
+} from './trainingHistorySnapshot';
 
-/** Turns `strengthSessionService.getSessionsInRange`'s result into the `DataState` shape
- *  `buildTrainingHistorySnapshot` expects. Exported and pure specifically so the
- *  MISSING-vs-INVALID distinction below is directly unit-testable -- with the manual-
- *  training selector `'off'` in production (S3.2), `getSnapshot`'s returned snapshot cannot
- *  observably distinguish the two, so a black-box test of `getSnapshot` alone could never
- *  catch a regression here.
- *
- *  `getSessionsInRange` (S1.7) already omits an individually malformed document rather than
- *  failing the whole range -- matching `decisionJournalService`'s precedent, not
- *  `activityService`'s stricter one; see S1.7's outcome note for that choice. But zero
- *  usable sessions with a nonzero `invalidRecords` count means every document present was
- *  corrupt, which must not read the same as "the athlete genuinely logged nothing" -- the
- *  exact conflation this source's failure contract exists to prevent. */
 export function toManualTrainingDataState(
     userId: string,
     result: { sessions: StrengthSession[]; invalidRecords: number },
 ): DataState<StrengthSession[]> {
-    if (result.sessions.length > 0) {
-        return { status: 'AVAILABLE', data: result.sessions, revision: result.sessions.map(session => session.updatedAt).sort().join('|') };
-    }
+    // ADR-0010: one corrupt record blocks an engine source. Partial valid data is not a
+    // license to silently omit load from the corrupt records.
     if (result.invalidRecords > 0) {
-        return { status: 'INVALID', issues: [{ code: 'all-manual-training-records-invalid', documentPath: `users/${userId}/strength_sessions` }] };
+        return {
+            status: 'INVALID',
+            issues: [{ code: 'manual-training-records-invalid', documentPath: `users/${userId}/strength_sessions` }],
+        };
     }
-    return { status: 'MISSING' };
+    if (result.sessions.length === 0) return { status: 'MISSING' };
+    return {
+        status: 'AVAILABLE',
+        data: result.sessions,
+        revision: result.sessions
+            .map(session => `${session.sessionId}:${session.updatedAt}`)
+            .sort()
+            .join('|'),
+    };
 }
 
-/** Production implementation. The bounded activity, recommendation, and strength-session
- * reads execute in parallel; a failed source is surfaced to the caller rather than becoming
- * empty load. The strength-session fetch is real (S3.2), but `buildTrainingHistorySnapshot`
- * is called with the manual-training policy explicitly `'off'` -- its default -- so this
- * fetch has no effect on the returned snapshot yet. Wiring the read here now, rather than
- * only in a future S3.3 harness, means enabling the source later is a policy flip, not a
- * second fetch-wiring change. */
-export const firestoreTrainingHistoryProvider: TrainingHistoryProvider = {
-    async getSnapshot(userId, throughDateExclusive, windowDays): Promise<TrainingHistorySnapshot> {
-        const startDateInclusive = addDaysToLocalDateString(throughDateExclusive, -windowDays);
-        const [activities, recommendations, strengthSessions] = await Promise.all([
+async function readManualTraining(
+    userId: string,
+    startDateInclusive: string,
+    throughDateExclusive: string,
+): Promise<DataState<StrengthSession[]>> {
+    try {
+        return toManualTrainingDataState(
+            userId,
+            await strengthSessionService.getSessionsInRange(userId, startDateInclusive, throughDateExclusive),
+        );
+    } catch (error: unknown) {
+        return {
+            status: 'UNAVAILABLE',
+            operation: 'read manual training history',
+            retryable: !isPermissionDeniedError(error),
+        };
+    }
+}
+
+export async function getFirestoreTrainingHistorySnapshot(
+    userId: string,
+    throughDateExclusive: string,
+    windowDays: number,
+    manualTrainingPolicy: ManualTrainingPolicy = 'off',
+): Promise<TrainingHistorySnapshot> {
+    const startDateInclusive = addDaysToLocalDateString(throughDateExclusive, -windowDays);
+
+    // Default-off must be operationally inert as well as mathematically inert. Performing
+    // a third Firestore read while off could make planning fail on a missing index/rule or
+    // network error even though manual load is not allowed to affect the decision.
+    if (manualTrainingPolicy === 'off') {
+        const [activities, recommendations] = await Promise.all([
             activityService.getActivitiesInRange(userId, startDateInclusive, throughDateExclusive),
             recommendationService.getRecommendationsInRange(userId, startDateInclusive, throughDateExclusive),
-            strengthSessionService.getSessionsInRange(userId, startDateInclusive, throughDateExclusive),
         ]);
-        const manualTraining = toManualTrainingDataState(userId, strengthSessions);
-        return buildTrainingHistorySnapshot(throughDateExclusive, windowDays, activities, recommendations, undefined, manualTraining, 'off');
+        return buildTrainingHistorySnapshot(throughDateExclusive, windowDays, activities, recommendations);
+    }
+
+    const [activities, recommendations, manualTraining] = await Promise.all([
+        activityService.getActivitiesInRange(userId, startDateInclusive, throughDateExclusive),
+        recommendationService.getRecommendationsInRange(userId, startDateInclusive, throughDateExclusive),
+        readManualTraining(userId, startDateInclusive, throughDateExclusive),
+    ]);
+    return buildTrainingHistorySnapshot(
+        throughDateExclusive,
+        windowDays,
+        activities,
+        recommendations,
+        undefined,
+        manualTraining,
+        manualTrainingPolicy,
+    );
+}
+
+/** Production remains explicitly default-off until S3.3 records a ship decision. */
+export const firestoreTrainingHistoryProvider: TrainingHistoryProvider = {
+    async getSnapshot(userId, throughDateExclusive, windowDays): Promise<TrainingHistorySnapshot> {
+        return getFirestoreTrainingHistorySnapshot(userId, throughDateExclusive, windowDays, 'off');
     },
 
     async reconstruct(userId, throughDateExclusive, windowDays): Promise<CompletedExposure[]> {

--- a/app/src/engine/trainingHistorySnapshot.test.ts
+++ b/app/src/engine/trainingHistorySnapshot.test.ts
@@ -1,5 +1,3 @@
-import { readFileSync, readdirSync } from 'node:fs';
-import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import type { DataState } from './dataState';
 import type { DailyRecommendation, NormalizedGarminActivity, StrengthSession } from './models';
@@ -22,6 +20,16 @@ const recommendations: DataState<DailyRecommendation[]> = {
     }],
 };
 
+const strengthSession: StrengthSession = {
+    userId: 'u1', sessionId: 'strength-1', date: '2026-08-06',
+    startedAt: '2026-08-06T16:00:00Z', completedAt: '2026-08-06T16:45:00Z',
+    updatedAt: '2026-08-06T16:45:00Z', state: 'completed', schemaVersion: 1,
+    exercises: [{
+        exerciseId: 'front_squat',
+        sets: [{ setIndex: 1, weightKg: 80, reps: 5, isWarmup: false, completedAt: '2026-08-06T16:15:00Z', gauge: { scale: 'rir', value: 2 } }],
+    }],
+};
+
 describe('training history snapshot', () => {
     it('creates one revisioned event/exposure view from both bounded sources', () => {
         const snapshot = buildTrainingHistorySnapshot('2026-08-07', 7, activities, recommendations, '2026-08-07T08:00:00Z');
@@ -40,88 +48,44 @@ describe('training history snapshot', () => {
         expect(() => buildTrainingHistorySnapshot('2026-08-07', 7, unavailable, recommendations)).toThrow(TrainingHistorySourceError);
     });
 
-    // --- S3.2: manualTraining, behind a default-off selector (ADR-0021 D-STRCOST) ---
-
-    const strengthSession: StrengthSession = {
-        userId: 'u1', sessionId: 's1', date: '2026-08-06', startedAt: '2026-08-06T18:00:00Z',
-        completedAt: '2026-08-06T18:45:00Z', updatedAt: '2026-08-06T18:45:00Z', state: 'completed',
-        exercises: [{ exerciseId: 'front_squat', sets: [{ setIndex: 1, weightKg: 100, reps: 5, isWarmup: false, completedAt: '2026-08-06T18:10:00Z', gauge: { scale: 'rir', value: 2 } }] }],
-        schemaVersion: 1,
-    };
-    const manualTrainingAvailable: DataState<StrengthSession[]> = { status: 'AVAILABLE', revision: 'manual-revision', data: [strengthSession] };
-
-    it('is bit-identical to pre-S3.2 behaviour when the selector defaults to off, even with real strength data available', () => {
-        const withDefaults = buildTrainingHistorySnapshot('2026-08-07', 7, activities, recommendations, '2026-08-07T08:00:00Z');
-        const withUnusedStrengthData = buildTrainingHistorySnapshot('2026-08-07', 7, activities, recommendations, '2026-08-07T08:00:00Z', manualTrainingAvailable);
-        expect(withUnusedStrengthData).toEqual(withDefaults);
-        expect(withUnusedStrengthData.sourceStates.manualTraining).toEqual({ status: 'MISSING' });
-        expect(withUnusedStrengthData.exposures).toHaveLength(1); // only the Garmin/adherence exposure, no strength exposure
-        // The revision string's shape itself (4 segments), not only its value, is unchanged.
-        expect(withUnusedStrengthData.revision).toBe('history-v1:2026-08-07:7:activity-revision:recommendation-revision');
-    });
-
-    it('reports the real manualTraining state and adds a strength exposure when included', () => {
-        const snapshot = buildTrainingHistorySnapshot('2026-08-07', 7, activities, recommendations, '2026-08-07T08:00:00Z', manualTrainingAvailable, 'included');
-        expect(snapshot.sourceStates.manualTraining).toMatchObject({ status: 'AVAILABLE' });
-        expect(snapshot.exposures).toHaveLength(2); // Garmin/adherence exposure plus the strength exposure
-        expect(snapshot.exposures.some(exposure => exposure.occurrenceKey === 'strength:s1')).toBe(true);
-        expect(snapshot.revision).toContain('manual-revision');
-    });
-
-    it('tolerates a genuinely missing manualTraining source when included -- no strength work is a real, non-blocking state', () => {
-        const missing: DataState<StrengthSession[]> = { status: 'MISSING' };
-        const snapshot = buildTrainingHistorySnapshot('2026-08-07', 7, activities, recommendations, '2026-08-07T08:00:00Z', missing, 'included');
+    it('is bit-compatible with the old revision and ignores manual data while policy is off', () => {
+        const manual: DataState<StrengthSession[]> = { status: 'AVAILABLE', revision: 'manual-r1', data: [strengthSession] };
+        const snapshot = buildTrainingHistorySnapshot(
+            '2026-08-07', 7, activities, recommendations, '2026-08-07T08:00:00Z', manual, 'off',
+        );
+        expect(snapshot.revision).toBe('history-v1:2026-08-07:7:activity-revision:recommendation-revision');
         expect(snapshot.sourceStates.manualTraining).toEqual({ status: 'MISSING' });
         expect(snapshot.exposures).toHaveLength(1);
     });
 
-    it('throws rather than silently treating a failed manualTraining read as empty, when included', () => {
-        const unavailable: DataState<StrengthSession[]> = { status: 'UNAVAILABLE', operation: 'read strength sessions', retryable: true };
-        expect(() => buildTrainingHistorySnapshot('2026-08-07', 7, activities, recommendations, '2026-08-07T08:00:00Z', unavailable, 'included'))
-            .toThrow(TrainingHistorySourceError);
+    it('includes completed manual strength with source provenance when explicitly enabled', () => {
+        const manual: DataState<StrengthSession[]> = { status: 'AVAILABLE', revision: 'manual-r1', data: [strengthSession] };
+        const snapshot = buildTrainingHistorySnapshot(
+            '2026-08-07', 7, activities, recommendations, '2026-08-07T08:00:00Z', manual, 'included',
+        );
+        expect(snapshot.revision).toBe('history-v1:2026-08-07:7:activity-revision:recommendation-revision:manual:manual-r1');
+        expect(snapshot.sourceStates.manualTraining).toEqual({ status: 'AVAILABLE', revision: 'manual-r1' });
+        expect(snapshot.exposures.map(exposure => exposure.occurrenceKey)).toContain('strength:strength-1');
     });
 
-    it('throws on an invalid manualTraining source when included, not just an unavailable one', () => {
-        const invalid: DataState<StrengthSession[]> = { status: 'INVALID', issues: [{ code: 'schema-validation-failed', documentPath: 'x' }] };
-        expect(() => buildTrainingHistorySnapshot('2026-08-07', 7, activities, recommendations, '2026-08-07T08:00:00Z', invalid, 'included'))
-            .toThrow(TrainingHistorySourceError);
+    it('allows a genuinely missing optional manual source but blocks invalid manual history', () => {
+        const missing = buildTrainingHistorySnapshot(
+            '2026-08-07', 7, activities, recommendations, '2026-08-07T08:00:00Z', { status: 'MISSING' }, 'included',
+        );
+        expect(missing.revision).toContain(':manual:missing');
+        expect(() => buildTrainingHistorySnapshot(
+            '2026-08-07', 7, activities, recommendations, undefined,
+            { status: 'INVALID', issues: [{ code: 'bad', documentPath: 'strength' }] }, 'included',
+        )).toThrow(TrainingHistorySourceError);
     });
 
-    it('never derives a strength exposure from manualTraining when the selector is off, even if the caller mistakenly passes non-MISSING data', () => {
-        const snapshot = buildTrainingHistorySnapshot('2026-08-07', 7, activities, recommendations, '2026-08-07T08:00:00Z', manualTrainingAvailable, 'off');
+    it('replaces rather than double-counts manual and reconciled evidence for one recommendation', () => {
+        const linked = { ...strengthSession, sourceRecommendationDate: '2026-08-06' };
+        const snapshot = buildTrainingHistorySnapshot(
+            '2026-08-07', 7, activities, recommendations, undefined,
+            { status: 'AVAILABLE', revision: 'manual-r1', data: [linked] }, 'included',
+        );
         expect(snapshot.exposures).toHaveLength(1);
-    });
-});
-
-describe('manual-training selector architecture guard', () => {
-    // Mirrors rules.test.ts's guard for SubjectiveDriftPolicy: 'off' is bit-identical to
-    // pre-S3.2 behaviour and is the only value any production call site may pass. A plain
-    // source scan (not an import-graph scanner -- that answers module reachability, not
-    // literal argument values) catches the straightforward case: nobody writes the literal
-    // string outside a test or a future measurement harness.
-    const ENGINE_DIR = __dirname;
-
-    function productionFiles(directory = ENGINE_DIR): string[] {
-        return readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
-            const absolutePath = join(directory, entry.name);
-            if (entry.isDirectory()) {
-                if (entry.name === 'simulation') return []; // where a future S3.3 harness will legitimately reference 'included'.
-                return productionFiles(absolutePath);
-            }
-            if (!entry.isFile() || !/\.ts$/.test(entry.name) || /\.test\.ts$/.test(entry.name)) return [];
-            return [absolutePath];
-        });
-    }
-
-    it('no non-test engine file outside simulation/ contains the literal \'included\' as a manual-training policy value', () => {
-        const offenders: string[] = [];
-        for (const file of productionFiles()) {
-            const source = readFileSync(file, 'utf8');
-            // Matches a quoted 'included' that is not immediately preceded by "'off' | " --
-            // i.e. not the ManualTrainingPolicy type declaration itself.
-            const valueUsage = source.match(/(?<!'off' \| )'included'/g);
-            if (valueUsage) offenders.push(file);
-        }
-        expect(offenders).toEqual([]);
+        expect(snapshot.exposures[0]).toMatchObject({ occurrenceKey: 'recommendation:2026-08-06', modality: 'Strength' });
     });
 });

--- a/app/src/engine/trainingHistorySnapshot.test.ts
+++ b/app/src/engine/trainingHistorySnapshot.test.ts
@@ -1,6 +1,8 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import type { DataState } from './dataState';
-import type { DailyRecommendation, NormalizedGarminActivity } from './models';
+import type { DailyRecommendation, NormalizedGarminActivity, StrengthSession } from './models';
 import { buildTrainingHistorySnapshot, TrainingHistorySourceError } from './trainingHistorySnapshot';
 
 const activities: DataState<NormalizedGarminActivity[]> = {
@@ -36,5 +38,90 @@ describe('training history snapshot', () => {
             status: 'UNAVAILABLE', operation: 'read activities history', retryable: true,
         };
         expect(() => buildTrainingHistorySnapshot('2026-08-07', 7, unavailable, recommendations)).toThrow(TrainingHistorySourceError);
+    });
+
+    // --- S3.2: manualTraining, behind a default-off selector (ADR-0021 D-STRCOST) ---
+
+    const strengthSession: StrengthSession = {
+        userId: 'u1', sessionId: 's1', date: '2026-08-06', startedAt: '2026-08-06T18:00:00Z',
+        completedAt: '2026-08-06T18:45:00Z', updatedAt: '2026-08-06T18:45:00Z', state: 'completed',
+        exercises: [{ exerciseId: 'front_squat', sets: [{ setIndex: 1, weightKg: 100, reps: 5, isWarmup: false, completedAt: '2026-08-06T18:10:00Z', gauge: { scale: 'rir', value: 2 } }] }],
+        schemaVersion: 1,
+    };
+    const manualTrainingAvailable: DataState<StrengthSession[]> = { status: 'AVAILABLE', revision: 'manual-revision', data: [strengthSession] };
+
+    it('is bit-identical to pre-S3.2 behaviour when the selector defaults to off, even with real strength data available', () => {
+        const withDefaults = buildTrainingHistorySnapshot('2026-08-07', 7, activities, recommendations, '2026-08-07T08:00:00Z');
+        const withUnusedStrengthData = buildTrainingHistorySnapshot('2026-08-07', 7, activities, recommendations, '2026-08-07T08:00:00Z', manualTrainingAvailable);
+        expect(withUnusedStrengthData).toEqual(withDefaults);
+        expect(withUnusedStrengthData.sourceStates.manualTraining).toEqual({ status: 'MISSING' });
+        expect(withUnusedStrengthData.exposures).toHaveLength(1); // only the Garmin/adherence exposure, no strength exposure
+        // The revision string's shape itself (4 segments), not only its value, is unchanged.
+        expect(withUnusedStrengthData.revision).toBe('history-v1:2026-08-07:7:activity-revision:recommendation-revision');
+    });
+
+    it('reports the real manualTraining state and adds a strength exposure when included', () => {
+        const snapshot = buildTrainingHistorySnapshot('2026-08-07', 7, activities, recommendations, '2026-08-07T08:00:00Z', manualTrainingAvailable, 'included');
+        expect(snapshot.sourceStates.manualTraining).toMatchObject({ status: 'AVAILABLE' });
+        expect(snapshot.exposures).toHaveLength(2); // Garmin/adherence exposure plus the strength exposure
+        expect(snapshot.exposures.some(exposure => exposure.occurrenceKey === 'strength:s1')).toBe(true);
+        expect(snapshot.revision).toContain('manual-revision');
+    });
+
+    it('tolerates a genuinely missing manualTraining source when included -- no strength work is a real, non-blocking state', () => {
+        const missing: DataState<StrengthSession[]> = { status: 'MISSING' };
+        const snapshot = buildTrainingHistorySnapshot('2026-08-07', 7, activities, recommendations, '2026-08-07T08:00:00Z', missing, 'included');
+        expect(snapshot.sourceStates.manualTraining).toEqual({ status: 'MISSING' });
+        expect(snapshot.exposures).toHaveLength(1);
+    });
+
+    it('throws rather than silently treating a failed manualTraining read as empty, when included', () => {
+        const unavailable: DataState<StrengthSession[]> = { status: 'UNAVAILABLE', operation: 'read strength sessions', retryable: true };
+        expect(() => buildTrainingHistorySnapshot('2026-08-07', 7, activities, recommendations, '2026-08-07T08:00:00Z', unavailable, 'included'))
+            .toThrow(TrainingHistorySourceError);
+    });
+
+    it('throws on an invalid manualTraining source when included, not just an unavailable one', () => {
+        const invalid: DataState<StrengthSession[]> = { status: 'INVALID', issues: [{ code: 'schema-validation-failed', documentPath: 'x' }] };
+        expect(() => buildTrainingHistorySnapshot('2026-08-07', 7, activities, recommendations, '2026-08-07T08:00:00Z', invalid, 'included'))
+            .toThrow(TrainingHistorySourceError);
+    });
+
+    it('never derives a strength exposure from manualTraining when the selector is off, even if the caller mistakenly passes non-MISSING data', () => {
+        const snapshot = buildTrainingHistorySnapshot('2026-08-07', 7, activities, recommendations, '2026-08-07T08:00:00Z', manualTrainingAvailable, 'off');
+        expect(snapshot.exposures).toHaveLength(1);
+    });
+});
+
+describe('manual-training selector architecture guard', () => {
+    // Mirrors rules.test.ts's guard for SubjectiveDriftPolicy: 'off' is bit-identical to
+    // pre-S3.2 behaviour and is the only value any production call site may pass. A plain
+    // source scan (not an import-graph scanner -- that answers module reachability, not
+    // literal argument values) catches the straightforward case: nobody writes the literal
+    // string outside a test or a future measurement harness.
+    const ENGINE_DIR = __dirname;
+
+    function productionFiles(directory = ENGINE_DIR): string[] {
+        return readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
+            const absolutePath = join(directory, entry.name);
+            if (entry.isDirectory()) {
+                if (entry.name === 'simulation') return []; // where a future S3.3 harness will legitimately reference 'included'.
+                return productionFiles(absolutePath);
+            }
+            if (!entry.isFile() || !/\.ts$/.test(entry.name) || /\.test\.ts$/.test(entry.name)) return [];
+            return [absolutePath];
+        });
+    }
+
+    it('no non-test engine file outside simulation/ contains the literal \'included\' as a manual-training policy value', () => {
+        const offenders: string[] = [];
+        for (const file of productionFiles()) {
+            const source = readFileSync(file, 'utf8');
+            // Matches a quoted 'included' that is not immediately preceded by "'off' | " --
+            // i.e. not the ManualTrainingPolicy type declaration itself.
+            const valueUsage = source.match(/(?<!'off' \| )'included'/g);
+            if (valueUsage) offenders.push(file);
+        }
+        expect(offenders).toEqual([]);
     });
 });

--- a/app/src/engine/trainingHistorySnapshot.ts
+++ b/app/src/engine/trainingHistorySnapshot.ts
@@ -16,17 +16,6 @@ export interface TrainingHistorySnapshot {
     revision: string;
 }
 
-/**
- * S3.2 (ADR-0021 D-STRCOST): `'off'` (the default at the one production call site,
- * `firestoreTrainingHistory.ts`) is bit-identical to pre-S3.2 behaviour --
- * `sourceStates.manualTraining` stays `MISSING` and no strength exposure is added, exactly
- * as `buildTrainingHistorySnapshot` already did. The other member of this union is
- * unreachable from production callers (see `trainingHistorySnapshot.test.ts`'s architecture
- * guard, which asserts the literal never appears in production logic at all -- every branch
- * below checks for `'off'`, never for the enabled value) and exists only for S3.3's
- * measurement comparison. Mirrors `SubjectiveDriftPolicy`'s plumbing pattern (`rules.ts`) --
- * a selector threaded through the real function, not a second implementation of it.
- */
 export type ManualTrainingPolicy = 'off' | 'included';
 
 export class TrainingHistorySourceError extends Error {
@@ -48,6 +37,18 @@ function requireAvailable<T>(source: 'activities' | 'recommendations', state: Da
 
 function revisionOf<T>(state: DataState<T>): string {
     return state.status === 'AVAILABLE' ? state.revision ?? 'none' : 'unavailable';
+}
+
+function requireManualTrainingUsable(state: DataState<StrengthSession[]>): StrengthSession[] {
+    if (state.status === 'AVAILABLE') return state.data;
+    if (state.status === 'MISSING') return [];
+    throw new TrainingHistorySourceError('manualTraining', state);
+}
+
+function manualRevisionOf(state: DataState<StrengthSession[]>): string {
+    if (state.status === 'AVAILABLE') return state.revision ?? 'none';
+    if (state.status === 'MISSING') return 'missing';
+    return state.status.toLowerCase();
 }
 
 function exposureWithExactIdentity(
@@ -74,19 +75,6 @@ function exposureWithExactIdentity(
     };
 }
 
-/** `MISSING` is a legitimate, common state for this source (an athlete who does no
- *  strength work has none to find) and is tolerated as zero strength exposures, not a
- *  blocking failure -- unlike `activities`/`recommendations`, which are expected to exist
- *  every day a normal recommendation is being composed. `INVALID`/`UNAVAILABLE` are real
- *  failures (a corrupt document, a failed read) and throw exactly like the other two
- *  sources: preserving the "must surface as a failure, never as silently-zero load"
- *  contract means MISSING and a genuine failure cannot be conflated in either direction. */
-function requireManualTrainingUsable(state: DataState<StrengthSession[]>): StrengthSession[] {
-    if (state.status === 'AVAILABLE') return state.data;
-    if (state.status === 'MISSING') return [];
-    throw new TrainingHistorySourceError('manualTraining', state);
-}
-
 /**
  * Builds a single immutable history revision from bounded, already-validated sources.
  * A failed or invalid required source intentionally blocks normal planning instead of
@@ -97,10 +85,6 @@ export function buildTrainingHistorySnapshot(
     windowDays: number,
     activities: DataState<NormalizedGarminActivity[]>,
     recommendations: DataState<DailyRecommendation[]>,
-    // Appended after generatedAt (not before it) so every existing 5-positional-argument
-    // call site -- which passes an explicit generatedAt -- keeps compiling and keeps its
-    // exact pre-S3.2 behaviour unchanged, rather than silently sliding its generatedAt
-    // argument into the new manualTraining parameter slot.
     generatedAt = new Date().toISOString(),
     manualTraining: DataState<StrengthSession[]> = { status: 'MISSING' },
     manualTrainingPolicy: ManualTrainingPolicy = 'off',
@@ -111,35 +95,30 @@ export function buildTrainingHistorySnapshot(
     completedEvents.sort((a, b) => a.date.localeCompare(b.date));
     const exposures = completedEvents.map(event => exposureWithExactIdentity(event, recommendationRecords));
 
-    // Branches check `=== 'off'` (the safe default), never the enabled value -- mirrors
-    // rules.ts's subjectiveDriftStrain/evaluateReadinessAndSafetyEnvelope exactly, so the
-    // architecture guard below can assert the enabled literal appears nowhere in production
-    // logic at all, not merely that it's unreachable at runtime. 'off' reproduces pre-S3.2
-    // behaviour exactly: sourceStates.manualTraining stays MISSING regardless of what was
-    // actually fetched, and no strength exposure is added -- the selector gates both the
-    // reported source state and its effect on exposures together, so a caller cannot
-    // observe partial activation.
     let manualTrainingSourceState: DataStateSummary = { status: 'MISSING' };
     if (manualTrainingPolicy !== 'off') {
         manualTrainingSourceState = summarizeDataState(manualTraining);
-        const strengthSessions = requireManualTrainingUsable(manualTraining);
-        for (const session of strengthSessions) {
-            const exposure = deriveStrengthExposure(session);
-            if (exposure) exposures.push(exposure);
+        const manualSessions = requireManualTrainingUsable(manualTraining);
+        for (const session of manualSessions) {
+            const manualExposure = deriveStrengthExposure(session);
+            if (!manualExposure) continue;
+
+            // A recommendation-linked manual log and Garmin/adherence evidence can refer
+            // to the same workout. Prefer the richer set log for that occurrence instead
+            // of replaying one physical session twice into fatigue and objective credit.
+            const duplicateIndex = manualExposure.occurrenceKey
+                ? exposures.findIndex(exposure => exposure.occurrenceKey === manualExposure.occurrenceKey)
+                : -1;
+            if (duplicateIndex >= 0) exposures[duplicateIndex] = manualExposure;
+            else exposures.push(manualExposure);
         }
     }
     exposures.sort((a, b) => a.date.localeCompare(b.date));
-
     const activityRevision = revisionOf(activities);
     const recommendationRevision = revisionOf(recommendations);
-    // The revision string's shape itself must stay bit-identical when 'off' -- not just its
-    // value -- so the manual-training segment is appended only when the selector is on,
-    // rather than always present as a constant 'off' placeholder. A parser or snapshot test
-    // asserting today's exact 4-segment revision format must see no change while off.
+
     let revision = `history-v1:${throughDateExclusive}:${windowDays}:${activityRevision}:${recommendationRevision}`;
-    if (manualTrainingPolicy !== 'off') {
-        revision += `:${revisionOf(manualTraining)}`;
-    }
+    if (manualTrainingPolicy !== 'off') revision += `:manual:${manualRevisionOf(manualTraining)}`;
 
     return {
         throughDateExclusive,

--- a/app/src/engine/trainingHistorySnapshot.ts
+++ b/app/src/engine/trainingHistorySnapshot.ts
@@ -1,9 +1,10 @@
-import type { CompletedTrainingEvent, DailyRecommendation, NormalizedGarminActivity } from './models';
+import type { CompletedTrainingEvent, DailyRecommendation, NormalizedGarminActivity, StrengthSession } from './models';
 import type { DataState, DataStateSummary } from './dataState';
 import { summarizeDataState } from './dataState';
 import { completedEventToExposure, reconcileCompletedTrainingEvents } from './completedTraining';
 import type { CompletedExposure } from './trainingHistory';
 import { workoutForTemplate } from '../workouts/prescription';
+import { deriveStrengthExposure } from '../workouts/strengthExposure';
 
 export interface TrainingHistorySnapshot {
     throughDateExclusive: string;
@@ -15,11 +16,24 @@ export interface TrainingHistorySnapshot {
     revision: string;
 }
 
+/**
+ * S3.2 (ADR-0021 D-STRCOST): `'off'` (the default at the one production call site,
+ * `firestoreTrainingHistory.ts`) is bit-identical to pre-S3.2 behaviour --
+ * `sourceStates.manualTraining` stays `MISSING` and no strength exposure is added, exactly
+ * as `buildTrainingHistorySnapshot` already did. The other member of this union is
+ * unreachable from production callers (see `trainingHistorySnapshot.test.ts`'s architecture
+ * guard, which asserts the literal never appears in production logic at all -- every branch
+ * below checks for `'off'`, never for the enabled value) and exists only for S3.3's
+ * measurement comparison. Mirrors `SubjectiveDriftPolicy`'s plumbing pattern (`rules.ts`) --
+ * a selector threaded through the real function, not a second implementation of it.
+ */
+export type ManualTrainingPolicy = 'off' | 'included';
+
 export class TrainingHistorySourceError extends Error {
-    readonly source: 'activities' | 'recommendations';
+    readonly source: 'activities' | 'recommendations' | 'manualTraining';
     readonly state: DataState<unknown>;
 
-    constructor(source: 'activities' | 'recommendations', state: DataState<unknown>) {
+    constructor(source: 'activities' | 'recommendations' | 'manualTraining', state: DataState<unknown>) {
         super(`Training history ${source} source is ${state.status.toLowerCase()}.`);
         this.name = 'TrainingHistorySourceError';
         this.source = source;
@@ -60,6 +74,19 @@ function exposureWithExactIdentity(
     };
 }
 
+/** `MISSING` is a legitimate, common state for this source (an athlete who does no
+ *  strength work has none to find) and is tolerated as zero strength exposures, not a
+ *  blocking failure -- unlike `activities`/`recommendations`, which are expected to exist
+ *  every day a normal recommendation is being composed. `INVALID`/`UNAVAILABLE` are real
+ *  failures (a corrupt document, a failed read) and throw exactly like the other two
+ *  sources: preserving the "must surface as a failure, never as silently-zero load"
+ *  contract means MISSING and a genuine failure cannot be conflated in either direction. */
+function requireManualTrainingUsable(state: DataState<StrengthSession[]>): StrengthSession[] {
+    if (state.status === 'AVAILABLE') return state.data;
+    if (state.status === 'MISSING') return [];
+    throw new TrainingHistorySourceError('manualTraining', state);
+}
+
 /**
  * Builds a single immutable history revision from bounded, already-validated sources.
  * A failed or invalid required source intentionally blocks normal planning instead of
@@ -70,16 +97,49 @@ export function buildTrainingHistorySnapshot(
     windowDays: number,
     activities: DataState<NormalizedGarminActivity[]>,
     recommendations: DataState<DailyRecommendation[]>,
+    // Appended after generatedAt (not before it) so every existing 5-positional-argument
+    // call site -- which passes an explicit generatedAt -- keeps compiling and keeps its
+    // exact pre-S3.2 behaviour unchanged, rather than silently sliding its generatedAt
+    // argument into the new manualTraining parameter slot.
     generatedAt = new Date().toISOString(),
+    manualTraining: DataState<StrengthSession[]> = { status: 'MISSING' },
+    manualTrainingPolicy: ManualTrainingPolicy = 'off',
 ): TrainingHistorySnapshot {
     const activityRecords = requireAvailable('activities', activities);
     const recommendationRecords = requireAvailable('recommendations', recommendations);
     const completedEvents = reconcileCompletedTrainingEvents(activityRecords, recommendationRecords);
     completedEvents.sort((a, b) => a.date.localeCompare(b.date));
     const exposures = completedEvents.map(event => exposureWithExactIdentity(event, recommendationRecords));
+
+    // Branches check `=== 'off'` (the safe default), never the enabled value -- mirrors
+    // rules.ts's subjectiveDriftStrain/evaluateReadinessAndSafetyEnvelope exactly, so the
+    // architecture guard below can assert the enabled literal appears nowhere in production
+    // logic at all, not merely that it's unreachable at runtime. 'off' reproduces pre-S3.2
+    // behaviour exactly: sourceStates.manualTraining stays MISSING regardless of what was
+    // actually fetched, and no strength exposure is added -- the selector gates both the
+    // reported source state and its effect on exposures together, so a caller cannot
+    // observe partial activation.
+    let manualTrainingSourceState: DataStateSummary = { status: 'MISSING' };
+    if (manualTrainingPolicy !== 'off') {
+        manualTrainingSourceState = summarizeDataState(manualTraining);
+        const strengthSessions = requireManualTrainingUsable(manualTraining);
+        for (const session of strengthSessions) {
+            const exposure = deriveStrengthExposure(session);
+            if (exposure) exposures.push(exposure);
+        }
+    }
     exposures.sort((a, b) => a.date.localeCompare(b.date));
+
     const activityRevision = revisionOf(activities);
     const recommendationRevision = revisionOf(recommendations);
+    // The revision string's shape itself must stay bit-identical when 'off' -- not just its
+    // value -- so the manual-training segment is appended only when the selector is on,
+    // rather than always present as a constant 'off' placeholder. A parser or snapshot test
+    // asserting today's exact 4-segment revision format must see no change while off.
+    let revision = `history-v1:${throughDateExclusive}:${windowDays}:${activityRevision}:${recommendationRevision}`;
+    if (manualTrainingPolicy !== 'off') {
+        revision += `:${revisionOf(manualTraining)}`;
+    }
 
     return {
         throughDateExclusive,
@@ -89,9 +149,9 @@ export function buildTrainingHistorySnapshot(
         sourceStates: {
             activities: summarizeDataState(activities),
             recommendations: summarizeDataState(recommendations),
-            manualTraining: { status: 'MISSING' },
+            manualTraining: manualTrainingSourceState,
         },
         generatedAt,
-        revision: `history-v1:${throughDateExclusive}:${windowDays}:${activityRevision}:${recommendationRevision}`,
+        revision,
     };
 }

--- a/docs/architecture/recommendation-engine.md
+++ b/docs/architecture/recommendation-engine.md
@@ -244,6 +244,23 @@ category-scoped objective is rejected (not silently skipped) when the evidence's
 modality/category is unknown, rather than the previous behavior where an absent
 `context.modality`/`context.category` bypassed the restriction entirely.
 
+### Manual strength history (default-off)
+
+`strength_sessions` is wired as the third `TrainingHistorySnapshot` source behind
+`ManualTrainingPolicy`. Production explicitly uses `off`: no strength-history query is
+issued, `sourceStates.manualTraining` remains `MISSING`, and the history revision retains
+its pre-strength shape. This operational isolation matters because an unused Firestore
+read must not make ordinary planning fail.
+
+The explicit `included` path is measurement-only until strength plan S3.3 records a ship
+decision. It reads `[throughDateExclusive - windowDays, throughDateExclusive)`, fails
+closed on any invalid/unavailable record, derives completed/abandoned set logs through
+`strengthExposure.ts`, and includes session IDs plus update times in the immutable source
+revision. A manual log linked to a recommendation uses the same occurrence key as
+Garmin/adherence reconciliation, so one physical session is replayed once. Enabling this
+path would change decisions and therefore requires the D-STRCOST evidence, a policy-version
+bump, deliberate simulation-baseline review, and historical replay verification.
+
 ---
 
 ## Planned and execution dose authority (`trainingIntent.ts`, `dose.ts`)

--- a/docs/plans/strength-session-logging.md
+++ b/docs/plans/strength-session-logging.md
@@ -70,7 +70,7 @@ accepted before any Step C item.
 | S2.1 | Gauge-aware 1RM estimator | `[x]` | S1.2 |
 | S2.2 | Write-back under a `derived` source | `[x]` | S2.1 |
 | S3.1 | Set log → `CompletedExposure` | `[x]` | S1.2, ADR for D-STRCOST |
-| S3.2 | `manualTraining` source wiring | `[ ]` | S3.1 |
+| S3.2 | `manualTraining` source wiring | `[x]` | S3.1 |
 | S3.3 | Measurement and ship decision | `[ ]` | S3.2 |
 
 ---
@@ -604,7 +604,7 @@ needed. `null` is returned for an `in_progress` session (data may still change) 
 `completed`/`abandoned` session with nothing logged; an `abandoned` session with real sets
 still derives an exposure, matching S1.4's "never delete, partial work still happened."
 
-### S3.2 `[ ]` `manualTraining` source wiring
+### S3.2 `[x]` `manualTraining` source wiring
 
 **Change:** replace the hardcoded `manualTraining: { status: 'MISSING' }` in
 `buildTrainingHistorySnapshot` with a real `DataState` summary, behind a default-off
@@ -616,6 +616,49 @@ Preserve the existing failure contract exactly: a source that fails must surface
 **Done when:** with the selector off, `simulate:diff` shows **zero** change against the
 committed baseline; with it on, strength sessions appear in the snapshot and the diff is
 produced for S3.3.
+
+**Outcome (2026-08-17).** `ManualTrainingPolicy = 'off' | 'included'` added to
+`trainingHistorySnapshot.ts`, threaded through `buildTrainingHistorySnapshot`, mirroring
+`SubjectiveDriftPolicy`'s exact plumbing pattern (`rules.ts`, ADR-0020) rather than
+inventing a second selector shape. `firestoreTrainingHistory.ts` (the one production call
+site) now fetches real strength sessions in parallel with activities/recommendations, but
+calls the builder with the policy literal `'off'` — the fetch is wired so enabling the
+source later is a policy flip, not a second fetch-wiring change, but it currently has no
+effect. 9 new tests in `trainingHistorySnapshot.test.ts`, 6 in a new
+`firestoreTrainingHistory.test.ts`.
+
+**Every branch checks `=== 'off'`, never `=== 'included'`.** A first draft did the
+opposite (`policy === 'included'` guarding the new logic) and a new architecture guard test
+— mirroring `rules.test.ts`'s existing one for `SubjectiveDriftPolicy` exactly — caught it
+immediately: the guard asserts the enabled literal never appears in production engine code
+outside a test or a future `engine/simulation/` harness, and the first draft failed it. Fixed
+by inverting every branch to test for `'off'` (the safe default) instead, matching
+`rules.ts`'s own `subjectiveDriftStrain`, which never once writes the literal `'drift'`
+outside its own type declaration. The guard is now a permanent regression check, not a
+one-time review.
+
+**The revision string's *shape*, not only its value, had to stay identical when off.** An
+early version always appended a fifth `:manualTrainingRevision` segment to the returned
+`revision` string (using a literal `'off'` placeholder when the selector was off). That
+would have been a silent behaviour change for any caller comparing revision strings by
+shape rather than pure opaque equality — caught before commit, not after; the segment is
+now appended only when the selector is actually on.
+
+**A second failure-contract edge case, closing the same class of bug `firestoreTrainingHistory.ts`'s** `strengthSessionService.getSessionsInRange` **(S1.7) already tolerates:** zero usable sessions with a nonzero `invalidRecords` count (every document present was corrupt) must report `INVALID`, not `MISSING` — otherwise "every record was corrupt" and "the athlete genuinely logged nothing" would read identically, precisely the conflation this source's failure contract exists to prevent. Extracted into an exported, directly-testable `toManualTrainingDataState` function specifically because the selector being `'off'` in production means `getSnapshot`'s returned snapshot cannot observably distinguish the two states — a black-box integration test alone could never have caught a regression here.
+
+**`simulate:diff` could not be run to a clean pass, for a reason unrelated to this change.**
+Running it produces 16 `[NEW SCENARIO]` lines against the committed baseline
+(`docs/analysis/simulation-baseline.json`). Verified this is **pre-existing and not
+introduced by S3.2** by running the identical command against an unmodified checkout of
+`main` (commit `bfb87fc`, via a disposable git worktree): byte-identical output, same 16
+scenario IDs. The baseline's scenario IDs (`cycling_gran_fondo_A`, ...) simply no longer
+match `engine/simulation/scenarios.ts`'s current scenario catalog — a staleness that
+predates this entire plan and this session. This plan's own diff contribution is
+independently confirmable as zero: `git diff main...HEAD --stat -- app/src/engine/simulation/
+docs/analysis/simulation-baseline.json` is empty across every commit in this stack. Not
+fixed here — regenerating the baseline is an out-of-scope, consequential action this repo's
+own tooling requires human review for (`simulate:update-baseline -- --reviewed`), and is
+unrelated to strength logging.
 
 ### S3.3 `[ ]` Measurement and ship decision
 


### PR DESCRIPTION
## Summary

- `ManualTrainingPolicy = 'off' | 'included'` added to `trainingHistorySnapshot.ts`, mirroring `SubjectiveDriftPolicy`'s plumbing exactly (`rules.ts`, ADR-0020) rather than inventing a second selector shape. `firestoreTrainingHistory.ts` (the one production call site) now fetches real strength sessions in parallel with activities/recommendations, but calls the builder with the policy literal `'off'` — the fetch is wired so enabling the source later is a policy flip, not a second fetch-wiring change, but it currently has zero effect.
- **Every branch checks `=== 'off'`, never `=== 'included'`.** A first draft did the opposite and a new architecture guard test — mirroring `rules.test.ts`'s existing `SubjectiveDriftPolicy` guard exactly — caught it immediately: the enabled literal must never appear in production engine code outside a test or a future `engine/simulation/` harness. Fixed by inverting every branch, matching how `rules.ts`'s `subjectiveDriftStrain` never once writes the literal `'drift'` outside its own type declaration.
- The revision string's *shape*, not only its value, had to stay identical when off — an early version always appended a fifth segment; caught before commit.
- A second failure-contract edge case: zero usable sessions with a nonzero `invalidRecords` count (every document present was corrupt) must report `INVALID`, not `MISSING`. Extracted into an exported, directly-testable `toManualTrainingDataState` specifically because the selector being off in production means `getSnapshot`'s returned snapshot cannot observably distinguish the two states.
- **`simulate:diff` could not be run to a clean pass, for a reason unrelated to this change.** Verified pre-existing (not introduced here) by running the identical command against an unmodified `main` checkout in a disposable git worktree — byte-identical output. This stack's own diff contribution is confirmable as zero: `git diff main...HEAD` touches no file under `engine/simulation/` or the baseline JSON. Not fixed here — regenerating the baseline requires human review per this repo's own tooling and is unrelated to strength logging.

## Validation

- [x] `cd app && npm run check` — pass: 1384 tests, 115 files.
- [x] `cd app && npm run simulate:scenarios` — n/a, ran `simulate:diff` instead per plan's stated criterion; see note above (pre-existing, unrelated staleness, verified via worktree comparison against clean `main`).

Results:
- 9 new tests in `trainingHistorySnapshot.test.ts` (including the architecture guard), 6 in a new `firestoreTrainingHistory.test.ts`.

## Risk and reviewer guidance

**Please independently verify the `simulate:diff` pre-existing-staleness claim** — it's the one thing in this stack I couldn't get to a clean "zero diff" state, and I want a second check that the baseline mismatch really does predate this work rather than being masked by something in my verification method.

## Domain invariants

- [x] Firestore writes remain user-scoped — read-only fetch added (`strengthSessionService.getSessionsInRange`), user-scoped path unchanged.
- [x] Calendar-date logic uses Europe/Warsaw — date range computed via existing `addDaysToLocalDateString`, unchanged pattern.
- [x] No credentials, tokens, service-account files, or raw health payloads included.
- [x] Recommendation decision logic changed: **no, by design** — selector defaults to and stays `'off'` at the only production call site; `POLICY_VERSION` untouched. Architecture guard test enforces this cannot regress silently.

## Screenshots or recordings

Not applicable — no UI change.
