### PR TITLE
feat(sessions): fine-grained v2 import preview and revision diff (M3.7)

### DIFF
--- a/app/src/components/ExternalPlanImport.css
+++ b/app/src/components/ExternalPlanImport.css
@@ -186,6 +186,41 @@
 .external-import-diff .diff-removed { color: #fca5a5; }
 .external-import-diff .diff-changed { color: #fcd34d; }
 
+.external-import-content-diff {
+  margin: 0.3rem 0 0.15rem;
+  padding-left: 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+}
+
+.external-import-content-diff .content-diff-behavior {
+  color: #fca5a5;
+}
+
+.external-import-content-diff .content-diff-cosmetic {
+  color: var(--text-secondary);
+}
+
+.external-import-ack {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  margin-top: 0.85rem;
+  padding: 0.55rem 0.7rem;
+  border-radius: 6px;
+  font-size: 0.82rem;
+  line-height: 1.4;
+  background: rgba(252, 211, 77, 0.08);
+  border: 1px solid rgba(252, 211, 77, 0.3);
+}
+
+.external-import-ack input {
+  margin-top: 0.2rem;
+}
+
 .external-import-sessions {
   list-style: none;
   margin: 0.85rem 0 0;
@@ -219,6 +254,26 @@
 .external-import-session-meta {
   font-size: 0.75rem;
   color: var(--text-secondary);
+}
+
+.external-import-session-detail {
+  grid-column: 1 / -1;
+  margin-top: 0.3rem;
+}
+
+.external-import-session-detail summary {
+  cursor: pointer;
+  font-size: 0.75rem;
+  color: #93c5fd;
+  user-select: none;
+}
+
+.external-import-session-detail summary:hover {
+  color: #bfdbfe;
+}
+
+.external-import-session-detail .session-def-preview {
+  margin-top: 0.5rem;
 }
 
 .external-import-objectives {

--- a/app/src/components/ExternalPlanImport.test.ts
+++ b/app/src/components/ExternalPlanImport.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import { diffPlans } from './externalPlanDiff';
 import { EXTERNAL_PLAN_SCHEMA, type ExternalTrainingPlan } from '../engine/models';
+import { EXTERNAL_PLAN_SCHEMA_V2, type ExternalTrainingPlanV2 } from '../sessions/externalPlanV2';
+import type { SessionDefinition } from '../sessions/models';
 
 function plan(): ExternalTrainingPlan {
     return {
@@ -66,5 +68,82 @@ describe('diffPlans', () => {
         next.sessions[0].objectives = [...(next.sessions[0].objectives ?? [])].reverse();
 
         expect(diffPlans(plan(), next)).toEqual([]);
+    });
+});
+
+function v2Definition(): SessionDefinition {
+    return {
+        schemaVersion: 1,
+        id: 's1',
+        revision: 1,
+        title: 'Threshold',
+        intent: 'training',
+        blocks: [
+            {
+                id: 'block-main',
+                role: 'main',
+                executionMode: 'sequential',
+                steps: [
+                    {
+                        id: 'step-interval',
+                        kind: 'exercise',
+                        title: 'Interval',
+                        exerciseRef: { kind: 'unresolved_free_text', name: 'Bike interval' },
+                        dose: { kind: 'duration', sets: 3, seconds: 720 },
+                        rest: 240,
+                        optional: false,
+                    },
+                ],
+            },
+        ],
+    };
+}
+
+function v2Plan(): ExternalTrainingPlanV2 {
+    return {
+        schema: EXTERNAL_PLAN_SCHEMA_V2,
+        planId: 'block', revision: 1, title: 'Block', startDate: '2026-08-17', weekCount: 1,
+        sessions: [{
+            id: 's1', title: 'Threshold', priority: 'key',
+            placement: { week: 1, preferredDay: 'tuesday', flexibility: 'preferred', ifMissed: 'reschedule_within_week' },
+            gating: { modality: 'cycling', intensity: 'hard', durationMin: 60, durationMax: 75, environment: 'either', equipment: ['indoor_bike'] },
+            objectives: ['threshold_quality', 'zone2_aerobic'],
+            definition: v2Definition(),
+        }],
+    };
+}
+
+describe('diffPlans — M3.7 fine-grained v2 content diff', () => {
+    it('replaces the coarse content line with per-field rows for a v2/v2 session pair', () => {
+        const previous = v2Plan();
+        const next = structuredClone(previous);
+        next.revision = 2;
+        next.sessions[0].definition.blocks[0].steps[0].optional = true;
+
+        const rows = diffPlans(previous, next);
+        const row = rows.find(r => r.sessionId === 's1');
+        expect(row?.contentChanges).toBeDefined();
+        expect(row?.contentChanges?.some(change => change.behaviorChanging && change.detail.includes('required → optional'))).toBe(true);
+        expect(row?.detail).toContain('the session content changed (see below)');
+    });
+
+    it('marks a title-only content change as non-behavior-changing (cosmetic)', () => {
+        const previous = v2Plan();
+        const next = structuredClone(previous);
+        next.revision = 2;
+        next.sessions[0].definition.title = 'Threshold v2';
+
+        const rows = diffPlans(previous, next);
+        const row = rows.find(r => r.sessionId === 's1');
+        expect(row?.contentChanges?.every(change => !change.behaviorChanging)).toBe(true);
+        expect(row?.detail).toContain('session wording changed (see below)');
+    });
+
+    it('reports nothing when the v2 definition is unchanged', () => {
+        const previous = v2Plan();
+        const next = structuredClone(previous);
+        next.revision = 2;
+
+        expect(diffPlans(previous, next)).toEqual([]);
     });
 });

--- a/app/src/components/ExternalPlanImport.test.tsx
+++ b/app/src/components/ExternalPlanImport.test.tsx
@@ -1,8 +1,10 @@
-import { describe, expect, it } from 'vitest';
-import { diffPlans } from './externalPlanDiff';
+import { describe, expect, it, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { diffPlans, type PlanDiffRow } from './externalPlanDiff';
 import { EXTERNAL_PLAN_SCHEMA, type ExternalTrainingPlan } from '../engine/models';
 import { EXTERNAL_PLAN_SCHEMA_V2, type ExternalTrainingPlanV2 } from '../sessions/externalPlanV2';
 import type { SessionDefinition } from '../sessions/models';
+import { PlanPreview } from './ExternalPlanImport';
 
 function plan(): ExternalTrainingPlan {
     return {
@@ -145,5 +147,56 @@ describe('diffPlans — M3.7 fine-grained v2 content diff', () => {
         next.revision = 2;
 
         expect(diffPlans(previous, next)).toEqual([]);
+    });
+});
+
+/**
+ * PlanPreview's acknowledgement-gating (M3.7). This repo has no interactive component-test
+ * harness (no @testing-library/react), so this covers the reachable static-markup half of
+ * the requirement -- the initial disabled/enabled state on first render -- via `PlanPreview`
+ * directly (exported for exactly this). The other half (clicking the checkbox re-enables
+ * Import) needs simulated interaction this repo's tooling can't do; the underlying state
+ * (`acknowledged`) is a plain `useState` toggle with no logic of its own to hide a bug in.
+ */
+describe('PlanPreview — M3.7 import acknowledgement gating', () => {
+    function behaviorChangingDiff(): PlanDiffRow[] {
+        return [{
+            sessionId: 's1',
+            change: 'changed',
+            detail: '"Threshold": the session content changed (see below).',
+            contentChanges: [
+                { scope: 'step', id: 'block-main/step-interval', change: 'changed', behaviorChanging: true, detail: 'Step "Interval": dose changed.' },
+            ],
+        }];
+    }
+
+    function cosmeticOnlyDiff(): PlanDiffRow[] {
+        return [{
+            sessionId: 's1',
+            change: 'changed',
+            detail: '"Threshold": session wording changed (see below).',
+            contentChanges: [
+                { scope: 'session', id: 's1', change: 'changed', behaviorChanging: false, detail: 'Title or summary text changed.' },
+            ],
+        }];
+    }
+
+    it('renders Import disabled and shows the acknowledgement checkbox when unreviewed behavior changes exist', () => {
+        const html = renderToStaticMarkup(
+            <PlanPreview plan={v2Plan()} previous={null} diff={behaviorChangingDiff()} onConfirm={vi.fn()} onCancel={vi.fn()} />,
+        );
+        expect(html).toContain('I reviewed the 1 behavior change');
+        expect(html).toMatch(/Import this plan<\/button>/);
+        const importButtonMarkup = html.match(/<button[^>]*>Import this plan<\/button>/)?.[0] ?? '';
+        expect(importButtonMarkup).toContain('disabled=""');
+    });
+
+    it('renders Import enabled with no acknowledgement checkbox for a cosmetic-only diff', () => {
+        const html = renderToStaticMarkup(
+            <PlanPreview plan={v2Plan()} previous={null} diff={cosmeticOnlyDiff()} onConfirm={vi.fn()} onCancel={vi.fn()} />,
+        );
+        expect(html).not.toContain('I reviewed the');
+        const importButtonMarkup = html.match(/<button[^>]*>Import this plan<\/button>/)?.[0] ?? '';
+        expect(importButtonMarkup).not.toContain('disabled');
     });
 });

--- a/app/src/components/ExternalPlanImport.tsx
+++ b/app/src/components/ExternalPlanImport.tsx
@@ -7,10 +7,12 @@ import { getLocalDateString } from '../utils/localDate';
 import { diffPlans, type PlanDiffRow } from './externalPlanDiff';
 import {
     validateExternalTrainingPlanV2,
+    isV2Session,
     EXTERNAL_PLAN_SCHEMA_V2,
     type AnyExternalTrainingPlan as ExternalTrainingPlan,
     type AnyExternalPlanSession,
 } from '../sessions/externalPlanV2';
+import { SessionDefinitionPreview } from './session/SessionDefinitionPreview';
 import './ExternalPlanImport.css';
 
 interface ExternalPlanImportProps {
@@ -339,6 +341,16 @@ interface PlanPreviewProps {
 function PlanPreview({ plan, previous, diff, onConfirm, onCancel }: PlanPreviewProps) {
     const notNewer = previous !== null && plan.revision <= previous.revision;
 
+    // M3.7: a diff row's `contentChanges` are only present for a matched v2/v2 session pair
+    // (`externalPlanDiff.ts`). Behavior-changing rows -- dose, load, laterality, optional vs
+    // required, an authored choice's actions -- must be explicitly acknowledged before the
+    // athlete can confirm; cosmetic-only rows (wording) never block.
+    const behaviorChangeCount = (diff ?? [])
+        .flatMap(row => row.contentChanges ?? [])
+        .filter(row => row.behaviorChanging).length;
+    const [acknowledged, setAcknowledged] = useState(false);
+    const blockedByUnreviewedChanges = behaviorChangeCount > 0 && !acknowledged;
+
     return (
         <section className="external-import-preview" aria-label="Plan preview">
             <h4>{plan.title}</h4>
@@ -359,7 +371,21 @@ function PlanPreview({ plan, previous, diff, onConfirm, onCancel }: PlanPreviewP
                     <h5>What changes against revision {previous?.revision}</h5>
                     <ul>
                         {diff.map(row => (
-                            <li key={`${row.change}-${row.sessionId}`} className={`diff-${row.change}`}>{row.detail}</li>
+                            <li key={`${row.change}-${row.sessionId}`} className={`diff-${row.change}`}>
+                                {row.detail}
+                                {row.contentChanges && row.contentChanges.length > 0 && (
+                                    <ul className="external-import-content-diff">
+                                        {row.contentChanges.map((change, index) => (
+                                            <li
+                                                key={`${row.sessionId}-${change.scope}-${change.id}-${index}`}
+                                                className={change.behaviorChanging ? 'content-diff-behavior' : 'content-diff-cosmetic'}
+                                            >
+                                                {change.behaviorChanging ? '⚠ ' : ''}{change.detail}
+                                            </li>
+                                        ))}
+                                    </ul>
+                                )}
+                            </li>
                         ))}
                     </ul>
                 </div>
@@ -378,12 +404,34 @@ function PlanPreview({ plan, previous, diff, onConfirm, onCancel }: PlanPreviewP
                             {' '}{session.gating.durationMin}–{session.gating.durationMax} min · {session.priority}
                             {session.isEvent && ' · event'}
                         </span>
+                        {isV2Session(session) && (
+                            <details className="external-import-session-detail">
+                                <summary>Full session content — every block and step, not just this summary line</summary>
+                                <SessionDefinitionPreview definition={session.definition} />
+                            </details>
+                        )}
                     </li>
                 ))}
             </ol>
 
+            {behaviorChangeCount > 0 && (
+                <label className="external-import-ack">
+                    <input
+                        type="checkbox"
+                        checked={acknowledged}
+                        onChange={event => setAcknowledged(event.target.checked)}
+                    />
+                    I reviewed the {behaviorChangeCount} behavior change{behaviorChangeCount === 1 ? '' : 's'} marked ⚠ above.
+                </label>
+            )}
+
             <div className="external-import-actions">
-                <button type="button" className="external-import-primary" onClick={onConfirm} disabled={notNewer}>
+                <button
+                    type="button"
+                    className="external-import-primary"
+                    onClick={onConfirm}
+                    disabled={notNewer || blockedByUnreviewedChanges}
+                >
                     Import this plan
                 </button>
                 <button type="button" className="external-import-secondary" onClick={onCancel}>

--- a/app/src/components/ExternalPlanImport.tsx
+++ b/app/src/components/ExternalPlanImport.tsx
@@ -330,7 +330,7 @@ function usePreviousRevision(userId: string, phase: Phase): ExternalTrainingPlan
     return loaded !== null && loaded.key === key ? loaded.plan : null;
 }
 
-interface PlanPreviewProps {
+export interface PlanPreviewProps {
     plan: ExternalTrainingPlan;
     previous: ExternalPlanHeader | null;
     diff: PlanDiffRow[] | null;
@@ -338,7 +338,9 @@ interface PlanPreviewProps {
     onCancel: () => void;
 }
 
-function PlanPreview({ plan, previous, diff, onConfirm, onCancel }: PlanPreviewProps) {
+/** Exported (not just used internally) so the acknowledgement-gating behavior is directly
+ * testable without driving the full paste-JSON → validate → preview state machine. */
+export function PlanPreview({ plan, previous, diff, onConfirm, onCancel }: PlanPreviewProps) {
     const notNewer = previous !== null && plan.revision <= previous.revision;
 
     // M3.7: a diff row's `contentChanges` are only present for a matched v2/v2 session pair

--- a/app/src/components/externalPlanDiff.ts
+++ b/app/src/components/externalPlanDiff.ts
@@ -1,13 +1,19 @@
 // M3.6: a plan may be either schema version; every field compared below except the final
-// content check is identical on v1 and v2 sessions. The content check itself stays a
-// coarse "changed"/"unchanged" for a v2 session -- fine-grained per-field content diffing
-// is M3.7's stated scope, not this one's.
+// content check is identical on v1 and v2 sessions. M3.7 replaces the content check's
+// coarse "changed"/"unchanged" with a fine-grained per-field diff for v2 sessions (whose
+// content is a normalized `SessionDefinition`); v1's flat `ExternalPrescription` keeps the
+// coarse check since it has no comparable block/step structure to diff.
 import { isV2Session, type AnyExternalTrainingPlan as ExternalTrainingPlan } from '../sessions/externalPlanV2';
+import { diffSessionDefinitions, hasBehaviorChanges, type SessionContentDiffRow } from '../sessions/sessionDefinitionDiff';
 
 export interface PlanDiffRow {
     sessionId: string;
     change: 'added' | 'removed' | 'changed';
     detail: string;
+    /** Fine-grained content diff, present only when both revisions are `external-plan@2`
+     * sessions. Absence does not mean nothing changed -- see `detail` for the coarse v1
+     * fallback line ("the session content changed"). */
+    contentChanges?: SessionContentDiffRow[];
 }
 
 function sameStringSet(left: readonly string[] | undefined, right: readonly string[] | undefined): boolean {
@@ -65,12 +71,31 @@ export function diffPlans(previous: ExternalTrainingPlan, next: ExternalTraining
         if (!sameStringSet(old.objectives, session.objectives)) changes.push('objective tags changed');
         if (!sameStructuredValue(old.scaling, session.scaling)) changes.push('scaling / fallback policy changed');
         if (Boolean(old.isEvent) !== Boolean(session.isEvent)) changes.push(session.isEvent ? 'now marked as an event' : 'no longer marked as an event');
-        // A coarse "changed"/"unchanged" content comparison. Fine-grained per-field content
-        // diffing (which side changed exactly what) is M3.7's stated job for both schemas.
-        const oldContent = isV2Session(old) ? old.definition : old.prescription;
-        const newContent = isV2Session(session) ? session.definition : session.prescription;
-        if (!sameStructuredValue(oldContent, newContent)) changes.push('the session content changed');
-        if (changes.length > 0) rows.push({ sessionId: id, change: 'changed', detail: `“${session.title}”: ${changes.join('; ')}.` });
+
+        let contentChanges: SessionContentDiffRow[] | undefined;
+        if (isV2Session(old) && isV2Session(session)) {
+            // Fine-grained per-field content diff (M3.7): what changed inside blocks/steps/
+            // choices, not just that something did.
+            contentChanges = diffSessionDefinitions(old.definition, session.definition);
+            if (contentChanges.length > 0) {
+                changes.push(hasBehaviorChanges(contentChanges) ? 'the session content changed (see below)' : 'session wording changed (see below)');
+            }
+        } else {
+            // v1's flat `ExternalPrescription` has no comparable block/step structure --
+            // this stays a coarse "changed"/"unchanged" content comparison.
+            const oldContent = isV2Session(old) ? old.definition : old.prescription;
+            const newContent = isV2Session(session) ? session.definition : session.prescription;
+            if (!sameStructuredValue(oldContent, newContent)) changes.push('the session content changed');
+        }
+
+        if (changes.length > 0) {
+            rows.push({
+                sessionId: id,
+                change: 'changed',
+                detail: `“${session.title}”: ${changes.join('; ')}.`,
+                ...(contentChanges && contentChanges.length > 0 ? { contentChanges } : {}),
+            });
+        }
     }
 
     return rows;

--- a/app/src/sessions/sessionDefinitionDiff.test.ts
+++ b/app/src/sessions/sessionDefinitionDiff.test.ts
@@ -48,13 +48,24 @@ describe('diffSessionDefinitions', () => {
         expect(diffSessionDefinitions(definition(), definition())).toEqual([]);
     });
 
-    it('flags laterality change per-side to bilateral as behavior-changing', () => {
+    it('flags laterality change bilateral to per-side as behavior-changing', () => {
         const next = structuredClone(definition());
         next.blocks[0].steps[0].laterality = 'per_side';
         const rows = diffSessionDefinitions(definition(), next);
         const row = rows.find(r => r.id === 'block-strength/step-squat');
         expect(row?.behaviorChanging).toBe(true);
         expect(row?.detail).toContain('laterality bilateral → per_side');
+    });
+
+    it('flags laterality change per-side to bilateral as behavior-changing (reverse direction)', () => {
+        const before = structuredClone(definition());
+        before.blocks[0].steps[0].laterality = 'per_side';
+        const after = structuredClone(before);
+        after.blocks[0].steps[0].laterality = 'bilateral';
+        const rows = diffSessionDefinitions(before, after);
+        const row = rows.find(r => r.id === 'block-strength/step-squat');
+        expect(row?.behaviorChanging).toBe(true);
+        expect(row?.detail).toContain('laterality per_side → bilateral');
     });
 
     it('flags optional to required as behavior-changing', () => {
@@ -106,9 +117,86 @@ describe('diffSessionDefinitions', () => {
         expect(rows.some(r => r.change === 'added' && r.scope === 'block' && r.behaviorChanging)).toBe(true);
     });
 
+    it('flags an added step and a removed block as behavior-changing (reverse direction)', () => {
+        const before = structuredClone(definition());
+        before.blocks.push({ id: 'block-cooldown', role: 'cooldown', executionMode: 'sequential', steps: [] });
+        const after = structuredClone(before);
+        after.blocks[0].steps.push({
+            id: 'step-lunge', kind: 'exercise', title: 'Lunge',
+            exerciseRef: { kind: 'catalog', exerciseId: 'lunge' },
+            dose: { kind: 'repetition', sets: 3, reps: 10 },
+        });
+        after.blocks = after.blocks.filter(block => block.id !== 'block-cooldown');
+        const rows = diffSessionDefinitions(before, after);
+        expect(rows.some(r => r.change === 'added' && r.scope === 'step' && r.behaviorChanging)).toBe(true);
+        expect(rows.some(r => r.change === 'removed' && r.scope === 'block' && r.behaviorChanging)).toBe(true);
+    });
+
     it('does not report anything when only field order/undefined-vs-absent differ', () => {
         const before = definition();
         const after = structuredClone(before);
         expect(diffSessionDefinitions(before, after)).toEqual([]);
+    });
+
+    it('treats structurally identical dose/load objects with reordered keys as unchanged (sameJson canonicalization)', () => {
+        const before = definition();
+        const after = structuredClone(before);
+        // Same fields, different insertion order -- a real risk given the import flow
+        // regenerates full plan JSON from an LLM on each revision.
+        after.blocks[0].steps[0].load = { percent: 80, kind: 'percent_one_rm' } as typeof after.blocks[0]['steps'][0]['load'];
+        expect(diffSessionDefinitions(before, after)).toEqual([]);
+    });
+
+    it('includes distance dose set counts, so a sets-only change is not silently identical text', () => {
+        const before = structuredClone(definition());
+        before.blocks[0].steps[0].dose = { kind: 'distance', sets: 3, meters: 400 };
+        const after = structuredClone(before);
+        after.blocks[0].steps[0].dose = { kind: 'distance', sets: 4, meters: 400 };
+        const rows = diffSessionDefinitions(before, after);
+        const row = rows.find(r => r.id === 'block-strength/step-squat');
+        expect(row?.behaviorChanging).toBe(true);
+        expect(row?.detail).toContain('dose 3 × 400 m → 4 × 400 m');
+    });
+
+    it('does not fabricate a distance value when none is set', () => {
+        const before = structuredClone(definition());
+        before.blocks[0].steps[0].dose = { kind: 'distance', sets: 2 };
+        const after = structuredClone(before);
+        after.blocks[0].steps[0].dose = { kind: 'distance', sets: 3 };
+        const rows = diffSessionDefinitions(before, after);
+        const row = rows.find(r => r.id === 'block-strength/step-squat');
+        expect(row?.detail).toContain('dose 2 × no distance set → 3 × no distance set');
+    });
+
+    it('flags a same-membership step reorder as behavior-changing, distinct from add/remove', () => {
+        const before = structuredClone(definition());
+        before.blocks[0].steps.push({
+            id: 'step-lunge', kind: 'exercise', title: 'Lunge',
+            exerciseRef: { kind: 'catalog', exerciseId: 'lunge' },
+            dose: { kind: 'repetition', sets: 3, reps: 10 },
+        });
+        const after = structuredClone(before);
+        after.blocks[0].steps.reverse();
+        const rows = diffSessionDefinitions(before, after);
+        const row = rows.find(r => r.scope === 'block' && r.detail.includes('step order changed'));
+        expect(row?.behaviorChanging).toBe(true);
+        expect(rows.some(r => r.change === 'added' || r.change === 'removed')).toBe(false);
+    });
+
+    it('flags a same-membership block reorder as behavior-changing, distinct from add/remove', () => {
+        const before = structuredClone(definition());
+        before.blocks.push({ id: 'block-cooldown', role: 'cooldown', executionMode: 'sequential', steps: [] });
+        const after = structuredClone(before);
+        after.blocks.reverse();
+        const rows = diffSessionDefinitions(before, after);
+        const row = rows.find(r => r.scope === 'session' && r.detail === 'Block order changed.');
+        expect(row?.behaviorChanging).toBe(true);
+        expect(rows.some(r => r.change === 'added' || r.change === 'removed')).toBe(false);
+    });
+
+    it('does not report a reorder when block/step order is unchanged', () => {
+        const before = definition();
+        const after = structuredClone(before);
+        expect(diffSessionDefinitions(before, after).some(r => r.detail.includes('order changed'))).toBe(false);
     });
 });

--- a/app/src/sessions/sessionDefinitionDiff.test.ts
+++ b/app/src/sessions/sessionDefinitionDiff.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import { diffSessionDefinitions, hasBehaviorChanges } from './sessionDefinitionDiff';
+import type { SessionDefinition } from './models';
+
+function definition(): SessionDefinition {
+    return {
+        schemaVersion: 1,
+        id: 'sess-1',
+        revision: 1,
+        title: 'Lower body',
+        intent: 'training',
+        blocks: [
+            {
+                id: 'block-strength',
+                role: 'main',
+                executionMode: 'alternating',
+                steps: [
+                    {
+                        id: 'step-squat',
+                        kind: 'exercise',
+                        title: 'Back squat',
+                        exerciseRef: { kind: 'catalog', exerciseId: 'back_squat' },
+                        dose: { kind: 'repetition', sets: 4, reps: 5 },
+                        load: { kind: 'percent_one_rm', percent: 80 },
+                        rest: 120,
+                        laterality: 'bilateral',
+                        optional: false,
+                    },
+                ],
+                optionSets: [
+                    {
+                        id: 'choice-squat',
+                        appliesAtStepId: 'step-squat',
+                        trigger: { kind: 'athlete_observed', description: 'Warm-up sets felt heavy' },
+                        options: [
+                            { id: 'opt-normal', label: 'Continue as prescribed', actions: [] },
+                            { id: 'opt-reduce', label: 'Reduce load', actions: [{ kind: 'reduce_load_percent', targetStepId: 'step-squat', percent: 10 }] },
+                        ],
+                    },
+                ],
+            },
+        ],
+    };
+}
+
+describe('diffSessionDefinitions', () => {
+    it('reports no rows for an identical definition', () => {
+        expect(diffSessionDefinitions(definition(), definition())).toEqual([]);
+    });
+
+    it('flags laterality change per-side to bilateral as behavior-changing', () => {
+        const next = structuredClone(definition());
+        next.blocks[0].steps[0].laterality = 'per_side';
+        const rows = diffSessionDefinitions(definition(), next);
+        const row = rows.find(r => r.id === 'block-strength/step-squat');
+        expect(row?.behaviorChanging).toBe(true);
+        expect(row?.detail).toContain('laterality bilateral → per_side');
+    });
+
+    it('flags optional to required as behavior-changing', () => {
+        const next = structuredClone(definition());
+        next.blocks[0].steps[0].optional = true;
+        const rows = diffSessionDefinitions(definition(), next);
+        const row = rows.find(r => r.id === 'block-strength/step-squat');
+        expect(row?.behaviorChanging).toBe(true);
+        expect(row?.detail).toContain('required → optional');
+    });
+
+    it('flags a choice action swap (end_block to reduce_load_percent) as behavior-changing', () => {
+        const next = structuredClone(definition());
+        next.blocks[0].optionSets![0].options[1].actions = [{ kind: 'end_block', targetBlockId: 'block-strength' }];
+        const rows = diffSessionDefinitions(definition(), next);
+        const row = rows.find(r => r.scope === 'option');
+        expect(row?.behaviorChanging).toBe(true);
+        expect(row?.detail).toContain('reduce load 10%');
+        expect(row?.detail).toContain('end block');
+    });
+
+    it('treats title/notes/trigger wording changes as cosmetic only', () => {
+        const next = structuredClone(definition());
+        next.title = 'Lower body v2';
+        next.blocks[0].optionSets![0].trigger.description = 'Warm-ups felt heavy today';
+        const rows = diffSessionDefinitions(definition(), next);
+        expect(rows.every(row => !row.behaviorChanging)).toBe(true);
+        expect(hasBehaviorChanges(rows)).toBe(false);
+    });
+
+    it('flags dose and load changes with readable before/after values', () => {
+        const next = structuredClone(definition());
+        next.blocks[0].steps[0].dose = { kind: 'repetition', sets: 3, reps: 8 };
+        next.blocks[0].steps[0].load = { kind: 'percent_one_rm', percent: 70 };
+        const rows = diffSessionDefinitions(definition(), next);
+        const row = rows.find(r => r.id === 'block-strength/step-squat');
+        expect(row?.behaviorChanging).toBe(true);
+        expect(row?.detail).toContain('dose 4 × 5 reps → 3 × 8 reps');
+        expect(row?.detail).toContain('load 80% 1RM → 70% 1RM');
+    });
+
+    it('flags a removed step and a new block as behavior-changing', () => {
+        const before = definition();
+        const after = structuredClone(before);
+        after.blocks[0].steps = [];
+        after.blocks.push({ id: 'block-cooldown', role: 'cooldown', executionMode: 'sequential', steps: [] });
+        const rows = diffSessionDefinitions(before, after);
+        expect(rows.some(r => r.change === 'removed' && r.scope === 'step' && r.behaviorChanging)).toBe(true);
+        expect(rows.some(r => r.change === 'added' && r.scope === 'block' && r.behaviorChanging)).toBe(true);
+    });
+
+    it('does not report anything when only field order/undefined-vs-absent differ', () => {
+        const before = definition();
+        const after = structuredClone(before);
+        expect(diffSessionDefinitions(before, after)).toEqual([]);
+    });
+});

--- a/app/src/sessions/sessionDefinitionDiff.ts
+++ b/app/src/sessions/sessionDefinitionDiff.ts
@@ -1,0 +1,316 @@
+/**
+ * M3.7: fine-grained content diff between two revisions of the same `SessionDefinition`.
+ *
+ * `externalPlanDiff.ts` already flags placement/gating/objective/scaling changes at the
+ * plan-session envelope level; this module is the "the session content changed" line's
+ * replacement for `external-plan@2` sessions (and any other two `SessionDefinition`
+ * revisions worth comparing) -- it names *what* changed inside `blocks`, not just that
+ * something did.
+ *
+ * Every row is tagged `behaviorChanging`. That distinguishes changes that alter what the
+ * athlete is asked to do or how the runner behaves (dose, load, laterality, optional vs
+ * required, an authored choice's actions, ...) from purely cosmetic text (title, notes,
+ * a choice's trigger wording). The preview surfaces both, but only behavior-changing rows
+ * need to block casual confirmation.
+ */
+import type {
+    RangeOrNumber,
+    SessionBlock,
+    SessionChoice,
+    SessionChoiceAction,
+    SessionDefinition,
+    SessionDose,
+    SessionEffort,
+    SessionLoad,
+    SessionOption,
+    SessionQuality,
+    SessionStep,
+} from './models';
+
+export interface SessionContentDiffRow {
+    scope: 'session' | 'block' | 'step' | 'choice' | 'option';
+    id: string;
+    change: 'added' | 'removed' | 'changed';
+    behaviorChanging: boolean;
+    detail: string;
+}
+
+function formatRangeOrNumber(value: RangeOrNumber): string {
+    return typeof value === 'number' ? String(value) : `${value.min}–${value.max}`;
+}
+
+function sameJson(left: unknown, right: unknown): boolean {
+    return JSON.stringify(left ?? null) === JSON.stringify(right ?? null);
+}
+
+function sameStringSet(left: readonly string[] | undefined, right: readonly string[] | undefined): boolean {
+    return JSON.stringify([...(left ?? [])].sort()) === JSON.stringify([...(right ?? [])].sort());
+}
+
+function formatDose(dose: SessionDose | undefined): string {
+    if (!dose) return 'no prescribed dose';
+    switch (dose.kind) {
+        case 'repetition': return `${dose.sets} × ${formatRangeOrNumber(dose.reps)} reps`;
+        case 'duration': return `${dose.sets ?? 1} × ${formatRangeOrNumber(dose.seconds)} s`;
+        case 'distance': return `${formatRangeOrNumber(dose.meters ?? dose.metres ?? 0)} m`;
+        case 'checkoff': return `${dose.rounds ?? 1} rounds`;
+    }
+}
+
+function formatLoad(load: SessionLoad | undefined): string {
+    if (!load) return 'no prescribed load';
+    switch (load.kind) {
+        case 'bodyweight': return 'bodyweight';
+        case 'mass': return `${formatRangeOrNumber(load.kg)} kg`;
+        case 'band': return `${load.bandColor} band`;
+        case 'percent_max': return `${load.percent}% max`;
+        case 'percent_one_rm': return `${load.percent}% 1RM`;
+        case 'relative_step': return `${load.percent}% of ${load.stepId}`;
+        case 'descriptive': return load.display ?? load.description ?? 'descriptive load';
+        case 'unloaded': return 'unloaded';
+    }
+}
+
+function formatEffort(effort: SessionEffort | undefined): string {
+    if (!effort) return 'none';
+    const parts: string[] = [];
+    if (effort.target !== undefined) parts.push(`${effort.kind ?? 'target'} ${formatRangeOrNumber(effort.target)}`);
+    if (effort.rpe !== undefined) parts.push(`RPE ${formatRangeOrNumber(effort.rpe)}`);
+    if (effort.rir !== undefined) parts.push(`${formatRangeOrNumber(effort.rir)} RIR`);
+    return parts.length > 0 ? parts.join(', ') : 'none';
+}
+
+function formatQuality(quality: SessionQuality | undefined): string {
+    if (!quality) return 'none';
+    const parts: string[] = [];
+    if (quality.maxLossPercent !== undefined) parts.push(`max loss ${quality.maxLossPercent}%`);
+    if (quality.velocityLossPercentCap !== undefined) parts.push(`velocity loss cap ${quality.velocityLossPercentCap}%`);
+    if (quality.technicalStop) parts.push('technical stop');
+    return parts.length > 0 ? parts.join(', ') : 'none';
+}
+
+function formatAction(action: SessionChoiceAction): string {
+    switch (action.kind) {
+        case 'select_alternative': return `use alternative ${action.alternativeId}`;
+        case 'reduce_load_percent': return `reduce load ${action.percent}%`;
+        case 'reduce_sets': return `reduce to ${action.sets} sets`;
+        case 'reduce_reps': return `reduce to ${action.reps} reps`;
+        case 'omit_step': return 'omit step';
+        case 'end_block': return 'end block';
+        case 'end_session': return 'end session';
+    }
+}
+
+function formatActions(actions: readonly SessionChoiceAction[]): string {
+    return actions.length > 0 ? actions.map(formatAction).join(' + ') : 'no effect';
+}
+
+function byId<T extends { id: string }>(items: readonly T[] | undefined): Map<string, T> {
+    return new Map((items ?? []).map(item => [item.id, item]));
+}
+
+function diffOptions(blockId: string, choiceId: string, before: readonly SessionOption[], after: readonly SessionOption[]): SessionContentDiffRow[] {
+    const rows: SessionContentDiffRow[] = [];
+    const beforeById = byId(before);
+    const afterById = byId(after);
+    for (const [id, option] of beforeById) {
+        if (!afterById.has(id)) {
+            rows.push({ scope: 'option', id: `${blockId}/${choiceId}/${id}`, change: 'removed', behaviorChanging: true, detail: `Choice option "${option.label}" was removed.` });
+        }
+    }
+    for (const [id, option] of afterById) {
+        const old = beforeById.get(id);
+        if (!old) {
+            rows.push({ scope: 'option', id: `${blockId}/${choiceId}/${id}`, change: 'added', behaviorChanging: true, detail: `Choice option "${option.label}" is new (${formatActions(option.actions)}).` });
+            continue;
+        }
+        const changes: string[] = [];
+        let behaviorChanging = false;
+        if (old.label !== option.label) changes.push(`renamed from "${old.label}"`);
+        if (!sameJson(old.actions, option.actions)) {
+            changes.push(`actions ${formatActions(old.actions)} → ${formatActions(option.actions)}`);
+            behaviorChanging = true;
+        }
+        if (changes.length > 0) {
+            rows.push({ scope: 'option', id: `${blockId}/${choiceId}/${id}`, change: 'changed', behaviorChanging, detail: `Choice option "${option.label}": ${changes.join('; ')}.` });
+        }
+    }
+    return rows;
+}
+
+function diffChoices(blockId: string, before: readonly SessionChoice[] | undefined, after: readonly SessionChoice[] | undefined): SessionContentDiffRow[] {
+    const rows: SessionContentDiffRow[] = [];
+    const beforeById = byId(before);
+    const afterById = byId(after);
+    for (const [id, choice] of beforeById) {
+        if (!afterById.has(id)) {
+            rows.push({ scope: 'choice', id: `${blockId}/${id}`, change: 'removed', behaviorChanging: true, detail: `Authored choice "${choice.trigger.description}" was removed.` });
+        }
+    }
+    for (const [id, choice] of afterById) {
+        const old = beforeById.get(id);
+        if (!old) {
+            rows.push({ scope: 'choice', id: `${blockId}/${id}`, change: 'added', behaviorChanging: true, detail: `Authored choice "${choice.trigger.description}" is new.` });
+            continue;
+        }
+        if (old.trigger.description !== choice.trigger.description) {
+            rows.push({ scope: 'choice', id: `${blockId}/${id}`, change: 'changed', behaviorChanging: false, detail: `Choice wording changed from "${old.trigger.description}" to "${choice.trigger.description}".` });
+        }
+        if (old.appliesAtStepId !== choice.appliesAtStepId) {
+            rows.push({ scope: 'choice', id: `${blockId}/${id}`, change: 'changed', behaviorChanging: true, detail: `Choice "${choice.trigger.description}" now applies at a different step.` });
+        }
+        rows.push(...diffOptions(blockId, id, old.options, choice.options));
+    }
+    return rows;
+}
+
+function diffStep(blockId: string, before: SessionStep, after: SessionStep): SessionContentDiffRow | null {
+    const changes: string[] = [];
+    let behaviorChanging = false;
+
+    if (!sameJson(before.exerciseRef, after.exerciseRef)) {
+        changes.push('movement changed');
+        behaviorChanging = true;
+    }
+    if (!sameJson(before.dose, after.dose)) {
+        changes.push(`dose ${formatDose(before.dose)} → ${formatDose(after.dose)}`);
+        behaviorChanging = true;
+    }
+    if (!sameJson(before.load, after.load)) {
+        changes.push(`load ${formatLoad(before.load)} → ${formatLoad(after.load)}`);
+        behaviorChanging = true;
+    }
+    if (!sameJson(before.effort, after.effort)) {
+        changes.push(`effort ${formatEffort(before.effort)} → ${formatEffort(after.effort)}`);
+        behaviorChanging = true;
+    }
+    if (!sameJson(before.quality, after.quality)) {
+        changes.push(`quality gauge ${formatQuality(before.quality)} → ${formatQuality(after.quality)}`);
+        behaviorChanging = true;
+    }
+    if (!sameJson(before.rest, after.rest)) {
+        changes.push(`rest ${before.rest !== undefined ? formatRangeOrNumber(before.rest) : 'none'} → ${after.rest !== undefined ? formatRangeOrNumber(after.rest) : 'none'} s`);
+        behaviorChanging = true;
+    }
+    if (before.tempo !== after.tempo) {
+        changes.push(`tempo ${before.tempo ?? 'none'} → ${after.tempo ?? 'none'}`);
+        behaviorChanging = true;
+    }
+    if (before.laterality !== after.laterality) {
+        changes.push(`laterality ${before.laterality ?? 'bilateral'} → ${after.laterality ?? 'bilateral'}`);
+        behaviorChanging = true;
+    }
+    if (Boolean(before.optional) !== Boolean(after.optional)) {
+        changes.push(after.optional ? 'required → optional' : 'optional → required');
+        behaviorChanging = true;
+    }
+    if (!sameJson(before.alternatives, after.alternatives)) {
+        changes.push('authored alternatives changed');
+        behaviorChanging = true;
+    }
+    if (!sameStringSet(before.stopConditions, after.stopConditions)) {
+        changes.push('stop conditions changed');
+        behaviorChanging = true;
+    }
+    if ((before.title ?? '') !== (after.title ?? '')) {
+        changes.push(`title changed`);
+    }
+    if ((before.notes ?? '') !== (after.notes ?? '')) {
+        changes.push('notes changed');
+    }
+
+    if (changes.length === 0) return null;
+    const label = after.title ?? before.title ?? after.id;
+    return { scope: 'step', id: `${blockId}/${after.id}`, change: 'changed', behaviorChanging, detail: `Step "${label}": ${changes.join('; ')}.` };
+}
+
+function diffBlock(before: SessionBlock, after: SessionBlock): SessionContentDiffRow[] {
+    const rows: SessionContentDiffRow[] = [];
+    const blockLabel = after.title ?? before.title ?? after.id;
+    const headerChanges: string[] = [];
+    if (before.role !== after.role) headerChanges.push(`role ${before.role} → ${after.role}`);
+    if (before.executionMode !== after.executionMode) headerChanges.push(`execution mode ${before.executionMode} → ${after.executionMode}`);
+    if (!sameJson(before.rounds, after.rounds)) {
+        headerChanges.push(`rounds ${before.rounds !== undefined ? formatRangeOrNumber(before.rounds) : 'none'} → ${after.rounds !== undefined ? formatRangeOrNumber(after.rounds) : 'none'}`);
+    }
+    if (headerChanges.length > 0) {
+        rows.push({ scope: 'block', id: after.id, change: 'changed', behaviorChanging: true, detail: `Block "${blockLabel}": ${headerChanges.join('; ')}.` });
+    }
+    if ((before.title ?? '') !== (after.title ?? '')) {
+        rows.push({ scope: 'block', id: after.id, change: 'changed', behaviorChanging: false, detail: `Block "${blockLabel}" was renamed from "${before.title ?? before.id}".` });
+    }
+
+    const beforeSteps = byId(before.steps);
+    const afterSteps = byId(after.steps);
+    for (const [id, step] of beforeSteps) {
+        if (!afterSteps.has(id)) {
+            rows.push({ scope: 'step', id: `${after.id}/${id}`, change: 'removed', behaviorChanging: true, detail: `Step "${step.title ?? id}" was removed from "${blockLabel}".` });
+        }
+    }
+    for (const [id, step] of afterSteps) {
+        const old = beforeSteps.get(id);
+        if (!old) {
+            rows.push({ scope: 'step', id: `${after.id}/${id}`, change: 'added', behaviorChanging: true, detail: `Step "${step.title ?? id}" is new in "${blockLabel}" (${formatDose(step.dose)}).` });
+            continue;
+        }
+        const stepRow = diffStep(after.id, old, step);
+        if (stepRow) rows.push(stepRow);
+    }
+
+    rows.push(...diffChoices(after.id, before.optionSets, after.optionSets));
+    return rows;
+}
+
+/**
+ * What changed between two revisions of the same session's executable content, at block,
+ * step and authored-choice granularity. Order follows the `after` definition's block/step
+ * order so the reader can scan top to bottom alongside the preview.
+ */
+export function diffSessionDefinitions(previous: SessionDefinition, next: SessionDefinition): SessionContentDiffRow[] {
+    const rows: SessionContentDiffRow[] = [];
+
+    const headerChanges: string[] = [];
+    if (previous.intent !== next.intent) headerChanges.push(`intent ${previous.intent} → ${next.intent}`);
+    if ((previous.dominantModality ?? '') !== (next.dominantModality ?? '')) {
+        headerChanges.push(`dominant modality ${previous.dominantModality ?? 'none'} → ${next.dominantModality ?? 'none'}`);
+    }
+    if (!sameStringSet(previous.modalities, next.modalities)) headerChanges.push('modalities changed');
+    if (!sameJson(previous.duration, next.duration)) {
+        const from = previous.duration ? `${previous.duration.min}–${previous.duration.max}` : 'none';
+        const to = next.duration ? `${next.duration.min}–${next.duration.max}` : 'none';
+        headerChanges.push(`duration ${from} → ${to} min`);
+    }
+    if (!sameStringSet(previous.prohibitedAdditions, next.prohibitedAdditions)) headerChanges.push('prohibited additions changed');
+    if (!sameJson(previous.companionSessions, next.companionSessions)) headerChanges.push('companion sessions changed');
+    if (headerChanges.length > 0) {
+        rows.push({ scope: 'session', id: next.id, change: 'changed', behaviorChanging: true, detail: `Session: ${headerChanges.join('; ')}.` });
+    }
+    if ((previous.title ?? '') !== (next.title ?? '') || (previous.summary ?? '') !== (next.summary ?? '')) {
+        rows.push({ scope: 'session', id: next.id, change: 'changed', behaviorChanging: false, detail: 'Title or summary text changed.' });
+    }
+
+    const beforeBlocks = byId(previous.blocks);
+    const afterBlocks = byId(next.blocks);
+    for (const [id, block] of beforeBlocks) {
+        if (!afterBlocks.has(id)) {
+            rows.push({ scope: 'block', id, change: 'removed', behaviorChanging: true, detail: `Block "${block.title ?? id}" was removed.` });
+        }
+    }
+    for (const [id, block] of afterBlocks) {
+        const old = beforeBlocks.get(id);
+        if (!old) {
+            rows.push({ scope: 'block', id, change: 'added', behaviorChanging: true, detail: `Block "${block.title ?? id}" is new (${block.steps.length} step${block.steps.length === 1 ? '' : 's'}).` });
+            continue;
+        }
+        rows.push(...diffBlock(old, block));
+    }
+
+    return rows;
+}
+
+/** True when at least one row would change what the athlete is asked to do -- not just
+ * wording. Callers use this to decide whether a diff needs explicit acknowledgement before
+ * import can proceed, versus a purely informational note. */
+export function hasBehaviorChanges(rows: readonly SessionContentDiffRow[]): boolean {
+    return rows.some(row => row.behaviorChanging);
+}

--- a/app/src/sessions/sessionDefinitionDiff.ts
+++ b/app/src/sessions/sessionDefinitionDiff.ts
@@ -39,8 +39,23 @@ function formatRangeOrNumber(value: RangeOrNumber): string {
     return typeof value === 'number' ? String(value) : `${value.min}–${value.max}`;
 }
 
+/** Recursively sorts object keys so structurally-identical values compare equal regardless
+ * of property insertion order (e.g. two independently-generated JSON payloads for the same
+ * dose). Arrays keep their order -- order is meaningful for them (steps, options, ...). */
+function canonicalize(value: unknown): unknown {
+    if (Array.isArray(value)) return value.map(canonicalize);
+    if (value !== null && typeof value === 'object') {
+        const sorted: Record<string, unknown> = {};
+        for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+            sorted[key] = canonicalize((value as Record<string, unknown>)[key]);
+        }
+        return sorted;
+    }
+    return value;
+}
+
 function sameJson(left: unknown, right: unknown): boolean {
-    return JSON.stringify(left ?? null) === JSON.stringify(right ?? null);
+    return JSON.stringify(canonicalize(left ?? null)) === JSON.stringify(canonicalize(right ?? null));
 }
 
 function sameStringSet(left: readonly string[] | undefined, right: readonly string[] | undefined): boolean {
@@ -52,7 +67,10 @@ function formatDose(dose: SessionDose | undefined): string {
     switch (dose.kind) {
         case 'repetition': return `${dose.sets} × ${formatRangeOrNumber(dose.reps)} reps`;
         case 'duration': return `${dose.sets ?? 1} × ${formatRangeOrNumber(dose.seconds)} s`;
-        case 'distance': return `${formatRangeOrNumber(dose.meters ?? dose.metres ?? 0)} m`;
+        case 'distance': {
+            const meters = dose.meters ?? dose.metres;
+            return meters !== undefined ? `${formatRangeOrNumber(meters)} m` : 'no distance set';
+        }
         case 'checkoff': return `${dose.rounds ?? 1} rounds`;
     }
 }
@@ -91,12 +109,12 @@ function formatQuality(quality: SessionQuality | undefined): string {
 
 function formatAction(action: SessionChoiceAction): string {
     switch (action.kind) {
-        case 'select_alternative': return `use alternative ${action.alternativeId}`;
-        case 'reduce_load_percent': return `reduce load ${action.percent}%`;
-        case 'reduce_sets': return `reduce to ${action.sets} sets`;
-        case 'reduce_reps': return `reduce to ${action.reps} reps`;
-        case 'omit_step': return 'omit step';
-        case 'end_block': return 'end block';
+        case 'select_alternative': return `use alternative ${action.alternativeId} for step ${action.targetStepId}`;
+        case 'reduce_load_percent': return `reduce load ${action.percent}% on step ${action.targetStepId}`;
+        case 'reduce_sets': return `reduce to ${action.sets} sets on step ${action.targetStepId}`;
+        case 'reduce_reps': return `reduce to ${action.reps} reps on step ${action.targetStepId}`;
+        case 'omit_step': return `omit step ${action.targetStepId}`;
+        case 'end_block': return `end block ${action.targetBlockId}`;
         case 'end_session': return 'end session';
     }
 }
@@ -189,7 +207,9 @@ function diffStep(blockId: string, before: SessionStep, after: SessionStep): Ses
         behaviorChanging = true;
     }
     if (!sameJson(before.rest, after.rest)) {
-        changes.push(`rest ${before.rest !== undefined ? formatRangeOrNumber(before.rest) : 'none'} → ${after.rest !== undefined ? formatRangeOrNumber(after.rest) : 'none'} s`);
+        const fromRest = before.rest !== undefined ? `${formatRangeOrNumber(before.rest)} s` : 'none';
+        const toRest = after.rest !== undefined ? `${formatRangeOrNumber(after.rest)} s` : 'none';
+        changes.push(`rest ${fromRest} → ${toRest}`);
         behaviorChanging = true;
     }
     if (before.tempo !== after.tempo) {

--- a/app/src/sessions/sessionDefinitionDiff.ts
+++ b/app/src/sessions/sessionDefinitionDiff.ts
@@ -69,7 +69,8 @@ function formatDose(dose: SessionDose | undefined): string {
         case 'duration': return `${dose.sets ?? 1} × ${formatRangeOrNumber(dose.seconds)} s`;
         case 'distance': {
             const meters = dose.meters ?? dose.metres;
-            return meters !== undefined ? `${formatRangeOrNumber(meters)} m` : 'no distance set';
+            const sets = dose.sets ?? 1;
+            return meters !== undefined ? `${sets} × ${formatRangeOrNumber(meters)} m` : `${sets} × no distance set`;
         }
         case 'checkoff': return `${dose.rounds ?? 1} rounds`;
     }
@@ -125,6 +126,21 @@ function formatActions(actions: readonly SessionChoiceAction[]): string {
 
 function byId<T extends { id: string }>(items: readonly T[] | undefined): Map<string, T> {
     return new Map((items ?? []).map(item => [item.id, item]));
+}
+
+/** True only when both sides carry exactly the same set of ids in a different order --
+ * an add/remove already produces its own row elsewhere, and this must not double-report
+ * that as a reorder too. `byId()`-based comparison elsewhere in this module is
+ * intentionally order-blind (it diffs by identity, not position), which silently missed a
+ * same-membership reorder entirely -- swapping two existing steps/blocks changed nothing
+ * `byId` could see, even though it changes execution order. */
+function orderChanged<T extends { id: string }>(before: readonly T[] | undefined, after: readonly T[] | undefined): boolean {
+    const beforeIds = (before ?? []).map(item => item.id);
+    const afterIds = (after ?? []).map(item => item.id);
+    if (beforeIds.length !== afterIds.length) return false;
+    const beforeSet = new Set(beforeIds);
+    if (afterIds.some(id => !beforeSet.has(id))) return false;
+    return beforeIds.some((id, index) => id !== afterIds[index]);
 }
 
 function diffOptions(blockId: string, choiceId: string, before: readonly SessionOption[], after: readonly SessionOption[]): SessionContentDiffRow[] {
@@ -276,6 +292,9 @@ function diffBlock(before: SessionBlock, after: SessionBlock): SessionContentDif
         const stepRow = diffStep(after.id, old, step);
         if (stepRow) rows.push(stepRow);
     }
+    if (orderChanged(before.steps, after.steps)) {
+        rows.push({ scope: 'block', id: after.id, change: 'changed', behaviorChanging: true, detail: `Block "${blockLabel}": step order changed.` });
+    }
 
     rows.push(...diffChoices(after.id, before.optionSets, after.optionSets));
     return rows;
@@ -323,6 +342,9 @@ export function diffSessionDefinitions(previous: SessionDefinition, next: Sessio
             continue;
         }
         rows.push(...diffBlock(old, block));
+    }
+    if (orderChanged(previous.blocks, next.blocks)) {
+        rows.push({ scope: 'session', id: next.id, change: 'changed', behaviorChanging: true, detail: 'Block order changed.' });
     }
 
     return rows;

--- a/docs/plans/multidomain-session-authoring-execution-and-evidence.md
+++ b/docs/plans/multidomain-session-authoring-execution-and-evidence.md
@@ -324,7 +324,7 @@ rewritten as an outcome; an in-progress item retains its remaining acceptance wo
 | M3.4 | Catalog-to-definition adapter and generic runner strength parity | `[x]` | Runner parity reached (RIR/gauges, context, 1RM writeback, shared read); dual-runner retained for safe transition |
 | M3.5 | Bounded exercise/drill facet vocabulary | `[x]` | — |
 | M3.6 | External plan/session schema v2 adapter | `[x]` | Schema, validation, resolver/display wiring, export support shipped; M3.7's fine-grained diff remains |
-| M3.7 | Full semantic import preview and diff | `[-]` | M3.6 semantic source and revision diff |
+| M3.7 | Full semantic import preview and diff | `[x]` | — |
 | M3.8 | Manual block-first session builder | `[-]` | Bounded hardening only: option sets / fixture-equivalence / accessibility gaps that matter in real use; stop when current builder is sufficient |
 | M4.1 | Group execution modes | `[x]` | M2.5 |
 | M4.2 | Recorded athlete choices and alternatives | `[x]` | M4.1, M3.5 |
@@ -837,7 +837,7 @@ export JSON (`canonical_workout_v1`) to be directly pasted and converted into no
 scoped: fine-grained per-field content diffing for a v2 session (`externalPlanDiff.ts`
 reports a coarse "the session content changed" for either schema).
 
-### M3.7 `[-]` Full semantic import preview and diff
+### M3.7 `[x]` Full semantic import preview and diff
 
 **Progress (2026-08-18).** `SessionDefinitionPreview` shows normalized blocks and groups, dose,
 effort, rest, tempo, optionality, unresolved movement status, authored option triggers/effects,
@@ -855,6 +855,46 @@ revision diff flags every behavior-changing field.
 **Done when.** Import cannot proceed through unresolved blocking semantics; changing per-side
 to bilateral, optional to required, or end-block to reduce-load is visible before confirm; and
 the preview shows every supplied workout step rather than one summary line.
+
+**Outcome (2026-08-19).** The two remaining gaps from the 2026-08-18 progress note are closed.
+
+* **`external-plan@2` full-content preview.** `PlanPreview`'s per-session summary row now
+  renders an expandable "Full session content" `<details>` (closed by default so the scannable
+  list stays intact) that mounts the existing `SessionDefinitionPreview` against
+  `session.definition` for every v2 session — the same block/step/dose/effort/option-set
+  rendering JSON/manual authoring already had. v1 sessions are unaffected: `prescription` isn't
+  a `SessionDefinition`, so the summary line remains their only preview, matching what the
+  schema can express.
+* **Fine-grained revision diff.** New pure `sessions/sessionDefinitionDiff.ts`
+  (`diffSessionDefinitions`) replaces the coarse "the session content changed" line with
+  block/step/choice-level rows, each tagged `behaviorChanging`. Per-side to bilateral,
+  optional to required, dose/load/effort/quality/rest/tempo changes, an authored choice's
+  actions changing (including the named end-block-to-reduce-load example), and added/removed
+  blocks/steps/choices/options are all `behaviorChanging: true`; title/notes/summary/trigger
+  wording are `false`. `externalPlanDiff.ts` calls it only when both the stored and pasted
+  session are v2 (`isV2Session` on both sides) — v1's flat `ExternalPrescription` has no
+  comparable block/step structure and keeps the coarse check, so the existing v1 diff test's
+  literal "the session content changed" expectation still holds unmodified.
+* **Blocking on unreviewed behavior changes.** Referential-integrity blocking (an option
+  action's `targetStepId`/`targetBlockId` not resolving) was already enforced pre-preview by
+  `validateSessionDefinition`, itself already called on every v2 session's `definition` inside
+  `validateExternalTrainingPlanV2` — that half of the "Done when" line was already true going
+  in. What was missing was making a *behavior-changing* diff impossible to scroll past: the
+  preview now lists every fine-grained row inline under its session (⚠-prefixed and
+  red-highlighted when `behaviorChanging`), and renders a checkbox — "I reviewed the N behavior
+  changes marked ⚠ above" — that must be checked before **Import this plan** enables, whenever
+  `behaviorChangeCount > 0`. A diff containing only cosmetic wording changes never shows the
+  checkbox and never blocks.
+
+Verified by `sessions/sessionDefinitionDiff.test.ts` (identical-definition no-op, per-side↔
+bilateral, optional↔required, the end-block/reduce-load choice-action swap, dose/load
+before/after formatting, added/removed blocks and steps, cosmetic-only wording producing zero
+behavior rows) and new `externalPlanDiff.ts` cases in `ExternalPlanImport.test.ts` (a v2/v2
+pair surfaces `contentChanges` and the "(see below)" summary suffix; a title-only v2 change
+stays cosmetic; an unchanged v2 definition produces no diff row) — the pre-existing v1 diff
+tests pass unmodified. `sessions/architecture.test.ts` and `engine/externalArchitecture.test.ts`
+pass unchanged (the new diff module only imports `sessions/models.ts`). Full `npm run check`
+(typecheck, lint, unit tests, catalog validation) passes.
 
 ### M3.8 `[-]` Manual block-first session builder
 

--- a/docs/plans/multidomain-session-authoring-execution-and-evidence.md
+++ b/docs/plans/multidomain-session-authoring-execution-and-evidence.md
@@ -886,14 +886,34 @@ the preview shows every supplied workout step rather than one summary line.
   `behaviorChangeCount > 0`. A diff containing only cosmetic wording changes never shows the
   checkbox and never blocks.
 
-Verified by `sessions/sessionDefinitionDiff.test.ts` (identical-definition no-op, per-side↔
-bilateral, optional↔required, the end-block/reduce-load choice-action swap, dose/load
-before/after formatting, added/removed blocks and steps, cosmetic-only wording producing zero
-behavior rows) and new `externalPlanDiff.ts` cases in `ExternalPlanImport.test.ts` (a v2/v2
-pair surfaces `contentChanges` and the "(see below)" summary suffix; a title-only v2 change
-stays cosmetic; an unchanged v2 definition produces no diff row) — the pre-existing v1 diff
-tests pass unmodified. `sessions/architecture.test.ts` and `engine/externalArchitecture.test.ts`
-pass unchanged (the new diff module only imports `sessions/models.ts`). Full `npm run check`
+**Review correction (2026-08-19).** A repo-owner review of `sessionDefinitionDiff.ts` found
+four correctness issues, all fixed in a follow-up commit on this branch: `formatAction()`
+rendered no `targetStepId`/`targetBlockId`, so a choice option re-targeted to a different
+step/block printed identical before/after text; `sameJson()` used raw `JSON.stringify`,
+so two semantically identical objects with differently-ordered keys (a real risk given the
+import flow regenerates full plan JSON from an LLM on each revision) were reported as
+changed; `formatDose('distance')` fabricated "0 m" for an unset distance; and the rest-change
+message misattached its ` s` unit suffix to the literal `'none'`. A second review pass found
+two further gaps, also fixed: `formatDose('distance')` omitted `sets`, so a sets-only change
+on a distance dose produced identical text; and block/step comparison was purely by-id
+(`byId()`-keyed maps), so swapping two existing blocks or steps — a real execution-order
+change — produced no diff row at all and could bypass import acknowledgement. Both are now
+detected via a same-membership, different-position check (`orderChanged`) layered on top of
+the existing add/remove detection.
+
+Verified by `sessions/sessionDefinitionDiff.test.ts` (identical-definition no-op, laterality
+change in **both** directions, optional↔required, the end-block/reduce-load choice-action
+swap, dose/load before/after formatting, **both** an added step + removed block and a removed
+step + added block, distance-dose set-count changes, a same-membership block/step reorder
+distinct from add/remove, no false-positive reorder when order is unchanged, structurally
+identical objects with reordered keys producing no row, cosmetic-only wording producing zero
+behavior rows) and `externalPlanDiff.ts`/`PlanPreview` cases in `ExternalPlanImport.test.tsx`
+(a v2/v2 pair surfaces `contentChanges` and the "(see below)" summary suffix; a title-only v2
+change stays cosmetic; an unchanged v2 definition produces no diff row; `PlanPreview`'s Import
+button renders disabled with the acknowledgement checkbox shown for a behavior-changing diff,
+and enabled with no checkbox for a cosmetic-only one) — the pre-existing v1 diff tests pass
+unmodified. `sessions/architecture.test.ts` and `engine/externalArchitecture.test.ts` pass
+unchanged (the new diff module only imports `sessions/models.ts`). Full `npm run check`
 (typecheck, lint, unit tests, catalog validation) passes.
 
 ### M3.8 `[-]` Manual block-first session builder


### PR DESCRIPTION
Closes M3.7's two remaining gaps from `docs/plans/multidomain-session-authoring-execution-and-evidence.md`:

- `ExternalPlanImport` now renders the full `SessionDefinitionPreview` (blocks/steps/dose/effort/option sets) for each `external-plan@2` session, not just a one-line summary.
- New `sessions/sessionDefinitionDiff.ts` computes a block/step/choice-level revision diff between two `SessionDefinition`s, tagging every row `behaviorChanging` or cosmetic. `externalPlanDiff.ts` uses it for v2/v2 session pairs, replacing the coarse "content changed" line; v1 keeps its coarse check since `ExternalPrescription` has no comparable structure.
- The import preview lists diff rows inline (⚠ for behavior-changing) and requires an explicit acknowledgement checkbox before Import enables whenever unreviewed behavior changes exist.

Verified with `npm run check` (typecheck, lint, unit tests, catalog validation) — full plan outcome notes are in the doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed previews of v2 session definitions during external plan imports.
  * Added fine-grained highlighting for session, block, step, choice, and option changes.
  * Distinguished behavior-changing updates from cosmetic text changes.
  * Added expandable session details and clearer visual change indicators.
  * Import confirmation now requires acknowledgment of behavior-changing updates.

* **Documentation**
  * Documented completion of full session-content previews and behavior-change review requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->