### PR TITLE
feat(garmin): preview sync fidelity before queueing

### DIFF
--- a/app/src/components/WorkoutExportMenu.css
+++ b/app/src/components/WorkoutExportMenu.css
@@ -88,3 +88,35 @@
   color: var(--text-secondary, #94a3b8);
   margin-top: 0.1rem;
 }
+
+.workout-export-item.primary-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.workout-export-fidelity {
+  border-radius: 6px;
+  padding: 0.5rem 0.6rem;
+  font-size: 0.72rem;
+  line-height: 1.35;
+}
+
+.workout-export-fidelity p {
+  margin: 0;
+}
+
+.workout-export-fidelity p + p {
+  margin-top: 0.35rem;
+}
+
+.workout-export-fidelity-error {
+  background: rgba(248, 113, 113, 0.12);
+  border: 1px solid rgba(248, 113, 113, 0.35);
+  color: #fecaca;
+}
+
+.workout-export-fidelity-warning {
+  background: rgba(250, 204, 21, 0.1);
+  border: 1px solid rgba(250, 204, 21, 0.3);
+  color: #fde68a;
+}

--- a/app/src/components/WorkoutExportMenu.tsx
+++ b/app/src/components/WorkoutExportMenu.tsx
@@ -1,7 +1,15 @@
-import { useState, useCallback, useRef, useEffect } from 'react';
+import { useState, useCallback, useMemo, useRef, useEffect } from 'react';
 import type { WorkoutPrescription } from '../workouts/models';
 import { generateZwiftFromPrescription, generateZwiftFromExternalSession, generateZwiftFromExternalSessionV2, downloadZwiftFile } from '../utils/zwiftExport';
-import { exportWorkoutPrescriptionToJson, exportExternalSessionToJson, exportExternalSessionV2ToJson, downloadJsonFile, copyJsonToClipboard, type CanonicalWorkoutExport } from '../utils/workoutJsonExport';
+import {
+    exportWorkoutPrescriptionToJson,
+    exportExternalSessionToJson,
+    exportExternalSessionV2ToJson,
+    downloadJsonFile,
+    copyJsonToClipboard,
+    validateGarminExportFidelity,
+    type CanonicalWorkoutExport,
+} from '../utils/workoutJsonExport';
 import { garminWorkoutQueueService } from '../services/garminWorkoutQueueService';
 import { isV2Session, type AnyExternalPlanSession } from '../sessions/externalPlanV2';
 import './WorkoutExportMenu.css';
@@ -50,6 +58,18 @@ export function WorkoutExportMenu({
         };
     }, [prescription, externalSession, title, modality]);
 
+    // Pre-sync fidelity preview: surfaces lossy/ambiguous prescriptions (e.g. a
+    // compound "2 x 3-5 ... plus 2 x 4-6 ..." step, or strength sets with no
+    // usable rep target) before they're silently flattened by Garmin sync.
+    // Only computed while the menu is open, since it re-derives the full
+    // canonical export.
+    const fidelityIssues = useMemo(
+        () => (isOpen ? validateGarminExportFidelity(getCanonicalExport()) : []),
+        [isOpen, getCanonicalExport],
+    );
+    const fidelityErrors = fidelityIssues.filter(issue => issue.level === 'error');
+    const fidelityWarnings = fidelityIssues.filter(issue => issue.level === 'warning');
+
     const handleDownloadZwift = () => {
         let xml = '';
         if (prescription) {
@@ -79,9 +99,19 @@ export function WorkoutExportMenu({
     };
 
     const handleQueueGarminSync = async () => {
+        const payload = getCanonicalExport();
+        const blockingIssues = validateGarminExportFidelity(payload).filter(issue => issue.level === 'error');
+        if (blockingIssues.length > 0) {
+            // Refuse to queue a workout that would silently lose or
+            // misrepresent a prescription (e.g. a compound sets/reps step,
+            // or strength sets with no usable rep target). JSON download and
+            // copy remain available for debugging.
+            setSyncState('error');
+            setTimeout(() => setSyncState('idle'), 3000);
+            return;
+        }
         setSyncState('queuing');
         try {
-            const payload = getCanonicalExport();
             await garminWorkoutQueueService.queueWorkout(userId, date, payload);
             setSyncState('queued');
             onSyncQueued?.();
@@ -123,12 +153,28 @@ export function WorkoutExportMenu({
 
             {isOpen && (
                 <div className="workout-export-dropdown" role="menu">
+                    {fidelityErrors.length > 0 && (
+                        <div className="workout-export-fidelity workout-export-fidelity-error" role="alert">
+                            {fidelityErrors.map((issue, i) => (
+                                <p key={i}>⛔ {issue.message}</p>
+                            ))}
+                        </div>
+                    )}
+                    {fidelityErrors.length === 0 && fidelityWarnings.length > 0 && (
+                        <div className="workout-export-fidelity workout-export-fidelity-warning">
+                            {fidelityWarnings.map((issue, i) => (
+                                <p key={i}>⚠️ {issue.message}</p>
+                            ))}
+                        </div>
+                    )}
+
                     <button
                         type="button"
                         className="workout-export-item primary-action"
                         role="menuitem"
                         onClick={handleQueueGarminSync}
-                        disabled={syncState === 'queuing'}
+                        disabled={syncState === 'queuing' || fidelityErrors.length > 0}
+                        title={fidelityErrors.length > 0 ? 'Fix the fidelity issue(s) above before syncing' : undefined}
                     >
                         <span className="export-icon">⚡</span>
                         <div className="export-text">
@@ -136,7 +182,9 @@ export function WorkoutExportMenu({
                             <span>
                                 {syncState === 'queuing' ? 'Queuing sync...' :
                                  syncState === 'queued' ? '✓ Queued for Garmin push!' :
+                                 syncState === 'error' && fidelityErrors.length > 0 ? 'Blocked: fix fidelity issue(s) above' :
                                  syncState === 'error' ? 'Failed to queue sync' :
+                                 fidelityErrors.length > 0 ? 'Cannot sync until fidelity issue(s) are resolved' :
                                  'Upload & schedule to your Garmin calendar'}
                             </span>
                         </div>


### PR DESCRIPTION
## Summary

Stacked on #93 (`fix/garmin-export-fidelity-detection`). Wires `validateGarminExportFidelity` into `WorkoutExportMenu` so lossy/ambiguous prescriptions are visible **before** a workout is queued for Garmin sync, not discovered afterward in Garmin Connect.

## Behavior

- Opening the export menu computes the fidelity issues for the current workout.
- **Error**-level issues (compound multi-prescription step, invalid sets/reps, strength sets with no usable rep target) are listed inline and disable the "Sync to Garmin Connect" button.
- **Warning**-level issues (no explicit rest, a rep range collapsed to Garmin's single target, a deliberately time-based block) are shown but don't block sync.
- `handleQueueGarminSync` re-validates immediately before queueing (not just at menu-open time), so a stale computation can't let a blocked sync through.
- JSON download/copy stay available regardless, for debugging.

## Tests

`npm run check` (typecheck + eslint + full vitest suite + workout catalog validation) — all clean. No new component-interaction tests were added: the repo's component tests use `renderToStaticMarkup` only (no `@testing-library`/jsdom interaction harness present), so the closed-menu smoke tests in `WorkoutExportMenu.test.ts` still pass unchanged; the underlying `validateGarminExportFidelity` logic itself is covered by the unit tests in #93.

## Base branch

This targets `fix/garmin-export-fidelity-detection` (#93), not `main`, since it depends on `validateGarminExportFidelity` added there. Merge #93 first, then retarget/merge this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)