### PR TITLE
feat(contextBrief): include detailed Garmin activity telemetry

### DIFF
--- a/app/src/engine/contextBriefActivityTelemetry.test.ts
+++ b/app/src/engine/contextBriefActivityTelemetry.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import type { NormalizedGarminActivity } from './models';
+import {
+    injectActivityTelemetryIntoContextBrief,
+    renderContextBriefActivityTelemetry,
+} from './contextBriefActivityTelemetry';
+
+function activity(
+    overrides: Partial<NormalizedGarminActivity> = {},
+): NormalizedGarminActivity {
+    return {
+        activityId: 'ride-1',
+        date: '2026-08-19',
+        type: 'road_biking',
+        durationMin: 58,
+        trainingEffectAerobic: 4.2,
+        trainingEffectAnaerobic: 2.1,
+        averageHr: 156,
+        activityTrainingLoad: 186,
+        intensityTag: 'hard',
+        ...overrides,
+    };
+}
+
+describe('renderContextBriefActivityTelemetry', () => {
+    it('returns no section when the activity has only summary telemetry', () => {
+        expect(renderContextBriefActivityTelemetry([activity()])).toBe('');
+    });
+
+    it('renders power, HR zones, and lap summaries for an enriched cycling activity', () => {
+        const text = renderContextBriefActivityTelemetry([
+            activity({
+                normalizedPower: 287,
+                intensityFactor: 0.93,
+                variabilityIndex: 1.06,
+                powerInZones: [
+                    { zoneNumber: 2, secondsInZone: 900, lowBoundary: 150 },
+                    { zoneNumber: 5, secondsInZone: 300, lowBoundary: 300 },
+                ],
+                hrInZones: [
+                    { zoneNumber: 3, secondsInZone: 600, lowBoundary: 140 },
+                    { zoneNumber: 4, secondsInZone: 600, lowBoundary: 156 },
+                ],
+                laps: [
+                    {
+                        lapIndex: 1,
+                        durationSeconds: 600,
+                        averagePowerWatts: 260,
+                        averageHrBpm: 145,
+                    },
+                    {
+                        lapIndex: 2,
+                        durationSeconds: 300,
+                        averagePowerWatts: 330,
+                        averageHrBpm: 162,
+                    },
+                ],
+            }),
+        ]);
+
+        expect(text).toContain('### Detailed activity telemetry');
+        expect(text).toContain('#### 2026-08-19 — Road cycling — hard');
+        expect(text).toContain('normalized power 287 W · IF 0.93 · VI 1.06');
+        expect(text).toContain('Z2: 15:00 · 75% · low boundary 150 W');
+        expect(text).toContain('Z4: 10:00 · 50% · low boundary 156 bpm');
+        expect(text).toContain('| 2 | 5:00 | 330 W | 162 bpm |');
+    });
+
+    it('renders partial telemetry without inventing missing power data', () => {
+        const text = renderContextBriefActivityTelemetry([
+            activity({
+                type: 'cycling',
+                hrInZones: [{ zoneNumber: 4, secondsInZone: 420 }],
+            }),
+        ]);
+
+        expect(text).toContain('Heart-rate zones');
+        expect(text).not.toContain('Power summary');
+        expect(text).not.toContain('Power zones');
+    });
+});
+
+describe('injectActivityTelemetryIntoContextBrief', () => {
+    it('keeps section 4 after the detailed telemetry subsection', () => {
+        const brief = '# Training context brief\n\n## 3. Completed training (recorded by the wearable)\n\nSummary\n\n## 4. Subjective check-ins';
+        const text = injectActivityTelemetryIntoContextBrief(
+            brief,
+            [activity({ normalizedPower: 287 })],
+        );
+
+        const telemetryIndex = text.indexOf('### Detailed activity telemetry');
+        const subjectiveIndex = text.indexOf('## 4. Subjective check-ins');
+        expect(telemetryIndex).toBeGreaterThan(-1);
+        expect(subjectiveIndex).toBeGreaterThan(telemetryIndex);
+    });
+
+    it('leaves an ordinary brief byte-for-byte unchanged when no detail exists', () => {
+        const brief = '# Training context brief\n\n## 4. Subjective check-ins';
+        expect(injectActivityTelemetryIntoContextBrief(brief, [activity()])).toBe(brief);
+    });
+});

--- a/app/src/engine/contextBriefActivityTelemetry.ts
+++ b/app/src/engine/contextBriefActivityTelemetry.ts
@@ -134,5 +134,5 @@ export function injectActivityTelemetryIntoContextBrief(
     const markerIndex = brief.indexOf(nextSectionMarker);
     if (markerIndex === -1) return `${brief.trimEnd()}\n\n${telemetry}\n`;
 
-    return `${brief.slice(0, markerIndex)}\n\n${telemetry}${brief.slice(markerIndex)}`;
+    return `${brief.slice(0, markerIndex)}\n\n${telemetry}\n${brief.slice(markerIndex)}`;
 }

--- a/app/src/engine/contextBriefActivityTelemetry.ts
+++ b/app/src/engine/contextBriefActivityTelemetry.ts
@@ -1,0 +1,138 @@
+import type { ActivityLapSummary, ActivityZoneBucket, NormalizedGarminActivity } from './models';
+
+const ACTIVITY_TYPE_LABELS: Record<string, string> = {
+    road_biking: 'Road cycling',
+    cycling: 'Cycling',
+    virtual_ride: 'Virtual cycling',
+    gravel_cycling: 'Gravel cycling',
+    mountain_biking: 'Mountain biking',
+    cyclocross: 'Cyclocross',
+    indoor_cycling: 'Indoor cycling',
+};
+
+function formatActivityType(typeKey: string): string {
+    const label = ACTIVITY_TYPE_LABELS[typeKey];
+    if (label) return label;
+    const words = typeKey.replace(/_/g, ' ');
+    return words.length > 0 ? `${words[0].toUpperCase()}${words.slice(1)}` : 'Activity';
+}
+
+function hasDetailedTelemetry(activity: NormalizedGarminActivity): boolean {
+    return activity.normalizedPower !== undefined
+        || activity.intensityFactor !== undefined
+        || activity.variabilityIndex !== undefined
+        || (activity.powerInZones?.length ?? 0) > 0
+        || (activity.hrInZones?.length ?? 0) > 0
+        || (activity.laps?.length ?? 0) > 0;
+}
+
+function formatDuration(seconds: number): string {
+    const roundedSeconds = Math.max(0, Math.round(seconds));
+    const hours = Math.floor(roundedSeconds / 3600);
+    const minutes = Math.floor((roundedSeconds % 3600) / 60);
+    const secs = roundedSeconds % 60;
+    if (hours > 0) return `${hours}:${String(minutes).padStart(2, '0')}:${String(secs).padStart(2, '0')}`;
+    return `${minutes}:${String(secs).padStart(2, '0')}`;
+}
+
+function formatNumber(value: number, places: number): string {
+    const factor = 10 ** places;
+    return String(Math.round(value * factor) / factor);
+}
+
+function renderZones(
+    label: string,
+    buckets: readonly ActivityZoneBucket[],
+    boundaryUnit: 'W' | 'bpm',
+): string[] {
+    const totalSeconds = buckets.reduce((sum, bucket) => sum + bucket.secondsInZone, 0);
+    const lines = [`- ${label}:`];
+    for (const bucket of [...buckets].sort((a, b) => a.zoneNumber - b.zoneNumber)) {
+        const share = totalSeconds > 0 ? (bucket.secondsInZone / totalSeconds) * 100 : null;
+        const shareText = share === null ? '' : ` · ${formatNumber(share, 1)}%`;
+        const boundary = bucket.lowBoundary === undefined
+            ? ''
+            : ` · low boundary ${formatNumber(bucket.lowBoundary, 0)} ${boundaryUnit}`;
+        lines.push(`  - Z${bucket.zoneNumber}: ${formatDuration(bucket.secondsInZone)}${shareText}${boundary}`);
+    }
+    return lines;
+}
+
+function renderLaps(laps: readonly ActivityLapSummary[]): string[] {
+    const lines = [
+        '- Laps:',
+        '',
+        '  | Lap | Duration | Avg power | Avg HR |',
+        '  |---:|---:|---:|---:|',
+    ];
+    for (const lap of [...laps].sort((a, b) => a.lapIndex - b.lapIndex)) {
+        const power = lap.averagePowerWatts === undefined ? '—' : `${formatNumber(lap.averagePowerWatts, 0)} W`;
+        const hr = lap.averageHrBpm === undefined ? '—' : `${formatNumber(lap.averageHrBpm, 0)} bpm`;
+        lines.push(`  | ${lap.lapIndex} | ${formatDuration(lap.durationSeconds)} | ${power} | ${hr} |`);
+    }
+    return lines;
+}
+
+/**
+ * Compact, paste-ready activity detail for an external training analysis. The daily
+ * context brief already carries load/recovery context; this section preserves the
+ * workout-specific evidence that would otherwise be discarded by the summary table.
+ */
+export function renderContextBriefActivityTelemetry(
+    activities: readonly NormalizedGarminActivity[],
+): string {
+    const detailed = activities
+        .filter(hasDetailedTelemetry)
+        .sort((a, b) => a.date.localeCompare(b.date) || a.activityId.localeCompare(b.activityId));
+    if (detailed.length === 0) return '';
+
+    const lines: string[] = [
+        '### Detailed activity telemetry',
+        '',
+        'Only activities with Garmin detail telemetry are expanded below; absent fields were not reported by Garmin.',
+    ];
+
+    for (const activity of detailed) {
+        lines.push('', `#### ${activity.date} — ${formatActivityType(activity.type)} — ${activity.intensityTag}`);
+
+        const powerSummary: string[] = [];
+        if (activity.normalizedPower !== undefined) {
+            powerSummary.push(`normalized power ${formatNumber(activity.normalizedPower, 0)} W`);
+        }
+        if (activity.intensityFactor !== undefined) {
+            powerSummary.push(`IF ${formatNumber(activity.intensityFactor, 2)}`);
+        }
+        if (activity.variabilityIndex !== undefined) {
+            powerSummary.push(`VI ${formatNumber(activity.variabilityIndex, 2)}`);
+        }
+        if (powerSummary.length > 0) lines.push(`- Power summary: ${powerSummary.join(' · ')}`);
+
+        if (activity.powerInZones?.length) {
+            lines.push(...renderZones('Power zones', activity.powerInZones, 'W'));
+        }
+        if (activity.hrInZones?.length) {
+            lines.push(...renderZones('Heart-rate zones', activity.hrInZones, 'bpm'));
+        }
+        if (activity.laps?.length) {
+            lines.push(...renderLaps(activity.laps));
+        }
+    }
+
+    return lines.join('\n');
+}
+
+/** Insert detailed activity telemetry as a subsection of completed training (section 3).
+ * The fallback append keeps the handoff useful if the parent brief heading ever changes. */
+export function injectActivityTelemetryIntoContextBrief(
+    brief: string,
+    activities: readonly NormalizedGarminActivity[],
+): string {
+    const telemetry = renderContextBriefActivityTelemetry(activities);
+    if (!telemetry) return brief;
+
+    const nextSectionMarker = '\n## 4. Subjective';
+    const markerIndex = brief.indexOf(nextSectionMarker);
+    if (markerIndex === -1) return `${brief.trimEnd()}\n\n${telemetry}\n`;
+
+    return `${brief.slice(0, markerIndex)}\n\n${telemetry}${brief.slice(markerIndex)}`;
+}

--- a/app/src/services/contextBriefService.ts
+++ b/app/src/services/contextBriefService.ts
@@ -6,6 +6,7 @@ import {
     SUBJECTIVE_BASELINE_DAYS,
     type ContextBriefInput,
 } from '../engine/contextBrief';
+import { injectActivityTelemetryIntoContextBrief } from '../engine/contextBriefActivityTelemetry';
 import { parseSubjectiveCheckin } from '../persistence/parsers/decisionInputs';
 import { addDaysToLocalDateString, getLocalDateString } from '../utils/localDate';
 import { activityService } from './activityService';
@@ -160,9 +161,10 @@ export class ContextBriefService {
             intentProfile,
             goals,
         };
+        const text = injectActivityTelemetryIntoContextBrief(buildContextBrief(input), activities);
 
         return {
-            text: buildContextBrief(input),
+            text,
             startDate,
             asOfDate: targetDate,
             windowDays,


### PR DESCRIPTION
## Summary
- keep the existing Export Brief as the single AI handoff
- expand only activities that have Garmin detail telemetry
- include normalized power, IF, VI, power/HR zone durations and shares, zone low boundaries, and lap summaries
- insert the detail directly under Completed training so the macro recovery/load context and workout evidence stay in one paste-ready artifact
- leave briefs without detailed telemetry unchanged

## Design
This is read-only presentation logic and does not change recommendation policy or completed-training credit. Detailed telemetry is rendered from the already-normalized `users/{uid}/activities/{activityId}` records; missing Garmin fields stay absent rather than being inferred.

## Tests
Added focused unit coverage for:
- full cycling telemetry
- partial HR-only telemetry
- no-detail byte-for-byte no-op
- placement before section 4

Repository CI should run the full frontend validation suite on the PR.