### PR TITLE
feat(sessions): companion occurrence start + Garmin dedup plumbing (M4.3)

### DIFF
--- a/app/src/components/session/SessionRunner.tsx
+++ b/app/src/components/session/SessionRunner.tsx
@@ -84,6 +84,16 @@ export const SessionRunner: React.FC<SessionRunnerProps> = ({
     const [savedDefinitions, setSavedDefinitions] = useState<SessionDefinitionHeader[]>([]);
     const [savedDefinitionsError, setSavedDefinitionsError] = useState<string | null>(null);
     const [startingSavedDefinitionId, setStartingSavedDefinitionId] = useState<string | null>(null);
+    // M4.3: a companion is a separately executable session referenced from the one that just
+    // finished (SessionDefinition.companionSessions), never an embedded block -- those already
+    // render inline within the same execution. Starting one creates its own execution; it may
+    // just as well be skipped. `finishedTitle` is only for the prompt's header copy.
+    const [companionPrompt, setCompanionPrompt] = useState<{
+        finishedTitle: string;
+        companions: NonNullable<SessionDefinition['companionSessions']>;
+    } | null>(null);
+    const [startingCompanionId, setStartingCompanionId] = useState<string | null>(null);
+    const [companionError, setCompanionError] = useState<string | null>(null);
     const [pendingGroupAdvance, setPendingGroupAdvance] = useState<{
         blockIndex: number;
         stepIndex: number;
@@ -179,6 +189,41 @@ export const SessionRunner: React.FC<SessionRunnerProps> = ({
         }
     };
 
+    /** Resolves a companion's `definitionRef` the same two ways the fixture/saved-session
+     * pickers above already resolve a startable definition -- a known reviewed fixture
+     * (covers the M0.2 corpus's recovery-spin companion) or one of the athlete's own saved
+     * manual definitions -- and starts it as its own independent, no-selection-authority
+     * execution (D-MAUTH `unplanned_log`), exactly like starting any other unplanned session. */
+    const startCompanion = async (companion: NonNullable<SessionDefinition['companionSessions']>[number]) => {
+        setStartingCompanionId(companion.id);
+        setCompanionError(null);
+        try {
+            const fixture = AVAILABLE_FIXTURES.find(candidate => candidate.id === companion.definitionRef);
+            if (fixture) {
+                await runner.startFixtureSession(fixture);
+                setCompanionPrompt(null);
+                return;
+            }
+            const header = savedDefinitions.find(candidate => candidate.definitionId === companion.definitionRef);
+            if (header) {
+                const result = await sessionDefinitionService.getDefinitionRevision(userId, header.definitionId, header.latestRevision);
+                if (result.status !== 'AVAILABLE') throw new Error('The companion session cannot be read safely.');
+                const launch = await prepareUnplannedSessionLaunch(userId, result.data);
+                await runner.startSession(launch.definition, launch.binding.sessionSource, {
+                    occurrenceId: launch.binding.occurrenceId,
+                    prescriptionHash: launch.binding.prescriptionHash,
+                });
+                setCompanionPrompt(null);
+                return;
+            }
+            throw new Error(`Could not find "${companion.definitionRef}" among reviewed fixtures or your saved sessions.`);
+        } catch (error) {
+            setCompanionError(error instanceof Error ? error.message : 'Could not start the companion session.');
+        } finally {
+            setStartingCompanionId(null);
+        }
+    };
+
     const handleEntrySubmit = async (payload: SessionEntryPayload) => {
         if (!runner.definition || !runner.activeBlock || !runner.activeStep) return;
 
@@ -223,6 +268,48 @@ export const SessionRunner: React.FC<SessionRunnerProps> = ({
     }
 
     if (!runner.definition || !runner.execution || runner.execution.state !== 'in_progress') {
+        // M4.3: offered once, right after the primary session finishes (completed or
+        // abandoned) -- never concurrently with it. Starting a companion creates its own
+        // execution and takes over this same "active session" view normally; skipping just
+        // dismisses the prompt. Takes priority over the ordinary picker below.
+        if (companionPrompt) {
+            return (
+                <div className="session-runner-container no-active">
+                    <header className="session-runner-header">
+                        <h2>Companion session available</h2>
+                        <p className="session-runner-subtitle">
+                            {companionPrompt.finishedTitle} lists {companionPrompt.companions.length === 1 ? 'a' : companionPrompt.companions.length}
+                            {' '}separately executable companion{companionPrompt.companions.length === 1 ? '' : 's'}. Start now or later — skipping records nothing.
+                        </p>
+                    </header>
+                    {companionError && <p className="session-runner-error" role="alert">{companionError}</p>}
+                    <div className="fixture-grid">
+                        {companionPrompt.companions.map(companion => (
+                            <div key={companion.id} className="fixture-card">
+                                <div className="fixture-info">
+                                    <span className="fixture-intent-badge">{companion.relation.replaceAll('_', ' ')}{companion.optional ? ' · optional' : ''}</span>
+                                    <h3 className="fixture-title">{companion.definitionRef}</h3>
+                                    {companion.note && <p className="fixture-summary">{companion.note}</p>}
+                                </div>
+                                <button
+                                    type="button"
+                                    className="start-fixture-btn"
+                                    disabled={startingCompanionId !== null}
+                                    onClick={() => startCompanion(companion)}
+                                >
+                                    {startingCompanionId === companion.id ? 'Starting…' : 'Start companion →'}
+                                </button>
+                            </div>
+                        ))}
+                    </div>
+                    <div className="session-authoring-actions">
+                        <button type="button" className="start-fixture-btn secondary-authoring-btn" onClick={() => { setCompanionPrompt(null); onClose?.(); }}>
+                            Not now
+                        </button>
+                    </div>
+                </div>
+            );
+        }
         if (runner.execution?.state === 'in_progress') {
             return (
                 <div className="session-runner-container no-active">
@@ -608,23 +695,41 @@ export const SessionRunner: React.FC<SessionRunnerProps> = ({
                         setCompletionError(null);
                     }}
                     onComplete={async (payload) => {
+                        // Captured before completeSession() clears runner.definition, so the
+                        // companion prompt (if any) still knows what just finished and what it
+                        // separately unlocks.
+                        const finishedTitle = definition.title;
+                        const companions = definition.companionSessions;
                         try {
                             await runner.completeSession(payload);
                             setShowCompletionSheet(false);
                             setShowAbandonConfirmation(false);
                             setCompletionError(null);
-                            if (onClose) onClose();
+                            if (companions && companions.length > 0) {
+                                setCompanionPrompt({ finishedTitle, companions });
+                            } else if (onClose) {
+                                onClose();
+                            }
                         } catch {
                             setCompletionError('Could not save completion feedback. Your session is still open, so you can retry.');
                         }
                     }}
                     onAbandon={async () => {
+                        const finishedTitle = definition.title;
+                        const companions = definition.companionSessions;
                         try {
                             await runner.abandonSession();
                             setShowCompletionSheet(false);
                             setShowAbandonConfirmation(false);
                             setCompletionError(null);
-                            if (onClose) onClose();
+                            // A skipped/abandoned primary session still leaves an independently
+                            // executable companion (e.g. the recovery spin) worth offering --
+                            // it is never gated on the primary's own completion.
+                            if (companions && companions.length > 0) {
+                                setCompanionPrompt({ finishedTitle, companions });
+                            } else if (onClose) {
+                                onClose();
+                            }
                         } catch {
                             setCompletionError('Could not abandon the session. It remains open, so you can retry.');
                         }

--- a/app/src/components/session/SessionRunner.tsx
+++ b/app/src/components/session/SessionRunner.tsx
@@ -41,6 +41,18 @@ function formatRange(value: RangeOrNumber): string {
     return typeof value === 'number' ? String(value) : `${value.min}–${value.max}`;
 }
 
+/** M4.3: `notEarlierThanMinutesAfter` is an authored timing constraint (e.g. tissue/hydration
+ * recovery before a companion), not just documentation -- a companion with none set is always
+ * eligible immediately. */
+function isCompanionEligibleNow(
+    companion: { notEarlierThanMinutesAfter?: number },
+    finishedAt: number,
+    now: number,
+): boolean {
+    if (companion.notEarlierThanMinutesAfter === undefined) return true;
+    return now >= finishedAt + companion.notEarlierThanMinutesAfter * 60_000;
+}
+
 function formatEffort(step: SessionStep): string | null {
     const effort = step.effort;
     if (!effort) return null;
@@ -90,10 +102,19 @@ export const SessionRunner: React.FC<SessionRunnerProps> = ({
     // just as well be skipped. `finishedTitle` is only for the prompt's header copy.
     const [companionPrompt, setCompanionPrompt] = useState<{
         finishedTitle: string;
+        finishedAt: number;
         companions: NonNullable<SessionDefinition['companionSessions']>;
     } | null>(null);
     const [startingCompanionId, setStartingCompanionId] = useState<string | null>(null);
     const [companionError, setCompanionError] = useState<string | null>(null);
+    // Ticks the companion prompt's "available in N minutes" copy toward eligibility -- only
+    // runs while the prompt is open, so it costs nothing the rest of the runner's lifetime.
+    const [companionPromptNow, setCompanionPromptNow] = useState(() => Date.now());
+    useEffect(() => {
+        if (!companionPrompt) return;
+        const interval = setInterval(() => setCompanionPromptNow(Date.now()), 15_000);
+        return () => clearInterval(interval);
+    }, [companionPrompt]);
     const [pendingGroupAdvance, setPendingGroupAdvance] = useState<{
         blockIndex: number;
         stepIndex: number;
@@ -195,6 +216,10 @@ export const SessionRunner: React.FC<SessionRunnerProps> = ({
      * manual definitions -- and starts it as its own independent, no-selection-authority
      * execution (D-MAUTH `unplanned_log`), exactly like starting any other unplanned session. */
     const startCompanion = async (companion: NonNullable<SessionDefinition['companionSessions']>[number]) => {
+        if (companionPrompt && !isCompanionEligibleNow(companion, companionPrompt.finishedAt, companionPromptNow)) {
+            setCompanionError(`"${companion.definitionRef}" isn't available yet -- it opens ${companion.notEarlierThanMinutesAfter} minutes after the primary session finished.`);
+            return;
+        }
         setStartingCompanionId(companion.id);
         setCompanionError(null);
         try {
@@ -284,23 +309,28 @@ export const SessionRunner: React.FC<SessionRunnerProps> = ({
                     </header>
                     {companionError && <p className="session-runner-error" role="alert">{companionError}</p>}
                     <div className="fixture-grid">
-                        {companionPrompt.companions.map(companion => (
-                            <div key={companion.id} className="fixture-card">
-                                <div className="fixture-info">
-                                    <span className="fixture-intent-badge">{companion.relation.replaceAll('_', ' ')}{companion.optional ? ' · optional' : ''}</span>
-                                    <h3 className="fixture-title">{companion.definitionRef}</h3>
-                                    {companion.note && <p className="fixture-summary">{companion.note}</p>}
+                        {companionPrompt.companions.map(companion => {
+                            const eligible = isCompanionEligibleNow(companion, companionPrompt.finishedAt, companionPromptNow);
+                            const minutesRemaining = eligible ? 0 : Math.ceil((companionPrompt.finishedAt + (companion.notEarlierThanMinutesAfter ?? 0) * 60_000 - companionPromptNow) / 60_000);
+                            return (
+                                <div key={companion.id} className="fixture-card">
+                                    <div className="fixture-info">
+                                        <span className="fixture-intent-badge">{companion.relation.replaceAll('_', ' ')}{companion.optional ? ' · optional' : ''}</span>
+                                        <h3 className="fixture-title">{companion.definitionRef}</h3>
+                                        {companion.note && <p className="fixture-summary">{companion.note}</p>}
+                                        {!eligible && <p className="fixture-summary">Available in {minutesRemaining} minute{minutesRemaining === 1 ? '' : 's'}.</p>}
+                                    </div>
+                                    <button
+                                        type="button"
+                                        className="start-fixture-btn"
+                                        disabled={startingCompanionId !== null || !eligible}
+                                        onClick={() => startCompanion(companion)}
+                                    >
+                                        {startingCompanionId === companion.id ? 'Starting…' : eligible ? 'Start companion →' : 'Not yet available'}
+                                    </button>
                                 </div>
-                                <button
-                                    type="button"
-                                    className="start-fixture-btn"
-                                    disabled={startingCompanionId !== null}
-                                    onClick={() => startCompanion(companion)}
-                                >
-                                    {startingCompanionId === companion.id ? 'Starting…' : 'Start companion →'}
-                                </button>
-                            </div>
-                        ))}
+                            );
+                        })}
                     </div>
                     <div className="session-authoring-actions">
                         <button type="button" className="start-fixture-btn secondary-authoring-btn" onClick={() => { setCompanionPrompt(null); onClose?.(); }}>
@@ -706,7 +736,7 @@ export const SessionRunner: React.FC<SessionRunnerProps> = ({
                             setShowAbandonConfirmation(false);
                             setCompletionError(null);
                             if (companions && companions.length > 0) {
-                                setCompanionPrompt({ finishedTitle, companions });
+                                setCompanionPrompt({ finishedTitle, finishedAt: Date.now(), companions });
                             } else if (onClose) {
                                 onClose();
                             }
@@ -726,7 +756,7 @@ export const SessionRunner: React.FC<SessionRunnerProps> = ({
                             // executable companion (e.g. the recovery spin) worth offering --
                             // it is never gated on the primary's own completion.
                             if (companions && companions.length > 0) {
-                                setCompanionPrompt({ finishedTitle, companions });
+                                setCompanionPrompt({ finishedTitle, finishedAt: Date.now(), companions });
                             } else if (onClose) {
                                 onClose();
                             }

--- a/app/src/sessions/occurrenceReconciliation.test.ts
+++ b/app/src/sessions/occurrenceReconciliation.test.ts
@@ -80,13 +80,14 @@ describe('matchExecutionsToGarminActivities', () => {
 
     it('claims each Garmin activity for at most one execution, preferring the closer duration match', () => {
         const matches = matchExecutionsToGarminActivities(
-            [execution({ executionId: 'exec-a', durationMin: 29 }), execution({ executionId: 'exec-b', durationMin: 20 })],
+            [execution({ executionId: 'exec-a', durationMin: 20 }), execution({ executionId: 'exec-b', durationMin: 29 })],
             [activity({ durationMin: 30 })],
         );
-        // Both are within tolerance of the same single activity; sorted execution order
-        // (exec-a before exec-b) claims it first -- exactly one match, never two, for one
-        // Garmin activity.
-        expect(matches).toEqual([{ executionId: 'exec-a', activityId: 'act-1', executionDurationMin: 29, activityDurationMin: 30 }]);
+        // Both are within tolerance of the same single activity; exec-a sorts first
+        // alphabetically but is the *worse* duration match (diff 10 vs exec-b's diff 1) -- the
+        // genuinely closer match must win regardless of execution order, and exactly one match
+        // is produced, never two, for one Garmin activity.
+        expect(matches).toEqual([{ executionId: 'exec-b', activityId: 'act-1', executionDurationMin: 29, activityDurationMin: 30 }]);
     });
 
     it('never matches the same Garmin activity to two different executions', () => {

--- a/app/src/sessions/occurrenceReconciliation.test.ts
+++ b/app/src/sessions/occurrenceReconciliation.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import {
+    matchExecutionsToGarminActivities,
+    sessionExecutionOccurrenceKey,
+    summarizeExecutionForReconciliation,
+    type ExecutionOccurrenceSummary,
+} from './occurrenceReconciliation';
+import type { NormalizedGarminActivity } from '../engine/models';
+
+function activity(overrides: Partial<NormalizedGarminActivity> = {}): NormalizedGarminActivity {
+    return {
+        activityId: 'act-1', date: '2026-08-19', type: 'cycling', durationMin: 30,
+        trainingEffectAerobic: null, trainingEffectAnaerobic: null, averageHr: null,
+        activityTrainingLoad: null, intensityTag: 'easy',
+        ...overrides,
+    };
+}
+
+function execution(overrides: Partial<ExecutionOccurrenceSummary> = {}): ExecutionOccurrenceSummary {
+    return { executionId: 'exec-1', date: '2026-08-19', modality: 'cycling', durationMin: 28, ...overrides };
+}
+
+describe('sessionExecutionOccurrenceKey', () => {
+    it('keys by occurrenceId when the execution has selection authority', () => {
+        expect(sessionExecutionOccurrenceKey({ executionId: 'e1', occurrenceId: 'occ-1' })).toBe('occurrence:occ-1');
+    });
+
+    it('keys by executionId for an unplanned/companion execution with no occurrence', () => {
+        expect(sessionExecutionOccurrenceKey({ executionId: 'e1' })).toBe('execution:e1');
+    });
+});
+
+describe('summarizeExecutionForReconciliation', () => {
+    it('computes duration in minutes from started/completed timestamps', () => {
+        const summary = summarizeExecutionForReconciliation({
+            executionId: 'e1', date: '2026-08-19',
+            startedAt: '2026-08-19T10:00:00.000Z', completedAt: '2026-08-19T10:28:00.000Z',
+        }, 'cycling');
+        expect(summary).toEqual({ executionId: 'e1', occurrenceId: undefined, date: '2026-08-19', modality: 'cycling', durationMin: 28 });
+    });
+
+    it('reports null duration for a still-in-progress execution', () => {
+        const summary = summarizeExecutionForReconciliation({
+            executionId: 'e1', date: '2026-08-19', startedAt: '2026-08-19T10:00:00.000Z',
+        });
+        expect(summary.durationMin).toBeNull();
+    });
+});
+
+describe('matchExecutionsToGarminActivities', () => {
+    it('matches a companion execution to the corresponding Garmin ride within tolerance', () => {
+        const matches = matchExecutionsToGarminActivities([execution()], [activity()]);
+        expect(matches).toEqual([{ executionId: 'exec-1', activityId: 'act-1', executionDurationMin: 28, activityDurationMin: 30 }]);
+    });
+
+    it('does not match across a different date', () => {
+        const matches = matchExecutionsToGarminActivities([execution()], [activity({ date: '2026-08-18' })]);
+        expect(matches).toEqual([]);
+    });
+
+    it('does not match across an incompatible modality', () => {
+        const matches = matchExecutionsToGarminActivities([execution({ modality: 'strength' })], [activity({ type: 'cycling' })]);
+        expect(matches).toEqual([]);
+    });
+
+    it('matches on date/duration alone when the execution has no resolved modality', () => {
+        const matches = matchExecutionsToGarminActivities([execution({ modality: undefined })], [activity({ type: 'unknown_sport' })]);
+        expect(matches).toHaveLength(1);
+    });
+
+    it('does not match outside the duration tolerance', () => {
+        const matches = matchExecutionsToGarminActivities([execution({ durationMin: 5 })], [activity({ durationMin: 60 })]);
+        expect(matches).toEqual([]);
+    });
+
+    it('never matches an execution with no completed duration', () => {
+        const matches = matchExecutionsToGarminActivities([execution({ durationMin: null })], [activity()]);
+        expect(matches).toEqual([]);
+    });
+
+    it('claims each Garmin activity for at most one execution, preferring the closer duration match', () => {
+        const matches = matchExecutionsToGarminActivities(
+            [execution({ executionId: 'exec-a', durationMin: 29 }), execution({ executionId: 'exec-b', durationMin: 20 })],
+            [activity({ durationMin: 30 })],
+        );
+        // Both are within tolerance of the same single activity; sorted execution order
+        // (exec-a before exec-b) claims it first -- exactly one match, never two, for one
+        // Garmin activity.
+        expect(matches).toEqual([{ executionId: 'exec-a', activityId: 'act-1', executionDurationMin: 29, activityDurationMin: 30 }]);
+    });
+
+    it('never matches the same Garmin activity to two different executions', () => {
+        const matches = matchExecutionsToGarminActivities(
+            [execution({ executionId: 'exec-a' }), execution({ executionId: 'exec-b' })],
+            [activity()],
+        );
+        expect(matches).toHaveLength(1);
+    });
+});

--- a/app/src/sessions/occurrenceReconciliation.ts
+++ b/app/src/sessions/occurrenceReconciliation.ts
@@ -1,0 +1,144 @@
+/**
+ * M4.3: companion occurrence identity and duplicate reconciliation.
+ *
+ * An embedded segment (another block inside the same `SessionDefinition`, e.g. fixture 01's
+ * Olympic power block ahead of its strength pairing) is never a companion -- the model
+ * already keeps those apart structurally (`SessionDefinition.blocks` vs.
+ * `SessionDefinition.companionSessions`), and the runner/preview already render them
+ * separately (M3.7). What this module adds is the piece that was actually missing: a stable
+ * identity for a `SessionExecution` occurrence, and a way to recognize when a manually
+ * logged execution and a Garmin-synced activity are evidence for the same physical
+ * occurrence, so a later companion (e.g. the recovery-bike spin in fixture 03/08) that gets
+ * both logged in-app and synced from Garmin is not counted twice.
+ *
+ * Per D-MPOLICY, "domain exposure" derived from general (non-Strength) session executions
+ * remains a default-off evidence candidate until its own ship decision -- exactly the
+ * discipline `deriveStrengthExposure`'s legacy `manualTrainingPolicy` gate already applies
+ * to `strength_sessions`. This module computes reconciliation and stable keys; it
+ * deliberately is not wired into `buildTrainingHistorySnapshot` or any other live engine
+ * cost/stimulus path. It is forward-compatible plumbing for when that becomes its own
+ * evidenced decision, not a silent activation now.
+ */
+import type { NormalizedGarminActivity } from '../engine/models';
+import type { SessionExecution } from './models';
+
+export interface ExecutionOccurrenceSummary {
+    executionId: string;
+    occurrenceId?: string;
+    /** Warsaw-local calendar date the execution happened on (`SessionExecution.date`). */
+    date: string;
+    /** The resolved definition's `dominantModality`, in the same lowercase vocabulary
+     * `ManualSessionBuilder`/`ExerciseDefinition` use -- absent when the definition could not
+     * be resolved, in which case matching is date-only. */
+    modality?: string;
+    /** Minutes between `startedAt` and `completedAt`; `null` while still in progress or if
+     * the execution never recorded a completion. An execution with no comparable duration
+     * cannot be matched against a Garmin activity's measured duration. */
+    durationMin: number | null;
+}
+
+/** A stable identity for one logged occurrence, independent of Garmin reconciliation --
+ * scoped to the authority-bearing occurrence when one exists, and to the execution itself
+ * otherwise (an `unplanned_log`/companion execution has no `occurrenceId` per D-MAUTH, but
+ * still deserves one stable, idempotent key). */
+export function sessionExecutionOccurrenceKey(execution: Pick<SessionExecution, 'executionId' | 'occurrenceId'>): string {
+    return execution.occurrenceId ? `occurrence:${execution.occurrenceId}` : `execution:${execution.executionId}`;
+}
+
+export function summarizeExecutionForReconciliation(
+    execution: Pick<SessionExecution, 'executionId' | 'occurrenceId' | 'date' | 'startedAt' | 'completedAt'>,
+    dominantModality?: string,
+): ExecutionOccurrenceSummary {
+    const durationMin = execution.completedAt
+        ? Math.max(0, Math.round((Date.parse(execution.completedAt) - Date.parse(execution.startedAt)) / 60000))
+        : null;
+    return {
+        executionId: execution.executionId,
+        occurrenceId: execution.occurrenceId,
+        date: execution.date,
+        ...(dominantModality ? { modality: dominantModality } : {}),
+        durationMin,
+    };
+}
+
+// Mirrors engine/completedTraining.ts's own (private) activity-type classification in
+// spirit, not by import: that module's vocabulary is the capitalized SessionTemplate
+// modality union, while a resolved SessionDefinition's `dominantModality` uses the
+// lowercase catalog/workout vocabulary this module actually receives. Kept deliberately
+// small and local rather than exported/shared, since the two vocabularies are genuinely
+// different types, not the same list spelled differently.
+const GARMIN_ACTIVITY_TYPE_KEYWORDS: Record<string, string[]> = {
+    cycling: ['cycl', 'bike'],
+    running: ['run'],
+    strength: ['strength', 'weight', 'lift'],
+    field: ['soccer', 'football', 'field'],
+    mobility: ['yoga', 'mobility'],
+    cross_training: ['swim', 'row', 'ellipt', 'cardio'],
+};
+
+function normalizedGarminModality(activityType: string): string | null {
+    const normalized = activityType.toLowerCase();
+    for (const [modality, keywords] of Object.entries(GARMIN_ACTIVITY_TYPE_KEYWORDS)) {
+        if (keywords.some(keyword => normalized.includes(keyword))) return modality;
+    }
+    return null;
+}
+
+const DEFAULT_DURATION_TOLERANCE_MIN = 20;
+
+export interface ExecutionGarminMatch {
+    executionId: string;
+    activityId: string;
+    executionDurationMin: number;
+    activityDurationMin: number;
+}
+
+/**
+ * For each execution, finds the closest same-date, compatible-modality, comparable-duration
+ * Garmin activity not already claimed by an earlier (sorted) execution -- one activity
+ * reconciles to at most one execution, mirroring `completedTraining.ts`'s own
+ * adherence-to-Garmin matching tolerance and exclusivity so the two reconciliation paths
+ * behave consistently. An execution with no resolved modality still matches on date and
+ * duration alone; an execution with no completed duration is never matched (nothing to
+ * compare yet, and "counted once" isn't at risk until it's counted at all).
+ */
+export function matchExecutionsToGarminActivities(
+    executions: readonly ExecutionOccurrenceSummary[],
+    activities: readonly NormalizedGarminActivity[],
+    toleranceMinutes: number = DEFAULT_DURATION_TOLERANCE_MIN,
+): ExecutionGarminMatch[] {
+    const claimedActivityIds = new Set<string>();
+    const matches: ExecutionGarminMatch[] = [];
+
+    const orderedExecutions = [...executions].sort((left, right) => left.executionId.localeCompare(right.executionId));
+    for (const execution of orderedExecutions) {
+        if (execution.durationMin === null) continue;
+
+        let bestActivity: NormalizedGarminActivity | null = null;
+        let bestDifference = Infinity;
+        for (const activity of activities) {
+            if (claimedActivityIds.has(activity.activityId)) continue;
+            if (activity.date !== execution.date) continue;
+            if (activity.durationMin === null) continue;
+            if (execution.modality && normalizedGarminModality(activity.type) !== execution.modality) continue;
+            const difference = Math.abs(activity.durationMin - execution.durationMin);
+            if (difference > toleranceMinutes) continue;
+            if (difference < bestDifference) {
+                bestDifference = difference;
+                bestActivity = activity;
+            }
+        }
+
+        if (bestActivity) {
+            claimedActivityIds.add(bestActivity.activityId);
+            matches.push({
+                executionId: execution.executionId,
+                activityId: bestActivity.activityId,
+                executionDurationMin: execution.durationMin,
+                activityDurationMin: bestActivity.durationMin!,
+            });
+        }
+    }
+
+    return matches;
+}

--- a/app/src/sessions/occurrenceReconciliation.ts
+++ b/app/src/sessions/occurrenceReconciliation.ts
@@ -94,50 +94,62 @@ export interface ExecutionGarminMatch {
 }
 
 /**
- * For each execution, finds the closest same-date, compatible-modality, comparable-duration
- * Garmin activity not already claimed by an earlier (sorted) execution -- one activity
- * reconciles to at most one execution, mirroring `completedTraining.ts`'s own
- * adherence-to-Garmin matching tolerance and exclusivity so the two reconciliation paths
- * behave consistently. An execution with no resolved modality still matches on date and
- * duration alone; an execution with no completed duration is never matched (nothing to
- * compare yet, and "counted once" isn't at risk until it's counted at all).
+ * Finds the closest same-date, compatible-modality, comparable-duration Garmin activity for
+ * each execution -- one activity reconciles to at most one execution, mirroring
+ * `completedTraining.ts`'s own adherence-to-Garmin matching tolerance and exclusivity so the
+ * two reconciliation paths behave consistently. An execution with no resolved modality still
+ * matches on date and duration alone; an execution with no completed duration is never
+ * matched (nothing to compare yet, and "counted once" isn't at risk until it's counted at
+ * all).
+ *
+ * Matching is global, not per-execution-in-isolation: every valid (execution, activity) pair
+ * within tolerance is a candidate, and candidates are claimed in order of increasing duration
+ * difference. That way a Garmin activity contested by two executions goes to whichever one is
+ * genuinely the closer duration match, not whichever execution happens to sort first.
  */
 export function matchExecutionsToGarminActivities(
     executions: readonly ExecutionOccurrenceSummary[],
     activities: readonly NormalizedGarminActivity[],
     toleranceMinutes: number = DEFAULT_DURATION_TOLERANCE_MIN,
 ): ExecutionGarminMatch[] {
-    const claimedActivityIds = new Set<string>();
-    const matches: ExecutionGarminMatch[] = [];
+    interface Candidate {
+        execution: ExecutionOccurrenceSummary;
+        activity: NormalizedGarminActivity;
+        difference: number;
+    }
 
-    const orderedExecutions = [...executions].sort((left, right) => left.executionId.localeCompare(right.executionId));
-    for (const execution of orderedExecutions) {
+    const candidates: Candidate[] = [];
+    for (const execution of executions) {
         if (execution.durationMin === null) continue;
-
-        let bestActivity: NormalizedGarminActivity | null = null;
-        let bestDifference = Infinity;
         for (const activity of activities) {
-            if (claimedActivityIds.has(activity.activityId)) continue;
             if (activity.date !== execution.date) continue;
             if (activity.durationMin === null) continue;
             if (execution.modality && normalizedGarminModality(activity.type) !== execution.modality) continue;
             const difference = Math.abs(activity.durationMin - execution.durationMin);
             if (difference > toleranceMinutes) continue;
-            if (difference < bestDifference) {
-                bestDifference = difference;
-                bestActivity = activity;
-            }
+            candidates.push({ execution, activity, difference });
         }
+    }
 
-        if (bestActivity) {
-            claimedActivityIds.add(bestActivity.activityId);
-            matches.push({
-                executionId: execution.executionId,
-                activityId: bestActivity.activityId,
-                executionDurationMin: execution.durationMin,
-                activityDurationMin: bestActivity.durationMin!,
-            });
-        }
+    // Closest difference first; ties broken deterministically by id rather than input order.
+    candidates.sort((left, right) => left.difference - right.difference
+        || left.execution.executionId.localeCompare(right.execution.executionId)
+        || left.activity.activityId.localeCompare(right.activity.activityId));
+
+    const claimedActivityIds = new Set<string>();
+    const claimedExecutionIds = new Set<string>();
+    const matches: ExecutionGarminMatch[] = [];
+    for (const candidate of candidates) {
+        if (claimedActivityIds.has(candidate.activity.activityId)) continue;
+        if (claimedExecutionIds.has(candidate.execution.executionId)) continue;
+        claimedActivityIds.add(candidate.activity.activityId);
+        claimedExecutionIds.add(candidate.execution.executionId);
+        matches.push({
+            executionId: candidate.execution.executionId,
+            activityId: candidate.activity.activityId,
+            executionDurationMin: candidate.execution.durationMin!,
+            activityDurationMin: candidate.activity.durationMin!,
+        });
     }
 
     return matches;

--- a/docs/plans/multidomain-session-authoring-execution-and-evidence.md
+++ b/docs/plans/multidomain-session-authoring-execution-and-evidence.md
@@ -328,7 +328,7 @@ rewritten as an outcome; an in-progress item retains its remaining acceptance wo
 | M3.8 | Manual block-first session builder | `[x]` | — |
 | M4.1 | Group execution modes | `[x]` | M2.5 |
 | M4.2 | Recorded athlete choices and alternatives | `[x]` | M4.1, M3.5 |
-| M4.3 | Companion occurrence and duplicate reconciliation | `[ ]` | M2.4, M3.3 |
+| M4.3 | Companion occurrence and duplicate reconciliation | `[x]` | — |
 | M5.1 | Occurrence-linked response generalization | `[ ]` | M1.7, M2.6, M4.3 |
 | M5.2 | Later-day and next-morning follow-up | `[ ]` | M5.1 |
 | M5.3 | Outcome/override evidence report | `[ ]` | M5.2; richer history UI only after a usage trigger |
@@ -1248,7 +1248,7 @@ the actual runner was not possible in this environment (no real Firebase credent
 architecture test extension to `hooks/useSessionRunner.ts` mechanically enforces the same
 optimizer/planner import boundary that a manual check would otherwise stand in for.
 
-### M4.3 `[ ]` Companion occurrence and duplicate reconciliation
+### M4.3 `[x]` Companion occurrence and duplicate reconciliation
 
 **Change.** Distinguish embedded segments from later companion occurrences. Starting a
 companion creates its own execution. Extend occurrence keys and reconciliation so a manual
@@ -1259,6 +1259,48 @@ adapters, new `sessions/occurrenceReconciliation.ts`; UI companion card.
 
 **Done when.** An embedded bike warm-up stays inside Strength; a later recovery spin may be
 started or skipped independently; a matching Garmin ride is counted exactly once.
+
+**Outcome (2026-08-19).** The embedded-vs-companion distinction needed no new code: the model
+already keeps them apart structurally (`SessionDefinition.blocks` vs. `companionSessions[]`,
+rendered separately since M3.7), so fixture 01's embedded Olympic power block already stays
+inside its own execution with no change here.
+
+* **Starting a companion creates its own execution.** `SessionRunner.tsx` captures the
+  finishing session's `title`/`companionSessions` before `completeSession`/`abandonSession`
+  runs (both clear `runner.definition`), then — only once the primary session is no longer
+  active, never concurrently with it, since the runner architecture holds exactly one active
+  execution at a time — offers a "Companion session available" prompt. **Start** resolves the
+  companion's `definitionRef` the same two ways the existing fixture/saved-session pickers
+  already do (a reviewed fixture, e.g. `08-recovery-spin-companion`, or one of the athlete's own
+  saved manual definitions) and calls `runner.startFixtureSession`/`startSession` — the ordinary
+  unplanned-log path (D-MAUTH: no selection authority, no occurrence). The now-active companion
+  execution is then rendered by the runner's normal in-progress view; no separate companion-mode
+  UI was needed. **Skip** just dismisses the prompt and records nothing. The prompt also appears
+  after an *abandoned* primary session, not only a completed one — the companion's own value
+  (e.g. "looser legs") doesn't depend on the primary having finished.
+* **Occurrence keys and Garmin reconciliation.** New `sessions/occurrenceReconciliation.ts`:
+  `sessionExecutionOccurrenceKey` gives every execution a stable identity (`occurrence:{id}`
+  when it carries selection authority, `execution:{id}` otherwise — a companion execution has
+  no `occurrenceId` per D-MAUTH but still needs one idempotent key). `matchExecutionsToGarminActivities`
+  reconciles a set of executions against Garmin activities by same date, compatible resolved
+  modality, and comparable duration (20-minute tolerance, mirroring
+  `completedTraining.ts`'s own adherence-matching tolerance), claiming each Garmin activity for
+  at most one execution so a manually logged companion and its Garmin sync are recognized as
+  one physical occurrence rather than two.
+* **Deliberately not wired into the live engine pipeline.** Per D-MPOLICY, "domain exposure"
+  derived from general (non-Strength) session executions remains a default-off evidence
+  candidate until its own ship decision — the same discipline `deriveStrengthExposure`'s legacy
+  `manualTrainingPolicy` gate already applies to `strength_sessions`. Wiring
+  `occurrenceReconciliation.ts` into `buildTrainingHistorySnapshot`'s live cost/stimulus path
+  would grant a new engine-consumed evidence source without that decision. This module is
+  therefore forward-compatible plumbing — correct, tested, and ready for M6.4/M8 to consume if
+  and when general session-execution exposure is separately evidenced — not a silent
+  activation now. `engine/completedTraining.ts`/`trainingHistory.ts` are unchanged.
+
+Verified by `sessions/occurrenceReconciliation.test.ts` (12 cases: key derivation for both
+authority states, duration computation including the in-progress/no-completion case, date/
+modality/tolerance matching, and the one-activity-claims-at-most-one-execution exclusivity
+property) and a full unit/typecheck/lint/catalog-validation pass with no regressions.
 
 ---
 

--- a/docs/plans/multidomain-session-authoring-execution-and-evidence.md
+++ b/docs/plans/multidomain-session-authoring-execution-and-evidence.md
@@ -1267,9 +1267,11 @@ inside its own execution with no change here.
 
 * **Starting a companion creates its own execution.** `SessionRunner.tsx` captures the
   finishing session's `title`/`companionSessions` before `completeSession`/`abandonSession`
-  runs (both clear `runner.definition`), then — only once the primary session is no longer
+  runs, since neither clears `runner.definition` itself (it stays the just-finished session's
+  definition until the next `startSession` call overwrites it) — the capture is what the
+  companion prompt actually relies on. Then — only once the primary session is no longer
   active, never concurrently with it, since the runner architecture holds exactly one active
-  execution at a time — offers a "Companion session available" prompt. **Start** resolves the
+  execution at a time — it offers a "Companion session available" prompt. **Start** resolves the
   companion's `definitionRef` the same two ways the existing fixture/saved-session pickers
   already do (a reviewed fixture, e.g. `08-recovery-spin-companion`, or one of the athlete's own
   saved manual definitions) and calls `runner.startFixtureSession`/`startSession` — the ordinary


### PR DESCRIPTION
Stacked on #97 (M3.8).

- `SessionRunner` offers a "Companion session available" prompt right after the primary session completes or is abandoned (never concurrently, per the single-active-execution runner model). Starting a companion resolves its `definitionRef` (known fixture or the athlete's own saved definition) and calls `startFixtureSession`/`startSession`, creating its own independent, no-authority execution; skipping records nothing. Embedded segments (`SessionDefinition.blocks`) were already structurally distinct from `companionSessions[]` and needed no change.
- New `sessions/occurrenceReconciliation.ts`: `sessionExecutionOccurrenceKey` gives every execution a stable identity; `matchExecutionsToGarminActivities` reconciles executions against Garmin activities by date/modality/duration tolerance so one physical occurrence isn't double-counted. Deliberately **not** wired into `buildTrainingHistorySnapshot`'s live engine path per D-MPOLICY (domain exposure from general session executions stays a default-off evidence candidate until its own ship decision) — forward-compatible plumbing, not activation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)