### PR TITLE
🧹 Refactor `archive` method to use `ArchiveRecord` dataclass

### DIFF
--- a/src/garmin_sync/archive.py
+++ b/src/garmin_sync/archive.py
@@ -3,9 +3,20 @@ import hashlib
 import json
 import logging
 import re
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Protocol
+
+
+@dataclass
+class ArchiveRecord:
+    endpoint: str
+    logical_date: str
+    payload: Any
+    sync_run_id: str
+    garminconnect_version: str | None = None
+
 
 logger = logging.getLogger(__name__)
 
@@ -42,14 +53,7 @@ def _object_dir(prefix: str, endpoint: str, logical_date: str) -> str:
 
 
 class RawArchiveStore(Protocol):
-    def archive(
-        self,
-        endpoint: str,
-        logical_date: str,
-        payload: Any,
-        sync_run_id: str,
-        garminconnect_version: str | None = None,
-    ) -> str | None:
+    def archive(self, record: ArchiveRecord) -> str | None:
         """Archive a raw payload for (endpoint, logical_date). Returns the object path,
         or None if skipped because an identical payload is already archived for that
         date (content-addressed idempotency -- repeated same-day syncs don't duplicate)."""
@@ -69,14 +73,7 @@ class RawArchiveStore(Protocol):
 class NullArchiveStore:
     """No-op store used when archiving is disabled."""
 
-    def archive(
-        self,
-        endpoint: str,
-        logical_date: str,
-        payload: Any,
-        sync_run_id: str,
-        garminconnect_version: str | None = None,
-    ) -> None:
+    def archive(self, record: ArchiveRecord) -> None:
         return None
 
     def load(self, endpoint: str, logical_date: str) -> None:
@@ -96,17 +93,10 @@ class LocalRawArchiveStore:
     def _dir(self, endpoint: str, logical_date: str) -> Path:
         return self.base_dir / _object_dir(self.prefix, endpoint, logical_date)
 
-    def archive(
-        self,
-        endpoint: str,
-        logical_date: str,
-        payload: Any,
-        sync_run_id: str,
-        garminconnect_version: str | None = None,
-    ) -> str | None:
-        _validate_archive_identifier(sync_run_id, "sync run ID")
-        target_dir = self._dir(endpoint, logical_date)
-        payload_hash = _payload_sha256(payload)
+    def archive(self, record: ArchiveRecord) -> str | None:
+        _validate_archive_identifier(record.sync_run_id, "sync run ID")
+        target_dir = self._dir(record.endpoint, record.logical_date)
+        payload_hash = _payload_sha256(record.payload)
 
         if target_dir.exists():
             for existing in target_dir.glob("*.meta.json"):
@@ -114,30 +104,30 @@ class LocalRawArchiveStore:
                     meta = json.loads(existing.read_text())
                     if meta.get("payloadSha256") == payload_hash:
                         logger.debug(
-                            f"Skipping archive for {endpoint}/{logical_date}: identical payload already archived."
+                            f"Skipping archive for {record.endpoint}/{record.logical_date}: identical payload already archived."
                         )
                         return None
                 except Exception:
                     continue
 
         target_dir.mkdir(parents=True, exist_ok=True)
-        object_path = target_dir / f"{sync_run_id}.json.gz"
-        meta_path = target_dir / f"{sync_run_id}.meta.json"
+        object_path = target_dir / f"{record.sync_run_id}.json.gz"
+        meta_path = target_dir / f"{record.sync_run_id}.meta.json"
 
         with gzip.open(object_path, "wt", encoding="utf-8") as f:
-            json.dump(payload, f, default=str)
+            json.dump(record.payload, f, default=str)
 
         metadata = {
             "provider": "garmin_connect_unofficial",
-            "endpoint": endpoint,
-            "logicalDate": logical_date,
+            "endpoint": record.endpoint,
+            "logicalDate": record.logical_date,
             "collectedAt": datetime.now(timezone.utc).isoformat(),
-            "garminconnectVersion": garminconnect_version,
+            "garminconnectVersion": record.garminconnect_version,
             "payloadSha256": payload_hash,
-            "syncRunId": sync_run_id,
+            "syncRunId": record.sync_run_id,
         }
         meta_path.write_text(json.dumps(metadata, indent=2))
-        logger.info(f"Archived {endpoint}/{logical_date} -> {object_path}")
+        logger.info(f"Archived {record.endpoint}/{record.logical_date} -> {object_path}")
         return str(object_path)
 
     def load(self, endpoint: str, logical_date: str) -> Any | None:
@@ -177,20 +167,13 @@ class GcsRawArchiveStore:
 
         return storage.Client()
 
-    def archive(
-        self,
-        endpoint: str,
-        logical_date: str,
-        payload: Any,
-        sync_run_id: str,
-        garminconnect_version: str | None = None,
-    ) -> str | None:
+    def archive(self, record: ArchiveRecord) -> str | None:
         try:
-            _validate_archive_identifier(sync_run_id, "sync run ID")
+            _validate_archive_identifier(record.sync_run_id, "sync run ID")
             client = self._client()
             bucket = client.bucket(self.bucket_name)
-            object_dir = _object_dir(self.prefix, endpoint, logical_date)
-            payload_hash = _payload_sha256(payload)
+            object_dir = _object_dir(self.prefix, record.endpoint, record.logical_date)
+            payload_hash = _payload_sha256(record.payload)
 
             for existing_blob in client.list_blobs(bucket, prefix=f"{object_dir}/"):
                 if (
@@ -198,31 +181,31 @@ class GcsRawArchiveStore:
                     and existing_blob.metadata.get("payloadSha256") == payload_hash
                 ):
                     logger.debug(
-                        f"Skipping GCS archive for {endpoint}/{logical_date}: identical payload already archived."
+                        f"Skipping GCS archive for {record.endpoint}/{record.logical_date}: identical payload already archived."
                     )
                     return None
 
-            object_path = f"{object_dir}/{sync_run_id}.json.gz"
+            object_path = f"{object_dir}/{record.sync_run_id}.json.gz"
             blob = bucket.blob(object_path)
             blob.metadata = {
                 "provider": "garmin_connect_unofficial",
-                "endpoint": endpoint,
-                "logicalDate": logical_date,
+                "endpoint": record.endpoint,
+                "logicalDate": record.logical_date,
                 "collectedAt": datetime.now(timezone.utc).isoformat(),
-                "garminconnectVersion": garminconnect_version or "",
+                "garminconnectVersion": record.garminconnect_version or "",
                 "payloadSha256": payload_hash,
-                "syncRunId": sync_run_id,
+                "syncRunId": record.sync_run_id,
             }
-            body = json.dumps(payload, default=str).encode("utf-8")
+            body = json.dumps(record.payload, default=str).encode("utf-8")
             compressed = gzip.compress(body)
             blob.content_encoding = "gzip"
             blob.upload_from_string(compressed, content_type="application/json")
             logger.info(
-                f"Archived {endpoint}/{logical_date} -> gs://{self.bucket_name}/{object_path}"
+                f"Archived {record.endpoint}/{record.logical_date} -> gs://{self.bucket_name}/{object_path}"
             )
             return object_path
         except Exception as e:
-            logger.error(f"Failed to archive {endpoint}/{logical_date} to GCS: {e}")
+            logger.error(f"Failed to archive {record.endpoint}/{record.logical_date} to GCS: {e}")
             return None
 
     def load(self, endpoint: str, logical_date: str) -> Any | None:

--- a/src/garmin_sync/service.py
+++ b/src/garmin_sync/service.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from garminconnect import GarminConnectTooManyRequestsError
 
-from .archive import RawArchiveStore, create_archive_store
+from .archive import ArchiveRecord, RawArchiveStore, create_archive_store
 from .canonical import CanonicalActivity, CanonicalActivityDetail, CanonicalDailyMetrics
 from .config import Settings
 from .dates import get_date_range, get_date_string, local_today, n_days_ago, parse_date_string
@@ -111,9 +111,14 @@ class GarminSyncService:
         self, endpoint: str, logical_date: str, payload: Any, sync_run_id: str
     ) -> None:
         """No-op when archiving is disabled (NullArchiveStore)."""
-        self.archive_store.archive(
-            endpoint, logical_date, payload, sync_run_id, self.garminconnect_version
+        record = ArchiveRecord(
+            endpoint=endpoint,
+            logical_date=logical_date,
+            payload=payload,
+            sync_run_id=sync_run_id,
+            garminconnect_version=self.garminconnect_version,
         )
+        self.archive_store.archive(record)
 
     def _archive_daily_payloads(
         self, raw_payloads: dict[str, Any], target_iso: str, yesterday_iso: str, sync_run_id: str

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1,35 +1,44 @@
 import pytest
 
-from garmin_sync.archive import LocalRawArchiveStore, NullArchiveStore, create_archive_store
+from garmin_sync.archive import (
+    ArchiveRecord,
+    LocalRawArchiveStore,
+    NullArchiveStore,
+    create_archive_store,
+)
 
 
-def test_local_archive_round_trip(tmp_path):
+def test_local_archive_round_trip(tmp_path) -> None:
     store = LocalRawArchiveStore(base_dir=tmp_path)
     payload = {"restingHeartRate": 50, "totalSteps": 10000}
 
-    object_path = store.archive("stats", "2026-08-06", payload, "run-1", "0.3.8")
+    object_path = store.archive(ArchiveRecord("stats", "2026-08-06", payload, "run-1", "0.3.8"))
 
     assert object_path is not None
     loaded = store.load("stats", "2026-08-06")
     assert loaded == payload
 
 
-def test_local_archive_idempotent_skip_on_identical_payload(tmp_path):
+def test_local_archive_idempotent_skip_on_identical_payload(tmp_path) -> None:
     store = LocalRawArchiveStore(base_dir=tmp_path)
     payload = {"restingHeartRate": 50}
 
-    first = store.archive("stats", "2026-08-06", payload, "run-1", "0.3.8")
-    second = store.archive("stats", "2026-08-06", payload, "run-2", "0.3.8")
+    first = store.archive(ArchiveRecord("stats", "2026-08-06", payload, "run-1", "0.3.8"))
+    second = store.archive(ArchiveRecord("stats", "2026-08-06", payload, "run-2", "0.3.8"))
 
     assert first is not None
     assert second is None  # identical payload -> skipped, not re-uploaded
 
 
-def test_local_archive_different_payload_same_date_not_skipped(tmp_path):
+def test_local_archive_different_payload_same_date_not_skipped(tmp_path) -> None:
     store = LocalRawArchiveStore(base_dir=tmp_path)
 
-    first = store.archive("stats", "2026-08-06", {"restingHeartRate": 50}, "run-1", "0.3.8")
-    second = store.archive("stats", "2026-08-06", {"restingHeartRate": 52}, "run-2", "0.3.8")
+    first = store.archive(
+        ArchiveRecord("stats", "2026-08-06", {"restingHeartRate": 50}, "run-1", "0.3.8")
+    )
+    second = store.archive(
+        ArchiveRecord("stats", "2026-08-06", {"restingHeartRate": 52}, "run-2", "0.3.8")
+    )
 
     assert first is not None
     assert second is not None
@@ -37,45 +46,45 @@ def test_local_archive_different_payload_same_date_not_skipped(tmp_path):
     assert store.load("stats", "2026-08-06") == {"restingHeartRate": 52}
 
 
-def test_local_archive_load_missing_returns_none(tmp_path):
+def test_local_archive_load_missing_returns_none(tmp_path) -> None:
     store = LocalRawArchiveStore(base_dir=tmp_path)
     assert store.load("stats", "2026-08-06") is None
 
 
-def test_local_archive_list_archived_dates_range_filter(tmp_path):
+def test_local_archive_list_archived_dates_range_filter(tmp_path) -> None:
     store = LocalRawArchiveStore(base_dir=tmp_path)
-    store.archive("sleep", "2026-08-01", {"a": 1}, "run-1", None)
-    store.archive("sleep", "2026-08-05", {"a": 2}, "run-2", None)
-    store.archive("sleep", "2026-08-10", {"a": 3}, "run-3", None)
+    store.archive(ArchiveRecord("sleep", "2026-08-01", {"a": 1}, "run-1", None))
+    store.archive(ArchiveRecord("sleep", "2026-08-05", {"a": 2}, "run-2", None))
+    store.archive(ArchiveRecord("sleep", "2026-08-10", {"a": 3}, "run-3", None))
 
     found = store.list_archived_dates("sleep", "2026-08-02", "2026-08-06")
 
     assert found == {"2026-08-05"}
 
 
-def test_null_archive_store_is_always_a_noop(tmp_path):
+def test_null_archive_store_is_always_a_noop(tmp_path) -> None:
     store = NullArchiveStore()
-    assert store.archive("stats", "2026-08-06", {"x": 1}, "run-1") is None
+    assert store.archive(ArchiveRecord("stats", "2026-08-06", {"x": 1}, "run-1")) is None
     assert store.load("stats", "2026-08-06") is None
     assert store.list_archived_dates("stats", "2026-08-01", "2026-08-31") == set()
 
 
-def test_archive_rejects_path_traversal_identifiers(tmp_path):
+def test_archive_rejects_path_traversal_identifiers(tmp_path) -> None:
     store = LocalRawArchiveStore(base_dir=tmp_path)
     with pytest.raises(ValueError, match="endpoint"):
-        store.archive("../tokens", "2026-08-06", {"x": 1}, "run-1")
+        store.archive(ArchiveRecord("../tokens", "2026-08-06", {"x": 1}, "run-1"))
     with pytest.raises(ValueError, match="logical date"):
-        store.archive("stats", "2026-02-30", {"x": 1}, "run-1")
+        store.archive(ArchiveRecord("stats", "2026-02-30", {"x": 1}, "run-1"))
     with pytest.raises(ValueError, match="sync run ID"):
-        store.archive("stats", "2026-08-06", {"x": 1}, "../run")
+        store.archive(ArchiveRecord("stats", "2026-08-06", {"x": 1}, "../run"))
 
 
-def test_create_archive_store_disabled_returns_null_store():
+def test_create_archive_store_disabled_returns_null_store() -> None:
     store = create_archive_store(enabled=False)
     assert isinstance(store, NullArchiveStore)
 
 
-def test_create_archive_store_gcs_requires_bucket():
+def test_create_archive_store_gcs_requires_bucket() -> None:
     import pytest
 
     with pytest.raises(ValueError, match="bucket"):

--- a/tests/test_rebuild_and_audit.py
+++ b/tests/test_rebuild_and_audit.py
@@ -1,25 +1,33 @@
 from unittest.mock import MagicMock
 
-from garmin_sync.archive import LocalRawArchiveStore
+from garmin_sync.archive import ArchiveRecord, LocalRawArchiveStore
 from garmin_sync.audit import run_audit
 from garmin_sync.config import Settings
 from garmin_sync.service import GarminSyncService
 
 
 def _seed_full_day(store: LocalRawArchiveStore, date_iso: str, run_id: str = "run-seed") -> None:
-    store.archive("stats", date_iso, {"restingHeartRate": 50, "totalSteps": 9000}, run_id, "0.3.8")
     store.archive(
-        "sleep",
-        date_iso,
-        {"dailySleepDTO": {"sleepScores": {"overall": {"value": 80}}}},
-        run_id,
-        "0.3.8",
+        ArchiveRecord(
+            "stats", date_iso, {"restingHeartRate": 50, "totalSteps": 9000}, run_id, "0.3.8"
+        )
     )
-    store.archive("hrv", date_iso, {"hrvSummary": {"lastNightAvg": 60}}, run_id, "0.3.8")
-    store.archive("activities", date_iso, [], run_id, "0.3.8")
+    store.archive(
+        ArchiveRecord(
+            "sleep",
+            date_iso,
+            {"dailySleepDTO": {"sleepScores": {"overall": {"value": 80}}}},
+            run_id,
+            "0.3.8",
+        )
+    )
+    store.archive(
+        ArchiveRecord("hrv", date_iso, {"hrvSummary": {"lastNightAvg": 60}}, run_id, "0.3.8")
+    )
+    store.archive(ArchiveRecord("activities", date_iso, [], run_id, "0.3.8"))
 
 
-def test_rebuild_reproduces_snapshot_from_archive_without_garmin_calls(tmp_path):
+def test_rebuild_reproduces_snapshot_from_archive_without_garmin_calls(tmp_path) -> None:
     archive_store = LocalRawArchiveStore(base_dir=tmp_path)
     _seed_full_day(archive_store, "2026-08-06")
     # yesterday's stats/sleep archived too, exercising fallback lookups
@@ -49,12 +57,14 @@ def test_rebuild_reproduces_snapshot_from_archive_without_garmin_calls(tmp_path)
     assert saved_payload["raw"]["restingHr"] == 50
 
 
-def test_rebuild_skips_date_missing_archived_payload(tmp_path):
+def test_rebuild_skips_date_missing_archived_payload(tmp_path) -> None:
     archive_store = LocalRawArchiveStore(base_dir=tmp_path)
     # Missing "activities" endpoint for this date -> not rebuildable
-    archive_store.archive("stats", "2026-08-06", {"restingHeartRate": 50}, "run-1", "0.3.8")
-    archive_store.archive("sleep", "2026-08-06", {}, "run-1", "0.3.8")
-    archive_store.archive("hrv", "2026-08-06", {}, "run-1", "0.3.8")
+    archive_store.archive(
+        ArchiveRecord("stats", "2026-08-06", {"restingHeartRate": 50}, "run-1", "0.3.8")
+    )
+    archive_store.archive(ArchiveRecord("sleep", "2026-08-06", {}, "run-1", "0.3.8"))
+    archive_store.archive(ArchiveRecord("hrv", "2026-08-06", {}, "run-1", "0.3.8"))
 
     settings = Settings(app_user_id="test_uid_789")
     mock_repo = MagicMock()
@@ -75,17 +85,31 @@ def test_rebuild_skips_date_missing_archived_payload(tmp_path):
     assert mock_client.mock_calls == []
 
 
-def test_rebuild_preserves_existing_firestore_history_on_skipped_dates(tmp_path):
+def test_rebuild_preserves_existing_firestore_history_on_skipped_dates(tmp_path) -> None:
     archive_store = LocalRawArchiveStore(base_dir=tmp_path)
     # Day 2 is fully archived
-    archive_store.archive("stats", "2026-08-07", {"restingHeartRate": 50}, "run-1", "0.3.8")
     archive_store.archive(
-        "sleep", "2026-08-07", {"sleepScores": {"overallScore": {"value": 80}}}, "run-1", "0.3.8"
+        ArchiveRecord("stats", "2026-08-07", {"restingHeartRate": 50}, "run-1", "0.3.8")
     )
     archive_store.archive(
-        "hrv", "2026-08-07", {"hrvSummary": {"weeklyAvg": 55, "lastNightAvg": 55}}, "run-1", "0.3.8"
+        ArchiveRecord(
+            "sleep",
+            "2026-08-07",
+            {"sleepScores": {"overallScore": {"value": 80}}},
+            "run-1",
+            "0.3.8",
+        )
     )
-    archive_store.archive("activities", "2026-08-07", [], "run-1", "0.3.8")
+    archive_store.archive(
+        ArchiveRecord(
+            "hrv",
+            "2026-08-07",
+            {"hrvSummary": {"weeklyAvg": 55, "lastNightAvg": 55}},
+            "run-1",
+            "0.3.8",
+        )
+    )
+    archive_store.archive(ArchiveRecord("activities", "2026-08-07", [], "run-1", "0.3.8"))
 
     settings = Settings(app_user_id="test_uid_789")
     mock_repo = MagicMock()
@@ -131,7 +155,7 @@ def test_rebuild_preserves_existing_firestore_history_on_skipped_dates(tmp_path)
     assert snapshot_dict["derived"]["steps28dAvg"] == 6000.0
 
 
-def test_audit_reports_missing_snapshots_and_availability():
+def test_audit_reports_missing_snapshots_and_availability() -> None:
     settings = Settings(app_user_id="test_uid_789")
     mock_repo = MagicMock()
     mock_repo.count_activities_in_range.return_value = 12


### PR DESCRIPTION
🎯 **What:** Introduced the `ArchiveRecord` dataclass to encapsulate the parameters used in the `archive` method of `RawArchiveStore` and its implementations. Updated `GarminSyncService` and related test cases to use the new object.

💡 **Why:** The `archive` method had an overly large parameter list (`endpoint`, `logical_date`, `payload`, `sync_run_id`, `garminconnect_version`). Utilizing a configuration object (`ArchiveRecord`) significantly improves the maintainability and readability of the API and call sites.

✅ **Verification:** 
- Successfully executed the complete test suite utilizing `uv run pytest` (169 tests passed).
- Successfully executed Python static type checking with `uv run mypy src/ tests/`.
- Validated code style with `uv run ruff check .` and `uv run ruff format .`.

✨ **Result:** A cleaner and more extensible API for archiving payloads, paving the way for future extensions without causing parameter bloat in the interface.

---
*PR created automatically by Jules for task [12596399052715123592](https://jules.google.com/task/12596399052715123592) started by @Szczepanov*