### PR TITLE
Fix CI handling for intentional Firestore rules drift

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -23,10 +23,15 @@ on:
         required: true
         default: true
       deploy_rules:
-        description: "Deploy app/firestore.rules (drift-checked first; refuses to overwrite on mismatch)"
+        description: "Deploy app/firestore.rules"
         type: boolean
         required: true
         default: true
+      confirm_rules_drift:
+        description: "I reviewed Firestore rules drift and intend to replace production with the repo version"
+        type: boolean
+        required: true
+        default: false
 
 permissions:
   contents: read
@@ -128,12 +133,20 @@ jobs:
         if: ${{ inputs.deploy_hosting }}
         run: npm exec --no -- firebase deploy --only hosting --project "${GCP_PROJECT}" --non-interactive
 
-      # Fails closed on drift, same as the documented local procedure: if the deployed rules
-      # don't match app/firestore.rules, stop here rather than overwrite blindly. Investigate
-      # (docs/ops/firestore-rules-deployment.md#drift-and-remediation) and rerun once resolved.
-      - name: Check Firestore rules drift (safety gate)
-        if: ${{ inputs.deploy_rules }}
+      # Default path remains fail-closed: unexpected drift stops the run before any rules
+      # deployment. This is the safe choice for ordinary frontend/rules deploys.
+      - name: Check Firestore rules drift (fail closed)
+        if: ${{ inputs.deploy_rules && !inputs.confirm_rules_drift }}
         run: npm run firestore:rules:drift
+
+      # An intentional repository rules change necessarily means local != deployed before
+      # deployment. The operator must explicitly acknowledge that mismatch in workflow_dispatch.
+      # --allow-drift only changes this pre-deploy gate; the deployment script still saves the
+      # active ruleset for rollback, runs the emulator suite, deploys only Firestore rules, and
+      # verifies the deployed source hash matches app/firestore.rules afterwards.
+      - name: Acknowledge reviewed Firestore rules drift
+        if: ${{ inputs.deploy_rules && inputs.confirm_rules_drift }}
+        run: npm run firestore:rules:drift -- --allow-drift
 
       - name: Deploy Firestore security rules
         if: ${{ inputs.deploy_rules }}

--- a/docs/ops/frontend-deployment.md
+++ b/docs/ops/frontend-deployment.md
@@ -62,20 +62,33 @@ frontend from a local machine before.
 ## Deploy
 
 Run the **Deploy Frontend & Firestore Rules** workflow (Actions tab -> select it -> Run
-workflow). Two independent inputs, both default on:
+workflow). It has three inputs:
 
 * `deploy_hosting` -- runs `npm run build` (which runs the full `npm run check`: typecheck,
   lint, unit tests, workout-catalog validation -- never deploys a build that hasn't passed
   those) then `firebase deploy --only hosting`.
-* `deploy_rules` -- mirrors the local procedure in
-  [`firestore-rules-deployment.md`](./firestore-rules-deployment.md): a drift check first
-  (fails closed if the deployed rules don't match `app/firestore.rules` -- investigate rather
-  than override, same as the local flow), then the emulator test suite, then the deploy, then
-  a post-deploy hash re-check.
+* `deploy_rules` -- runs the Firestore rules safety/deployment flow.
+* `confirm_rules_drift` -- defaults to `false`. Leave it off for ordinary runs. If the
+  deployed production rules differ from `app/firestore.rules`, the run stops before changing
+  production. Turn it on only after reviewing the mismatch and intentionally choosing the
+  repository version as the next production ruleset.
 
-Turn either off to deploy just one side -- e.g. `deploy_rules: false` for a frontend-only
-change, or `deploy_hosting: false` to ship a reviewed rules change without also cutting a new
-Hosting release.
+For an intentional rules change, `confirm_rules_drift: true` acknowledges only the expected
+pre-deployment mismatch. It does **not** bypass the rest of the safety flow: the existing
+rules deployment script still saves the active ruleset for rollback, runs the mandatory
+Firestore emulator tests, deploys only `firestore:rules`, reads production back, and fails if
+the deployed source hash does not exactly match `app/firestore.rules`.
+
+This gives a phone-only recovery path for legitimate drift without weakening the default:
+
+1. Run with `deploy_rules: true` and `confirm_rules_drift: false` first.
+2. If the drift gate fails, review the production-vs-repository difference in Firebase/GitHub.
+3. If the repository version is the intended reviewed version, rerun with
+   `confirm_rules_drift: true`.
+
+Turn either deployment target off to deploy just one side -- e.g. `deploy_rules: false` for a
+frontend-only change, or `deploy_hosting: false` to ship a reviewed rules change without also
+cutting a new Hosting release.
 
 ## Rollback stays local
 


### PR DESCRIPTION
## Summary

Fixes the `Deploy Frontend & Firestore Rules` workflow so legitimate Firestore rules changes can be deployed from GitHub Actions without requiring a local PC, while preserving fail-closed behavior by default.

## What changes

- adds `confirm_rules_drift` manual workflow input, default `false`
- ordinary runs still fail immediately when deployed Firestore rules differ from `app/firestore.rules`
- when drift was explicitly reviewed and `confirm_rules_drift` is enabled, CI runs the existing drift checker with `--allow-drift` and continues
- the actual deploy path remains unchanged and still:
  - saves the active production ruleset metadata for rollback
  - runs the mandatory Firestore emulator suite
  - deploys only Firestore security rules
  - reads production back and verifies its SHA-256 exactly matches `app/firestore.rules`
- documents the phone-only remediation flow

## Why

The previous workflow made every intentional rules change impossible to deploy through CI: the pre-deploy drift gate failed whenever the repository candidate differed from production, so the already-safe confirmed deployment script was never reached.

The new explicit acknowledgement distinguishes expected reviewed drift from unexpected production drift without weakening the default safety gate.

## Current incident

Run `32446344892` showed:

- local SHA-256: `59ffe7c34d213aada0dfe39769fb2d116092cfca1b18ec96cec39f9280b728c2`
- deployed SHA-256: `eda7fc1bbf0f1072d44397ff068ce557f0b49c790e40f31819dd79e147b56385`

After this PR is merged, the intended repository rules can be deployed from the Actions UI by running rules deployment with `confirm_rules_drift: true` after reviewing the mismatch.