### PR TITLE
fix(export): detect lossy compound strength prescriptions

### DIFF
--- a/app/src/utils/workoutJsonExport.test.ts
+++ b/app/src/utils/workoutJsonExport.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { exportWorkoutPrescriptionToJson, exportExternalSessionToJson, exportExternalSessionV2ToJson } from './workoutJsonExport';
+import {
+    exportWorkoutPrescriptionToJson,
+    exportExternalSessionToJson,
+    exportExternalSessionV2ToJson,
+    extractSetsAndRepsFromText,
+    hasMultipleSetsAndRepsPrescriptions,
+    validateGarminExportFidelity,
+} from './workoutJsonExport';
 import type { WorkoutPrescription } from '../workouts/models';
 import type { ExternalPlanSession } from '../engine/models';
 import type { ExternalPlanSessionV2 } from '../sessions/externalPlanV2';
@@ -260,5 +267,89 @@ describe('workoutJsonExport', () => {
         const json = exportExternalSessionToJson(session);
         expect(json.blocks[0].steps[0].sets).toBe(2);
         expect(json.blocks[0].steps[0].repetitions).toBe(8);
+    });
+
+    it('exports v1 "4 x 2" strength text as sets=4, repetitions=2', () => {
+        expect(extractSetsAndRepsFromText('4 x 2 fast repetitions, RPE 5-6')).toEqual({
+            sets: 4,
+            repetitions: 2,
+        });
+    });
+
+    it('flags a v1 strength step containing two sets-x-reps prescriptions', () => {
+        const compoundText = '2 x 3-5 squat or split-squat repetitions plus 2 x 4-6 hinge repetitions, RPE 5-6';
+        expect(hasMultipleSetsAndRepsPrescriptions(compoundText)).toBe(true);
+        expect(hasMultipleSetsAndRepsPrescriptions('4 x 2 fast repetitions, RPE 5-6')).toBe(false);
+
+        const session: ExternalPlanSession = {
+            id: 'w1-lower-body',
+            title: 'Low-Fatigue Strength Maintenance',
+            priority: 'key',
+            placement: { week: 1, preferredDay: 'wednesday', flexibility: 'preferred', ifMissed: 'drop' },
+            gating: { modality: 'strength', intensity: 'easy', durationMin: 25, durationMax: 40, environment: 'indoor', equipment: [] },
+            prescription: {
+                summary: 'Very low fatigue, finish fresh.',
+                steps: [{ name: 'Lower-body strength', target: compoundText }],
+            },
+        };
+
+        const json = exportExternalSessionToJson(session);
+        const issues = validateGarminExportFidelity(json);
+        expect(issues).toContainEqual(
+            expect.objectContaining({ level: 'error', code: 'multiple_prescriptions', stepName: 'Lower-body strength' }),
+        );
+    });
+
+    it('does not invent rest when the source has no recovery field', () => {
+        const session: ExternalPlanSession = {
+            id: 'w1-explosive',
+            title: 'Low-Fatigue Strength Maintenance',
+            priority: 'key',
+            placement: { week: 1, preferredDay: 'wednesday', flexibility: 'preferred', ifMissed: 'drop' },
+            gating: { modality: 'strength', intensity: 'easy', durationMin: 25, durationMax: 40, environment: 'indoor', equipment: [] },
+            prescription: {
+                summary: 'Very low fatigue, finish fresh.',
+                steps: [{ name: 'Explosive lift', repeat: 2, sets: 4 }],
+            },
+        };
+
+        const json = exportExternalSessionToJson(session);
+        expect(json.blocks[0].steps[0].restAfterSec).toBeUndefined();
+        expect(json.blocks[0].steps[0].setRecoverySec).toBeUndefined();
+
+        const issues = validateGarminExportFidelity(json);
+        expect(issues).toContainEqual(
+            expect.objectContaining({ level: 'warning', code: 'no_explicit_rest', stepName: 'Explosive lift' }),
+        );
+        // A missing rest field must never be silently backfilled with a
+        // fabricated duration -- only surfaced as a warning.
+        expect(json.blocks[0].steps[0].restAfterSec).toBeUndefined();
+    });
+
+    it('v2 strength SessionDefinition exports exact sets, representative reps and rest with no fidelity errors', () => {
+        const session: ExternalPlanSessionV2 = {
+            id: 'w1-strength-loaded',
+            title: 'Lower Body Strength',
+            priority: 'key',
+            placement: { week: 1, preferredDay: 'monday', flexibility: 'preferred', ifMissed: 'drop' },
+            gating: { modality: 'strength', intensity: 'hard', durationMin: 50, durationMax: 60, environment: 'indoor', equipment: ['free_weights'] },
+            definition: {
+                schemaVersion: 1, id: 'w1-strength-loaded', revision: 1, title: 'Lower Body Strength', intent: 'training',
+                blocks: [{
+                    id: 'block-main', role: 'main', executionMode: 'sequential',
+                    steps: [{
+                        id: 'step-squat-mass', kind: 'exercise', title: 'Squat Mass',
+                        exerciseRef: { kind: 'unresolved_free_text', name: 'Back Squat' },
+                        dose: { kind: 'repetition', sets: 4, reps: { min: 6, max: 8 } },
+                        load: { kind: 'mass', kg: { min: 95, max: 105 } },
+                        rest: 180,
+                    }],
+                }],
+            },
+        };
+
+        const json = exportExternalSessionV2ToJson(session);
+        expect(json.blocks[0].steps[0]).toMatchObject({ sets: 4, repetitions: 7, restAfterSec: 180 });
+        expect(validateGarminExportFidelity(json)).toEqual([]);
     });
 });

--- a/app/src/utils/workoutJsonExport.ts
+++ b/app/src/utils/workoutJsonExport.ts
@@ -177,6 +177,133 @@ export function resolveSetsAndRepetitions(
     return inferred;
 }
 
+/**
+ * Detects whether free text contains more than one distinct `sets x reps`
+ * prescription, e.g. "2 x 3-5 squat or split-squat repetitions plus 2 x 4-6
+ * hinge repetitions". `extractSetsAndRepsFromText` only ever returns the
+ * first match, so a step flagged here is losing whichever prescription
+ * comes after the first unless it is atomized into separate steps upstream.
+ *
+ * This is a coarse structural signal only: it cannot tell whether the two
+ * matches are genuinely distinct exercises, so callers must not use it to
+ * auto-split prose -- only to surface the ambiguity.
+ */
+export function hasMultipleSetsAndRepsPrescriptions(text: string): boolean {
+    if (!text) return false;
+    const pattern = /(\d+)\s*(?:sets\s*)?[x×]\s*(\d+)(?:\s*[-–]\s*(\d+))?/gi;
+    const matches = text.match(pattern);
+    return !!matches && matches.length > 1;
+}
+
+export interface GarminExportFidelityIssue {
+    level: 'error' | 'warning';
+    blockName?: string;
+    stepName: string;
+    code:
+        | 'multiple_prescriptions'
+        | 'no_usable_dose'
+        | 'invalid_dose'
+        | 'no_explicit_rest'
+        | 'rep_range_reduced'
+        | 'time_based_block';
+    message: string;
+}
+
+/**
+ * Source-neutral pre-sync validation. Runs over the already-built canonical
+ * export (not the source prose) so it applies equally to v1- and
+ * v2-authored sessions and to catalog prescriptions.
+ *
+ * `error` issues mean sync would silently lose or misrepresent a
+ * prescription and should block sync until resolved; `warning` issues are
+ * safe to sync but worth surfacing (e.g. an unspecified rest, or a rep
+ * range collapsed to Garmin's single numeric target).
+ */
+export function validateGarminExportFidelity(workout: CanonicalWorkoutExport): GarminExportFidelityIssue[] {
+    const issues: GarminExportFidelityIssue[] = [];
+    const isStrength = workout.modality === 'strength';
+    const repRangePattern = /\b\d+\s*[-–]\s*\d+\b/;
+
+    for (const block of workout.blocks) {
+        for (const step of block.steps) {
+            const rawText = `${step.notes ?? ''} ${step.name} ${(step.targets ?? []).join(' ')}`.trim();
+
+            if (hasMultipleSetsAndRepsPrescriptions(rawText)) {
+                issues.push({
+                    level: 'error',
+                    blockName: block.name,
+                    stepName: step.name,
+                    code: 'multiple_prescriptions',
+                    message: `Cannot faithfully sync "${step.name}": this step contains more than one set/rep prescription. Split it into separate executable steps before Garmin sync.`,
+                });
+                // A step already flagged as lossy shouldn't also collect
+                // secondary warnings that assume a single resolved dose.
+                continue;
+            }
+
+            if (!isStrength) continue;
+
+            const hasSets = step.sets !== undefined;
+            const hasReps = step.repetitions !== undefined;
+            const hasDuration = step.durationSeconds !== undefined && step.durationSeconds > 0;
+
+            if ((hasSets && (step.sets as number) <= 0) || (hasReps && (step.repetitions as number) <= 0)) {
+                issues.push({
+                    level: 'error',
+                    blockName: block.name,
+                    stepName: step.name,
+                    code: 'invalid_dose',
+                    message: `"${step.name}" has an invalid sets/repetitions value; sets and repetitions must be greater than zero.`,
+                });
+                continue;
+            }
+
+            if (hasSets && (step.sets as number) > 1 && !hasReps && !hasDuration) {
+                issues.push({
+                    level: 'error',
+                    blockName: block.name,
+                    stepName: step.name,
+                    code: 'no_usable_dose',
+                    message: `"${step.name}" has ${step.sets} sets but no repetition target or duration. Add reps or a duration before syncing.`,
+                });
+                continue;
+            }
+
+            if (hasSets && (step.sets as number) > 1 && hasReps && !step.restAfterSec && !step.setRecoverySec) {
+                issues.push({
+                    level: 'warning',
+                    blockName: block.name,
+                    stepName: step.name,
+                    code: 'no_explicit_rest',
+                    message: `"${step.name}" has no explicit rest between sets; Garmin will not show a recovery step.`,
+                });
+            }
+
+            if (hasReps && repRangePattern.test(rawText)) {
+                issues.push({
+                    level: 'warning',
+                    blockName: block.name,
+                    stepName: step.name,
+                    code: 'rep_range_reduced',
+                    message: `"${step.name}"'s rep range was reduced to a single Garmin target of ${step.repetitions}; the original range is preserved in the description only.`,
+                });
+            }
+
+            if (!hasSets && !hasReps && hasDuration) {
+                issues.push({
+                    level: 'warning',
+                    blockName: block.name,
+                    stepName: step.name,
+                    code: 'time_based_block',
+                    message: `"${step.name}" will sync as a ${Math.round((step.durationSeconds ?? 0) / 60)}-minute time block rather than explicit sets/reps.`,
+                });
+            }
+        }
+    }
+
+    return issues;
+}
+
 export function extractRecoveryTargetFromText(text: string): string | undefined {
     if (!text) return undefined;
     const match = text.match(/followed\s+by\s+\d+\s*(?:s|sec|min|m)?\s+(?:at|below|around|approximately|about)\s+([^.,;]+)/i);


### PR DESCRIPTION
## Summary

`extractSetsAndRepsFromText` (v1 external-plan free-text parsing) only ever returns the **first** `sets x reps` match in a step's text. For a source line like:

> `2 x 3-5 squat or split-squat repetitions plus 2 x 4-6 hinge repetitions, RPE 5-6`

(the actual **Lower-body strength** line from the reported Garmin sync bug), the exporter silently produces `sets=2, repetitions=4` and the hinge prescription is only present as unstructured prose — it never becomes an executable step. This is independent of and complementary to #92 (the backend `sets`/`reps`/rest fix): even with that fix, this exact step is still lossy because it's really two prescriptions merged into one.

## What this adds

- `hasMultipleSetsAndRepsPrescriptions(text)` — detects when a step's text contains more than one `sets x reps` pattern. **Detection only**, not auto-splitting: regex can't reliably infer exercise identity, alternatives ("squat or split-squat"), or laterality, so silently splitting prose risks worse damage than leaving it alone.
- `validateGarminExportFidelity(canonicalWorkout)` — a source-neutral diagnostic that runs over the already-built canonical export, so it applies equally to v1 prose-parsed steps, v2 `SessionDefinition` steps, and catalog prescriptions:
  - **error** (should block sync): multiple prescriptions in one step, invalid (`<= 0`) sets/reps, or `sets > 1` with no usable rep target and no duration.
  - **warning** (safe to sync): sets/reps present but no explicit rest, a rep range collapsed to Garmin's single numeric target, or a deliberately time-based strength block.

## Tests

New tests in `workoutJsonExport.test.ts`:
- `4 x 2` text parses to `sets=4, repetitions=2`.
- the compound lower-body text is flagged as `multiple_prescriptions`.
- a step with no rest field produces a `no_explicit_rest` warning and never has a rest value backfilled.
- a fully-specified v2 strength step produces zero fidelity issues.

`npm run check` (typecheck + eslint + full vitest suite + workout catalog validation) — all clean.

## Follow-up

A separate PR wires `validateGarminExportFidelity` into the export UI (`WorkoutExportMenu`) to block sync on errors and surface warnings before queueing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)