### PR TITLE
🧹 Refactor long strength workout builder function

### DIFF
--- a/src/garmin_sync/workout_export.py
+++ b/src/garmin_sync/workout_export.py
@@ -203,7 +203,9 @@ def _get_strength_step_desc(step: dict[str, Any], step_name: str) -> str | None:
     return " ".join(desc_parts) if desc_parts else None
 
 
-def _get_strength_step_type(step_name_lower: str, default_step_type: dict[str, Any]) -> dict[str, Any]:
+def _get_strength_step_type(
+    step_name_lower: str, default_step_type: dict[str, Any]
+) -> dict[str, Any]:
     if "warm" in step_name_lower:
         return STEP_TYPE_MAP["warmup"]
     if "cool" in step_name_lower:
@@ -211,9 +213,7 @@ def _get_strength_step_type(step_name_lower: str, default_step_type: dict[str, A
     return default_step_type
 
 
-def _get_strength_end_condition(
-    reps: Any, duration_sec: Any
-) -> tuple[dict[str, Any], Any]:
+def _get_strength_end_condition(reps: Any, duration_sec: Any) -> tuple[dict[str, Any], Any]:
     if reps and reps > 0:
         return END_CONDITION_MAP["reps"], reps
     if duration_sec and duration_sec > 0:

--- a/src/garmin_sync/workout_export.py
+++ b/src/garmin_sync/workout_export.py
@@ -195,6 +195,35 @@ def _resolve_strength_rest_seconds(step: dict[str, Any]) -> int | None:
     return None
 
 
+def _get_strength_step_desc(step: dict[str, Any], step_name: str) -> str | None:
+    targets = step.get("targets")
+    desc_parts = [step_name] if step_name else []
+    if targets and isinstance(targets, list) and targets:
+        desc_parts.append(f"({'; '.join(targets)})")
+    return " ".join(desc_parts) if desc_parts else None
+
+
+def _get_strength_step_type(step_name_lower: str, default_step_type: dict[str, Any]) -> dict[str, Any]:
+    if "warm" in step_name_lower:
+        return STEP_TYPE_MAP["warmup"]
+    if "cool" in step_name_lower:
+        return STEP_TYPE_MAP["cooldown"]
+    return default_step_type
+
+
+def _get_strength_end_condition(
+    reps: Any, duration_sec: Any
+) -> tuple[dict[str, Any], Any]:
+    if reps and reps > 0:
+        return END_CONDITION_MAP["reps"], reps
+    if duration_sec and duration_sec > 0:
+        return END_CONDITION_MAP["time"], duration_sec
+    # No usable rep target and no duration: prefer an explicit/manual
+    # completion condition over fabricating a duration or using the
+    # set count as the rep target.
+    return END_CONDITION_MAP["lap_button"], None
+
+
 def _build_strength_step_or_group(
     step: dict[str, Any],
     step_order: int,
@@ -226,30 +255,10 @@ def _build_strength_step_or_group(
 
     step_name = str(step.get("name", "")).strip()
     step_name_lower = step_name.lower()
-    targets = step.get("targets")
-    desc_parts = [step_name] if step_name else []
-    if targets and isinstance(targets, list) and targets:
-        desc_parts.append(f"({'; '.join(targets)})")
-    step_desc = " ".join(desc_parts) if desc_parts else None
 
-    step_type = default_step_type
-    if "warm" in step_name_lower:
-        step_type = STEP_TYPE_MAP["warmup"]
-    elif "cool" in step_name_lower:
-        step_type = STEP_TYPE_MAP["cooldown"]
-
-    if reps and reps > 0:
-        end_condition = END_CONDITION_MAP["reps"]
-        end_condition_value: Any = reps
-    elif duration_sec and duration_sec > 0:
-        end_condition = END_CONDITION_MAP["time"]
-        end_condition_value = duration_sec
-    else:
-        # No usable rep target and no duration: prefer an explicit/manual
-        # completion condition over fabricating a duration or using the
-        # set count as the rep target.
-        end_condition = END_CONDITION_MAP["lap_button"]
-        end_condition_value = None
+    step_desc = _get_strength_step_desc(step, step_name)
+    step_type = _get_strength_step_type(step_name_lower, default_step_type)
+    end_condition, end_condition_value = _get_strength_end_condition(reps, duration_sec)
 
     exercise_dto: dict[str, Any] = {
         "type": "ExecutableStepDTO",


### PR DESCRIPTION
🎯 **What:** Extracted logical blocks from `_build_strength_step_or_group` into private helper functions (`_get_strength_step_desc`, `_get_strength_step_type`, `_get_strength_end_condition`).
💡 **Why:** The function was overly long and handled multiple distinct responsibilities (parsing descriptions, mapping step types, resolving end conditions) alongside building the final DTOs. Extracting these makes the function much easier to read and test.
✅ **Verification:** Verified by running the full test suite (`uv run pytest tests/`), ensuring static types remain sound (`uv run mypy src/garmin_sync/workout_export.py`), and confirming `ruff` format/lint checks pass.
✨ **Result:** The `_build_strength_step_or_group` function is shorter, its purpose is clearer, and the codebase maintainability is improved without changing behavior.

---
*PR created automatically by Jules for task [7185553640468886529](https://jules.google.com/task/7185553640468886529) started by @Szczepanov*