### PR TITLE
Make context brief a safe collaborative planning handoff

### DIFF
--- a/app/src/engine/contextBriefPlanningHandoff.test.ts
+++ b/app/src/engine/contextBriefPlanningHandoff.test.ts
@@ -218,6 +218,14 @@ function handoffInput(overrides: Partial<ContextBriefPlanningHandoffInput> = {})
             status: 'planned',
             moved: false,
             isEvent: false,
+            prescription: {
+                summary: '3 x 10 min threshold with controlled recovery',
+                steps: [
+                    { name: 'Warm-up', durationMin: 15, target: 'easy' },
+                    { name: 'Threshold', sets: 3, durationMin: 10, target: 'RPE 7–8', recoverySec: 240 },
+                    { name: 'Cool-down', durationMin: 10, target: 'easy' },
+                ],
+            },
         }],
         unavailableSources: [],
         ...overrides,
@@ -291,13 +299,16 @@ describe('enhanceContextBriefForPlanning', () => {
         expect(text).toContain('Steps are the completed D-1 total');
     });
 
-    it('exports fixed commitments and already-imported sessions before asking for a new plan', () => {
+    it('exports fixed commitments, imported sessions and their authored prescriptions', () => {
         const text = enhanceContextBriefForPlanning(BASE, handoffInput());
 
         expect(text).toContain('## 7. Existing commitments / imported plan');
         expect(text).toContain('2026-08-21 | Imported plan: Race prep | Threshold quality | 60–75 min · hard | key · preferred');
         expect(text).toContain('2026-08-22 | Fixed activity | 6v6 football | 90 min | fixed | start 19:00 · outdoor');
         expect(text).toContain('Preserve these when proposing days unless the user explicitly asks');
+        expect(text).toContain('Imported-session prescription detail:');
+        expect(text).toContain('2026-08-21 — Threshold quality:** 3 x 10 min threshold with controlled recovery');
+        expect(text).toContain('Threshold: 3 sets · 10 min · RPE 7–8 · 240s recovery');
     });
 
     it('exports travel scaling overlays as constraints rather than workouts', () => {

--- a/app/src/engine/contextBriefPlanningHandoff.test.ts
+++ b/app/src/engine/contextBriefPlanningHandoff.test.ts
@@ -5,7 +5,6 @@ import type {
     DailyRecoverySnapshot,
     DailySubjectiveCheckin,
     FixedActivity,
-    TrainingIntentProfile,
     TrainingSettings,
     UserGoal,
     UserPreferences,
@@ -133,17 +132,6 @@ function checkin(date = AS_OF): DailySubjectiveCheckin {
     };
 }
 
-const intentProfile: TrainingIntentProfile = {
-    userId: 'u1',
-    planningMode: 'externally_planned',
-    priorities: ['endurance'],
-    weeklyCommitment: { minSessions: 4, targetSessions: 5, maxSessions: 7 },
-    organizationPreference: 'auto',
-    schemaVersion: 1,
-    createdAt: '2026-08-01T00:00:00Z',
-    updatedAt: '2026-08-01T00:00:00Z',
-};
-
 function recommendation(): DailyRecommendation {
     return {
         userId: 'u1',
@@ -208,7 +196,9 @@ function handoffInput(overrides: Partial<ContextBriefPlanningHandoffInput> = {})
         recommendations: [recommendation()],
         trainingSettings: null,
         preferences: null,
-        intentProfile,
+        planningMode: 'externally_planned',
+        externalFallback: false,
+        eventStrategy: null,
         goals: [],
         upcomingFixedActivities: [fixedActivity()],
         upcomingPlanBlocks: [],
@@ -255,14 +245,24 @@ describe('enhanceContextBriefForPlanning', () => {
         expect(text).toContain('means "unknown", not "none"');
     });
 
-    it('exports data freshness, planning mode and the app recommendation without making it authoritative', () => {
+    it('exports data freshness, resolved planning mode and the app recommendation without making it authoritative', () => {
         const text = enhanceContextBriefForPlanning(BASE, handoffInput());
 
-        expect(text).toContain('Planning mode: externally_planned');
+        expect(text).toContain('Effective planning mode today: externally_planned');
         expect(text).toContain('Garmin sync timestamp 2026-08-20T05:20:00Z');
         expect(text).toContain('activities through 2026-08-20');
         expect(text).toContain('App recommendation for 2026-08-20: train — Zone 2 ride (Cycling)');
         expect(text).toContain('not as authority over current symptoms or tissue response');
+    });
+
+    it('explains an authority-resolved external fallback instead of pretending the persisted mode is effective', () => {
+        const text = enhanceContextBriefForPlanning(BASE, handoffInput({
+            planningMode: 'evergreen',
+            externalFallback: true,
+        }));
+
+        expect(text).toContain('Effective planning mode today: evergreen (external-plan fallback today: no imported session is placed on this date)');
+        expect(text).toContain('imported sessions later in this horizon remain authoritative');
     });
 
     it('exports sensor capability and planning preferences so prescriptions are executable', () => {
@@ -307,7 +307,7 @@ describe('enhanceContextBriefForPlanning', () => {
         expect(text).toContain('Authored travel blocks scale the surrounding plan rather than representing an extra workout');
     });
 
-    it('adds specific goal outcomes and uncertain timing when those fields exist', () => {
+    it('adds specific goal outcomes, resolved event demands and uncertain timing', () => {
         const goal = {
             title: 'September road race',
             status: 'active',
@@ -315,7 +315,8 @@ describe('enhanceContextBriefForPlanning', () => {
             targetMetric: 'finish_time',
             targetValue: 50,
             targetUnit: 'min',
-            eventPreset: 'short_road_race',
+            eventCategory: 'cycling_event',
+            eventPreset: 'road_race',
             timing: {
                 earliestDate: '2026-09-12',
                 latestDate: '2026-09-20',
@@ -328,19 +329,22 @@ describe('enhanceContextBriefForPlanning', () => {
         expect(text).toContain('### Goal specifics relevant to planning');
         expect(text).toContain('success: Be competitive over ~50 minutes with repeated surges');
         expect(text).toContain('target: finish_time 50 min');
-        expect(text).toContain('event preset: short_road_race');
+        expect(text).toContain('event: Road race (cycling_event, preset road_race)');
+        expect(text).toContain('demand 0–1: endurance 0.8 · threshold 0.75 · VO2 0.4 · repeated surges 0.6 · sprint 0.3 · fatigue resistance 0.8 · neuromuscular 0.3');
         expect(text).toContain('window 2026-09-12–2026-09-20, planning date 2026-09-12');
     });
 
-    it('warns instead of inventing a replacement when externally planned mode has no visible session', () => {
+    it('warns instead of inventing a replacement when external fallback has no visible imported session', () => {
         const text = enhanceContextBriefForPlanning(BASE, handoffInput({
+            planningMode: 'evergreen',
+            externalFallback: true,
             upcomingFixedActivities: [],
             upcomingPlanBlocks: [],
             upcomingExternalSessions: [],
         }));
 
-        expect(text).toContain('Planning mode is `externally_planned`, but no active imported session was found');
-        expect(text).toContain('Do not silently replace the plan');
+        expect(text).toContain('External-plan fallback is active today and no imported session is visible in this 7-day horizon');
+        expect(text).toContain('Do not silently invent a replacement block');
     });
 
     it('warns when current-day subjective data is stale', () => {

--- a/app/src/engine/contextBriefPlanningHandoff.test.ts
+++ b/app/src/engine/contextBriefPlanningHandoff.test.ts
@@ -1,0 +1,281 @@
+import { describe, expect, it } from 'vitest';
+import type {
+    DailyRecommendation,
+    DailyRecoverySnapshot,
+    DailySubjectiveCheckin,
+    FixedActivity,
+    TrainingIntentProfile,
+} from './models';
+import {
+    enhanceContextBriefForPlanning,
+    type ContextBriefPlanningHandoffInput,
+} from './contextBriefPlanningHandoff';
+
+const AS_OF = '2026-08-20';
+const BASE = `# Training context brief
+
+Window: 2026-08-07 → 2026-08-20 (14 days).
+
+## 1. Constraints
+
+- Equipment available: indoor bike
+
+## 2. Objective recovery (wearable)
+
+- HRV: 60
+
+## 3. Completed training (recorded by the wearable)
+
+No recorded sessions in this window.
+
+## 4. Subjective reports (self-scored each morning, 1–10)
+
+No check-ins in this window.
+
+## 5. Plan adherence
+
+No recommendations recorded in this window.
+
+## 6. Goals & training intent
+
+- Priorities, in order: endurance
+
+## Requested output
+
+Design the next training block using the above.`;
+
+function snapshot(date = AS_OF): DailyRecoverySnapshot {
+    return {
+        userId: 'u1',
+        date,
+        source: {
+            garminSyncedAt: `${date}T05:20:00Z`,
+            sourceSchemaVersion: 3,
+            metricDates: {
+                sleep: date,
+                hrv: date,
+                restingHr: date,
+                stress: date,
+                steps: '2026-08-19',
+                activitiesThrough: date,
+            },
+        },
+        raw: {
+            sleepScore: 88,
+            sleepDurationSec: 28_000,
+            restingHr: 44,
+            hrvOvernightAvg: 70,
+            hrvStatus: 'balanced',
+            respirationAvg: 13,
+            bodyBatteryWake: 82,
+            bodyBatteryChange: 40,
+            totalSteps: 9_000,
+            last3DaysHardSessionsCount: 1,
+            yesterdayTraining: null,
+            stress: { avg: 22, max: 48 },
+        },
+        derived: {
+            baselineComputationVersion: 5,
+            sleepScore7dAvg: 82,
+            sleepScore28dAvg: 80,
+            restingHr7dAvg: 45,
+            restingHr28dAvg: 46,
+            hrv7dAvg: 66,
+            hrv28dAvg: 64,
+            respiration7dAvg: 13,
+            respiration28dAvg: 13,
+            deltas: {
+                sleepScoreVs7d: 6,
+                sleepScoreVs28d: 8,
+                restingHrVs7d: -1,
+                restingHrVs28d: -2,
+                hrvVs7d: 4,
+                hrvVs28d: 6,
+                respirationVs7d: 0,
+                respirationVs28d: 0,
+            },
+        },
+        dataQuality: {
+            sleepScoreAvailable: true,
+            restingHrAvailable: true,
+            hrvAvailable: true,
+            baseline7dReady: true,
+            baseline28dReady: true,
+        },
+    };
+}
+
+function checkin(date = AS_OF): DailySubjectiveCheckin {
+    return {
+        userId: 'u1',
+        date,
+        readiness: 8,
+        sleepQuality: 8,
+        fatigue: 2,
+        soreness: 3,
+        mentalStress: 2,
+        motivation: 9,
+        painOrInjury: false,
+        illnessSymptoms: false,
+        unusuallyLimitedTime: false,
+        alreadyTrainedToday: false,
+        availability: { timeAvailableMin: 90, preferredModalityToday: null, indoorOnly: false },
+        notes: null,
+        submittedAt: `${date}T05:40:00Z`,
+        dataQuality: { isComplete: true, missingFields: [] },
+        schemaVersion: 1,
+        createdAt: `${date}T05:40:00Z`,
+        updatedAt: `${date}T05:40:00Z`,
+    };
+}
+
+const intentProfile: TrainingIntentProfile = {
+    userId: 'u1',
+    planningMode: 'externally_planned',
+    priorities: ['endurance'],
+    weeklyCommitment: { minSessions: 4, targetSessions: 5, maxSessions: 7 },
+    organizationPreference: 'auto',
+    schemaVersion: 1,
+    createdAt: '2026-08-01T00:00:00Z',
+    updatedAt: '2026-08-01T00:00:00Z',
+};
+
+function recommendation(): DailyRecommendation {
+    return {
+        userId: 'u1',
+        date: AS_OF,
+        templateId: 'z2',
+        templateTitle: 'Zone 2 ride',
+        category: 'Easy Endurance',
+        modality: 'Cycling',
+        mode: 'train',
+        rationale: 'ready',
+        schemaVersion: 3,
+        createdAt: `${AS_OF}T06:00:00Z`,
+        updatedAt: `${AS_OF}T06:00:00Z`,
+        adherence: {
+            respondedAt: null,
+            followed: null,
+            actualModality: null,
+            actualDurationMin: null,
+            skipped: false,
+            notes: null,
+        },
+    };
+}
+
+function fixedActivity(): FixedActivity {
+    return {
+        id: 'match-1',
+        userId: 'u1',
+        title: '6v6 football',
+        date: '2026-08-22',
+        startTime: '19:00',
+        durationMin: 90,
+        fixed: true,
+        environment: 'outdoor',
+        equipment: [],
+        isCompleted: false,
+        createdAt: '2026-08-01T00:00:00Z',
+        updatedAt: '2026-08-01T00:00:00Z',
+    };
+}
+
+function handoffInput(overrides: Partial<ContextBriefPlanningHandoffInput> = {}): ContextBriefPlanningHandoffInput {
+    return {
+        asOfDate: AS_OF,
+        snapshots: [snapshot()],
+        checkins: [checkin()],
+        activities: [],
+        recommendations: [recommendation()],
+        intentProfile,
+        upcomingFixedActivities: [fixedActivity()],
+        upcomingExternalSessions: [{
+            date: '2026-08-21',
+            planId: 'p1',
+            planTitle: 'Race prep',
+            revision: 2,
+            sessionId: 's1',
+            title: 'Threshold quality',
+            priority: 'key',
+            modality: 'cycling',
+            intensity: 'hard',
+            durationMin: 60,
+            durationMax: 75,
+            flexibility: 'preferred',
+            status: 'planned',
+            moved: false,
+            isEvent: false,
+        }],
+        unavailableSources: [],
+        ...overrides,
+    };
+}
+
+describe('enhanceContextBriefForPlanning', () => {
+    it('turns the copied brief into context rather than an unconditional plan command', () => {
+        const text = enhanceContextBriefForPlanning(BASE, handoffInput());
+
+        expect(text).toContain('Use this as context for the conversation, not as a standalone command');
+        expect(text).toContain('Answer the user\'s actual question');
+        expect(text).not.toContain('## Requested output');
+        expect(text).toContain('### If the user asks for an importable schedule');
+        expect(text).toContain('### Day YYYY-MM-DD: <Session Name>');
+    });
+
+    it('puts source failures inside the copied text and says absence means unknown', () => {
+        const text = enhanceContextBriefForPlanning(BASE, handoffInput({
+            unavailableSources: ['recorded activities', 'future fixed activities'],
+        }));
+
+        expect(text).toContain('DATA INCOMPLETE');
+        expect(text).toContain('recorded activities; future fixed activities');
+        expect(text).toContain('means "unknown", not "none"');
+    });
+
+    it('exports data freshness, planning mode and the app recommendation without making it authoritative', () => {
+        const text = enhanceContextBriefForPlanning(BASE, handoffInput());
+
+        expect(text).toContain('Planning mode: externally_planned');
+        expect(text).toContain('Garmin sync timestamp 2026-08-20T05:20:00Z');
+        expect(text).toContain('activities through 2026-08-20');
+        expect(text).toContain('App recommendation for 2026-08-20: train — Zone 2 ride (Cycling)');
+        expect(text).toContain('not as authority over current symptoms or tissue response');
+    });
+
+    it('adds a seven-day cross-signal timeline rather than only window averages', () => {
+        const text = enhanceContextBriefForPlanning(BASE, handoffInput());
+
+        expect(text).toContain('### Recent 7-day recovery timeline');
+        expect(text).toContain('| 2026-08-20 | 88 | 70 | 44 | 13 | 82 | 22 | 8 | 2 | 3 |');
+        expect(text).toContain('| 2026-08-14 | — | — | — | — | — | — | — | — | — |');
+    });
+
+    it('exports fixed commitments and already-imported sessions before asking for a new plan', () => {
+        const text = enhanceContextBriefForPlanning(BASE, handoffInput());
+
+        expect(text).toContain('## 7. Existing commitments / imported plan');
+        expect(text).toContain('2026-08-21 | Imported plan: Race prep | Threshold quality | 60–75 min · hard | key · preferred');
+        expect(text).toContain('2026-08-22 | Fixed activity | 6v6 football | 90 min | fixed | start 19:00 · outdoor');
+        expect(text).toContain('Preserve these when proposing days unless the user explicitly asks');
+    });
+
+    it('warns instead of inventing a replacement when externally planned mode has no visible session', () => {
+        const text = enhanceContextBriefForPlanning(BASE, handoffInput({
+            upcomingFixedActivities: [],
+            upcomingExternalSessions: [],
+        }));
+
+        expect(text).toContain('Planning mode is `externally_planned`, but no active imported session was found');
+        expect(text).toContain('Do not silently replace the plan');
+    });
+
+    it('warns when current-day subjective data is stale', () => {
+        const text = enhanceContextBriefForPlanning(BASE, handoffInput({
+            checkins: [checkin('2026-08-19')],
+        }));
+
+        expect(text).toContain('no check-in for 2026-08-20; latest available is 2026-08-19');
+        expect(text).toContain('Do not assume subjective readiness, pain or availability are current');
+    });
+});

--- a/app/src/engine/contextBriefPlanningHandoff.test.ts
+++ b/app/src/engine/contextBriefPlanningHandoff.test.ts
@@ -196,8 +196,9 @@ function handoffInput(overrides: Partial<ContextBriefPlanningHandoffInput> = {})
         recommendations: [recommendation()],
         trainingSettings: null,
         preferences: null,
-        planningMode: 'externally_planned',
+        effectivePlanningMode: 'externally_planned',
         externalFallback: false,
+        externalFallbackUncertain: false,
         eventStrategy: null,
         goals: [],
         upcomingFixedActivities: [fixedActivity()],
@@ -265,7 +266,7 @@ describe('enhanceContextBriefForPlanning', () => {
 
     it('explains an authority-resolved external fallback instead of pretending the persisted mode is effective', () => {
         const text = enhanceContextBriefForPlanning(BASE, handoffInput({
-            planningMode: 'evergreen',
+            effectivePlanningMode: 'evergreen',
             externalFallback: true,
         }));
 
@@ -311,6 +312,38 @@ describe('enhanceContextBriefForPlanning', () => {
         expect(text).toContain('Threshold: 3 sets · 10 min · RPE 7–8 · 240s recovery');
     });
 
+    it('includes minute-denominated recovery doses instead of dropping them from the copied handoff', () => {
+        const text = enhanceContextBriefForPlanning(BASE, handoffInput({
+            upcomingExternalSessions: [{
+                date: '2026-08-21',
+                planId: 'p1',
+                planTitle: 'Race prep',
+                revision: 2,
+                sessionId: 's2',
+                title: 'Tempo block',
+                priority: 'key',
+                modality: 'cycling',
+                intensity: 'moderate',
+                durationMin: 45,
+                durationMax: 45,
+                flexibility: 'preferred',
+                status: 'planned',
+                moved: false,
+                isEvent: false,
+                prescription: {
+                    summary: '2 x 20 min tempo',
+                    steps: [
+                        { name: 'Tempo', sets: 2, durationMin: 20, target: '85% FTP', recoveryMin: 5 },
+                        { name: 'VO2 rep', durationSec: 30, recoverySec: 15, repeat: 10, sets: 3, setRecoveryMin: 4 },
+                    ],
+                },
+            }],
+        }));
+
+        expect(text).toContain('Tempo: 2 sets · 20 min · 85% FTP · 5 min recovery');
+        expect(text).toContain('VO2 rep: 3 sets · 10 reps · 30 s · 15s recovery · 4 min set recovery');
+    });
+
     it('exports travel scaling overlays as constraints rather than workouts', () => {
         const text = enhanceContextBriefForPlanning(BASE, handoffInput({ upcomingPlanBlocks: [travelBlock()] }));
 
@@ -347,7 +380,7 @@ describe('enhanceContextBriefForPlanning', () => {
 
     it('warns instead of inventing a replacement when external fallback has no visible imported session', () => {
         const text = enhanceContextBriefForPlanning(BASE, handoffInput({
-            planningMode: 'evergreen',
+            effectivePlanningMode: 'evergreen',
             externalFallback: true,
             upcomingFixedActivities: [],
             upcomingPlanBlocks: [],
@@ -356,6 +389,22 @@ describe('enhanceContextBriefForPlanning', () => {
 
         expect(text).toContain('External-plan fallback is active today and no imported session is visible in this 7-day horizon');
         expect(text).toContain('Do not silently invent a replacement block');
+    });
+
+    it('marks external fallback as unconfirmed instead of a confirmed absence when today\'s plan read failed', () => {
+        const text = enhanceContextBriefForPlanning(BASE, handoffInput({
+            effectivePlanningMode: 'evergreen',
+            externalFallback: true,
+            externalFallbackUncertain: true,
+            upcomingFixedActivities: [],
+            upcomingPlanBlocks: [],
+            upcomingExternalSessions: [],
+        }));
+
+        expect(text).toContain('external-plan fallback today: UNCONFIRMED');
+        expect(text).toContain('could not be read, so this may reflect an unreadable session rather than a confirmed absence');
+        expect(text).not.toContain('external-plan fallback today: no imported session is placed on this date');
+        expect(text).toContain('this is unconfirmed — treat it as unreadable, not as a confirmed absence');
     });
 
     it('warns when current-day subjective data is stale', () => {

--- a/app/src/engine/contextBriefPlanningHandoff.test.ts
+++ b/app/src/engine/contextBriefPlanningHandoff.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it } from 'vitest';
 import type {
+    AuthoredPlanBlock,
     DailyRecommendation,
     DailyRecoverySnapshot,
     DailySubjectiveCheckin,
     FixedActivity,
     TrainingIntentProfile,
+    TrainingSettings,
+    UserGoal,
+    UserPreferences,
 } from './models';
 import {
     enhanceContextBriefForPlanning,
@@ -181,6 +185,20 @@ function fixedActivity(): FixedActivity {
     };
 }
 
+function travelBlock(): AuthoredPlanBlock {
+    return {
+        id: 'travel-1',
+        userId: 'u1',
+        phase: 'travel',
+        startDate: '2026-08-23',
+        endDate: '2026-08-25',
+        volumeScale: 0.65,
+        intensityScale: 0.8,
+        createdAt: '2026-08-01T00:00:00Z',
+        updatedAt: '2026-08-01T00:00:00Z',
+    };
+}
+
 function handoffInput(overrides: Partial<ContextBriefPlanningHandoffInput> = {}): ContextBriefPlanningHandoffInput {
     return {
         asOfDate: AS_OF,
@@ -188,8 +206,12 @@ function handoffInput(overrides: Partial<ContextBriefPlanningHandoffInput> = {})
         checkins: [checkin()],
         activities: [],
         recommendations: [recommendation()],
+        trainingSettings: null,
+        preferences: null,
         intentProfile,
+        goals: [],
         upcomingFixedActivities: [fixedActivity()],
+        upcomingPlanBlocks: [],
         upcomingExternalSessions: [{
             date: '2026-08-21',
             planId: 'p1',
@@ -243,12 +265,30 @@ describe('enhanceContextBriefForPlanning', () => {
         expect(text).toContain('not as authority over current symptoms or tissue response');
     });
 
+    it('exports sensor capability and planning preferences so prescriptions are executable', () => {
+        const trainingSettings = {
+            capabilities: { powerMeter: true, heartRateMonitor: true, cadenceData: false },
+        } as TrainingSettings;
+        const preferences = {
+            preferredRecoveryStyle: 'active',
+            preferredTimeOfDay: 'morning',
+            conservativeBias: true,
+            extraRecoveryMargin: false,
+        } as UserPreferences;
+        const text = enhanceContextBriefForPlanning(BASE, handoffInput({ trainingSettings, preferences }));
+
+        expect(text).toContain('Sensor capabilities: power meter yes · heart-rate monitor yes · cadence data no');
+        expect(text).toContain('Planning preferences: recovery style active · preferred time morning · conservative bias on · extra recovery margin off');
+        expect(text).toContain('If a sensor is unknown or unavailable');
+    });
+
     it('adds a seven-day cross-signal timeline rather than only window averages', () => {
         const text = enhanceContextBriefForPlanning(BASE, handoffInput());
 
         expect(text).toContain('### Recent 7-day recovery timeline');
-        expect(text).toContain('| 2026-08-20 | 88 | 70 | 44 | 13 | 82 | 22 | 8 | 2 | 3 |');
-        expect(text).toContain('| 2026-08-14 | — | — | — | — | — | — | — | — | — |');
+        expect(text).toContain('| 2026-08-20 | 88 | 70 | 44 | 13 | 82 | 22 | 9000 | 8 | 2 | 3 |');
+        expect(text).toContain('| 2026-08-14 | — | — | — | — | — | — | — | — | — | — |');
+        expect(text).toContain('Steps are the completed D-1 total');
     });
 
     it('exports fixed commitments and already-imported sessions before asking for a new plan', () => {
@@ -260,9 +300,42 @@ describe('enhanceContextBriefForPlanning', () => {
         expect(text).toContain('Preserve these when proposing days unless the user explicitly asks');
     });
 
+    it('exports travel scaling overlays as constraints rather than workouts', () => {
+        const text = enhanceContextBriefForPlanning(BASE, handoffInput({ upcomingPlanBlocks: [travelBlock()] }));
+
+        expect(text).toContain('2026-08-23→2026-08-25 | Plan block | Travel | volume ×0.65 · intensity ×0.8 | authored overlay');
+        expect(text).toContain('Authored travel blocks scale the surrounding plan rather than representing an extra workout');
+    });
+
+    it('adds specific goal outcomes and uncertain timing when those fields exist', () => {
+        const goal = {
+            title: 'September road race',
+            status: 'active',
+            targetOutcome: 'Be competitive over ~50 minutes with repeated surges',
+            targetMetric: 'finish_time',
+            targetValue: 50,
+            targetUnit: 'min',
+            eventPreset: 'short_road_race',
+            timing: {
+                earliestDate: '2026-09-12',
+                latestDate: '2026-09-20',
+                planningDate: '2026-09-12',
+            },
+            description: 'Repeated accelerations; preserve football readiness.',
+        } as UserGoal;
+        const text = enhanceContextBriefForPlanning(BASE, handoffInput({ goals: [goal] }));
+
+        expect(text).toContain('### Goal specifics relevant to planning');
+        expect(text).toContain('success: Be competitive over ~50 minutes with repeated surges');
+        expect(text).toContain('target: finish_time 50 min');
+        expect(text).toContain('event preset: short_road_race');
+        expect(text).toContain('window 2026-09-12–2026-09-20, planning date 2026-09-12');
+    });
+
     it('warns instead of inventing a replacement when externally planned mode has no visible session', () => {
         const text = enhanceContextBriefForPlanning(BASE, handoffInput({
             upcomingFixedActivities: [],
+            upcomingPlanBlocks: [],
             upcomingExternalSessions: [],
         }));
 

--- a/app/src/engine/contextBriefPlanningHandoff.ts
+++ b/app/src/engine/contextBriefPlanningHandoff.ts
@@ -5,11 +5,12 @@ import type {
     DailySubjectiveCheckin,
     FixedActivity,
     NormalizedGarminActivity,
-    TrainingIntentProfile,
+    PlanningMode,
     TrainingSettings,
     UserGoal,
     UserPreferences,
 } from './models';
+import { EVENT_PRESETS, resolveDemandProfile } from './eventPresets';
 import { addDaysToLocalDateString } from '../utils/localDate';
 
 export const UPCOMING_CONTEXT_DAYS = 7;
@@ -41,7 +42,9 @@ export interface ContextBriefPlanningHandoffInput {
     recommendations: readonly DailyRecommendation[];
     trainingSettings: TrainingSettings | null;
     preferences: UserPreferences | null;
-    intentProfile: TrainingIntentProfile | null;
+    planningMode: PlanningMode;
+    externalFallback: boolean;
+    eventStrategy: 'structured_plan' | 'demand_derived' | null;
     goals: readonly UserGoal[];
     upcomingFixedActivities: readonly FixedActivity[];
     upcomingPlanBlocks: readonly AuthoredPlanBlock[];
@@ -54,8 +57,8 @@ function latestByDate<T extends { date: string }>(items: readonly T[]): T | null
     return [...items].sort((a, b) => b.date.localeCompare(a.date))[0];
 }
 
-function textNumber(value: number | null | undefined, suffix = ''): string {
-    return typeof value === 'number' && Number.isFinite(value) ? `${value}${suffix}` : '—';
+function textNumber(value: number | null | undefined): string {
+    return typeof value === 'number' && Number.isFinite(value) ? String(value) : '—';
 }
 
 function compactText(value: string): string {
@@ -77,12 +80,18 @@ function renderDataHandoff(input: ContextBriefPlanningHandoffInput): string {
         .filter(item => item.date === input.asOfDate)
         .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))[0] ?? null;
 
+    const modeDetail = input.externalFallback
+        ? `${input.planningMode} (external-plan fallback today: no imported session is placed on this date)`
+        : input.eventStrategy
+            ? `${input.planningMode} (${input.eventStrategy.replace('_', ' ')})`
+            : input.planningMode;
+
     const lines: string[] = [
         '## 0. Planning handoff & data currency',
         '',
         '**Use this as context for the conversation, not as a standalone command.** Answer the user\'s actual question that accompanies or follows this brief; do not generate a new plan merely because the brief was pasted.',
         `- Planning date: ${input.asOfDate} (Europe/Warsaw calendar date).`,
-        `- Planning mode: ${input.intentProfile?.planningMode ?? 'not configured'}.`,
+        `- Effective planning mode today: ${modeDetail}.`,
     ];
 
     if (input.trainingSettings) {
@@ -206,7 +215,17 @@ function renderGoalSpecifics(goals: readonly UserGoal[]): string {
         if (goal.targetMetric && goal.targetValue !== null && goal.targetValue !== undefined) {
             details.push(`target: ${goal.targetMetric} ${goal.targetValue}${goal.targetUnit ? ` ${goal.targetUnit}` : ''}`);
         }
-        if (goal.eventPreset) details.push(`event preset: ${goal.eventPreset}`);
+        if (goal.eventCategory) {
+            const preset = EVENT_PRESETS[goal.eventCategory].find(item => item.id === goal.eventPreset)
+                ?? EVENT_PRESETS[goal.eventCategory][0];
+            const demand = resolveDemandProfile(goal.eventCategory, goal.eventPreset);
+            details.push(`event: ${preset.label} (${goal.eventCategory}, preset ${preset.id})`);
+            details.push(
+                `demand 0–1: endurance ${demand.aerobicEndurance} · threshold ${demand.thresholdPower} · `
+                + `VO2 ${demand.vo2MaxPower} · repeated surges ${demand.repeatedSurges} · sprint ${demand.sprintPower} · `
+                + `fatigue resistance ${demand.fatigueResistance} · neuromuscular ${demand.neuromuscular}`,
+            );
+        }
         if (goal.timing) {
             const timing = goal.timing.confirmedDate
                 ? `confirmed ${goal.timing.confirmedDate}`
@@ -271,13 +290,14 @@ function renderUpcoming(input: ContextBriefPlanningHandoffInput): string {
         'Preserve these when proposing days unless the user explicitly asks to move, replace or re-plan them. Authored travel blocks scale the surrounding plan rather than representing an extra workout.',
     ];
 
+    if (input.externalFallback && external.length === 0) {
+        lines.push('', '> External-plan fallback is active today and no imported session is visible in this 7-day horizon. Do not silently invent a replacement block; the imported block may have ended, start later, or be unavailable.');
+    } else if (input.externalFallback && external.length > 0) {
+        lines.push('', '> External-plan fallback is active today because no imported session is placed today; imported sessions later in this horizon remain authoritative on their placed dates, subject to readiness/safety gating.');
+    }
+
     if (rows.length === 0) {
-        lines.push('');
-        if (input.intentProfile?.planningMode === 'externally_planned') {
-            lines.push('> Planning mode is `externally_planned`, but no active imported session was found in this 7-day horizon. Do not silently replace the plan; clarify whether the prior block ended, the next block starts later, or plan data is unavailable.');
-        } else {
-            lines.push('No fixed activity, travel block or imported-plan session is recorded in this 7-day horizon. This only describes app-held commitments; it does not prove the athlete has no calendar constraints outside the app.');
-        }
+        lines.push('', 'No fixed activity, travel block or imported-plan session is recorded in this 7-day horizon. This only describes app-held commitments; it does not prove the athlete has no calendar constraints outside the app.');
         return lines.join('\n');
     }
 

--- a/app/src/engine/contextBriefPlanningHandoff.ts
+++ b/app/src/engine/contextBriefPlanningHandoff.ts
@@ -1,0 +1,268 @@
+import type {
+    DailyRecommendation,
+    DailyRecoverySnapshot,
+    DailySubjectiveCheckin,
+    FixedActivity,
+    NormalizedGarminActivity,
+    TrainingIntentProfile,
+} from './models';
+import { addDaysToLocalDateString } from '../utils/localDate';
+
+export const UPCOMING_CONTEXT_DAYS = 7;
+export const RECOVERY_TIMELINE_DAYS = 7;
+
+export interface UpcomingExternalPlanSession {
+    date: string;
+    planId: string;
+    planTitle: string;
+    revision: number;
+    sessionId: string;
+    title: string;
+    priority: 'key' | 'supporting' | 'optional';
+    modality: string;
+    intensity: string;
+    durationMin: number;
+    durationMax: number;
+    flexibility: 'fixed' | 'preferred' | 'any_day';
+    status: 'planned' | 'moved';
+    moved: boolean;
+    isEvent: boolean;
+}
+
+export interface ContextBriefPlanningHandoffInput {
+    asOfDate: string;
+    snapshots: readonly DailyRecoverySnapshot[];
+    checkins: readonly DailySubjectiveCheckin[];
+    activities: readonly NormalizedGarminActivity[];
+    recommendations: readonly DailyRecommendation[];
+    intentProfile: TrainingIntentProfile | null;
+    upcomingFixedActivities: readonly FixedActivity[];
+    upcomingExternalSessions: readonly UpcomingExternalPlanSession[];
+    unavailableSources: readonly string[];
+}
+
+function latestByDate<T extends { date: string }>(items: readonly T[]): T | null {
+    if (items.length === 0) return null;
+    return [...items].sort((a, b) => b.date.localeCompare(a.date))[0];
+}
+
+function textNumber(value: number | null | undefined, suffix = ''): string {
+    return typeof value === 'number' && Number.isFinite(value) ? `${value}${suffix}` : '—';
+}
+
+function renderDataHandoff(input: ContextBriefPlanningHandoffInput): string {
+    const latestSnapshot = latestByDate(input.snapshots);
+    const latestCheckin = latestByDate(input.checkins);
+    const currentCheckin = input.checkins.find(item => item.date === input.asOfDate) ?? null;
+    const todayActivities = input.activities.filter(item => item.date === input.asOfDate);
+    const todayRecommendation = [...input.recommendations]
+        .filter(item => item.date === input.asOfDate)
+        .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))[0] ?? null;
+
+    const lines: string[] = [
+        '## 0. Planning handoff & data currency',
+        '',
+        '**Use this as context for the conversation, not as a standalone command.** Answer the user\'s actual question that accompanies or follows this brief; do not generate a new plan merely because the brief was pasted.',
+        `- Planning date: ${input.asOfDate} (Europe/Warsaw calendar date).`,
+        `- Planning mode: ${input.intentProfile?.planningMode ?? 'not configured'}.`,
+    ];
+
+    if (latestSnapshot) {
+        const source = latestSnapshot.source;
+        lines.push(`- Latest wearable snapshot: ${latestSnapshot.date}; Garmin sync timestamp ${source.garminSyncedAt}.`);
+        const metricDates = source.metricDates;
+        if (metricDates) {
+            const freshness = [
+                metricDates.sleep ? `sleep ${metricDates.sleep}` : null,
+                metricDates.hrv ? `HRV ${metricDates.hrv}` : null,
+                metricDates.restingHr ? `RHR ${metricDates.restingHr}` : null,
+                metricDates.stress ? `stress ${metricDates.stress}` : null,
+                metricDates.steps ? `steps ${metricDates.steps}` : null,
+                metricDates.activitiesThrough ? `activities through ${metricDates.activitiesThrough}` : null,
+            ].filter((item): item is string => item !== null);
+            if (freshness.length > 0) lines.push(`- Wearable metric dates: ${freshness.join(' · ')}.`);
+        }
+        if (latestSnapshot.date < input.asOfDate) {
+            lines.push(`> Wearable caution: no snapshot for ${input.asOfDate}; the newest wearable state is ${latestSnapshot.date}. Do not treat it as current-day readiness.`);
+        }
+    } else {
+        lines.push('- Latest wearable snapshot: none available in the exported window.');
+    }
+
+    if (currentCheckin) {
+        lines.push(`- Current-day check-in: ${currentCheckin.dataQuality.isComplete ? 'complete' : 'partial'} (${currentCheckin.submittedAt}).`);
+    } else if (latestCheckin) {
+        lines.push(`> Check-in caution: no check-in for ${input.asOfDate}; latest available is ${latestCheckin.date}. Do not assume subjective readiness, pain or availability are current.`);
+    } else {
+        lines.push('> Check-in caution: no subjective check-in is available in the exported window.');
+    }
+
+    if (todayActivities.length > 0) {
+        const hard = todayActivities.filter(item => item.intensityTag === 'hard').length;
+        lines.push(`- Recorded activity on planning date: ${todayActivities.length} session(s)${hard > 0 ? `, ${hard} tagged hard` : ''}.`);
+    } else {
+        lines.push('- No activity record is currently dated to the planning date. Same-day Garmin activity can lag until a post-session sync, so this is not proof that no training occurred.');
+    }
+
+    if (todayRecommendation) {
+        lines.push(`- App recommendation for ${input.asOfDate}: ${todayRecommendation.mode} — ${todayRecommendation.templateTitle} (${todayRecommendation.modality}). Treat this as one planning input, not as authority over current symptoms or tissue response.`);
+    }
+
+    if (input.unavailableSources.length > 0) {
+        lines.push('');
+        lines.push(`> **DATA INCOMPLETE:** could not reliably read: ${input.unavailableSources.join('; ')}. Absence from the affected sections means "unknown", not "none". Do not fill those gaps with assumptions.`);
+    }
+
+    return lines.join('\n');
+}
+
+function renderRecoveryTimeline(input: ContextBriefPlanningHandoffInput): string {
+    const firstDate = addDaysToLocalDateString(input.asOfDate, -(RECOVERY_TIMELINE_DAYS - 1));
+    const snapshots = new Map(input.snapshots.filter(item => item.date >= firstDate && item.date <= input.asOfDate).map(item => [item.date, item]));
+    const checkins = new Map(input.checkins.filter(item => item.date >= firstDate && item.date <= input.asOfDate).map(item => [item.date, item]));
+    const activitiesByDate = new Map<string, NormalizedGarminActivity[]>();
+    for (const activity of input.activities.filter(item => item.date >= firstDate && item.date <= input.asOfDate)) {
+        const sameDay = activitiesByDate.get(activity.date) ?? [];
+        sameDay.push(activity);
+        activitiesByDate.set(activity.date, sameDay);
+    }
+
+    if (snapshots.size === 0 && checkins.size === 0) return '';
+
+    const lines = [
+        '### Recent 7-day recovery timeline',
+        '',
+        'Calendar-day rows preserve direction and clustering that window averages can hide. “—” means not recorded.',
+        '',
+        '| Date | Sleep | HRV | RHR | Resp | BB | Stress | Ready | Fatigue | Sore | Training / flags |',
+        '|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|',
+    ];
+
+    for (let offset = 0; offset < RECOVERY_TIMELINE_DAYS; offset++) {
+        const date = addDaysToLocalDateString(firstDate, offset);
+        const snapshot = snapshots.get(date);
+        const checkin = checkins.get(date);
+        const activities = activitiesByDate.get(date) ?? [];
+        const flags: string[] = [];
+        if (activities.length > 0) {
+            const hard = activities.filter(item => item.intensityTag === 'hard').length;
+            flags.push(`${activities.length} activity${activities.length === 1 ? '' : 'ies'}${hard > 0 ? ` (${hard} hard)` : ''}`);
+        }
+        if (checkin?.alreadyTrainedToday && activities.length === 0) flags.push('reported trained');
+        if (checkin?.painOrInjury) flags.push('pain/injury');
+        if (checkin?.illnessSymptoms) flags.push('illness');
+        if (checkin?.unusuallyLimitedTime) flags.push('limited time');
+
+        lines.push(`| ${date} | ${textNumber(snapshot?.raw.sleepScore)} | ${textNumber(snapshot?.raw.hrvOvernightAvg)} | ${textNumber(snapshot?.raw.restingHr)} | ${textNumber(snapshot?.raw.respirationAvg)} | ${textNumber(snapshot?.raw.bodyBatteryWake)} | ${textNumber(snapshot?.raw.stress?.avg)} | ${textNumber(checkin?.readiness)} | ${textNumber(checkin?.fatigue)} | ${textNumber(checkin?.soreness)} | ${flags.join(', ') || '—'} |`);
+    }
+
+    return lines.join('\n');
+}
+
+function renderUpcoming(input: ContextBriefPlanningHandoffInput): string {
+    const endDate = addDaysToLocalDateString(input.asOfDate, UPCOMING_CONTEXT_DAYS - 1);
+    const fixed = input.upcomingFixedActivities
+        .filter(item => !item.isCompleted && item.date >= input.asOfDate && item.date <= endDate)
+        .map(item => ({
+            date: item.date,
+            source: 'Fixed activity',
+            title: item.title,
+            dose: `${item.durationMin} min`,
+            authority: item.fixed ? 'fixed' : 'movable',
+            notes: [
+                item.startTime ? `start ${item.startTime}` : null,
+                item.environment,
+                item.availabilityOverride !== undefined ? `day budget ${item.availabilityOverride} min` : null,
+                item.availabilityContextOverride?.environment ? `day environment ${item.availabilityContextOverride.environment}` : null,
+            ].filter((value): value is string => value !== null).join(' · '),
+        }));
+    const external = input.upcomingExternalSessions
+        .filter(item => item.date >= input.asOfDate && item.date <= endDate)
+        .map(item => ({
+            date: item.date,
+            source: `Imported plan: ${item.planTitle}`,
+            title: item.title,
+            dose: `${item.durationMin}${item.durationMax !== item.durationMin ? `–${item.durationMax}` : ''} min · ${item.intensity}`,
+            authority: `${item.priority} · ${item.flexibility}${item.moved ? ' · moved' : ''}${item.isEvent ? ' · EVENT' : ''}`,
+            notes: `revision ${item.revision}`,
+        }));
+    const rows = [...fixed, ...external].sort((a, b) => a.date.localeCompare(b.date) || a.source.localeCompare(b.source));
+
+    const lines: string[] = [
+        `## 7. Existing commitments / imported plan (${input.asOfDate} → ${endDate})`,
+        '',
+        'Preserve these when proposing days unless the user explicitly asks to move, replace or re-plan them.',
+    ];
+
+    if (rows.length === 0) {
+        lines.push('');
+        if (input.intentProfile?.planningMode === 'externally_planned') {
+            lines.push('> Planning mode is `externally_planned`, but no active imported session was found in this 7-day horizon. Do not silently replace the plan; clarify whether the prior block ended, the next block starts later, or plan data is unavailable.');
+        } else {
+            lines.push('No fixed activity or imported-plan session is recorded in this 7-day horizon. This only describes app-held commitments; it does not prove the athlete has no calendar constraints outside the app.');
+        }
+        return lines.join('\n');
+    }
+
+    lines.push('', '| Date | Source | Session / commitment | Dose | Priority / flexibility | Notes |', '|---|---|---|---|---|---|');
+    for (const row of rows) {
+        lines.push(`| ${row.date} | ${row.source} | ${row.title} | ${row.dose} | ${row.authority} | ${row.notes || '—'} |`);
+    }
+    return lines.join('\n');
+}
+
+function renderUseInstructions(): string {
+    return [
+        '## 8. How to use this handoff',
+        '',
+        '- Treat the brief as **state/context**, not as a request to automatically create a plan. Answer the user\'s actual question first.',
+        '- For **today**, current illness/pain/tissue response and current-day availability outrank favorable wearable metrics. A green wearable day does not justify overriding a local warning signal.',
+        '- For **future days**, preserve the intended purpose and hard/easy spacing of key sessions. Do not pre-emptively downgrade a future quality day merely because the preceding planned work may create normal fatigue; reassess that day when current data exists.',
+        '- Favorable recovery metrics may support proceeding with the intended dose, but are not a reason by themselves to add volume or intensity beyond the plan.',
+        '- Treat respiration robust statistics and the observation-only median/MAD fields as context for pattern recognition, not independent additive penalties.',
+        '- Respect fixed activities and imported-plan sessions above. If a change is warranted, explain which constraint or new evidence justifies it.',
+        '- Prefer dated/current records when information conflicts. Explicitly call out missing or stale data instead of assuming normality.',
+        '',
+        '### If the user asks for an importable schedule',
+        '',
+        'Use this exact day-block format so it remains compatible with 1-click plan import:',
+        '```markdown',
+        '### Day YYYY-MM-DD: <Session Name>',
+        '- Modality: <Cycling | Running | Strength | Mobility | Field | Cross Training>',
+        '- Duration: <minutes> min',
+        '- Intensity: <easy | moderate | hard>',
+        '- Objectives: <zone2 aerobic | threshold quality | surge repeatability | vo2 max | strength maintenance | strength development | race specific endurance> (or omit if recovery)',
+        '- Description: <Interval structure, target power/HR zones, or workout instructions>',
+        '```',
+    ].join('\n');
+}
+
+/**
+ * Adds the planning-specific information a fresh external AI chat needs without changing
+ * the baseline/recovery renderer itself. This is deliberately a post-processing layer:
+ * the existing brief remains the source of retrospective metrics, while this module adds
+ * data currency, day-level trend, future commitments and a safer handoff contract.
+ */
+export function enhanceContextBriefForPlanning(
+    baseBrief: string,
+    input: ContextBriefPlanningHandoffInput,
+): string {
+    const requestedOutputMarker = '\n## Requested output';
+    const requestedIndex = baseBrief.indexOf(requestedOutputMarker);
+    const retrospective = requestedIndex >= 0 ? baseBrief.slice(0, requestedIndex) : baseBrief;
+
+    const constraintMarker = '\n## 1. Constraints';
+    const constraintIndex = retrospective.indexOf(constraintMarker);
+    const withHandoff = constraintIndex >= 0
+        ? `${retrospective.slice(0, constraintIndex)}\n\n${renderDataHandoff(input)}${retrospective.slice(constraintIndex)}`
+        : `${renderDataHandoff(input)}\n\n${retrospective}`;
+
+    const timeline = renderRecoveryTimeline(input);
+    const trainingMarker = '\n## 3. Completed training';
+    const trainingIndex = withHandoff.indexOf(trainingMarker);
+    const withTimeline = timeline && trainingIndex >= 0
+        ? `${withHandoff.slice(0, trainingIndex)}\n\n${timeline}${withHandoff.slice(trainingIndex)}`
+        : timeline ? `${withHandoff}\n\n${timeline}` : withHandoff;
+
+    return `${withTimeline.trimEnd()}\n\n${renderUpcoming(input)}\n\n${renderUseInstructions()}\n`;
+}

--- a/app/src/engine/contextBriefPlanningHandoff.ts
+++ b/app/src/engine/contextBriefPlanningHandoff.ts
@@ -1,10 +1,14 @@
 import type {
+    AuthoredPlanBlock,
     DailyRecommendation,
     DailyRecoverySnapshot,
     DailySubjectiveCheckin,
     FixedActivity,
     NormalizedGarminActivity,
     TrainingIntentProfile,
+    TrainingSettings,
+    UserGoal,
+    UserPreferences,
 } from './models';
 import { addDaysToLocalDateString } from '../utils/localDate';
 
@@ -35,8 +39,12 @@ export interface ContextBriefPlanningHandoffInput {
     checkins: readonly DailySubjectiveCheckin[];
     activities: readonly NormalizedGarminActivity[];
     recommendations: readonly DailyRecommendation[];
+    trainingSettings: TrainingSettings | null;
+    preferences: UserPreferences | null;
     intentProfile: TrainingIntentProfile | null;
+    goals: readonly UserGoal[];
     upcomingFixedActivities: readonly FixedActivity[];
+    upcomingPlanBlocks: readonly AuthoredPlanBlock[];
     upcomingExternalSessions: readonly UpcomingExternalPlanSession[];
     unavailableSources: readonly string[];
 }
@@ -48,6 +56,16 @@ function latestByDate<T extends { date: string }>(items: readonly T[]): T | null
 
 function textNumber(value: number | null | undefined, suffix = ''): string {
     return typeof value === 'number' && Number.isFinite(value) ? `${value}${suffix}` : '—';
+}
+
+function compactText(value: string): string {
+    return value.replace(/\s+/g, ' ').trim();
+}
+
+function yesNoUnknown(value: boolean | undefined): string {
+    if (value === true) return 'yes';
+    if (value === false) return 'no';
+    return 'unknown';
 }
 
 function renderDataHandoff(input: ContextBriefPlanningHandoffInput): string {
@@ -66,6 +84,26 @@ function renderDataHandoff(input: ContextBriefPlanningHandoffInput): string {
         `- Planning date: ${input.asOfDate} (Europe/Warsaw calendar date).`,
         `- Planning mode: ${input.intentProfile?.planningMode ?? 'not configured'}.`,
     ];
+
+    if (input.trainingSettings) {
+        const capabilities = input.trainingSettings.capabilities;
+        lines.push(
+            `- Sensor capabilities: power meter ${yesNoUnknown(capabilities?.powerMeter)} · `
+            + `heart-rate monitor ${yesNoUnknown(capabilities?.heartRateMonitor)} · `
+            + `cadence data ${yesNoUnknown(capabilities?.cadenceData)}.`,
+        );
+    }
+    if (input.preferences) {
+        const margin = input.preferences.extraRecoveryMargin === undefined
+            ? 'not set'
+            : input.preferences.extraRecoveryMargin ? 'on' : 'off';
+        lines.push(
+            `- Planning preferences: recovery style ${input.preferences.preferredRecoveryStyle} · `
+            + `preferred time ${input.preferences.preferredTimeOfDay} · `
+            + `conservative bias ${input.preferences.conservativeBias ? 'on' : 'off'} · `
+            + `extra recovery margin ${margin}.`,
+        );
+    }
 
     if (latestSnapshot) {
         const source = latestSnapshot.source;
@@ -132,10 +170,10 @@ function renderRecoveryTimeline(input: ContextBriefPlanningHandoffInput): string
     const lines = [
         '### Recent 7-day recovery timeline',
         '',
-        'Calendar-day rows preserve direction and clustering that window averages can hide. “—” means not recorded.',
+        'Calendar-day rows preserve direction and clustering that window averages can hide. Steps are the completed D-1 total carried by that morning\'s snapshot. “—” means not recorded.',
         '',
-        '| Date | Sleep | HRV | RHR | Resp | BB | Stress | Ready | Fatigue | Sore | Training / flags |',
-        '|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|',
+        '| Date | Sleep | HRV | RHR | Resp | BB | Stress | Steps D-1 | Ready | Fatigue | Sore | Training / flags |',
+        '|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|',
     ];
 
     for (let offset = 0; offset < RECOVERY_TIMELINE_DAYS; offset++) {
@@ -154,10 +192,32 @@ function renderRecoveryTimeline(input: ContextBriefPlanningHandoffInput): string
         if (checkin?.illnessSymptoms) flags.push('illness');
         if (checkin?.unusuallyLimitedTime) flags.push('limited time');
 
-        lines.push(`| ${date} | ${textNumber(snapshot?.raw.sleepScore)} | ${textNumber(snapshot?.raw.hrvOvernightAvg)} | ${textNumber(snapshot?.raw.restingHr)} | ${textNumber(snapshot?.raw.respirationAvg)} | ${textNumber(snapshot?.raw.bodyBatteryWake)} | ${textNumber(snapshot?.raw.stress?.avg)} | ${textNumber(checkin?.readiness)} | ${textNumber(checkin?.fatigue)} | ${textNumber(checkin?.soreness)} | ${flags.join(', ') || '—'} |`);
+        lines.push(`| ${date} | ${textNumber(snapshot?.raw.sleepScore)} | ${textNumber(snapshot?.raw.hrvOvernightAvg)} | ${textNumber(snapshot?.raw.restingHr)} | ${textNumber(snapshot?.raw.respirationAvg)} | ${textNumber(snapshot?.raw.bodyBatteryWake)} | ${textNumber(snapshot?.raw.stress?.avg)} | ${textNumber(snapshot?.raw.totalSteps)} | ${textNumber(checkin?.readiness)} | ${textNumber(checkin?.fatigue)} | ${textNumber(checkin?.soreness)} | ${flags.join(', ') || '—'} |`);
     }
 
     return lines.join('\n');
+}
+
+function renderGoalSpecifics(goals: readonly UserGoal[]): string {
+    const lines: string[] = [];
+    for (const goal of goals.filter(item => item.status === 'active')) {
+        const details: string[] = [];
+        if (goal.targetOutcome) details.push(`success: ${compactText(goal.targetOutcome)}`);
+        if (goal.targetMetric && goal.targetValue !== null && goal.targetValue !== undefined) {
+            details.push(`target: ${goal.targetMetric} ${goal.targetValue}${goal.targetUnit ? ` ${goal.targetUnit}` : ''}`);
+        }
+        if (goal.eventPreset) details.push(`event preset: ${goal.eventPreset}`);
+        if (goal.timing) {
+            const timing = goal.timing.confirmedDate
+                ? `confirmed ${goal.timing.confirmedDate}`
+                : `window ${goal.timing.earliestDate}–${goal.timing.latestDate}, planning date ${goal.timing.planningDate}`;
+            details.push(`timing: ${timing}`);
+        }
+        if (goal.description) details.push(`description: ${compactText(goal.description)}`);
+        if (details.length > 0) lines.push(`- **${goal.title}** — ${details.join(' · ')}`);
+    }
+    if (lines.length === 0) return '';
+    return ['### Goal specifics relevant to planning', '', ...lines].join('\n');
 }
 
 function renderUpcoming(input: ContextBriefPlanningHandoffInput): string {
@@ -177,6 +237,22 @@ function renderUpcoming(input: ContextBriefPlanningHandoffInput): string {
                 item.availabilityContextOverride?.environment ? `day environment ${item.availabilityContextOverride.environment}` : null,
             ].filter((value): value is string => value !== null).join(' · '),
         }));
+    const travel = input.upcomingPlanBlocks
+        .filter(item => item.endDate >= input.asOfDate && item.startDate <= endDate)
+        .map(item => {
+            const visibleStart = item.startDate < input.asOfDate ? input.asOfDate : item.startDate;
+            const visibleEnd = item.endDate > endDate ? endDate : item.endDate;
+            return {
+                date: visibleStart === visibleEnd ? visibleStart : `${visibleStart}→${visibleEnd}`,
+                source: 'Plan block',
+                title: 'Travel',
+                dose: `volume ×${item.volumeScale} · intensity ×${item.intensityScale}`,
+                authority: 'authored overlay',
+                notes: item.startDate === visibleStart && item.endDate === visibleEnd
+                    ? 'travel block'
+                    : `full block ${item.startDate}→${item.endDate}`,
+            };
+        });
     const external = input.upcomingExternalSessions
         .filter(item => item.date >= input.asOfDate && item.date <= endDate)
         .map(item => ({
@@ -187,12 +263,12 @@ function renderUpcoming(input: ContextBriefPlanningHandoffInput): string {
             authority: `${item.priority} · ${item.flexibility}${item.moved ? ' · moved' : ''}${item.isEvent ? ' · EVENT' : ''}`,
             notes: `revision ${item.revision}`,
         }));
-    const rows = [...fixed, ...external].sort((a, b) => a.date.localeCompare(b.date) || a.source.localeCompare(b.source));
+    const rows = [...fixed, ...travel, ...external].sort((a, b) => a.date.localeCompare(b.date) || a.source.localeCompare(b.source));
 
     const lines: string[] = [
         `## 7. Existing commitments / imported plan (${input.asOfDate} → ${endDate})`,
         '',
-        'Preserve these when proposing days unless the user explicitly asks to move, replace or re-plan them.',
+        'Preserve these when proposing days unless the user explicitly asks to move, replace or re-plan them. Authored travel blocks scale the surrounding plan rather than representing an extra workout.',
     ];
 
     if (rows.length === 0) {
@@ -200,12 +276,12 @@ function renderUpcoming(input: ContextBriefPlanningHandoffInput): string {
         if (input.intentProfile?.planningMode === 'externally_planned') {
             lines.push('> Planning mode is `externally_planned`, but no active imported session was found in this 7-day horizon. Do not silently replace the plan; clarify whether the prior block ended, the next block starts later, or plan data is unavailable.');
         } else {
-            lines.push('No fixed activity or imported-plan session is recorded in this 7-day horizon. This only describes app-held commitments; it does not prove the athlete has no calendar constraints outside the app.');
+            lines.push('No fixed activity, travel block or imported-plan session is recorded in this 7-day horizon. This only describes app-held commitments; it does not prove the athlete has no calendar constraints outside the app.');
         }
         return lines.join('\n');
     }
 
-    lines.push('', '| Date | Source | Session / commitment | Dose | Priority / flexibility | Notes |', '|---|---|---|---|---|---|');
+    lines.push('', '| Date / range | Source | Session / commitment | Dose / scaling | Priority / flexibility | Notes |', '|---|---|---|---|---|---|');
     for (const row of rows) {
         lines.push(`| ${row.date} | ${row.source} | ${row.title} | ${row.dose} | ${row.authority} | ${row.notes || '—'} |`);
     }
@@ -221,7 +297,8 @@ function renderUseInstructions(): string {
         '- For **future days**, preserve the intended purpose and hard/easy spacing of key sessions. Do not pre-emptively downgrade a future quality day merely because the preceding planned work may create normal fatigue; reassess that day when current data exists.',
         '- Favorable recovery metrics may support proceeding with the intended dose, but are not a reason by themselves to add volume or intensity beyond the plan.',
         '- Treat respiration robust statistics and the observation-only median/MAD fields as context for pattern recognition, not independent additive penalties.',
-        '- Respect fixed activities and imported-plan sessions above. If a change is warranted, explain which constraint or new evidence justifies it.',
+        '- Respect fixed activities, travel scaling blocks and imported-plan sessions above. If a change is warranted, explain which constraint or new evidence justifies it.',
+        '- Honor recorded sensor capabilities. If a sensor is unknown or unavailable, do not make the session depend solely on that sensor; provide an executable RPE/HR/feel alternative as appropriate.',
         '- Prefer dated/current records when information conflicts. Explicitly call out missing or stale data instead of assuming normality.',
         '',
         '### If the user asks for an importable schedule',
@@ -265,5 +342,7 @@ export function enhanceContextBriefForPlanning(
         ? `${withHandoff.slice(0, trainingIndex)}\n\n${timeline}${withHandoff.slice(trainingIndex)}`
         : timeline ? `${withHandoff}\n\n${timeline}` : withHandoff;
 
-    return `${withTimeline.trimEnd()}\n\n${renderUpcoming(input)}\n\n${renderUseInstructions()}\n`;
+    const goalSpecifics = renderGoalSpecifics(input.goals);
+    const goalDetail = goalSpecifics ? `\n\n${goalSpecifics}` : '';
+    return `${withTimeline.trimEnd()}${goalDetail}\n\n${renderUpcoming(input)}\n\n${renderUseInstructions()}\n`;
 }

--- a/app/src/engine/contextBriefPlanningHandoff.ts
+++ b/app/src/engine/contextBriefPlanningHandoff.ts
@@ -146,7 +146,8 @@ function renderRecoveryTimeline(input: ContextBriefPlanningHandoffInput): string
         const flags: string[] = [];
         if (activities.length > 0) {
             const hard = activities.filter(item => item.intensityTag === 'hard').length;
-            flags.push(`${activities.length} activity${activities.length === 1 ? '' : 'ies'}${hard > 0 ? ` (${hard} hard)` : ''}`);
+            const activityLabel = activities.length === 1 ? 'activity' : 'activities';
+            flags.push(`${activities.length} ${activityLabel}${hard > 0 ? ` (${hard} hard)` : ''}`);
         }
         if (checkin?.alreadyTrainedToday && activities.length === 0) flags.push('reported trained');
         if (checkin?.painOrInjury) flags.push('pain/injury');

--- a/app/src/engine/contextBriefPlanningHandoff.ts
+++ b/app/src/engine/contextBriefPlanningHandoff.ts
@@ -45,8 +45,16 @@ export interface ContextBriefPlanningHandoffInput {
     recommendations: readonly DailyRecommendation[];
     trainingSettings: TrainingSettings | null;
     preferences: UserPreferences | null;
-    planningMode: PlanningMode;
+    /** Already-resolved by planningMode.ts (ADR-0017); this module renders it, it does not
+     * derive it. Named distinctly from `TrainingIntentProfile.planningMode` so the
+     * whole-app architecture guard (planningModeArchitecture.test.ts) can't mistake this
+     * consumption for a re-derivation of the persisted field. */
+    effectivePlanningMode: PlanningMode;
     externalFallback: boolean;
+    /** True when `externalFallback` could not actually be confirmed today because today's
+     * own external-plan read failed (occupancy or plan-state), so a null resolved session
+     * reflects an unreadable day rather than a confirmed absence. */
+    externalFallbackUncertain: boolean;
     eventStrategy: 'structured_plan' | 'demand_derived' | null;
     goals: readonly UserGoal[];
     upcomingFixedActivities: readonly FixedActivity[];
@@ -84,10 +92,12 @@ function renderDataHandoff(input: ContextBriefPlanningHandoffInput): string {
         .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))[0] ?? null;
 
     const modeDetail = input.externalFallback
-        ? `${input.planningMode} (external-plan fallback today: no imported session is placed on this date)`
+        ? (input.externalFallbackUncertain
+            ? `${input.effectivePlanningMode} (external-plan fallback today: UNCONFIRMED — today's external plan schedule could not be read, so this may reflect an unreadable session rather than a confirmed absence)`
+            : `${input.effectivePlanningMode} (external-plan fallback today: no imported session is placed on this date)`)
         : input.eventStrategy
-            ? `${input.planningMode} (${input.eventStrategy.replace('_', ' ')})`
-            : input.planningMode;
+            ? `${input.effectivePlanningMode} (${input.eventStrategy.replace('_', ' ')})`
+            : input.effectivePlanningMode;
 
     const lines: string[] = [
         '## 0. Planning handoff & data currency',
@@ -249,7 +259,9 @@ function renderPrescriptionStep(step: ExternalPrescriptionStep): string {
     if (step.durationMin !== undefined) dose.push(`${step.durationMin} min`);
     if (step.durationSec !== undefined) dose.push(`${step.durationSec} s`);
     if (step.target) dose.push(step.target);
+    if (step.recoveryMin !== undefined) dose.push(`${step.recoveryMin} min recovery`);
     if (step.recoverySec !== undefined) dose.push(`${step.recoverySec}s recovery`);
+    if (step.setRecoveryMin !== undefined) dose.push(`${step.setRecoveryMin} min set recovery`);
     if (step.setRecoverySec !== undefined) dose.push(`${step.setRecoverySec}s set recovery`);
     if (step.notes) dose.push(compactText(step.notes));
     return dose.length > 0 ? `${step.name}: ${dose.join(' · ')}` : step.name;
@@ -318,10 +330,13 @@ function renderUpcoming(input: ContextBriefPlanningHandoffInput): string {
         'Preserve these when proposing days unless the user explicitly asks to move, replace or re-plan them. Authored travel blocks scale the surrounding plan rather than representing an extra workout.',
     ];
 
+    const fallbackUncertainNote = input.externalFallbackUncertain
+        ? ' Today\'s external plan schedule could not be read, so this is unconfirmed — treat it as unreadable, not as a confirmed absence.'
+        : '';
     if (input.externalFallback && external.length === 0) {
-        lines.push('', '> External-plan fallback is active today and no imported session is visible in this 7-day horizon. Do not silently invent a replacement block; the imported block may have ended, start later, or be unavailable.');
+        lines.push('', `> External-plan fallback is active today and no imported session is visible in this 7-day horizon. Do not silently invent a replacement block; the imported block may have ended, start later, or be unavailable.${fallbackUncertainNote}`);
     } else if (input.externalFallback && external.length > 0) {
-        lines.push('', '> External-plan fallback is active today because no imported session is placed today; imported sessions later in this horizon remain authoritative on their placed dates, subject to readiness/safety gating.');
+        lines.push('', `> External-plan fallback is active today because no imported session is placed today; imported sessions later in this horizon remain authoritative on their placed dates, subject to readiness/safety gating.${fallbackUncertainNote}`);
     }
 
     if (rows.length === 0) {

--- a/app/src/engine/contextBriefPlanningHandoff.ts
+++ b/app/src/engine/contextBriefPlanningHandoff.ts
@@ -3,6 +3,8 @@ import type {
     DailyRecommendation,
     DailyRecoverySnapshot,
     DailySubjectiveCheckin,
+    ExternalPrescription,
+    ExternalPrescriptionStep,
     FixedActivity,
     NormalizedGarminActivity,
     PlanningMode,
@@ -32,6 +34,7 @@ export interface UpcomingExternalPlanSession {
     status: 'planned' | 'moved';
     moved: boolean;
     isEvent: boolean;
+    prescription: ExternalPrescription;
 }
 
 export interface ContextBriefPlanningHandoffInput {
@@ -239,6 +242,31 @@ function renderGoalSpecifics(goals: readonly UserGoal[]): string {
     return ['### Goal specifics relevant to planning', '', ...lines].join('\n');
 }
 
+function renderPrescriptionStep(step: ExternalPrescriptionStep): string {
+    const dose: string[] = [];
+    if (step.sets !== undefined) dose.push(`${step.sets} set${step.sets === 1 ? '' : 's'}`);
+    if (step.repeat !== undefined) dose.push(`${step.repeat} rep${step.repeat === 1 ? '' : 's'}`);
+    if (step.durationMin !== undefined) dose.push(`${step.durationMin} min`);
+    if (step.durationSec !== undefined) dose.push(`${step.durationSec} s`);
+    if (step.target) dose.push(step.target);
+    if (step.recoverySec !== undefined) dose.push(`${step.recoverySec}s recovery`);
+    if (step.setRecoverySec !== undefined) dose.push(`${step.setRecoverySec}s set recovery`);
+    if (step.notes) dose.push(compactText(step.notes));
+    return dose.length > 0 ? `${step.name}: ${dose.join(' · ')}` : step.name;
+}
+
+function renderImportedPrescriptions(sessions: readonly UpcomingExternalPlanSession[]): string[] {
+    if (sessions.length === 0) return [];
+    const lines: string[] = ['', 'Imported-session prescription detail:'];
+    for (const session of sessions) {
+        lines.push(`- **${session.date} — ${session.title}:** ${compactText(session.prescription.summary)}`);
+        for (const step of session.prescription.steps ?? []) {
+            lines.push(`  - ${renderPrescriptionStep(step)}`);
+        }
+    }
+    return lines;
+}
+
 function renderUpcoming(input: ContextBriefPlanningHandoffInput): string {
     const endDate = addDaysToLocalDateString(input.asOfDate, UPCOMING_CONTEXT_DAYS - 1);
     const fixed = input.upcomingFixedActivities
@@ -272,16 +300,16 @@ function renderUpcoming(input: ContextBriefPlanningHandoffInput): string {
                     : `full block ${item.startDate}→${item.endDate}`,
             };
         });
-    const external = input.upcomingExternalSessions
-        .filter(item => item.date >= input.asOfDate && item.date <= endDate)
-        .map(item => ({
-            date: item.date,
-            source: `Imported plan: ${item.planTitle}`,
-            title: item.title,
-            dose: `${item.durationMin}${item.durationMax !== item.durationMin ? `–${item.durationMax}` : ''} min · ${item.intensity}`,
-            authority: `${item.priority} · ${item.flexibility}${item.moved ? ' · moved' : ''}${item.isEvent ? ' · EVENT' : ''}`,
-            notes: `revision ${item.revision}`,
-        }));
+    const visibleExternalSessions = input.upcomingExternalSessions
+        .filter(item => item.date >= input.asOfDate && item.date <= endDate);
+    const external = visibleExternalSessions.map(item => ({
+        date: item.date,
+        source: `Imported plan: ${item.planTitle}`,
+        title: item.title,
+        dose: `${item.durationMin}${item.durationMax !== item.durationMin ? `–${item.durationMax}` : ''} min · ${item.intensity}`,
+        authority: `${item.priority} · ${item.flexibility}${item.moved ? ' · moved' : ''}${item.isEvent ? ' · EVENT' : ''}`,
+        notes: `revision ${item.revision}`,
+    }));
     const rows = [...fixed, ...travel, ...external].sort((a, b) => a.date.localeCompare(b.date) || a.source.localeCompare(b.source));
 
     const lines: string[] = [
@@ -305,6 +333,7 @@ function renderUpcoming(input: ContextBriefPlanningHandoffInput): string {
     for (const row of rows) {
         lines.push(`| ${row.date} | ${row.source} | ${row.title} | ${row.dose} | ${row.authority} | ${row.notes || '—'} |`);
     }
+    lines.push(...renderImportedPrescriptions(visibleExternalSessions));
     return lines.join('\n');
 }
 

--- a/app/src/services/contextBriefService.test.ts
+++ b/app/src/services/contextBriefService.test.ts
@@ -60,13 +60,39 @@ describe('ContextBriefService', () => {
         expect(services.getCheckinsInRange).toHaveBeenCalledWith('u1', '2026-06-21', '2026-08-16');
     });
 
-    it('reads fixed commitments and resolves active imported sessions across the next seven days', async () => {
+    it('reads padded fixed-activity occupancy and resolves active imported sessions across the next seven days', async () => {
         await new ContextBriefService().build('u1', AS_OF, 14);
 
-        expect(services.getFixedActivitiesInRangeState).toHaveBeenCalledWith('u1', '2026-08-15', '2026-08-21');
+        // Visible handoff is 2026-08-15..21. Six days of padding on both sides covers
+        // every whole plan week that can affect a flexible placement in that horizon.
+        expect(services.getFixedActivitiesInRangeState).toHaveBeenCalledWith('u1', '2026-08-09', '2026-08-27');
         expect(services.getActivePlanState).toHaveBeenCalledTimes(7);
         expect(services.getActivePlanState).toHaveBeenNthCalledWith(1, 'u1', '2026-08-15', []);
         expect(services.getActivePlanState).toHaveBeenNthCalledWith(7, 'u1', '2026-08-21', []);
+    });
+
+    it('uses padded fixed activities for placement but only exports commitments inside the visible horizon', async () => {
+        const priorWeekOccupancy = {
+            id: 'fixed-prior',
+            userId: 'u1',
+            title: 'Prior fixed commitment',
+            date: '2026-08-12',
+            durationMin: 60,
+            fixed: true,
+            environment: 'either',
+            equipment: [],
+            isCompleted: false,
+            createdAt: '2026-08-01T00:00:00Z',
+            updatedAt: '2026-08-01T00:00:00Z',
+        };
+        services.getFixedActivitiesInRangeState.mockResolvedValue({
+            status: 'AVAILABLE', data: [priorWeekOccupancy], revision: 'r1',
+        });
+
+        const result = await new ContextBriefService().build('u1', AS_OF, 14);
+
+        expect(services.getActivePlanState).toHaveBeenNthCalledWith(1, 'u1', '2026-08-15', [priorWeekOccupancy]);
+        expect(result.text).not.toContain('Prior fixed commitment');
     });
 
     it('does not report missing snapshot days as a read failure', async () => {

--- a/app/src/services/contextBriefService.test.ts
+++ b/app/src/services/contextBriefService.test.ts
@@ -11,6 +11,7 @@ const services = vi.hoisted(() => ({
     getProfileState: vi.fn(),
     getActiveGoalsState: vi.fn(),
     getFixedActivitiesInRangeState: vi.fn(),
+    getPlanBlocksInRangeState: vi.fn(),
     getActivePlanState: vi.fn(),
 }));
 
@@ -26,6 +27,7 @@ vi.mock('./preferencesService', () => ({ preferencesService: { getPreferencesSta
 vi.mock('./trainingIntentProfileService', () => ({ trainingIntentProfileService: { getProfileState: services.getProfileState } }));
 vi.mock('./goalService', () => ({ goalService: { getActiveGoalsState: services.getActiveGoalsState } }));
 vi.mock('./fixedActivityService', () => ({ fixedActivityService: { getActivitiesInRangeState: services.getFixedActivitiesInRangeState } }));
+vi.mock('./planBlockService', () => ({ planBlockService: { getBlocksInRangeState: services.getPlanBlocksInRangeState } }));
 vi.mock('./activeExternalPlanService', () => ({ activeExternalPlanService: { getActivePlanState: services.getActivePlanState } }));
 
 import { ContextBriefService } from './contextBriefService';
@@ -45,6 +47,7 @@ describe('ContextBriefService', () => {
         services.getProfileState.mockResolvedValue({ status: 'MISSING' });
         services.getActiveGoalsState.mockResolvedValue({ status: 'MISSING' });
         services.getFixedActivitiesInRangeState.mockResolvedValue({ status: 'AVAILABLE', data: [], revision: null });
+        services.getPlanBlocksInRangeState.mockResolvedValue({ status: 'AVAILABLE', data: [], revision: null });
         services.getActivePlanState.mockResolvedValue({ status: 'MISSING' });
     });
 
@@ -69,6 +72,29 @@ describe('ContextBriefService', () => {
         expect(services.getActivePlanState).toHaveBeenCalledTimes(7);
         expect(services.getActivePlanState).toHaveBeenNthCalledWith(1, 'u1', '2026-08-15', []);
         expect(services.getActivePlanState).toHaveBeenNthCalledWith(7, 'u1', '2026-08-21', []);
+    });
+
+    it('reads authored plan blocks across the visible handoff and exports travel scaling', async () => {
+        services.getPlanBlocksInRangeState.mockResolvedValue({
+            status: 'AVAILABLE',
+            revision: 'travel:r1',
+            data: [{
+                id: 'travel',
+                userId: 'u1',
+                phase: 'travel',
+                startDate: '2026-08-18',
+                endDate: '2026-08-20',
+                volumeScale: 0.6,
+                intensityScale: 0.8,
+                createdAt: '2026-08-01T00:00:00Z',
+                updatedAt: '2026-08-01T00:00:00Z',
+            }],
+        });
+
+        const result = await new ContextBriefService().build('u1', AS_OF, 14);
+
+        expect(services.getPlanBlocksInRangeState).toHaveBeenCalledWith('u1', '2026-08-15', '2026-08-21');
+        expect(result.text).toContain('2026-08-18→2026-08-20 | Plan block | Travel | volume ×0.6 · intensity ×0.8 | authored overlay');
     });
 
     it('uses padded fixed activities for placement but only exports commitments inside the visible horizon', async () => {
@@ -143,6 +169,14 @@ describe('ContextBriefService', () => {
         expect(result.text).toContain('active goals');
     });
 
+    it('reports unreadable travel overlays instead of treating them as no travel', async () => {
+        services.getPlanBlocksInRangeState.mockResolvedValue({ status: 'UNAVAILABLE', operation: 'read plan blocks', retryable: true });
+        const result = await new ContextBriefService().build('u1', AS_OF, 14);
+
+        expect(result.unavailableSources).toContain('plan blocks / travel overlays');
+        expect(result.text).toContain('plan blocks / travel overlays');
+    });
+
     it('fails closed on external placement when fixed-activity occupancy cannot be read', async () => {
         services.getFixedActivitiesInRangeState.mockResolvedValue({ status: 'UNAVAILABLE', operation: 'read fixed activities', retryable: true });
         const result = await new ContextBriefService().build('u1', AS_OF, 14);
@@ -191,11 +225,13 @@ describe('ContextBriefService', () => {
         services.getProfileState.mockRejectedValue(new Error('offline'));
         services.getActiveGoalsState.mockRejectedValue(new Error('offline'));
         services.getFixedActivitiesInRangeState.mockRejectedValue(new Error('offline'));
+        services.getPlanBlocksInRangeState.mockRejectedValue(new Error('offline'));
 
         const result = await new ContextBriefService().build('u1', AS_OF, 14);
         expect(result.text).toContain('# Training context brief');
         expect(result.unavailableSources).toContain('recovery snapshots');
         expect(result.unavailableSources).toContain('training settings');
+        expect(result.unavailableSources).toContain('plan blocks / travel overlays');
         expect(result.text).toContain('Do not assume any equipment or absence of injury');
         expect(result.text).toContain('DATA INCOMPLETE');
     });

--- a/app/src/services/contextBriefService.test.ts
+++ b/app/src/services/contextBriefService.test.ts
@@ -10,6 +10,8 @@ const services = vi.hoisted(() => ({
     getPreferencesState: vi.fn(),
     getProfileState: vi.fn(),
     getActiveGoalsState: vi.fn(),
+    getFixedActivitiesInRangeState: vi.fn(),
+    getActivePlanState: vi.fn(),
 }));
 
 vi.mock('./recoverySnapshotService', () => ({ recoverySnapshotService: { getRecoverySnapshotState: services.getRecoverySnapshotState } }));
@@ -23,6 +25,8 @@ vi.mock('./trainingSettingsService', () => ({ trainingSettingsService: {
 vi.mock('./preferencesService', () => ({ preferencesService: { getPreferencesState: services.getPreferencesState } }));
 vi.mock('./trainingIntentProfileService', () => ({ trainingIntentProfileService: { getProfileState: services.getProfileState } }));
 vi.mock('./goalService', () => ({ goalService: { getActiveGoalsState: services.getActiveGoalsState } }));
+vi.mock('./fixedActivityService', () => ({ fixedActivityService: { getActivitiesInRangeState: services.getFixedActivitiesInRangeState } }));
+vi.mock('./activeExternalPlanService', () => ({ activeExternalPlanService: { getActivePlanState: services.getActivePlanState } }));
 
 import { ContextBriefService } from './contextBriefService';
 
@@ -40,6 +44,8 @@ describe('ContextBriefService', () => {
         services.getPreferencesState.mockResolvedValue({ status: 'MISSING' });
         services.getProfileState.mockResolvedValue({ status: 'MISSING' });
         services.getActiveGoalsState.mockResolvedValue({ status: 'MISSING' });
+        services.getFixedActivitiesInRangeState.mockResolvedValue({ status: 'AVAILABLE', data: [], revision: null });
+        services.getActivePlanState.mockResolvedValue({ status: 'MISSING' });
     });
 
     it('reads check-ins over a date range covering the full baseline, inclusive of asOfDate', async () => {
@@ -54,6 +60,15 @@ describe('ContextBriefService', () => {
         expect(services.getCheckinsInRange).toHaveBeenCalledWith('u1', '2026-06-21', '2026-08-16');
     });
 
+    it('reads fixed commitments and resolves active imported sessions across the next seven days', async () => {
+        await new ContextBriefService().build('u1', AS_OF, 14);
+
+        expect(services.getFixedActivitiesInRangeState).toHaveBeenCalledWith('u1', '2026-08-15', '2026-08-21');
+        expect(services.getActivePlanState).toHaveBeenCalledTimes(7);
+        expect(services.getActivePlanState).toHaveBeenNthCalledWith(1, 'u1', '2026-08-15', []);
+        expect(services.getActivePlanState).toHaveBeenNthCalledWith(7, 'u1', '2026-08-21', []);
+    });
+
     it('does not report missing snapshot days as a read failure', async () => {
         const result = await new ContextBriefService().build('u1', AS_OF, 14);
         expect(result.unavailableSources).not.toContain('recovery snapshots');
@@ -65,6 +80,8 @@ describe('ContextBriefService', () => {
         services.getRecoverySnapshotState.mockResolvedValueOnce({ status: 'INVALID', issues: [] });
         const result = await new ContextBriefService().build('u1', AS_OF, 14);
         expect(result.unavailableSources).toContain('recovery snapshots (2 day(s) unreadable)');
+        expect(result.text).toContain('DATA INCOMPLETE');
+        expect(result.text).toContain('recovery snapshots (2 day(s) unreadable)');
     });
 
     it('omits malformed range-query check-ins instead of treating them as valid history', async () => {
@@ -78,6 +95,7 @@ describe('ContextBriefService', () => {
 
         expect(result.unavailableSources).toContain('subjective check-ins (1 invalid record(s) omitted)');
         expect(result.text).toContain('No check-ins in this window.');
+        expect(result.text).toContain('means "unknown", not "none"');
     });
 
     it('reports a failed preferences read, because it owns a hard modality exclusion', async () => {
@@ -91,6 +109,51 @@ describe('ContextBriefService', () => {
         expect(result.unavailableSources.join()).not.toContain('preferences');
     });
 
+    it('reports unreadable goals instead of silently turning them into no goals', async () => {
+        services.getActiveGoalsState.mockResolvedValue({ status: 'UNAVAILABLE', operation: 'read goals', retryable: true });
+        const result = await new ContextBriefService().build('u1', AS_OF, 14);
+
+        expect(result.unavailableSources).toContain('active goals');
+        expect(result.text).toContain('active goals');
+    });
+
+    it('fails closed on external placement when fixed-activity occupancy cannot be read', async () => {
+        services.getFixedActivitiesInRangeState.mockResolvedValue({ status: 'UNAVAILABLE', operation: 'read fixed activities', retryable: true });
+        const result = await new ContextBriefService().build('u1', AS_OF, 14);
+
+        expect(services.getActivePlanState).not.toHaveBeenCalled();
+        expect(result.unavailableSources).toContain('future fixed activities');
+        expect(result.unavailableSources).toContain('external plan schedule (fixed-activity occupancy unavailable)');
+        expect(result.text).toContain('fixed-activity occupancy unavailable');
+    });
+
+    it('renders an imported future session into the copied handoff', async () => {
+        services.getActivePlanState.mockImplementation(async (_userId: string, date: string) => {
+            if (date !== '2026-08-17') return { status: 'MISSING' };
+            return {
+                status: 'AVAILABLE',
+                data: {
+                    header: { planId: 'p1', title: 'Race prep', revision: 2 },
+                    placed: [{
+                        date,
+                        status: 'planned',
+                        moved: false,
+                        session: {
+                            id: 's1',
+                            title: 'Threshold quality',
+                            priority: 'key',
+                            placement: { flexibility: 'preferred' },
+                            gating: { modality: 'cycling', intensity: 'hard', durationMin: 60, durationMax: 75 },
+                        },
+                    }],
+                },
+            };
+        });
+
+        const result = await new ContextBriefService().build('u1', AS_OF, 14);
+        expect(result.text).toContain('2026-08-17 | Imported plan: Race prep | Threshold quality | 60–75 min · hard | key · preferred');
+    });
+
     it('still returns a brief when every source rejects', async () => {
         services.getRecoverySnapshotState.mockRejectedValue(new Error('offline'));
         services.getCheckinsInRange.mockRejectedValue(new Error('offline'));
@@ -101,12 +164,14 @@ describe('ContextBriefService', () => {
         services.getPreferencesState.mockRejectedValue(new Error('offline'));
         services.getProfileState.mockRejectedValue(new Error('offline'));
         services.getActiveGoalsState.mockRejectedValue(new Error('offline'));
+        services.getFixedActivitiesInRangeState.mockRejectedValue(new Error('offline'));
 
         const result = await new ContextBriefService().build('u1', AS_OF, 14);
         expect(result.text).toContain('# Training context brief');
         expect(result.unavailableSources).toContain('recovery snapshots');
         expect(result.unavailableSources).toContain('training settings');
         expect(result.text).toContain('Do not assume any equipment or absence of injury');
+        expect(result.text).toContain('DATA INCOMPLETE');
     });
 
     it('never writes a training settings profile as a side effect of being read', async () => {

--- a/app/src/services/contextBriefService.test.ts
+++ b/app/src/services/contextBriefService.test.ts
@@ -191,6 +191,32 @@ describe('ContextBriefService', () => {
         expect(result.text).toContain('fixed-activity occupancy unavailable');
     });
 
+    it('marks external fallback as unconfirmed, not a confirmed absence, when only today\'s plan-state read fails', async () => {
+        services.getProfileState.mockResolvedValue({
+            status: 'AVAILABLE',
+            data: {
+                userId: 'u1',
+                planningMode: 'externally_planned',
+                priorities: [],
+                weeklyCommitment: { minSessions: 3, targetSessions: 5, maxSessions: 6 },
+                organizationPreference: 'auto',
+                schemaVersion: 1,
+                createdAt: '2026-01-01T00:00:00Z',
+                updatedAt: '2026-01-01T00:00:00Z',
+            },
+        });
+        services.getActivePlanState.mockImplementation(async (_userId: string, date: string) => {
+            if (date === AS_OF) return { status: 'UNAVAILABLE', operation: 'read plan', retryable: true };
+            return { status: 'MISSING' };
+        });
+        const result = await new ContextBriefService().build('u1', AS_OF, 14);
+
+        expect(result.unavailableSources).toContain('external plan schedule (1 day(s) unreadable)');
+        expect(result.text).toContain('external-plan fallback today: UNCONFIRMED');
+        expect(result.text).toContain('could not be read, so this may reflect an unreadable session rather than a confirmed absence');
+        expect(result.text).not.toContain('external-plan fallback today: no imported session is placed on this date');
+    });
+
     it('renders an imported future session and its authored prescription into the copied handoff', async () => {
         services.getActivePlanState.mockImplementation(async (_userId: string, date: string) => {
             if (date !== '2026-08-17') return { status: 'MISSING' };

--- a/app/src/services/contextBriefService.test.ts
+++ b/app/src/services/contextBriefService.test.ts
@@ -28,7 +28,11 @@ vi.mock('./trainingIntentProfileService', () => ({ trainingIntentProfileService:
 vi.mock('./goalService', () => ({ goalService: { getActiveGoalsState: services.getActiveGoalsState } }));
 vi.mock('./fixedActivityService', () => ({ fixedActivityService: { getActivitiesInRangeState: services.getFixedActivitiesInRangeState } }));
 vi.mock('./planBlockService', () => ({ planBlockService: { getBlocksInRangeState: services.getPlanBlocksInRangeState } }));
-vi.mock('./activeExternalPlanService', () => ({ activeExternalPlanService: { getActivePlanState: services.getActivePlanState } }));
+vi.mock('./activeExternalPlanService', () => ({
+    activeExternalPlanService: { getActivePlanState: services.getActivePlanState },
+    placedSessionForDate: (active: { placed: Array<{ date: string; status: string }> }, date: string) =>
+        active.placed.find(item => item.date === date && (item.status === 'planned' || item.status === 'moved')) ?? null,
+}));
 
 import { ContextBriefService } from './contextBriefService';
 
@@ -187,7 +191,7 @@ describe('ContextBriefService', () => {
         expect(result.text).toContain('fixed-activity occupancy unavailable');
     });
 
-    it('renders an imported future session into the copied handoff', async () => {
+    it('renders an imported future session and its authored prescription into the copied handoff', async () => {
         services.getActivePlanState.mockImplementation(async (_userId: string, date: string) => {
             if (date !== '2026-08-17') return { status: 'MISSING' };
             return {
@@ -204,6 +208,10 @@ describe('ContextBriefService', () => {
                             priority: 'key',
                             placement: { flexibility: 'preferred' },
                             gating: { modality: 'cycling', intensity: 'hard', durationMin: 60, durationMax: 75 },
+                            prescription: {
+                                summary: '3 x 10 min threshold',
+                                steps: [{ name: 'Threshold', sets: 3, durationMin: 10, target: 'RPE 7–8', recoverySec: 240 }],
+                            },
                         },
                     }],
                 },
@@ -212,6 +220,8 @@ describe('ContextBriefService', () => {
 
         const result = await new ContextBriefService().build('u1', AS_OF, 14);
         expect(result.text).toContain('2026-08-17 | Imported plan: Race prep | Threshold quality | 60–75 min · hard | key · preferred');
+        expect(result.text).toContain('2026-08-17 — Threshold quality:** 3 x 10 min threshold');
+        expect(result.text).toContain('Threshold: 3 sets · 10 min · RPE 7–8 · 240s recovery');
     });
 
     it('still returns a brief when every source rejects', async () => {

--- a/app/src/services/contextBriefService.ts
+++ b/app/src/services/contextBriefService.ts
@@ -7,10 +7,17 @@ import {
     type ContextBriefInput,
 } from '../engine/contextBrief';
 import { injectActivityTelemetryIntoContextBrief } from '../engine/contextBriefActivityTelemetry';
+import {
+    enhanceContextBriefForPlanning,
+    UPCOMING_CONTEXT_DAYS,
+    type UpcomingExternalPlanSession,
+} from '../engine/contextBriefPlanningHandoff';
 import { parseSubjectiveCheckin } from '../persistence/parsers/decisionInputs';
 import { addDaysToLocalDateString, getLocalDateString } from '../utils/localDate';
+import { activeExternalPlanService } from './activeExternalPlanService';
 import { activityService } from './activityService';
 import { checkinService } from './checkinService';
+import { fixedActivityService } from './fixedActivityService';
 import { goalService } from './goalService';
 import { preferencesService } from './preferencesService';
 import { recommendationService } from './recommendationService';
@@ -42,6 +49,11 @@ export class ContextBriefService {
         // Activity and recommendation range queries are end-exclusive; the brief window
         // is inclusive of targetDate, so the fetch reaches one day further.
         const throughExclusive = addDaysToLocalDateString(targetDate, 1);
+        const upcomingEndDate = addDaysToLocalDateString(targetDate, UPCOMING_CONTEXT_DAYS - 1);
+        const upcomingDates = Array.from(
+            { length: UPCOMING_CONTEXT_DAYS },
+            (_, offset) => addDaysToLocalDateString(targetDate, offset),
+        );
         const unavailableSources: string[] = [];
 
         const snapshotDates = Array.from(
@@ -49,7 +61,7 @@ export class ContextBriefService {
             (_, offset) => addDaysToLocalDateString(startDate, offset),
         );
 
-        const [snapshotResults, checkinResult, activityResult, recommendationResult, settingsResult, preferencesResult, intentResult, goalsResult] =
+        const [snapshotResults, checkinResult, activityResult, recommendationResult, settingsResult, preferencesResult, intentResult, goalsResult, fixedActivityResult] =
             await Promise.allSettled([
                 // getRecoverySnapshotByDate collapses UNAVAILABLE and MISSING to null, so a
                 // read outage would be indistinguishable from "no data that day" and the
@@ -67,6 +79,9 @@ export class ContextBriefService {
                 preferencesService.getPreferencesState(userId),
                 trainingIntentProfileService.getProfileState(userId),
                 goalService.getActiveGoalsState(userId),
+                // Future fixed activities are part of the planning state, not history.
+                // The query is inclusive at both ends, matching FixedActivityService.
+                fixedActivityService.getActivitiesInRangeState(userId, targetDate, upcomingEndDate),
             ] as const);
 
         const snapshots: DailyRecoverySnapshot[] = [];
@@ -147,6 +162,70 @@ export class ContextBriefService {
         const goals = goalsResult.status === 'fulfilled' && goalsResult.value.status === 'AVAILABLE'
             ? goalsResult.value.data
             : [];
+        if (goalsResult.status !== 'fulfilled' || !['AVAILABLE', 'MISSING'].includes(goalsResult.value.status)) {
+            unavailableSources.push('active goals');
+        }
+
+        const fixedActivitiesReadable = fixedActivityResult.status === 'fulfilled'
+            && ['AVAILABLE', 'MISSING'].includes(fixedActivityResult.value.status);
+        const upcomingFixedActivities = fixedActivityResult.status === 'fulfilled' && fixedActivityResult.value.status === 'AVAILABLE'
+            ? fixedActivityResult.value.data.filter(activity => !activity.isCompleted)
+            : [];
+        if (!fixedActivitiesReadable) {
+            unavailableSources.push('future fixed activities');
+        }
+
+        const upcomingExternalSessions: UpcomingExternalPlanSession[] = [];
+        if (fixedActivitiesReadable) {
+            // Resolve the active plan independently for each future date so plan revision
+            // effective-from boundaries and overlapping re-imports are respected. The same
+            // fixed-activity occupancy is supplied to every placement resolution.
+            const activePlanResults = await Promise.allSettled(
+                upcomingDates.map(date => activeExternalPlanService.getActivePlanState(userId, date, upcomingFixedActivities)),
+            );
+            let unreadablePlanDays = 0;
+            for (let index = 0; index < activePlanResults.length; index++) {
+                const date = upcomingDates[index];
+                const settled = activePlanResults[index];
+                if (settled.status === 'rejected') {
+                    unreadablePlanDays += 1;
+                    continue;
+                }
+                const state = settled.value;
+                if (state.status === 'MISSING') continue;
+                if (state.status !== 'AVAILABLE') {
+                    unreadablePlanDays += 1;
+                    continue;
+                }
+                for (const placed of state.data.placed.filter(item =>
+                    item.date === date && (item.status === 'planned' || item.status === 'moved'))) {
+                    upcomingExternalSessions.push({
+                        date,
+                        planId: state.data.header.planId,
+                        planTitle: state.data.header.title,
+                        revision: state.data.header.revision,
+                        sessionId: placed.session.id,
+                        title: placed.session.title,
+                        priority: placed.session.priority,
+                        modality: placed.session.gating.modality,
+                        intensity: placed.session.gating.intensity,
+                        durationMin: placed.session.gating.durationMin,
+                        durationMax: placed.session.gating.durationMax,
+                        flexibility: placed.session.placement.flexibility,
+                        status: placed.status === 'moved' ? 'moved' : 'planned',
+                        moved: placed.moved,
+                        isEvent: placed.session.isEvent === true,
+                    });
+                }
+            }
+            if (unreadablePlanDays > 0) {
+                unavailableSources.push(`external plan schedule (${unreadablePlanDays} day(s) unreadable)`);
+            }
+        } else {
+            // Placement depends on fixed-activity occupancy; showing a schedule resolved
+            // against an unknown occupancy set would be confidently wrong.
+            unavailableSources.push('external plan schedule (fixed-activity occupancy unavailable)');
+        }
 
         const input: ContextBriefInput = {
             asOfDate: targetDate,
@@ -161,7 +240,18 @@ export class ContextBriefService {
             intentProfile,
             goals,
         };
-        const text = injectActivityTelemetryIntoContextBrief(buildContextBrief(input), activities);
+        const retrospectiveText = injectActivityTelemetryIntoContextBrief(buildContextBrief(input), activities);
+        const text = enhanceContextBriefForPlanning(retrospectiveText, {
+            asOfDate: targetDate,
+            snapshots,
+            checkins,
+            activities,
+            recommendations,
+            intentProfile,
+            upcomingFixedActivities,
+            upcomingExternalSessions,
+            unavailableSources,
+        });
 
         return {
             text,

--- a/app/src/services/contextBriefService.ts
+++ b/app/src/services/contextBriefService.ts
@@ -20,7 +20,7 @@ import { externalSessionDisplayPrescription } from '../engine/externalSessionPro
 import { resolvePlanningContext } from '../engine/planningMode';
 import { evaluatePeriodizationPhase, goalToUserEvent } from '../engine/periodization';
 import { parseSubjectiveCheckin } from '../persistence/parsers/decisionInputs';
-import type { AnyExternalPlanSession } from '../sessions/externalPlanV2';
+import { isV2Session, type AnyExternalPlanSession } from '../sessions/externalPlanV2';
 import { addDaysToLocalDateString, getLocalDateString } from '../utils/localDate';
 import { activeExternalPlanService, placedSessionForDate } from './activeExternalPlanService';
 import { activityService } from './activityService';
@@ -54,7 +54,7 @@ export interface ContextBriefResult {
  * context's externalSession is deliberately not consumed by this brief.
  */
 function planningAuthoritySession(session: AnyExternalPlanSession): LegacyExternalPlanSession {
-    if ('prescription' in session) return session;
+    if (!isV2Session(session)) return session;
     return {
         id: session.id,
         title: session.title,
@@ -238,6 +238,12 @@ export class ContextBriefService {
 
         const upcomingExternalSessions: UpcomingExternalPlanSession[] = [];
         let currentExternalSession: AnyExternalPlanSession | null = null;
+        // Whether "no session placed today" can be asserted as a confirmed fact. Starts
+        // false whenever occupancy itself is unreadable (the else branch below), and is
+        // also cleared if today's own plan-state read specifically fails, so a resolved
+        // `externalFallback: true` downstream is never presented as certain when the day
+        // that mattered most could not actually be read.
+        let externalScheduleTodayConfirmed = fixedActivitiesReadable;
         if (fixedActivitiesReadable) {
             // Resolve the active plan independently for each future date so plan revision
             // effective-from boundaries and overlapping re-imports are respected. Use the
@@ -252,12 +258,14 @@ export class ContextBriefService {
                 const settled = activePlanResults[index];
                 if (settled.status === 'rejected') {
                     unreadablePlanDays += 1;
+                    if (date === targetDate) externalScheduleTodayConfirmed = false;
                     continue;
                 }
                 const state = settled.value;
                 if (state.status === 'MISSING') continue;
                 if (state.status !== 'AVAILABLE') {
                     unreadablePlanDays += 1;
+                    if (date === targetDate) externalScheduleTodayConfirmed = false;
                     continue;
                 }
                 if (date === targetDate) {
@@ -305,6 +313,12 @@ export class ContextBriefService {
             targetDate,
             currentExternalSession ? planningAuthoritySession(currentExternalSession) : null,
         );
+        // resolvePlanningContext treats a null externalSession as "confirmed nothing is
+        // placed today" and reports externalFallback accordingly. That is only true when
+        // today's own plan-state read actually succeeded; when it didn't,
+        // externalScheduleTodayConfirmed is false and the fallback claim is unconfirmed,
+        // not negative.
+        const externalFallbackUncertain = planningContext.externalFallback && !externalScheduleTodayConfirmed;
 
         const input: ContextBriefInput = {
             asOfDate: targetDate,
@@ -328,8 +342,9 @@ export class ContextBriefService {
             recommendations,
             trainingSettings,
             preferences,
-            planningMode: planningContext.mode,
+            effectivePlanningMode: planningContext.mode,
             externalFallback: planningContext.externalFallback,
+            externalFallbackUncertain,
             eventStrategy: planningContext.eventStrategy,
             goals,
             upcomingFixedActivities,

--- a/app/src/services/contextBriefService.ts
+++ b/app/src/services/contextBriefService.ts
@@ -54,6 +54,13 @@ export class ContextBriefService {
             { length: UPCOMING_CONTEXT_DAYS },
             (_, offset) => addDaysToLocalDateString(targetDate, offset),
         );
+        // External-plan placement spreads flexible sessions within their whole plan week.
+        // A fixed activity just before or after the 7-day handoff horizon can therefore
+        // change which date a session resolves onto inside the horizon. Six calendar days
+        // of padding on both sides fully covers every Monday-Sunday plan week intersecting
+        // the handoff, without requiring timezone-sensitive weekday arithmetic here.
+        const placementOccupancyStart = addDaysToLocalDateString(targetDate, -6);
+        const placementOccupancyEnd = addDaysToLocalDateString(upcomingEndDate, 6);
         const unavailableSources: string[] = [];
 
         const snapshotDates = Array.from(
@@ -79,9 +86,9 @@ export class ContextBriefService {
                 preferencesService.getPreferencesState(userId),
                 trainingIntentProfileService.getProfileState(userId),
                 goalService.getActiveGoalsState(userId),
-                // Future fixed activities are part of the planning state, not history.
-                // The query is inclusive at both ends, matching FixedActivityService.
-                fixedActivityService.getActivitiesInRangeState(userId, targetDate, upcomingEndDate),
+                // Fixed activities are fetched slightly wider than the visible handoff so
+                // imported-plan placement has the full occupancy of every intersecting week.
+                fixedActivityService.getActivitiesInRangeState(userId, placementOccupancyStart, placementOccupancyEnd),
             ] as const);
 
         const snapshots: DailyRecoverySnapshot[] = [];
@@ -168,9 +175,11 @@ export class ContextBriefService {
 
         const fixedActivitiesReadable = fixedActivityResult.status === 'fulfilled'
             && ['AVAILABLE', 'MISSING'].includes(fixedActivityResult.value.status);
-        const upcomingFixedActivities = fixedActivityResult.status === 'fulfilled' && fixedActivityResult.value.status === 'AVAILABLE'
+        const placementFixedActivities = fixedActivityResult.status === 'fulfilled' && fixedActivityResult.value.status === 'AVAILABLE'
             ? fixedActivityResult.value.data.filter(activity => !activity.isCompleted)
             : [];
+        const upcomingFixedActivities = placementFixedActivities.filter(activity =>
+            activity.date >= targetDate && activity.date <= upcomingEndDate);
         if (!fixedActivitiesReadable) {
             unavailableSources.push('future fixed activities');
         }
@@ -178,10 +187,11 @@ export class ContextBriefService {
         const upcomingExternalSessions: UpcomingExternalPlanSession[] = [];
         if (fixedActivitiesReadable) {
             // Resolve the active plan independently for each future date so plan revision
-            // effective-from boundaries and overlapping re-imports are respected. The same
-            // fixed-activity occupancy is supplied to every placement resolution.
+            // effective-from boundaries and overlapping re-imports are respected. Use the
+            // padded occupancy set above, not only visible future commitments, because an
+            // earlier/later fixed day in the same plan week can move a flexible session.
             const activePlanResults = await Promise.allSettled(
-                upcomingDates.map(date => activeExternalPlanService.getActivePlanState(userId, date, upcomingFixedActivities)),
+                upcomingDates.map(date => activeExternalPlanService.getActivePlanState(userId, date, placementFixedActivities)),
             );
             let unreadablePlanDays = 0;
             for (let index = 0; index < activePlanResults.length; index++) {

--- a/app/src/services/contextBriefService.ts
+++ b/app/src/services/contextBriefService.ts
@@ -16,6 +16,7 @@ import {
     UPCOMING_CONTEXT_DAYS,
     type UpcomingExternalPlanSession,
 } from '../engine/contextBriefPlanningHandoff';
+import { externalSessionDisplayPrescription } from '../engine/externalSessionProfiles';
 import { resolvePlanningContext } from '../engine/planningMode';
 import { evaluatePeriodizationPhase, goalToUserEvent } from '../engine/periodization';
 import { parseSubjectiveCheckin } from '../persistence/parsers/decisionInputs';
@@ -46,11 +47,11 @@ export interface ContextBriefResult {
 
 /**
  * `resolvePlanningContext` still accepts the v1 external-session type, while placement may
- * return either external-plan schema. Planning-mode authority only needs to know that a
- * real session is placed on the date; all envelope fields below are common to v1/v2. A
- * v2 definition is not translated into fake executable v1 content -- the placeholder
- * summary exists only to satisfy the legacy type at this authority boundary, and the
- * returned context's externalSession is deliberately not consumed by this brief.
+ * return either external-plan schema. Planning-mode authority only needs the presence and
+ * shared envelope of a session placed on this date. `externalSessionDisplayPrescription`
+ * is the repository's canonical v1/v2 display adapter, so the compatibility facade keeps
+ * truthful authored display content rather than inventing a prescription. The returned
+ * context's externalSession is deliberately not consumed by this brief.
  */
 function planningAuthoritySession(session: AnyExternalPlanSession): LegacyExternalPlanSession {
     if ('prescription' in session) return session;
@@ -60,10 +61,10 @@ function planningAuthoritySession(session: AnyExternalPlanSession): LegacyExtern
         priority: session.priority,
         placement: session.placement,
         gating: session.gating,
-        objectives: session.objectives,
-        prescription: { summary: session.title },
-        scaling: session.scaling,
-        isEvent: session.isEvent,
+        ...(session.objectives ? { objectives: [...session.objectives] } : {}),
+        prescription: externalSessionDisplayPrescription(session),
+        ...(session.scaling ? { scaling: session.scaling } : {}),
+        ...(session.isEvent !== undefined ? { isEvent: session.isEvent } : {}),
     };
 }
 
@@ -280,6 +281,7 @@ export class ContextBriefService {
                         status: placed.status === 'moved' ? 'moved' : 'planned',
                         moved: placed.moved,
                         isEvent: placed.session.isEvent === true,
+                        prescription: externalSessionDisplayPrescription(placed.session),
                     });
                 }
             }

--- a/app/src/services/contextBriefService.ts
+++ b/app/src/services/contextBriefService.ts
@@ -19,6 +19,7 @@ import { activityService } from './activityService';
 import { checkinService } from './checkinService';
 import { fixedActivityService } from './fixedActivityService';
 import { goalService } from './goalService';
+import { planBlockService } from './planBlockService';
 import { preferencesService } from './preferencesService';
 import { recommendationService } from './recommendationService';
 import { recoverySnapshotService } from './recoverySnapshotService';
@@ -68,28 +69,41 @@ export class ContextBriefService {
             (_, offset) => addDaysToLocalDateString(startDate, offset),
         );
 
-        const [snapshotResults, checkinResult, activityResult, recommendationResult, settingsResult, preferencesResult, intentResult, goalsResult, fixedActivityResult] =
-            await Promise.allSettled([
-                // getRecoverySnapshotByDate collapses UNAVAILABLE and MISSING to null, so a
-                // read outage would be indistinguishable from "no data that day" and the
-                // brief would silently under-report the window. Read the state instead.
-                Promise.all(snapshotDates.map(date => recoverySnapshotService.getRecoverySnapshotState(userId, date))),
-                // Activity, recommendation, and check-in range queries are end-exclusive;
-                // the brief window is inclusive of targetDate, so the fetch reaches throughExclusive.
-                checkinService.getCheckinsInRange(userId, baselineStart, throughExclusive),
-                activityService.getActivitiesInRange(userId, startDate, throughExclusive),
-                recommendationService.getRecommendationsInRange(userId, startDate, throughExclusive),
-                // peek, not get: the brief is read-only and must not create a settings
-                // profile as a side effect of being looked at (DataView presents it as
-                // "generating it changes nothing").
-                trainingSettingsService.peekTrainingSettingsState(userId),
-                preferencesService.getPreferencesState(userId),
-                trainingIntentProfileService.getProfileState(userId),
-                goalService.getActiveGoalsState(userId),
-                // Fixed activities are fetched slightly wider than the visible handoff so
-                // imported-plan placement has the full occupancy of every intersecting week.
-                fixedActivityService.getActivitiesInRangeState(userId, placementOccupancyStart, placementOccupancyEnd),
-            ] as const);
+        const [
+            snapshotResults,
+            checkinResult,
+            activityResult,
+            recommendationResult,
+            settingsResult,
+            preferencesResult,
+            intentResult,
+            goalsResult,
+            fixedActivityResult,
+            planBlockResult,
+        ] = await Promise.allSettled([
+            // getRecoverySnapshotByDate collapses UNAVAILABLE and MISSING to null, so a
+            // read outage would be indistinguishable from "no data that day" and the
+            // brief would silently under-report the window. Read the state instead.
+            Promise.all(snapshotDates.map(date => recoverySnapshotService.getRecoverySnapshotState(userId, date))),
+            // Activity, recommendation, and check-in range queries are end-exclusive;
+            // the brief window is inclusive of targetDate, so the fetch reaches throughExclusive.
+            checkinService.getCheckinsInRange(userId, baselineStart, throughExclusive),
+            activityService.getActivitiesInRange(userId, startDate, throughExclusive),
+            recommendationService.getRecommendationsInRange(userId, startDate, throughExclusive),
+            // peek, not get: the brief is read-only and must not create a settings
+            // profile as a side effect of being looked at (DataView presents it as
+            // "generating it changes nothing").
+            trainingSettingsService.peekTrainingSettingsState(userId),
+            preferencesService.getPreferencesState(userId),
+            trainingIntentProfileService.getProfileState(userId),
+            goalService.getActiveGoalsState(userId),
+            // Fixed activities are fetched slightly wider than the visible handoff so
+            // imported-plan placement has the full occupancy of every intersecting week.
+            fixedActivityService.getActivitiesInRangeState(userId, placementOccupancyStart, placementOccupancyEnd),
+            // Plan blocks are range-overlays (currently explicit travel) and the service
+            // returns any block intersecting this visible horizon, including one that began earlier.
+            planBlockService.getBlocksInRangeState(userId, targetDate, upcomingEndDate),
+        ] as const);
 
         const snapshots: DailyRecoverySnapshot[] = [];
         if (snapshotResults.status === 'fulfilled') {
@@ -184,6 +198,13 @@ export class ContextBriefService {
             unavailableSources.push('future fixed activities');
         }
 
+        const upcomingPlanBlocks = planBlockResult.status === 'fulfilled' && planBlockResult.value.status === 'AVAILABLE'
+            ? planBlockResult.value.data
+            : [];
+        if (planBlockResult.status !== 'fulfilled' || !['AVAILABLE', 'MISSING'].includes(planBlockResult.value.status)) {
+            unavailableSources.push('plan blocks / travel overlays');
+        }
+
         const upcomingExternalSessions: UpcomingExternalPlanSession[] = [];
         if (fixedActivitiesReadable) {
             // Resolve the active plan independently for each future date so plan revision
@@ -257,8 +278,12 @@ export class ContextBriefService {
             checkins,
             activities,
             recommendations,
+            trainingSettings,
+            preferences,
             intentProfile,
+            goals,
             upcomingFixedActivities,
+            upcomingPlanBlocks,
             upcomingExternalSessions,
             unavailableSources,
         });

--- a/app/src/services/contextBriefService.ts
+++ b/app/src/services/contextBriefService.ts
@@ -1,4 +1,8 @@
-import type { DailyRecoverySnapshot, DailySubjectiveCheckin } from '../engine/models';
+import type {
+    DailyRecoverySnapshot,
+    DailySubjectiveCheckin,
+    ExternalPlanSession as LegacyExternalPlanSession,
+} from '../engine/models';
 import {
     briefWindowStart,
     buildContextBrief,
@@ -12,9 +16,12 @@ import {
     UPCOMING_CONTEXT_DAYS,
     type UpcomingExternalPlanSession,
 } from '../engine/contextBriefPlanningHandoff';
+import { resolvePlanningContext } from '../engine/planningMode';
+import { evaluatePeriodizationPhase, goalToUserEvent } from '../engine/periodization';
 import { parseSubjectiveCheckin } from '../persistence/parsers/decisionInputs';
+import type { AnyExternalPlanSession } from '../sessions/externalPlanV2';
 import { addDaysToLocalDateString, getLocalDateString } from '../utils/localDate';
-import { activeExternalPlanService } from './activeExternalPlanService';
+import { activeExternalPlanService, placedSessionForDate } from './activeExternalPlanService';
 import { activityService } from './activityService';
 import { checkinService } from './checkinService';
 import { fixedActivityService } from './fixedActivityService';
@@ -35,6 +42,29 @@ export interface ContextBriefResult {
     /** Sources that could not be read. The brief still renders; it says what is missing
      * rather than presenting a partial window as complete. */
     unavailableSources: string[];
+}
+
+/**
+ * `resolvePlanningContext` still accepts the v1 external-session type, while placement may
+ * return either external-plan schema. Planning-mode authority only needs to know that a
+ * real session is placed on the date; all envelope fields below are common to v1/v2. A
+ * v2 definition is not translated into fake executable v1 content -- the placeholder
+ * summary exists only to satisfy the legacy type at this authority boundary, and the
+ * returned context's externalSession is deliberately not consumed by this brief.
+ */
+function planningAuthoritySession(session: AnyExternalPlanSession): LegacyExternalPlanSession {
+    if ('prescription' in session) return session;
+    return {
+        id: session.id,
+        title: session.title,
+        priority: session.priority,
+        placement: session.placement,
+        gating: session.gating,
+        objectives: session.objectives,
+        prescription: { summary: session.title },
+        scaling: session.scaling,
+        isEvent: session.isEvent,
+    };
 }
 
 /** Assembles the context brief from the user-scoped stores. Read-only: it persists
@@ -206,6 +236,7 @@ export class ContextBriefService {
         }
 
         const upcomingExternalSessions: UpcomingExternalPlanSession[] = [];
+        let currentExternalSession: AnyExternalPlanSession | null = null;
         if (fixedActivitiesReadable) {
             // Resolve the active plan independently for each future date so plan revision
             // effective-from boundaries and overlapping re-imports are respected. Use the
@@ -227,6 +258,9 @@ export class ContextBriefService {
                 if (state.status !== 'AVAILABLE') {
                     unreadablePlanDays += 1;
                     continue;
+                }
+                if (date === targetDate) {
+                    currentExternalSession = placedSessionForDate(state.data, date)?.session ?? null;
                 }
                 for (const placed of state.data.placed.filter(item =>
                     item.date === date && (item.status === 'planned' || item.status === 'moved'))) {
@@ -258,6 +292,18 @@ export class ContextBriefService {
             unavailableSources.push('external plan schedule (fixed-activity occupancy unavailable)');
         }
 
+        // ADR-0017: planningMode.ts is the sole authority for the effective mode. The
+        // persisted profile is athlete intent; effective mode also depends on whether an
+        // eligible event/session actually governs this date.
+        const events = goals.map(goalToUserEvent).filter((event): event is NonNullable<typeof event> => event !== null);
+        const periodization = evaluatePeriodizationPhase(events, targetDate);
+        const planningContext = resolvePlanningContext(
+            intentProfile,
+            periodization,
+            targetDate,
+            currentExternalSession ? planningAuthoritySession(currentExternalSession) : null,
+        );
+
         const input: ContextBriefInput = {
             asOfDate: targetDate,
             windowDays,
@@ -280,7 +326,9 @@ export class ContextBriefService {
             recommendations,
             trainingSettings,
             preferences,
-            intentProfile,
+            planningMode: planningContext.mode,
+            externalFallback: planningContext.externalFallback,
+            eventStrategy: planningContext.eventStrategy,
             goals,
             upcomingFixedActivities,
             upcomingPlanBlocks,


### PR DESCRIPTION
## Why

The context brief is pasted into a fresh AI chat and used for day-by-day planning. On `main`, it is strong retrospectively but has three important handoff gaps:

1. source failures are shown in DataView UI but are **not copied into the brief text**, so an external planner can read an unavailable activity source as “No recorded sessions”;
2. it does not expose **already-planned future state** (fixed activities / imported plan sessions), so a fresh chat can unknowingly plan over a match or existing session;
3. the final `Requested output` block acts like an embedded command, which can make a fresh model generate a plan immediately instead of treating the pasted document as context for the user’s next question.

## Changes

- adds a planning-handoff layer around the existing tested retrospective brief rather than rewriting baseline/recovery logic;
- copied text now includes:
  - planning date and planning mode;
  - latest Garmin snapshot/sync timestamp and metric freshness dates;
  - explicit current-day check-in freshness;
  - same-day activity sync caveat;
  - current app recommendation, labelled as advisory rather than authority;
  - **DATA INCOMPLETE** warning inside the copied text whenever a source is unreadable;
  - a compact 7-calendar-day cross-signal timeline for sleep/HRV/RHR/respiration/Body Battery/stress/readiness/fatigue/soreness/training/flags;
  - next 7 days of fixed activities and active imported-plan sessions, including dose, priority/flexibility and moved/event status;
- future external-plan placement fails closed when fixed-activity occupancy cannot be read;
- unreadable active-goal state is now surfaced instead of silently becoming “no goals”;
- replaces the unconditional `Requested output` command with `How to use this handoff`:
  - answer the user’s actual question first;
  - current illness/pain/tissue response outranks favorable wearables;
  - do not add load solely because wearables look green;
  - preserve future key-session intent and hard/easy spacing;
  - preserve fixed/imported sessions unless the user asks to change them;
  - the exact importable day-block schema remains available conditionally when requested.

## Scope

The existing `buildContextBrief()` retrospective renderer, biometric estimator semantics and detailed Garmin activity telemetry remain unchanged. The new layer is intentionally additive/post-processing so the already-validated baseline logic stays stable.

## Tests

Adds focused unit coverage for:
- copied source-failure warnings;
- stale/current wearable and check-in semantics;
- 7-day cross-signal timeline;
- fixed and imported future sessions;
- externally-planned mode with no visible session;
- service future-range resolution and fail-closed occupancy behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added planning-focused context briefs with current data freshness, planning mode, sensor and preference status, goals, commitments, imported sessions, travel details, and recovery timelines.
  * Added clear notices when information is incomplete, unavailable, stale, or uncertain.
  * Improved handling of upcoming schedules and external plans, including safe fallbacks when details cannot be confirmed.
  * Preserved retrospective context while adding actionable planning guidance and usage instructions.
* **Bug Fixes**
  * Improved reporting for unreadable goals, overlays, check-ins, and incomplete data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->