### PR TITLE
feat(sessions): bounded M3.8 builder hardening (load/effort/choices)

### DIFF
--- a/app/src/components/session/ManualSessionBuilder.css
+++ b/app/src/components/session/ManualSessionBuilder.css
@@ -322,6 +322,217 @@
     min-height: 0;
 }
 
+.builder-alternatives {
+    grid-column: 1 / -1;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    padding-top: 0.35rem;
+    border-top: 1px solid #334155;
+}
+
+.builder-alternatives-header,
+.builder-choices-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.5rem;
+    color: #94a3b8;
+    font-size: 0.75rem;
+}
+
+.builder-alternatives-header button,
+.builder-choices-header button {
+    background: transparent;
+    border: 1px dashed #475569;
+    color: #94a3b8;
+    border-radius: 4px;
+    padding: 0.25rem 0.5rem;
+    font-size: 0.72rem;
+    cursor: pointer;
+    white-space: nowrap;
+}
+
+.builder-alternative-row {
+    display: flex;
+    gap: 0.4rem;
+    align-items: center;
+}
+
+.builder-alternative-row input,
+.builder-alternative-row select {
+    flex: 1;
+    min-height: 36px;
+    box-sizing: border-box;
+    padding: 0.3rem 0.4rem;
+    border: 1px solid #475569;
+    border-radius: 4px;
+    background: #1e293b;
+    color: #f8fafc;
+    font-size: 0.8rem;
+}
+
+.builder-alternative-row button {
+    border: 0;
+    background: transparent;
+    color: #fca5a5;
+    cursor: pointer;
+    min-height: 36px;
+    font-size: 0.72rem;
+}
+
+.builder-choices {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding-top: 0.5rem;
+    border-top: 1px dashed #334155;
+}
+
+.builder-choice-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    padding: 0.6rem;
+    background: #111c33;
+    border: 1px solid #334155;
+    border-radius: 6px;
+}
+
+.builder-choice-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.builder-choice-card label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    color: #94a3b8;
+    font-size: 0.75rem;
+}
+
+.builder-choice-card > label input {
+    box-sizing: border-box;
+    width: 100%;
+    min-height: 36px;
+    padding: 0.35rem 0.45rem;
+    border: 1px solid #475569;
+    border-radius: 4px;
+    background: #1e293b;
+    color: #f8fafc;
+}
+
+.builder-choice-row select {
+    min-height: 36px;
+    padding: 0.3rem 0.4rem;
+    border: 1px solid #475569;
+    border-radius: 4px;
+    background: #1e293b;
+    color: #f8fafc;
+}
+
+.builder-choice-row button,
+.builder-option-row button {
+    border: 0;
+    background: transparent;
+    color: #fca5a5;
+    cursor: pointer;
+    min-height: 36px;
+    font-size: 0.72rem;
+    white-space: nowrap;
+}
+
+.builder-options-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    padding-left: 0.5rem;
+    border-left: 2px solid #334155;
+}
+
+.builder-option-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+}
+
+.builder-option-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.builder-option-row input {
+    flex: 1;
+    min-height: 36px;
+    box-sizing: border-box;
+    padding: 0.3rem 0.4rem;
+    border: 1px solid #475569;
+    border-radius: 4px;
+    background: #1e293b;
+    color: #f8fafc;
+    font-size: 0.8rem;
+}
+
+.builder-action-row {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    flex-wrap: wrap;
+    padding-left: 0.5rem;
+}
+
+.builder-action-row select,
+.builder-action-row input {
+    min-height: 36px;
+    box-sizing: border-box;
+    padding: 0.3rem 0.4rem;
+    border: 1px solid #475569;
+    border-radius: 4px;
+    background: #1e293b;
+    color: #f8fafc;
+    font-size: 0.78rem;
+}
+
+.builder-action-row label {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+    color: #94a3b8;
+    font-size: 0.72rem;
+}
+
+.builder-action-row button {
+    border: 0;
+    background: transparent;
+    color: #fca5a5;
+    cursor: pointer;
+    min-height: 36px;
+    font-size: 0.72rem;
+}
+
+.builder-choice-warning {
+    color: #fbbf24;
+    font-size: 0.72rem;
+    font-style: normal;
+}
+
+.add-action-btn,
+.add-option-btn {
+    align-self: flex-start;
+    background: transparent;
+    border: 1px dashed #475569;
+    color: #94a3b8;
+    border-radius: 6px;
+    padding: 0.3rem 0.55rem;
+    font-size: 0.72rem;
+    cursor: pointer;
+}
+
 .builder-actions {
     margin-top: 0.75rem;
 }
@@ -354,6 +565,12 @@
     }
 
     .builder-step-row {
+        flex-wrap: wrap;
+    }
+
+    .builder-alternative-row,
+    .builder-choice-row,
+    .builder-option-row {
         flex-wrap: wrap;
     }
 }

--- a/app/src/components/session/ManualSessionBuilder.test.tsx
+++ b/app/src/components/session/ManualSessionBuilder.test.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { ManualSessionBuilder } from './ManualSessionBuilder';
+
+vi.mock('../../services/sessionDefinitionService', () => ({ sessionDefinitionService: { saveDefinitionRevision: vi.fn() } }));
+vi.mock('../../services/sessionAuthoringService', () => ({ prepareUnplannedSessionLaunch: vi.fn() }));
+vi.mock('../../services/sessionOccurrenceService', () => ({
+    sessionOccurrenceService: {
+        scheduleOccurrence: vi.fn(), replaceRecommendationOccurrence: vi.fn(), addAdditionalSessionOccurrence: vi.fn(),
+    },
+}));
+
+/**
+ * M3.8 bounded hardening: the builder gained load, effort (RIR), alternative and authored
+ * choice editing so the M0.2 fixtures' shapes are reachable without JSON. This repo has no
+ * interactive component-test harness (no @testing-library/react) -- these are markup-level
+ * smoke tests, matching the existing convention for sibling session components
+ * (SessionJsonImport.test.tsx, SessionDestinationSheet.test.tsx). The underlying reducer
+ * logic (choice/option/action/alternative defaults) is covered directly in
+ * sessions/sessionDraft.test.ts.
+ */
+describe('ManualSessionBuilder (M3.8 bounded hardening)', () => {
+    it('renders the load, effort and authored-choice controls the fixtures need', () => {
+        const html = renderToStaticMarkup(
+            <ManualSessionBuilder userId="u1" onClose={vi.fn()} onStartExecution={vi.fn()} />,
+        );
+
+        // Load kinds needed by fixtures 01/02 (percent_one_rm, descriptive, ...).
+        expect(html).toContain('% of 1RM');
+        expect(html).toContain('Descriptive (last reviewed load)');
+        expect(html).toContain('Bodyweight');
+
+        // Effort now offers RIR alongside RPE (fixture 01 uses RIR for both strength steps).
+        expect(html).toContain('>RPE<');
+        expect(html).toContain('>RIR<');
+
+        // Authored choices (D-MCHOICE) are buildable without JSON.
+        expect(html).toContain('Authored choices');
+        expect(html).toContain('Add choice');
+        expect(html).toContain('Add alternative');
+    });
+});

--- a/app/src/components/session/ManualSessionBuilder.tsx
+++ b/app/src/components/session/ManualSessionBuilder.tsx
@@ -174,12 +174,27 @@ export const ManualSessionBuilder: React.FC<ManualSessionBuilderProps> = ({ user
         }),
     }));
 
-    const removeAlternative = (blockIndex: number, stepIndex: number, altId: string) => setBlocks(current => current.map((block, index) => index !== blockIndex ? block : {
-        ...block,
-        steps: block.steps.map((step, stepAt) => stepAt !== stepIndex ? step : {
-            ...step,
-            alternatives: (step.alternatives ?? []).filter(alt => alt.id !== altId),
-        }),
+    // Also clears alternativeId on any select_alternative action targeting this step that
+    // referenced the removed alternative -- otherwise it dangles silently: validation only
+    // checks targetStepId/targetBlockId, and the runner's applySelectAlternative no-ops on an
+    // unresolvable id, so the athlete would pick "switch exercise" and nothing would happen.
+    const removeAlternative = (blockIndex: number, stepIndex: number, altId: string) => setBlocks(current => current.map((block, index) => {
+        if (index !== blockIndex) return block;
+        const removedFromStepId = block.steps[stepIndex]?.id;
+        return {
+            ...block,
+            steps: block.steps.map((step, stepAt) => stepAt !== stepIndex ? step : {
+                ...step,
+                alternatives: (step.alternatives ?? []).filter(alt => alt.id !== altId),
+            }),
+            optionSets: (block.optionSets ?? []).map(choice => choice.appliesAtStepId !== removedFromStepId ? choice : {
+                ...choice,
+                options: choice.options.map(option => ({
+                    ...option,
+                    actions: option.actions.map(action => action.kind === 'select_alternative' && action.alternativeId === altId ? { ...action, alternativeId: '' } : action),
+                })),
+            }),
+        };
     }));
 
     const updateAlternative = (blockIndex: number, stepIndex: number, altId: string, exerciseId: string | undefined, title: string) => setBlocks(current => current.map((block, index) => index !== blockIndex ? block : {
@@ -204,6 +219,29 @@ export const ManualSessionBuilder: React.FC<ManualSessionBuilderProps> = ({ user
     const removeChoice = (blockIndex: number, choiceId: string) => updateChoices(blockIndex, choices => choices.filter(choice => choice.id !== choiceId));
     const updateChoice = (blockIndex: number, choiceId: string, patch: Partial<SessionChoice>) => updateChoices(blockIndex, choices => choices.map(choice => choice.id !== choiceId ? choice : { ...choice, ...patch }));
 
+    // Retargets every action across this choice's options that pointed at the previous
+    // `appliesAtStepId`, so switching which step a choice applies to can't silently leave an
+    // action mutating the *old* step. `select_alternative` additionally loses its alternativeId
+    // -- alternatives are step-scoped, so an alternative id valid on the old step is meaningless
+    // (and may not even exist) on the new one; the author must re-pick it.
+    const updateChoiceAppliesAtStep = (blockIndex: number, choiceId: string, nextStepId: string) => updateChoices(blockIndex, choices => choices.map(choice => {
+        if (choice.id !== choiceId) return choice;
+        const previousStepId = choice.appliesAtStepId;
+        return {
+            ...choice,
+            appliesAtStepId: nextStepId,
+            options: choice.options.map(option => ({
+                ...option,
+                actions: option.actions.map(action => {
+                    if (!('targetStepId' in action) || action.targetStepId !== previousStepId) return action;
+                    return action.kind === 'select_alternative'
+                        ? { ...action, targetStepId: nextStepId, alternativeId: '' }
+                        : { ...action, targetStepId: nextStepId };
+                }),
+            })),
+        };
+    }));
+
     const updateOptions = (blockIndex: number, choiceId: string, updater: (options: SessionOption[]) => SessionOption[]) => updateChoices(blockIndex, choices => choices.map(choice => choice.id !== choiceId ? choice : { ...choice, options: updater(choice.options) }));
     const addOption = (blockIndex: number, choiceId: string) => updateOptions(blockIndex, choiceId, options => [...options, createDraftOption(newId)]);
     const removeOption = (blockIndex: number, choiceId: string, optionId: string) => updateOptions(blockIndex, choiceId, options => options.filter(option => option.id !== optionId));
@@ -216,7 +254,12 @@ export const ManualSessionBuilder: React.FC<ManualSessionBuilderProps> = ({ user
         updateActions(blockIndex, choice.id, optionId, actions => [...actions, createDraftAction(kind, { stepId: choice.appliesAtStepId, blockId: block.id, firstAlternativeId })]);
     };
     const removeAction = (blockIndex: number, choiceId: string, optionId: string, actionIndex: number) => updateActions(blockIndex, choiceId, optionId, actions => actions.filter((_, index) => index !== actionIndex));
+    // Patches fields on the action *without* changing its kind (%, sets, reps, alternativeId, ...).
     const updateAction = (blockIndex: number, choiceId: string, optionId: string, actionIndex: number, patch: Partial<SessionChoiceAction>) => updateActions(blockIndex, choiceId, optionId, actions => actions.map((action, index) => index !== actionIndex ? action : { ...action, ...patch } as SessionChoiceAction));
+    // Swaps the action's kind entirely. Merging a patch (as updateAction does) would leave stale
+    // fields from the previous kind on the object -- e.g. switching reduce_load_percent to
+    // end_session must drop `percent`/`targetStepId`, not keep them alongside the new kind.
+    const replaceAction = (blockIndex: number, choiceId: string, optionId: string, actionIndex: number, next: SessionChoiceAction) => updateActions(blockIndex, choiceId, optionId, actions => actions.map((action, index) => index !== actionIndex ? action : next));
 
     const review = () => {
         const result = validateSessionDefinition(definition);
@@ -348,7 +391,7 @@ export const ManualSessionBuilder: React.FC<ManualSessionBuilderProps> = ({ user
                                 </div>
                                 {(block.optionSets ?? []).map(choice => <div key={choice.id} className="builder-choice-card">
                                     <div className="builder-choice-row">
-                                        <label>Applies at<select value={choice.appliesAtStepId} onChange={event => updateChoice(blockIndex, choice.id, { appliesAtStepId: event.target.value })}>
+                                        <label>Applies at<select value={choice.appliesAtStepId} onChange={event => updateChoiceAppliesAtStep(blockIndex, choice.id, event.target.value)}>
                                             {block.steps.map(step => <option key={step.id} value={step.id}>{step.title ?? step.id}</option>)}
                                         </select></label>
                                         <button type="button" onClick={() => removeChoice(blockIndex, choice.id)} aria-label="Remove choice">Remove choice</button>
@@ -358,12 +401,12 @@ export const ManualSessionBuilder: React.FC<ManualSessionBuilderProps> = ({ user
                                         {choice.options.map(option => <div key={option.id} className="builder-option-card">
                                             <div className="builder-option-row">
                                                 <input value={option.label} onChange={event => updateOptionLabel(blockIndex, choice.id, option.id, event.target.value)} aria-label="Option label" />
-                                                <button type="button" onClick={() => removeOption(blockIndex, choice.id, option.id)} aria-label="Remove option">Remove</button>
+                                                <button type="button" disabled={choice.options.length <= 1} onClick={() => removeOption(blockIndex, choice.id, option.id)} aria-label="Remove option">Remove</button>
                                             </div>
                                             {option.actions.map((action, actionIndex) => {
                                                 const targetStep = block.steps.find(step => step.id === choice.appliesAtStepId);
                                                 return <div key={actionIndex} className="builder-action-row">
-                                                    <select value={action.kind} onChange={event => updateAction(blockIndex, choice.id, option.id, actionIndex, createDraftAction(event.target.value as SessionChoiceAction['kind'], { stepId: choice.appliesAtStepId, blockId: block.id, firstAlternativeId: targetStep?.alternatives?.[0]?.id }))}>
+                                                    <select value={action.kind} onChange={event => replaceAction(blockIndex, choice.id, option.id, actionIndex, createDraftAction(event.target.value as SessionChoiceAction['kind'], { stepId: choice.appliesAtStepId, blockId: block.id, firstAlternativeId: targetStep?.alternatives?.[0]?.id }))}>
                                                         {ACTION_KINDS.map(kind => <option key={kind} value={kind}>{ACTION_KIND_LABELS[kind]}</option>)}
                                                     </select>
                                                     {action.kind === 'reduce_load_percent' && <label>%<input type="number" min={1} max={99} value={action.percent} onChange={event => updateAction(blockIndex, choice.id, option.id, actionIndex, { percent: Math.max(1, Number(event.target.value) || 1) })} /></label>}

--- a/app/src/components/session/ManualSessionBuilder.tsx
+++ b/app/src/components/session/ManualSessionBuilder.tsx
@@ -1,8 +1,27 @@
 import React, { useMemo, useState } from 'react';
-import type { BlockExecutionMode, BlockRole, SessionBlock, SessionDefinition, SessionDose, SessionStep } from '../../sessions/models';
+import type {
+    BlockExecutionMode,
+    BlockRole,
+    SessionBlock,
+    SessionChoice,
+    SessionChoiceAction,
+    SessionDefinition,
+    SessionDose,
+    SessionLoad,
+    SessionOption,
+    SessionStep,
+} from '../../sessions/models';
 import { validateSessionDefinition } from '../../sessions/validation';
 import { EXERCISES } from '../../workouts/exercises';
-import { duplicateDraftBlock, duplicateDraftStep, moveDraftItem } from '../../sessions/sessionDraft';
+import {
+    createDraftAction,
+    createDraftAlternative,
+    createDraftChoice,
+    createDraftOption,
+    duplicateDraftBlock,
+    duplicateDraftStep,
+    moveDraftItem,
+} from '../../sessions/sessionDraft';
 import { SessionDefinitionPreview } from './SessionDefinitionPreview';
 import { type PreparedSessionLaunch, SessionDestinationSheet } from './SessionDestinationSheet';
 import './ManualSessionBuilder.css';
@@ -10,6 +29,32 @@ import './ManualSessionBuilder.css';
 type ManualModality = 'strength' | 'cycling' | 'running' | 'field' | 'mobility' | 'cross_training';
 const BLOCK_ROLES: BlockRole[] = ['warmup', 'main', 'accessory', 'cooldown', 'recovery'];
 const EXECUTION_MODES: BlockExecutionMode[] = ['sequential', 'circuit', 'superset', 'alternating'];
+type LoadKind = SessionLoad['kind'] | 'none';
+const LOAD_KINDS: LoadKind[] = ['none', 'bodyweight', 'mass', 'percent_max', 'percent_one_rm', 'band', 'descriptive', 'unloaded'];
+const LOAD_KIND_LABELS: Record<LoadKind, string> = {
+    none: 'Not prescribed', bodyweight: 'Bodyweight', mass: 'Mass (kg)', percent_max: '% of max',
+    percent_one_rm: '% of 1RM', band: 'Resistance band', descriptive: 'Descriptive (last reviewed load)',
+    unloaded: 'Unloaded', relative_step: '% of another step',
+};
+const ACTION_KINDS: SessionChoiceAction['kind'][] = ['reduce_load_percent', 'reduce_sets', 'reduce_reps', 'omit_step', 'select_alternative', 'end_block', 'end_session'];
+const ACTION_KIND_LABELS: Record<SessionChoiceAction['kind'], string> = {
+    reduce_load_percent: 'Reduce load %', reduce_sets: 'Reduce to N sets', reduce_reps: 'Reduce to N reps',
+    omit_step: 'Omit this movement', select_alternative: 'Switch to an alternative movement',
+    end_block: 'End this block', end_session: 'End the session',
+};
+
+function defaultLoadForKind(kind: SessionLoad['kind']): SessionLoad {
+    switch (kind) {
+        case 'mass': return { kind, kg: 20 };
+        case 'percent_max': return { kind, percent: 70 };
+        case 'percent_one_rm': return { kind, percent: 70 };
+        case 'band': return { kind, bandColor: 'medium' };
+        case 'descriptive': return { kind, display: '' };
+        case 'bodyweight': return { kind };
+        case 'unloaded': return { kind };
+        case 'relative_step': return { kind, stepId: '', percent: 100 };
+    }
+}
 
 function newId(prefix: string): string {
     return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
@@ -115,6 +160,64 @@ export const ManualSessionBuilder: React.FC<ManualSessionBuilderProps> = ({ user
         updateStep(blockIndex, stepIndex, { dose });
     };
 
+    const changeLoad = (blockIndex: number, stepIndex: number, kind: LoadKind) =>
+        updateStep(blockIndex, stepIndex, { load: kind === 'none' ? undefined : defaultLoadForKind(kind) });
+
+    const changeEffort = (blockIndex: number, stepIndex: number, kind: 'none' | 'rpe' | 'rir') =>
+        updateStep(blockIndex, stepIndex, { effort: kind === 'none' ? undefined : { kind, target: kind === 'rpe' ? 7 : 3 } });
+
+    const addAlternative = (blockIndex: number, stepIndex: number) => setBlocks(current => current.map((block, index) => index !== blockIndex ? block : {
+        ...block,
+        steps: block.steps.map((step, stepAt) => stepAt !== stepIndex ? step : {
+            ...step,
+            alternatives: [...(step.alternatives ?? []), createDraftAlternative(undefined, 'Alternative movement', newId)],
+        }),
+    }));
+
+    const removeAlternative = (blockIndex: number, stepIndex: number, altId: string) => setBlocks(current => current.map((block, index) => index !== blockIndex ? block : {
+        ...block,
+        steps: block.steps.map((step, stepAt) => stepAt !== stepIndex ? step : {
+            ...step,
+            alternatives: (step.alternatives ?? []).filter(alt => alt.id !== altId),
+        }),
+    }));
+
+    const updateAlternative = (blockIndex: number, stepIndex: number, altId: string, exerciseId: string | undefined, title: string) => setBlocks(current => current.map((block, index) => index !== blockIndex ? block : {
+        ...block,
+        steps: block.steps.map((step, stepAt) => stepAt !== stepIndex ? step : {
+            ...step,
+            alternatives: (step.alternatives ?? []).map(alt => alt.id !== altId ? alt : {
+                ...alt, title, exerciseRef: exerciseId ? { kind: 'catalog', exerciseId } : { kind: 'unresolved_free_text', name: title },
+            }),
+        }),
+    }));
+
+    // Authored choices (D-MCHOICE) live on the block, not the step, so a single choice can be
+    // remapped for multiple steps' alternatives -- but every fixture and this builder only ever
+    // scopes one to `appliesAtStepId`. Mutations are keyed by choice/option id, not index, since
+    // an option's action list can change length independently of its siblings.
+    const updateChoices = (blockIndex: number, updater: (choices: SessionChoice[]) => SessionChoice[]) => setBlocks(current => current.map((block, index) => index !== blockIndex ? block : {
+        ...block, optionSets: updater(block.optionSets ?? []),
+    }));
+
+    const addChoice = (blockIndex: number, appliesAtStepId: string) => updateChoices(blockIndex, choices => [...choices, createDraftChoice(appliesAtStepId, newId)]);
+    const removeChoice = (blockIndex: number, choiceId: string) => updateChoices(blockIndex, choices => choices.filter(choice => choice.id !== choiceId));
+    const updateChoice = (blockIndex: number, choiceId: string, patch: Partial<SessionChoice>) => updateChoices(blockIndex, choices => choices.map(choice => choice.id !== choiceId ? choice : { ...choice, ...patch }));
+
+    const updateOptions = (blockIndex: number, choiceId: string, updater: (options: SessionOption[]) => SessionOption[]) => updateChoices(blockIndex, choices => choices.map(choice => choice.id !== choiceId ? choice : { ...choice, options: updater(choice.options) }));
+    const addOption = (blockIndex: number, choiceId: string) => updateOptions(blockIndex, choiceId, options => [...options, createDraftOption(newId)]);
+    const removeOption = (blockIndex: number, choiceId: string, optionId: string) => updateOptions(blockIndex, choiceId, options => options.filter(option => option.id !== optionId));
+    const updateOptionLabel = (blockIndex: number, choiceId: string, optionId: string, label: string) => updateOptions(blockIndex, choiceId, options => options.map(option => option.id !== optionId ? option : { ...option, label }));
+
+    const updateActions = (blockIndex: number, choiceId: string, optionId: string, updater: (actions: SessionChoiceAction[]) => SessionChoiceAction[]) => updateOptions(blockIndex, choiceId, options => options.map(option => option.id !== optionId ? option : { ...option, actions: updater(option.actions) }));
+    const addAction = (blockIndex: number, block: SessionBlock, choice: SessionChoice, optionId: string, kind: SessionChoiceAction['kind']) => {
+        const targetStep = block.steps.find(step => step.id === choice.appliesAtStepId);
+        const firstAlternativeId = targetStep?.alternatives?.[0]?.id;
+        updateActions(blockIndex, choice.id, optionId, actions => [...actions, createDraftAction(kind, { stepId: choice.appliesAtStepId, blockId: block.id, firstAlternativeId })]);
+    };
+    const removeAction = (blockIndex: number, choiceId: string, optionId: string, actionIndex: number) => updateActions(blockIndex, choiceId, optionId, actions => actions.filter((_, index) => index !== actionIndex));
+    const updateAction = (blockIndex: number, choiceId: string, optionId: string, actionIndex: number, patch: Partial<SessionChoiceAction>) => updateActions(blockIndex, choiceId, optionId, actions => actions.map((action, index) => index !== actionIndex ? action : { ...action, ...patch } as SessionChoiceAction));
+
     const review = () => {
         const result = validateSessionDefinition(definition);
         if (!result.ok) {
@@ -176,7 +279,9 @@ export const ManualSessionBuilder: React.FC<ManualSessionBuilderProps> = ({ user
                                 {block.steps.map((step, stepIndex) => {
                                     const selectedExercise = step.exerciseRef?.kind === 'catalog' ? step.exerciseRef.exerciseId : '__custom__';
                                     const dose = step.dose;
-                                    const rpe = step.effort?.kind === 'rpe' && typeof step.effort.target === 'number' ? step.effort.target : '';
+                                    const effortKind: 'none' | 'rpe' | 'rir' = step.effort?.kind === 'rir' ? 'rir' : step.effort?.kind === 'rpe' ? 'rpe' : 'none';
+                                    const effortTarget = typeof step.effort?.target === 'number' ? step.effort.target : '';
+                                    const loadKind: LoadKind = step.load?.kind ?? 'none';
                                     return <div key={step.id} className="builder-step-card">
                                         <div className="builder-step-row"><span className="step-idx">{stepIndex + 1}.</span>
                                             <input className="step-title-input" value={step.title ?? ''} onChange={event => updateStep(blockIndex, stepIndex, {
@@ -199,7 +304,8 @@ export const ManualSessionBuilder: React.FC<ManualSessionBuilderProps> = ({ user
                                             {dose?.kind === 'repetition' && <><label>Sets<input type="number" min={1} value={dose.sets} onChange={event => updateStep(blockIndex, stepIndex, { dose: { ...dose, sets: Math.max(1, Number(event.target.value) || 1) } })} /></label><label>Reps<input type="number" min={1} value={typeof dose.reps === 'number' ? dose.reps : dose.reps.min} onChange={event => updateStep(blockIndex, stepIndex, { dose: { ...dose, reps: Math.max(1, Number(event.target.value) || 1) } })} /></label></>}
                                             {dose?.kind === 'duration' && <><label>Sets<input type="number" min={1} value={dose.sets ?? 1} onChange={event => updateStep(blockIndex, stepIndex, { dose: { ...dose, sets: Math.max(1, Number(event.target.value) || 1) } })} /></label><label>Seconds<input type="number" min={1} value={typeof dose.seconds === 'number' ? dose.seconds : dose.seconds.min} onChange={event => updateStep(blockIndex, stepIndex, { dose: { ...dose, seconds: Math.max(1, Number(event.target.value) || 1) } })} /></label></>}
                                             {dose?.kind === 'distance' && <><label>Sets<input type="number" min={1} value={dose.sets ?? 1} onChange={event => updateStep(blockIndex, stepIndex, { dose: { ...dose, sets: Math.max(1, Number(event.target.value) || 1) } })} /></label><label>Metres<input type="number" min={1} value={typeof dose.meters === 'number' ? dose.meters : (typeof dose.metres === 'number' ? dose.metres : '')} onChange={event => updateStep(blockIndex, stepIndex, { dose: { ...dose, meters: Math.max(1, Number(event.target.value) || 1), metres: undefined } })} /></label></>}
-                                            <label>RPE<input type="number" min={1} max={10} step={0.5} placeholder="Optional" value={rpe} onChange={event => updateStep(blockIndex, stepIndex, { effort: event.target.value === '' ? undefined : { kind: 'rpe', target: Number(event.target.value) } })} /></label>
+                                            <label>Effort<select value={effortKind} onChange={event => changeEffort(blockIndex, stepIndex, event.target.value as 'none' | 'rpe' | 'rir')}><option value="none">Not tracked</option><option value="rpe">RPE</option><option value="rir">RIR</option></select></label>
+                                            {effortKind !== 'none' && <label>{effortKind === 'rpe' ? 'RPE target' : 'RIR target'}<input type="number" min={0} max={10} step={0.5} value={effortTarget} onChange={event => updateStep(blockIndex, stepIndex, { effort: { kind: effortKind, target: Number(event.target.value) || 0 } })} /></label>}
                                             <label>Rest (sec)<input type="number" min={1} placeholder="Optional" value={typeof step.rest === 'number' ? step.rest : ''} onChange={event => updateStep(blockIndex, stepIndex, { rest: event.target.value === '' ? undefined : Math.max(1, Number(event.target.value)) })} /></label>
                                         </div>
                                         <details className="builder-advanced-fields">
@@ -207,13 +313,75 @@ export const ManualSessionBuilder: React.FC<ManualSessionBuilderProps> = ({ user
                                             <label><input type="checkbox" checked={Boolean(step.optional)} onChange={event => updateStep(blockIndex, stepIndex, { optional: event.target.checked || undefined })} /> Optional movement</label>
                                             <label>Laterality<select value={step.laterality ?? 'bilateral'} onChange={event => updateStep(blockIndex, stepIndex, { laterality: event.target.value as SessionStep['laterality'] })}><option value="bilateral">Bilateral</option><option value="per_side">Per side</option><option value="alternating">Alternating sides</option></select></label>
                                             <label>Tempo<input value={step.tempo ?? ''} placeholder="e.g. 2-0-X-0" onChange={event => updateStep(blockIndex, stepIndex, { tempo: event.target.value || undefined })} /></label>
+                                            <label>Load<select value={loadKind} onChange={event => changeLoad(blockIndex, stepIndex, event.target.value as LoadKind)}>
+                                                {LOAD_KINDS.map(kind => <option key={kind} value={kind}>{LOAD_KIND_LABELS[kind]}</option>)}
+                                            </select></label>
+                                            {step.load?.kind === 'mass' && <label>Mass (kg)<input type="number" min={0} step={0.5} value={typeof step.load.kg === 'number' ? step.load.kg : ''} onChange={event => updateStep(blockIndex, stepIndex, { load: { kind: 'mass', kg: Math.max(0, Number(event.target.value) || 0) } })} /></label>}
+                                            {(step.load?.kind === 'percent_max' || step.load?.kind === 'percent_one_rm') && <label>Percent<input type="number" min={1} max={100} value={step.load.percent} onChange={event => updateStep(blockIndex, stepIndex, { load: { ...step.load as { kind: 'percent_max' | 'percent_one_rm'; percent: number }, percent: Math.max(1, Number(event.target.value) || 1) } })} /></label>}
+                                            {step.load?.kind === 'band' && <label>Band<input value={step.load.bandColor} onChange={event => updateStep(blockIndex, stepIndex, { load: { kind: 'band', bandColor: event.target.value } })} /></label>}
+                                            {step.load?.kind === 'descriptive' && <label>Load note<input value={step.load.display ?? ''} placeholder="e.g. last reviewed working load" onChange={event => updateStep(blockIndex, stepIndex, { load: { kind: 'descriptive', display: event.target.value } })} /></label>}
                                             <label>Step notes<textarea rows={2} value={step.notes ?? ''} onChange={event => updateStep(blockIndex, stepIndex, { notes: event.target.value || undefined })} /></label>
                                             <label>Stop conditions (one per line)<textarea rows={2} value={(step.stopConditions ?? []).join('\n')} onChange={event => updateStep(blockIndex, stepIndex, { stopConditions: event.target.value.split('\n').map(value => value.trim()).filter(Boolean) })} /></label>
+                                            <div className="builder-alternatives">
+                                                <div className="builder-alternatives-header"><span>Alternatives (for authored choices to switch to)</span><button type="button" onClick={() => addAlternative(blockIndex, stepIndex)}>Add alternative</button></div>
+                                                {(step.alternatives ?? []).map(alt => {
+                                                    const altExercise = alt.exerciseRef.kind === 'catalog' ? alt.exerciseRef.exerciseId : '__custom__';
+                                                    return <div key={alt.id} className="builder-alternative-row">
+                                                        <input value={alt.title} onChange={event => updateAlternative(blockIndex, stepIndex, alt.id, altExercise === '__custom__' ? undefined : altExercise, event.target.value)} aria-label="Alternative title" />
+                                                        <select value={altExercise} onChange={event => {
+                                                            const exercise = EXERCISES.find(item => item.id === event.target.value);
+                                                            updateAlternative(blockIndex, stepIndex, alt.id, exercise?.id, exercise?.name ?? alt.title);
+                                                        }} aria-label="Alternative movement"><option value="__custom__">Custom / free text</option>{EXERCISES.map(exercise => <option key={exercise.id} value={exercise.id}>{exercise.name}</option>)}</select>
+                                                        <button type="button" onClick={() => removeAlternative(blockIndex, stepIndex, alt.id)} aria-label="Remove alternative">Remove</button>
+                                                    </div>;
+                                                })}
+                                            </div>
                                         </details>
                                     </div>;
                                 })}
                                 <button type="button" className="add-step-btn" onClick={() => addStep(blockIndex)}>Add movement</button>
                             </div>
+                            <section className="builder-choices">
+                                <div className="builder-choices-header">
+                                    <span>Authored choices — a bounded option set the athlete answers at a step (D-MCHOICE)</span>
+                                    <button type="button" disabled={block.steps.length === 0} onClick={() => addChoice(blockIndex, block.steps[0].id)}>Add choice</button>
+                                </div>
+                                {(block.optionSets ?? []).map(choice => <div key={choice.id} className="builder-choice-card">
+                                    <div className="builder-choice-row">
+                                        <label>Applies at<select value={choice.appliesAtStepId} onChange={event => updateChoice(blockIndex, choice.id, { appliesAtStepId: event.target.value })}>
+                                            {block.steps.map(step => <option key={step.id} value={step.id}>{step.title ?? step.id}</option>)}
+                                        </select></label>
+                                        <button type="button" onClick={() => removeChoice(blockIndex, choice.id)} aria-label="Remove choice">Remove choice</button>
+                                    </div>
+                                    <label>Trigger — what the athlete observes<input value={choice.trigger.description} placeholder="e.g. How did the warm-up sets feel?" onChange={event => updateChoice(blockIndex, choice.id, { trigger: { kind: 'athlete_observed', description: event.target.value } })} /></label>
+                                    <div className="builder-options-list">
+                                        {choice.options.map(option => <div key={option.id} className="builder-option-card">
+                                            <div className="builder-option-row">
+                                                <input value={option.label} onChange={event => updateOptionLabel(blockIndex, choice.id, option.id, event.target.value)} aria-label="Option label" />
+                                                <button type="button" onClick={() => removeOption(blockIndex, choice.id, option.id)} aria-label="Remove option">Remove</button>
+                                            </div>
+                                            {option.actions.map((action, actionIndex) => {
+                                                const targetStep = block.steps.find(step => step.id === choice.appliesAtStepId);
+                                                return <div key={actionIndex} className="builder-action-row">
+                                                    <select value={action.kind} onChange={event => updateAction(blockIndex, choice.id, option.id, actionIndex, createDraftAction(event.target.value as SessionChoiceAction['kind'], { stepId: choice.appliesAtStepId, blockId: block.id, firstAlternativeId: targetStep?.alternatives?.[0]?.id }))}>
+                                                        {ACTION_KINDS.map(kind => <option key={kind} value={kind}>{ACTION_KIND_LABELS[kind]}</option>)}
+                                                    </select>
+                                                    {action.kind === 'reduce_load_percent' && <label>%<input type="number" min={1} max={99} value={action.percent} onChange={event => updateAction(blockIndex, choice.id, option.id, actionIndex, { percent: Math.max(1, Number(event.target.value) || 1) })} /></label>}
+                                                    {action.kind === 'reduce_sets' && <label>Sets<input type="number" min={1} value={action.sets} onChange={event => updateAction(blockIndex, choice.id, option.id, actionIndex, { sets: Math.max(1, Number(event.target.value) || 1) })} /></label>}
+                                                    {action.kind === 'reduce_reps' && <label>Reps<input type="number" min={1} value={action.reps} onChange={event => updateAction(blockIndex, choice.id, option.id, actionIndex, { reps: Math.max(1, Number(event.target.value) || 1) })} /></label>}
+                                                    {action.kind === 'select_alternative' && <label>Alternative<select value={action.alternativeId} onChange={event => updateAction(blockIndex, choice.id, option.id, actionIndex, { alternativeId: event.target.value })}>
+                                                        <option value="">Choose…</option>
+                                                        {(targetStep?.alternatives ?? []).map(alt => <option key={alt.id} value={alt.id}>{alt.title}</option>)}
+                                                    </select>{(targetStep?.alternatives ?? []).length === 0 && <em className="builder-choice-warning">Add an alternative to “{targetStep?.title ?? choice.appliesAtStepId}” first</em>}</label>}
+                                                    <button type="button" onClick={() => removeAction(blockIndex, choice.id, option.id, actionIndex)} aria-label="Remove action">Remove action</button>
+                                                </div>;
+                                            })}
+                                            <button type="button" className="add-action-btn" onClick={() => addAction(blockIndex, block, choice, option.id, 'reduce_load_percent')}>Add action</button>
+                                        </div>)}
+                                        <button type="button" className="add-option-btn" onClick={() => addOption(blockIndex, choice.id)}>Add option</button>
+                                    </div>
+                                </div>)}
+                            </section>
                         </article>
                     ))}
                 </section>

--- a/app/src/sessions/sessionDraft.test.ts
+++ b/app/src/sessions/sessionDraft.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from 'vitest';
 import type { SessionBlock } from './models';
-import { duplicateDraftBlock, duplicateDraftStep, moveDraftItem } from './sessionDraft';
+import {
+    createDraftAction,
+    createDraftAlternative,
+    createDraftChoice,
+    createDraftOption,
+    duplicateDraftBlock,
+    duplicateDraftStep,
+    moveDraftItem,
+} from './sessionDraft';
 
 describe('manual session draft operations', () => {
     it('reorders blocks and steps without changing their identities', () => {
@@ -33,5 +41,46 @@ describe('manual session draft operations', () => {
     it('duplicates a movement with a new id while retaining its prescription', () => {
         const copy = duplicateDraftStep({ id: 'press', kind: 'exercise', title: 'Press', dose: { kind: 'repetition', sets: 3, reps: 8 } }, () => 'step-copy');
         expect(copy).toMatchObject({ id: 'step-copy', title: 'Press (copy)', dose: { kind: 'repetition', sets: 3, reps: 8 } });
+    });
+
+    it('creates a new authored choice with one no-op continue option (M3.8)', () => {
+        let sequence = 0;
+        const choice = createDraftChoice('squat', prefix => `${prefix}-${++sequence}`);
+        expect(choice).toEqual({
+            id: 'choice-1',
+            appliesAtStepId: 'squat',
+            trigger: { kind: 'athlete_observed', description: '' },
+            options: [{ id: 'option-2', label: 'Continue as prescribed', actions: [] }],
+        });
+    });
+
+    it('creates a new blank option', () => {
+        const option = createDraftOption(() => 'option-x');
+        expect(option).toEqual({ id: 'option-x', label: 'New option', actions: [] });
+    });
+
+    it('creates a catalog alternative when an exercise id is given, free text otherwise', () => {
+        expect(createDraftAlternative('goblet_squat', 'Goblet Squat', () => 'alt-1')).toEqual({
+            id: 'alt-1', title: 'Goblet Squat', exerciseRef: { kind: 'catalog', exerciseId: 'goblet_squat' },
+        });
+        expect(createDraftAlternative(undefined, 'Custom sub', () => 'alt-2')).toEqual({
+            id: 'alt-2', title: 'Custom sub', exerciseRef: { kind: 'unresolved_free_text', name: 'Custom sub' },
+        });
+    });
+
+    it('creates a structurally valid default action for every action kind, scoped to the authoring step/block', () => {
+        const context = { stepId: 'squat', blockId: 'block-main', firstAlternativeId: 'alt-goblet' };
+        expect(createDraftAction('select_alternative', context)).toEqual({ kind: 'select_alternative', targetStepId: 'squat', alternativeId: 'alt-goblet' });
+        expect(createDraftAction('reduce_load_percent', context)).toEqual({ kind: 'reduce_load_percent', targetStepId: 'squat', percent: 10 });
+        expect(createDraftAction('reduce_sets', context)).toEqual({ kind: 'reduce_sets', targetStepId: 'squat', sets: 1 });
+        expect(createDraftAction('reduce_reps', context)).toEqual({ kind: 'reduce_reps', targetStepId: 'squat', reps: 1 });
+        expect(createDraftAction('omit_step', context)).toEqual({ kind: 'omit_step', targetStepId: 'squat' });
+        expect(createDraftAction('end_block', context)).toEqual({ kind: 'end_block', targetBlockId: 'block-main' });
+        expect(createDraftAction('end_session', context)).toEqual({ kind: 'end_session' });
+    });
+
+    it('defaults select_alternative to an empty alternativeId when the step has no alternatives yet', () => {
+        expect(createDraftAction('select_alternative', { stepId: 'squat', blockId: 'block-main' }))
+            .toEqual({ kind: 'select_alternative', targetStepId: 'squat', alternativeId: '' });
     });
 });

--- a/app/src/sessions/sessionDraft.ts
+++ b/app/src/sessions/sessionDraft.ts
@@ -1,4 +1,4 @@
-import type { SessionBlock, SessionChoice, SessionChoiceAction, SessionStep } from './models';
+import type { SessionBlock, SessionChoice, SessionChoiceAction, SessionOption, SessionStep, StepAlternative } from './models';
 
 /** Moves an item without changing the identity of any item in the collection. */
 export function moveDraftItem<T>(items: readonly T[], fromIndex: number, toIndex: number): T[] {
@@ -50,4 +50,48 @@ export function duplicateDraftBlock(block: SessionBlock, createId: (prefix: 'blo
 
 export function duplicateDraftStep(step: SessionStep, createId: (prefix: 'step') => string): SessionStep {
     return { ...step, id: createId('step'), title: step.title ? `${step.title} (copy)` : 'Movement (copy)' };
+}
+
+/**
+ * M3.8 bounded hardening: default factories for authored option sets, used by the manual
+ * builder's choice editor. A new choice always starts with one no-op "continue as prescribed"
+ * option so an author can add branches incrementally without an ever-invalid interim state.
+ */
+export function createDraftChoice(appliesAtStepId: string, createId: (prefix: 'choice' | 'option') => string): SessionChoice {
+    return {
+        id: createId('choice'),
+        appliesAtStepId,
+        trigger: { kind: 'athlete_observed', description: '' },
+        options: [{ id: createId('option'), label: 'Continue as prescribed', actions: [] }],
+    };
+}
+
+export function createDraftOption(createId: (prefix: 'option') => string): SessionOption {
+    return { id: createId('option'), label: 'New option', actions: [] };
+}
+
+export function createDraftAlternative(exerciseId: string | undefined, title: string, createId: (prefix: 'alt') => string): StepAlternative {
+    return {
+        id: createId('alt'),
+        title,
+        exerciseRef: exerciseId ? { kind: 'catalog', exerciseId } : { kind: 'unresolved_free_text', name: title },
+    };
+}
+
+/** A blank default action for a newly added action row, given the block/step it lives on --
+ * `end_block`/`select_alternative` need an in-scope target to stay structurally valid the
+ * moment they're added, not just once the author fills every field in. */
+export function createDraftAction(
+    kind: SessionChoiceAction['kind'],
+    context: { stepId: string; blockId: string; firstAlternativeId?: string },
+): SessionChoiceAction {
+    switch (kind) {
+        case 'select_alternative': return { kind, targetStepId: context.stepId, alternativeId: context.firstAlternativeId ?? '' };
+        case 'reduce_load_percent': return { kind, targetStepId: context.stepId, percent: 10 };
+        case 'reduce_sets': return { kind, targetStepId: context.stepId, sets: 1 };
+        case 'reduce_reps': return { kind, targetStepId: context.stepId, reps: 1 };
+        case 'omit_step': return { kind, targetStepId: context.stepId };
+        case 'end_block': return { kind, targetBlockId: context.blockId };
+        case 'end_session': return { kind };
+    }
 }

--- a/app/src/sessions/validation.ts
+++ b/app/src/sessions/validation.ts
@@ -193,6 +193,7 @@ export function validateSessionDefinition(raw: unknown): ValidationResult<Sessio
     const blockIds = new Set<string>();
     const allStepIds = new Set<string>();
     const stepOrder: string[] = [];
+    const stepAlternativeIds = new Map<string, Set<string>>();
 
     // First pass to collect step IDs and check duplicates
     raw.blocks.forEach((block, bIdx) => {
@@ -217,6 +218,13 @@ export function validateSessionDefinition(raw: unknown): ValidationResult<Sessio
                     }
                     allStepIds.add(step.id);
                     stepOrder.push(step.id);
+                    const altIds = new Set<string>();
+                    if (Array.isArray(step.alternatives)) {
+                        step.alternatives.forEach(alt => {
+                            if (isObject(alt) && typeof alt.id === 'string' && alt.id.length > 0) altIds.add(alt.id);
+                        });
+                    }
+                    stepAlternativeIds.set(step.id, altIds);
                 }
             });
         }
@@ -364,6 +372,8 @@ export function validateSessionDefinition(raw: unknown): ValidationResult<Sessio
                 }
                 if (!Array.isArray(choice.options)) {
                     issues.push({ path: `${cPath}.options`, message: 'Choice options must be an array' });
+                } else if (choice.options.length === 0) {
+                    issues.push({ path: `${cPath}.options`, message: 'Choice options must contain at least one option' });
                 } else {
                     choice.options.forEach((opt, oIdx) => {
                         const oPath = `${cPath}.options[${oIdx}]`;
@@ -389,6 +399,12 @@ export function validateSessionDefinition(raw: unknown): ValidationResult<Sessio
                                 }
                                 if ('targetBlockId' in act && (typeof act.targetBlockId !== 'string' || !blockIds.has(act.targetBlockId))) {
                                     issues.push({ path: `${aPath}.targetBlockId`, message: `targetBlockId '${String(act.targetBlockId)}' not found in definition` });
+                                }
+                                if (kind === 'select_alternative') {
+                                    const validAlternativeIds = typeof act.targetStepId === 'string' ? stepAlternativeIds.get(act.targetStepId) : undefined;
+                                    if (typeof act.alternativeId !== 'string' || act.alternativeId.length === 0 || !validAlternativeIds?.has(act.alternativeId)) {
+                                        issues.push({ path: `${aPath}.alternativeId`, message: `alternativeId '${String(act.alternativeId)}' not found among targetStepId's alternatives` });
+                                    }
                                 }
                             });
                         }

--- a/docs/plans/multidomain-session-authoring-execution-and-evidence.md
+++ b/docs/plans/multidomain-session-authoring-execution-and-evidence.md
@@ -325,7 +325,7 @@ rewritten as an outcome; an in-progress item retains its remaining acceptance wo
 | M3.5 | Bounded exercise/drill facet vocabulary | `[x]` | — |
 | M3.6 | External plan/session schema v2 adapter | `[x]` | Schema, validation, resolver/display wiring, export support shipped; M3.7's fine-grained diff remains |
 | M3.7 | Full semantic import preview and diff | `[x]` | — |
-| M3.8 | Manual block-first session builder | `[-]` | Bounded hardening only: option sets / fixture-equivalence / accessibility gaps that matter in real use; stop when current builder is sufficient |
+| M3.8 | Manual block-first session builder | `[x]` | — |
 | M4.1 | Group execution modes | `[x]` | M2.5 |
 | M4.2 | Recorded athlete choices and alternatives | `[x]` | M4.1, M3.5 |
 | M4.3 | Companion occurrence and duplicate reconciliation | `[ ]` | M2.4, M3.3 |
@@ -916,7 +916,7 @@ unmodified. `sessions/architecture.test.ts` and `engine/externalArchitecture.tes
 unchanged (the new diff module only imports `sessions/models.ts`). Full `npm run check`
 (typecheck, lint, unit tests, catalog validation) passes.
 
-### M3.8 `[-]` Manual block-first session builder
+### M3.8 `[x]` Manual block-first session builder
 
 **Progress (2026-08-18).** The current mobile-capable editor supports title, modality, duration,
 notes, blocks, group modes and rounds, catalog/free-text movement selection, repetition/timed/
@@ -949,6 +949,54 @@ fixture equivalence, mobile visual fixtures, keyboard and accessibility.
 editing JSON and preview identically to their normalized fixtures — **or** a dated note records
 that the current builder plus import proved sufficient and the remaining advanced controls are
 deferred.
+
+**Outcome (2026-08-19).** Built the two gaps the Change section actually named — "authored
+option sets where actually used" and "richer load/effort fields needed by the fixtures" — then
+stopped there per the cutline's own instruction not to expand the form for completeness.
+
+* **Load editor.** Every well-defined `SessionLoad` kind the fixtures use is now editable:
+  bodyweight, mass (kg), % of max, % of 1RM, resistance band, descriptive (free-text "last
+  reviewed load"), and unloaded. `relative_step` is exposed as a labelled option but not yet
+  field-editable (no fixture uses it and it needs a same-block step picker; deferred, not
+  silently dropped).
+* **Effort.** The RPE-only field became an effort-kind selector (none/RPE/RIR) with a target
+  input — fixture 01's back squat and bench press steps both prescribe RIR, which the builder
+  could not previously express at all.
+* **Authored choices (D-MCHOICE).** A block-scoped "Authored choices" editor: add/remove a
+  choice, edit its trigger description and which step it applies at, add/remove options per
+  choice, edit an option's label, and add/remove/edit that option's actions (all seven
+  `SessionChoiceAction` kinds, via `sessionDraft.ts`'s new `createDraftAction` factory scoped to
+  the authoring step/block so a freshly added `end_block`/`select_alternative` action is
+  structurally valid the instant it's added, not just once every field is filled in).
+* **Step alternatives.** A per-step alternatives editor (catalog-or-free-text movement, title)
+  so `select_alternative` actions have somewhere real to point — fixture 01's
+  warm-up-heavy-squat/symptom choices both depend on this.
+
+New pure factories in `sessions/sessionDraft.ts` (`createDraftChoice`, `createDraftOption`,
+`createDraftAlternative`, `createDraftAction`) carry the default-value logic and are unit
+tested directly (`sessionDraft.test.ts`); `ManualSessionBuilder.tsx` wires them through the
+same immutable block-array update pattern the existing step/block editors already use, keyed by
+choice/option id rather than index since an option's action list changes length independently
+of its siblings. `ManualSessionBuilder.test.tsx` (new; this repo has no interactive
+component-test harness, so it's a markup-level smoke test matching the existing convention for
+sibling session components) confirms the new controls render.
+
+**Deferred, not built (recorded rather than silently dropped, per the cutline's own escape
+hatch).** Full fixture-equivalence with fixtures 01/02 needs more than this: `rest` stays a
+single number in the builder (fixtures use `{min, max}` ranges), `quality`/technical stop-rule
+fields have no editor (and are already unvalidated/loosely typed even in the canonical fixture
+JSON — a pre-existing model/fixture mismatch outside this item's scope, flagged separately
+rather than fixed here), and session-level `sessionTargets`/`prohibitedAdditions` have no UI.
+None of these block authoring a real session — every fixture remains buildable via JSON import
+(M3.6), and a built session that skips these fields is still a valid, executable
+`SessionDefinition`; they are narrower prescription-fidelity gaps, not missing capability. Given
+the athlete who owns this repository already has working JSON import, expanding the form to
+close every one of these before real use demonstrates a need would be exactly the "building by
+default" the cutline warns against (C7).
+
+Verified by `sessionDraft.test.ts` (8 new cases covering every factory), the new
+`ManualSessionBuilder.test.tsx`, and a full `npm run check`-equivalent pass (typecheck, lint,
+1654 unit tests, catalog validation) with no regressions.
 
 ---
 


### PR DESCRIPTION
Stacked on #96 (M3.7).

Adds the two gaps the M3.8 cutline named, then stops per its own "do not build by default" instruction:

- Load editor for bodyweight/mass/%max/%1RM/band/descriptive/unloaded.
- Effort selector adds RIR alongside RPE.
- Block-scoped authored-choice editor (add/remove choice, trigger text, applies-at step, options, and per-option actions for all seven `SessionChoiceAction` kinds).
- Per-step alternatives editor so `select_alternative` actions have a real target.

New pure factories in `sessions/sessionDraft.ts` (`createDraftChoice`/`Option`/`Alternative`/`Action`) carry default-value logic and are unit tested.

Deliberately deferred (recorded, not silently dropped): rest ranges, quality/technical-stop fields, and session-level `sessionTargets`/`prohibitedAdditions` remain JSON-import-only — still fully buildable via M3.6 JSON import, not a missing capability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)