### PR TITLE
fix: grant github-deployer access to Cloud Build's staging bucket

### DIFF
--- a/docs/ops/cloud-run-deployment.md
+++ b/docs/ops/cloud-run-deployment.md
@@ -254,7 +254,7 @@ one run.
 
 ### Design: infra setup and routine deploys use different identities
 
-`setup-workload-identity.sh` provisions everything (APIs, bucket, service accounts, Artifact
+`setup-workload-identity.sh` provisions everything (APIs, buckets, service accounts, Artifact
 Registry repo) itself, run once with your own full-privilege `gcloud` session. The
 `github-deployer` identity that `deploy-garmin-sync.yml` authenticates as afterward only ever
 holds deployment-scoped roles -- Cloud Run, Artifact Registry push, Cloud Build, Cloud

--- a/docs/ops/setup-workload-identity.sh
+++ b/docs/ops/setup-workload-identity.sh
@@ -18,8 +18,9 @@
 #   - A Workload Identity Pool + OIDC Provider trusting GitHub Actions tokens, restricted to
 #     one exact repository AND its main branch (`assertion.ref == refs/heads/main`) -- a
 #     workflow run from any other branch or a fork cannot obtain a token here at all.
-#   - The token bucket, the two runtime/scheduler service accounts, the Artifact Registry
-#     repository -- everything the two GitHub Actions workflows need to already exist.
+#   - The token bucket, Cloud Build's source-staging bucket, the two runtime/scheduler
+#     service accounts, the Artifact Registry repository -- everything the two GitHub
+#     Actions workflows need to already exist.
 #   - A "github-deployer" service account, scoped to deployment actions only (Cloud Run,
 #     Artifact Registry push, Cloud Build, Cloud Scheduler, and impersonating -- only --
 #     garmin-sync-job to attach it to the Jobs it deploys).
@@ -102,6 +103,17 @@ gcloud artifacts repositories describe garmin-sync --location="${REGION}" >/dev/
   gcloud artifacts repositories create garmin-sync \
     --repository-format=docker --location="${REGION}"
 
+# `gcloud builds submit` (deploy-garmin-sync.yml's image build step) uploads the checked-out
+# source as a tarball to this bucket before Cloud Build reads it -- the exact name/naming
+# scheme `gcloud builds submit` uses itself when no --gcs-source-staging-dir is given. Ensuring
+# it exists here (its IAM binding for github-deployer follows once that SA exists, below)
+# means the deploy workflow never needs any storage role of its own: everything it touches is
+# prepared once, in this one-time setup.
+CLOUDBUILD_STAGING_BUCKET="${GCP_PROJECT}_cloudbuild"
+echo "==> Ensuring the Cloud Build source-staging bucket exists"
+gcloud storage buckets describe "gs://${CLOUDBUILD_STAGING_BUCKET}" >/dev/null 2>&1 || \
+  gcloud storage buckets create "gs://${CLOUDBUILD_STAGING_BUCKET}" --location="${REGION}"
+
 echo "==> Creating github-deployer service account (skipping if it already exists)"
 if ! gcloud iam service-accounts describe "${DEPLOYER_SA_EMAIL}" >/dev/null 2>&1; then
   gcloud iam service-accounts create "${DEPLOYER_SA_NAME}" \
@@ -124,6 +136,12 @@ for ROLE in \
     --role="${ROLE}" \
     --condition=None >/dev/null
 done
+
+# Resource-level, not project-wide: the only storage access github-deployer ever gets is
+# write access to Cloud Build's own source-staging bucket, created above.
+echo "==> Allowing github-deployer to upload build source"
+gcloud storage buckets add-iam-policy-binding "gs://${CLOUDBUILD_STAGING_BUCKET}" \
+  --member="serviceAccount:${DEPLOYER_SA_EMAIL}" --role="roles/storage.objectAdmin" >/dev/null
 
 # Resource-level, not project-wide: github-deployer may act as garmin-sync-job specifically
 # (required to attach it to a Cloud Run Job it deploys) and nothing else.


### PR DESCRIPTION
## Summary

- Real deploy failure, confirmed against the author's actual GitHub Actions run: `setup-workload-identity.sh` completed and WIF auth succeeded, but `gcloud builds submit` (inside `deploy-garmin-sync.yml`) failed with `ERROR: (gcloud.builds.submit) The user is forbidden from accessing the bucket [PROJECT_cloudbuild]`.
- `gcloud builds submit` uploads the checked-out source to Cloud Build's auto-managed staging bucket (`{PROJECT_ID}_cloudbuild`) before building. Narrowing `github-deployer` to deployment-only roles in the prior PR (#120) removed all storage access, missing this one legitimate need.
- `docs/ops/setup-workload-identity.sh` now creates that bucket (if missing) and grants `github-deployer` `roles/storage.objectAdmin` on it specifically — resource-level, matching the same scoping pattern already used for the token bucket and the job-SA impersonation binding, not a project-wide storage role.
- `deploy-garmin-sync.yml` needs no change — it still holds no storage role of its own; the fix is entirely in the one-time setup script, which the operator re-runs (idempotent) to pick it up.

## Validation

- `bash -n docs/ops/setup-workload-identity.sh` — syntax check passes.
- Manually re-read the full script top to bottom to confirm ordering: the new bucket-creation step runs before `github-deployer` exists (fine, no dependency), but the new IAM-binding step was placed *after* the `github-deployer` service-account-creation step and its other role grants — binding an IAM policy to a service-account member that doesn't exist yet would fail, so this ordering matters and was checked explicitly.
- Not run against the real GCP project from this session (same sandbox network/credential limitation as PR #120) — the author will re-run the script and confirm.

- [ ] `uv run pytest` — not applicable, no Python source changed
- [ ] `cd app && npm run check` — not applicable, no frontend changes

## Risk and reviewer guidance

Low risk: additive-only (one new bucket, one new resource-scoped IAM binding), idempotent, no change to the deploy workflow's own permission surface or to any already-granted role. Re-running `setup-workload-identity.sh` after this lands is required to actually unblock the failing deploy; re-running is safe against the author's already-partially-provisioned project.

## Domain invariants

Not applicable — ops/infra script only, no Firestore writes, date logic, or credentials committed.

## Screenshots or recordings

Not applicable.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tuq2oZ9KxXgNPT7YjswQ9z)_