### PR TITLE
fix: close correctness gaps found reviewing PR #141

### DIFF
--- a/app/src/engine/contextBriefPlanningHandoff.test.ts
+++ b/app/src/engine/contextBriefPlanningHandoff.test.ts
@@ -196,8 +196,9 @@ function handoffInput(overrides: Partial<ContextBriefPlanningHandoffInput> = {})
         recommendations: [recommendation()],
         trainingSettings: null,
         preferences: null,
-        planningMode: 'externally_planned',
+        effectivePlanningMode: 'externally_planned',
         externalFallback: false,
+        externalFallbackUncertain: false,
         eventStrategy: null,
         goals: [],
         upcomingFixedActivities: [fixedActivity()],
@@ -265,7 +266,7 @@ describe('enhanceContextBriefForPlanning', () => {
 
     it('explains an authority-resolved external fallback instead of pretending the persisted mode is effective', () => {
         const text = enhanceContextBriefForPlanning(BASE, handoffInput({
-            planningMode: 'evergreen',
+            effectivePlanningMode: 'evergreen',
             externalFallback: true,
         }));
 
@@ -311,6 +312,38 @@ describe('enhanceContextBriefForPlanning', () => {
         expect(text).toContain('Threshold: 3 sets · 10 min · RPE 7–8 · 240s recovery');
     });
 
+    it('includes minute-denominated recovery doses instead of dropping them from the copied handoff', () => {
+        const text = enhanceContextBriefForPlanning(BASE, handoffInput({
+            upcomingExternalSessions: [{
+                date: '2026-08-21',
+                planId: 'p1',
+                planTitle: 'Race prep',
+                revision: 2,
+                sessionId: 's2',
+                title: 'Tempo block',
+                priority: 'key',
+                modality: 'cycling',
+                intensity: 'moderate',
+                durationMin: 45,
+                durationMax: 45,
+                flexibility: 'preferred',
+                status: 'planned',
+                moved: false,
+                isEvent: false,
+                prescription: {
+                    summary: '2 x 20 min tempo',
+                    steps: [
+                        { name: 'Tempo', sets: 2, durationMin: 20, target: '85% FTP', recoveryMin: 5 },
+                        { name: 'VO2 rep', durationSec: 30, recoverySec: 15, repeat: 10, sets: 3, setRecoveryMin: 4 },
+                    ],
+                },
+            }],
+        }));
+
+        expect(text).toContain('Tempo: 2 sets · 20 min · 85% FTP · 5 min recovery');
+        expect(text).toContain('VO2 rep: 3 sets · 10 reps · 30 s · 15s recovery · 4 min set recovery');
+    });
+
     it('exports travel scaling overlays as constraints rather than workouts', () => {
         const text = enhanceContextBriefForPlanning(BASE, handoffInput({ upcomingPlanBlocks: [travelBlock()] }));
 
@@ -347,7 +380,7 @@ describe('enhanceContextBriefForPlanning', () => {
 
     it('warns instead of inventing a replacement when external fallback has no visible imported session', () => {
         const text = enhanceContextBriefForPlanning(BASE, handoffInput({
-            planningMode: 'evergreen',
+            effectivePlanningMode: 'evergreen',
             externalFallback: true,
             upcomingFixedActivities: [],
             upcomingPlanBlocks: [],
@@ -356,6 +389,22 @@ describe('enhanceContextBriefForPlanning', () => {
 
         expect(text).toContain('External-plan fallback is active today and no imported session is visible in this 7-day horizon');
         expect(text).toContain('Do not silently invent a replacement block');
+    });
+
+    it('marks external fallback as unconfirmed instead of a confirmed absence when today\'s plan read failed', () => {
+        const text = enhanceContextBriefForPlanning(BASE, handoffInput({
+            effectivePlanningMode: 'evergreen',
+            externalFallback: true,
+            externalFallbackUncertain: true,
+            upcomingFixedActivities: [],
+            upcomingPlanBlocks: [],
+            upcomingExternalSessions: [],
+        }));
+
+        expect(text).toContain('external-plan fallback today: UNCONFIRMED');
+        expect(text).toContain('could not be read, so this may reflect an unreadable session rather than a confirmed absence');
+        expect(text).not.toContain('external-plan fallback today: no imported session is placed on this date');
+        expect(text).toContain('this is unconfirmed — treat it as unreadable, not as a confirmed absence');
     });
 
     it('warns when current-day subjective data is stale', () => {

--- a/app/src/engine/contextBriefPlanningHandoff.ts
+++ b/app/src/engine/contextBriefPlanningHandoff.ts
@@ -45,8 +45,16 @@ export interface ContextBriefPlanningHandoffInput {
     recommendations: readonly DailyRecommendation[];
     trainingSettings: TrainingSettings | null;
     preferences: UserPreferences | null;
-    planningMode: PlanningMode;
+    /** Already-resolved by planningMode.ts (ADR-0017); this module renders it, it does not
+     * derive it. Named distinctly from `TrainingIntentProfile.planningMode` so the
+     * whole-app architecture guard (planningModeArchitecture.test.ts) can't mistake this
+     * consumption for a re-derivation of the persisted field. */
+    effectivePlanningMode: PlanningMode;
     externalFallback: boolean;
+    /** True when `externalFallback` could not actually be confirmed today because today's
+     * own external-plan read failed (occupancy or plan-state), so a null resolved session
+     * reflects an unreadable day rather than a confirmed absence. */
+    externalFallbackUncertain: boolean;
     eventStrategy: 'structured_plan' | 'demand_derived' | null;
     goals: readonly UserGoal[];
     upcomingFixedActivities: readonly FixedActivity[];
@@ -84,10 +92,12 @@ function renderDataHandoff(input: ContextBriefPlanningHandoffInput): string {
         .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))[0] ?? null;
 
     const modeDetail = input.externalFallback
-        ? `${input.planningMode} (external-plan fallback today: no imported session is placed on this date)`
+        ? (input.externalFallbackUncertain
+            ? `${input.effectivePlanningMode} (external-plan fallback today: UNCONFIRMED — today's external plan schedule could not be read, so this may reflect an unreadable session rather than a confirmed absence)`
+            : `${input.effectivePlanningMode} (external-plan fallback today: no imported session is placed on this date)`)
         : input.eventStrategy
-            ? `${input.planningMode} (${input.eventStrategy.replace('_', ' ')})`
-            : input.planningMode;
+            ? `${input.effectivePlanningMode} (${input.eventStrategy.replace('_', ' ')})`
+            : input.effectivePlanningMode;
 
     const lines: string[] = [
         '## 0. Planning handoff & data currency',
@@ -249,7 +259,9 @@ function renderPrescriptionStep(step: ExternalPrescriptionStep): string {
     if (step.durationMin !== undefined) dose.push(`${step.durationMin} min`);
     if (step.durationSec !== undefined) dose.push(`${step.durationSec} s`);
     if (step.target) dose.push(step.target);
+    if (step.recoveryMin !== undefined) dose.push(`${step.recoveryMin} min recovery`);
     if (step.recoverySec !== undefined) dose.push(`${step.recoverySec}s recovery`);
+    if (step.setRecoveryMin !== undefined) dose.push(`${step.setRecoveryMin} min set recovery`);
     if (step.setRecoverySec !== undefined) dose.push(`${step.setRecoverySec}s set recovery`);
     if (step.notes) dose.push(compactText(step.notes));
     return dose.length > 0 ? `${step.name}: ${dose.join(' · ')}` : step.name;
@@ -318,10 +330,13 @@ function renderUpcoming(input: ContextBriefPlanningHandoffInput): string {
         'Preserve these when proposing days unless the user explicitly asks to move, replace or re-plan them. Authored travel blocks scale the surrounding plan rather than representing an extra workout.',
     ];
 
+    const fallbackUncertainNote = input.externalFallbackUncertain
+        ? ' Today\'s external plan schedule could not be read, so this is unconfirmed — treat it as unreadable, not as a confirmed absence.'
+        : '';
     if (input.externalFallback && external.length === 0) {
-        lines.push('', '> External-plan fallback is active today and no imported session is visible in this 7-day horizon. Do not silently invent a replacement block; the imported block may have ended, start later, or be unavailable.');
+        lines.push('', `> External-plan fallback is active today and no imported session is visible in this 7-day horizon. Do not silently invent a replacement block; the imported block may have ended, start later, or be unavailable.${fallbackUncertainNote}`);
     } else if (input.externalFallback && external.length > 0) {
-        lines.push('', '> External-plan fallback is active today because no imported session is placed today; imported sessions later in this horizon remain authoritative on their placed dates, subject to readiness/safety gating.');
+        lines.push('', `> External-plan fallback is active today because no imported session is placed today; imported sessions later in this horizon remain authoritative on their placed dates, subject to readiness/safety gating.${fallbackUncertainNote}`);
     }
 
     if (rows.length === 0) {

--- a/app/src/services/contextBriefService.test.ts
+++ b/app/src/services/contextBriefService.test.ts
@@ -191,6 +191,32 @@ describe('ContextBriefService', () => {
         expect(result.text).toContain('fixed-activity occupancy unavailable');
     });
 
+    it('marks external fallback as unconfirmed, not a confirmed absence, when only today\'s plan-state read fails', async () => {
+        services.getProfileState.mockResolvedValue({
+            status: 'AVAILABLE',
+            data: {
+                userId: 'u1',
+                planningMode: 'externally_planned',
+                priorities: [],
+                weeklyCommitment: { minSessions: 3, targetSessions: 5, maxSessions: 6 },
+                organizationPreference: 'auto',
+                schemaVersion: 1,
+                createdAt: '2026-01-01T00:00:00Z',
+                updatedAt: '2026-01-01T00:00:00Z',
+            },
+        });
+        services.getActivePlanState.mockImplementation(async (_userId: string, date: string) => {
+            if (date === AS_OF) return { status: 'UNAVAILABLE', operation: 'read plan', retryable: true };
+            return { status: 'MISSING' };
+        });
+        const result = await new ContextBriefService().build('u1', AS_OF, 14);
+
+        expect(result.unavailableSources).toContain('external plan schedule (1 day(s) unreadable)');
+        expect(result.text).toContain('external-plan fallback today: UNCONFIRMED');
+        expect(result.text).toContain('could not be read, so this may reflect an unreadable session rather than a confirmed absence');
+        expect(result.text).not.toContain('external-plan fallback today: no imported session is placed on this date');
+    });
+
     it('renders an imported future session and its authored prescription into the copied handoff', async () => {
         services.getActivePlanState.mockImplementation(async (_userId: string, date: string) => {
             if (date !== '2026-08-17') return { status: 'MISSING' };

--- a/app/src/services/contextBriefService.ts
+++ b/app/src/services/contextBriefService.ts
@@ -20,7 +20,7 @@ import { externalSessionDisplayPrescription } from '../engine/externalSessionPro
 import { resolvePlanningContext } from '../engine/planningMode';
 import { evaluatePeriodizationPhase, goalToUserEvent } from '../engine/periodization';
 import { parseSubjectiveCheckin } from '../persistence/parsers/decisionInputs';
-import type { AnyExternalPlanSession } from '../sessions/externalPlanV2';
+import { isV2Session, type AnyExternalPlanSession } from '../sessions/externalPlanV2';
 import { addDaysToLocalDateString, getLocalDateString } from '../utils/localDate';
 import { activeExternalPlanService, placedSessionForDate } from './activeExternalPlanService';
 import { activityService } from './activityService';
@@ -54,7 +54,7 @@ export interface ContextBriefResult {
  * context's externalSession is deliberately not consumed by this brief.
  */
 function planningAuthoritySession(session: AnyExternalPlanSession): LegacyExternalPlanSession {
-    if ('prescription' in session) return session;
+    if (!isV2Session(session)) return session;
     return {
         id: session.id,
         title: session.title,
@@ -238,6 +238,12 @@ export class ContextBriefService {
 
         const upcomingExternalSessions: UpcomingExternalPlanSession[] = [];
         let currentExternalSession: AnyExternalPlanSession | null = null;
+        // Whether "no session placed today" can be asserted as a confirmed fact. Starts
+        // false whenever occupancy itself is unreadable (the else branch below), and is
+        // also cleared if today's own plan-state read specifically fails, so a resolved
+        // `externalFallback: true` downstream is never presented as certain when the day
+        // that mattered most could not actually be read.
+        let externalScheduleTodayConfirmed = fixedActivitiesReadable;
         if (fixedActivitiesReadable) {
             // Resolve the active plan independently for each future date so plan revision
             // effective-from boundaries and overlapping re-imports are respected. Use the
@@ -252,12 +258,14 @@ export class ContextBriefService {
                 const settled = activePlanResults[index];
                 if (settled.status === 'rejected') {
                     unreadablePlanDays += 1;
+                    if (date === targetDate) externalScheduleTodayConfirmed = false;
                     continue;
                 }
                 const state = settled.value;
                 if (state.status === 'MISSING') continue;
                 if (state.status !== 'AVAILABLE') {
                     unreadablePlanDays += 1;
+                    if (date === targetDate) externalScheduleTodayConfirmed = false;
                     continue;
                 }
                 if (date === targetDate) {
@@ -305,6 +313,12 @@ export class ContextBriefService {
             targetDate,
             currentExternalSession ? planningAuthoritySession(currentExternalSession) : null,
         );
+        // resolvePlanningContext treats a null externalSession as "confirmed nothing is
+        // placed today" and reports externalFallback accordingly. That is only true when
+        // today's own plan-state read actually succeeded; when it didn't,
+        // externalScheduleTodayConfirmed is false and the fallback claim is unconfirmed,
+        // not negative.
+        const externalFallbackUncertain = planningContext.externalFallback && !externalScheduleTodayConfirmed;
 
         const input: ContextBriefInput = {
             asOfDate: targetDate,
@@ -328,8 +342,9 @@ export class ContextBriefService {
             recommendations,
             trainingSettings,
             preferences,
-            planningMode: planningContext.mode,
+            effectivePlanningMode: planningContext.mode,
             externalFallback: planningContext.externalFallback,
+            externalFallbackUncertain,
             eventStrategy: planningContext.eventStrategy,
             goals,
             upcomingFixedActivities,


### PR DESCRIPTION
## Summary

- Reviewed #141 (planning-handoff layer) and found the whole-app ADR-0017 architecture guard (`planningModeArchitecture.test.ts`) was **failing on that branch** — `contextBriefPlanningHandoff.ts` reads a field named `planningMode` on its input, and the guard flags any `.planningMode` property read outside the authority module by name, regardless of type. Renamed `ContextBriefPlanningHandoffInput.planningMode` → `effectivePlanningMode` (it's already-resolved `PlanningContext.mode`, not the persisted `TrainingIntentProfile.planningMode`) so the guard can't collide with it. `npm run check` is red on `feat/context-brief-planning-handoff-v2` without this.
- Imported-session prescription steps with `recoveryMin`/`setRecoveryMin` (minute-denominated recovery, as opposed to `recoverySec`/`setRecoverySec`) were silently dropped from the copied handoff text — real dose data missing from the document an external planner reads.
- When today's own external-plan read fails (rejected promise, or a non-`AVAILABLE`/non-`MISSING` state) while occupancy is otherwise readable, the brief asserted "no imported session is placed on this date" as a confirmed fact. It's actually unknown. The brief now says `UNCONFIRMED` in that case, consistent with the PR's own stated fail-closed intent for the fixed-activity-occupancy-unreadable case.
- `planningAuthoritySession()` reimplemented the v1/v2 session discriminator inline; switched to the existing `isV2Session()` helper to avoid drift.

## Validation

Results:
- `cd app && npm run check` (typecheck + lint + vitest + workout catalog validation): pass — 1795 passed, 83 skipped, including the previously-failing `planningModeArchitecture.test.ts` guard.

## Risk and reviewer guidance

Scoped entirely to `app/src/engine/contextBriefPlanningHandoff.ts` and `app/src/services/contextBriefService.ts` (plus their tests) — the same two files #141 touches. No behavior changes to the retrospective brief, baseline/recovery logic, or any other planning-mode consumer. The field rename is mechanical and covered by the type checker; the two fail-closed/data-loss fixes each have new unit coverage at both the renderer and service-integration level.

## Domain invariants

- [x] Firestore writes remain user-scoped — not applicable, this brief is read-only.
- [x] Calendar-date logic uses `Europe/Warsaw` — unchanged.
- [x] No credentials, tokens, or raw health payloads included.
- [ ] Recommendation decision logic — not applicable, this only changes a copied-text export, not recommendation output.

## Screenshots or recordings

Not applicable — text-export changes only, no UI.

---

Targets `feat/context-brief-planning-handoff-v2` (PR #141's head) rather than `main`, since these are fixes to that PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_019CiXDWiN4zSiBS9orahfLr)_