### PR TITLE
feat(responses): later-day and next-morning follow-up prompts (M5.2)

### DIFF
--- a/app/src/components/DailyCheckin.tsx
+++ b/app/src/components/DailyCheckin.tsx
@@ -1,6 +1,10 @@
 import { useState, useEffect, useCallback, useId } from 'react';
 import { checkinService } from '../services/checkinService';
 import { recoverySnapshotService } from '../services/recoverySnapshotService';
+import { sessionExecutionService } from '../services/sessionExecutionService';
+import { sessionResponseService } from '../services/sessionResponseService';
+import { relevantFollowupRegions } from '../responses/followupSchedule';
+import { EXERCISES } from '../workouts/exercises';
 import type { BodyRegion, DailySubjectiveCheckin, RegionTissueResponse, TissueResponseLevel } from '../engine/models';
 import { BODY_REGIONS, TISSUE_LEVELS } from '../engine/models';
 import { getLocalDateString, addDaysToLocalDateString } from '../utils/localDate';
@@ -119,21 +123,55 @@ export function DailyCheckin({ userId, onNavigate, onBack }: DailyCheckinProps) 
         const snapshot = await recoverySnapshotService.getRecoverySnapshotByDate(userId, today);
         setRecoverySnapshot(snapshot ?? null);
 
-        // Check if yesterday's checkin or session logged tissue reactions requiring follow-up (M1.7)
+        // Check if yesterday's checkin or session logged tissue reactions requiring
+        // follow-up (M1.7), generalized (M5.2) to also derive candidate regions from
+        // yesterday's own completed session_executions via M3.5 tissue tags -- so a novel
+        // session the athlete never manually flagged a region for during/after still gets
+        // asked about a region its own movements make relevant. A region the athlete's own
+        // manual tissueResponses flag already covers takes priority (keeps whatever
+        // sourceSessionRef that flag already carries); the session-derived scan only fills
+        // in what the athlete didn't already flag. Legacy strength_sessions are out of this
+        // generalization's scope -- their own manual tissueResponses flag still works
+        // unchanged, exactly as before M5.2.
         const yesterday = addDaysToLocalDateString(today, -1);
         const yesterdayCheckin = await checkinService.getCheckin(userId, yesterday);
+        const needed: Array<{ region: BodyRegion; sessionRef?: RegionTissueResponse['sourceSessionRef'] }> = [];
+        const coveredRegions = new Set<BodyRegion>();
         if (yesterdayCheckin?.tissueResponses) {
-          const needed: Array<{ region: BodyRegion; sessionRef?: RegionTissueResponse['sourceSessionRef'] }> = [];
           for (const [regionKey, response] of Object.entries(yesterdayCheckin.tissueResponses)) {
             const region = regionKey as BodyRegion;
             if (response && (response.painDuringTraining || response.afterTrainingState || response.sourceSessionRef)) {
+              coveredRegions.add(region);
               if (!existing?.tissueResponses?.[region]?.nextMorningReaction) {
                 needed.push({ region, sessionRef: response.sourceSessionRef });
               }
             }
           }
-          setPendingFollowups(needed);
         }
+        try {
+          const { executions } = await sessionExecutionService.getExecutionsInRange(userId, yesterday, today);
+          for (const { execution, entries } of executions) {
+            if (execution.state === 'in_progress') continue;
+            const exerciseIds: string[] = [];
+            for (const entry of entries) {
+              if (entry.exerciseRef?.kind === 'catalog') exerciseIds.push(entry.exerciseRef.exerciseId);
+            }
+            const facets = exerciseIds
+              .map(id => EXERCISES.find(item => item.id === id)?.facets)
+              .filter((facet): facet is NonNullable<typeof facet> => !!facet);
+            const sessionRef: RegionTissueResponse['sourceSessionRef'] = { kind: 'execution', id: execution.executionId, date: execution.date };
+            for (const region of relevantFollowupRegions(facets)) {
+              if (coveredRegions.has(region)) continue;
+              if (existing?.tissueResponses?.[region]?.nextMorningReaction) continue;
+              coveredRegions.add(region);
+              needed.push({ region, sessionRef });
+            }
+          }
+        } catch {
+          // Session-derived candidates are an enhancement, not a requirement -- a failed
+          // read here must not block the check-in itself from loading.
+        }
+        setPendingFollowups(needed);
 
         if (existing) {
           setCheckin(existing);
@@ -268,6 +306,21 @@ export function DailyCheckin({ userId, onNavigate, onBack }: DailyCheckinProps) 
     setPendingFollowups(prev => prev.filter(item => item.region !== region));
     if (checkin.userId && checkin.date) {
       await checkinService.upsertTodayCheckin(checkin.userId, updatedCheckin);
+    }
+    // M5.2: one session-level SessionResponse per session for the next_morning window --
+    // several regions of the same session must not create duplicates, so an existing one
+    // is checked for first. The tissue value itself is never written here or duplicated
+    // into it (D-MRESP) -- the check-in write above is the only tissue authority.
+    if (sessionRef && checkin.userId && checkin.date) {
+      try {
+        const already = await sessionResponseService.getResponseForWindow(checkin.userId, sessionRef, 'next_morning');
+        if (!already) {
+          await sessionResponseService.recordResponse(checkin.userId, sessionRef, 'next_morning', checkin.date, checkin.date, {});
+        }
+      } catch {
+        // Best-effort session-level linkage; the tissue answer above already succeeded and
+        // remains the source of truth injuryPolicy.ts/D-SUBJFLOOR consume.
+      }
     }
   };
 

--- a/app/src/components/DailyCheckin.tsx
+++ b/app/src/components/DailyCheckin.tsx
@@ -136,12 +136,13 @@ export function DailyCheckin({ userId, onNavigate, onBack }: DailyCheckinProps) 
         const yesterday = addDaysToLocalDateString(today, -1);
         const yesterdayCheckin = await checkinService.getCheckin(userId, yesterday);
         const needed: Array<{ region: BodyRegion; sessionRef?: RegionTissueResponse['sourceSessionRef'] }> = [];
-        const coveredRegions = new Set<BodyRegion>();
+        const coveredRegionSessionKeys = new Set<string>();
         if (yesterdayCheckin?.tissueResponses) {
           for (const [regionKey, response] of Object.entries(yesterdayCheckin.tissueResponses)) {
             const region = regionKey as BodyRegion;
             if (response && (response.painDuringTraining || response.afterTrainingState || response.sourceSessionRef)) {
-              coveredRegions.add(region);
+              const sessionKey = response.sourceSessionRef ? `${response.sourceSessionRef.kind}:${response.sourceSessionRef.id}` : 'checkin';
+              coveredRegionSessionKeys.add(`${sessionKey}:${region}`);
               if (!existing?.tissueResponses?.[region]?.nextMorningReaction) {
                 needed.push({ region, sessionRef: response.sourceSessionRef });
               }
@@ -160,10 +161,12 @@ export function DailyCheckin({ userId, onNavigate, onBack }: DailyCheckinProps) 
               .map(id => EXERCISES.find(item => item.id === id)?.facets)
               .filter((facet): facet is NonNullable<typeof facet> => !!facet);
             const sessionRef: RegionTissueResponse['sourceSessionRef'] = { kind: 'execution', id: execution.executionId, date: execution.date };
+            const sessionKey = `execution:${execution.executionId}`;
             for (const region of relevantFollowupRegions(facets)) {
-              if (coveredRegions.has(region)) continue;
+              const key = `${sessionKey}:${region}`;
+              if (coveredRegionSessionKeys.has(key)) continue;
+              coveredRegionSessionKeys.add(key);
               if (existing?.tissueResponses?.[region]?.nextMorningReaction) continue;
-              coveredRegions.add(region);
               needed.push({ region, sessionRef });
             }
           }
@@ -303,7 +306,7 @@ export function DailyCheckin({ userId, onNavigate, onBack }: DailyCheckinProps) 
       painOrInjury: level !== 'normal' ? true : checkin.painOrInjury,
     };
     setCheckin(updatedCheckin);
-    setPendingFollowups(prev => prev.filter(item => item.region !== region));
+    setPendingFollowups(prev => prev.filter(item => !(item.region === region && item.sessionRef?.id === sessionRef?.id && item.sessionRef?.kind === sessionRef?.kind)));
     if (checkin.userId && checkin.date) {
       await checkinService.upsertTodayCheckin(checkin.userId, updatedCheckin);
     }
@@ -324,8 +327,8 @@ export function DailyCheckin({ userId, onNavigate, onBack }: DailyCheckinProps) 
     }
   };
 
-  const handleSkipFollowup = (region: BodyRegion) => {
-    setPendingFollowups(prev => prev.filter(item => item.region !== region));
+  const handleSkipFollowup = (region: BodyRegion, sessionRef?: RegionTissueResponse['sourceSessionRef']) => {
+    setPendingFollowups(prev => prev.filter(item => !(item.region === region && item.sessionRef?.id === sessionRef?.id && item.sessionRef?.kind === sessionRef?.kind)));
   };
 
   const handleAvailabilityChange = (field: string, value: number | string | boolean | null) => {
@@ -445,7 +448,7 @@ export function DailyCheckin({ userId, onNavigate, onBack }: DailyCheckinProps) 
             <button
               type="button"
               className="btn-followup-skip"
-              onClick={() => handleSkipFollowup(pendingFollowups[0].region)}
+              onClick={() => handleSkipFollowup(pendingFollowups[0].region, pendingFollowups[0].sessionRef)}
             >
               Skip
             </button>

--- a/app/src/components/Home.tsx
+++ b/app/src/components/Home.tsx
@@ -31,12 +31,17 @@ import {
   type ActiveExternalPlan,
 } from '../services/activeExternalPlanService';
 import { checkinService } from '../services/checkinService';
+import { sessionExecutionService } from '../services/sessionExecutionService';
+import { sessionResponseService } from '../services/sessionResponseService';
+import { relevantFollowupRegions } from '../responses/followupSchedule';
+import { EXERCISES } from '../workouts/exercises';
 import { ExternalVerdictBanner } from './ExternalVerdictBanner';
 import { WorkoutExportMenu } from './WorkoutExportMenu';
 import { AdherencePrompt, type AdherenceAnswer } from './AdherencePrompt';
 import { DecisionJournalCard } from './DecisionJournalCard';
 import { MinimumSafetyCheckin } from './MinimumSafetyCheckin';
 import { WeekAheadStrip } from './WeekAheadStrip';
+import { LaterDayFollowupCard, type LaterDayFollowupTarget } from './session/LaterDayFollowupCard';
 import {
   canGenerateNormalRecommendation,
   createProvisionalSafetyRecommendation,
@@ -226,6 +231,75 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
     });
     return () => { cancelled = true; };
   }, [userId, decisionInput]);
+
+  // M5.2: same-day "later_day" follow-up -- distinct from the next-morning tissue prompt
+  // above, which the check-in model has no same-day field for. Gated on M3.5 tissue-tag
+  // relevance (relevantFollowupRegions) so an ordinary easy session with nothing
+  // tissue-relevant in it never nags; only offered once per execution per mount
+  // (dismissedLaterDayKeys), and never for a window a SessionResponse already answers.
+  const [laterDayFollowup, setLaterDayFollowup] = useState<LaterDayFollowupTarget | null>(null);
+  const [dismissedLaterDayKeys, setDismissedLaterDayKeys] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!decisionInput) {
+      setLaterDayFollowup(null);
+      return;
+    }
+    let cancelled = false;
+    const today = decisionInput.date;
+    const tomorrow = addDaysToLocalDateString(today, 1);
+    (async () => {
+      try {
+        const { executions } = await sessionExecutionService.getExecutionsInRange(userId, today, tomorrow);
+        const finished = executions
+          .filter(item => item.execution.state !== 'in_progress')
+          .sort((a, b) => (b.execution.completedAt ?? b.execution.updatedAt).localeCompare(a.execution.completedAt ?? a.execution.updatedAt));
+
+        for (const { execution, entries } of finished) {
+          const key = `execution:${execution.executionId}`;
+          if (dismissedLaterDayKeys.has(key)) continue;
+
+          const exerciseIds: string[] = [];
+          for (const entry of entries) {
+            if (entry.exerciseRef?.kind === 'catalog') exerciseIds.push(entry.exerciseRef.exerciseId);
+          }
+          const facets = exerciseIds
+            .map(id => EXERCISES.find(item => item.id === id)?.facets)
+            .filter((facet): facet is NonNullable<typeof facet> => !!facet);
+          if (relevantFollowupRegions(facets).length === 0) continue;
+
+          const existing = await sessionResponseService.getResponseForWindow(
+            userId,
+            { kind: 'execution', id: execution.executionId },
+            'later_day',
+          );
+          if (existing) continue;
+
+          if (!cancelled) {
+            setLaterDayFollowup({
+              sourceSession: { kind: 'execution', id: execution.executionId, date: execution.date },
+              ...(execution.occurrenceId ? { occurrenceId: execution.occurrenceId } : {}),
+              date: execution.date,
+              title: 'today’s session',
+            });
+          }
+          return;
+        }
+        if (!cancelled) setLaterDayFollowup(null);
+      } catch {
+        if (!cancelled) setLaterDayFollowup(null);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [userId, decisionInput, dismissedLaterDayKeys]);
+
+  const dismissLaterDayFollowup = useCallback(() => {
+    setLaterDayFollowup(current => {
+      if (current) setDismissedLaterDayKeys(prev => new Set(prev).add(`execution:${current.sourceSession.id}`));
+      return null;
+    });
+  }, []);
+  const handleLaterDayAnswered = useCallback(() => setLaterDayFollowup(null), []);
   const activeSettings = useMemo(() => {
     if (!decisionInput) return [];
     const { equipment, guardrails, defaults } = decisionInput.trainingSettings;
@@ -777,6 +851,15 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
           </div>
           <button type="button" onClick={() => onNavigate('checkin')}>Answer follow-up</button>
         </aside>
+      )}
+
+      {laterDayFollowup && (
+        <LaterDayFollowupCard
+          userId={userId}
+          target={laterDayFollowup}
+          onAnswered={handleLaterDayAnswered}
+          onDismiss={dismissLaterDayFollowup}
+        />
       )}
 
       {isCheckinMissing && (

--- a/app/src/components/Home.tsx
+++ b/app/src/components/Home.tsx
@@ -239,6 +239,7 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
   // (dismissedLaterDayKeys), and never for a window a SessionResponse already answers.
   const [laterDayFollowup, setLaterDayFollowup] = useState<LaterDayFollowupTarget | null>(null);
   const [dismissedLaterDayKeys, setDismissedLaterDayKeys] = useState<Set<string>>(new Set());
+  const [laterDayFollowupRevision, setLaterDayFollowupRevision] = useState(0);
 
   useEffect(() => {
     if (!decisionInput) {
@@ -291,7 +292,7 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
       }
     })();
     return () => { cancelled = true; };
-  }, [userId, decisionInput, dismissedLaterDayKeys]);
+  }, [userId, decisionInput, dismissedLaterDayKeys, laterDayFollowupRevision]);
 
   const dismissLaterDayFollowup = useCallback(() => {
     setLaterDayFollowup(current => {
@@ -299,7 +300,10 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
       return null;
     });
   }, []);
-  const handleLaterDayAnswered = useCallback(() => setLaterDayFollowup(null), []);
+  const handleLaterDayAnswered = useCallback(() => {
+    setLaterDayFollowup(null);
+    setLaterDayFollowupRevision(current => current + 1);
+  }, []);
   const activeSettings = useMemo(() => {
     if (!decisionInput) return [];
     const { equipment, guardrails, defaults } = decisionInput.trainingSettings;

--- a/app/src/components/session/LaterDayFollowupCard.css
+++ b/app/src/components/session/LaterDayFollowupCard.css
@@ -1,0 +1,67 @@
+.later-day-followup-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+  padding: 0.85rem 1rem;
+  border: 1px solid rgba(251, 191, 36, 0.45);
+  border-radius: 0.75rem;
+  background: rgba(180, 83, 9, 0.16);
+  color: #fef3c7;
+}
+
+.later-day-followup-card > div:first-child {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.later-day-followup-card span {
+  color: #fde68a;
+  font-size: 0.875rem;
+}
+
+.later-day-followup-error {
+  color: #fca5a5 !important;
+}
+
+.later-day-followup-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  flex: 0 0 auto;
+}
+
+.later-day-followup-actions button {
+  min-height: 44px;
+  padding: 0.45rem 0.8rem;
+  border: 1px solid rgba(253, 230, 138, 0.55);
+  border-radius: 0.45rem;
+  background: transparent;
+  color: #fef3c7;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.later-day-followup-actions button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.later-day-followup-dismiss {
+  font-weight: 500 !important;
+  opacity: 0.8;
+}
+
+@media (max-width: 520px) {
+  .later-day-followup-card {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .later-day-followup-actions {
+    flex-direction: column;
+  }
+}

--- a/app/src/components/session/LaterDayFollowupCard.test.tsx
+++ b/app/src/components/session/LaterDayFollowupCard.test.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { LaterDayFollowupCard, type LaterDayFollowupTarget } from './LaterDayFollowupCard';
+
+vi.mock('../../services/sessionResponseService', () => ({ sessionResponseService: { recordResponse: vi.fn() } }));
+
+const target: LaterDayFollowupTarget = {
+    sourceSession: { kind: 'execution', id: 'exec-1', date: '2026-08-19' },
+    date: '2026-08-19',
+    title: 'today’s session',
+};
+
+describe('LaterDayFollowupCard (M5.2)', () => {
+    it('renders the same-day prompt with answer and skip controls', () => {
+        const html = renderToStaticMarkup(
+            <LaterDayFollowupCard userId="u1" target={target} onAnswered={vi.fn()} onDismiss={vi.fn()} />,
+        );
+        expect(html).toContain('Feeling normal');
+        expect(html).toContain('Unexpectedly fatigued');
+        expect(html).toContain('Not now');
+        expect(html).toContain('today’s session');
+    });
+});

--- a/app/src/components/session/LaterDayFollowupCard.test.tsx
+++ b/app/src/components/session/LaterDayFollowupCard.test.tsx
@@ -1,16 +1,23 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { LaterDayFollowupCard, type LaterDayFollowupTarget } from './LaterDayFollowupCard';
+import { LaterDayFollowupCard } from './LaterDayFollowupCard';
+import { recordLaterDayFollowup, type LaterDayFollowupTarget } from './laterDayFollowupAction';
+import { sessionResponseService } from '../../services/sessionResponseService';
 
 vi.mock('../../services/sessionResponseService', () => ({ sessionResponseService: { recordResponse: vi.fn() } }));
 
 const target: LaterDayFollowupTarget = {
     sourceSession: { kind: 'execution', id: 'exec-1', date: '2026-08-19' },
+    occurrenceId: 'occ-1',
     date: '2026-08-19',
     title: 'today’s session',
 };
 
 describe('LaterDayFollowupCard (M5.2)', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
     it('renders the same-day prompt with answer and skip controls', () => {
         const html = renderToStaticMarkup(
             <LaterDayFollowupCard userId="u1" target={target} onAnswered={vi.fn()} onDismiss={vi.fn()} />,
@@ -19,5 +26,38 @@ describe('LaterDayFollowupCard (M5.2)', () => {
         expect(html).toContain('Unexpectedly fatigued');
         expect(html).toContain('Not now');
         expect(html).toContain('today’s session');
+    });
+
+    it('records a later_day response with target details when answered feeling normal', async () => {
+        await recordLaterDayFollowup('u1', target, false);
+        expect(sessionResponseService.recordResponse).toHaveBeenCalledWith(
+            'u1',
+            target.sourceSession,
+            'later_day',
+            '2026-08-19',
+            '2026-08-19',
+            { unexpectedFatigue: false },
+            'occ-1',
+        );
+    });
+
+    it('records a later_day response with unexpectedFatigue true when answered fatigued', async () => {
+        await recordLaterDayFollowup('u1', target, true);
+        expect(sessionResponseService.recordResponse).toHaveBeenCalledWith(
+            'u1',
+            target.sourceSession,
+            'later_day',
+            '2026-08-19',
+            '2026-08-19',
+            { unexpectedFatigue: true },
+            'occ-1',
+        );
+    });
+
+    it('does not write any response when dismissed via onDismiss', () => {
+        const onDismiss = vi.fn();
+        onDismiss();
+        expect(onDismiss).toHaveBeenCalled();
+        expect(sessionResponseService.recordResponse).not.toHaveBeenCalled();
     });
 });

--- a/app/src/components/session/LaterDayFollowupCard.tsx
+++ b/app/src/components/session/LaterDayFollowupCard.tsx
@@ -1,17 +1,8 @@
 import React, { useState } from 'react';
-import type { SessionResponseSourceRef } from '../../responses/models';
-import { sessionResponseService } from '../../services/sessionResponseService';
+import { recordLaterDayFollowup, type LaterDayFollowupTarget } from './laterDayFollowupAction';
 import './LaterDayFollowupCard.css';
 
-export interface LaterDayFollowupTarget {
-    sourceSession: SessionResponseSourceRef;
-    occurrenceId?: string;
-    /** Warsaw-local date the session happened on -- this window's own `date` and the
-     * check-in it references are both this same day (M5.2: `later_day` is a same-day
-     * follow-up, distinct from the next-morning tissue prompt). */
-    date: string;
-    title: string;
-}
+export type { LaterDayFollowupTarget };
 
 interface LaterDayFollowupCardProps {
     userId: string;
@@ -35,15 +26,7 @@ export const LaterDayFollowupCard: React.FC<LaterDayFollowupCardProps> = ({ user
         setSaving(true);
         setError(null);
         try {
-            await sessionResponseService.recordResponse(
-                userId,
-                target.sourceSession,
-                'later_day',
-                target.date,
-                target.date,
-                { unexpectedFatigue },
-                target.occurrenceId,
-            );
+            await recordLaterDayFollowup(userId, target, unexpectedFatigue);
             onAnswered();
         } catch {
             setError('Could not save this. You can answer again later.');

--- a/app/src/components/session/LaterDayFollowupCard.tsx
+++ b/app/src/components/session/LaterDayFollowupCard.tsx
@@ -1,0 +1,69 @@
+import React, { useState } from 'react';
+import type { SessionResponseSourceRef } from '../../responses/models';
+import { sessionResponseService } from '../../services/sessionResponseService';
+import './LaterDayFollowupCard.css';
+
+export interface LaterDayFollowupTarget {
+    sourceSession: SessionResponseSourceRef;
+    occurrenceId?: string;
+    /** Warsaw-local date the session happened on -- this window's own `date` and the
+     * check-in it references are both this same day (M5.2: `later_day` is a same-day
+     * follow-up, distinct from the next-morning tissue prompt). */
+    date: string;
+    title: string;
+}
+
+interface LaterDayFollowupCardProps {
+    userId: string;
+    target: LaterDayFollowupTarget;
+    onAnswered: () => void;
+    onDismiss: () => void;
+}
+
+/**
+ * M5.2: a same-day, whole-session follow-up -- distinct from the next-morning per-region
+ * tissue prompt (`DailyCheckin.tsx`), which the check-in model has no same-day field for.
+ * Answering records a session-level `SessionResponse` (M5.1: linkage plus non-tissue facts
+ * only, never a tissue value); "Not now" dismisses without writing anything, so a skipped
+ * prompt stays unknown rather than defaulting to "felt normal".
+ */
+export const LaterDayFollowupCard: React.FC<LaterDayFollowupCardProps> = ({ userId, target, onAnswered, onDismiss }) => {
+    const [saving, setSaving] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const answer = async (unexpectedFatigue: boolean) => {
+        setSaving(true);
+        setError(null);
+        try {
+            await sessionResponseService.recordResponse(
+                userId,
+                target.sourceSession,
+                'later_day',
+                target.date,
+                target.date,
+                { unexpectedFatigue },
+                target.occurrenceId,
+            );
+            onAnswered();
+        } catch {
+            setError('Could not save this. You can answer again later.');
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    return (
+        <aside className="later-day-followup-card" aria-label="Later-day session follow-up">
+            <div>
+                <strong>How does {target.title} feel now?</strong>
+                <span>A few hours on, not right after finishing.</span>
+                {error && <span className="later-day-followup-error" role="alert">{error}</span>}
+            </div>
+            <div className="later-day-followup-actions">
+                <button type="button" disabled={saving} onClick={() => answer(false)}>Feeling normal</button>
+                <button type="button" disabled={saving} onClick={() => answer(true)}>Unexpectedly fatigued</button>
+                <button type="button" className="later-day-followup-dismiss" disabled={saving} onClick={onDismiss}>Not now</button>
+            </div>
+        </aside>
+    );
+};

--- a/app/src/components/session/laterDayFollowupAction.ts
+++ b/app/src/components/session/laterDayFollowupAction.ts
@@ -1,0 +1,29 @@
+import type { SessionResponseSourceRef } from '../../responses/models';
+import { sessionResponseService, type SessionResponseService } from '../../services/sessionResponseService';
+
+export interface LaterDayFollowupTarget {
+    sourceSession: SessionResponseSourceRef;
+    occurrenceId?: string;
+    /** Warsaw-local date the session happened on -- this window's own `date` and the
+     * check-in it references are both this same day (M5.2: `later_day` is a same-day
+     * follow-up, distinct from the next-morning tissue prompt). */
+    date: string;
+    title: string;
+}
+
+export async function recordLaterDayFollowup(
+    userId: string,
+    target: LaterDayFollowupTarget,
+    unexpectedFatigue: boolean,
+    service: SessionResponseService = sessionResponseService,
+): Promise<void> {
+    await service.recordResponse(
+        userId,
+        target.sourceSession,
+        'later_day',
+        target.date,
+        target.date,
+        { unexpectedFatigue },
+        target.occurrenceId,
+    );
+}

--- a/app/src/responses/followupSchedule.test.ts
+++ b/app/src/responses/followupSchedule.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { relevantFollowupRegions } from './followupSchedule';
+
+describe('relevantFollowupRegions', () => {
+    it('maps back_squat-style tissueDemand/safetyTags to knee', () => {
+        const regions = relevantFollowupRegions([{ tissueDemand: ['knee_extensor', 'hip_extensor'], safetyTags: ['knee_swelling'] }]);
+        expect(regions).toContain('knee');
+        expect(regions).toContain('hip');
+    });
+
+    it('maps a field sprint drill to hamstring/calf-relevant regions', () => {
+        const regions = relevantFollowupRegions([{ tissueDemand: ['posterior_chain', 'calf'], safetyTags: ['acute_hamstring_pain', 'worsening_achilles_pain'] }]);
+        expect(regions).toEqual(expect.arrayContaining(['calf', 'hamstring', 'achilles']));
+    });
+
+    it('returns empty for an exercise with no tissue/safety tags', () => {
+        expect(relevantFollowupRegions([{}])).toEqual([]);
+    });
+
+    it('returns empty for no exercises at all (e.g. an easy aerobic session)', () => {
+        expect(relevantFollowupRegions([])).toEqual([]);
+    });
+
+    it('does not guess a region for an unrecognized tag', () => {
+        expect(relevantFollowupRegions([{ tissueDemand: ['some_future_tag_nobody_mapped_yet'] }])).toEqual([]);
+    });
+
+    it('deduplicates and sorts regions across multiple exercises', () => {
+        const regions = relevantFollowupRegions([
+            { tissueDemand: ['knee_extensor'] },
+            { tissueDemand: ['knee_extensor'] },
+            { safetyTags: ['acute_hamstring_pain'] },
+        ]);
+        expect(regions).toEqual(['hamstring', 'knee']);
+    });
+
+    it('is case-insensitive', () => {
+        expect(relevantFollowupRegions([{ tissueDemand: ['KNEE_EXTENSOR'] }])).toEqual(['knee']);
+    });
+});

--- a/app/src/responses/followupSchedule.ts
+++ b/app/src/responses/followupSchedule.ts
@@ -1,0 +1,60 @@
+/**
+ * M5.2: which body regions a completed session's own catalog movements make worth asking
+ * about, derived from M3.5's `ExerciseDefinition.facets.tissueDemand`/`safetyTags` -- coarse,
+ * heuristic labels (M3.5's own framing), not a diagnosis. An exercise whose tags don't map to
+ * a recognized `BodyRegion` contributes no region rather than guessing one; an unresolved
+ * free-text movement (C8) has no catalog facets at all and likewise contributes nothing.
+ *
+ * Pure and Firestore-free, matching `sessions/`'s established convention: callers resolve
+ * executions/entries/exercises themselves (`Home.tsx`, `DailyCheckin.tsx`) and pass in plain
+ * data. Nothing here writes a tissue value, fabricates a response, or decides an outcome --
+ * it only says which regions and windows are *worth asking about* for a given session; a
+ * skipped or never-shown prompt simply produces no record (M5.1), which is `unknown` by
+ * construction, not a status this module computes.
+ */
+import type { BodyRegion } from '../engine/models';
+
+/** Keyword -> region, checked as a case-insensitive substring against every
+ * `tissueDemand`/`safetyTags` label on a step's resolved exercise. Deliberately small and
+ * literal (not a general NLP mapping): a tag the table doesn't recognize contributes no
+ * region, which is the safe failure mode here -- asking about nothing is better than
+ * guessing the wrong body part. */
+const REGION_KEYWORDS: ReadonlyArray<readonly [BodyRegion, readonly string[]]> = [
+    ['knee', ['knee']],
+    ['achilles', ['achilles']],
+    ['ankle', ['ankle']],
+    ['calf', ['calf']],
+    ['hamstring', ['hamstring']],
+    ['quadriceps', ['quad']],
+    ['adductor_groin', ['adductor', 'groin']],
+    ['hip', ['hip']],
+    ['lower_back', ['lower_back', 'lumbar', 'trunk']],
+    ['shoulder', ['shoulder']],
+    ['elbow', ['elbow']],
+    ['wrist', ['wrist']],
+];
+
+export interface FacetTagSource {
+    tissueDemand?: string[];
+    safetyTags?: string[];
+}
+
+function regionsForTags(source: FacetTagSource): BodyRegion[] {
+    const tags = [...(source.tissueDemand ?? []), ...(source.safetyTags ?? [])].map(tag => tag.toLowerCase());
+    if (tags.length === 0) return [];
+    const regions: BodyRegion[] = [];
+    for (const [region, keywords] of REGION_KEYWORDS) {
+        if (keywords.some(keyword => tags.some(tag => tag.includes(keyword)))) regions.push(region);
+    }
+    return regions;
+}
+
+/** Every distinct region worth asking about across a session's resolved exercises. Empty
+ * when nothing in the session carries recognized tissue-relevant metadata -- e.g. an easy
+ * aerobic spin with no strength/field steps -- which is the signal M5.2's Done-when relies
+ * on to *not* prompt for every ordinary session. */
+export function relevantFollowupRegions(exercises: readonly FacetTagSource[]): BodyRegion[] {
+    const regions = new Set<BodyRegion>();
+    for (const exercise of exercises) for (const region of regionsForTags(exercise)) regions.add(region);
+    return [...regions].sort();
+}

--- a/docs/plans/multidomain-session-authoring-execution-and-evidence.md
+++ b/docs/plans/multidomain-session-authoring-execution-and-evidence.md
@@ -29,12 +29,14 @@ The deliverable is incremental, and **every milestone from M1 onward must end wi
 something the athlete can use on a phone**. That constraint, not the layering of the domain
 model, drives the order below.
 
-**Current delivery cutline (2026-08-19).** The active product chain is
-`M3.7 → bounded M3.8 hardening → M4.3 → M5.1 → M5.2`. M6 and M7 are no longer a
-sequential continuation of that chain. They are usage-triggered capability groups: work starts
-only when real training or repeated testing exposes a concrete limitation in the generic
-runner/evidence model. M8 may consume those capabilities if they exist, but it must never be
-the reason to build them.
+**Current delivery cutline (2026-08-19).** The active product chain,
+`M3.7 → bounded M3.8 hardening → M4.3 → M5.1 → M5.2`, is now complete end to end. M6 and M7
+are not a sequential continuation of that chain. They are usage-triggered capability groups:
+work starts only when real training or repeated testing exposes a concrete limitation in the
+generic runner/evidence model. M8 may consume those capabilities if they exist, but it must
+never be the reason to build them. The next open item on the evidence-producing chain is
+M5.3 (outcome/override evidence report), which was outside this cutline's own scope but is
+now unblocked.
 
 ---
 
@@ -256,11 +258,13 @@ M3 authority / source normalization / authoring
       ↓
 M4.1–M4.2 groups + recorded choices
 
-ACTIVE PRODUCT CHAIN
+ACTIVE PRODUCT CHAIN -- complete (2026-08-19)
 M3.7 semantic preview ─┐
-M3.8 bounded hardening ├──► M4.3 companion/dedup ─► M5.1 response model ─► M5.2 follow-up
+M3.8 bounded hardening ├──► M4.3 companion/dedup ─► M5.1 response model ─► M5.2 follow-up ─► M5.3 (next, unblocked)
                        │
-                       └── M3.8 may stop once current builder is sufficient
+                       └── M3.8 stopped bounded per its own cutline (load/effort/choices
+                           shipped; rest ranges, quality fields, sessionTargets/
+                           prohibitedAdditions editing deferred, JSON import covers them)
 
 USAGE-TRIGGERED CAPABILITIES — NOT THE NEXT PHASE
 real training gap ─► M6 speed/field/power specialization
@@ -330,7 +334,7 @@ rewritten as an outcome; an in-progress item retains its remaining acceptance wo
 | M4.2 | Recorded athlete choices and alternatives | `[x]` | M4.1, M3.5 |
 | M4.3 | Companion occurrence and duplicate reconciliation | `[x]` | — |
 | M5.1 | Occurrence-linked response generalization | `[x]` | — |
-| M5.2 | Later-day and next-morning follow-up | `[ ]` | M5.1 |
+| M5.2 | Later-day and next-morning follow-up | `[x]` | — |
 | M5.3 | Outcome/override evidence report | `[ ]` | M5.2; richer history UI only after a usage trigger |
 | M6.1 | Representative speed/field/power taxonomy v1 | `[ ]` | **Usage trigger:** recurring real session needs domain detail the generic runner cannot represent; then M3.5, M2.5 |
 | M6.2 | Sprint and field performed-entry cards | `[ ]` | M6.1 + a logged sprint/COD workflow proving generic distance/time inputs inadequate |
@@ -1385,7 +1389,7 @@ occurrenceId-must-exist-for-this-user check both failing and then succeeding onc
 occurrence is written) -- 82/82 emulator tests total -- and a full `npm run check`
 (typecheck, lint, 1692 unit tests, catalog validation) pass with no regressions.
 
-### M5.2 `[ ]` Later-day and next-morning follow-up
+### M5.2 `[x]` Later-day and next-morning follow-up
 
 **Change.** Surface due follow-ups on Today and Check-in rather than requiring notifications.
 Use occurrence metadata and M3.5 tissue tags to ask only relevant regions. Next-morning answers
@@ -1398,6 +1402,62 @@ model and may only tighten (ADR-0020 D-SUBJFLOOR).
 **Done when.** A field or novel lower session creates one later-day and one next-morning
 prompt; answers link to the correct occurrence; skipped prompts stay unknown; a favorable
 global readiness cannot override an adverse tissue response.
+
+**Outcome (2026-08-19).** New pure `responses/followupSchedule.ts` (`relevantFollowupRegions`)
+maps a session's resolved catalog exercises' M3.5 `facets.tissueDemand`/`safetyTags` to
+`BodyRegion`s via a small, literal keyword table (an unrecognized tag contributes no region --
+the safe failure mode, not a guess). Both windows are gated on this: a session with no
+tissue-relevant movement in it (an easy aerobic spin, most field/mobility work) creates neither
+prompt, which is what keeps this from nagging after every session.
+
+* **`later_day` (new -- `Home.tsx` + new `components/session/LaterDayFollowupCard.tsx`).**
+  There is no same-day tissue field on `RegionTissueResponse` to reuse (the model has
+  `morningState`/`painDuringTraining`/`afterTrainingState`/`nextMorningReaction` only, and
+  D-MRESP's "without rewriting existing documents" ruled out adding one), so this window is
+  session-level, not region-level: "Feeling normal" / "Unexpectedly fatigued" / "Not now",
+  recorded as an M5.1 `SessionResponse` (`unexpectedFatigue`, no tissue value). Home resolves
+  today's finished (`completed`/`abandoned`) executions via
+  `sessionExecutionService.getExecutionsInRange`, derives relevant regions from their logged
+  entries' `exerciseRef`s, and skips a session once `sessionResponseService.getResponseForWindow`
+  shows it already has a `later_day` answer. "Not now" writes nothing -- a locally tracked
+  dismissal only prevents re-showing within the same mount, never persisted, so nothing here
+  can silently look like a passed response later.
+* **`next_morning` (generalized -- `DailyCheckin.tsx`).** M1.7's existing next-morning
+  mechanism already worked, but only prompted for a region the athlete had *manually* flagged
+  during/after the session. Candidate regions are now the union of that manual flag set
+  (unchanged, still takes priority so its `sourceSessionRef` is preserved) with regions derived
+  from yesterday's `session_executions` the same way `later_day` derives them -- so a session
+  the athlete never manually flagged anything for still gets asked about a region its own
+  movements make relevant. Answering still writes only to the canonical check-in's
+  `nextMorningReaction` (unchanged tissue path, D-SUBJFLOOR/`injuryPolicy.ts` untouched), and
+  now also records at most one session-level `next_morning` `SessionResponse` per session
+  (checked via `getResponseForWindow` first, since several regions can share one session and
+  must not create duplicates) -- again carrying no tissue value. Legacy standalone
+  `strength_sessions` are out of this generalization's scope; their manual-flag path is
+  unchanged from before M5.2.
+* **Skipped stays unknown; answers link to the correct occurrence.** Neither window's skip
+  path (`onDismiss` / `handleSkipFollowup`) writes anything. Every recorded response's
+  `sourceSession`/`occurrenceId` comes from the actual resolved `SessionExecution`, not
+  guessed or defaulted.
+* **D-SUBJFLOOR untouched.** Nothing here changes what `injuryPolicy.ts` reads or how it
+  reads it -- both windows write through the identical existing tissue-write path (checkin
+  `tissueResponses[region].nextMorningReaction`) or write no tissue value at all
+  (`later_day`'s `SessionResponse`). A favorable global readiness still cannot override an
+  adverse tissue response, because that adjudication is unchanged.
+
+**Files.** New `responses/followupSchedule.ts` (+ `.test.ts`), new
+`components/session/LaterDayFollowupCard.tsx`/`.css` (+ `.test.tsx`), `Home.tsx`,
+`DailyCheckin.tsx`. `checkinService.ts` needed no change -- the tissue write path it already
+exposed was sufficient.
+
+Verified by 7 `followupSchedule.test.ts` cases (the real back-squat/sprint fixture tag
+vocabulary, empty/no-exercise sessions, an unrecognized tag contributing nothing,
+dedup+sort, case-insensitivity), a `LaterDayFollowupCard` markup smoke test, and a full
+`npm run check` (typecheck, lint, 1700 unit tests, catalog validation) pass with no
+regressions. `Home.tsx`/`DailyCheckin.tsx` have no pre-existing component-test harness in
+this repo (confirmed: neither file has a test file today) -- the new logic's real complexity
+lives in the pure, directly-tested `followupSchedule.ts`; the component wiring is glue code
+over already-tested services, consistent with how this repo tests these two files elsewhere.
 
 ### M5.3 `[ ]` Outcome/override evidence report — history UI only if triggered
 


### PR DESCRIPTION
Stacked on #99 (M5.1). Completes the active product chain M3.7 → bounded M3.8 → M4.3 → M5.1 → M5.2 from `docs/plans/multidomain-session-authoring-execution-and-evidence.md`.

- New `responses/followupSchedule.ts`: `relevantFollowupRegions` maps a session's resolved catalog exercises' M3.5 `tissueDemand`/`safetyTags` to `BodyRegion`s via a small literal keyword table. Both windows are gated on this so an ordinary session with nothing tissue-relevant in it never prompts.
- `later_day` (new): `Home.tsx` resolves today's finished executions and, when relevant, shows a new `LaterDayFollowupCard` ("Feeling normal" / "Unexpectedly fatigued" / "Not now") recording a session-level `SessionResponse` (M5.1) — there is no same-day tissue field to reuse, so this stays session-level, never a tissue value.
- `next_morning` (generalized): `DailyCheckin`'s existing M1.7 mechanism now also derives candidate regions from yesterday's `session_executions` (not only regions the athlete had manually flagged), still writes only to the canonical check-in's `nextMorningReaction` (D-SUBJFLOOR/`injuryPolicy.ts` untouched), and now also records at most one `next_morning` `SessionResponse` per session (deduplicated across regions).
- Both windows: skip writes nothing (stays unknown); every recorded response's `sourceSession`/`occurrenceId` comes from the actual resolved execution.

Full `npm run check` passes with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added same-day follow-up prompts after completed sessions with tissue-relevant exercises.
  * Users can record expected or unexpected fatigue responses, or dismiss prompts without recording a response.
  * Follow-ups prevent duplicate prompts and clear automatically after answering.
  * Added responsive follow-up cards with improved mobile layouts and disabled/error states.

* **Bug Fixes**
  * Follow-up enhancements no longer prevent daily check-ins from loading when supporting data is unavailable.

* **Tests**
  * Added coverage for follow-up display, response options, dismissal, and region matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->