### PR TITLE
fix: grant github-deployer actAs on garmin-scheduler-invoker

### DIFF
--- a/docs/ops/setup-workload-identity.sh
+++ b/docs/ops/setup-workload-identity.sh
@@ -148,6 +148,18 @@ gcloud iam service-accounts add-iam-policy-binding "${JOB_SA_EMAIL}" \
   --member="serviceAccount:${DEPLOYER_SA_EMAIL}" \
   --role="roles/iam.serviceAccountUser" >/dev/null
 
+# Also resource-level, not project-wide: Cloud Scheduler requires the identity creating (or
+# updating the OAuth target of) an HTTP job to be able to actAs the service account named in
+# --oauth-service-account-email -- confirmed live: `gcloud scheduler jobs create http ...
+# --oauth-service-account-email=garmin-scheduler-invoker@...` failed with
+# `PERMISSION_DENIED: ... lacks IAM permission "iam.serviceAccounts.actAs" for the resource
+# "garmin-scheduler-invoker@..."` before this binding existed. Distinct from the Cloud Build
+# staging-bucket saga above -- this one really was a missing grant, not a WIF quirk.
+echo "==> Allowing github-deployer to act as garmin-scheduler-invoker only"
+gcloud iam service-accounts add-iam-policy-binding "${SCHEDULER_SA_EMAIL}" \
+  --member="serviceAccount:${DEPLOYER_SA_EMAIL}" \
+  --role="roles/iam.serviceAccountUser" >/dev/null
+
 echo "==> Allowing GitHub Actions runs in ${GITHUB_REPO}@main to impersonate github-deployer"
 gcloud iam service-accounts add-iam-policy-binding "${DEPLOYER_SA_EMAIL}" \
   --role="roles/iam.workloadIdentityUser" \


### PR DESCRIPTION
## Summary

- The docker build/push pivot (previous PR, merged) worked cleanly on the next live run --
  build, push, and both Cloud Run Jobs deployed successfully
  (`.../actions/runs/32382066566/job/96467453138`). The pipeline then failed one step later,
  in Cloud Scheduler:

  ```
  ERROR: (gcloud.scheduler.jobs.create.http) PERMISSION_DENIED: The principal (user or
  service account) lacks IAM permission "iam.serviceAccounts.actAs" for the resource
  "garmin-scheduler-invoker@***.iam.gserviceaccount.com" (or the resource may not exist).
  ```

- Creating (or updating the OAuth target of) an HTTP Cloud Scheduler job requires the calling
  identity to be able to `actAs` the service account named in `--oauth-service-account-email`.
  `setup-workload-identity.sh` already grants `github-deployer` that on `garmin-sync-job` (to
  attach it to Cloud Run Jobs) but never granted the equivalent on `garmin-scheduler-invoker`
  -- a genuine gap in the setup script, unrelated to the earlier Cloud Build/WIF compatibility
  issue.
- Adds the same resource-level (not project-wide) `roles/iam.serviceAccountUser` binding on
  `garmin-scheduler-invoker`.

## Validation

- `bash -n docs/ops/setup-workload-identity.sh`.
- **Not yet re-run against the real GCP project** -- needs merging (or the one-liner below run
  ahead of time) and a fresh **Deploy Garmin Sync** run to confirm the Scheduler step now
  succeeds.

- [ ] `uv run pytest` -- not applicable, no Python source changed
- [ ] `cd app && npm run check` -- not applicable, no frontend changes

## Risk and reviewer guidance

Low risk, purely additive: one more resource-scoped IAM binding, following the exact same
least-privilege pattern already used for `garmin-sync-job` two lines above it. Doesn't touch
`github-deployer`'s project-level roles or any other identity.

Unlike a code change, this can be applied immediately without waiting for merge -- from Cloud
Shell:

```bash
gcloud iam service-accounts add-iam-policy-binding \
  garmin-scheduler-invoker@<project>.iam.gserviceaccount.com \
  --member="serviceAccount:github-deployer@<project>.iam.gserviceaccount.com" \
  --role="roles/iam.serviceAccountUser"
```

## Domain invariants

Not applicable -- ops/infra script only.

## Screenshots or recordings

Not applicable.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tuq2oZ9KxXgNPT7YjswQ9z)_