### PR TITLE
docs: tighten shadow-block operational sequencing

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Garmin device
     ↓ Garmin Connect sync
 Garmin Connect API
     ↓
-Cloud Scheduler (06:15 Europe/Warsaw)
+Cloud Scheduler (05:00–09:45 Europe/Warsaw, every 15 min)
     ↓
 Cloud Run Job
     ├── TokenStore (Downloads/Uploads encrypted garmin_tokens.json from/to GCS)
@@ -130,7 +130,7 @@ Set the following environment variables (e.g. in `.env` locally or Secret Manage
 | `GARMIN_TOKEN_PATH` | No | `.garmin_tokens/garmin_tokens.json` | Path to local single token JSON file |
 | `GARMIN_TOKEN_STORE` | No | `local` | Token store backend (`local` or `gcs`) |
 | `GARMIN_TOKEN_BUCKET` | For GCS | — | Private GCS bucket name storing Garmin token JSON |
-| `GARMIN_TOKEN_OBJECT` | For GCS | `garmin/garmin_tokens.json` | GCS token object name |
+| `GARMIN_TOKEN_OBJECT` | No | `garmin/garmin_tokens.json` | GCS token object name |
 | `GARMIN_STALENESS_MINUTES` | No | `60` | Skip Garmin API fetch if snapshot updated within N mins |
 | `GARMIN_RESYNC_LOOKBACK_DAYS` | No | `1` | After syncing the target date, also force-resync this many preceding day(s), to pick up Garmin data that finalized/arrived after that day's own sync ran (e.g. a training session logged later that day). Override per-run with `sync --resync-days N` |
 | `GARMIN_ALLOW_CREDENTIAL_LOGIN` | No | `false` | Cloud/automated runs set `false` (token-only); bootstrap sets `true` |
@@ -258,6 +258,7 @@ Create a Cloud Run Job executing `python -m garmin_sync sync`:
 
 ### 3. Cloud Scheduler Setup
 
-Create a Cloud Scheduler job triggering the Cloud Run Job:
-* Schedule: `06:15`
+Use the repository-owned runbook in `docs/ops/cloud-run-deployment.md` for the scheduler and IAM commands. The recovery sync uses a morning polling window rather than a single fixed run:
+* Schedule: `*/15 5-9 * * *`
 * Timezone: `Europe/Warsaw`
+* Do **not** pass `--force`; `GARMIN_STALENESS_MINUTES` lets most ticks stop after the Firestore freshness check without calling Garmin.

--- a/docs/plans/phase-9-0-shadow-mode-and-decision-journal.md
+++ b/docs/plans/phase-9-0-shadow-mode-and-decision-journal.md
@@ -26,6 +26,7 @@ The code in this phase collects evidence; it does not change recommendation poli
 
 * **9.0.1 must be complete before the block starts.** Shadowing against ingestion gaps measures the sync, not the engine.
 * The athlete keeps prompting their AI exactly as today. Changing the manual loop mid-block invalidates the comparison.
+* **Keep the decision policy stable during the block.** Once 9.0.7 starts, do not change recommendation thresholds, selection behavior, decision-field equality, or replay/provenance semantics inside the same evidence segment. Evidence-only/UI work may continue when it cannot reach the engine or change reveal/journal ordering. If a decision-affecting change is unavoidable, end the segment, record the policy/version boundary, and report the segments separately rather than pooling them as one stable-policy block.
 
 ---
 
@@ -35,11 +36,11 @@ The code in this phase collects evidence; it does not change recommendation poli
 
 Operational, not code:
 
-1. Deploy the Cloud Run Job and Cloud Scheduler trigger documented in `docs/ops/cloud-run-deployment.md`, scheduled daily at `05:00 Europe/Warsaw` (`0 5 * * *`).
+1. Deploy the Cloud Run Job and the **morning polling** Cloud Scheduler trigger documented in `docs/ops/cloud-run-deployment.md`: `*/15 5-9 * * *` in `Europe/Warsaw`, without `--force`. The Firestore freshness gate (`GARMIN_STALENESS_MINUTES`) is what keeps most scheduler ticks from calling Garmin.
 2. Run `uv run python -m garmin_sync backfill --days 56` so the 28-day objective baselines are mature before day 1.
-3. Run `uv run python -m garmin_sync audit` over the block window and record the coverage result.
+3. Run `uv run python -m garmin_sync audit` over the pre-block/backfill window and record the coverage result. Record the deployed scheduler expression and staleness setting with the operational evidence so the block can be reproduced.
 
-**Done when.** Seven consecutive days land unattended and the audit reports no gap in the backfilled window. A gap discovered mid-block is a confound, not a data point.
+**Done when.** Seven consecutive days land unattended under the documented polling schedule and the audit reports no gap in the backfilled window. A gap discovered mid-block is a confound, not a data point.
 
 ---
 
@@ -157,6 +158,8 @@ This boundary is load-bearing: a journal that can influence the decision it meas
 
 Not a code task. Run 4–6 weeks of: check-in, record the AI verdict, read the engine verdict, answer adherence.
 
+Keep each day's `policyVersion` in the export as already designed. If a decision-affecting version boundary occurs despite the precondition above, treat it as a new evidence segment and report agreement separately by stable-policy segment.
+
 **Done when** the export contains:
 
 * **≥ 28 days** with both engine and external verdicts;
@@ -172,6 +175,7 @@ If the third gate is not met, the data may still support Phase 9's corpus, but a
 Write a dated analysis in `docs/analysis/` reporting:
 
 * agreement overall and split by `sawEngineVerdictFirst`;
+* agreement split by stable `policyVersion` segment if the block crossed a decision-affecting version boundary;
 * every disagreement row with the athlete's journal note;
 * directional bias (engine systematically more or less conservative);
 * whether disagreements concentrate on days where subjective scores diverge from the athlete's own trailing average, the hypothesis in [ADR-0020](../adr/0020-subjective-baselines-in-readiness-mode.md).
@@ -206,6 +210,7 @@ Then choose one:
 | Selective evidence editing/deletion. | Morning verdict, note, anchoring flag, and creation timestamp are immutable; journal deletion is denied. |
 | Malformed rows silently improve apparent coverage. | Strict parser plus explicit invalid-record count in export source status. |
 | Exact imported verdict is lost behind the three-value mode. | Persist exact five-value `engineVerdict`; legacy fallback only for rows that predate it. |
+| Decision policy changes during the block and contaminates the comparison. | Keep policy/equality/replay semantics stable; if an unavoidable decision-affecting change lands, end the evidence segment and report the versions separately rather than pooling them. |
 | The log starts influencing recommendations. | 9.0.6 makes that a structural test failure. |
 | The athlete stops recording. | Report the lapse rather than silently retry/backfill; daily-use viability is itself evidence. |
 | Five values flatten nuance. | Keep `externalNote` verbatim and inspect all disagreement rows in 9.0.8. |


### PR DESCRIPTION
## Summary

Align the Phase 9.0 critical-path operational step with the repository-owned Cloud Run/Scheduler runbook and make the prospective shadow-block evidence protocol explicit.

### Changes

- update Phase 9.0 `9.0.1` from the stale single 05:00 cron to the documented `*/15 5-9 * * *` Europe/Warsaw morning polling window
- record the deployed scheduler/staleness configuration as part of the operational evidence
- require stable decision policy / decision equality / replay-provenance semantics inside a shadow evidence segment
- if a decision-affecting change is unavoidable, require a new segment and separate readout rather than pooling versions
- align the root README scheduler summary with `docs/ops/cloud-run-deployment.md`

## Why now

`docs/plans/README.md` identifies 9.0.1 as the remaining operational gate before the 4–6 week shadow block can start. The ops runbook has evolved to a morning polling window, while Phase 9.0 and the root README still described older fixed schedules. Because the block is the gating real-athlete evidence for Phase 9.8 and the manual-loop retirement decision, the operational protocol should be unambiguous before day 1.

## Suggested execution after merge

1. deploy/verify unattended Garmin ingestion using the runbook
2. backfill 56 days and audit coverage
3. prove seven consecutive unattended days
4. start the 4–6 week shadow block as soon as the gate is met
5. continue evidence-only/UI work during the block, but avoid decision-affecting engine/replay changes in the same evidence segment

Docs-only change; no production recommendation behavior or `POLICY_VERSION` change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Cloud Scheduler guidance to run every 15 minutes from 05:00–09:45 Europe/Warsaw.
  - Refined deployment instructions, including repository runbook usage and avoiding forced deployments.
  - Clarified optional token configuration and staleness-based request handling.
  - Expanded shadow-mode planning with policy-version segmentation, polling, backfill auditing, and contamination-risk reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->