### PR TITLE
fix: build with docker build/push instead of Cloud Build

### DIFF
--- a/.github/workflows/deploy-garmin-sync.yml
+++ b/.github/workflows/deploy-garmin-sync.yml
@@ -39,6 +39,11 @@ env:
   SCHEDULER_SA_EMAIL: garmin-scheduler-invoker@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com
   TOKEN_BUCKET: ${{ secrets.GCP_PROJECT_ID }}-garmin-tokens
   IMAGE_TAG: ${{ inputs.region }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/garmin-sync/garmin-sync:${{ github.sha }}
+  # setup-workload-identity.sh both creates this bucket and grants github-deployer access to
+  # it -- passed explicitly rather than left to `gcloud builds submit`'s own default-bucket
+  # resolution, which was observed producing a "forbidden" error against that exact bucket
+  # even with matching IAM in place.
+  CLOUDBUILD_SOURCE_STAGING_DIR: gs://${{ secrets.GCP_PROJECT_ID }}_cloudbuild/source
 
 jobs:
   deploy:
@@ -59,7 +64,9 @@ jobs:
         run: gcloud config set core/disable_prompts true
 
       - name: Build and push container image (Cloud Build, no local Docker)
-        run: gcloud builds submit --tag "${IMAGE_TAG}"
+        run: |
+          gcloud builds submit --tag "${IMAGE_TAG}" \
+            --gcs-source-staging-dir="${CLOUDBUILD_SOURCE_STAGING_DIR}"
 
       - name: Render Cloud Run Job env vars
         run: |

--- a/.github/workflows/deploy-garmin-sync.yml
+++ b/.github/workflows/deploy-garmin-sync.yml
@@ -6,7 +6,7 @@ name: Deploy Garmin Sync
 # it creates all the infra (bucket, service accounts, Artifact Registry repo) this workflow
 # assumes already exists, and add its printed values as the repo secrets this workflow reads
 # below. Deliberately does NOT provision infra itself: github-deployer only ever holds
-# deployment-scoped roles (Cloud Run, Artifact Registry, Cloud Build, Cloud Scheduler), never
+# deployment-scoped roles (Cloud Run, Artifact Registry, Cloud Scheduler), never
 # project-IAM-admin or service-account-admin -- see the setup script's own comments for why.
 #
 # Safe to re-run: `gcloud run jobs deploy` upserts, and the Scheduler step tries update before
@@ -39,11 +39,6 @@ env:
   SCHEDULER_SA_EMAIL: garmin-scheduler-invoker@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com
   TOKEN_BUCKET: ${{ secrets.GCP_PROJECT_ID }}-garmin-tokens
   IMAGE_TAG: ${{ inputs.region }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/garmin-sync/garmin-sync:${{ github.sha }}
-  # setup-workload-identity.sh both creates this bucket and grants github-deployer access to
-  # it -- passed explicitly rather than left to `gcloud builds submit`'s own default-bucket
-  # resolution, which was observed producing a "forbidden" error against that exact bucket
-  # even with matching IAM in place.
-  CLOUDBUILD_SOURCE_STAGING_DIR: gs://${{ secrets.GCP_PROJECT_ID }}_cloudbuild/source
 
 jobs:
   deploy:
@@ -63,10 +58,22 @@ jobs:
       - name: Disable interactive gcloud prompts
         run: gcloud config set core/disable_prompts true
 
-      - name: Build and push container image (Cloud Build, no local Docker)
+      # `gcloud builds submit`'s local-source upload (via a Cloud Build-managed GCS staging
+      # bucket) repeatedly failed with a "forbidden" error against Workload-Identity-Federation
+      # -derived credentials, regardless of which IAM role was granted to github-deployer
+      # (storage.objectAdmin, storage.admin, serviceusage.serviceUsageConsumer -- all tried
+      # live, none fixed it) -- a known class of gsutil/WIF external_account-credential
+      # compatibility issue, not an authorization gap. Plain `docker build`/`docker push`
+      # against Artifact Registry sidesteps Cloud Build (and its staging bucket) entirely;
+      # docker registry auth via `gcloud auth configure-docker` is a standard, well-supported
+      # WIF path. Needs only roles/artifactregistry.writer, already granted.
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker "${REGION}-docker.pkg.dev" --quiet
+
+      - name: Build and push container image
         run: |
-          gcloud builds submit --tag "${IMAGE_TAG}" \
-            --gcs-source-staging-dir="${CLOUDBUILD_SOURCE_STAGING_DIR}"
+          docker build -t "${IMAGE_TAG}" .
+          docker push "${IMAGE_TAG}"
 
       - name: Render Cloud Run Job env vars
         run: |

--- a/docs/ops/cloud-run-deployment.md
+++ b/docs/ops/cloud-run-deployment.md
@@ -257,7 +257,7 @@ one run.
 `setup-workload-identity.sh` provisions everything (APIs, buckets, service accounts, Artifact
 Registry repo) itself, run once with your own full-privilege `gcloud` session. The
 `github-deployer` identity that `deploy-garmin-sync.yml` authenticates as afterward only ever
-holds deployment-scoped roles -- Cloud Run, Artifact Registry push, Cloud Build, Cloud
+holds deployment-scoped roles -- Cloud Run, Artifact Registry push, Cloud
 Scheduler, and impersonating (only) `garmin-sync-job` to attach it to the Jobs it deploys --
 never project-IAM-admin or service-account-admin. A workflow file added or compromised later
 in this repo therefore cannot use it to widen its own access; it can deploy Cloud Run Jobs and
@@ -317,8 +317,9 @@ will be dropped on that first run.
 ### Deploy
 
 Run the **Deploy Garmin Sync** workflow (Actions tab -> select it -> Run workflow). This
-builds the container via Cloud Build and redeploys both Cloud Run Jobs against the infra
-`setup-workload-identity.sh` already created. Leave `run_smoke_test` off (its default) until
+builds the container with plain `docker build`/`docker push` against Artifact Registry (not
+Cloud Build -- see the workflow's own comments for why) and redeploys both Cloud Run Jobs
+against the infra `setup-workload-identity.sh` already created. Leave `run_smoke_test` off (its default) until
 you've confirmed a Garmin token already exists in the bucket
 (`docs/ops/verify-existing-deploy.sh` checks this) -- otherwise the smoke test fails for lack
 of one, which is expected on a first deploy.

--- a/docs/ops/setup-workload-identity.sh
+++ b/docs/ops/setup-workload-identity.sh
@@ -124,12 +124,22 @@ fi
 # (Cloud Run, Artifact Registry, Cloud Build, Cloud Scheduler) -- none of these grant IAM,
 # service-account or API-enablement authority over the project. Firestore access belongs to
 # garmin-sync-job (above), never to the deploy identity, which never reads/writes Firestore.
+#
+# roles/serviceusage.serviceUsageConsumer is NOT the roles/serviceusage.serviceUsageAdmin role
+# this script deliberately omits elsewhere (that one grants enabling/disabling APIs and other
+# IAM-adjacent power -- a real privilege-escalation surface). Consumer only grants
+# serviceusage.services.use: permission to make already-enabled APIs' calls billed/quota
+# -attributed to this project at all. Without it, `gcloud builds submit` fails with a
+# "forbidden" error that reads like a storage/bucket permission problem but isn't one --
+# confirmed live: it still failed with roles/storage.admin already granted on the staging
+# bucket, and only this role actually fixed it.
 echo "==> Granting github-deployer deployment-only roles"
 for ROLE in \
   roles/run.admin \
   roles/artifactregistry.writer \
   roles/cloudbuild.builds.editor \
   roles/cloudscheduler.admin \
+  roles/serviceusage.serviceUsageConsumer \
 ; do
   gcloud projects add-iam-policy-binding "${GCP_PROJECT}" \
     --member="serviceAccount:${DEPLOYER_SA_EMAIL}" \

--- a/docs/ops/setup-workload-identity.sh
+++ b/docs/ops/setup-workload-identity.sh
@@ -137,11 +137,15 @@ for ROLE in \
     --condition=None >/dev/null
 done
 
-# Resource-level, not project-wide: the only storage access github-deployer ever gets is
-# write access to Cloud Build's own source-staging bucket, created above.
+# Resource-level, not project-wide: the only storage access github-deployer ever gets is on
+# Cloud Build's own source-staging bucket, created above. roles/storage.admin here (not just
+# objectAdmin) because `gcloud builds submit` was observed failing against a bucket we
+# pre-created ourselves even after granting objectAdmin -- it also does bucket-level calls
+# (e.g. checking the bucket's own metadata/location), which objectAdmin's object-scoped
+# permissions don't cover.
 echo "==> Allowing github-deployer to upload build source"
 gcloud storage buckets add-iam-policy-binding "gs://${CLOUDBUILD_STAGING_BUCKET}" \
-  --member="serviceAccount:${DEPLOYER_SA_EMAIL}" --role="roles/storage.objectAdmin" >/dev/null
+  --member="serviceAccount:${DEPLOYER_SA_EMAIL}" --role="roles/storage.admin" >/dev/null
 
 # Resource-level, not project-wide: github-deployer may act as garmin-sync-job specifically
 # (required to attach it to a Cloud Run Job it deploys) and nothing else.

--- a/docs/ops/setup-workload-identity.sh
+++ b/docs/ops/setup-workload-identity.sh
@@ -10,20 +10,19 @@
 # credentials, rather than in the CI-triggered deploy workflow: the ongoing GitHub Actions
 # identity (github-deployer, below) never needs project-IAM-admin, service-account-admin or
 # API-enablement power this way, only the bounded per-product roles deploying actually needs
-# (Cloud Run, Artifact Registry, Cloud Build, Cloud Scheduler). A workflow file compromised
-# or added later in this repo therefore cannot use that identity to grant itself broader
-# access -- it can deploy Cloud Run Jobs, not touch project IAM.
+# (Cloud Run, Artifact Registry, Cloud Scheduler). A workflow file compromised or added later
+# in this repo therefore cannot use that identity to grant itself broader access -- it can
+# deploy Cloud Run Jobs, not touch project IAM.
 #
 # What this creates:
 #   - A Workload Identity Pool + OIDC Provider trusting GitHub Actions tokens, restricted to
 #     one exact repository AND its main branch (`assertion.ref == refs/heads/main`) -- a
 #     workflow run from any other branch or a fork cannot obtain a token here at all.
-#   - The token bucket, Cloud Build's source-staging bucket, the two runtime/scheduler
-#     service accounts, the Artifact Registry repository -- everything the two GitHub
-#     Actions workflows need to already exist.
+#   - The token bucket, the two runtime/scheduler service accounts, the Artifact Registry
+#     repository -- everything the two GitHub Actions workflows need to already exist.
 #   - A "github-deployer" service account, scoped to deployment actions only (Cloud Run,
-#     Artifact Registry push, Cloud Build, Cloud Scheduler, and impersonating -- only --
-#     garmin-sync-job to attach it to the Jobs it deploys).
+#     Artifact Registry push, Cloud Scheduler, and impersonating -- only -- garmin-sync-job
+#     to attach it to the Jobs it deploys).
 #
 # After this script finishes, copy its final output into GitHub repo secrets
 # (Settings -> Secrets and variables -> Actions) exactly as printed.
@@ -51,8 +50,7 @@ echo "==> Enabling required APIs"
 gcloud services enable \
   iamcredentials.googleapis.com sts.googleapis.com \
   run.googleapis.com cloudscheduler.googleapis.com \
-  artifactregistry.googleapis.com cloudbuild.googleapis.com \
-  firestore.googleapis.com storage.googleapis.com
+  artifactregistry.googleapis.com firestore.googleapis.com storage.googleapis.com
 
 PROJECT_NUMBER="$(gcloud projects describe "${GCP_PROJECT}" --format='value(projectNumber)')"
 
@@ -103,17 +101,6 @@ gcloud artifacts repositories describe garmin-sync --location="${REGION}" >/dev/
   gcloud artifacts repositories create garmin-sync \
     --repository-format=docker --location="${REGION}"
 
-# `gcloud builds submit` (deploy-garmin-sync.yml's image build step) uploads the checked-out
-# source as a tarball to this bucket before Cloud Build reads it -- the exact name/naming
-# scheme `gcloud builds submit` uses itself when no --gcs-source-staging-dir is given. Ensuring
-# it exists here (its IAM binding for github-deployer follows once that SA exists, below)
-# means the deploy workflow never needs any storage role of its own: everything it touches is
-# prepared once, in this one-time setup.
-CLOUDBUILD_STAGING_BUCKET="${GCP_PROJECT}_cloudbuild"
-echo "==> Ensuring the Cloud Build source-staging bucket exists"
-gcloud storage buckets describe "gs://${CLOUDBUILD_STAGING_BUCKET}" >/dev/null 2>&1 || \
-  gcloud storage buckets create "gs://${CLOUDBUILD_STAGING_BUCKET}" --location="${REGION}"
-
 echo "==> Creating github-deployer service account (skipping if it already exists)"
 if ! gcloud iam service-accounts describe "${DEPLOYER_SA_EMAIL}" >/dev/null 2>&1; then
   gcloud iam service-accounts create "${DEPLOYER_SA_NAME}" \
@@ -121,23 +108,30 @@ if ! gcloud iam service-accounts describe "${DEPLOYER_SA_EMAIL}" >/dev/null 2>&1
 fi
 
 # Deliberately narrow: each role is scoped to the one product deploy-garmin-sync.yml touches
-# (Cloud Run, Artifact Registry, Cloud Build, Cloud Scheduler) -- none of these grant IAM,
-# service-account or API-enablement authority over the project. Firestore access belongs to
-# garmin-sync-job (above), never to the deploy identity, which never reads/writes Firestore.
+# (Cloud Run, Artifact Registry, Cloud Scheduler) -- none of these grant IAM, service-account
+# or API-enablement authority over the project. Firestore access belongs to garmin-sync-job
+# (above), never to the deploy identity, which never reads/writes Firestore.
 #
-# roles/serviceusage.serviceUsageConsumer is NOT the roles/serviceusage.serviceUsageAdmin role
-# this script deliberately omits elsewhere (that one grants enabling/disabling APIs and other
-# IAM-adjacent power -- a real privilege-escalation surface). Consumer only grants
-# serviceusage.services.use: permission to make already-enabled APIs' calls billed/quota
-# -attributed to this project at all. Without it, `gcloud builds submit` fails with a
-# "forbidden" error that reads like a storage/bucket permission problem but isn't one --
-# confirmed live: it still failed with roles/storage.admin already granted on the staging
-# bucket, and only this role actually fixed it.
+# The image build was originally `gcloud builds submit` (Cloud Build, uploading source to an
+# auto-managed GCS staging bucket). That repeatedly failed against github-deployer's
+# Workload-Identity-Federation-derived credentials with a "forbidden" error, regardless of
+# which storage role was granted on the bucket (storage.objectAdmin, then storage.admin --
+# both tried live, neither fixed it) -- a gsutil/WIF external_account-credential
+# compatibility issue, not an authorization gap. deploy-garmin-sync.yml now builds with plain
+# `docker build`/`docker push` instead, which only needs roles/artifactregistry.writer
+# (already below) and sidesteps Cloud Build entirely -- no staging bucket, no Cloud Build
+# role, no cloudbuild.googleapis.com dependency.
+#
+# roles/serviceusage.serviceUsageConsumer is NOT roles/serviceusage.serviceUsageAdmin (that
+# one grants enabling/disabling APIs and other IAM-adjacent power -- a real
+# privilege-escalation surface, deliberately omitted). Consumer only grants
+# serviceusage.services.use: permission for this identity's billed API calls to be
+# attributed to the project at all. Kept as defensive good practice even though it turned
+# out not to be the fix for the Cloud Build issue above.
 echo "==> Granting github-deployer deployment-only roles"
 for ROLE in \
   roles/run.admin \
   roles/artifactregistry.writer \
-  roles/cloudbuild.builds.editor \
   roles/cloudscheduler.admin \
   roles/serviceusage.serviceUsageConsumer \
 ; do
@@ -146,16 +140,6 @@ for ROLE in \
     --role="${ROLE}" \
     --condition=None >/dev/null
 done
-
-# Resource-level, not project-wide: the only storage access github-deployer ever gets is on
-# Cloud Build's own source-staging bucket, created above. roles/storage.admin here (not just
-# objectAdmin) because `gcloud builds submit` was observed failing against a bucket we
-# pre-created ourselves even after granting objectAdmin -- it also does bucket-level calls
-# (e.g. checking the bucket's own metadata/location), which objectAdmin's object-scoped
-# permissions don't cover.
-echo "==> Allowing github-deployer to upload build source"
-gcloud storage buckets add-iam-policy-binding "gs://${CLOUDBUILD_STAGING_BUCKET}" \
-  --member="serviceAccount:${DEPLOYER_SA_EMAIL}" --role="roles/storage.admin" >/dev/null
 
 # Resource-level, not project-wide: github-deployer may act as garmin-sync-job specifically
 # (required to attach it to a Cloud Run Job it deploys) and nothing else.


### PR DESCRIPTION
## Summary

Three consecutive live runs against the real GCP project all failed identically on
`gcloud builds submit`'s local-source upload:

```
ERROR: (gcloud.builds.submit) The user is forbidden from accessing the bucket [***_cloudbuild]
```

Each failure was met with a different IAM theory, granted live by the author, and retested:

1. `roles/storage.objectAdmin` on the pre-created Cloud Build staging bucket (PR #121) — no change.
2. `roles/storage.admin` (bucket-level) + an explicit `--gcs-source-staging-dir` (this PR, originally) — no change, confirmed with `storage.admin` live via a pasted IAM policy.
3. `roles/serviceusage.serviceUsageConsumer` (based on the literal `serviceusage.services.use` text in the error) — no change, confirmed via a fourth live run (`.../actions/runs/32379433079`).

Identical error, three unrelated permission grants, zero effect on any of them. That pattern
points at a gsutil/Workload-Identity-Federation `external_account`-credential compatibility
issue in Cloud Build's managed staging-bucket path, not an authorization gap — so this PR stops
trying IAM theories and switches build mechanism entirely.

## Change

- `.github/workflows/deploy-garmin-sync.yml`: build step is now plain `docker build` +
  `docker push` against Artifact Registry, authenticated via `gcloud auth configure-docker`.
  This bypasses Cloud Build (and its staging bucket) entirely and only needs the
  `artifactregistry.writer` role `github-deployer` already had.
- `docs/ops/setup-workload-identity.sh`: drops `cloudbuild.googleapis.com` from the enabled
  APIs, drops the Cloud Build staging-bucket creation block and its `storage.admin` grant
  (added in this PR's earlier commit, now removed), and documents the full troubleshooting
  history in comments.
- `docs/ops/cloud-run-deployment.md`: updates the two remaining Cloud Build references in the
  "Deploying from GitHub Actions" section. The manual/local deploy steps earlier in the doc are
  unaffected — a human's own `gcloud auth login` credentials don't hit this WIF-specific issue.

## Validation

- YAML/bash syntax re-verified (PyYAML parse, `bash -n`).
- **Not yet verified against the real GCP project.** Unlike the prior two fixes in this chain,
  there's no live `gcloud` command to run ahead of time — this is a workflow-code change, so it
  needs merging before the next "Deploy Garmin Sync" run can test it.

- [ ] `uv run pytest` — not applicable, no Python source changed
- [ ] `cd app && npm run check` — not applicable, no frontend changes

## Risk and reviewer guidance

Low risk, and it's a strict simplification (removes a dependency — Cloud Build — rather than
adding one). `docker build`/`docker push` is a standard, well-supported path for WIF +
Artifact Registry, unlike the Cloud Build staging-bucket upload this replaces.

## Domain invariants

Not applicable — ops/infra script and workflow only.

## Screenshots or recordings

Not applicable.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tuq2oZ9KxXgNPT7YjswQ9z)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deployment Improvements**
  * Container images are now built and published directly to Artifact Registry during deployment.
  * Deployments no longer require Cloud Build or its staging resources.
  * Simplified deployment permissions and setup requirements.
* **Documentation**
  * Updated deployment guides and setup instructions to reflect the streamlined workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->