### PR TITLE
Add GitHub Actions workflow to deploy frontend + Firestore rules

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -32,6 +32,13 @@ permissions:
   contents: read
   id-token: write # required for keyless Workload Identity Federation auth
 
+# A second manual run started before the first finishes could both pass the Firestore drift
+# check, then race to deploy -- the later one silently wins and clobbers the earlier release.
+# Queue instead of running concurrently; never cancel a deploy that's already underway.
+concurrency:
+  group: deploy-frontend-${{ github.repository }}
+  cancel-in-progress: false
+
 env:
   GCP_PROJECT: ${{ secrets.GCP_PROJECT_ID }}
   CLOUDSDK_CORE_PROJECT: ${{ secrets.GCP_PROJECT_ID }} # process-scoped; never mutates a persisted gcloud config
@@ -45,6 +52,14 @@ jobs:
         working-directory: app
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false # this job never needs to push; don't leave the token in git config
+
+      - name: Require at least one deployment target
+        if: ${{ !inputs.deploy_hosting && !inputs.deploy_rules }}
+        run: |
+          echo "Both deploy_hosting and deploy_rules are false -- nothing to do. Enable at least one." >&2
+          exit 1
 
       - name: Authenticate to GCP (Workload Identity Federation, no key)
         uses: google-github-actions/auth@v2
@@ -76,6 +91,20 @@ jobs:
       - name: Install Node dependencies
         run: npm ci
 
+      # Firebase project ID and GCP project ID are the same string for this project (see
+      # docs/ops/cloud-run-deployment.md), but they're two independently-set secrets --
+      # nothing stops them drifting apart. If they ever did, this would build correctly and
+      # deploy successfully, just to the wrong Firebase project, silently. Fail before build.
+      - name: Verify VITE_FIREBASE_PROJECT_ID matches GCP_PROJECT_ID
+        if: ${{ inputs.deploy_hosting }}
+        env:
+          VITE_FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}
+        run: |
+          if [ "${VITE_FIREBASE_PROJECT_ID}" != "${GCP_PROJECT}" ]; then
+            echo "VITE_FIREBASE_PROJECT_ID (${VITE_FIREBASE_PROJECT_ID}) != GCP_PROJECT_ID (${GCP_PROJECT}) -- refusing to deploy to a possibly-wrong Firebase project." >&2
+            exit 1
+          fi
+
       # `npm run build` runs the full `npm run check` first (typecheck, lint, unit tests,
       # workout-catalog validation) -- never deploy a build that hasn't passed those.
       - name: Build frontend
@@ -90,9 +119,12 @@ jobs:
           VITE_FIREBASE_MEASUREMENT_ID: ${{ secrets.VITE_FIREBASE_MEASUREMENT_ID }}
         run: npm run build
 
+      # `npm exec --no --` (rather than bare `npx`) refuses to fall back to fetching an
+      # unreviewed package version from the registry if firebase-tools somehow isn't already
+      # installed -- it only ever runs the exact lockfile-pinned local binary.
       - name: Deploy to Firebase Hosting
         if: ${{ inputs.deploy_hosting }}
-        run: npx firebase deploy --only hosting --project "${GCP_PROJECT}" --non-interactive
+        run: npm exec --no -- firebase deploy --only hosting --project "${GCP_PROJECT}" --non-interactive
 
       # Fails closed on drift, same as the documented local procedure: if the deployed rules
       # don't match app/firestore.rules, stop here rather than overwrite blindly. Investigate

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -1,0 +1,120 @@
+name: Deploy Frontend & Firestore Rules
+
+# Deploys the web app to Firebase Hosting and/or Firestore Security Rules without needing a
+# local machine -- works the same way as deploy-garmin-sync.yml (see that workflow and
+# docs/ops/setup-workload-identity.sh for the design rationale). One-time prerequisite: rerun
+# docs/ops/setup-workload-identity.sh (idempotent) -- it now also provisions the
+# github-frontend-deployer identity this workflow authenticates as, and prints the repo
+# secret this workflow reads below.
+#
+# Deliberately a SEPARATE identity from garmin-sync's github-deployer: github-frontend-deployer
+# holds only roles/firebasehosting.admin and roles/firebaserules.admin, nothing about Cloud
+# Run, Artifact Registry, or Cloud Scheduler, and vice versa -- see docs/ops/frontend-deployment.md.
+#
+# Firestore indexes are deliberately out of scope here too, same as the local
+# `npm run firestore:rules:deploy` procedure this mirrors (docs/ops/firestore-rules-deployment.md)
+# -- use `make deploy-indexes` locally for those.
+on:
+  workflow_dispatch:
+    inputs:
+      deploy_hosting:
+        description: "Build and deploy the web app to Firebase Hosting"
+        type: boolean
+        required: true
+        default: true
+      deploy_rules:
+        description: "Deploy app/firestore.rules (drift-checked first; refuses to overwrite on mismatch)"
+        type: boolean
+        required: true
+        default: true
+
+permissions:
+  contents: read
+  id-token: write # required for keyless Workload Identity Federation auth
+
+env:
+  GCP_PROJECT: ${{ secrets.GCP_PROJECT_ID }}
+  CLOUDSDK_CORE_PROJECT: ${{ secrets.GCP_PROJECT_ID }} # process-scoped; never mutates a persisted gcloud config
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: app
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to GCP (Workload Identity Federation, no key)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_FRONTEND_DEPLOYER_SA_EMAIL }}
+
+      # Needed for `gcloud auth application-default print-access-token`, which
+      # scripts/check-firestore-rules-drift.mjs calls to read the deployed ruleset via the
+      # Firebase Rules REST API -- it picks up the WIF credentials the auth step just wrote to
+      # GOOGLE_APPLICATION_CREDENTIALS as Application Default Credentials automatically.
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: app/package-lock.json
+
+      # Only firestore:rules:deploy needs this (it runs the emulator suite before deploying),
+      # but it's cheap enough to always install rather than condition on deploy_rules.
+      - name: Set up Java for Firestore Emulator
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      # `npm run build` runs the full `npm run check` first (typecheck, lint, unit tests,
+      # workout-catalog validation) -- never deploy a build that hasn't passed those.
+      - name: Build frontend
+        if: ${{ inputs.deploy_hosting }}
+        env:
+          VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY }}
+          VITE_FIREBASE_AUTH_DOMAIN: ${{ secrets.VITE_FIREBASE_AUTH_DOMAIN }}
+          VITE_FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}
+          VITE_FIREBASE_STORAGE_BUCKET: ${{ secrets.VITE_FIREBASE_STORAGE_BUCKET }}
+          VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
+          VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
+          VITE_FIREBASE_MEASUREMENT_ID: ${{ secrets.VITE_FIREBASE_MEASUREMENT_ID }}
+        run: npm run build
+
+      - name: Deploy to Firebase Hosting
+        if: ${{ inputs.deploy_hosting }}
+        run: npx firebase deploy --only hosting --project "${GCP_PROJECT}" --non-interactive
+
+      # Fails closed on drift, same as the documented local procedure: if the deployed rules
+      # don't match app/firestore.rules, stop here rather than overwrite blindly. Investigate
+      # (docs/ops/firestore-rules-deployment.md#drift-and-remediation) and rerun once resolved.
+      - name: Check Firestore rules drift (safety gate)
+        if: ${{ inputs.deploy_rules }}
+        run: npm run firestore:rules:drift
+
+      - name: Deploy Firestore security rules
+        if: ${{ inputs.deploy_rules }}
+        run: npm run firestore:rules:deploy -- --confirm
+
+      # The deploy script writes a rollback JSON to app/artifacts/firestore-rules-rollbacks/
+      # (gitignored, and the runner is thrown away after this job) -- upload it so a rollback
+      # is still possible after the fact. Download it and run
+      # `npm run firestore:rules:rollback -- --backup <file> --confirm` locally per
+      # docs/ops/firestore-rules-deployment.md#rollback (rollback itself stays a local,
+      # deliberate operation, same as before this workflow existed).
+      - name: Upload Firestore rules rollback backup
+        if: always() && inputs.deploy_rules
+        uses: actions/upload-artifact@v4
+        with:
+          name: firestore-rules-rollback-backup
+          path: app/artifacts/firestore-rules-rollbacks/
+          if-no-files-found: ignore

--- a/docs/ops/firestore-rules-deployment.md
+++ b/docs/ops/firestore-rules-deployment.md
@@ -1,8 +1,14 @@
 # Firestore Rules Deployment
 
 Production Cloud Firestore rules for `adaptive-training-recommender` are owned by this
-repository and deployed by an authenticated local operator. This is intentionally a local
-workflow: no GitHub Actions deployment identity or Firebase credential is configured.
+repository. This document is the reference for what a rules deployment actually does and why
+-- drift check, mandatory emulator suite, deploy, post-deploy hash verification, rollback
+backup -- regardless of whether you run it locally (below) or via the **Deploy Frontend &
+Firestore Rules** GitHub Actions workflow (see
+[`frontend-deployment.md`](./frontend-deployment.md), which runs this same sequence with a
+narrowly-scoped Workload Identity Federation identity, no local machine needed). **Rollback
+stays a local-only, deliberate operation either way** -- see [Rollback](#rollback) below;
+`frontend-deployment.md` explains how to retrieve the backup file from a CI-driven deploy.
 
 Only `app/firestore.rules` is deployed. Hosting, functions, data, and indexes are outside
 this procedure.

--- a/docs/ops/frontend-deployment.md
+++ b/docs/ops/frontend-deployment.md
@@ -91,5 +91,6 @@ npm run firestore:rules:rollback -- --backup <downloaded-file>.json --confirm
 ```
 
 Hosting releases don't need this: Firebase Hosting keeps prior releases browsable in the
-console, and `firebase hosting:rollback` (via the Firebase console or CLI) repoints traffic to
-any of them directly -- no separate backup file to manage.
+console, and rolling back (Hosting -> your site -> release history -> **Rollback** on any
+prior release) repoints traffic to it directly -- no separate backup file to manage. There is
+no `firebase hosting:rollback` CLI command; the console is the only supported way to do this.

--- a/docs/ops/frontend-deployment.md
+++ b/docs/ops/frontend-deployment.md
@@ -1,0 +1,95 @@
+# Frontend & Firestore Rules Deployment (GitHub Actions)
+
+Deploys the web app (`app/`) to Firebase Hosting and/or `app/firestore.rules` to Cloud
+Firestore, entirely from the GitHub web UI -- no local machine or `gcloud`/`firebase` CLI
+needed. This is the **`Deploy Frontend & Firestore Rules`** workflow
+(`.github/workflows/deploy-frontend.yml`), triggered as `workflow_dispatch` (works fine from a
+phone/tablet browser).
+
+It authenticates the same way `deploy-garmin-sync.yml` does -- **Workload Identity
+Federation**: no service-account JSON key is ever stored as a secret, only a provider resource
+name and a service-account email GitHub proves it's allowed to impersonate for that one run.
+
+Firestore **indexes** are out of scope here, same as the local `npm run firestore:rules:deploy`
+procedure this mirrors -- use `make deploy-indexes` locally for those (rare enough not to need
+its own CI path yet).
+
+## Design: a separate identity from garmin-sync's
+
+`github-deployer` (used by `deploy-garmin-sync.yml`) and `github-frontend-deployer` (used
+here) are two different service accounts, both provisioned by the same one-time
+`docs/ops/setup-workload-identity.sh`, both trusting the same Workload Identity Pool/Provider
+(restricted to this repo's `main` branch -- a run from any other branch or a fork can't
+authenticate as either at all). `github-frontend-deployer` only ever holds
+`roles/firebasehosting.admin` and `roles/firebaserules.admin` -- nothing about Cloud Run,
+Artifact Registry, Cloud Scheduler, or general Firestore data/index access. A workflow file
+compromised or added later in this repo therefore can't use it to reach garmin-sync's
+infrastructure, or vice versa: each identity can only touch the one surface it's scoped to.
+
+## One-time setup
+
+If you've already run `docs/ops/setup-workload-identity.sh` for `deploy-garmin-sync.yml`,
+rerun it (idempotent -- it only fills in what's missing, including the new
+`github-frontend-deployer` identity this workflow needs):
+
+```bash
+export GCP_PROJECT=adaptive-training-recommender   # your Firebase/GCP project id
+export GITHUB_REPO=OWNER/REPO                       # e.g. Szczepanov/adaptive-training-recommender
+bash docs/ops/setup-workload-identity.sh
+```
+
+Add the printed `GCP_FRONTEND_DEPLOYER_SA_EMAIL` as a repo secret (alongside
+`GCP_PROJECT_ID` and `GCP_WORKLOAD_IDENTITY_PROVIDER`, already added if you set up
+`deploy-garmin-sync.yml` -- both workflows share those two).
+
+You also need your **production Firebase web app config** as repo secrets -- this is the
+public client-side config embedded in the built bundle (not a credential), found in the
+Firebase console under Project settings -> General -> Your apps:
+
+| Secret | Value |
+|---|---|
+| `VITE_FIREBASE_API_KEY` | from the Firebase console |
+| `VITE_FIREBASE_AUTH_DOMAIN` | from the Firebase console |
+| `VITE_FIREBASE_PROJECT_ID` | from the Firebase console |
+| `VITE_FIREBASE_STORAGE_BUCKET` | from the Firebase console |
+| `VITE_FIREBASE_MESSAGING_SENDER_ID` | from the Firebase console |
+| `VITE_FIREBASE_APP_ID` | from the Firebase console |
+| `VITE_FIREBASE_MEASUREMENT_ID` | optional, only if you use Analytics |
+
+These are the same values your local `.env` (gitignored) already has, if you've deployed the
+frontend from a local machine before.
+
+## Deploy
+
+Run the **Deploy Frontend & Firestore Rules** workflow (Actions tab -> select it -> Run
+workflow). Two independent inputs, both default on:
+
+* `deploy_hosting` -- runs `npm run build` (which runs the full `npm run check`: typecheck,
+  lint, unit tests, workout-catalog validation -- never deploys a build that hasn't passed
+  those) then `firebase deploy --only hosting`.
+* `deploy_rules` -- mirrors the local procedure in
+  [`firestore-rules-deployment.md`](./firestore-rules-deployment.md): a drift check first
+  (fails closed if the deployed rules don't match `app/firestore.rules` -- investigate rather
+  than override, same as the local flow), then the emulator test suite, then the deploy, then
+  a post-deploy hash re-check.
+
+Turn either off to deploy just one side -- e.g. `deploy_rules: false` for a frontend-only
+change, or `deploy_hosting: false` to ship a reviewed rules change without also cutting a new
+Hosting release.
+
+## Rollback stays local
+
+`deploy_rules` uploads its rollback backup JSON as a workflow run artifact (the runner itself
+is thrown away after the job, and the local procedure's `app/artifacts/firestore-rules-rollbacks/`
+is gitignored) -- download it from the run's **Artifacts** section if you ever need it. Rolling
+back is still a deliberate local operation, unchanged from
+[`firestore-rules-deployment.md`](./firestore-rules-deployment.md#rollback): download the
+backup, then from `app/` with `gcloud auth application-default login` done once,
+
+```bash
+npm run firestore:rules:rollback -- --backup <downloaded-file>.json --confirm
+```
+
+Hosting releases don't need this: Firebase Hosting keeps prior releases browsable in the
+console, and `firebase hosting:rollback` (via the Firebase console or CLI) repoints traffic to
+any of them directly -- no separate backup file to manage.

--- a/docs/ops/setup-workload-identity.sh
+++ b/docs/ops/setup-workload-identity.sh
@@ -19,11 +19,17 @@
 #     one exact repository AND its main branch (`assertion.ref == refs/heads/main`) -- a
 #     workflow run from any other branch or a fork cannot obtain a token here at all.
 #   - The token bucket, Cloud Build's source-staging bucket, the two runtime/scheduler
-#     service accounts, the Artifact Registry repository -- everything the two GitHub
-#     Actions workflows need to already exist.
+#     service accounts, the Artifact Registry repository -- everything the GitHub Actions
+#     workflows need to already exist.
 #   - A "github-deployer" service account, scoped to deployment actions only (Cloud Run,
 #     Artifact Registry push, Cloud Build, Cloud Scheduler, and impersonating -- only --
 #     garmin-sync-job to attach it to the Jobs it deploys).
+#   - A separate "github-frontend-deployer" service account for deploy-frontend.yml, scoped
+#     only to Firebase Hosting and Firebase Rules -- kept apart from github-deployer so a
+#     compromised/buggy workflow touching one surface (Cloud Run Jobs vs. the web app +
+#     Firestore rules) can't reach the other's resources. Both trust the same Workload
+#     Identity Pool/Provider above; only which service account a workflow asks to
+#     impersonate differs.
 #
 # After this script finishes, copy its final output into GitHub repo secrets
 # (Settings -> Secrets and variables -> Actions) exactly as printed.
@@ -37,6 +43,8 @@ POOL_ID="github-pool"
 PROVIDER_ID="github-provider"
 DEPLOYER_SA_NAME="github-deployer"
 DEPLOYER_SA_EMAIL="${DEPLOYER_SA_NAME}@${GCP_PROJECT}.iam.gserviceaccount.com"
+FRONTEND_DEPLOYER_SA_NAME="github-frontend-deployer"
+FRONTEND_DEPLOYER_SA_EMAIL="${FRONTEND_DEPLOYER_SA_NAME}@${GCP_PROJECT}.iam.gserviceaccount.com"
 JOB_SA_EMAIL="garmin-sync-job@${GCP_PROJECT}.iam.gserviceaccount.com"
 SCHEDULER_SA_EMAIL="garmin-scheduler-invoker@${GCP_PROJECT}.iam.gserviceaccount.com"
 TOKEN_BUCKET="${GCP_PROJECT}-garmin-tokens"
@@ -52,7 +60,8 @@ gcloud services enable \
   iamcredentials.googleapis.com sts.googleapis.com \
   run.googleapis.com cloudscheduler.googleapis.com \
   artifactregistry.googleapis.com cloudbuild.googleapis.com \
-  firestore.googleapis.com storage.googleapis.com
+  firestore.googleapis.com storage.googleapis.com \
+  firebasehosting.googleapis.com firebaserules.googleapis.com
 
 PROJECT_NUMBER="$(gcloud projects describe "${GCP_PROJECT}" --format='value(projectNumber)')"
 
@@ -155,6 +164,32 @@ gcloud iam service-accounts add-iam-policy-binding "${DEPLOYER_SA_EMAIL}" \
   --role="roles/iam.workloadIdentityUser" \
   --member="principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL_ID}/attribute.repository/${GITHUB_REPO}"
 
+echo "==> Creating github-frontend-deployer service account (skipping if it already exists)"
+if ! gcloud iam service-accounts describe "${FRONTEND_DEPLOYER_SA_EMAIL}" >/dev/null 2>&1; then
+  gcloud iam service-accounts create "${FRONTEND_DEPLOYER_SA_NAME}" \
+    --display-name="GitHub Actions frontend/rules deploy identity (WIF, no key)"
+fi
+
+# Deliberately just these two: Firebase Hosting releases and Firebase Security Rules
+# (Firestore rules) are the only two things deploy-frontend.yml touches. No Cloud Run,
+# Artifact Registry, Cloud Scheduler, or Firestore data/index access -- see that workflow's
+# own comments and docs/ops/frontend-deployment.md.
+echo "==> Granting github-frontend-deployer deployment-only roles"
+for ROLE in \
+  roles/firebasehosting.admin \
+  roles/firebaserules.admin \
+; do
+  gcloud projects add-iam-policy-binding "${GCP_PROJECT}" \
+    --member="serviceAccount:${FRONTEND_DEPLOYER_SA_EMAIL}" \
+    --role="${ROLE}" \
+    --condition=None >/dev/null
+done
+
+echo "==> Allowing GitHub Actions runs in ${GITHUB_REPO}@main to impersonate github-frontend-deployer"
+gcloud iam service-accounts add-iam-policy-binding "${FRONTEND_DEPLOYER_SA_EMAIL}" \
+  --role="roles/iam.workloadIdentityUser" \
+  --member="principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL_ID}/attribute.repository/${GITHUB_REPO}"
+
 WIF_PROVIDER="projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL_ID}/providers/${PROVIDER_ID}"
 
 cat <<EOF
@@ -163,9 +198,10 @@ cat <<EOF
 Setup complete. Add these as GitHub repo secrets
 (Settings -> Secrets and variables -> Actions -> New repository secret):
 
-  GCP_PROJECT_ID                  = ${GCP_PROJECT}
-  GCP_WORKLOAD_IDENTITY_PROVIDER  = ${WIF_PROVIDER}
-  GCP_DEPLOYER_SA_EMAIL           = ${DEPLOYER_SA_EMAIL}
+  GCP_PROJECT_ID                    = ${GCP_PROJECT}
+  GCP_WORKLOAD_IDENTITY_PROVIDER    = ${WIF_PROVIDER}
+  GCP_DEPLOYER_SA_EMAIL             = ${DEPLOYER_SA_EMAIL}
+  GCP_FRONTEND_DEPLOYER_SA_EMAIL    = ${FRONTEND_DEPLOYER_SA_EMAIL}
 
 You'll also need (see docs/ops/cloud-run-deployment.md for what each is for):
 
@@ -179,6 +215,19 @@ account has 2FA via an authenticator app -- see that workflow's own notes):
   GARMIN_TOTP_SECRET = the base32 shared secret your authenticator app was
                         given when you enrolled it (not a 6-digit code)
 
-Then run the "Deploy Garmin Sync" workflow from the Actions tab.
+For the "Deploy Frontend & Firestore Rules" workflow (see
+docs/ops/frontend-deployment.md), also add your production Firebase web app
+config -- Project settings -> General -> Your apps in the Firebase console:
+
+  VITE_FIREBASE_API_KEY
+  VITE_FIREBASE_AUTH_DOMAIN
+  VITE_FIREBASE_PROJECT_ID
+  VITE_FIREBASE_STORAGE_BUCKET
+  VITE_FIREBASE_MESSAGING_SENDER_ID
+  VITE_FIREBASE_APP_ID
+  VITE_FIREBASE_MEASUREMENT_ID (optional -- only if you use Analytics)
+
+Then run the "Deploy Garmin Sync" and/or "Deploy Frontend & Firestore Rules"
+workflows from the Actions tab.
 ==============================================================================
 EOF

--- a/docs/ops/setup-workload-identity.sh
+++ b/docs/ops/setup-workload-identity.sh
@@ -70,6 +70,8 @@ if ! gcloud iam workload-identity-pools describe "${POOL_ID}" --location=global 
     --display-name="GitHub Actions pool"
 fi
 
+EXPECTED_CONDITION="assertion.repository == '${GITHUB_REPO}' && assertion.ref == 'refs/heads/main'"
+
 echo "==> Creating OIDC Provider restricted to ${GITHUB_REPO}@main (skipping if it already exists)"
 if ! gcloud iam workload-identity-pools providers describe "${PROVIDER_ID}" \
     --location=global --workload-identity-pool="${POOL_ID}" >/dev/null 2>&1; then
@@ -78,8 +80,27 @@ if ! gcloud iam workload-identity-pools providers describe "${PROVIDER_ID}" \
     --workload-identity-pool="${POOL_ID}" \
     --display-name="GitHub Actions provider" \
     --attribute-mapping="google.subject=assertion.sub,attribute.repository=assertion.repository,attribute.ref=assertion.ref" \
-    --attribute-condition="assertion.repository == '${GITHUB_REPO}' && assertion.ref == 'refs/heads/main'" \
+    --attribute-condition="${EXPECTED_CONDITION}" \
     --issuer-uri="https://token.actions.githubusercontent.com"
+else
+  # The "skip if it already exists" path above never re-applies --attribute-condition, so a
+  # provider left over from before this restriction existed (or edited by hand) would
+  # silently keep trusting every branch/fork -- and every downstream workloadIdentityUser
+  # binding (github-deployer's below, github-frontend-deployer's further down) trusts
+  # whatever this provider accepts. Fail loudly rather than quietly granting broader trust
+  # than the rest of this script documents.
+  ACTUAL_CONDITION="$(gcloud iam workload-identity-pools providers describe "${PROVIDER_ID}" \
+    --location=global --workload-identity-pool="${POOL_ID}" \
+    --format='value(attributeCondition)')"
+  if [ "${ACTUAL_CONDITION}" != "${EXPECTED_CONDITION}" ]; then
+    echo "ERROR: existing OIDC provider '${PROVIDER_ID}' has attributeCondition:" >&2
+    echo "  ${ACTUAL_CONDITION}" >&2
+    echo "expected:" >&2
+    echo "  ${EXPECTED_CONDITION}" >&2
+    echo "Fix it (gcloud iam workload-identity-pools providers update-oidc ...) or delete and" >&2
+    echo "let this script recreate it before granting any identity access to this pool." >&2
+    exit 1
+  fi
 fi
 
 echo "==> Creating runtime service accounts (skipping if they already exist)"

--- a/docs/ops/verify-existing-deploy.sh
+++ b/docs/ops/verify-existing-deploy.sh
@@ -56,6 +56,8 @@ check "Workload Identity Pool github-pool" \
   gcloud iam workload-identity-pools describe github-pool --location=global
 check "Service account github-deployer@${GCP_PROJECT}.iam.gserviceaccount.com" \
   gcloud iam service-accounts describe "github-deployer@${GCP_PROJECT}.iam.gserviceaccount.com"
+check "Service account github-frontend-deployer@${GCP_PROJECT}.iam.gserviceaccount.com" \
+  gcloud iam service-accounts describe "github-frontend-deployer@${GCP_PROJECT}.iam.gserviceaccount.com"
 
 echo
 echo "Any MISSING line above means re-running docs/ops/setup-workload-identity.sh will create"


### PR DESCRIPTION
## Summary

- Adds a third `workflow_dispatch` workflow, **Deploy Frontend & Firestore Rules**
  (`.github/workflows/deploy-frontend.yml`), so deploying the web app to Firebase Hosting
  and/or `app/firestore.rules` no longer requires a local machine -- same Workload Identity
  Federation (no key) pattern already used by `deploy-garmin-sync.yml`.
- Two independent boolean inputs, `deploy_hosting` and `deploy_rules` (both default on), so a
  frontend-only or rules-only change doesn't force redeploying both.
- Rules deploy runs the *exact same* safety sequence as the existing local procedure in
  `docs/ops/firestore-rules-deployment.md`: drift check first (fails closed on mismatch,
  never overwrites blindly), the mandatory Firestore emulator suite, deploy, then a
  post-deploy hash re-verification. The rollback backup JSON is uploaded as a workflow
  artifact (the runner's disk doesn't survive the job); rollback itself stays a deliberate,
  local-only operation, unchanged.
- New, separate `github-frontend-deployer` service account (provisioned by
  `docs/ops/setup-workload-identity.sh`, extended in this PR) -- only
  `roles/firebasehosting.admin` and `roles/firebaserules.admin`, nothing about Cloud
  Run/Artifact Registry/Cloud Scheduler and vice versa for the existing `github-deployer`.
  Same split-identity least-privilege design this repo already uses for garmin-sync: a
  compromised or buggy workflow touching one surface can't reach the other's resources. Both
  identities trust the same Workload Identity Pool/Provider (still restricted to this repo's
  `main` branch).
- New doc `docs/ops/frontend-deployment.md` (setup, usage, rollback pointer). Updated the
  opening framing of `docs/ops/firestore-rules-deployment.md`, which previously stated no
  GitHub Actions identity was configured for rules deploys -- no longer accurate now that this
  workflow exists; the manual/local procedure it documents is otherwise unchanged and is
  exactly what the new workflow's rules-deploy step runs.
- `docs/ops/verify-existing-deploy.sh` now also checks for the new service account.

## Validation

- YAML syntax verified (`python3 -c "import yaml; yaml.safe_load(...)"`).
- `bash -n` on the two modified/touched shell scripts.
- **Not yet run against the real GCP project.** Like the garmin-sync WIF workflows before it,
  this needs a real `workflow_dispatch` run to confirm end-to-end -- flagging clearly rather
  than claiming certainty.

- [ ] `uv run pytest` -- not applicable, no Python source changed
- [ ] `cd app && npm run check` -- not applicable, no application source changed (workflow/docs only)
- [ ] `cd app && npm run test:rules` -- not applicable here; this PR doesn't change `firestore.rules`, it changes how an existing, unchanged deploy procedure is triggered

## Risk and reviewer guidance

Low risk: this is additive (a new workflow + a new, narrowly-scoped service account) and
doesn't touch the existing `deploy-garmin-sync.yml`/`github-deployer` path at all. The rules
side reuses the same scripts (`npm run firestore:rules:drift`, `npm run
firestore:rules:deploy -- --confirm`) the local procedure already runs, unmodified -- CI is
just a new way to trigger the identical, already-reviewed logic. Worth double-checking:
`roles/firebasehosting.admin` + `roles/firebaserules.admin` are believed sufficient for
`firebase deploy --only hosting` / `--only firestore:rules` respectively; if the first real
run surfaces a permission gap, that's the next thing to fix (same iterative pattern used to
land the garmin-sync workflows).

## Domain invariants

- [x] No credentials, tokens, service-account files, or raw health payloads are included --
  Workload Identity Federation only, no service-account key ever generated or stored; the new
  `VITE_FIREBASE_*` secrets are the public client-side Firebase web config, not credentials.
- Not applicable otherwise -- ops/infra workflow and docs only, no recommendation-engine or
  Firestore-write-path logic touched.

## Screenshots or recordings

Not applicable -- no UI change.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tuq2oZ9KxXgNPT7YjswQ9z)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manually triggered workflow for deploying Firebase Hosting and Firestore security rules.
  * Added independent deployment options for hosting and rules, with validation, drift checks, and rollback backups.
  * Added setup support for a dedicated, least-privilege frontend deployment identity.

* **Documentation**
  * Documented deployment configuration, required setup, validation, rollback procedures, and workflow usage.
  * Clarified production rules ownership and the standard deployment sequence.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->