### PR TITLE
Expose frontend build commit SHA

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -117,6 +117,8 @@ jobs:
           VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
           VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
           VITE_FIREBASE_MEASUREMENT_ID: ${{ secrets.VITE_FIREBASE_MEASUREMENT_ID }}
+          VITE_GIT_SHA: ${{ github.sha }}
+          VITE_GIT_DIRTY: "false"
         run: npm run build
 
       # `npm exec --no --` (rather than bare `npx`) refuses to fall back to fetching an

--- a/app/src/buildInfo.ts
+++ b/app/src/buildInfo.ts
@@ -1,0 +1,9 @@
+const gitSha = import.meta.env.VITE_GIT_SHA?.trim() || 'unknown';
+const dirty = import.meta.env.VITE_GIT_DIRTY === 'true';
+
+export const buildInfo = {
+  gitSha,
+  shortGitSha: gitSha === 'unknown' ? gitSha : gitSha.slice(0, 7),
+  dirty,
+  label: `${gitSha === 'unknown' ? gitSha : gitSha.slice(0, 7)}${dirty ? '-dirty' : ''}`,
+} as const;

--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useEffect } from 'react';
 import type { Screen } from '../types/navigation';
 import { getAuthInstance } from '../firebase';
+import { buildInfo } from '../buildInfo';
 import { GarminSyncBadge } from './GarminSyncBadge';
 
 interface HeaderProps {
@@ -48,6 +49,8 @@ export const Header: React.FC<HeaderProps> = ({
     const { signOut } = await import('firebase/auth');
     await signOut(getAuthInstance());
   };
+
+  const buildTitle = `Git commit ${buildInfo.gitSha}${buildInfo.dirty ? ' (local working tree has uncommitted changes)' : ''}`;
 
   return (
     <header className="global-navbar">
@@ -143,6 +146,15 @@ export const Header: React.FC<HeaderProps> = ({
                 >
                   <span className="item-icon">⚙️</span> Coach Preferences
                 </button>
+                <div className="dropdown-divider" />
+                <div
+                  className="dropdown-item"
+                  title={buildTitle}
+                  aria-label={`Build ${buildInfo.label}`}
+                  style={{ cursor: 'default', opacity: 0.72 }}
+                >
+                  <span className="item-icon">ℹ️</span> Build {buildInfo.label}
+                </div>
                 <div className="dropdown-divider" />
                 <button className="dropdown-item logout" onClick={handleLogout} role="menuitem">
                   <span className="item-icon">🚪</span> Sign Out

--- a/app/src/components/MobileNav.tsx
+++ b/app/src/components/MobileNav.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useEffect } from 'react';
 import type { Screen } from '../types/navigation';
 import { getAuthInstance } from '../firebase';
+import { buildInfo } from '../buildInfo';
 
 interface MobileNavProps {
   screen: Screen;
@@ -62,6 +63,8 @@ export const MobileNav: React.FC<MobileNavProps> = ({ screen, handleNavigate, lo
     const { signOut } = await import('firebase/auth');
     await signOut(getAuthInstance());
   };
+
+  const buildTitle = `Git commit ${buildInfo.gitSha}${buildInfo.dirty ? ' (local working tree has uncommitted changes)' : ''}`;
 
   return (
     <>
@@ -181,6 +184,23 @@ export const MobileNav: React.FC<MobileNavProps> = ({ screen, handleNavigate, lo
                   <span className="item-sub">Compile recent metrics & prompt for your AI</span>
                 </div>
               </button>
+
+              <div className="drawer-divider" />
+
+              <div
+                className="drawer-item"
+                title={buildTitle}
+                aria-label={`Build ${buildInfo.label}`}
+                style={{ cursor: 'default', opacity: 0.72 }}
+              >
+                <span className="item-icon">ℹ️</span>
+                <div className="item-text">
+                  <span className="item-title">Build {buildInfo.label}</span>
+                  <span className="item-sub">
+                    {buildInfo.dirty ? 'Local working tree has uncommitted changes' : 'Exact Git commit for this app build'}
+                  </span>
+                </div>
+              </div>
 
               <div className="drawer-divider" />
 

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -1,8 +1,26 @@
+import { execFileSync } from 'node:child_process';
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 import { VitePWA } from 'vite-plugin-pwa';
 
+function readGit(args: string[]): string | undefined {
+  try {
+    return execFileSync('git', args, { encoding: 'utf8' }).trim();
+  } catch {
+    return undefined;
+  }
+}
+
+const gitSha = process.env.VITE_GIT_SHA?.trim() || readGit(['rev-parse', 'HEAD']) || 'unknown';
+const gitDirty = process.env.VITE_GIT_DIRTY !== undefined
+  ? process.env.VITE_GIT_DIRTY === 'true'
+  : Boolean(readGit(['status', '--porcelain']));
+
 export default defineConfig({
+  define: {
+    'import.meta.env.VITE_GIT_SHA': JSON.stringify(gitSha),
+    'import.meta.env.VITE_GIT_DIRTY': JSON.stringify(String(gitDirty)),
+  },
   plugins: [
     react(),
     VitePWA({


### PR DESCRIPTION
## Summary
- stamp Firebase frontend builds with the exact GitHub Actions commit SHA
- derive the same metadata from the local Git checkout when running/building locally
- mark local builds as `-dirty` when tracked/untracked working-tree changes are present
- show the short build SHA in desktop Settings and the mobile More drawer, with the full SHA in the title/tooltip

## Why
This makes it possible to answer which source revision is actually running without inferring it from deployment history. Garmin Sync already uses commit-SHA-tagged container images; this brings equivalent traceability to the frontend.

## Behavior
- deployed via GitHub Actions: `Build abcdef1`
- local clean checkout: `Build abcdef1`
- local checkout with uncommitted changes: `Build abcdef1-dirty`
- if Git metadata cannot be resolved: `Build unknown`

## Validation
The normal PR CI pipeline should run the frontend typecheck/lint/tests/build, Python checks, and Docker build.