### PR TITLE
✍️ Scribe: [Clarify diagnostic limits of readiness telemetry]

### DIFF
--- a/docs/architecture/recommendation-engine.md
+++ b/docs/architecture/recommendation-engine.md
@@ -183,6 +183,9 @@ ownership and constrain availability before candidates are selected.
 
 Three modes, not four: **`train`**, **`modify`**, **`recover`**.
 
+> "Separates acute deviation from longer-term adverse trend for decision support; it does
+> not diagnose non-functional overreaching or overtraining syndrome."
+
 Objective strain is a continuous, **self-normalised** score — not fixed absolute
 thresholds. Each of HRV, RHR and sleep score contributes two z-scored terms:
 


### PR DESCRIPTION
* **📄 What:** The `docs/architecture/recommendation-engine.md` document was updated to clarify the diagnostic limits of the objective strain metrics.
* **⚠️ Problem:** According to finding F-ADR-3 from `docs/analysis/2026-08-16-adr-review.md`, the documentation's reliance on ADR-0006 overstated what readiness telemetry can establish. Specifically, the model cannot diagnose overtraining syndrome; it only provides signals of strain and recovery state.
* **📚 Source of truth:** The architecture review document `docs/analysis/2026-08-16-adr-review.md` (Finding F-ADR-3).
* **✅ Verification:** I ran `make check` to ensure all tests, linting, and typechecks passed successfully after the modification.
* **🎯 Impact:** Ensures that operators and contributors do not misunderstand the system's capabilities, explicitly avoiding any implied diagnostic capability for clinical conditions.
* **🔒 Governance:** Confirmed that product scope, authority, privacy, licensing, and operational limits are unchanged. This change only aligns documentation with established safety invariants.

---
*PR created automatically by Jules for task [8888950756988761051](https://jules.google.com/task/8888950756988761051) started by @Szczepanov*