### PR TITLE
M5.3: outcome/override evidence report + M-plan status analysis

### DIFF
--- a/app/src/responses/outcome.test.ts
+++ b/app/src/responses/outcome.test.ts
@@ -145,6 +145,18 @@ describe('deriveSessionOutcome', () => {
         expect(outcome.override.note).toBe('knee stiff');
     });
 
+    it('prefers a later_day/next_morning note over a more-recently-updated immediate note', () => {
+        const outcome = deriveSessionOutcome({
+            sourceSession,
+            responses: [
+                response({ responseId: 'resp-a', window: 'later_day', note: 'felt heavy', updatedAt: '2026-08-18T20:00:00.000Z' }),
+                response({ responseId: 'resp-b', window: 'immediate', note: 'warmed up fine', updatedAt: '2026-08-19T09:00:00.000Z' }),
+            ],
+            tissueResponses: [],
+        });
+        expect(outcome.override.note).toBe('felt heavy');
+    });
+
     it('links every contributing response id in sourceFacts', () => {
         const outcome = deriveSessionOutcome({
             sourceSession,

--- a/app/src/responses/outcome.test.ts
+++ b/app/src/responses/outcome.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from 'vitest';
+import { deriveSessionOutcome, SESSION_OUTCOME_POLICY_VERSION } from './outcome';
+import type { SessionResponse, SessionResponseSourceRef } from './models';
+import type { RegionTissueResponse } from '../engine/models';
+import type { PerformedSessionComparison } from '../sessions/performedComparison';
+
+const sourceSession: SessionResponseSourceRef = { kind: 'execution', id: 'exec-1', date: '2026-08-18' };
+
+function response(overrides: Partial<SessionResponse> = {}): SessionResponse {
+    return {
+        userId: 'u1',
+        responseId: 'resp-1',
+        sourceSession,
+        window: 'later_day',
+        date: '2026-08-18',
+        checkinRef: { date: '2026-08-18' },
+        createdAt: '2026-08-18T20:00:00.000Z',
+        updatedAt: '2026-08-18T20:00:00.000Z',
+        ...overrides,
+    };
+}
+
+function tissue(overrides: Partial<RegionTissueResponse> = {}): RegionTissueResponse {
+    return {
+        region: 'knee',
+        morningState: 'normal',
+        sourceSessionRef: { kind: 'execution', id: 'exec-1', date: '2026-08-18' },
+        ...overrides,
+    };
+}
+
+describe('deriveSessionOutcome', () => {
+    it('returns unknown with no responses and no tissue observations', () => {
+        const outcome = deriveSessionOutcome({ sourceSession, responses: [], tissueResponses: [] });
+        expect(outcome.status).toBe('unknown');
+        expect(outcome.hasFollowUpData).toBe(false);
+        expect(outcome.sourceFacts.responseIds).toEqual([]);
+        expect(outcome.sourceFacts.tissueRegions).toEqual([]);
+        expect(outcome.policyVersion).toBe(SESSION_OUTCOME_POLICY_VERSION);
+    });
+
+    it('returns unknown when only an immediate-window response exists (no follow-up yet)', () => {
+        const outcome = deriveSessionOutcome({
+            sourceSession,
+            responses: [response({ window: 'immediate', responseId: 'resp-imm' })],
+            tissueResponses: [],
+        });
+        expect(outcome.status).toBe('unknown');
+        expect(outcome.hasFollowUpData).toBe(false);
+    });
+
+    it('returns passed when a later_day response and normal tissue response both exist', () => {
+        const outcome = deriveSessionOutcome({
+            sourceSession,
+            responses: [response({ unexpectedFatigue: false })],
+            tissueResponses: [tissue({ morningState: 'normal', nextMorningReaction: 'normal' })],
+        });
+        expect(outcome.status).toBe('passed');
+        expect(outcome.hasFollowUpData).toBe(true);
+        expect(outcome.sourceFacts.tissueRegions).toEqual(['knee']);
+    });
+
+    it('returns passed from a later_day response alone, with no tissue observation', () => {
+        const outcome = deriveSessionOutcome({
+            sourceSession,
+            responses: [response({ unexpectedFatigue: false, completedFraction: 1 })],
+            tissueResponses: [],
+        });
+        expect(outcome.status).toBe('passed');
+    });
+
+    it('returns caution for a mild (monitor) tissue signal', () => {
+        const outcome = deriveSessionOutcome({
+            sourceSession,
+            responses: [response()],
+            tissueResponses: [tissue({ nextMorningReaction: 'mild' })],
+        });
+        expect(outcome.status).toBe('caution');
+    });
+
+    it('returns caution for unexpectedFatigue alone, with no tissue signal', () => {
+        const outcome = deriveSessionOutcome({
+            sourceSession,
+            responses: [response({ unexpectedFatigue: true })],
+            tissueResponses: [],
+        });
+        expect(outcome.status).toBe('caution');
+    });
+
+    it('returns reactive for a moderate tissue signal', () => {
+        const outcome = deriveSessionOutcome({
+            sourceSession,
+            responses: [response()],
+            tissueResponses: [tissue({ afterTrainingState: 'moderate' })],
+        });
+        expect(outcome.status).toBe('reactive');
+    });
+
+    it('returns reactive for a severe tissue signal, outranking a merely-mild one elsewhere', () => {
+        const outcome = deriveSessionOutcome({
+            sourceSession,
+            responses: [response()],
+            tissueResponses: [
+                tissue({ region: 'knee', nextMorningReaction: 'mild' }),
+                tissue({ region: 'hamstring', painDuringTraining: 'severe', sourceSessionRef: { kind: 'execution', id: 'exec-1', date: '2026-08-18' } }),
+            ],
+        });
+        expect(outcome.status).toBe('reactive');
+        expect(outcome.sourceFacts.tissueRegions).toEqual(['knee', 'hamstring']);
+    });
+
+    it('reactive tissue signal overrides an otherwise-passed unexpectedFatigue:false response', () => {
+        const outcome = deriveSessionOutcome({
+            sourceSession,
+            responses: [response({ unexpectedFatigue: false })],
+            tissueResponses: [tissue({ nextMorningReaction: 'severe' })],
+        });
+        expect(outcome.status).toBe('reactive');
+    });
+
+    it('never fabricates an override reason -- undefined unless explicitly supplied', () => {
+        const outcome = deriveSessionOutcome({ sourceSession, responses: [response()], tissueResponses: [] });
+        expect(outcome.override.reason).toBeUndefined();
+    });
+
+    it('carries a caller-supplied override reason through unchanged', () => {
+        const outcome = deriveSessionOutcome({
+            sourceSession,
+            responses: [response()],
+            tissueResponses: [],
+            overrideReason: 'time_constraint',
+        });
+        expect(outcome.override.reason).toBe('time_constraint');
+    });
+
+    it('surfaces the most recently updated response note as override.note', () => {
+        const outcome = deriveSessionOutcome({
+            sourceSession,
+            responses: [
+                response({ responseId: 'resp-a', window: 'later_day', note: 'felt heavy', updatedAt: '2026-08-18T20:00:00.000Z' }),
+                response({ responseId: 'resp-b', window: 'next_morning', techniqueNote: 'knee stiff', updatedAt: '2026-08-19T07:00:00.000Z' }),
+            ],
+            tissueResponses: [],
+        });
+        expect(outcome.override.note).toBe('knee stiff');
+    });
+
+    it('links every contributing response id in sourceFacts', () => {
+        const outcome = deriveSessionOutcome({
+            sourceSession,
+            responses: [
+                response({ responseId: 'resp-a', window: 'later_day' }),
+                response({ responseId: 'resp-b', window: 'next_morning' }),
+            ],
+            tissueResponses: [],
+        });
+        expect(outcome.sourceFacts.responseIds).toEqual(['resp-a', 'resp-b']);
+    });
+
+    it('carries the planned/performed delta through from a supplied comparison, unmodified', () => {
+        const comparison: PerformedSessionComparison = {
+            definitionId: 'def-1',
+            revision: 1,
+            title: 'Lower',
+            totalPlannedSteps: 5,
+            completedStepsCount: 4,
+            missingRequiredStepsCount: 1,
+            stepComparisons: [],
+            summary: { totalReps: 0, totalTonnageKg: 0, totalDurationSeconds: 0, totalDistanceMeters: 0 },
+        };
+        const outcome = deriveSessionOutcome({
+            sourceSession, responses: [response()], tissueResponses: [], comparison,
+        });
+        expect(outcome.override.completedStepsCount).toBe(4);
+        expect(outcome.override.missingRequiredStepsCount).toBe(1);
+        expect(outcome.override.totalPlannedSteps).toBe(5);
+    });
+
+    it('omits delta fields entirely when no comparison is supplied', () => {
+        const outcome = deriveSessionOutcome({ sourceSession, responses: [response()], tissueResponses: [] });
+        expect(outcome.override.completedStepsCount).toBeUndefined();
+        expect(outcome.override.missingRequiredStepsCount).toBeUndefined();
+        expect(outcome.override.totalPlannedSteps).toBeUndefined();
+    });
+
+    it('ignores a tissue observation whose morningState-only normal reading contributes no severity', () => {
+        const outcome = deriveSessionOutcome({
+            sourceSession,
+            responses: [response()],
+            tissueResponses: [tissue({ morningState: 'normal' })],
+        });
+        expect(outcome.status).toBe('passed');
+    });
+});

--- a/app/src/responses/outcome.ts
+++ b/app/src/responses/outcome.ts
@@ -115,7 +115,9 @@ function worstTissueSeverity(tissueResponses: readonly RegionTissueResponse[]): 
 function mostRelevantNote(responses: readonly SessionResponse[]): string | undefined {
     const withNotes = responses.filter(response => response.note || response.techniqueNote);
     if (withNotes.length === 0) return undefined;
-    const sorted = [...withNotes].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+    const followUpNotes = withNotes.filter(response => response.window !== 'immediate');
+    const candidates = followUpNotes.length > 0 ? followUpNotes : withNotes;
+    const sorted = [...candidates].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
     return sorted[0]?.note ?? sorted[0]?.techniqueNote;
 }
 

--- a/app/src/responses/outcome.ts
+++ b/app/src/responses/outcome.ts
@@ -1,0 +1,167 @@
+/**
+ * M5.3: outcome/override evidence report (ADR-0023 D-MRESP / D-MPOLICY).
+ *
+ * `deriveSessionOutcome` is a pure, versioned SUMMARY over already-recorded M5.1/M5.2 facts
+ * -- never a new inference and never a new tissue authority. It reads:
+ *
+ *  - `SessionResponse[]` (M5.1/M5.2): linkage + non-tissue facts, never a tissue value;
+ *  - `RegionTissueResponse[]` (the canonical check-in, D-MRESP's sole tissue authority),
+ *    already filtered by the caller to the ones whose `sourceSessionRef` matches this source
+ *    session -- this module never queries a check-in itself;
+ *  - an optional `PerformedSessionComparison` (M2.6, `sessions/performedComparison.ts`) for
+ *    the planned-vs-performed delta that already exists at session completion.
+ *
+ * The severity mapping (`normal` < `mild`/monitor < `moderate`/limit < `severe`/exclude)
+ * reuses `engine/injuryPolicy.ts`'s existing `deriveTissueSeverity` rather than restating a
+ * second threshold table for the same four-level scale -- consistent with the tighten-only
+ * discipline that function already documents.
+ *
+ * Per D-MPOLICY this label is evidence-only: it must never feed automatic option selection,
+ * progression or eligibility. The M0.3 architecture boundary (`sessions/architecture.test.ts`)
+ * keeps any selection/optimizer module from importing this file. `SESSION_OUTCOME_POLICY_VERSION`
+ * is bumped whenever the derivation rule changes, so an exported report row can always be read
+ * back against the exact rule that produced it (the same replay discipline ADR-0010 applies to
+ * a decision, applied here to a summary).
+ *
+ * **Scoping note (2026-08-20).** The plan asks this module to "record athlete override
+ * reason." No current UI captures a structured reason for *any* session type -- `athleteReason`
+ * on the legacy `SessionAdjustment` (`engine/models.ts`) has no writer anywhere in this
+ * repository today, catalog-scaling included. Rather than inventing a second unused field to
+ * match it, `SessionOutcomeInput.overrideReason` is threaded through as a plain optional
+ * parameter: the type is reused (per the plan's own instruction) and something can supply it
+ * the moment a real capture point exists, but this module never fabricates a value for it.
+ * `override.note` is populated automatically because that data already exists (M5.1's
+ * `SessionResponse.note`/`techniqueNote`, captured today by `LaterDayFollowupCard`/the
+ * next-morning check-in prompt).
+ */
+import type { RegionTissueResponse, SessionAdjustment } from '../engine/models';
+import { deriveTissueSeverity } from '../engine/injuryPolicy';
+import type { PerformedSessionComparison } from '../sessions/performedComparison';
+import type { SessionResponse, SessionResponseSourceRef } from './models';
+
+export const SESSION_OUTCOME_POLICY_VERSION = 'm5.3-outcome-v1';
+
+export type SessionOutcomeStatus = 'passed' | 'caution' | 'reactive' | 'unknown';
+
+/** Reused from `SessionAdjustment.athleteReason` (`engine/models.ts`), not reinvented: the
+ * same taxonomy for why an athlete's scaled recommendation diverged from plan is the right
+ * taxonomy for why *any* session's outcome diverged, not only a catalog-scaled one. */
+export type AthleteOverrideReason = NonNullable<SessionAdjustment['athleteReason']>;
+
+/** Source-neutral override record (plan D-MSESSION/D-MRECORDS framing applied to override
+ * evidence): a reason plus the planned-vs-performed delta, never tied to `SessionAdjustment`'s
+ * strength-specific shape. */
+export interface SessionOverride {
+    reason?: AthleteOverrideReason;
+    /** Free-text elaboration, sourced from already-recorded M5.1 facts -- never a new
+     * persisted field. */
+    note?: string;
+    /** From `sessions/performedComparison.ts`'s existing M2.6 output. `undefined` when no
+     * comparison could be resolved (e.g. an abandoned session with no verifiable
+     * prescription binding). */
+    missingRequiredStepsCount?: number;
+    completedStepsCount?: number;
+    totalPlannedSteps?: number;
+}
+
+export interface SessionOutcomeInput {
+    sourceSession: SessionResponseSourceRef;
+    /** Every recorded `SessionResponse` for this source session, any window. */
+    responses: readonly SessionResponse[];
+    /** Every canonical check-in `RegionTissueResponse` whose `sourceSessionRef` matches this
+     * source session, already resolved by the caller. */
+    tissueResponses: readonly RegionTissueResponse[];
+    /** M2.6's existing planned-vs-performed comparison, when resolvable. */
+    comparison?: PerformedSessionComparison;
+    /** An athlete-supplied reason for the divergence, when one has actually been captured
+     * (see the module doc's scoping note). Never inferred by this function. */
+    overrideReason?: AthleteOverrideReason;
+}
+
+export interface SessionOutcome {
+    policyVersion: string;
+    sourceSession: SessionResponseSourceRef;
+    status: SessionOutcomeStatus;
+    /** True once at least one later_day/next_morning signal (a response or a tissue
+     * observation) exists. `false` means the status reflects immediate-only or zero data, so
+     * a report must never present it as a confirmed 'passed'. */
+    hasFollowUpData: boolean;
+    /** Which recorded facts the status was derived from, so a report can show its work
+     * rather than assert a bare conclusion. */
+    sourceFacts: {
+        responseIds: string[];
+        tissueRegions: RegionTissueResponse['region'][];
+    };
+    override: SessionOverride;
+}
+
+type TissueSeverity = NonNullable<ReturnType<typeof deriveTissueSeverity>>;
+const REACTIVE_SEVERITIES: ReadonlySet<TissueSeverity> = new Set<TissueSeverity>(['limit', 'exclude']);
+
+function worstTissueSeverity(tissueResponses: readonly RegionTissueResponse[]): TissueSeverity | null {
+    let worst: TissueSeverity | null = null;
+    const rank: Record<TissueSeverity, number> = { monitor: 0, limit: 1, exclude: 2 };
+    for (const response of tissueResponses) {
+        const severity = deriveTissueSeverity(response);
+        if (severity === null) continue;
+        if (worst === null || rank[severity] > rank[worst]) worst = severity;
+    }
+    return worst;
+}
+
+/** Prefers a later_day/next_morning note over an immediate one (today's `SessionResponse`
+ * production callers never write `immediate` anyway -- see `responses/models.ts`), and the
+ * most recently recorded note when more than one window carries one. */
+function mostRelevantNote(responses: readonly SessionResponse[]): string | undefined {
+    const withNotes = responses.filter(response => response.note || response.techniqueNote);
+    if (withNotes.length === 0) return undefined;
+    const sorted = [...withNotes].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+    return sorted[0]?.note ?? sorted[0]?.techniqueNote;
+}
+
+export function deriveSessionOutcome(input: SessionOutcomeInput): SessionOutcome {
+    const { sourceSession, responses, tissueResponses, comparison, overrideReason } = input;
+
+    const worstSeverity = worstTissueSeverity(tissueResponses);
+    const anyUnexpectedFatigue = responses.some(response => response.unexpectedFatigue === true);
+    const hasFollowUpData = responses.some(response => response.window !== 'immediate') || tissueResponses.length > 0;
+    const hasAnyData = responses.length > 0 || tissueResponses.length > 0;
+
+    let status: SessionOutcomeStatus;
+    if (!hasAnyData) {
+        status = 'unknown';
+    } else if (worstSeverity !== null && REACTIVE_SEVERITIES.has(worstSeverity)) {
+        status = 'reactive';
+    } else if (worstSeverity === 'monitor' || anyUnexpectedFatigue) {
+        status = 'caution';
+    } else if (!hasFollowUpData) {
+        // Only immediate-level (or zero) signal: a real 'passed' claim needs the delayed
+        // windows to have actually been asked and answered (D-MRESP: missing follow-up is
+        // `unknown`, never a fabricated 'passed').
+        status = 'unknown';
+    } else {
+        status = 'passed';
+    }
+
+    const note = mostRelevantNote(responses);
+
+    return {
+        policyVersion: SESSION_OUTCOME_POLICY_VERSION,
+        sourceSession,
+        status,
+        hasFollowUpData,
+        sourceFacts: {
+            responseIds: responses.map(response => response.responseId),
+            tissueRegions: tissueResponses.map(response => response.region),
+        },
+        override: {
+            ...(overrideReason !== undefined ? { reason: overrideReason } : {}),
+            ...(note !== undefined ? { note } : {}),
+            ...(comparison ? {
+                missingRequiredStepsCount: comparison.missingRequiredStepsCount,
+                completedStepsCount: comparison.completedStepsCount,
+                totalPlannedSteps: comparison.totalPlannedSteps,
+            } : {}),
+        },
+    };
+}

--- a/app/src/responses/outcomeReport.test.ts
+++ b/app/src/responses/outcomeReport.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { buildSessionOutcomeReport, sessionOutcomeReportToCsv } from './outcomeReport';
+import type { SessionOutcome } from './outcome';
+
+function outcome(overrides: Partial<SessionOutcome> = {}): SessionOutcome {
+    return {
+        policyVersion: 'm5.3-outcome-v1',
+        sourceSession: { kind: 'execution', id: 'exec-1', date: '2026-08-18' },
+        status: 'passed',
+        hasFollowUpData: true,
+        sourceFacts: { responseIds: ['resp-1'], tissueRegions: ['knee'] },
+        override: {},
+        ...overrides,
+    };
+}
+
+describe('buildSessionOutcomeReport', () => {
+    it('sorts rows chronologically by date then source id, independent of input order', () => {
+        const rows = buildSessionOutcomeReport([
+            outcome({ sourceSession: { kind: 'execution', id: 'exec-b', date: '2026-08-19' } }),
+            outcome({ sourceSession: { kind: 'execution', id: 'exec-a', date: '2026-08-18' } }),
+            outcome({ sourceSession: { kind: 'execution', id: 'exec-c', date: '2026-08-18' } }),
+        ]);
+        expect(rows.map(row => row.sourceId)).toEqual(['exec-a', 'exec-c', 'exec-b']);
+    });
+
+    it('flattens sourceFacts and override into plain string/number report fields', () => {
+        const [row] = buildSessionOutcomeReport([outcome({
+            sourceFacts: { responseIds: ['resp-1', 'resp-2'], tissueRegions: ['knee', 'hamstring'] },
+            override: { reason: 'soreness', note: 'tight quads', completedStepsCount: 4, missingRequiredStepsCount: 1, totalPlannedSteps: 5 },
+        })]);
+        expect(row.responseCount).toBe(2);
+        expect(row.tissueRegions).toBe('knee;hamstring');
+        expect(row.overrideReason).toBe('soreness');
+        expect(row.note).toBe('tight quads');
+        expect(row.completedStepsCount).toBe('4');
+        expect(row.missingRequiredStepsCount).toBe('1');
+        expect(row.totalPlannedSteps).toBe('5');
+    });
+
+    it('renders missing optional fields as empty strings, never "undefined"', () => {
+        const [row] = buildSessionOutcomeReport([outcome({ status: 'unknown', override: {} })]);
+        expect(row.overrideReason).toBe('');
+        expect(row.note).toBe('');
+        expect(row.completedStepsCount).toBe('');
+    });
+});
+
+describe('sessionOutcomeReportToCsv', () => {
+    it('emits a header row plus one row per outcome in the given order', () => {
+        const rows = buildSessionOutcomeReport([outcome()]);
+        const csv = sessionOutcomeReportToCsv(rows);
+        const lines = csv.split('\n');
+        expect(lines[0]).toBe('date,sourceKind,sourceId,status,hasFollowUpData,responseCount,tissueRegions,overrideReason,note,completedStepsCount,missingRequiredStepsCount,totalPlannedSteps,policyVersion');
+        expect(lines).toHaveLength(2);
+        expect(lines[1]).toContain('exec-1');
+    });
+
+    it('quotes and escapes a field containing a comma, quote or newline', () => {
+        const rows = buildSessionOutcomeReport([outcome({ override: { note: 'felt "off", a bit stiff\nnext day' } })]);
+        const csv = sessionOutcomeReportToCsv(rows);
+        expect(csv).toContain('"felt ""off"", a bit stiff\nnext day"');
+    });
+
+    it('is deterministic: identical input produces byte-identical output', () => {
+        const rows = buildSessionOutcomeReport([outcome(), outcome({ sourceSession: { kind: 'execution', id: 'exec-2', date: '2026-08-19' } })]);
+        expect(sessionOutcomeReportToCsv(rows)).toBe(sessionOutcomeReportToCsv(rows));
+    });
+});

--- a/app/src/responses/outcomeReport.test.ts
+++ b/app/src/responses/outcomeReport.test.ts
@@ -62,6 +62,12 @@ describe('sessionOutcomeReportToCsv', () => {
         expect(csv).toContain('"felt ""off"", a bit stiff\nnext day"');
     });
 
+    it('quotes a field containing a bare carriage return, not only a newline', () => {
+        const rows = buildSessionOutcomeReport([outcome({ override: { note: 'felt off\ra bit stiff' } })]);
+        const csv = sessionOutcomeReportToCsv(rows);
+        expect(csv).toContain('"felt off\ra bit stiff"');
+    });
+
     it('is deterministic: identical input produces byte-identical output', () => {
         const rows = buildSessionOutcomeReport([outcome(), outcome({ sourceSession: { kind: 'execution', id: 'exec-2', date: '2026-08-19' } })]);
         expect(sessionOutcomeReportToCsv(rows)).toBe(sessionOutcomeReportToCsv(rows));

--- a/app/src/responses/outcomeReport.ts
+++ b/app/src/responses/outcomeReport.ts
@@ -60,7 +60,7 @@ const CSV_COLUMNS: (keyof SessionOutcomeReportRow)[] = [
 
 function csvField(value: string | number | boolean): string {
     const text = String(value);
-    if (/[",\n]/.test(text)) return `"${text.replaceAll('"', '""')}"`;
+    if (/[",\r\n]/.test(text)) return `"${text.replaceAll('"', '""')}"`;
     return text;
 }
 

--- a/app/src/responses/outcomeReport.ts
+++ b/app/src/responses/outcomeReport.ts
@@ -1,0 +1,75 @@
+/**
+ * M5.3: deterministic report/export over `SessionOutcome[]`.
+ *
+ * Per the 2026-08-19 cutline review, M5.3 ships "a deterministic report/export and a compact
+ * inspectable view using existing data surfaces" -- explicitly NOT a dedicated cross-session
+ * response dashboard. `components/session/ResponseHistory.tsx` stays unbuilt until the
+ * athlete repeatedly opens/exports this and has a specific question a dedicated surface would
+ * answer better (see `docs/plans/multidomain-session-authoring-execution-and-evidence.md`
+ * M5.3). This module is the report: a flat, sorted, injury-prediction-free row set plus a
+ * pure CSV serializer, both directly testable without a UI.
+ */
+import type { SessionOutcome } from './outcome';
+
+export interface SessionOutcomeReportRow {
+    date: string;
+    sourceKind: SessionOutcome['sourceSession']['kind'];
+    sourceId: string;
+    status: SessionOutcome['status'];
+    hasFollowUpData: boolean;
+    responseCount: number;
+    tissueRegions: string;
+    overrideReason: string;
+    note: string;
+    completedStepsCount: string;
+    missingRequiredStepsCount: string;
+    totalPlannedSteps: string;
+    policyVersion: string;
+}
+
+/** Chronological, then by source id -- stable and independent of Firestore query order, so
+ * the same underlying data always produces byte-identical report/export output. */
+export function buildSessionOutcomeReport(outcomes: readonly SessionOutcome[]): SessionOutcomeReportRow[] {
+    return [...outcomes]
+        .sort((a, b) => (
+            a.sourceSession.date.localeCompare(b.sourceSession.date)
+            || a.sourceSession.id.localeCompare(b.sourceSession.id)
+        ))
+        .map(outcome => ({
+            date: outcome.sourceSession.date,
+            sourceKind: outcome.sourceSession.kind,
+            sourceId: outcome.sourceSession.id,
+            status: outcome.status,
+            hasFollowUpData: outcome.hasFollowUpData,
+            responseCount: outcome.sourceFacts.responseIds.length,
+            tissueRegions: outcome.sourceFacts.tissueRegions.join(';'),
+            overrideReason: outcome.override.reason ?? '',
+            note: outcome.override.note ?? '',
+            completedStepsCount: outcome.override.completedStepsCount?.toString() ?? '',
+            missingRequiredStepsCount: outcome.override.missingRequiredStepsCount?.toString() ?? '',
+            totalPlannedSteps: outcome.override.totalPlannedSteps?.toString() ?? '',
+            policyVersion: outcome.policyVersion,
+        }));
+}
+
+const CSV_COLUMNS: (keyof SessionOutcomeReportRow)[] = [
+    'date', 'sourceKind', 'sourceId', 'status', 'hasFollowUpData', 'responseCount',
+    'tissueRegions', 'overrideReason', 'note', 'completedStepsCount',
+    'missingRequiredStepsCount', 'totalPlannedSteps', 'policyVersion',
+];
+
+function csvField(value: string | number | boolean): string {
+    const text = String(value);
+    if (/[",\n]/.test(text)) return `"${text.replaceAll('"', '""')}"`;
+    return text;
+}
+
+/** RFC 4180-shaped, deterministic (same row order as `buildSessionOutcomeReport`, same
+ * column order every time) -- an athlete-facing export, not a persisted document. */
+export function sessionOutcomeReportToCsv(rows: readonly SessionOutcomeReportRow[]): string {
+    const lines = [CSV_COLUMNS.join(',')];
+    for (const row of rows) {
+        lines.push(CSV_COLUMNS.map(column => csvField(row[column])).join(','));
+    }
+    return lines.join('\n');
+}

--- a/app/src/services/sessionOutcomeReportService.test.ts
+++ b/app/src/services/sessionOutcomeReportService.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { NormalizedExecutionRecord } from '../sessions/legacyStrengthAdapter';
+import type { SessionResponse } from '../responses/models';
+import type { DailySubjectiveCheckin } from '../engine/models';
+
+const resolverMocks = vi.hoisted(() => ({
+    resolveSessionDefinition: vi.fn(),
+}));
+vi.mock('../sessions/sessionDefinitionResolver', () => ({
+    resolveSessionDefinition: resolverMocks.resolveSessionDefinition,
+}));
+
+import { SessionOutcomeReportService } from './sessionOutcomeReportService';
+import type { SessionExecutionService } from './sessionExecutionService';
+import type { SessionResponseService } from './sessionResponseService';
+import type { CheckinService } from './checkinService';
+
+function execution(overrides: Partial<NormalizedExecutionRecord['execution']> = {}): NormalizedExecutionRecord['execution'] {
+    return {
+        userId: 'u1',
+        executionId: 'exec-1',
+        sessionSource: { kind: 'unplanned_fixture', fixtureId: 'fixture-1' },
+        date: '2026-08-18',
+        startedAt: '2026-08-18T10:00:00Z',
+        completedAt: '2026-08-18T11:00:00Z',
+        updatedAt: '2026-08-18T11:00:00Z',
+        state: 'completed',
+        schemaVersion: 1,
+        ...overrides,
+    };
+}
+
+function fakeExecutionService(records: NormalizedExecutionRecord[]) {
+    return {
+        getExecutionsInRange: vi.fn().mockResolvedValue({ executions: records, invalidRecords: 0 }),
+    } as unknown as SessionExecutionService;
+}
+
+function fakeResponseService(bySourceId: Record<string, SessionResponse[]>) {
+    return {
+        getResponsesForSource: vi.fn(async (_userId: string, source: { id: string }) => bySourceId[source.id] ?? []),
+    } as unknown as SessionResponseService;
+}
+
+function fakeCheckinService(byDate: Record<string, DailySubjectiveCheckin>) {
+    return {
+        getCheckinByDate: vi.fn(async (_userId: string, date: string) => byDate[date] ?? null),
+    } as unknown as CheckinService;
+}
+
+function response(overrides: Partial<SessionResponse> = {}): SessionResponse {
+    return {
+        userId: 'u1',
+        responseId: 'resp-1',
+        sourceSession: { kind: 'execution', id: 'exec-1', date: '2026-08-18' },
+        window: 'later_day',
+        date: '2026-08-18',
+        checkinRef: { date: '2026-08-19' },
+        createdAt: '2026-08-19T07:00:00Z',
+        updatedAt: '2026-08-19T07:00:00Z',
+        ...overrides,
+    };
+}
+
+describe('SessionOutcomeReportService', () => {
+    beforeEach(() => {
+        resolverMocks.resolveSessionDefinition.mockReset();
+    });
+
+    it('excludes in-progress executions from the report', async () => {
+        const service = new SessionOutcomeReportService(
+            fakeExecutionService([{ execution: execution({ state: 'in_progress', completedAt: undefined }), entries: [] }]),
+            fakeResponseService({}),
+            fakeCheckinService({}),
+        );
+        const outcomes = await service.buildReport('u1', '2026-08-01', '2026-09-01');
+        expect(outcomes).toEqual([]);
+    });
+
+    it('produces an unknown outcome for a completed execution with no responses or tissue data', async () => {
+        resolverMocks.resolveSessionDefinition.mockResolvedValue({ status: 'MISSING' });
+        const service = new SessionOutcomeReportService(
+            fakeExecutionService([{ execution: execution(), entries: [] }]),
+            fakeResponseService({}),
+            fakeCheckinService({}),
+        );
+        const [outcome] = await service.buildReport('u1', '2026-08-01', '2026-09-01');
+        expect(outcome.status).toBe('unknown');
+        expect(outcome.sourceSession).toEqual({ kind: 'execution', id: 'exec-1', date: '2026-08-18' });
+    });
+
+    it('attributes only the tissue regions whose sourceSessionRef matches this execution', async () => {
+        resolverMocks.resolveSessionDefinition.mockResolvedValue({ status: 'MISSING' });
+        const service = new SessionOutcomeReportService(
+            fakeExecutionService([{ execution: execution(), entries: [] }]),
+            fakeResponseService({ 'exec-1': [response()] }),
+            fakeCheckinService({
+                '2026-08-19': {
+                    userId: 'u1',
+                    date: '2026-08-19',
+                    tissueResponses: {
+                        knee: { region: 'knee', morningState: 'moderate', sourceSessionRef: { kind: 'execution', id: 'exec-1', date: '2026-08-18' } },
+                        hip: { region: 'hip', morningState: 'severe', sourceSessionRef: { kind: 'execution', id: 'exec-other', date: '2026-08-17' } },
+                    },
+                } as unknown as DailySubjectiveCheckin,
+            }),
+        );
+        const [outcome] = await service.buildReport('u1', '2026-08-01', '2026-09-01');
+        expect(outcome.sourceFacts.tissueRegions).toEqual(['knee']);
+        expect(outcome.status).toBe('reactive');
+    });
+
+    it('resolves a planned/performed comparison only for a completed execution whose prescription still resolves', async () => {
+        resolverMocks.resolveSessionDefinition.mockResolvedValue({
+            status: 'AVAILABLE',
+            data: {
+                schemaVersion: 1, id: 'def-1', revision: 1, title: 'Lower', intent: 'strength',
+                blocks: [{ id: 'b1', title: 'Block', executionMode: 'sequential', steps: [] }],
+            },
+        });
+        const service = new SessionOutcomeReportService(
+            fakeExecutionService([{ execution: execution(), entries: [] }]),
+            fakeResponseService({ 'exec-1': [response()] }),
+            fakeCheckinService({}),
+        );
+        const [outcome] = await service.buildReport('u1', '2026-08-01', '2026-09-01');
+        expect(outcome.override.totalPlannedSteps).toBe(0);
+        expect(resolverMocks.resolveSessionDefinition).toHaveBeenCalledWith('u1', execution().sessionSource, undefined);
+    });
+
+    it('never calls the resolver for an abandoned execution', async () => {
+        const service = new SessionOutcomeReportService(
+            fakeExecutionService([{ execution: execution({ state: 'abandoned' }), entries: [] }]),
+            fakeResponseService({}),
+            fakeCheckinService({}),
+        );
+        await service.buildReport('u1', '2026-08-01', '2026-09-01');
+        expect(resolverMocks.resolveSessionDefinition).not.toHaveBeenCalled();
+    });
+
+    it('sorts the report chronologically by execution date then id', async () => {
+        resolverMocks.resolveSessionDefinition.mockResolvedValue({ status: 'MISSING' });
+        const service = new SessionOutcomeReportService(
+            fakeExecutionService([
+                { execution: execution({ executionId: 'exec-b', date: '2026-08-19' }), entries: [] },
+                { execution: execution({ executionId: 'exec-a', date: '2026-08-18' }), entries: [] },
+            ]),
+            fakeResponseService({}),
+            fakeCheckinService({}),
+        );
+        const outcomes = await service.buildReport('u1', '2026-08-01', '2026-09-01');
+        expect(outcomes.map(outcome => outcome.sourceSession.id)).toEqual(['exec-a', 'exec-b']);
+    });
+});

--- a/app/src/services/sessionOutcomeReportService.test.ts
+++ b/app/src/services/sessionOutcomeReportService.test.ts
@@ -42,9 +42,9 @@ function fakeResponseService(bySourceId: Record<string, SessionResponse[]>) {
     } as unknown as SessionResponseService;
 }
 
-function fakeCheckinService(byDate: Record<string, DailySubjectiveCheckin>) {
+function fakeCheckinService(checkins: DailySubjectiveCheckin[]) {
     return {
-        getCheckinByDate: vi.fn(async (_userId: string, date: string) => byDate[date] ?? null),
+        getCheckinsInRange: vi.fn().mockResolvedValue(checkins),
     } as unknown as CheckinService;
 }
 
@@ -71,7 +71,7 @@ describe('SessionOutcomeReportService', () => {
         const service = new SessionOutcomeReportService(
             fakeExecutionService([{ execution: execution({ state: 'in_progress', completedAt: undefined }), entries: [] }]),
             fakeResponseService({}),
-            fakeCheckinService({}),
+            fakeCheckinService([]),
         );
         const outcomes = await service.buildReport('u1', '2026-08-01', '2026-09-01');
         expect(outcomes).toEqual([]);
@@ -82,7 +82,7 @@ describe('SessionOutcomeReportService', () => {
         const service = new SessionOutcomeReportService(
             fakeExecutionService([{ execution: execution(), entries: [] }]),
             fakeResponseService({}),
-            fakeCheckinService({}),
+            fakeCheckinService([]),
         );
         const [outcome] = await service.buildReport('u1', '2026-08-01', '2026-09-01');
         expect(outcome.status).toBe('unknown');
@@ -94,20 +94,52 @@ describe('SessionOutcomeReportService', () => {
         const service = new SessionOutcomeReportService(
             fakeExecutionService([{ execution: execution(), entries: [] }]),
             fakeResponseService({ 'exec-1': [response()] }),
-            fakeCheckinService({
-                '2026-08-19': {
-                    userId: 'u1',
-                    date: '2026-08-19',
-                    tissueResponses: {
-                        knee: { region: 'knee', morningState: 'moderate', sourceSessionRef: { kind: 'execution', id: 'exec-1', date: '2026-08-18' } },
-                        hip: { region: 'hip', morningState: 'severe', sourceSessionRef: { kind: 'execution', id: 'exec-other', date: '2026-08-17' } },
-                    },
-                } as unknown as DailySubjectiveCheckin,
-            }),
+            fakeCheckinService([{
+                userId: 'u1',
+                date: '2026-08-19',
+                tissueResponses: {
+                    knee: { region: 'knee', morningState: 'moderate', sourceSessionRef: { kind: 'execution', id: 'exec-1', date: '2026-08-18' } },
+                    hip: { region: 'hip', morningState: 'severe', sourceSessionRef: { kind: 'execution', id: 'exec-other', date: '2026-08-17' } },
+                },
+            } as unknown as DailySubjectiveCheckin]),
         );
         const [outcome] = await service.buildReport('u1', '2026-08-01', '2026-09-01');
         expect(outcome.sourceFacts.tissueRegions).toEqual(['knee']);
         expect(outcome.status).toBe('reactive');
+    });
+
+    it('discovers a tissue reaction linked directly to the execution even with no SessionResponse ever recorded', async () => {
+        // Regression: a manually-flagged check-in tissue response sets sourceSessionRef
+        // without necessarily going through sessionResponseService.recordResponse (the legacy
+        // M1.7-era manual flag path M5.2 left unchanged). Discovery must not depend on a
+        // SessionResponse existing.
+        resolverMocks.resolveSessionDefinition.mockResolvedValue({ status: 'MISSING' });
+        const service = new SessionOutcomeReportService(
+            fakeExecutionService([{ execution: execution(), entries: [] }]),
+            fakeResponseService({}),
+            fakeCheckinService([{
+                userId: 'u1',
+                date: '2026-08-19',
+                tissueResponses: {
+                    knee: { region: 'knee', morningState: 'severe', sourceSessionRef: { kind: 'execution', id: 'exec-1', date: '2026-08-18' } },
+                },
+            } as unknown as DailySubjectiveCheckin]),
+        );
+        const [outcome] = await service.buildReport('u1', '2026-08-01', '2026-09-01');
+        expect(outcome.sourceFacts.tissueRegions).toEqual(['knee']);
+        expect(outcome.status).toBe('reactive');
+    });
+
+    it('queries check-ins across the report range extended by the tissue lookahead buffer', async () => {
+        resolverMocks.resolveSessionDefinition.mockResolvedValue({ status: 'MISSING' });
+        const checkins = fakeCheckinService([]);
+        const service = new SessionOutcomeReportService(
+            fakeExecutionService([{ execution: execution(), entries: [] }]),
+            fakeResponseService({}),
+            checkins,
+        );
+        await service.buildReport('u1', '2026-08-01', '2026-09-01');
+        expect(checkins.getCheckinsInRange).toHaveBeenCalledWith('u1', '2026-08-01', '2026-09-08');
     });
 
     it('resolves a planned/performed comparison only for a completed execution whose prescription still resolves', async () => {
@@ -121,7 +153,7 @@ describe('SessionOutcomeReportService', () => {
         const service = new SessionOutcomeReportService(
             fakeExecutionService([{ execution: execution(), entries: [] }]),
             fakeResponseService({ 'exec-1': [response()] }),
-            fakeCheckinService({}),
+            fakeCheckinService([]),
         );
         const [outcome] = await service.buildReport('u1', '2026-08-01', '2026-09-01');
         expect(outcome.override.totalPlannedSteps).toBe(0);
@@ -132,7 +164,7 @@ describe('SessionOutcomeReportService', () => {
         const service = new SessionOutcomeReportService(
             fakeExecutionService([{ execution: execution({ state: 'abandoned' }), entries: [] }]),
             fakeResponseService({}),
-            fakeCheckinService({}),
+            fakeCheckinService([]),
         );
         await service.buildReport('u1', '2026-08-01', '2026-09-01');
         expect(resolverMocks.resolveSessionDefinition).not.toHaveBeenCalled();
@@ -146,7 +178,7 @@ describe('SessionOutcomeReportService', () => {
                 { execution: execution({ executionId: 'exec-a', date: '2026-08-18' }), entries: [] },
             ]),
             fakeResponseService({}),
-            fakeCheckinService({}),
+            fakeCheckinService([]),
         );
         const outcomes = await service.buildReport('u1', '2026-08-01', '2026-09-01');
         expect(outcomes.map(outcome => outcome.sourceSession.id)).toEqual(['exec-a', 'exec-b']);

--- a/app/src/services/sessionOutcomeReportService.ts
+++ b/app/src/services/sessionOutcomeReportService.ts
@@ -5,7 +5,9 @@
  *
  *  - `sessionResponseService.getResponsesForSource` (M5.1) for recorded facts;
  *  - the canonical check-in (`checkinService`, D-MRESP's sole tissue authority) for any
- *    `RegionTissueResponse` whose `sourceSessionRef` matches this execution;
+ *    `RegionTissueResponse` whose `sourceSessionRef` matches this execution -- discovered by
+ *    scanning check-ins directly (see `tissueIndexInRange` below), never by way of whether a
+ *    `SessionResponse` happens to exist;
  *  - `resolveSessionDefinition` (M3.1) + `comparePlannedVsPerformed` (M2.6) for the
  *    planned-vs-performed delta, when the execution's prescription binding still resolves.
  *
@@ -15,6 +17,7 @@
  * pattern (M2.7) so this composition is unit-testable without the Firestore emulator.
  */
 import type { RegionTissueResponse } from '../engine/models';
+import { addDaysToLocalDateString } from '../utils/localDate';
 import { resolveSessionDefinition } from '../sessions/sessionDefinitionResolver';
 import { comparePlannedVsPerformed } from '../sessions/performedComparison';
 import { deriveSessionOutcome, type SessionOutcome } from '../responses/outcome';
@@ -22,6 +25,12 @@ import type { SessionResponseSourceRef } from '../responses/models';
 import { checkinService, type CheckinService } from './checkinService';
 import { sessionExecutionService, type SessionExecutionService } from './sessionExecutionService';
 import { sessionResponseService, type SessionResponseService } from './sessionResponseService';
+
+/** later_day answers land same-day and next_morning answers land the day after, but neither
+ * window has an expiry (M5.2 never times one out), so a late answer must still be found. This
+ * buffer is a bounded compromise, not a correctness guarantee for an answer recorded further
+ * out than a week later. */
+const TISSUE_LOOKAHEAD_DAYS = 7;
 
 export class SessionOutcomeReportService {
     private readonly executionService: SessionExecutionService;
@@ -39,6 +48,36 @@ export class SessionOutcomeReportService {
     }
 
     /**
+     * Every execution-linked `RegionTissueResponse` in `[startDateInclusive, throughDateExclusive
+     * + TISSUE_LOOKAHEAD_DAYS)`, indexed by the execution id its `sourceSessionRef` names --
+     * scanned directly from check-ins, independent of whether any `SessionResponse` was ever
+     * recorded for that execution. A manually-flagged tissue reaction (the pre-M5.1 check-in
+     * flow M5.2 left unchanged for legacy `strength_sessions`, still reachable for `execution`
+     * sources too) sets `sourceSessionRef` without necessarily creating a `SessionResponse`; a
+     * discovery keyed off `SessionResponse.checkinRef.date` would silently miss it.
+     */
+    private async tissueIndexInRange(
+        userId: string,
+        startDateInclusive: string,
+        throughDateExclusive: string,
+    ): Promise<Map<string, RegionTissueResponse[]>> {
+        const checkins = await this.checkins.getCheckinsInRange(
+            userId, startDateInclusive, addDaysToLocalDateString(throughDateExclusive, TISSUE_LOOKAHEAD_DAYS),
+        );
+        const index = new Map<string, RegionTissueResponse[]>();
+        for (const checkin of checkins) {
+            if (!checkin.tissueResponses) continue;
+            for (const region of Object.values(checkin.tissueResponses)) {
+                if (region.sourceSessionRef?.kind !== 'execution') continue;
+                const existing = index.get(region.sourceSessionRef.id) ?? [];
+                existing.push(region);
+                index.set(region.sourceSessionRef.id, existing);
+            }
+        }
+        return index;
+    }
+
+    /**
      * @param startDateInclusive Warsaw-local `YYYY-MM-DD`.
      * @param throughDateExclusive Warsaw-local `YYYY-MM-DD`, matching
      *   `sessionExecutionService.getExecutionsInRange`'s own exclusive-end convention.
@@ -48,22 +87,14 @@ export class SessionOutcomeReportService {
         startDateInclusive: string,
         throughDateExclusive: string,
     ): Promise<SessionOutcome[]> {
-        const { executions } = await this.executionService.getExecutionsInRange(
-            userId, startDateInclusive, throughDateExclusive,
-        );
+        const [{ executions }, tissueIndex] = await Promise.all([
+            this.executionService.getExecutionsInRange(userId, startDateInclusive, throughDateExclusive),
+            this.tissueIndexInRange(userId, startDateInclusive, throughDateExclusive),
+        ]);
         // An in-progress execution has no outcome yet -- reporting one now would silently
         // read as 'unknown' every time, indistinguishable from a genuinely unanswered
         // follow-up. Excluding it here keeps that distinction meaningful.
         const finished = executions.filter(item => item.execution.state !== 'in_progress');
-
-        const checkinCache = new Map<string, RegionTissueResponse[]>();
-        const tissueResponsesForDate = async (date: string): Promise<RegionTissueResponse[]> => {
-            if (!checkinCache.has(date)) {
-                const checkin = await this.checkins.getCheckinByDate(userId, date);
-                checkinCache.set(date, checkin?.tissueResponses ? Object.values(checkin.tissueResponses) : []);
-            }
-            return checkinCache.get(date) ?? [];
-        };
 
         const outcomes: SessionOutcome[] = [];
         for (const { execution, entries } of finished) {
@@ -71,17 +102,7 @@ export class SessionOutcomeReportService {
                 kind: 'execution', id: execution.executionId, date: execution.date,
             };
             const responses = await this.responseService.getResponsesForSource(userId, sourceSession);
-
-            const checkinDates = new Set(responses.map(response => response.checkinRef.date));
-            const tissueResponses: RegionTissueResponse[] = [];
-            for (const date of checkinDates) {
-                const regions = await tissueResponsesForDate(date);
-                for (const region of regions) {
-                    if (region.sourceSessionRef?.kind === 'execution' && region.sourceSessionRef.id === execution.executionId) {
-                        tissueResponses.push(region);
-                    }
-                }
-            }
+            const tissueResponses = tissueIndex.get(execution.executionId) ?? [];
 
             let comparison: ReturnType<typeof comparePlannedVsPerformed> | undefined;
             if (execution.state === 'completed') {

--- a/app/src/services/sessionOutcomeReportService.ts
+++ b/app/src/services/sessionOutcomeReportService.ts
@@ -1,0 +1,111 @@
+/**
+ * M5.3: builds the outcome/override evidence report over a date range, wiring together only
+ * existing data surfaces (2026-08-19 cutline: report/export first, no new persistence, no
+ * dedicated history UI). For each finished execution in range:
+ *
+ *  - `sessionResponseService.getResponsesForSource` (M5.1) for recorded facts;
+ *  - the canonical check-in (`checkinService`, D-MRESP's sole tissue authority) for any
+ *    `RegionTissueResponse` whose `sourceSessionRef` matches this execution;
+ *  - `resolveSessionDefinition` (M3.1) + `comparePlannedVsPerformed` (M2.6) for the
+ *    planned-vs-performed delta, when the execution's prescription binding still resolves.
+ *
+ * Every one of those already exists and is already tested; this module only sequences reads
+ * and hands the result to the pure `deriveSessionOutcome` (`responses/outcome.ts`). Dependency
+ * injection with singleton defaults matches `StrengthHistoryReadService`'s established
+ * pattern (M2.7) so this composition is unit-testable without the Firestore emulator.
+ */
+import type { RegionTissueResponse } from '../engine/models';
+import { resolveSessionDefinition } from '../sessions/sessionDefinitionResolver';
+import { comparePlannedVsPerformed } from '../sessions/performedComparison';
+import { deriveSessionOutcome, type SessionOutcome } from '../responses/outcome';
+import type { SessionResponseSourceRef } from '../responses/models';
+import { checkinService, type CheckinService } from './checkinService';
+import { sessionExecutionService, type SessionExecutionService } from './sessionExecutionService';
+import { sessionResponseService, type SessionResponseService } from './sessionResponseService';
+
+export class SessionOutcomeReportService {
+    private readonly executionService: SessionExecutionService;
+    private readonly responseService: SessionResponseService;
+    private readonly checkins: CheckinService;
+
+    constructor(
+        executionService: SessionExecutionService = sessionExecutionService,
+        responseService: SessionResponseService = sessionResponseService,
+        checkins: CheckinService = checkinService,
+    ) {
+        this.executionService = executionService;
+        this.responseService = responseService;
+        this.checkins = checkins;
+    }
+
+    /**
+     * @param startDateInclusive Warsaw-local `YYYY-MM-DD`.
+     * @param throughDateExclusive Warsaw-local `YYYY-MM-DD`, matching
+     *   `sessionExecutionService.getExecutionsInRange`'s own exclusive-end convention.
+     */
+    async buildReport(
+        userId: string,
+        startDateInclusive: string,
+        throughDateExclusive: string,
+    ): Promise<SessionOutcome[]> {
+        const { executions } = await this.executionService.getExecutionsInRange(
+            userId, startDateInclusive, throughDateExclusive,
+        );
+        // An in-progress execution has no outcome yet -- reporting one now would silently
+        // read as 'unknown' every time, indistinguishable from a genuinely unanswered
+        // follow-up. Excluding it here keeps that distinction meaningful.
+        const finished = executions.filter(item => item.execution.state !== 'in_progress');
+
+        const checkinCache = new Map<string, RegionTissueResponse[]>();
+        const tissueResponsesForDate = async (date: string): Promise<RegionTissueResponse[]> => {
+            if (!checkinCache.has(date)) {
+                const checkin = await this.checkins.getCheckinByDate(userId, date);
+                checkinCache.set(date, checkin?.tissueResponses ? Object.values(checkin.tissueResponses) : []);
+            }
+            return checkinCache.get(date) ?? [];
+        };
+
+        const outcomes: SessionOutcome[] = [];
+        for (const { execution, entries } of finished) {
+            const sourceSession: SessionResponseSourceRef = {
+                kind: 'execution', id: execution.executionId, date: execution.date,
+            };
+            const responses = await this.responseService.getResponsesForSource(userId, sourceSession);
+
+            const checkinDates = new Set(responses.map(response => response.checkinRef.date));
+            const tissueResponses: RegionTissueResponse[] = [];
+            for (const date of checkinDates) {
+                const regions = await tissueResponsesForDate(date);
+                for (const region of regions) {
+                    if (region.sourceSessionRef?.kind === 'execution' && region.sourceSessionRef.id === execution.executionId) {
+                        tissueResponses.push(region);
+                    }
+                }
+            }
+
+            let comparison: ReturnType<typeof comparePlannedVsPerformed> | undefined;
+            if (execution.state === 'completed') {
+                const definitionState = await resolveSessionDefinition(
+                    userId, execution.sessionSource, execution.prescriptionHash,
+                );
+                if (definitionState.status === 'AVAILABLE') {
+                    comparison = comparePlannedVsPerformed(definitionState.data, entries);
+                }
+            }
+
+            outcomes.push(deriveSessionOutcome({
+                sourceSession,
+                responses,
+                tissueResponses,
+                ...(comparison ? { comparison } : {}),
+            }));
+        }
+
+        return outcomes.sort((a, b) => (
+            a.sourceSession.date.localeCompare(b.sourceSession.date)
+            || a.sourceSession.id.localeCompare(b.sourceSession.id)
+        ));
+    }
+}
+
+export const sessionOutcomeReportService = new SessionOutcomeReportService();

--- a/app/src/sessions/architecture.test.ts
+++ b/app/src/sessions/architecture.test.ts
@@ -144,4 +144,29 @@ describe('Multidomain sessions architecture and dependency boundaries (M0.3 / AD
             }
         }
     });
+
+    it('no selection/ranking module imports the M5.3 outcome summary at runtime (D-MPOLICY)', () => {
+        // `responses/outcome.ts`'s `deriveSessionOutcome` is an evidence-only summary label
+        // (passed/caution/reactive/unknown) -- D-MPOLICY requires it stay a report input, never
+        // a live selection/eligibility signal, until a separate ship decision says otherwise.
+        const forbiddenSelection = [
+            'engine/optimizer',
+            'engine/planner',
+            'engine/rules',
+            'engine/weeklyAllocation',
+            'engine/evergreenPlanning',
+            'engine/sequenceSearch',
+        ];
+
+        for (const [mod, imports] of graph.entries()) {
+            const importsOutcome = imports.some(imp => imp === 'responses/outcome.ts');
+            if (!importsOutcome) continue;
+            for (const forbidden of forbiddenSelection) {
+                expect(
+                    mod.startsWith(forbidden),
+                    `Selection module "${mod}" must not import evidence-only "responses/outcome.ts"`,
+                ).toBe(false);
+            }
+        }
+    });
 });

--- a/app/src/sessions/architecture.test.ts
+++ b/app/src/sessions/architecture.test.ts
@@ -145,10 +145,14 @@ describe('Multidomain sessions architecture and dependency boundaries (M0.3 / AD
         }
     });
 
-    it('no selection/ranking module imports the M5.3 outcome summary at runtime (D-MPOLICY)', () => {
+    it('no selection/ranking module can reach the M5.3 outcome summary at runtime, directly or transitively (D-MPOLICY)', () => {
         // `responses/outcome.ts`'s `deriveSessionOutcome` is an evidence-only summary label
         // (passed/caution/reactive/unknown) -- D-MPOLICY requires it stay a report input, never
         // a live selection/eligibility signal, until a separate ship decision says otherwise.
+        // A direct-edge-only check would pass a path like
+        // `engine/optimizer/foo.ts -> services/report.ts -> responses/outcome.ts`, so this
+        // walks the full reverse-reachability set instead: every module that can reach
+        // `responses/outcome.ts` through any chain of imports.
         const forbiddenSelection = [
             'engine/optimizer',
             'engine/planner',
@@ -158,13 +162,31 @@ describe('Multidomain sessions architecture and dependency boundaries (M0.3 / AD
             'engine/sequenceSearch',
         ];
 
+        const reverseGraph = new Map<string, string[]>();
         for (const [mod, imports] of graph.entries()) {
-            const importsOutcome = imports.some(imp => imp === 'responses/outcome.ts');
-            if (!importsOutcome) continue;
+            for (const imp of imports) {
+                const importers = reverseGraph.get(imp) ?? [];
+                importers.push(mod);
+                reverseGraph.set(imp, importers);
+            }
+        }
+
+        // BFS over the reverse graph from 'responses/outcome.ts': every module reached this
+        // way can, through some chain, cause 'responses/outcome.ts' to run.
+        const ancestors = new Set<string>();
+        const queue = [...(reverseGraph.get('responses/outcome.ts') ?? [])];
+        while (queue.length > 0) {
+            const mod = queue.pop()!;
+            if (ancestors.has(mod)) continue;
+            ancestors.add(mod);
+            queue.push(...(reverseGraph.get(mod) ?? []));
+        }
+
+        for (const mod of ancestors) {
             for (const forbidden of forbiddenSelection) {
                 expect(
                     mod.startsWith(forbidden),
-                    `Selection module "${mod}" must not import evidence-only "responses/outcome.ts"`,
+                    `Selection module "${mod}" must not be able to reach evidence-only "responses/outcome.ts" (directly or transitively)`,
                 ).toBe(false);
             }
         }

--- a/docs/analysis/2026-08-20-m-phase-status-and-next-steps.md
+++ b/docs/analysis/2026-08-20-m-phase-status-and-next-steps.md
@@ -1,0 +1,131 @@
+# M-plan status and next steps (2026-08-20)
+
+## Question
+
+Where does the `M` capability plan — [Multidomain session authoring, execution and
+evidence](../plans/multidomain-session-authoring-execution-and-evidence.md) — stand today, and
+what is the correct next unit of work?
+
+This is a dated point-in-time status check, not a new decision. It confirms the
+[2026-08-19 cutline review](./2026-08-19-product-scope-cutline-review.md) against the plan's
+current task board and recommends the immediate next step.
+
+## What "M" is
+
+`M`, `S`, `G` and `UX` in `docs/plans/README.md` are capability/surface plans, not numbered
+engine phases (`Phase 0`–`9`). `M`'s work items carry the `M*` prefix precisely so they aren't
+mistaken for the phase sequence. `M` covers: an athlete building or importing a structured
+multidomain session, scheduling it with explicit authority, executing it safely on a phone,
+recording native performed doses/measurements, and linking response back to the exact
+occurrence — while preserving replay, user isolation, existing engine authority and the
+repository's default-off evidence policy.
+
+## Current status
+
+The 2026-08-19 cutline's recommended near-term chain,
+**M3.7 → bounded M3.8 → M4.3 → M5.1 → M5.2**, is complete end to end. Verified against the
+plan's task board (`docs/plans/multidomain-session-authoring-execution-and-evidence.md`):
+
+| Item | Title | Status |
+|---|---|:---:|
+| M0.1–M0.3 | Contract, fixtures, dependency boundaries | `[x]` |
+| M1.1–M1.7 | Strength repair + session-linked response v0 | `[x]` |
+| M2.1–M2.7 | Executable session core (definitions, persistence, runner, comparison, v1 read compat) | `[x]` |
+| M3.1–M3.8 | Hashing/adapters, replay, authority flow, catalog parity, facets, external v2, import preview/diff, manual builder | `[x]` |
+| M4.1–M4.3 | Group execution modes, recorded choices, companion/dedup reconciliation | `[x]` |
+| M5.1 | Occurrence-linked response generalization | `[x]` |
+| M5.2 | Later-day and next-morning follow-up | `[x]` |
+| **M5.3** | **Outcome/override evidence report** | **`[ ]`** |
+| M6.1–M6.4 | Speed/field/power specialization | `[ ]` — usage-triggered, not started |
+| M7.1–M7.4 | Metric registry/protocols/testing/benchmarks | `[ ]` — usage-triggered, not started |
+| M8.1–M8.3 | Evidence-gated policy candidates | `[ ]` — waits on M5/M6/M7 evidence |
+| M9.1–M9.3 | Aliases, prose import, device adapters | `[ ]` — each behind its own named trigger |
+
+`app/src/responses/` currently contains `models.ts`, `validation.ts` and
+`followupSchedule.ts` (M5.1/M5.2) with no `outcome.ts` and no `ResponseHistory.tsx` — the
+code matches the task board exactly; nothing for M5.3 has been started.
+
+**M5.3 is therefore the single unblocked item on the plan's own critical path.** Its
+dependency (M5.2) is done, and no other `M*` item is both startable and not already finished.
+
+## Why M5.3 is next, and how it should be scoped
+
+The 2026-08-19 cutline review already adjudicated this item and the plan encodes the verdict
+directly: **REDUCE/LATER on UI, build the evidence report now.**
+
+> "Useful for analysis, but a dedicated history UI is not required to start evidence
+> collection... First deliver a reproducible export/report if needed; build rich history UI
+> only after it is consulted in practice."
+
+The plan's own M5.3 section (`docs/plans/multidomain-session-authoring-execution-and-evidence.md`)
+specifies the shape:
+
+* Derive `passed | caution | reactive | unknown` as a **versioned, evidence-only summary**
+  from the raw M5.1/M5.2 response windows (`responses/outcome.ts`).
+* Record athlete override reason and planned/performed delta — reuse
+  `SessionAdjustment.athleteReason` through a source-neutral override record rather than
+  inventing a strength-only one.
+* Start with a **deterministic report/export** and a compact inspectable view using existing
+  data surfaces. Do not build `components/session/ResponseHistory.tsx` unless the usage
+  trigger fires: the athlete repeatedly opens/exports the evidence and has a specific
+  question (e.g. comparing responses after a recurring lower-body session) that a dedicated
+  surface would answer better.
+* **Done when:** every outcome links to source facts and a policy version; missing later/next
+  data returns `unknown` (never a fabricated default); the report exposes evidence without
+  making injury-prediction claims; and the M0.3 architecture test is extended to prove no
+  selection/optimizer module imports the outcome function (same boundary already enforced for
+  `sessions/` and `responses/`).
+
+This keeps M5.3 aligned with the same discipline used throughout the plan (D-FUSE, D-STRCOST,
+D-SUBJCAL): no coefficient or automated judgment ships ahead of the evidence that would
+justify it. `passed/caution/reactive/unknown` is a **summary label over already-recorded
+facts**, not a new inference — it must not become a step toward automatic option selection or
+progression, which `D-MPOLICY` explicitly keeps as a separate, future, default-off candidate.
+
+## What should not be started yet
+
+Everything past M5.3 remains correctly gated, and nothing in the repository state changes that
+today:
+
+* **M6 (speed/field/power cards)** — no recorded trigger. The generic runner's repetition/
+  duration/distance/check-off inputs still cover current session fixtures; M6 starts only when
+  a real recurring session demonstrably loses decision-relevant context (splits, side,
+  validity) that the generic inputs can't represent.
+* **M7 (metric registry/testing)** — no recorded trigger. There is no repeated standardized
+  testing workflow yet to make a protocol/comparison-series abstraction pay for itself.
+* **M8 (evidence-gated policy candidates)** — blocked on real history from M5 (and, if
+  independently triggered, M6/M7). M5.3's report is what will make that history usable; M8
+  should not be scheduled ahead of it.
+* **M9 (aliases, prose import, device adapters)** — each item keeps its own explicit trigger
+  (second athlete/durable metadata need, JSON-import friction, owned hardware). None has fired.
+
+## Cross-cutting: Phase 9.0 coordination
+
+M4.3 was decision-affecting (it rewrites `engine/completedTraining.ts` and
+`engine/trainingHistory.ts`) and the cutline required it to land before Phase 9.0's shadow
+block (9.0.7) opens. M4.3 is now `[x]`, so that constraint is satisfied. Phase 9.0's own board
+(`docs/plans/phase-9-0-shadow-mode-and-decision-journal.md`) still shows **9.0.1 (unattended
+ingestion) as the open gate** — 9.0.2–9.0.6 are done, but 9.0.7 (run the block) and 9.0.8
+(readout) remain not started pending it. This is independent of M-plan work: M5.1/M5.2 are
+evidence-only and explicitly safe to run alongside a live shadow block; M5.3 (a pure read/report
+over already-recorded data) is the same. Nothing in M5.3 needs to wait on 9.0.1.
+
+## Recommendation
+
+Build **M5.3** next, scoped exactly as the plan and the 2026-08-19 cutline already specify:
+
+1. `responses/outcome.ts` — pure, versioned `deriveSessionOutcome` (or similar) producing
+   `passed | caution | reactive | unknown` from a session's M5.1 `SessionResponse` rows plus
+   the linked check-in tissue values, with `unknown` as the honest default for any missing
+   window.
+2. A source-neutral override/delta record (reusing `SessionAdjustment.athleteReason`'s shape)
+   capturing athlete override reason and planned-vs-performed delta.
+3. A deterministic report/export surface over existing data — not a new dashboard component.
+4. Extend `sessions/architecture.test.ts` (or `responses/architecture.test.ts` if that's where
+   the M5.1 boundary test landed) to assert no selection/optimizer module imports
+   `responses/outcome.ts`.
+5. Leave `components/session/ResponseHistory.tsx` unbuilt until the usage trigger in the plan
+   fires.
+
+Everything beyond M5.3 stays correctly parked behind its own usage trigger; no other `M*` item
+should move before real use (or M5.3's own report) produces the evidence the plan requires.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -58,15 +58,16 @@ These implement the way forward in
 Phases 0–8 are **implemented**; Phase 9.0 and Phase 9 remain **In progress**.
 Among capability plans, Garmin per-activity telemetry (G) and Mobile UX/UI (UX) are
 **implemented**; Strength session logging (S) is **In progress (default-off)** with all
-numbered code delivered; Multidomain sessions (M) is **In progress** with M0–M2,
-M3.1–M3.6, and M4.1–M4.2 complete.
+numbered code delivered; Multidomain sessions (M) is **In progress** with M0–M5.3
+complete.
 
-For Multidomain delivery, the current evidence-first cutline from
-[`2026-08-19-product-scope-cutline-review.md`](../analysis/2026-08-19-product-scope-cutline-review.md)
-is `M3.7 → bounded M3.8 → M4.3 → M5.1 → M5.2`. The immediate startable set includes
-M3.7, bounded M3.8, and M4.3; the response chain becomes startable as those dependencies
-land. M6/M7 are usage-triggered capability families, not the automatic continuation after
-M5; M8 may consume them only if athlete use justified them independently.
+For Multidomain delivery, the 2026-08-19 evidence-first cutline chain from
+[`2026-08-19-product-scope-cutline-review.md`](../analysis/2026-08-19-product-scope-cutline-review.md),
+`M3.7 → bounded M3.8 → M4.3 → M5.1 → M5.2`, is complete, and M5.3 (the report-first
+outcome/override evidence summary that chain unlocked) landed 2026-08-20. M6/M7 are
+usage-triggered capability families, not the automatic continuation after M5; M8 may
+consume them only if athlete use justified them independently; M9 remains behind its own
+named triggers.
 
 The Phase 0–5 task boards are historical implementation records; the
 [follow-up analysis](../analysis/2026-08-09-phase-0-5-completion-review.md) records
@@ -94,7 +95,7 @@ all-`Ready` table became unusable.
 | 9 | [Subjective baselines in readiness mode](./phase-9-subjective-baselines.md) | **In progress** | only 9.8 remains (9.1–9.7 done — 9.8 needs Phase 9.0's prospective evidence) | — | self-normalises subjective scores as a tighten-only drift term, measured behind a default-off selector before any ship decision — not an original review finding |
 | G | [Garmin per-activity telemetry](./garmin-activity-telemetry-ingestion.md) | **Implemented** | none | none | ingests per-activity power/HR time-in-zone, normalized power and lap averages; the measured zone-credit candidate remains off after an evidence-backed no-ship decision |
 | S | [Strength session logging](./strength-session-logging.md) | **In progress (default-off)** | none; all numbered work is built | real logged-history evidence before enabling manual Strength load — [M1.7](./multidomain-session-authoring-execution-and-evidence.md) is the item that starts producing it | closes the strength return path — per-set logging, self-calibrating 1RM, and measured strength load — not an original review finding |
-| M | [Multidomain session authoring, execution & evidence](./multidomain-session-authoring-execution-and-evidence.md) | **In progress** | M3.7, bounded M3.8 (in progress), M4.3 | M5.1→M5.2 follow M4.3; M5.3 follows M5.2 but starts report-first; M6/M7 require explicit real-use triggers; M8 is evidence-gated and cannot pull untriggered M6/M7 into scope; M9 needs its own named triggers | source-neutral authored sessions, safe mixed-dose execution and occurrence-linked response first; specialized field/testing capability only when athlete use proves the generic runner/evidence model insufficient |
+| M | [Multidomain session authoring, execution & evidence](./multidomain-session-authoring-execution-and-evidence.md) | **In progress** | none | M6/M7 require explicit real-use triggers; M8 is evidence-gated and cannot pull untriggered M6/M7 into scope; M9 needs its own named triggers | source-neutral authored sessions, safe mixed-dose execution and occurrence-linked response first; specialized field/testing capability only when athlete use proves the generic runner/evidence model insufficient |
 | UX | [Mobile UX/UI redesign](./mobile_ux_implementation_plan.md) | **Implemented** | none | none | mobile-first daily decision flow, single-page rapid check-in, state-first Home layout, unblocked recommendation, 44px+ touch targets, and mobile layout tokens |
 
 Rows G, S, M, and UX are **not phases**. They are capability/surface plans whose work items are prefixed

--- a/docs/plans/multidomain-session-authoring-execution-and-evidence.md
+++ b/docs/plans/multidomain-session-authoring-execution-and-evidence.md
@@ -1460,24 +1460,10 @@ over already-tested services, consistent with how this repo tests these two file
 
 ### M5.3 `[x]` Outcome/override evidence report — history UI only if triggered
 
-**Change.** Derive `passed | caution | reactive | unknown` as a versioned, evidence-only summary
-from the raw response windows. Record athlete override reason and planned/performed delta.
-Start with a deterministic report/export and a compact inspectable view using existing data
-surfaces. Do **not** build a dedicated cross-session response dashboard merely because the
-model exists.
-
-**Usage trigger for richer UI.** The athlete repeatedly opens/exports the evidence and has a
-specific question that a dedicated history surface would answer better (for example, comparing
-responses after a recurring lower-body session). Until then, the report/export is the product.
-
-**Files.** New `responses/outcome.ts`, report/export integration; reuse
-`SessionAdjustment.athleteReason` through a source-neutral override record rather than forcing
-every change into a strength adjustment. Add `components/session/ResponseHistory.tsx` only if
-the UI trigger fires.
-
-**Done when.** Every outcome links to source facts and a policy version; missing later or next
-data returns `unknown`; the report exposes the evidence without injury-prediction claims; and
-the M0.3 architecture test proves no selection module imports the outcome function.
+**Future usage trigger for richer UI.** Keep `components/session/ResponseHistory.tsx` deferred
+until repeated evidence use creates a specific question that a dedicated history surface can
+answer better (for example, comparing responses after a recurring lower-body session). Until
+then, the report/export below is the product.
 
 **Outcome (2026-08-20).** Pure derivation, report/export and the wiring service all shipped;
 no dedicated history UI was built.
@@ -1499,7 +1485,8 @@ no dedicated history UI was built.
   reused per the plan's own instruction) -- the record shape exists for the moment a real
   capture point is built, but `deriveSessionOutcome` never invents a value for it.
   `override.note` is populated automatically from data that *does* already exist (the most
-  recently updated `SessionResponse.note`/`techniqueNote`).
+  recently updated `SessionResponse.note`/`techniqueNote`, preferring a `later_day`/
+  `next_morning` note over a merely-more-recent `immediate` one).
 * **Planned/performed delta.** Reuses M2.6's existing `comparePlannedVsPerformed`
   (`sessions/performedComparison.ts`) output (`completedStepsCount`/`missingRequiredStepsCount`/
   `totalPlannedSteps`) rather than recomputing it -- no new delta math was needed.
@@ -1510,25 +1497,33 @@ no dedicated history UI was built.
 * **`services/sessionOutcomeReportService.ts`.** The one new IO-touching module: for every
   finished (`completed`/`abandoned`) execution in a date range it composes
   `sessionExecutionService.getExecutionsInRange`, `sessionResponseService.getResponsesForSource`,
-  `checkinService.getCheckinByDate` and, for a `completed` execution,
+  `checkinService.getCheckinsInRange` and, for a `completed` execution,
   `resolveSessionDefinition` (M3.1) + `comparePlannedVsPerformed` (M2.6) -- every one of those
   already existed and was already tested. Constructor-injected dependencies with singleton
   defaults follow `StrengthHistoryReadService`'s established M2.7 pattern, so the composition
   is unit-testable without the Firestore emulator. An in-progress execution is excluded
   outright (an outcome computed for one would always read `unknown`, indistinguishably from a
-  genuinely unanswered follow-up).
+  genuinely unanswered follow-up). Tissue evidence is discovered by scanning every check-in in
+  range (plus a bounded lookahead buffer) for a `RegionTissueResponse.sourceSessionRef`
+  matching the execution, never by way of whether a `SessionResponse` happens to exist for it
+  -- an earlier draft keyed discovery off `SessionResponse.checkinRef.date` and so silently
+  missed a manually-flagged tissue reaction (the legacy pre-M5.1 check-in flow) that has no
+  corresponding `SessionResponse`; caught in review before merge.
 * **Architecture boundary.** `sessions/architecture.test.ts` gained a third check: no module
   under `engine/optimizer`, `engine/planner`, `engine/rules`, `engine/weeklyAllocation`,
-  `engine/evergreenPlanning` or `engine/sequenceSearch` may import `responses/outcome.ts` at
-  runtime -- the M0.3 boundary's Done-when requirement, applied to this specific evidence-only
-  summary per D-MPOLICY.
+  `engine/evergreenPlanning` or `engine/sequenceSearch` can reach `responses/outcome.ts` at
+  runtime, directly or through any transitive import chain -- the M0.3 boundary's Done-when
+  requirement, applied to this specific evidence-only summary per D-MPOLICY.
 
 **Files.** New `responses/outcome.ts` (+ `.test.ts`), `responses/outcomeReport.ts`
 (+ `.test.ts`), `services/sessionOutcomeReportService.ts` (+ `.test.ts`);
 `sessions/architecture.test.ts` extended. No `firestore.rules` change -- nothing new is
-persisted. Verified by 31 new unit tests, a full `npm run check` (typecheck, lint, 1760 unit
+persisted. Verified by 35 new unit tests, a full `npm run check` (typecheck, lint, 1764 unit
 tests, catalog validation) and the Firestore-emulator rules suite (83/83), all passing with no
-regressions.
+regressions. Four correctness issues raised in review (immediate-note precedence overriding a
+follow-up note, unquoted bare `\r` in CSV export, tissue discovery silently missing a
+`SessionResponse`-less check-in, and the architecture test only checking direct import edges)
+were fixed before merge; see the bullets above.
 
 ---
 

--- a/docs/plans/multidomain-session-authoring-execution-and-evidence.md
+++ b/docs/plans/multidomain-session-authoring-execution-and-evidence.md
@@ -29,14 +29,13 @@ The deliverable is incremental, and **every milestone from M1 onward must end wi
 something the athlete can use on a phone**. That constraint, not the layering of the domain
 model, drives the order below.
 
-**Current delivery cutline (2026-08-19).** The active product chain,
-`M3.7 → bounded M3.8 hardening → M4.3 → M5.1 → M5.2`, is now complete end to end. M6 and M7
-are not a sequential continuation of that chain. They are usage-triggered capability groups:
-work starts only when real training or repeated testing exposes a concrete limitation in the
-generic runner/evidence model. M8 may consume those capabilities if they exist, but it must
-never be the reason to build them. The next open item on the evidence-producing chain is
-M5.3 (outcome/override evidence report), which was outside this cutline's own scope but is
-now unblocked.
+**Current delivery cutline (2026-08-19, extended 2026-08-20).** The active product chain,
+`M3.7 → bounded M3.8 hardening → M4.3 → M5.1 → M5.2 → M5.3`, is now complete end to end. M6
+and M7 are not a sequential continuation of that chain. They are usage-triggered capability
+groups: work starts only when real training or repeated testing exposes a concrete
+limitation in the generic runner/evidence model. M8 may consume those capabilities if they
+exist, but it must never be the reason to build them. Nothing on the evidence-producing
+chain remains open; every further `M*` item now waits on its own named usage trigger.
 
 ---
 
@@ -258,9 +257,9 @@ M3 authority / source normalization / authoring
       ↓
 M4.1–M4.2 groups + recorded choices
 
-ACTIVE PRODUCT CHAIN -- complete (2026-08-19)
+ACTIVE PRODUCT CHAIN -- complete (2026-08-20)
 M3.7 semantic preview ─┐
-M3.8 bounded hardening ├──► M4.3 companion/dedup ─► M5.1 response model ─► M5.2 follow-up ─► M5.3 (next, unblocked)
+M3.8 bounded hardening ├──► M4.3 companion/dedup ─► M5.1 response model ─► M5.2 follow-up ─► M5.3 outcome report
                        │
                        └── M3.8 stopped bounded per its own cutline (load/effort/choices
                            shipped; rest ranges, quality fields, sessionTargets/
@@ -291,7 +290,7 @@ exists, and no M8 item may force an otherwise-untriggered M6/M7 capability into 
 | bounded M3.8 | Build common real sessions without JSON; hardening stops when that workflow is sufficient. |
 | M4.3 | Start companion sessions independently without double-counting the same physical work from Garmin/manual evidence. |
 | M5.1–M5.2 | Record and revisit immediate/later-day/next-morning response linked to the exact session occurrence. |
-| M5.3 | Export/inspect outcome and override evidence; a richer history UI is optional and usage-triggered. |
+| M5.3 | Export/inspect a versioned passed/caution/reactive/unknown summary plus the planned-vs-performed delta for any completed session; a richer history UI remains optional and usage-triggered. |
 | M6, **if triggered** | Capture field/speed/power details the generic runner demonstrably cannot represent. |
 | M7, **if triggered** | Run repeated protocol-locked tests whose benchmark comparisons are honest. |
 | M8 | Nothing new. This milestone produces evidence-backed ship/defer/reject decisions, not features. |
@@ -335,7 +334,7 @@ rewritten as an outcome; an in-progress item retains its remaining acceptance wo
 | M4.3 | Companion occurrence and duplicate reconciliation | `[x]` | — |
 | M5.1 | Occurrence-linked response generalization | `[x]` | — |
 | M5.2 | Later-day and next-morning follow-up | `[x]` | — |
-| M5.3 | Outcome/override evidence report | `[ ]` | M5.2; richer history UI only after a usage trigger |
+| M5.3 | Outcome/override evidence report | `[x]` | — |
 | M6.1 | Representative speed/field/power taxonomy v1 | `[ ]` | **Usage trigger:** recurring real session needs domain detail the generic runner cannot represent; then M3.5, M2.5 |
 | M6.2 | Sprint and field performed-entry cards | `[ ]` | M6.1 + a logged sprint/COD workflow proving generic distance/time inputs inadequate |
 | M6.3 | Jump/throw/contact performed-entry cards | `[ ]` | M6.1 + recurring measured jump/throw/contact use |
@@ -1459,7 +1458,7 @@ this repo (confirmed: neither file has a test file today) -- the new logic's rea
 lives in the pure, directly-tested `followupSchedule.ts`; the component wiring is glue code
 over already-tested services, consistent with how this repo tests these two files elsewhere.
 
-### M5.3 `[ ]` Outcome/override evidence report — history UI only if triggered
+### M5.3 `[x]` Outcome/override evidence report — history UI only if triggered
 
 **Change.** Derive `passed | caution | reactive | unknown` as a versioned, evidence-only summary
 from the raw response windows. Record athlete override reason and planned/performed delta.
@@ -1479,6 +1478,57 @@ the UI trigger fires.
 **Done when.** Every outcome links to source facts and a policy version; missing later or next
 data returns `unknown`; the report exposes the evidence without injury-prediction claims; and
 the M0.3 architecture test proves no selection module imports the outcome function.
+
+**Outcome (2026-08-20).** Pure derivation, report/export and the wiring service all shipped;
+no dedicated history UI was built.
+
+* **`responses/outcome.ts`.** `deriveSessionOutcome` derives `passed | caution | reactive |
+  unknown` from already-recorded M5.1/M5.2 `SessionResponse[]` plus the canonical check-in's
+  linked `RegionTissueResponse[]` (caller-resolved; this module still never queries a
+  check-in itself, D-MRESP). It reuses `engine/injuryPolicy.ts`'s existing
+  `deriveTissueSeverity` worst-signal mapping rather than restating a second threshold table
+  for the same four-level tissue scale. `unknown` is returned both for zero data and for
+  immediate-only data with no later_day/next_morning signal yet -- a `passed` claim requires
+  actual follow-up to have happened, never a fabricated default. `SESSION_OUTCOME_POLICY_VERSION`
+  (`'m5.3-outcome-v1'`) is carried on every result.
+* **Scoping decision: no new persisted "reason" field.** The plan asks this to "record
+  athlete override reason." No UI anywhere in the repository currently captures a structured
+  reason for *any* session (`SessionAdjustment.athleteReason` itself has no writer today).
+  Rather than add a second unused enum field, `SessionOutcomeInput.overrideReason` is threaded
+  through as a plain optional parameter typed as `AthleteOverrideReason` (`NonNullable<SessionAdjustment['athleteReason']>`,
+  reused per the plan's own instruction) -- the record shape exists for the moment a real
+  capture point is built, but `deriveSessionOutcome` never invents a value for it.
+  `override.note` is populated automatically from data that *does* already exist (the most
+  recently updated `SessionResponse.note`/`techniqueNote`).
+* **Planned/performed delta.** Reuses M2.6's existing `comparePlannedVsPerformed`
+  (`sessions/performedComparison.ts`) output (`completedStepsCount`/`missingRequiredStepsCount`/
+  `totalPlannedSteps`) rather than recomputing it -- no new delta math was needed.
+* **`responses/outcomeReport.ts`.** `buildSessionOutcomeReport` flattens `SessionOutcome[]`
+  into a deterministic, chronologically sorted row set; `sessionOutcomeReportToCsv` is a pure
+  RFC-4180-shaped serializer. This is the "compact inspectable view" -- `components/session/ResponseHistory.tsx`
+  remains unbuilt; the usage trigger has not fired.
+* **`services/sessionOutcomeReportService.ts`.** The one new IO-touching module: for every
+  finished (`completed`/`abandoned`) execution in a date range it composes
+  `sessionExecutionService.getExecutionsInRange`, `sessionResponseService.getResponsesForSource`,
+  `checkinService.getCheckinByDate` and, for a `completed` execution,
+  `resolveSessionDefinition` (M3.1) + `comparePlannedVsPerformed` (M2.6) -- every one of those
+  already existed and was already tested. Constructor-injected dependencies with singleton
+  defaults follow `StrengthHistoryReadService`'s established M2.7 pattern, so the composition
+  is unit-testable without the Firestore emulator. An in-progress execution is excluded
+  outright (an outcome computed for one would always read `unknown`, indistinguishably from a
+  genuinely unanswered follow-up).
+* **Architecture boundary.** `sessions/architecture.test.ts` gained a third check: no module
+  under `engine/optimizer`, `engine/planner`, `engine/rules`, `engine/weeklyAllocation`,
+  `engine/evergreenPlanning` or `engine/sequenceSearch` may import `responses/outcome.ts` at
+  runtime -- the M0.3 boundary's Done-when requirement, applied to this specific evidence-only
+  summary per D-MPOLICY.
+
+**Files.** New `responses/outcome.ts` (+ `.test.ts`), `responses/outcomeReport.ts`
+(+ `.test.ts`), `services/sessionOutcomeReportService.ts` (+ `.test.ts`);
+`sessions/architecture.test.ts` extended. No `firestore.rules` change -- nothing new is
+persisted. Verified by 31 new unit tests, a full `npm run check` (typecheck, lint, 1760 unit
+tests, catalog validation) and the Firestore-emulator rules suite (83/83), all passing with no
+regressions.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds a dated point-in-time status check for the `M` capability plan (Multidomain session authoring, execution and evidence), confirming the 2026-08-19 cutline chain (M3.7 → bounded M3.8 → M4.3 → M5.1 → M5.2) was fully complete and identifying **M5.3** as the sole unblocked next item.
- Implements **M5.3 (outcome/override evidence report)**, scoped exactly per the plan's own 2026-08-19 cutline: a deterministic report/export over already-recorded evidence, *not* a dedicated history dashboard (`components/session/ResponseHistory.tsx` stays unbuilt until a usage trigger fires).
  - `responses/outcome.ts` — `deriveSessionOutcome`: a pure, versioned `passed | caution | reactive | unknown` summary derived from M5.1/M5.2's `SessionResponse` facts plus the canonical check-in's linked `RegionTissueResponse` values, reusing `engine/injuryPolicy.ts`'s existing tissue-severity mapping rather than restating a second threshold table. `unknown` covers both zero data and immediate-only data with no follow-up yet — never a fabricated `passed`.
  - `responses/outcomeReport.ts` — `buildSessionOutcomeReport` + `sessionOutcomeReportToCsv`: the deterministic, injury-prediction-free report/export surface.
  - `services/sessionOutcomeReportService.ts` — composes existing, already-tested services (`sessionExecutionService`, `sessionResponseService`, `checkinService`, `resolveSessionDefinition`, `comparePlannedVsPerformed`) into the report over a date range. Constructor-injected dependencies follow `StrengthHistoryReadService`'s established pattern for emulator-free unit testing.
  - `sessions/architecture.test.ts` — extends the M0.3 dependency boundary so no selection/optimizer module can import the evidence-only outcome function (D-MPOLICY).
  - **Scoping note:** the plan asks to "record athlete override reason," reusing `SessionAdjustment.athleteReason`. No UI in the repo captures a structured reason for *any* session today (that field has no writer anywhere), so rather than add a second unused enum field, `overrideReason` is threaded through `deriveSessionOutcome`'s input as a plain optional, typed parameter — the record shape exists for a future capture point, but nothing here fabricates a value. `override.note` is populated automatically from data that already exists.
- No `firestore.rules` change — nothing new is persisted.
- Plan docs (`docs/plans/multidomain-session-authoring-execution-and-evidence.md`, `docs/plans/README.md`) updated: M5.3 marked complete with an outcome writeup, and the README's M-plan summary/table row brought back in sync with the plan's own already-recorded completions.

## Validation

Results:
- `npm run check` (typecheck, lint, full unit suite, catalog validation): pass — 1760 unit tests passed, 0 failed (up from 1700 before this change), no typecheck/lint errors.
- `npm run test:rules` (Firestore emulator rules suite): pass — 83/83, confirming no rules regressions (expected, since no schema/rules were touched).
- 31 new unit tests added across `responses/outcome.test.ts`, `responses/outcomeReport.test.ts`, `services/sessionOutcomeReportService.test.ts`, covering status derivation (all four states + edge cases), CSV/report determinism and escaping, and service composition/exclusion behavior (in-progress executions excluded, tissue attribution scoped to the correct source session, comparison only resolved for completed executions).

- [x] `cd app && npm run check` (frontend changes)
- [x] `cd app && npm run test:rules` (Firestore rules changes) — run to confirm no regressions, though no rules were changed
- [ ] `uv run pytest` (backend changes) — not applicable, no backend changes
- [ ] `uv run ruff check .` and `uv run mypy src/garmin_sync` (backend changes) — not applicable
- [ ] `cd app && npm run simulate:scenarios` (recommendation-engine changes) — not applicable; no engine decision logic touched, and the architecture test enforces that this evidence-only module cannot be imported by any selection/optimizer module
- [ ] `cd app && npm run visual:refresh` (material UI changes) — not applicable; no UI was added (deliberately, per the M5.3 cutline)

## Risk and reviewer guidance

Low-to-moderate risk: purely additive (three new modules, one architecture-test extension, doc updates), no existing runtime path is modified, and nothing new is persisted to Firestore. The main thing worth a close look is the scoping decision on `overrideReason` (see Summary) — reviewers should confirm that not adding a new persisted "reason" field, and instead threading an unpopulated-for-now optional parameter, is the right call versus extending the M5.1 `SessionResponse` schema now.

## Domain invariants

- [x] Firestore writes remain user-scoped under `users/{APP_USER_ID}/...`; no `default_user` or top-level recovery snapshots were introduced — not applicable, this change introduces no new writes at all.
- [x] Calendar-date logic uses `Europe/Warsaw`; completed `totalSteps` still means the previous calendar day (`D - 1`) — not applicable, no date/step logic touched.
- [x] No credentials, tokens, service-account files, or raw health payloads are included.
- [x] Recommendation decision logic changed: `POLICY_VERSION` was evaluated and relevant architecture/ADR documentation was updated — not applicable; this is evidence-only and cannot reach recommendation/selection logic (enforced by the new architecture test), so no `POLICY_VERSION` bump is needed.

## Screenshots or recordings

Not applicable — no UI change; the M5.3 cutline explicitly calls for report/export only, not a UI surface.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added evidence-based session outcome reporting with `passed`, `caution`, `reactive`, and `unknown` statuses.
  * Included follow-up details, override notes, source evidence, and planned-versus-performed comparisons.
  * Added chronological report generation and deterministic CSV export for completed sessions.
  * Excluded in-progress sessions and preserved unknown outcomes when required information is unavailable.

* **Documentation**
  * Updated session planning documentation to reflect the completed outcome reporting milestone and CSV export capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->