### PR TITLE
feat(responses): occurrence-linked SessionResponse generalization (M5.1)

### DIFF
--- a/app/firestore.rules
+++ b/app/firestore.rules
@@ -908,6 +908,10 @@ service cloud.firestore {
         && isValidActivityDate(data.sourceSession.date)
         && data.window in ['immediate', 'later_day', 'next_morning']
         && isValidActivityDate(data.date)
+        // `date` equals sourceSession.date for `immediate`, strictly later otherwise
+        // (models.ts's own documented invariant) -- ISO YYYY-MM-DD strings compare
+        // lexicographically the same as chronologically.
+        && (data.window == 'immediate' ? data.date == data.sourceSession.date : data.date > data.sourceSession.date)
         && data.checkinRef is map
         && data.checkinRef.keys().hasOnly(['date'])
         && isValidActivityDate(data.checkinRef.date)
@@ -930,9 +934,13 @@ service cloud.firestore {
       allow create: if hasValidSessionResponse(userId, responseId);
       allow update: if hasValidSessionResponse(userId, responseId)
         && keepsOwnership(userId)
-        // Edits preserve provenance: identity/window/createdAt never change after
-        // creation -- only the non-tissue facts and updatedAt may be revised.
+        // Edits preserve provenance: identity/occurrence/window/createdAt never change
+        // after creation -- only the non-tissue facts and updatedAt may be revised.
+        // occurrenceId's presence and value are both pinned (not just its value when
+        // present), so a response created without one can't have one added later either.
         && request.resource.data.sourceSession == resource.data.sourceSession
+        && ('occurrenceId' in request.resource.data) == ('occurrenceId' in resource.data)
+        && (!('occurrenceId' in resource.data) || request.resource.data.occurrenceId == resource.data.occurrenceId)
         && request.resource.data.window == resource.data.window
         && request.resource.data.date == resource.data.date
         && request.resource.data.createdAt == resource.data.createdAt;

--- a/app/firestore.rules
+++ b/app/firestore.rules
@@ -891,6 +891,54 @@ service cloud.firestore {
       }
     }
 
+    // M5.1: SessionResponse -- linkage plus non-tissue session facts only (D-MRESP).
+    // DailySubjectiveCheckin.tissueResponses remains the sole tissue authority; this
+    // record never carries a tissue value.
+    function hasValidSessionResponse(userId, responseId) {
+      let data = request.resource.data;
+      return hasOwnedUserId(userId)
+        && data.keys().hasOnly(['userId', 'responseId', 'sourceSession', 'occurrenceId', 'window', 'date', 'checkinRef', 'sessionRpe', 'completedFraction', 'unexpectedFatigue', 'techniqueNote', 'note', 'createdAt', 'updatedAt'])
+        && data.keys().hasAll(['userId', 'responseId', 'sourceSession', 'window', 'date', 'checkinRef', 'createdAt', 'updatedAt'])
+        && data.responseId == responseId
+        && data.sourceSession is map
+        && data.sourceSession.keys().hasOnly(['kind', 'id', 'date'])
+        && data.sourceSession.keys().hasAll(['kind', 'id', 'date'])
+        && data.sourceSession.kind in ['strength', 'execution']
+        && data.sourceSession.id is string && data.sourceSession.id.size() > 0
+        && isValidActivityDate(data.sourceSession.date)
+        && data.window in ['immediate', 'later_day', 'next_morning']
+        && isValidActivityDate(data.date)
+        && data.checkinRef is map
+        && data.checkinRef.keys().hasOnly(['date'])
+        && isValidActivityDate(data.checkinRef.date)
+        && (!('occurrenceId' in data) || (
+          data.occurrenceId is string && data.occurrenceId.size() > 0
+          // Cannot reference another user's occurrence: it must exist under this same
+          // user's own path -- a cross-user id structurally cannot resolve here.
+          && exists(/databases/$(database)/documents/users/$(userId)/session_occurrences/$(data.occurrenceId))
+        ))
+        && (!('sessionRpe' in data) || (data.sessionRpe is number && data.sessionRpe >= 0 && data.sessionRpe <= 10))
+        && (!('completedFraction' in data) || (data.completedFraction is number && data.completedFraction >= 0 && data.completedFraction <= 1))
+        && (!('unexpectedFatigue' in data) || data.unexpectedFatigue is bool)
+        && (!('techniqueNote' in data) || (data.techniqueNote is string && data.techniqueNote.size() <= 2000))
+        && (!('note' in data) || (data.note is string && data.note.size() <= 2000))
+        && data.createdAt is string && data.updatedAt is string;
+    }
+
+    match /users/{userId}/session_responses/{responseId} {
+      allow read: if isOwner(userId);
+      allow create: if hasValidSessionResponse(userId, responseId);
+      allow update: if hasValidSessionResponse(userId, responseId)
+        && keepsOwnership(userId)
+        // Edits preserve provenance: identity/window/createdAt never change after
+        // creation -- only the non-tissue facts and updatedAt may be revised.
+        && request.resource.data.sourceSession == resource.data.sourceSession
+        && request.resource.data.window == resource.data.window
+        && request.resource.data.date == resource.data.date
+        && request.resource.data.createdAt == resource.data.createdAt;
+      allow delete: if isOwner(userId);
+    }
+
     match /users/{userId}/daily_recommendations/{date} {
       allow read: if isOwner(userId);
       allow create: if hasValidRecommendation(userId, date);

--- a/app/src/components/session/SessionRunner.tsx
+++ b/app/src/components/session/SessionRunner.tsx
@@ -109,9 +109,14 @@ export const SessionRunner: React.FC<SessionRunnerProps> = ({
     const [companionError, setCompanionError] = useState<string | null>(null);
     // Ticks the companion prompt's "available in N minutes" copy toward eligibility -- only
     // runs while the prompt is open, so it costs nothing the rest of the runner's lifetime.
+    // Re-synced to Date.now() the instant the prompt opens (not just on the first interval
+    // tick) -- otherwise this would hold whatever stale value it had from mount/the previous
+    // prompt (e.g. from ~40 minutes into a completed session) for up to 15 seconds, making an
+    // immediately-eligible companion appear falsely gated.
     const [companionPromptNow, setCompanionPromptNow] = useState(() => Date.now());
     useEffect(() => {
         if (!companionPrompt) return;
+        setCompanionPromptNow(Date.now());
         const interval = setInterval(() => setCompanionPromptNow(Date.now()), 15_000);
         return () => clearInterval(interval);
     }, [companionPrompt]);

--- a/app/src/emulator/firestoreRules.emulator.test.ts
+++ b/app/src/emulator/firestoreRules.emulator.test.ts
@@ -1480,6 +1480,30 @@ emulatorDescribe('Firestore security rules', () => {
         await assertFails(setDoc(doc(ownerDb, sessionResponsePath), { ...validSessionResponse(), userId: otherUserId }));
     });
 
+    it('rejects an edit that adds or changes occurrenceId after creation (provenance)', async () => {
+        const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+        await expect(assertSucceeds(setDoc(doc(ownerDb, sessionOccPath), validSessionOccurrence()))).resolves.toBeUndefined();
+        await expect(assertSucceeds(setDoc(doc(ownerDb, `users/${ownerId}/session_occurrences/occ-unplanned-2`), {
+            ...validSessionOccurrence(), occurrenceId: 'occ-unplanned-2',
+        }))).resolves.toBeUndefined();
+
+        // Created with no occurrenceId (e.g. a companion/unplanned execution) -- an edit
+        // cannot retroactively grant it selection authority by adding one.
+        await expect(assertSucceeds(setDoc(doc(ownerDb, sessionResponsePath), validSessionResponse()))).resolves.toBeUndefined();
+        await assertFails(setDoc(doc(ownerDb, sessionResponsePath), {
+            ...validSessionResponse(), occurrenceId: 'occ-unplanned-1',
+        }));
+
+        // Created with an occurrenceId -- an edit cannot swap it for a different one.
+        const withOccurrencePath = `${sessionResponsePath}-with-occ`;
+        await expect(assertSucceeds(setDoc(doc(ownerDb, withOccurrencePath), {
+            ...validSessionResponse(), responseId: 'resp-1-with-occ', occurrenceId: 'occ-unplanned-1',
+        }))).resolves.toBeUndefined();
+        await assertFails(setDoc(doc(ownerDb, withOccurrencePath), {
+            ...validSessionResponse(), responseId: 'resp-1-with-occ', occurrenceId: 'occ-unplanned-2',
+        }));
+    });
+
     it('rejects a response whose occurrenceId does not reference a real occurrence of this user', async () => {
         const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
         // No session_occurrences/occ-unplanned-1 document has been written in this test.

--- a/app/src/emulator/firestoreRules.emulator.test.ts
+++ b/app/src/emulator/firestoreRules.emulator.test.ts
@@ -1078,6 +1078,24 @@ emulatorDescribe('Firestore security rules', () => {
         };
     }
 
+    // --- M5.1: SessionResponse (occurrence-linked response generalization) ---
+
+    const sessionResponsePath = `users/${ownerId}/session_responses/resp-1`;
+
+    function validSessionResponse() {
+        return {
+            userId: ownerId,
+            responseId: 'resp-1',
+            sourceSession: { kind: 'execution', id: 'exec-1', date: '2026-08-18' },
+            window: 'immediate',
+            date: '2026-08-18',
+            checkinRef: { date: '2026-08-18' },
+            sessionRpe: 7,
+            createdAt: '2026-08-18T10:45:00Z',
+            updatedAt: '2026-08-18T10:45:00Z',
+        };
+    }
+
     it('allows an owner to manage session definition header and write-once revision', async () => {
         const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
         await expect(assertSucceeds(setDoc(doc(ownerDb, sessionDefHeaderPath), validSessionDefHeader()))).resolves.toBeUndefined();
@@ -1412,5 +1430,68 @@ emulatorDescribe('Firestore security rules', () => {
             ...validChoiceEntry,
             id: 'entry-choice-4',
         }));
+    });
+
+    it('allows an owner to record and revise a session response, and rejects a cross-user read/write', async () => {
+        const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+        await expect(assertSucceeds(setDoc(doc(ownerDb, sessionResponsePath), validSessionResponse()))).resolves.toBeUndefined();
+
+        // Edits preserve provenance: only non-tissue facts and updatedAt may change.
+        await expect(assertSucceeds(setDoc(doc(ownerDb, sessionResponsePath), {
+            ...validSessionResponse(),
+            sessionRpe: 8,
+            note: 'legs felt heavier than expected',
+            updatedAt: '2026-08-18T11:00:00Z',
+        }))).resolves.toBeUndefined();
+
+        // Another user can neither read nor write this response.
+        const otherDb = testEnvironment.authenticatedContext(otherUserId).firestore();
+        await assertFails(getDoc(doc(otherDb, sessionResponsePath)));
+        await assertFails(setDoc(doc(otherDb, sessionResponsePath), validSessionResponse()));
+    });
+
+    it('rejects an edit that changes sourceSession, window, date or createdAt (provenance)', async () => {
+        const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+        await expect(assertSucceeds(setDoc(doc(ownerDb, sessionResponsePath), validSessionResponse()))).resolves.toBeUndefined();
+
+        await assertFails(setDoc(doc(ownerDb, sessionResponsePath), {
+            ...validSessionResponse(),
+            sourceSession: { kind: 'strength', id: 'strength-1', date: '2026-08-18' },
+        }));
+        await assertFails(setDoc(doc(ownerDb, sessionResponsePath), { ...validSessionResponse(), window: 'later_day' }));
+        await assertFails(setDoc(doc(ownerDb, sessionResponsePath), { ...validSessionResponse(), date: '2026-08-19' }));
+        await assertFails(setDoc(doc(ownerDb, sessionResponsePath), { ...validSessionResponse(), createdAt: '2026-08-19T00:00:00Z' }));
+    });
+
+    it('rejects a malformed session response: bad window, out-of-range sessionRpe/completedFraction, extra field, foreign userId', async () => {
+        const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+        await assertFails(setDoc(doc(ownerDb, `${sessionResponsePath}-bad-window`), {
+            ...validSessionResponse(), responseId: 'resp-1-bad-window', window: 'next_week',
+        }));
+        await assertFails(setDoc(doc(ownerDb, `${sessionResponsePath}-bad-rpe`), {
+            ...validSessionResponse(), responseId: 'resp-1-bad-rpe', sessionRpe: 11,
+        }));
+        await assertFails(setDoc(doc(ownerDb, `${sessionResponsePath}-bad-fraction`), {
+            ...validSessionResponse(), responseId: 'resp-1-bad-fraction', completedFraction: 1.5,
+        }));
+        await assertFails(setDoc(doc(ownerDb, `${sessionResponsePath}-extra`), {
+            ...validSessionResponse(), responseId: 'resp-1-extra', unexpectedField: true,
+        }));
+        await assertFails(setDoc(doc(ownerDb, sessionResponsePath), { ...validSessionResponse(), userId: otherUserId }));
+    });
+
+    it('rejects a response whose occurrenceId does not reference a real occurrence of this user', async () => {
+        const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+        // No session_occurrences/occ-unplanned-1 document has been written in this test.
+        await assertFails(setDoc(doc(ownerDb, sessionResponsePath), {
+            ...validSessionResponse(),
+            occurrenceId: 'occ-unplanned-1',
+        }));
+
+        await expect(assertSucceeds(setDoc(doc(ownerDb, sessionOccPath), validSessionOccurrence()))).resolves.toBeUndefined();
+        await expect(assertSucceeds(setDoc(doc(ownerDb, sessionResponsePath), {
+            ...validSessionResponse(),
+            occurrenceId: 'occ-unplanned-1',
+        }))).resolves.toBeUndefined();
     });
 });

--- a/app/src/persistence/parsers/sessionResponse.test.ts
+++ b/app/src/persistence/parsers/sessionResponse.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { parseSessionResponseDocument } from './sessionResponse';
+import type { SessionResponse } from '../../responses/models';
+
+function response(): SessionResponse {
+    return {
+        userId: 'u1',
+        responseId: 'resp-1',
+        sourceSession: { kind: 'execution', id: 'exec-1', date: '2026-08-18' },
+        window: 'immediate',
+        date: '2026-08-18',
+        checkinRef: { date: '2026-08-18' },
+        createdAt: '2026-08-18T10:45:00.000Z',
+        updatedAt: '2026-08-18T10:45:00.000Z',
+    };
+}
+
+describe('parseSessionResponseDocument', () => {
+    it('reports MISSING for an absent document', () => {
+        expect(parseSessionResponseDocument(undefined, 'users/u1/session_responses/resp-1')).toEqual({ status: 'MISSING' });
+        expect(parseSessionResponseDocument(null, 'users/u1/session_responses/resp-1')).toEqual({ status: 'MISSING' });
+    });
+
+    it('parses a valid document as AVAILABLE', () => {
+        const result = parseSessionResponseDocument(response(), 'users/u1/session_responses/resp-1');
+        expect(result).toEqual({ status: 'AVAILABLE', data: response(), revision: null });
+    });
+
+    it('reports INVALID with a documentPath and issue detail for a malformed document', () => {
+        const result = parseSessionResponseDocument({ ...response(), window: 'next_week' }, 'users/u1/session_responses/resp-1');
+        expect(result.status).toBe('INVALID');
+        if (result.status === 'INVALID') {
+            expect(result.issues[0].documentPath).toBe('users/u1/session_responses/resp-1');
+            expect(result.issues[0].code).toBe('invalid-session-response');
+        }
+    });
+});

--- a/app/src/persistence/parsers/sessionResponse.ts
+++ b/app/src/persistence/parsers/sessionResponse.ts
@@ -1,0 +1,34 @@
+import type { DataIssue, DataState } from '../../engine/dataState';
+import type { SessionResponse } from '../../responses/models';
+import { validateSessionResponse } from '../../responses/validation';
+
+function invalid(documentPath: string, code: string, field?: string, message?: string): DataState<never> {
+    const issue: DataIssue = {
+        code,
+        documentPath,
+        ...(field ? { field } : {}),
+        ...(message ? { message } : {}),
+    };
+    return { status: 'INVALID', issues: [issue] };
+}
+
+export function parseSessionResponseDocument(
+    raw: unknown,
+    documentPath: string,
+): DataState<SessionResponse> {
+    if (raw === undefined || raw === null) {
+        return { status: 'MISSING' };
+    }
+
+    const validation = validateSessionResponse(raw);
+    if (!validation.ok) {
+        const first = validation.issues[0];
+        return invalid(documentPath, 'invalid-session-response', first?.path, first?.message);
+    }
+
+    return {
+        status: 'AVAILABLE',
+        data: validation.value,
+        revision: null,
+    };
+}

--- a/app/src/responses/models.ts
+++ b/app/src/responses/models.ts
@@ -1,0 +1,53 @@
+/**
+ * M5.1: session response linkage and non-tissue session facts (ADR-0023 D-MRESP).
+ *
+ * `DailySubjectiveCheckin.tissueResponses` remains the SOLE tissue authority --
+ * `RegionTissueResponse.morningState`/`painDuringTraining`/`afterTrainingState`/
+ * `nextMorningReaction` never move or get duplicated here. A `SessionResponse` is the
+ * complementary direction of linkage (session -> check-in, generalizing what M1.7/M2.6
+ * already write the other way via `RegionTissueResponse.sourceSessionRef`) plus the
+ * non-tissue facts a check-in has no field for: sRPE, completed fraction, unexpected
+ * fatigue, a technique note, a free note.
+ *
+ * Distinct record, distinct lifecycle (D-MRECORDS): a `SessionResponse` is never fabricated
+ * for a prompt the athlete never answered (M5.2 surfaces the prompt; this module only
+ * persists an actual answer), so a missing window is legible as "never asked/answered",
+ * not silently indistinguishable from "answered normally".
+ */
+
+export type ResponseWindow = 'immediate' | 'later_day' | 'next_morning';
+
+/** The same `{kind, id, date}` identity `RegionTissueResponse.sourceSessionRef` already
+ * uses (M1.7/M2.6) -- reused rather than reinvented, so a `SessionResponse` and the
+ * check-in's own tissue-side linkage can be joined on identical fields for the same
+ * session. `date` here is the SOURCE session's own date, not this response's `date`. */
+export interface SessionResponseSourceRef {
+    kind: 'strength' | 'execution';
+    id: string;
+    date: string;
+}
+
+export interface SessionResponse {
+    userId: string;
+    responseId: string;
+    sourceSession: SessionResponseSourceRef;
+    /** Present only when the source execution carried selection authority (D-MAUTH); a
+     * companion or otherwise unplanned execution has none. */
+    occurrenceId?: string;
+    window: ResponseWindow;
+    /** Warsaw-local date this response was recorded for -- equal to `sourceSession.date`
+     * for `immediate`, later for `later_day`/`next_morning`. */
+    date: string;
+    /** Points at the canonical daily check-in that holds this window's tissue values.
+     * Never duplicated here -- see the module doc comment. */
+    checkinRef: { date: string };
+    /** 0-10. Session RPE is a session-level fact the check-in has no field for. */
+    sessionRpe?: number;
+    /** 0-1 fraction of the prescribed session actually completed. */
+    completedFraction?: number;
+    unexpectedFatigue?: boolean;
+    techniqueNote?: string;
+    note?: string;
+    createdAt: string;
+    updatedAt: string;
+}

--- a/app/src/responses/validation.test.ts
+++ b/app/src/responses/validation.test.ts
@@ -30,7 +30,19 @@ describe('validateSessionResponse', () => {
     });
 
     it.each(['immediate', 'later_day', 'next_morning'] as const)('accepts window %s', window => {
-        expect(validateSessionResponse(response({ window })).ok).toBe(true);
+        // date equals sourceSession.date for immediate, strictly later otherwise.
+        const date = window === 'immediate' ? '2026-08-19' : '2026-08-20';
+        expect(validateSessionResponse(response({ window, date })).ok).toBe(true);
+    });
+
+    it('rejects an immediate-window response whose date does not equal sourceSession.date', () => {
+        const result = validateSessionResponse(response({ window: 'immediate', date: '2026-08-20' }));
+        expect(result.ok).toBe(false);
+    });
+
+    it.each(['later_day', 'next_morning'] as const)('rejects a %s response whose date is not strictly later than sourceSession.date', window => {
+        const result = validateSessionResponse(response({ window, date: '2026-08-19' }));
+        expect(result.ok).toBe(false);
     });
 
     it('rejects an invalid window', () => {

--- a/app/src/responses/validation.test.ts
+++ b/app/src/responses/validation.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { validateSessionResponse } from './validation';
+import type { SessionResponse } from './models';
+
+function response(overrides: Partial<SessionResponse> = {}): SessionResponse {
+    return {
+        userId: 'u1',
+        responseId: 'resp-1',
+        sourceSession: { kind: 'execution', id: 'exec-1', date: '2026-08-19' },
+        window: 'immediate',
+        date: '2026-08-19',
+        checkinRef: { date: '2026-08-19' },
+        createdAt: '2026-08-19T10:00:00.000Z',
+        updatedAt: '2026-08-19T10:00:00.000Z',
+        ...overrides,
+    };
+}
+
+describe('validateSessionResponse', () => {
+    it('accepts a minimal valid response', () => {
+        expect(validateSessionResponse(response())).toEqual({ ok: true, value: response() });
+    });
+
+    it('accepts every optional non-tissue fact', () => {
+        const full = response({
+            occurrenceId: 'occ-1', sessionRpe: 7, completedFraction: 0.9,
+            unexpectedFatigue: true, techniqueNote: 'form broke down late', note: 'felt good overall',
+        });
+        expect(validateSessionResponse(full)).toEqual({ ok: true, value: full });
+    });
+
+    it.each(['immediate', 'later_day', 'next_morning'] as const)('accepts window %s', window => {
+        expect(validateSessionResponse(response({ window })).ok).toBe(true);
+    });
+
+    it('rejects an invalid window', () => {
+        const result = validateSessionResponse(response({ window: 'next_week' as never }));
+        expect(result.ok).toBe(false);
+    });
+
+    it('rejects a malformed sourceSession', () => {
+        const result = validateSessionResponse({ ...response(), sourceSession: { kind: 'execution' } });
+        expect(result.ok).toBe(false);
+        if (!result.ok) expect(result.issues[0].path).toBe('sourceSession');
+    });
+
+    it('rejects an unrecognized sourceSession.kind', () => {
+        const result = validateSessionResponse({ ...response(), sourceSession: { kind: 'garmin', id: 'x', date: '2026-08-19' } });
+        expect(result.ok).toBe(false);
+    });
+
+    it('rejects sessionRpe outside 0-10', () => {
+        expect(validateSessionResponse(response({ sessionRpe: 11 })).ok).toBe(false);
+        expect(validateSessionResponse(response({ sessionRpe: -1 })).ok).toBe(false);
+    });
+
+    it('rejects completedFraction outside 0-1', () => {
+        expect(validateSessionResponse(response({ completedFraction: 1.5 })).ok).toBe(false);
+    });
+
+    it('rejects a malformed checkinRef', () => {
+        const result = validateSessionResponse({ ...response(), checkinRef: { date: 'not-a-date' } });
+        expect(result.ok).toBe(false);
+    });
+
+    it('rejects an empty occurrenceId when present', () => {
+        const result = validateSessionResponse({ ...response(), occurrenceId: '' });
+        expect(result.ok).toBe(false);
+    });
+
+    it('rejects an unrecognized top-level field', () => {
+        const result = validateSessionResponse({ ...response(), extraField: 'nope' });
+        expect(result.ok).toBe(false);
+        if (!result.ok) expect(result.issues.some(issue => issue.path === 'extraField')).toBe(true);
+    });
+
+    it('rejects a non-object input', () => {
+        expect(validateSessionResponse(null).ok).toBe(false);
+        expect(validateSessionResponse('nope').ok).toBe(false);
+        expect(validateSessionResponse([]).ok).toBe(false);
+    });
+
+    it('rejects missing required fields', () => {
+        const { userId, ...withoutUserId } = response();
+        void userId;
+        const result = validateSessionResponse(withoutUserId);
+        expect(result.ok).toBe(false);
+    });
+});

--- a/app/src/responses/validation.ts
+++ b/app/src/responses/validation.ts
@@ -1,0 +1,88 @@
+/**
+ * Pure validator for `SessionResponse` (M5.1). Self-contained like `sessions/validation.ts`
+ * rather than importing its helpers -- `responses/` is its own distinct-lifecycle domain
+ * (D-MRECORDS), and the date/object checks are a few lines each.
+ */
+import type { ResponseWindow, SessionResponse } from './models';
+
+export interface ValidationIssue {
+    path: string;
+    message: string;
+}
+
+export type ValidationResult<T> =
+    | { ok: true; value: T; issues?: never }
+    | { ok: false; issues: ValidationIssue[]; value?: never };
+
+const RESPONSE_WINDOWS: ResponseWindow[] = ['immediate', 'later_day', 'next_morning'];
+const SOURCE_KINDS = ['strength', 'execution'];
+const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+const RESPONSE_KEYS = [
+    'userId', 'responseId', 'sourceSession', 'occurrenceId', 'window', 'date', 'checkinRef',
+    'sessionRpe', 'completedFraction', 'unexpectedFatigue', 'techniqueNote', 'note', 'createdAt', 'updatedAt',
+];
+
+function isObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isValidCalendarDate(value: unknown): value is string {
+    if (typeof value !== 'string' || !DATE_REGEX.test(value)) return false;
+    const [year, month, day] = value.split('-').map(Number);
+    const parsed = new Date(Date.UTC(year, month - 1, day));
+    return parsed.getUTCFullYear() === year && parsed.getUTCMonth() === month - 1 && parsed.getUTCDate() === day;
+}
+
+export function validateSessionResponse(raw: unknown): ValidationResult<SessionResponse> {
+    const issues: ValidationIssue[] = [];
+    if (!isObject(raw)) return { ok: false, issues: [{ path: '', message: 'Expected object' }] };
+
+    if (typeof raw.userId !== 'string' || raw.userId.length === 0) issues.push({ path: 'userId', message: 'Missing userId' });
+    if (typeof raw.responseId !== 'string' || raw.responseId.length === 0) issues.push({ path: 'responseId', message: 'Missing responseId' });
+
+    if (!isObject(raw.sourceSession)
+        || !SOURCE_KINDS.includes(String(raw.sourceSession.kind))
+        || typeof raw.sourceSession.id !== 'string' || raw.sourceSession.id.length === 0
+        || !isValidCalendarDate(raw.sourceSession.date)) {
+        issues.push({ path: 'sourceSession', message: 'Invalid sourceSession: expected { kind: strength|execution, id, date }' });
+    }
+
+    if (raw.occurrenceId !== undefined && (typeof raw.occurrenceId !== 'string' || raw.occurrenceId.length === 0)) {
+        issues.push({ path: 'occurrenceId', message: 'occurrenceId must be a non-empty string when present' });
+    }
+
+    if (!RESPONSE_WINDOWS.includes(raw.window as ResponseWindow)) {
+        issues.push({ path: 'window', message: `Invalid window: ${String(raw.window)}` });
+    }
+
+    if (!isValidCalendarDate(raw.date)) issues.push({ path: 'date', message: 'date must be a YYYY-MM-DD string' });
+
+    if (!isObject(raw.checkinRef) || !isValidCalendarDate(raw.checkinRef.date)) {
+        issues.push({ path: 'checkinRef', message: 'Invalid checkinRef: expected { date }' });
+    }
+
+    if (raw.sessionRpe !== undefined && (typeof raw.sessionRpe !== 'number' || raw.sessionRpe < 0 || raw.sessionRpe > 10)) {
+        issues.push({ path: 'sessionRpe', message: 'sessionRpe must be a number between 0 and 10' });
+    }
+    if (raw.completedFraction !== undefined && (typeof raw.completedFraction !== 'number' || raw.completedFraction < 0 || raw.completedFraction > 1)) {
+        issues.push({ path: 'completedFraction', message: 'completedFraction must be a number between 0 and 1' });
+    }
+    if (raw.unexpectedFatigue !== undefined && typeof raw.unexpectedFatigue !== 'boolean') {
+        issues.push({ path: 'unexpectedFatigue', message: 'unexpectedFatigue must be boolean' });
+    }
+    if (raw.techniqueNote !== undefined && typeof raw.techniqueNote !== 'string') {
+        issues.push({ path: 'techniqueNote', message: 'techniqueNote must be a string' });
+    }
+    if (raw.note !== undefined && typeof raw.note !== 'string') {
+        issues.push({ path: 'note', message: 'note must be a string' });
+    }
+
+    if (typeof raw.createdAt !== 'string' || raw.createdAt.length === 0) issues.push({ path: 'createdAt', message: 'Missing createdAt' });
+    if (typeof raw.updatedAt !== 'string' || raw.updatedAt.length === 0) issues.push({ path: 'updatedAt', message: 'Missing updatedAt' });
+
+    const extra = Object.keys(raw).filter(key => !RESPONSE_KEYS.includes(key));
+    for (const key of extra) issues.push({ path: key, message: `Unrecognized field: ${key}` });
+
+    if (issues.length > 0) return { ok: false, issues };
+    return { ok: true, value: raw as unknown as SessionResponse };
+}

--- a/app/src/responses/validation.ts
+++ b/app/src/responses/validation.ts
@@ -55,7 +55,19 @@ export function validateSessionResponse(raw: unknown): ValidationResult<SessionR
         issues.push({ path: 'window', message: `Invalid window: ${String(raw.window)}` });
     }
 
-    if (!isValidCalendarDate(raw.date)) issues.push({ path: 'date', message: 'date must be a YYYY-MM-DD string' });
+    if (!isValidCalendarDate(raw.date)) {
+        issues.push({ path: 'date', message: 'date must be a YYYY-MM-DD string' });
+    } else if (isObject(raw.sourceSession) && isValidCalendarDate(raw.sourceSession.date)) {
+        // `date` equals sourceSession.date for `immediate`, strictly later otherwise
+        // (models.ts's own documented invariant) -- ISO YYYY-MM-DD strings compare
+        // lexicographically the same as chronologically, mirroring firestore.rules.
+        const sourceDate = raw.sourceSession.date;
+        if (raw.window === 'immediate' && raw.date !== sourceDate) {
+            issues.push({ path: 'date', message: 'date must equal sourceSession.date for an immediate-window response' });
+        } else if (raw.window !== 'immediate' && raw.date <= sourceDate) {
+            issues.push({ path: 'date', message: 'date must be strictly later than sourceSession.date for a later_day/next_morning response' });
+        }
+    }
 
     if (!isObject(raw.checkinRef) || !isValidCalendarDate(raw.checkinRef.date)) {
         issues.push({ path: 'checkinRef', message: 'Invalid checkinRef: expected { date }' });
@@ -70,11 +82,13 @@ export function validateSessionResponse(raw: unknown): ValidationResult<SessionR
     if (raw.unexpectedFatigue !== undefined && typeof raw.unexpectedFatigue !== 'boolean') {
         issues.push({ path: 'unexpectedFatigue', message: 'unexpectedFatigue must be boolean' });
     }
-    if (raw.techniqueNote !== undefined && typeof raw.techniqueNote !== 'string') {
-        issues.push({ path: 'techniqueNote', message: 'techniqueNote must be a string' });
+    // 2000-char cap mirrors firestore.rules' size() <= 2000 check, so a too-long note fails
+    // here rather than surfacing as an unexplained permission-denied at write time.
+    if (raw.techniqueNote !== undefined && (typeof raw.techniqueNote !== 'string' || raw.techniqueNote.length > 2000)) {
+        issues.push({ path: 'techniqueNote', message: 'techniqueNote must be a string of at most 2000 characters' });
     }
-    if (raw.note !== undefined && typeof raw.note !== 'string') {
-        issues.push({ path: 'note', message: 'note must be a string' });
+    if (raw.note !== undefined && (typeof raw.note !== 'string' || raw.note.length > 2000)) {
+        issues.push({ path: 'note', message: 'note must be a string of at most 2000 characters' });
     }
 
     if (typeof raw.createdAt !== 'string' || raw.createdAt.length === 0) issues.push({ path: 'createdAt', message: 'Missing createdAt' });

--- a/app/src/services/sessionResponseService.test.ts
+++ b/app/src/services/sessionResponseService.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SessionResponse } from '../responses/models';
+
+const firestore = vi.hoisted(() => ({
+    doc: vi.fn(),
+    setDoc: vi.fn(),
+    updateDoc: vi.fn(),
+    getDoc: vi.fn(),
+    collection: vi.fn(),
+    query: vi.fn(),
+    where: vi.fn(),
+    getDocs: vi.fn(),
+}));
+
+vi.mock('firebase/firestore', () => firestore);
+vi.mock('../firebase', () => ({ getDb: vi.fn(() => ({})) }));
+
+import { SessionResponseService } from './sessionResponseService';
+
+function responseDoc(overrides: Partial<SessionResponse> = {}): SessionResponse {
+    return {
+        userId: 'u1',
+        responseId: 'resp-1',
+        sourceSession: { kind: 'execution', id: 'exec-1', date: '2026-08-18' },
+        window: 'immediate',
+        date: '2026-08-18',
+        checkinRef: { date: '2026-08-18' },
+        createdAt: '2026-08-18T10:45:00.000Z',
+        updatedAt: '2026-08-18T10:45:00.000Z',
+        ...overrides,
+    };
+}
+
+describe('SessionResponseService (M5.1)', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        firestore.doc.mockReturnValue({ path: 'session_responses/x' });
+        firestore.setDoc.mockResolvedValue(undefined);
+        firestore.updateDoc.mockResolvedValue(undefined);
+        firestore.collection.mockReturnValue({ path: 'session_responses' });
+        firestore.query.mockReturnValue({});
+    });
+
+    it('recordResponse persists linkage and only the non-tissue facts supplied', async () => {
+        const service = new SessionResponseService();
+        const result = await service.recordResponse(
+            'u1',
+            { kind: 'execution', id: 'exec-1', date: '2026-08-18' },
+            'immediate',
+            '2026-08-18',
+            '2026-08-18',
+            { sessionRpe: 7 },
+        );
+
+        expect(result.sourceSession).toEqual({ kind: 'execution', id: 'exec-1', date: '2026-08-18' });
+        expect(result.window).toBe('immediate');
+        expect(result.checkinRef).toEqual({ date: '2026-08-18' });
+        expect(result.sessionRpe).toBe(7);
+        expect(result.completedFraction).toBeUndefined();
+        expect(result.createdAt).toBe(result.updatedAt);
+
+        const [, payload] = firestore.setDoc.mock.calls[0];
+        expect(payload).not.toHaveProperty('completedFraction');
+        expect(payload).not.toHaveProperty('unexpectedFatigue');
+    });
+
+    it('recordResponse omits occurrenceId when the source execution carries no selection authority', async () => {
+        const service = new SessionResponseService();
+        const result = await service.recordResponse(
+            'u1', { kind: 'execution', id: 'exec-1', date: '2026-08-18' }, 'immediate', '2026-08-18', '2026-08-18', {},
+        );
+        expect(result).not.toHaveProperty('occurrenceId');
+    });
+
+    it('recordResponse includes occurrenceId when supplied', async () => {
+        const service = new SessionResponseService();
+        const result = await service.recordResponse(
+            'u1', { kind: 'execution', id: 'exec-1', date: '2026-08-18' }, 'immediate', '2026-08-18', '2026-08-18', {}, 'occ-1',
+        );
+        expect(result.occurrenceId).toBe('occ-1');
+    });
+
+    it('each recorded response gets a distinct responseId', async () => {
+        const service = new SessionResponseService();
+        const a = await service.recordResponse('u1', { kind: 'execution', id: 'exec-1', date: '2026-08-18' }, 'immediate', '2026-08-18', '2026-08-18', {});
+        const b = await service.recordResponse('u1', { kind: 'execution', id: 'exec-1', date: '2026-08-18' }, 'later_day', '2026-08-18', '2026-08-18', {});
+        expect(a.responseId).not.toBe(b.responseId);
+    });
+
+    it('updateResponseFacts patches only the non-tissue facts and bumps updatedAt, via updateDoc not setDoc', async () => {
+        const service = new SessionResponseService();
+        await service.updateResponseFacts('u1', 'resp-1', { sessionRpe: 8, note: 'heavier than expected' }, '2026-08-19T00:00:00.000Z');
+
+        expect(firestore.setDoc).not.toHaveBeenCalled();
+        const [, patch] = firestore.updateDoc.mock.calls[0];
+        expect(patch).toEqual({ sessionRpe: 8, note: 'heavier than expected', updatedAt: '2026-08-19T00:00:00.000Z' });
+    });
+
+    it('getResponsesForSource filters by sourceSession.kind client-side after the single-field query', async () => {
+        firestore.getDocs.mockResolvedValue({
+            docs: [
+                { data: () => responseDoc({ responseId: 'r1', window: 'immediate' }), ref: { path: 'x' } },
+                // Same sourceSession.id, different kind -- must not be returned for an
+                // 'execution' query (the id alone isn't a unique cross-collection key).
+                { data: () => responseDoc({ responseId: 'r2', sourceSession: { kind: 'strength', id: 'exec-1', date: '2026-08-18' } }), ref: { path: 'x' } },
+                { data: () => responseDoc({ responseId: 'r3', window: 'next_morning' }), ref: { path: 'x' } },
+            ],
+        });
+        const service = new SessionResponseService();
+        const result = await service.getResponsesForSource('u1', { kind: 'execution', id: 'exec-1' });
+        expect(result.map(r => r.responseId)).toEqual(['r1', 'r3']);
+    });
+
+    it('getResponseForWindow returns null (never fabricated) when that window was never answered', async () => {
+        firestore.getDocs.mockResolvedValue({
+            docs: [{ data: () => responseDoc({ window: 'immediate' }), ref: { path: 'x' } }],
+        });
+        const service = new SessionResponseService();
+        const result = await service.getResponseForWindow('u1', { kind: 'execution', id: 'exec-1' }, 'next_morning');
+        expect(result).toBeNull();
+    });
+
+    it('getResponseForWindow returns the matching response when it exists', async () => {
+        firestore.getDocs.mockResolvedValue({
+            docs: [
+                { data: () => responseDoc({ responseId: 'r1', window: 'immediate' }), ref: { path: 'x' } },
+                { data: () => responseDoc({ responseId: 'r2', window: 'next_morning' }), ref: { path: 'x' } },
+            ],
+        });
+        const service = new SessionResponseService();
+        const result = await service.getResponseForWindow('u1', { kind: 'execution', id: 'exec-1' }, 'next_morning');
+        expect(result?.responseId).toBe('r2');
+    });
+});

--- a/app/src/services/sessionResponseService.test.ts
+++ b/app/src/services/sessionResponseService.test.ts
@@ -39,6 +39,9 @@ describe('SessionResponseService (M5.1)', () => {
         firestore.updateDoc.mockResolvedValue(undefined);
         firestore.collection.mockReturnValue({ path: 'session_responses' });
         firestore.query.mockReturnValue({});
+        // recordResponse's existence check; individual tests override for the "already
+        // exists" case.
+        firestore.getDoc.mockResolvedValue({ exists: () => false });
     });
 
     it('recordResponse persists linkage and only the non-tissue facts supplied', async () => {
@@ -87,6 +90,26 @@ describe('SessionResponseService (M5.1)', () => {
         expect(a.responseId).not.toBe(b.responseId);
     });
 
+    it('recordResponse rejects a second create for the same (sourceSession, window) instead of silently producing two documents', async () => {
+        firestore.getDoc.mockResolvedValue({ exists: () => true });
+        const service = new SessionResponseService();
+        await expect(service.recordResponse(
+            'u1', { kind: 'execution', id: 'exec-1', date: '2026-08-18' }, 'immediate', '2026-08-18', '2026-08-18', {},
+        )).rejects.toThrow(/already exists/);
+        expect(firestore.setDoc).not.toHaveBeenCalled();
+    });
+
+    it('recordResponse derives a deterministic id from (sourceSession, window) so a retry naturally targets the same document', async () => {
+        const service = new SessionResponseService();
+        const source = { kind: 'execution' as const, id: 'exec-1', date: '2026-08-18' };
+        const a = await service.recordResponse('u1', source, 'immediate', '2026-08-18', '2026-08-18', {});
+        firestore.getDoc.mockResolvedValueOnce({ exists: () => true });
+        // A second attempt for the exact same pair must be rejected -- it would otherwise
+        // resolve to the same responseId as `a` and silently overwrite it.
+        await expect(service.recordResponse('u1', source, 'immediate', '2026-08-18', '2026-08-18', {})).rejects.toThrow();
+        expect(a.responseId).toBe(`resp-${source.kind}-${source.id}-immediate`);
+    });
+
     it('updateResponseFacts patches only the non-tissue facts and bumps updatedAt, via updateDoc not setDoc', async () => {
         const service = new SessionResponseService();
         await service.updateResponseFacts('u1', 'resp-1', { sessionRpe: 8, note: 'heavier than expected' }, '2026-08-19T00:00:00.000Z');
@@ -103,7 +126,7 @@ describe('SessionResponseService (M5.1)', () => {
                 // Same sourceSession.id, different kind -- must not be returned for an
                 // 'execution' query (the id alone isn't a unique cross-collection key).
                 { data: () => responseDoc({ responseId: 'r2', sourceSession: { kind: 'strength', id: 'exec-1', date: '2026-08-18' } }), ref: { path: 'x' } },
-                { data: () => responseDoc({ responseId: 'r3', window: 'next_morning' }), ref: { path: 'x' } },
+                { data: () => responseDoc({ responseId: 'r3', window: 'next_morning', date: '2026-08-19' }), ref: { path: 'x' } },
             ],
         });
         const service = new SessionResponseService();
@@ -124,7 +147,7 @@ describe('SessionResponseService (M5.1)', () => {
         firestore.getDocs.mockResolvedValue({
             docs: [
                 { data: () => responseDoc({ responseId: 'r1', window: 'immediate' }), ref: { path: 'x' } },
-                { data: () => responseDoc({ responseId: 'r2', window: 'next_morning' }), ref: { path: 'x' } },
+                { data: () => responseDoc({ responseId: 'r2', window: 'next_morning', date: '2026-08-19' }), ref: { path: 'x' } },
             ],
         });
         const service = new SessionResponseService();

--- a/app/src/services/sessionResponseService.ts
+++ b/app/src/services/sessionResponseService.ts
@@ -1,0 +1,129 @@
+import {
+    doc,
+    getDoc,
+    setDoc,
+    updateDoc,
+    collection,
+    query,
+    where,
+    getDocs,
+    type Firestore,
+} from 'firebase/firestore';
+import { getDb } from '../firebase';
+import type { DataState } from '../engine/dataState';
+import type { ResponseWindow, SessionResponse, SessionResponseSourceRef } from '../responses/models';
+import { parseSessionResponseDocument } from '../persistence/parsers/sessionResponse';
+
+/**
+ * M5.1: user-scoped persistence for `SessionResponse` records. Per D-MRESP, this service
+ * never writes a tissue value -- only linkage and the non-tissue session facts
+ * (`responses/models.ts`'s doc comment). No record is ever fabricated here for a prompt the
+ * athlete never answered; a missing `(sourceSession, window)` pair simply has no document,
+ * which callers (M5.2's follow-up schedule, M5.3's outcome report) read as `unknown`.
+ */
+export class SessionResponseService {
+    private readonly db: Firestore;
+
+    constructor(db: Firestore = getDb()) {
+        this.db = db;
+    }
+
+    private responseRef(userId: string, responseId: string) {
+        return doc(this.db, 'users', userId, 'session_responses', responseId);
+    }
+
+    private newResponseId(): string {
+        return `resp-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    }
+
+    async getResponse(userId: string, responseId: string): Promise<DataState<SessionResponse>> {
+        const path = `users/${userId}/session_responses/${responseId}`;
+        try {
+            const snap = await getDoc(this.responseRef(userId, responseId));
+            return parseSessionResponseDocument(snap.exists() ? snap.data() : undefined, path);
+        } catch (err: unknown) {
+            const code = (err as { code?: string })?.code;
+            if (code === 'permission-denied') throw err;
+            return { status: 'UNAVAILABLE', operation: 'getResponse', retryable: true };
+        }
+    }
+
+    /** Every response recorded so far for one source session, across all windows -- the
+     * caller can tell "answered" from "never asked/answered" per window by which of
+     * `immediate`/`later_day`/`next_morning` actually appears here. A single-field query
+     * (`sourceSession.id`) plus a client-side `kind` filter avoids requiring a composite
+     * index for what is, per user, a small bounded collection. */
+    async getResponsesForSource(userId: string, source: Pick<SessionResponseSourceRef, 'kind' | 'id'>): Promise<SessionResponse[]> {
+        const coll = collection(this.db, 'users', userId, 'session_responses');
+        const q = query(coll, where('sourceSession.id', '==', source.id));
+        const snap = await getDocs(q);
+        const responses: SessionResponse[] = [];
+        for (const docSnap of snap.docs) {
+            const parsed = parseSessionResponseDocument(docSnap.data(), docSnap.ref.path);
+            if (parsed.status === 'AVAILABLE' && parsed.data.sourceSession.kind === source.kind) {
+                responses.push(parsed.data);
+            }
+        }
+        return responses.sort((a, b) => a.window.localeCompare(b.window));
+    }
+
+    /** The response for one specific window, if the athlete ever answered it -- `null`
+     * (never fabricated) if not. Distinguishing "missing" from "answered normal" is the
+     * whole point (D-MRESP); callers must not default this to a passing value. */
+    async getResponseForWindow(
+        userId: string,
+        source: Pick<SessionResponseSourceRef, 'kind' | 'id'>,
+        window: ResponseWindow,
+    ): Promise<SessionResponse | null> {
+        const responses = await this.getResponsesForSource(userId, source);
+        return responses.find(response => response.window === window) ?? null;
+    }
+
+    /** Creates a new response for a `(sourceSession, window)` pair that has never been
+     * answered before. Callers must check `getResponseForWindow` first and call
+     * `updateResponseFacts` instead when one already exists -- this never silently
+     * overwrites an existing answer's `createdAt`/identity. */
+    async recordResponse(
+        userId: string,
+        sourceSession: SessionResponseSourceRef,
+        window: ResponseWindow,
+        date: string,
+        checkinDate: string,
+        facts: Partial<Pick<SessionResponse, 'sessionRpe' | 'completedFraction' | 'unexpectedFatigue' | 'techniqueNote' | 'note'>>,
+        occurrenceId?: string,
+        now: string = new Date().toISOString(),
+    ): Promise<SessionResponse> {
+        const response: SessionResponse = {
+            userId,
+            responseId: this.newResponseId(),
+            sourceSession,
+            ...(occurrenceId ? { occurrenceId } : {}),
+            window,
+            date,
+            checkinRef: { date: checkinDate },
+            ...(facts.sessionRpe !== undefined ? { sessionRpe: facts.sessionRpe } : {}),
+            ...(facts.completedFraction !== undefined ? { completedFraction: facts.completedFraction } : {}),
+            ...(facts.unexpectedFatigue !== undefined ? { unexpectedFatigue: facts.unexpectedFatigue } : {}),
+            ...(facts.techniqueNote !== undefined ? { techniqueNote: facts.techniqueNote } : {}),
+            ...(facts.note !== undefined ? { note: facts.note } : {}),
+            createdAt: now,
+            updatedAt: now,
+        };
+        await setDoc(this.responseRef(userId, response.responseId), response);
+        return response;
+    }
+
+    /** Revises the non-tissue facts on an existing response. `sourceSession`, `occurrenceId`,
+     * `window`, `date` and `createdAt` are never part of the patch -- provenance (what this
+     * response is *of*, and when it was first recorded) is preserved across every edit. */
+    async updateResponseFacts(
+        userId: string,
+        responseId: string,
+        patch: Partial<Pick<SessionResponse, 'sessionRpe' | 'completedFraction' | 'unexpectedFatigue' | 'techniqueNote' | 'note'>>,
+        now: string = new Date().toISOString(),
+    ): Promise<void> {
+        await updateDoc(this.responseRef(userId, responseId), { ...patch, updatedAt: now });
+    }
+}
+
+export const sessionResponseService = new SessionResponseService();

--- a/app/src/services/sessionResponseService.ts
+++ b/app/src/services/sessionResponseService.ts
@@ -14,6 +14,11 @@ import type { DataState } from '../engine/dataState';
 import type { ResponseWindow, SessionResponse, SessionResponseSourceRef } from '../responses/models';
 import { parseSessionResponseDocument } from '../persistence/parsers/sessionResponse';
 
+// Explicit chronological order -- not left to `ResponseWindow` values sorting correctly by
+// coincidence (they currently do, alphabetically, but nothing enforces that: a future added
+// or renamed window would silently break an localeCompare-based sort with no test to catch it).
+const RESPONSE_WINDOW_ORDER: Record<ResponseWindow, number> = { immediate: 0, later_day: 1, next_morning: 2 };
+
 /**
  * M5.1: user-scoped persistence for `SessionResponse` records. Per D-MRESP, this service
  * never writes a tissue value -- only linkage and the non-tissue session facts
@@ -32,8 +37,13 @@ export class SessionResponseService {
         return doc(this.db, 'users', userId, 'session_responses', responseId);
     }
 
-    private newResponseId(): string {
-        return `resp-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    /** Deterministic, not random: a `(sourceSession, window)` pair has at most one answer
+     * (D-MRESP), so the id doubles as an idempotency key -- `recordResponse` can then detect
+     * (and reject) a second create for the same pair instead of a random id letting a
+     * double-tap/retry race silently produce two documents, only one of which any later read
+     * would ever find. */
+    private responseIdFor(sourceSession: SessionResponseSourceRef, window: ResponseWindow): string {
+        return `resp-${sourceSession.kind}-${encodeURIComponent(sourceSession.id)}-${window}`;
     }
 
     async getResponse(userId: string, responseId: string): Promise<DataState<SessionResponse>> {
@@ -64,7 +74,7 @@ export class SessionResponseService {
                 responses.push(parsed.data);
             }
         }
-        return responses.sort((a, b) => a.window.localeCompare(b.window));
+        return responses.sort((a, b) => RESPONSE_WINDOW_ORDER[a.window] - RESPONSE_WINDOW_ORDER[b.window]);
     }
 
     /** The response for one specific window, if the athlete ever answered it -- `null`
@@ -80,9 +90,11 @@ export class SessionResponseService {
     }
 
     /** Creates a new response for a `(sourceSession, window)` pair that has never been
-     * answered before. Callers must check `getResponseForWindow` first and call
-     * `updateResponseFacts` instead when one already exists -- this never silently
-     * overwrites an existing answer's `createdAt`/identity. */
+     * answered before. Callers should still check `getResponseForWindow` first and call
+     * `updateResponseFacts` instead when one already exists -- but the deterministic id
+     * backs that up: a second `recordResponse` for the same pair (e.g. a double-tap/retry
+     * race) throws rather than silently overwriting an existing answer's `createdAt`/facts
+     * or leaving two documents behind. */
     async recordResponse(
         userId: string,
         sourceSession: SessionResponseSourceRef,
@@ -93,9 +105,14 @@ export class SessionResponseService {
         occurrenceId?: string,
         now: string = new Date().toISOString(),
     ): Promise<SessionResponse> {
+        const responseId = this.responseIdFor(sourceSession, window);
+        const existing = await getDoc(this.responseRef(userId, responseId));
+        if (existing.exists()) {
+            throw new Error(`A response already exists for this session's ${window} window; call updateResponseFacts instead.`);
+        }
         const response: SessionResponse = {
             userId,
-            responseId: this.newResponseId(),
+            responseId,
             sourceSession,
             ...(occurrenceId ? { occurrenceId } : {}),
             window,

--- a/app/src/sessions/architecture.test.ts
+++ b/app/src/sessions/architecture.test.ts
@@ -80,7 +80,7 @@ function runtimeImportGraph(): Map<string, string[]> {
 describe('Multidomain sessions architecture and dependency boundaries (M0.3 / ADR-0023)', () => {
     const graph = runtimeImportGraph();
 
-    it('sessions/ domain modules do not import engine optimizer or planner modules at runtime', () => {
+    it('sessions/ and responses/ domain modules do not import engine optimizer or planner modules at runtime', () => {
         const forbiddenPrefixes = [
             'engine/optimizer',
             'engine/planner',
@@ -90,15 +90,20 @@ describe('Multidomain sessions architecture and dependency boundaries (M0.3 / AD
             'engine/sequenceSearch',
         ];
 
-        const sessionModules = Array.from(graph.keys()).filter(path => path.startsWith('sessions/'));
+        // M5.1 adds responses/ as a second distinct-lifecycle domain (D-MRECORDS) alongside
+        // sessions/ -- the M0.3 boundary ("sessions/ and observations/ domain types do not
+        // import selection/ranking modules") applies here for the same reason: a session's
+        // or a response's own record shape must never depend on how the engine ranks or
+        // selects anything.
+        const domainModules = Array.from(graph.keys()).filter(path => path.startsWith('sessions/') || path.startsWith('responses/'));
 
-        for (const mod of sessionModules) {
+        for (const mod of domainModules) {
             const imports = graph.get(mod) ?? [];
             for (const imp of imports) {
                 for (const forbidden of forbiddenPrefixes) {
                     expect(
                         imp.startsWith(forbidden),
-                        `Session domain module "${mod}" must not import selection/ranking module "${imp}"`,
+                        `Domain module "${mod}" must not import selection/ranking module "${imp}"`,
                     ).toBe(false);
                 }
             }

--- a/app/src/sessions/sessionDefinitionDiff.ts
+++ b/app/src/sessions/sessionDefinitionDiff.ts
@@ -26,6 +26,7 @@ import type {
     SessionQuality,
     SessionStep,
 } from './models';
+import { canonicalizeSessionData } from './sessionDefinitionHash';
 
 export interface SessionContentDiffRow {
     scope: 'session' | 'block' | 'step' | 'choice' | 'option';
@@ -39,23 +40,12 @@ function formatRangeOrNumber(value: RangeOrNumber): string {
     return typeof value === 'number' ? String(value) : `${value.min}–${value.max}`;
 }
 
-/** Recursively sorts object keys so structurally-identical values compare equal regardless
- * of property insertion order (e.g. two independently-generated JSON payloads for the same
- * dose). Arrays keep their order -- order is meaningful for them (steps, options, ...). */
-function canonicalize(value: unknown): unknown {
-    if (Array.isArray(value)) return value.map(canonicalize);
-    if (value !== null && typeof value === 'object') {
-        const sorted: Record<string, unknown> = {};
-        for (const key of Object.keys(value as Record<string, unknown>).sort()) {
-            sorted[key] = canonicalize((value as Record<string, unknown>)[key]);
-        }
-        return sorted;
-    }
-    return value;
-}
-
+// Reuses sessionDefinitionHash.ts's own key-sorting canonicalization (rather than a second,
+// subtly different local copy) so structurally-identical values compare equal regardless of
+// property insertion order (e.g. two independently-generated JSON payloads for the same
+// dose). Arrays keep their order -- order is meaningful for them (steps, options, ...).
 function sameJson(left: unknown, right: unknown): boolean {
-    return JSON.stringify(canonicalize(left ?? null)) === JSON.stringify(canonicalize(right ?? null));
+    return JSON.stringify(canonicalizeSessionData(left ?? null)) === JSON.stringify(canonicalizeSessionData(right ?? null));
 }
 
 function sameStringSet(left: readonly string[] | undefined, right: readonly string[] | undefined): boolean {

--- a/docs/plans/multidomain-session-authoring-execution-and-evidence.md
+++ b/docs/plans/multidomain-session-authoring-execution-and-evidence.md
@@ -329,7 +329,7 @@ rewritten as an outcome; an in-progress item retains its remaining acceptance wo
 | M4.1 | Group execution modes | `[x]` | M2.5 |
 | M4.2 | Recorded athlete choices and alternatives | `[x]` | M4.1, M3.5 |
 | M4.3 | Companion occurrence and duplicate reconciliation | `[x]` | — |
-| M5.1 | Occurrence-linked response generalization | `[ ]` | M1.7, M2.6, M4.3 |
+| M5.1 | Occurrence-linked response generalization | `[x]` | — |
 | M5.2 | Later-day and next-morning follow-up | `[ ]` | M5.1 |
 | M5.3 | Outcome/override evidence report | `[ ]` | M5.2; richer history UI only after a usage trigger |
 | M6.1 | Representative speed/field/power taxonomy v1 | `[ ]` | **Usage trigger:** recurring real session needs domain detail the generic runner cannot represent; then M3.5, M2.5 |
@@ -1312,7 +1312,7 @@ M1.7 already established the link against `strength_sessions`. This milestone ge
 any occurrence and adds the delayed windows. M5.1 and M5.2 are the near-term evidence-producing
 chain after M4.3; M5.3 is deliberately narrower than the original UI-heavy proposal.
 
-### M5.1 `[ ]` Occurrence-linked response generalization
+### M5.1 `[x]` Occurrence-linked response generalization
 
 **Change.** Add `SessionResponse` with occurrence/execution identity and window
 `immediate | later_day | next_morning`. Per D-MRESP it stores **linkage and non-tissue session
@@ -1331,6 +1331,59 @@ rules/emulator tests.
 **Done when.** A response cannot reference another user's occurrence; window and date are
 validated; edits preserve provenance; missing follow-up is distinguishable from normal; and a
 tissue value appears in exactly one collection.
+
+**Outcome (2026-08-19).** New `responses/` domain (own distinct lifecycle, per D-MRECORDS,
+alongside `sessions/`): `responses/models.ts` (`SessionResponse`, `ResponseWindow`,
+`SessionResponseSourceRef`), `responses/validation.ts` (`validateSessionResponse`, a
+self-contained strict validator mirroring `sessions/validation.ts`'s own conventions),
+`persistence/parsers/sessionResponse.ts`, and `services/sessionResponseService.ts`
+(`recordResponse`, `updateResponseFacts`, `getResponsesForSource`, `getResponseForWindow`).
+
+* **Reuses, not migrates, M1.7/M2.6's linkage shape.** `SessionResponseSourceRef` is exactly
+  the `{kind: 'strength'|'execution', id, date}` shape `RegionTissueResponse.sourceSessionRef`
+  already writes (M2.6 had already generalized `kind` beyond strength-only, ahead of this
+  item) -- reused rather than reinvented so a `SessionResponse` and the check-in's own
+  tissue-side linkage join on identical fields for the same session. No existing check-in
+  document needed rewriting; `sourceSessionRef` itself is untouched.
+* **Linkage and non-tissue facts only (D-MRESP).** `SessionResponse` stores `window`
+  (`immediate | later_day | next_morning`), `sessionRpe`, `completedFraction`,
+  `unexpectedFatigue`, `techniqueNote`, `note`, and a `checkinRef: { date }` pointing at the
+  canonical check-in that holds this window's tissue values -- never a tissue value itself.
+  `DailySubjectiveCheckin.tissueResponses` remains the sole tissue authority; nothing here
+  duplicates it.
+* **Missing follow-up is distinguishable from normal.** No `SessionResponse` document is ever
+  created except in direct answer to an athlete action (`recordResponse` is the only write
+  path that creates one); `getResponseForWindow` returns `null` -- never a fabricated
+  default -- when a window was never answered, so callers (M5.2's schedule, M5.3's outcome
+  report) can tell "never asked/answered" from every actual answer, including a normal one.
+* **Edits preserve provenance.** `updateResponseFacts` only ever patches the five non-tissue
+  fact fields plus `updatedAt`; `sourceSession`/`occurrenceId`/`window`/`date`/`createdAt` have
+  no code path that changes them after creation. Firestore rules enforce the same constraint
+  server-side (`request.resource.data.sourceSession/window/date/createdAt ==
+  resource.data....`), not just client discipline.
+* **Cannot reference another user's occurrence.** Beyond the standard owner-scoped path and
+  `userId` match, the rules require an `occurrenceId` (when present) to resolve via `exists()`
+  against `users/{userId}/session_occurrences/{occurrenceId}` under that same authenticated
+  user's own path -- a cross-user id structurally cannot resolve there, and a garbage/mistyped
+  id is rejected rather than silently stored.
+* **Window/date validated at both layers.** `window` and `sourceSession.kind` are checked
+  against their exact enums, and every date field (`date`, `sourceSession.date`,
+  `checkinRef.date`) is checked as a real calendar date, in both the TypeScript validator and
+  the Firestore rules (`isValidActivityDate`) -- the same fail-closed, two-layer pattern every
+  other M2/M3 record already uses.
+
+**Files.** `responses/models.ts`, `responses/validation.ts` (+ `.test.ts`),
+`persistence/parsers/sessionResponse.ts` (+ `.test.ts`), `services/sessionResponseService.ts`
+(+ `.test.ts`), `firestore.rules`, `emulator/firestoreRules.emulator.test.ts`. Extended
+`sessions/architecture.test.ts`'s optimizer/planner boundary check to also scan `responses/`
+(a second distinct-lifecycle domain now exists, not only `sessions/`).
+
+Verified by 15 validator cases, 8 service cases, 3 parser cases, 5 new Firestore-emulator
+cases (record + revise, provenance-preserving edit rejection on each of the four immutable
+fields, malformed-shape rejection, foreign-`userId` rejection, and the
+occurrenceId-must-exist-for-this-user check both failing and then succeeding once the
+occurrence is written) -- 82/82 emulator tests total -- and a full `npm run check`
+(typecheck, lint, 1692 unit tests, catalog validation) pass with no regressions.
 
 ### M5.2 `[ ]` Later-day and next-morning follow-up
 


### PR DESCRIPTION
Stacked on #98 (M4.3).

New `responses/` domain, distinct from `sessions/` per D-MRECORDS:

- `responses/models.ts`: `SessionResponse`, `ResponseWindow` (`immediate|later_day|next_morning`), `SessionResponseSourceRef` — reuses M1.7/M2.6's existing `{kind, id, date}` linkage shape rather than migrating it, so no existing check-in document needs rewriting.
- `responses/validation.ts` + `persistence/parsers/sessionResponse.ts`: self-contained strict validator/parser mirroring `sessions/` conventions.
- `services/sessionResponseService.ts`: `recordResponse` (create-only, never fabricated for an unanswered prompt), `updateResponseFacts` (patches only the five non-tissue facts, preserving `sourceSession`/`window`/`date`/`createdAt`), `getResponsesForSource`/`getResponseForWindow` (`null`, not a default, when a window was never answered).
- `firestore.rules`: ownership, window/date/shape validation, an `occurrenceId` (when present) must resolve to a real occurrence under this same user's own path, and update rules reject any change to `sourceSession`/`window`/`date`/`createdAt` server-side.

Per D-MRESP, `DailySubjectiveCheckin.tissueResponses` remains the sole tissue authority — `SessionResponse` never stores a tissue value.

Extended `sessions/architecture.test.ts`'s optimizer/planner import boundary to also scan `responses/`, the second distinct-lifecycle domain now alongside `sessions/`.

82/82 Firestore emulator tests pass (5 new); full `npm run check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)