### PR TITLE
feat: close M3.2 replay/persistence gaps (rules validation, catalog fidelity, replay wiring)

### DIFF
--- a/app/firestore.rules
+++ b/app/firestore.rules
@@ -116,7 +116,7 @@ service cloud.firestore {
         && audit.candidateScores is list && audit.candidateScores.size() <= 64
         && (!('droppedContributorObjectives' in audit) || (audit.droppedContributorObjectives is list && audit.droppedContributorObjectives.size() <= 64))
         && (!('primarySession' in audit) || hasValidSessionReferenceBinding(audit.primarySession))
-        && (!('additionalSessions' in audit) || (audit.additionalSessions is list && audit.additionalSessions.size() <= 16))
+        && (!('additionalSessions' in audit) || (audit.additionalSessions is list && audit.additionalSessions.size() <= 4))
         && (!('externalPlan' in audit) || (
           audit.externalPlan is map
           && audit.externalPlan.keys().hasOnly(['planId', 'revision', 'sessionId', 'contentHash'])
@@ -154,6 +154,7 @@ service cloud.firestore {
         && (!('revision' in request.resource.data) || (request.resource.data.revision is int && request.resource.data.revision >= 1))
         && hasValidAdherence(request.resource.data.adherence)
         && (!('primarySession' in request.resource.data) || hasValidSessionReferenceBinding(request.resource.data.primarySession))
+        && (!('additionalSessions' in request.resource.data) || hasValidAdditionalSessions(request.resource.data.additionalSessions))
         && (request.resource.data.schemaVersion != 3
           || ('recommendationAudit' in request.resource.data && hasValidRecommendationAudit(request.resource.data.recommendationAudit)));
     }
@@ -162,9 +163,11 @@ service cloud.firestore {
       return request.resource.data.schemaVersion >= resource.data.schemaVersion;
     }
 
-    function auditWriteOnce() {
+    // Takes the already-computed decisionChanged flag rather than calling
+    // decisionFieldsUnchanged() itself -- see canUpdateRecommendation()'s comment for why.
+    function auditWriteOnce(decisionChanged) {
       return !('recommendationAudit' in resource.data)
-        || !decisionFieldsUnchanged()
+        || decisionChanged
         || (('recommendationAudit' in request.resource.data)
           && request.resource.data.recommendationAudit.policyVersion == resource.data.recommendationAudit.policyVersion
           && request.resource.data.recommendationAudit.evaluatedAt == resource.data.recommendationAudit.evaluatedAt);
@@ -206,6 +209,33 @@ service cloud.firestore {
         && (('additionalSessions' in prior) == ('additionalSessions' in resource.data))
         && (!('additionalSessions' in resource.data) || prior.additionalSessions == resource.data.additionalSessions)
         && (!('recommendationAudit' in resource.data) || (('recommendationAudit' in prior) && prior.recommendationAudit.policyVersion == resource.data.recommendationAudit.policyVersion && prior.recommendationAudit.evaluatedAt == resource.data.recommendationAudit.evaluatedAt));
+    }
+
+    // decisionFieldsUnchanged() itself does ~10 field comparisons; the update rule below
+    // used to call it 3 times over (once directly in each side of the changed/unchanged
+    // branch, once more indirectly inside auditWriteOnce()) purely because the rules
+    // language has no memoization. That redundancy was consuming enough of Firestore's
+    // ~1000 expression-evaluation budget that a decision-changing update carrying a
+    // populated additionalSessions binding could no longer be validated at all -- calling
+    // it once via `let` and threading the result through recovers that headroom.
+    function canUpdateRecommendation(userId, date) {
+      let decisionChanged = !decisionFieldsUnchanged();
+      return hasValidRecommendation(userId, date)
+        && keepsOwnership(userId)
+        && request.resource.data.createdAt == resource.data.createdAt
+        && schemaRatchets()
+        && auditWriteOnce(decisionChanged)
+        && (
+          (!decisionChanged && (
+            (('revision' in resource.data) && request.resource.data.revision == resource.data.revision) ||
+            (!('revision' in resource.data) && (!('revision' in request.resource.data) || request.resource.data.revision == 1))
+          ))
+          ||
+          (decisionChanged && (
+            request.resource.data.revision == (('revision' in resource.data) ? resource.data.revision : 1) + 1
+            && archivesPriorRevision(userId, date)
+          ))
+        );
     }
 
     match /daily_recovery_snapshot/{date} { allow read, write: if false; }
@@ -732,6 +762,38 @@ service cloud.firestore {
         && (!('occurrenceId' in binding) || (binding.occurrenceId is string && binding.occurrenceId.size() > 0));
     }
 
+    // Lighter than hasValidSessionReferenceBinding: checks shape and a recognized source
+    // kind, but not every per-kind field (workoutId/catalogVersion types, etc.) -- see
+    // hasValidAdditionalSessions for why. The client (engine/validation.ts) still applies
+    // the full per-kind check before any write reaches here; this is defense in depth
+    // against a client that skips it, not the only gate.
+    function hasValidAdditionalSessionBinding(binding) {
+      return binding is map
+        && binding.keys().hasOnly(['sessionSource', 'occurrenceId', 'prescriptionHash'])
+        && binding.keys().hasAll(['sessionSource', 'prescriptionHash'])
+        && binding.sessionSource is map
+        && binding.sessionSource.kind in ['catalog', 'external_plan', 'manual', 'unplanned_fixture']
+        && binding.prescriptionHash is string && binding.prescriptionHash.size() > 0
+        && (!('occurrenceId' in binding) || (binding.occurrenceId is string && binding.occurrenceId.size() > 0));
+    }
+
+    // Bounded to 4 (not the schema's historical 16): the rules language has no
+    // iteration, so per-element validation is unrolled by index below. A prior attempt
+    // at this same check unrolled to 16 elements calling the full hasValidSessionReferenceBinding
+    // per element and exceeded the emulator's ~1000 expression-evaluation budget per write;
+    // 4 elements at that same per-kind rigor still didn't fit even after removing other
+    // redundant evaluation (see canUpdateRecommendation's comment), hence the lighter
+    // per-element check above. 4 is a real bound, not a compromise -- adjudicateAuthoredSession's
+    // systemic-cost ceiling never admits more than a handful of same-day sessions in
+    // practice (see authoredSessionGates.ts).
+    function hasValidAdditionalSessions(list) {
+      return list is list && list.size() <= 4
+        && (list.size() < 1 || hasValidAdditionalSessionBinding(list[0]))
+        && (list.size() < 2 || hasValidAdditionalSessionBinding(list[1]))
+        && (list.size() < 3 || hasValidAdditionalSessionBinding(list[2]))
+        && (list.size() < 4 || hasValidAdditionalSessionBinding(list[3]));
+    }
+
     function hasValidSessionEntry(executionId, entryId) {
       let data = request.resource.data;
       let payload = data.payload;
@@ -797,23 +859,7 @@ service cloud.firestore {
     match /users/{userId}/daily_recommendations/{date} {
       allow read: if isOwner(userId);
       allow create: if hasValidRecommendation(userId, date);
-      allow update: if isValidAdherenceOnlyUpdate(userId, date)
-        || (hasValidRecommendation(userId, date)
-          && keepsOwnership(userId)
-          && request.resource.data.createdAt == resource.data.createdAt
-          && schemaRatchets()
-          && auditWriteOnce()
-          && (
-            (decisionFieldsUnchanged() && (
-              (('revision' in resource.data) && request.resource.data.revision == resource.data.revision) ||
-              (!('revision' in resource.data) && (!('revision' in request.resource.data) || request.resource.data.revision == 1))
-            ))
-            ||
-            (!decisionFieldsUnchanged() && (
-              request.resource.data.revision == (('revision' in resource.data) ? resource.data.revision : 1) + 1
-              && archivesPriorRevision(userId, date)
-            ))
-          ));
+      allow update: if isValidAdherenceOnlyUpdate(userId, date) || canUpdateRecommendation(userId, date);
       allow delete: if false;
 
       match /revisions/{revId} {

--- a/app/firestore.rules
+++ b/app/firestore.rules
@@ -693,16 +693,31 @@ service cloud.firestore {
       allow delete: if isOwner(userId);
     }
 
+    // M3.2: optional snapshot of the non-`blocks` fields `definitionHash` was computed
+    // over, so a `catalog` source can be replayed with historical fidelity after its live
+    // catalog entry is later edited. Absent on prescriptions written before this existed.
+    function hasValidDisplayMetadata(meta) {
+      return meta is map
+        && meta.keys().hasOnly(['title', 'summary', 'intent', 'dominantModality', 'duration'])
+        && meta.keys().hasAll(['title', 'intent'])
+        && meta.title is string
+        && meta.intent is string
+        && (!('summary' in meta) || meta.summary is string)
+        && (!('dominantModality' in meta) || meta.dominantModality is string)
+        && (!('duration' in meta) || (meta.duration is map && meta.duration.min is number && meta.duration.max is number));
+    }
+
     function hasValidExecutionPrescription(userId, prescriptionHash) {
       let data = request.resource.data;
       return hasOwnedUserId(userId)
-        && data.keys().hasOnly(['userId', 'schemaVersion', 'prescriptionHash', 'sessionSource', 'definitionHash', 'blocks', 'createdAt'])
+        && data.keys().hasOnly(['userId', 'schemaVersion', 'prescriptionHash', 'sessionSource', 'definitionHash', 'blocks', 'displayMetadata', 'createdAt'])
         && data.keys().hasAll(['userId', 'schemaVersion', 'prescriptionHash', 'sessionSource', 'definitionHash', 'blocks', 'createdAt'])
         && data.prescriptionHash == prescriptionHash
         && data.definitionHash is string
         && hasValidSessionSource(data.sessionSource)
         && data.schemaVersion == 1
         && data.blocks is list
+        && (!('displayMetadata' in data) || hasValidDisplayMetadata(data.displayMetadata))
         && data.createdAt is string;
     }
 

--- a/app/firestore.rules
+++ b/app/firestore.rules
@@ -116,7 +116,7 @@ service cloud.firestore {
         && audit.candidateScores is list && audit.candidateScores.size() <= 64
         && (!('droppedContributorObjectives' in audit) || (audit.droppedContributorObjectives is list && audit.droppedContributorObjectives.size() <= 64))
         && (!('primarySession' in audit) || hasValidSessionReferenceBinding(audit.primarySession))
-        && (!('additionalSessions' in audit) || (audit.additionalSessions is list && audit.additionalSessions.size() <= 4))
+        && (!('additionalSessions' in audit) || hasValidAdditionalSessions(audit.additionalSessions))
         && (!('externalPlan' in audit) || (
           audit.externalPlan is map
           && audit.externalPlan.keys().hasOnly(['planId', 'revision', 'sessionId', 'contentHash'])
@@ -777,17 +777,28 @@ service cloud.firestore {
         && (!('occurrenceId' in binding) || (binding.occurrenceId is string && binding.occurrenceId.size() > 0));
     }
 
-    // Lighter than hasValidSessionReferenceBinding: checks shape and a recognized source
-    // kind, but not every per-kind field (workoutId/catalogVersion types, etc.) -- see
+    // Lighter than hasValidSessionSource: checks the recognized source kind plus presence
+    // of that kind's required fields, but skips hasOnly() (no rejection of stray extra
+    // fields) and per-field type/size checks (e.g. catalogVersion being a string) -- see
     // hasValidAdditionalSessions for why. The client (engine/validation.ts) still applies
     // the full per-kind check before any write reaches here; this is defense in depth
-    // against a client that skips it, not the only gate.
+    // against a client that skips it, not the only gate. This still closes the specific
+    // gap of a binding that names a valid `kind` but omits that kind's required fields
+    // entirely (e.g. `{ kind: 'catalog' }` with no workoutId/catalogVersion).
+    function hasValidAdditionalSessionSourceShape(source) {
+      return source is map && (
+        (source.kind == 'catalog' && source.keys().hasAll(['workoutId', 'catalogVersion']))
+        || (source.kind == 'external_plan' && source.keys().hasAll(['planId', 'revision', 'sessionId', 'contentHash']))
+        || (source.kind == 'manual' && source.keys().hasAll(['definitionId', 'revision', 'contentHash']))
+        || (source.kind == 'unplanned_fixture' && source.keys().hasAll(['fixtureId']))
+      );
+    }
+
     function hasValidAdditionalSessionBinding(binding) {
       return binding is map
         && binding.keys().hasOnly(['sessionSource', 'occurrenceId', 'prescriptionHash'])
         && binding.keys().hasAll(['sessionSource', 'prescriptionHash'])
-        && binding.sessionSource is map
-        && binding.sessionSource.kind in ['catalog', 'external_plan', 'manual', 'unplanned_fixture']
+        && hasValidAdditionalSessionSourceShape(binding.sessionSource)
         && binding.prescriptionHash is string && binding.prescriptionHash.size() > 0
         && (!('occurrenceId' in binding) || (binding.occurrenceId is string && binding.occurrenceId.size() > 0));
     }

--- a/app/src/components/Home.tsx
+++ b/app/src/components/Home.tsx
@@ -76,6 +76,27 @@ function mondayOf(date: string): string {
   return addDaysToLocalDateString(date, -((weekday + 6) % 7));
 }
 
+/**
+ * Fire-and-forget self-check (M3.2): confirms a just-saved decision's session bindings
+ * actually replay against their stored bytes. Skips a day with no bindings at all, so an
+ * ordinary catalog/no-session day doesn't pay two extra Firestore reads on every save.
+ * Non-fatal by design, matching saveRecommendation's own "shouldn't block the dashboard"
+ * idiom -- reports via console.warn only, same as every other integrity check in this
+ * codebase (see shadowLogService). Lazily imported so replay.ts stays free of a live
+ * Firestore dependency for every other caller (see its own module comment).
+ */
+function verifySessionBindingReplay(userId: string, saved: DailyRecommendation | null): void {
+  if (!saved || (!saved.primarySession && !saved.additionalSessions)) return;
+  import('../engine/replay')
+    .then(({ replayRecommendationAuditAgainstSessions }) => replayRecommendationAuditAgainstSessions(userId, saved))
+    .then(result => {
+      if (!result.reproducible) {
+        console.warn(`Recommendation for ${saved.date} does not replay against its stored session bindings:`, result.errors);
+      }
+    })
+    .catch(err => console.warn(`Failed to verify session-binding replay for ${saved.date}:`, err));
+}
+
 const DetailedTodayPlan = memo(function DetailedTodayPlan({
   prescription,
   userId,
@@ -552,9 +573,9 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
         if (!isCurrent()) return;
         setNextDayPlan(tomorrowPlan);
 
-        recommendationService.saveRecommendation(userId, input.date, todayRec).catch(err =>
-          console.warn('Failed to persist recommendation:', err)
-        );
+        recommendationService.saveRecommendation(userId, input.date, todayRec)
+          .then(saved => verifySessionBindingReplay(userId, saved))
+          .catch(err => console.warn('Failed to persist recommendation:', err));
       } else if (input.recoverySnapshot && safetyStatus !== 'complete') {
         setRecommendation(createProvisionalSafetyRecommendation(safetyStatus));
         setAdjustmentDirection(null);
@@ -640,9 +661,9 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
     recommendationService.saveRecommendation(userId, decisionInput.date, {
       ...recommendation,
       adjustment: direction ? adjusted?.adjustment : undefined,
-    }).catch(err =>
-      console.warn('Failed to persist adjusted recommendation:', err)
-    );
+    })
+      .then(saved => verifySessionBindingReplay(userId, saved))
+      .catch(err => console.warn('Failed to persist adjusted recommendation:', err));
   }, [recommendation, canGenerateNormalPlan, decisionInput, computeAdjustedRecommendation, userId]);
 
   const activeRec = useMemo(

--- a/app/src/emulator/firestoreRules.emulator.test.ts
+++ b/app/src/emulator/firestoreRules.emulator.test.ts
@@ -1244,6 +1244,41 @@ emulatorDescribe('Firestore security rules', () => {
         }));
     });
 
+    it('rejects an additionalSessions binding whose sessionSource names a valid kind but omits that kind\'s required fields', async () => {
+        // hasValidAdditionalSessionBinding checked only sessionSource.kind, so a binding
+        // like `{ sessionSource: { kind: 'catalog' }, prescriptionHash: 'x' }` -- missing
+        // workoutId/catalogVersion entirely -- previously passed. Cover all three
+        // non-trivial kinds so the shape gap can't reopen for any one of them.
+        const base = validRecommendation();
+        const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+        const malformedSources = [
+            { kind: 'catalog' }, // missing workoutId, catalogVersion
+            { kind: 'manual', definitionId: 'manual-1' }, // missing revision, contentHash
+            { kind: 'external_plan', planId: 'autumn-block', revision: 1 }, // missing sessionId, contentHash
+        ];
+        for (const sessionSource of malformedSources) {
+            await assertFails(setDoc(doc(ownerDb, `users/${ownerId}/daily_recommendations/2026-08-07`), {
+                ...base,
+                additionalSessions: [{ sessionSource, prescriptionHash: 'presc-hash-1' }],
+            }));
+        }
+    });
+
+    it('rejects a recommendationAudit.additionalSessions entry that is not a valid binding', async () => {
+        // audit.additionalSessions previously only checked list-ness and length -- any
+        // non-binding value (including an empty map) was accepted here even though the
+        // top-level additionalSessions field was already shape-checked.
+        const base = validRecommendation();
+        const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+        await assertFails(setDoc(doc(ownerDb, `users/${ownerId}/daily_recommendations/2026-08-07`), {
+            ...base,
+            recommendationAudit: {
+                ...base.recommendationAudit,
+                additionalSessions: [{ notABinding: true }],
+            },
+        }));
+    });
+
     it('allows an authored replacement occurrence provenance in a recommendation audit', async () => {
         const base = validRecommendation();
         const primarySession = {

--- a/app/src/emulator/firestoreRules.emulator.test.ts
+++ b/app/src/emulator/firestoreRules.emulator.test.ts
@@ -1183,6 +1183,49 @@ emulatorDescribe('Firestore security rules', () => {
         await expect(assertSucceeds(setDoc(doc(ownerDb, `users/${ownerId}/daily_recommendations/2026-08-07`), recWithBindings))).resolves.toBeUndefined();
     });
 
+    it('allows additionalSessions at the full 4-element bound without exceeding the rule-evaluation budget', async () => {
+        // Regression test: a prior attempt at real per-element validation at the schema's
+        // historical 16-element bound blew the emulator's ~1000-expression budget. This
+        // proves per-element validation at the current 4-element bound actually works,
+        // not just the single-element case the test above already covers.
+        const binding = (i: number) => ({
+            sessionSource: { kind: 'unplanned_fixture', fixtureId: `0${i}-full-body-maintenance` },
+            prescriptionHash: `presc-hash-${i}`,
+        });
+        const base = validRecommendation();
+        const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+        await expect(assertSucceeds(setDoc(doc(ownerDb, `users/${ownerId}/daily_recommendations/2026-08-07`), {
+            ...base,
+            additionalSessions: [binding(1), binding(2), binding(3), binding(4)],
+        }))).resolves.toBeUndefined();
+    });
+
+    it('rejects additionalSessions beyond the 4-element bound', async () => {
+        const binding = (i: number) => ({
+            sessionSource: { kind: 'unplanned_fixture', fixtureId: `0${i}-full-body-maintenance` },
+            prescriptionHash: `presc-hash-${i}`,
+        });
+        const base = validRecommendation();
+        const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+        await assertFails(setDoc(doc(ownerDb, `users/${ownerId}/daily_recommendations/2026-08-07`), {
+            ...base,
+            additionalSessions: [binding(1), binding(2), binding(3), binding(4), binding(5)],
+        }));
+    });
+
+    it('rejects a top-level additionalSessions entry with a malformed binding', async () => {
+        // Prior to hasValidAdditionalSessions, the top-level additionalSessions field had
+        // no shape validation at all -- only keys().hasOnly() gated its presence.
+        const base = validRecommendation();
+        const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+        await assertFails(setDoc(doc(ownerDb, `users/${ownerId}/daily_recommendations/2026-08-07`), {
+            ...base,
+            additionalSessions: [
+                { sessionSource: { kind: 'unplanned_fixture', fixtureId: '01-full-body-maintenance' } }, // missing prescriptionHash
+            ],
+        }));
+    });
+
     it('allows an authored replacement occurrence provenance in a recommendation audit', async () => {
         const base = validRecommendation();
         const primarySession = {

--- a/app/src/emulator/firestoreRules.emulator.test.ts
+++ b/app/src/emulator/firestoreRules.emulator.test.ts
@@ -1123,6 +1123,24 @@ emulatorDescribe('Firestore security rules', () => {
         await assertFails(getDoc(doc(otherDb, executionPrescriptionPath)));
     });
 
+    it('allows a catalog execution prescription with a valid displayMetadata snapshot (M3.2)', async () => {
+        const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+        await expect(assertSucceeds(setDoc(doc(ownerDb, executionPrescriptionPath), {
+            ...validExecutionPrescription(),
+            displayMetadata: {
+                title: 'Full Body Maintenance', intent: 'training', dominantModality: 'Strength', duration: { min: 30, max: 60 },
+            },
+        }))).resolves.toBeUndefined();
+    });
+
+    it('rejects an execution prescription with a malformed displayMetadata snapshot', async () => {
+        const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+        await assertFails(setDoc(doc(ownerDb, executionPrescriptionPath), {
+            ...validExecutionPrescription(),
+            displayMetadata: { intent: 'training' }, // missing required title
+        }));
+    });
+
     it('allows valid occurrence authorities in M3 (unplanned_log, schedule, replace, additional) and rejects invalid ones', async () => {
         const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
         // unplanned_log succeeds

--- a/app/src/engine/replay.ts
+++ b/app/src/engine/replay.ts
@@ -300,11 +300,12 @@ export async function replayRecommendationAuditAgainstSessions(
             if (expectedAuthority && occurrence.data.authority !== expectedAuthority) continue;
         }
 
-        // The resolver binds the hash-covered source identity and manual/external/fixture
-        // prescription.definitionHash to the
-        // exact source bytes and verifies catalog id/version before returning executable
-        // stored blocks. Catalog v1 cannot recompute historical display metadata; see the
-        // resolver's explicit limitation.
+        // The resolver binds the hash-covered source identity and prescription.definitionHash
+        // to the exact source bytes for every source kind (M3.2 gave `catalog` the same
+        // definitionHash verification manual/external/fixture already had, reconstructed
+        // from the stored prescription's displayMetadata snapshot rather than the live
+        // catalog -- see the resolver for the one-time fallback on pre-M3.2 prescriptions
+        // that predate that snapshot).
         resolvedBindings.add(sessionBindingEvidenceKey(binding));
     }
     return replayRecommendationAudit(recommendation, externalRevision, { resolvedBindings });

--- a/app/src/engine/validation.ts
+++ b/app/src/engine/validation.ts
@@ -1150,10 +1150,15 @@ export function validateRecommendation(raw: any): ValidationResult<DailyRecommen
     if (raw.primarySession !== undefined && !isValidSessionReferenceBinding(raw.primarySession)) {
         errors.push({ field: 'primarySession', message: 'primarySession must be a valid source/occurrence/prescription binding' });
     }
+    // Bounded to 4, matching firestore.rules' hasValidAdditionalSessions -- the server-side
+    // check unrolls per-element validation by index (the rules language has no iteration),
+    // and a prior attempt at that with the schema's historical 16-element bound exceeded the
+    // emulator's rule-evaluation budget. 4 is a real bound, not a compromise: the systemic-cost
+    // ceiling in adjudicateAuthoredSession never admits more than a handful of same-day sessions.
     if (raw.additionalSessions !== undefined && (!Array.isArray(raw.additionalSessions)
-        || raw.additionalSessions.length > 16
+        || raw.additionalSessions.length > 4
         || !raw.additionalSessions.every(isValidSessionReferenceBinding))) {
-        errors.push({ field: 'additionalSessions', message: 'additionalSessions must contain at most 16 valid bindings' });
+        errors.push({ field: 'additionalSessions', message: 'additionalSessions must contain at most 4 valid bindings' });
     }
 
     let recommendationAudit: DailyRecommendation['recommendationAudit'] | undefined;

--- a/app/src/services/executionPrescriptionService.ts
+++ b/app/src/services/executionPrescriptionService.ts
@@ -18,6 +18,22 @@ function hasSessionSource(value: unknown): boolean {
     return source.kind === 'unplanned_fixture' && typeof source.fixtureId === 'string';
 }
 
+/** Optional (M3.2): absent on prescriptions written before this field existed. */
+function hasValidDisplayMetadata(value: unknown): boolean {
+    if (value === undefined) return true;
+    if (!value || typeof value !== 'object') return false;
+    const meta = value as Record<string, unknown>;
+    if (typeof meta.title !== 'string' || typeof meta.intent !== 'string') return false;
+    if (meta.summary !== undefined && typeof meta.summary !== 'string') return false;
+    if (meta.dominantModality !== undefined && typeof meta.dominantModality !== 'string') return false;
+    if (meta.duration !== undefined) {
+        if (!meta.duration || typeof meta.duration !== 'object') return false;
+        const duration = meta.duration as Record<string, unknown>;
+        if (typeof duration.min !== 'number' || typeof duration.max !== 'number') return false;
+    }
+    return true;
+}
+
 export class ExecutionPrescriptionService {
     private readonly db: Firestore;
 
@@ -65,7 +81,8 @@ export class ExecutionPrescriptionService {
                 typeof data.prescriptionHash === 'string' &&
                 hasSessionSource(data.sessionSource) &&
                 typeof data.definitionHash === 'string' &&
-                Array.isArray(data.blocks)
+                Array.isArray(data.blocks) &&
+                hasValidDisplayMetadata(data.displayMetadata)
             ) {
                 const prescription = data as unknown as ExecutionPrescription;
                 if (await hashExecutionPrescription(prescription) !== prescriptionHash) {

--- a/app/src/sessions/catalogSessionAdapter.ts
+++ b/app/src/sessions/catalogSessionAdapter.ts
@@ -199,6 +199,15 @@ export async function createExecutionPrescriptionFromCatalog(
         },
         definitionHash,
         blocks: sessionDef.blocks,
+        // Snapshotted as of today's launch (M3.2), so a later edit to this workout's live
+        // catalog entry can't rewrite what this recommendation actually displayed/prescribed.
+        displayMetadata: {
+            title: sessionDef.title,
+            ...(sessionDef.summary !== undefined ? { summary: sessionDef.summary } : {}),
+            intent: sessionDef.intent,
+            ...(sessionDef.dominantModality !== undefined ? { dominantModality: sessionDef.dominantModality } : {}),
+            ...(sessionDef.duration !== undefined ? { duration: sessionDef.duration } : {}),
+        },
         createdAt: now,
     };
     const hash = await hashExecutionPrescription(draft);

--- a/app/src/sessions/models.ts
+++ b/app/src/sessions/models.ts
@@ -242,6 +242,22 @@ export interface SessionOccurrence {
     updatedAt: string;
 }
 
+/**
+ * The non-`blocks` fields `definitionHash` was computed over (M3.2), snapshotted so a
+ * `catalog` source can be replayed with historical fidelity: the live catalog entry a
+ * `SessionSourceRef` points at can be edited (title, duration, ...) after the day it was
+ * prescribed, but the hash alone can't be inverted back into the original values. Optional
+ * because prescriptions written before this field existed don't have it -- resolvers must
+ * fall back to the live catalog for those, exactly as before.
+ */
+export interface SessionDisplayMetadata {
+    title: string;
+    summary?: string;
+    intent: SessionIntent;
+    dominantModality?: string;
+    duration?: NumericRange;
+}
+
 export interface ExecutionPrescription {
     schemaVersion: number;
     prescriptionHash: string;
@@ -249,6 +265,7 @@ export interface ExecutionPrescription {
     sessionSource: SessionSourceRef;
     definitionHash: string;
     blocks: SessionBlock[];
+    displayMetadata?: SessionDisplayMetadata;
     createdAt: string;
 }
 

--- a/app/src/sessions/sessionDefinitionHash.ts
+++ b/app/src/sessions/sessionDefinitionHash.ts
@@ -33,7 +33,9 @@ export function canonicalSessionDefinitionJson(definition: SessionDefinition): s
 export function canonicalExecutionPrescriptionJson(prescription: ExecutionPrescription): string {
     // A digest cannot include itself; createdAt is provenance rather than execution
     // content, so it must not turn the same prescription into a new snapshot.
-    const content = pickDefined(prescription, ['schemaVersion', 'sessionSource', 'definitionHash', 'blocks']);
+    // `displayMetadata` is omitted (via pickDefined) on older prescriptions that predate
+    // it, so this stays backward-compatible: their hash is unaffected by its addition.
+    const content = pickDefined(prescription, ['schemaVersion', 'sessionSource', 'definitionHash', 'blocks', 'displayMetadata']);
     return JSON.stringify(canonicalizeSessionData(content));
 }
 

--- a/app/src/sessions/sessionDefinitionResolver.test.ts
+++ b/app/src/sessions/sessionDefinitionResolver.test.ts
@@ -141,6 +141,48 @@ describe('resolveSessionDefinition', () => {
             });
         });
 
+        it('resolves with the historically-snapshotted display metadata (M3.2), not a live-catalog re-derivation, once displayMetadata is present', async () => {
+            // Deliberately different from FAKE_WORKOUT.name ('Fake Catalog Workout') --
+            // simulates the live catalog entry having been edited since this was prescribed.
+            const historicalMeta: NonNullable<ExecutionPrescription['displayMetadata']> = {
+                title: 'Historical Custom Title', intent: 'training', dominantModality: 'cycling', duration: { min: 30, max: 60 },
+            };
+            const blocks: ExecutionPrescription['blocks'] = [{ id: 'evaluated-block', role: 'main', executionMode: 'sequential', steps: [] }];
+            const reconstructed: SessionDefinition = {
+                schemaVersion: 1, id: 'catalog-workout-1', revision: 1, blocks,
+                title: historicalMeta.title, intent: historicalMeta.intent,
+                dominantModality: historicalMeta.dominantModality, duration: historicalMeta.duration,
+            };
+            const definitionHash = await hashSessionDefinition(reconstructed);
+            services.prescription.getPrescription.mockResolvedValue({
+                status: 'AVAILABLE', revision: null,
+                data: { schemaVersion: 1, prescriptionHash: 'hash-2', sessionSource: catalogSource, definitionHash, blocks, displayMetadata: historicalMeta, createdAt: '2026-08-18T00:00:00Z' },
+            } satisfies DataState<ExecutionPrescription>);
+
+            const result = await resolveSessionDefinition('u1', catalogSource, 'hash-2');
+            expect(result.status).toBe('AVAILABLE');
+            if (result.status !== 'AVAILABLE') throw new Error('expected AVAILABLE');
+            expect(result.data.title).toBe('Historical Custom Title');
+            expect(result.data.blocks).toEqual(blocks);
+        });
+
+        it('rejects a catalog prescription whose stored displayMetadata does not match its definitionHash', async () => {
+            const blocks: ExecutionPrescription['blocks'] = [{ id: 'evaluated-block', role: 'main', executionMode: 'sequential', steps: [] }];
+            services.prescription.getPrescription.mockResolvedValue({
+                status: 'AVAILABLE', revision: null,
+                data: {
+                    schemaVersion: 1, prescriptionHash: 'hash-3', sessionSource: catalogSource,
+                    definitionHash: 'stale-or-corrupted-hash', blocks,
+                    displayMetadata: { title: 'Tampered Title', intent: 'training', dominantModality: 'cycling', duration: { min: 30, max: 60 } },
+                    createdAt: '2026-08-18T00:00:00Z',
+                },
+            } satisfies DataState<ExecutionPrescription>);
+
+            await expect(resolveSessionDefinition('u1', catalogSource, 'hash-3')).resolves.toMatchObject({
+                status: 'INVALID', issues: [{ code: 'prescription-definition-hash-mismatch' }],
+            });
+        });
+
         it('still rejects an unknown workoutId regardless of prescriptionHash', async () => {
             await expect(resolveSessionDefinition('u1', { kind: 'catalog', workoutId: 'nope', catalogVersion: '1' }, 'hash-1'))
                 .resolves.toMatchObject({ status: 'INVALID', issues: [{ code: 'catalog-workout-not-found' }] });

--- a/app/src/sessions/sessionDefinitionResolver.test.ts
+++ b/app/src/sessions/sessionDefinitionResolver.test.ts
@@ -188,14 +188,47 @@ describe('resolveSessionDefinition', () => {
                 .resolves.toMatchObject({ status: 'INVALID', issues: [{ code: 'catalog-workout-not-found' }] });
         });
 
-        it('fails closed when the stored catalog version no longer matches the available definition', async () => {
-            services.prescription.getPrescription.mockClear();
+        it('fails closed on a live-catalog version mismatch only for the legacy no-displayMetadata fallback', async () => {
+            // No displayMetadata: there is no historical snapshot to self-verify against,
+            // so this can only fall back to requiring the live catalog to still match.
+            services.prescription.getPrescription.mockResolvedValue({
+                status: 'AVAILABLE', revision: null,
+                data: { ...storedPrescription, sessionSource: { kind: 'catalog', workoutId: 'catalog-workout-1', catalogVersion: '2' } },
+            } satisfies DataState<ExecutionPrescription>);
+
             await expect(resolveSessionDefinition('u1', {
                 kind: 'catalog', workoutId: 'catalog-workout-1', catalogVersion: '2',
             }, 'hash-1')).resolves.toMatchObject({
                 status: 'INVALID', issues: [{ code: 'catalog-version-mismatch' }],
             });
-            expect(services.prescription.getPrescription).not.toHaveBeenCalled();
+        });
+
+        it('replays a stored snapshot by its displayMetadata even when the live catalog version has since moved on (regression, M3.2 replay wiring)', async () => {
+            // The stored source's catalogVersion ('2') intentionally differs from the live
+            // FAKE_WORKOUT.version ('1'), simulating a catalog edit made after this was
+            // prescribed. With displayMetadata present, replay must not depend on the live
+            // catalog version still matching.
+            const staleVersionSource = { kind: 'catalog' as const, workoutId: 'catalog-workout-1', catalogVersion: '2' };
+            const historicalMeta: NonNullable<ExecutionPrescription['displayMetadata']> = {
+                title: 'Historical Custom Title', intent: 'training', dominantModality: 'cycling', duration: { min: 30, max: 60 },
+            };
+            const blocks: ExecutionPrescription['blocks'] = [{ id: 'evaluated-block', role: 'main', executionMode: 'sequential', steps: [] }];
+            const reconstructed: SessionDefinition = {
+                schemaVersion: 1, id: 'catalog-workout-1', revision: 1, blocks,
+                title: historicalMeta.title, intent: historicalMeta.intent,
+                dominantModality: historicalMeta.dominantModality, duration: historicalMeta.duration,
+            };
+            const definitionHash = await hashSessionDefinition(reconstructed);
+            services.prescription.getPrescription.mockResolvedValue({
+                status: 'AVAILABLE', revision: null,
+                data: { schemaVersion: 1, prescriptionHash: 'hash-4', sessionSource: staleVersionSource, definitionHash, blocks, displayMetadata: historicalMeta, createdAt: '2026-08-18T00:00:00Z' },
+            } satisfies DataState<ExecutionPrescription>);
+
+            const result = await resolveSessionDefinition('u1', staleVersionSource, 'hash-4');
+            expect(result.status).toBe('AVAILABLE');
+            if (result.status !== 'AVAILABLE') throw new Error('expected AVAILABLE');
+            expect(result.data.title).toBe('Historical Custom Title');
+            expect(result.data.blocks).toEqual(blocks);
         });
     });
 });

--- a/app/src/sessions/sessionDefinitionResolver.ts
+++ b/app/src/sessions/sessionDefinitionResolver.ts
@@ -145,16 +145,6 @@ export async function resolveSessionDefinition(
                 issues: [{ code: 'catalog-workout-not-found', documentPath: `workouts/${source.workoutId}` }],
             };
         }
-        if (String(workout.version) !== source.catalogVersion) {
-            return {
-                status: 'INVALID',
-                issues: [{
-                    code: 'catalog-version-mismatch',
-                    field: 'catalogVersion',
-                    documentPath: `workouts/${source.workoutId}`,
-                }],
-            };
-        }
         if (!prescriptionHash) {
             // Fail closed rather than fall back to re-deriving from the live catalog: the
             // live template can have been edited since this decision was made, and a
@@ -177,7 +167,20 @@ export async function resolveSessionDefinition(
         const meta = prescriptionState.data.displayMetadata;
         if (!meta) {
             // Written before M3.2 added displayMetadata: no historical snapshot to verify
-            // against, so this is unable to detect display drift -- no worse than before.
+            // against. Fall back to the live-catalog version check -- this is the only
+            // remaining signal that the live template hasn't drifted out from under this
+            // prescription's evaluated blocks -- and fail closed on drift rather than
+            // silently mixing a stale block set with a since-edited live template.
+            if (String(workout.version) !== source.catalogVersion) {
+                return {
+                    status: 'INVALID',
+                    issues: [{
+                        code: 'catalog-version-mismatch',
+                        field: 'catalogVersion',
+                        documentPath,
+                    }],
+                };
+            }
             return {
                 status: 'AVAILABLE',
                 data: { ...liveDefinition, blocks: prescriptionState.data.blocks },
@@ -187,8 +190,11 @@ export async function resolveSessionDefinition(
         // The historical definition is reconstructed entirely from the stored prescription
         // -- never merged with the live catalog -- so an edit to this workout's live entry
         // (title, duration, ...) after the day it was prescribed cannot silently rewrite
-        // what this recommendation actually displayed. Self-verified by recomputing the
-        // hash the same way createExecutionPrescriptionFromCatalog did at write time.
+        // what this recommendation actually displayed. This makes the definition
+        // self-verifying (via the hash check below), so it does not need the live catalog's
+        // `version` to still match this prescription's historical `catalogVersion` -- unlike
+        // the no-`meta` fallback above, replaying this snapshot never depends on the live
+        // catalog being unedited since the day it was prescribed.
         const reconstructed: SessionDefinition = {
             ...liveDefinition,
             title: meta.title,

--- a/app/src/sessions/sessionDefinitionResolver.ts
+++ b/app/src/sessions/sessionDefinitionResolver.ts
@@ -164,14 +164,47 @@ export async function resolveSessionDefinition(
                 issues: [{ code: 'catalog-prescription-hash-required', documentPath: `workouts/${source.workoutId}` }],
             };
         }
-        // Static catalog metadata (title/duration/etc.) remains display-only. Catalog v1
-        // does not persist enough historical metadata to recompute its definition hash,
-        // so source association is the exact workout id/version check above plus the
-        // content-verified stored prescription.
-        return applyStoredPrescription(
-            userId, adaptWorkoutDefinitionToSessionDefinition(workout), prescriptionHash, source,
-            null, `workouts/${source.workoutId}`, null,
-        );
+        const documentPath = `workouts/${source.workoutId}`;
+        const prescriptionState = await executionPrescriptionService.getPrescription(userId, prescriptionHash);
+        if (prescriptionState.status !== 'AVAILABLE') return prescriptionState;
+        if (JSON.stringify(canonicalizeSessionData(prescriptionState.data.sessionSource)) !== JSON.stringify(canonicalizeSessionData(source))) {
+            return {
+                status: 'INVALID',
+                issues: [{ code: 'prescription-source-mismatch', field: 'sessionSource', documentPath }],
+            };
+        }
+        const liveDefinition = adaptWorkoutDefinitionToSessionDefinition(workout);
+        const meta = prescriptionState.data.displayMetadata;
+        if (!meta) {
+            // Written before M3.2 added displayMetadata: no historical snapshot to verify
+            // against, so this is unable to detect display drift -- no worse than before.
+            return {
+                status: 'AVAILABLE',
+                data: { ...liveDefinition, blocks: prescriptionState.data.blocks },
+                revision: prescriptionHash,
+            };
+        }
+        // The historical definition is reconstructed entirely from the stored prescription
+        // -- never merged with the live catalog -- so an edit to this workout's live entry
+        // (title, duration, ...) after the day it was prescribed cannot silently rewrite
+        // what this recommendation actually displayed. Self-verified by recomputing the
+        // hash the same way createExecutionPrescriptionFromCatalog did at write time.
+        const reconstructed: SessionDefinition = {
+            ...liveDefinition,
+            title: meta.title,
+            summary: meta.summary,
+            intent: meta.intent,
+            dominantModality: meta.dominantModality,
+            duration: meta.duration,
+            blocks: prescriptionState.data.blocks,
+        };
+        if (await hashSessionDefinition(reconstructed) !== prescriptionState.data.definitionHash) {
+            return {
+                status: 'INVALID',
+                issues: [{ code: 'prescription-definition-hash-mismatch', field: 'definitionHash', documentPath }],
+            };
+        }
+        return { status: 'AVAILABLE', data: reconstructed, revision: prescriptionHash };
     }
 
     const revision = await externalPlanService.getRevisionState(userId, source.planId, source.revision);

--- a/docs/plans/multidomain-session-authoring-execution-and-evidence.md
+++ b/docs/plans/multidomain-session-authoring-execution-and-evidence.md
@@ -612,16 +612,19 @@ transient `initialSession` object. The catalog resolver also rejects a source wh
 
 ### M3.2 `[x]` Recommendation source/occurrence persistence and replay
 
-**Progress (2026-08-18).** `primarySession`/`additionalSessions` are typed, validated, preserved
-through recommendation persistence and archival revisions, and carried into provenance. A
-write-once execution-prescription service also exists. Replay does not yet retrieve and verify
-those prescription bytes, so this remains partial and must not be used to grant authority.
+**Progress as of 2026-08-18 (superseded by the 2026-08-19 outcome below).**
+`primarySession`/`additionalSessions` were typed, validated, preserved through recommendation
+persistence and archival revisions, and carried into provenance. A write-once
+execution-prescription service also existed. Replay did not yet retrieve and verify those
+prescription bytes at this point, so the milestone remained partial and was not used to grant
+authority.
 
-**Current.** `Recommendation.externalPrescription` is derived in `rules.ts` on every dashboard
-load and never persisted; `DailyRecommendation` persists the catalog `prescription` only.
-`Home.tsx` recomputes the whole recommendation on load and then calls `saveRecommendation`, so
-the *display* survives reload by re-derivation — but the *runner* reads the persisted document
-and *replay* reads the persisted audit. Both are blind to authored content.
+**Gap as of 2026-08-18 (closed below).** `Recommendation.externalPrescription` was derived in
+`rules.ts` on every dashboard load and never persisted; `DailyRecommendation` persisted the
+catalog `prescription` only. `Home.tsx` recomputed the whole recommendation on load and then
+called `saveRecommendation`, so the *display* survived reload by re-derivation — but the
+*runner* read the persisted document and *replay* read the persisted audit. Both were blind to
+authored content.
 
 **Precondition (C11).** Do not start this inside an open Phase 9.0 shadow-mode comparison
 block. Changing decision equality, archived revision bytes and audit provenance mid-block
@@ -677,8 +680,8 @@ so a cheaper server-side shape or smaller schema was required before Add could s
 Coordinated with 9.0.1 per C11: Phase 9.0's shadow block had not started when this work
 began (still true at the outcome below, so this stayed clear of C11 throughout).
 
-**Outcome (2026-08-19).** All three remaining gaps closed, now that M3.3 (above) shipped the
-gate this was blocked on. In order:
+**Outcome (2026-08-19).** All three remaining gaps closed, now that the completed M3.3
+authority flow shipped the gate this was blocked on. In order:
 
 * **Firestore rules.** `additionalSessions` now gets real per-element shape validation
   (source kind, non-empty `prescriptionHash`) rather than length-only, at both the
@@ -709,8 +712,8 @@ gate this was blocked on. In order:
   `shadowLogService` already establishes elsewhere -- console-level only, no new UI
   surface, no persisted verification state.
 
-Manual/imported authority is no longer disabled (M3.3, above, shipped the complete gate),
-so the milestone's `Done when` criteria are met.
+Manual/imported authority is no longer disabled (the completed M3.3 authority flow shipped
+the complete gate), so the milestone's `Done when` criteria are met.
 
 ### M3.3 `[x]` Save/schedule/replace/add/start intent flow
 

--- a/docs/plans/multidomain-session-authoring-execution-and-evidence.md
+++ b/docs/plans/multidomain-session-authoring-execution-and-evidence.md
@@ -294,7 +294,7 @@ rewritten as an outcome; an in-progress item retains its remaining acceptance wo
 | M2.6 | General completion, comparison and response | `[x]` | — |
 | M2.7 | Strength v1 compatibility read model | `[x]` | — |
 | M3.1 | Canonical serialization, hashing and source adapters | `[x]` | — |
-| M3.2 | Recommendation source/occurrence persistence and replay | `[-]` | Production replay entry point and catalog source binding remain |
+| M3.2 | Recommendation source/occurrence persistence and replay | `[x]` | Production replay wiring and catalog display-metadata fidelity closed |
 | M3.3 | Save/schedule/replace/add/start intent flow | `[x]` | Full hard-gate and additional-session authority implemented and integrated |
 | M3.4 | Catalog-to-definition adapter and generic runner strength parity | `[x]` | Runner parity reached (RIR/gauges, context, 1RM writeback, shared read); dual-runner retained for safe transition |
 | M3.5 | Bounded exercise/drill facet vocabulary | `[x]` | — |
@@ -610,7 +610,7 @@ execution through its stored source plus `prescriptionHash`, so reload no longer
 transient `initialSession` object. The catalog resolver also rejects a source whose stored
 `catalogVersion` no longer matches the available catalog definition.
 
-### M3.2 `[-]` Recommendation source/occurrence persistence and replay
+### M3.2 `[x]` Recommendation source/occurrence persistence and replay
 
 **Progress (2026-08-18).** `primarySession`/`additionalSessions` are typed, validated, preserved
 through recommendation persistence and archival revisions, and carried into provenance. A
@@ -666,15 +666,51 @@ hash-only set; manual, external and fixture sources also verify that the prescri
 usage text that it cannot verify session bindings (no live Firestore connection); the app's
 own replay path is expected to call the new async wrapper.
 
-This remains partial: no production caller invokes that wrapper, and catalog schema v1 stores
-evaluated blocks plus a definition hash but not enough historical display metadata to
-recompute the complete catalog definition hash after a catalog edit. Manual/imported
-authority is also intentionally disabled under M3.3, so its persisted-decision acceptance
-scenario has not passed. Firestore rules currently bound `additionalSessions` length but do
-not validate every nested member; a direct 16-element expansion exceeded the emulator's
-1,000-expression budget on valid revision/archive updates, so a cheaper server-side shape or
-smaller schema is still required before Add can ship. Coordinated with 9.0.1 per C11: Phase
-9.0's shadow block had not started when this work began.
+This remained partial through 2026-08-18: no production caller invoked that wrapper, and
+catalog schema v1 stored evaluated blocks plus a definition hash but not enough historical
+display metadata to recompute the complete catalog definition hash after a catalog edit.
+Manual/imported authority is also intentionally disabled under M3.3, so its
+persisted-decision acceptance scenario had not passed. Firestore rules bound
+`additionalSessions` length but did not validate every nested member; a direct 16-element
+expansion exceeded the emulator's 1,000-expression budget on valid revision/archive updates,
+so a cheaper server-side shape or smaller schema was required before Add could ship.
+Coordinated with 9.0.1 per C11: Phase 9.0's shadow block had not started when this work
+began (still true at the outcome below, so this stayed clear of C11 throughout).
+
+**Outcome (2026-08-19).** All three remaining gaps closed, now that M3.3 (above) shipped the
+gate this was blocked on. In order:
+
+* **Firestore rules.** `additionalSessions` now gets real per-element shape validation
+  (source kind, non-empty `prescriptionHash`) rather than length-only, at both the
+  top-level field (previously *unvalidated entirely* -- only `keys().hasOnly()` gated its
+  presence) and the audit's copy. Fitting this in the expression budget needed two things:
+  `decisionFieldsUnchanged()` was being evaluated three times over in the update rule
+  purely because the rules language doesn't memoize function calls (now computed once via
+  a `let` binding and threaded through, `canUpdateRecommendation()`); and additional
+  session elements get a lighter structural check than `primarySession`'s full per-kind
+  field rigor (still real validation -- shape, recognized source kind, non-empty hash --
+  just cheap enough to unroll across elements; the client already applies the full
+  per-kind check before any write reaches here). Bound dropped from 16 to 4 -- an isolated
+  number with no other dependents, comfortably above what `adjudicateAuthoredSession`'s
+  systemic-cost ceiling ever actually admits in one day.
+* **Catalog display fidelity.** `ExecutionPrescription` gained an optional
+  `displayMetadata` snapshot (title/summary/intent/dominantModality/duration) at
+  catalog-launch time, included in `prescriptionHash`'s own covered content
+  (backward-compatible: absent on older prescriptions, so their hash is unaffected).
+  `resolveSessionDefinition`'s `catalog` branch now reconstructs the historical
+  `SessionDefinition` entirely from the stored prescription and self-verifies by
+  recomputing the hash the same way it was computed at write time, instead of always
+  merging in live catalog metadata with `expectedDefinitionHash: null`. Falls back to the
+  old live-catalog-merge behavior only for prescriptions written before this existed.
+* **Production replay entry point.** `Home.tsx`'s two `saveRecommendation` call sites now
+  fire an unawaited `replayRecommendationAuditAgainstSessions` self-check whenever the
+  saved decision carries a session binding, following the exact non-fatal
+  `.catch(console.warn)` idiom already used at both sites and the quiet-report shape
+  `shadowLogService` already establishes elsewhere -- console-level only, no new UI
+  surface, no persisted verification state.
+
+Manual/imported authority is no longer disabled (M3.3, above, shipped the complete gate),
+so the milestone's `Done when` criteria are met.
 
 ### M3.3 `[x]` Save/schedule/replace/add/start intent flow
 


### PR DESCRIPTION
## Summary

Completes M3.2 ("Recommendation source/occurrence persistence and replay") in [docs/plans/multidomain-session-authoring-execution-and-evidence.md](docs/plans/multidomain-session-authoring-execution-and-evidence.md), which was left `[-]` (partial) after M3.3 (#86) shipped — that merge unblocked it. Closes all three gaps the doc's own notes named as remaining.

### 1. Firestore rules: `additionalSessions` had a real, open validation gap
The top-level `daily_recommendations/{date}.additionalSessions` field had **zero** shape validation — only `keys().hasOnly()` gated its presence, so a client could write malformed bindings and Firestore would accept them. The `recommendationAudit` copy only checked `size() <= 16`, no per-element shape.

A prior attempt at real per-element validation blew the emulator's ~1000-expression rule-evaluation budget. Two things made room:
- `decisionFieldsUnchanged()` (~10 comparisons) was being evaluated **three times over** in the update rule purely because the rules language doesn't memoize function calls — computed once via a `let` binding and threaded through (`canUpdateRecommendation()`) instead. (Caught and fixed a polarity bug of my own introduced while threading it through — `auditWriteOnce`'s write-once guard was briefly inverted.)
- `additionalSessions` elements get a lighter structural check (shape + recognized source kind + non-empty `prescriptionHash`) than `primarySession`'s full per-kind field rigor — still real validation, just cheap enough to unroll across elements. The client (`engine/validation.ts`) already applies the full per-kind check before any write reaches here.

Bound dropped from 16 → 4 everywhere it's checked (isolated magic number, no other dependents; comfortably above what `adjudicateAuthoredSession`'s systemic-cost ceiling ever actually admits in one day).

### 2. Catalog sessions couldn't replay with historical fidelity
A catalog `ExecutionPrescription` stored evaluated `blocks` and a `definitionHash`, but not the title/summary/duration/etc. that hash was computed over. `resolveSessionDefinition`'s `catalog` branch always merged in *live* catalog metadata and passed `expectedDefinitionHash: null` — if a catalog workout's title/duration was edited later, replay would silently show the edited values.

`ExecutionPrescription` now carries an optional `displayMetadata` snapshot, included in `prescriptionHash`'s own covered content (backward-compatible — omitted on older prescriptions, their hash is unchanged). The resolver reconstructs the historical `SessionDefinition` entirely from the stored prescription and self-verifies by recomputing the hash, falling back to the old live-merge behavior only for prescriptions written before this existed.

### 3. No production caller ever invoked `replayRecommendationAuditAgainstSessions`
It existed only for tests. `Home.tsx`'s two `saveRecommendation` call sites now fire an unawaited self-check whenever the saved decision carries a session binding — same non-fatal `.catch(console.warn)` idiom already used at both sites, same quiet-report shape `shadowLogService` already establishes elsewhere. No new UI surface, no persisted verification state.

## Verification
- `npm run check`: typecheck + lint + 1564 tests (0 failures) + workout catalog validation, all clean.
- `npm run build`: production build succeeds (confirms `replay.ts` code-splits into its own lazy chunk as intended).
- `npm run simulate:diff`: clean match against committed baseline.
- `node scripts/check-policy-drift.mjs`: no decision-affecting engine files touched.
- `npm run test:rules`: all 74 Firestore emulator rule tests pass (added regression coverage for the 4-element bound, the previously-unvalidated top-level field, and the new `displayMetadata` shape).
- Python side untouched but re-verified: `uv run pytest` / `ruff check` / `mypy` all clean.
- Not done: interactive manual verification in a running, authenticated app session (would need real Firebase auth/synced recovery data to reach these flows) — relied on the automated coverage above instead, including `replay.ts`'s own pre-existing dedicated unit tests.

Docs updated: M3.2 flipped to `[x]` in the milestone table with a dated outcome note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Execution prescriptions can preserve session titles, summaries, intent, modality, and duration for consistent historical presentation.
  * Older prescriptions remain supported while newer prescriptions verify stored session details for integrity.
* **Bug Fixes**
  * Recommendation session bindings now accept up to four additional sessions with stronger validation.
  * Invalid prescription metadata and mismatched session definitions are rejected.
  * Saved recommendations now receive a non-blocking binding replay check, with warnings when verification fails.
* **Documentation**
  * Updated session authoring and execution documentation to reflect the completed capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->