### PR TITLE
Harden repo security posture: dependabot, blocking audits, SECURITY.md

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   # Python (root pyproject.toml, managed with uv)
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,47 @@
+version: 2
+updates:
+  # Python (root pyproject.toml, managed with uv)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      python-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    labels:
+      - "dependencies"
+      - "python"
+
+  # Frontend app
+  - package-ecosystem: "npm"
+    directory: "/app"
+    schedule:
+      interval: "weekly"
+    groups:
+      frontend-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    labels:
+      - "dependencies"
+      - "frontend"
+
+  # GitHub Actions used in workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "ci"
+
+  # Container base image
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "docker"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,6 @@ jobs:
 
       - name: Python dependency audit
         run: uvx pip-audit
-        continue-on-error: true
 
   frontend-build:
     name: Frontend Build & Firestore Rules
@@ -141,7 +140,6 @@ jobs:
 
       - name: Node dependency audit
         run: npm audit --audit-level=high
-        continue-on-error: true
 
   docker-build:
     name: Docker Image Build

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,7 +19,8 @@ This opens a private discussion with the maintainer that isn't visible to
 other users until a fix is available.
 
 If private reporting is not enabled for this repository, please reach out to
-the maintainer through their GitHub profile instead of filing a public issue.
+the maintainer via their GitHub profile (https://github.com/Szczepanov)
+instead of filing a public issue.
 
 ## Scope
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Supported Versions
+
+This is a single-maintainer personal project with no versioned releases —
+only the `main` branch is supported. Security fixes are applied there.
+
+## Reporting a Vulnerability
+
+Please **do not** open a public issue for security vulnerabilities.
+
+Instead, use GitHub's private vulnerability reporting for this repository:
+
+1. Go to the **Security** tab.
+2. Click **Report a vulnerability** under "Advisories".
+3. Fill in the details of the issue.
+
+This opens a private discussion with the maintainer that isn't visible to
+other users until a fix is available.
+
+If private reporting is not enabled for this repository, please reach out to
+the maintainer through their GitHub profile instead of filing a public issue.
+
+## Scope
+
+This repository ingests personal Garmin health/fitness data and deploys
+infrastructure to a private GCP project. Reports involving credential
+handling, token storage (`.garth`, Garmin OAuth tokens, Firebase service
+account keys), Firestore security rules (`app/firestore.rules`), or the
+GitHub Actions deployment workflows (`.github/workflows/`) are especially
+appreciated.


### PR DESCRIPTION
## Summary

Follow-up to a repo permissions/settings audit. Implements the recommendations that are code-level changes (the rest — branch-protection rule details, "auto-delete merged branches," and bulk stale-branch cleanup — are GitHub repo *settings*, not code, and need to be done manually in the GitHub UI):

- Add `.github/dependabot.yml` covering `pip` (root `pyproject.toml`, managed with `uv`), `npm` (`app/`), `github-actions`, and `docker` on a weekly schedule, grouping minor/patch bumps to cut PR noise for a single-maintainer repo.
- Remove `continue-on-error: true` from the `pip-audit` and `npm audit --audit-level=high` CI steps so new dependency vulnerabilities actually fail the build instead of being silently reported.
- Add `SECURITY.md` pointing reporters at GitHub's private vulnerability reporting flow (Security tab → "Report a vulnerability") instead of a public email/issue, since this repo is public.

## Validation

Results:
- `uv run ruff check .`: pass
- `uvx pip-audit`: pass — "No known vulnerabilities found" (confirms the now-blocking CI step won't break the build)
- `cd app && npm ci && npm audit --audit-level=high`: pass, exit 0 — only pre-existing *moderate*-severity transitive advisories in `firebase-tools`'s dependency chain (`@opentelemetry/core`, `uuid`), below the configured `high` threshold, so the now-blocking CI step won't break the build either

- [ ] `uv run pytest` (backend changes) — not applicable, no Python source changed
- [x] `uv run ruff check .` and `uv run mypy src/garmin_sync` (backend changes) — ruff: pass; mypy not run, no `src/garmin_sync` changes
- [ ] `cd app && npm run check` (frontend changes) — not applicable, no frontend source changed
- [ ] `cd app && npm run test:rules` (Firestore rules changes) — not applicable
- [ ] `cd app && npm run simulate:scenarios` (recommendation-engine changes) — not applicable
- [ ] `cd app && npm run visual:refresh` (material UI changes) — not applicable

## Risk and reviewer guidance

Low risk: this only touches CI workflow config and adds two new docs/config files — no application code paths change. The main thing to double-check is that `--audit-level=high` genuinely stays at exit 0 today (confirmed above) so this PR itself doesn't turn CI red on merge. Going forward, a future `npm audit`/`pip-audit` finding at or above the threshold will now legitimately fail CI — that's the intended behavior change.

## Domain invariants

Not applicable — no Firestore writes, date logic, credentials, or recommendation decision logic touched.

## Screenshots or recordings

Not applicable — no UI change.

---

### Manual follow-ups (not doable via available tools in this session)

- **Verify `main` branch protection rules** (Settings → Branches → `main`): confirm required reviews, required status checks (`python-tests`, `frontend-build`, `docker-build`), and that force-push/deletion are blocked.
- **Enable "Automatically delete head branches"** (Settings → General → Pull Requests) to stop merged PR branches from accumulating.
- **Clean up stale branches**: the repo currently has ~110 branches outside `main`, spanning many different automation-tool prefixes (`bolt/`, `codex/`, `gemini-`, `chatgpt/`, `jules-`, `claude/`, `agent/`, etc.) with merged or abandoned work. Worth a bulk sweep.
- **Enable GitHub private vulnerability reporting** (Settings → Security) so the flow described in the new `SECURITY.md` actually works.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SeywxvSqYci9hqEr7YS2Hq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added guidance for reporting vulnerabilities, including supported versions and covered security concerns.
  * Security audits now block continuous integration when issues are detected.

* **Chores**
  * Added automated weekly dependency update checks for Python, npm, GitHub Actions, and Docker packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->