### PR TITLE
Stop dev-cache fallback from logging a misleading JSON parse error

### DIFF
--- a/app/src/services/localDataService.test.ts
+++ b/app/src/services/localDataService.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { LocalDataService } from './localDataService';
+
+function jsonResponse(body: unknown): Response {
+    return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+    });
+}
+
+function htmlFallbackResponse(): Response {
+    // What a SPA host (or a Vite dev server with no raw_cache.json fixture in
+    // app/public) actually returns for an unmatched static path: index.html, 200 OK.
+    return new Response('<!doctype html><html></html>', {
+        status: 200,
+        headers: { 'content-type': 'text/html' },
+    });
+}
+
+describe('LocalDataService', () => {
+    const fetchSpy = vi.fn();
+
+    beforeEach(() => {
+        fetchSpy.mockReset();
+        vi.stubGlobal('fetch', fetchSpy);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.unstubAllEnvs();
+    });
+
+    it('never fetches the dev fixture outside DEV (no build ever ships raw_cache.json)', async () => {
+        vi.stubEnv('DEV', false);
+        const service = new LocalDataService();
+
+        const snapshot = await service.getRecoverySnapshot('2026-08-21', 'u1');
+
+        expect(snapshot).toBeNull();
+        expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('treats an HTML SPA-fallback response as "no cache" instead of a JSON parse error', async () => {
+        vi.stubEnv('DEV', true);
+        fetchSpy.mockResolvedValue(htmlFallbackResponse());
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        const service = new LocalDataService();
+
+        const snapshot = await service.getRecoverySnapshot('2026-08-21', 'u1');
+
+        expect(snapshot).toBeNull();
+        expect(errorSpy).not.toHaveBeenCalled();
+    });
+
+    it('caches a miss so repeated lookups do not keep re-fetching', async () => {
+        vi.stubEnv('DEV', true);
+        fetchSpy.mockResolvedValue(htmlFallbackResponse());
+        const service = new LocalDataService();
+
+        await service.getRecoverySnapshot('2026-08-19', 'u1');
+        await service.getRecoverySnapshot('2026-08-20', 'u1');
+        await service.getAvailableDates();
+
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('still reads a real fixture in DEV when one is present', async () => {
+        vi.stubEnv('DEV', true);
+        fetchSpy.mockResolvedValue(jsonResponse({ '2026-08-21': { sleepScore: 80 } }));
+        const service = new LocalDataService();
+
+        const snapshot = await service.getRecoverySnapshot('2026-08-21', 'u1');
+
+        expect(snapshot?.raw.sleepScore).toBe(80);
+    });
+});

--- a/app/src/services/localDataService.ts
+++ b/app/src/services/localDataService.ts
@@ -31,17 +31,32 @@ export class LocalDataService {
             return this.cacheData;
         }
 
+        // This fixture is a dev-only convenience for local testing without Firestore --
+        // no build ever ships a raw_cache.json static asset. In production (and in dev
+        // when nobody has dropped the fixture in app/public), the request either 404s or
+        // -- on a host that rewrites unmatched paths for SPA routing -- resolves to
+        // index.html with a 200. Either way there is no cache to read, and that is the
+        // expected, common case (e.g. every morning before Garmin sync has produced
+        // today's snapshot), not an error worth alarming the console over.
+        if (!import.meta.env.DEV) {
+            this.cacheData = {};
+            return this.cacheData;
+        }
+
         try {
-            // In development, we can import the JSON file directly
             const response = await fetch('/raw_cache.json');
-            if (!response.ok) {
-                throw new Error('Failed to load cache file');
+            const contentType = response.headers.get('content-type') ?? '';
+            if (!response.ok || !contentType.includes('application/json')) {
+                this.cacheData = {};
+                return this.cacheData;
             }
-            this.cacheData = await response.json();
-            return this.cacheData || {};
+            const parsed: Record<string, RawCacheSnapshot> = (await response.json()) ?? {};
+            this.cacheData = parsed;
+            return parsed;
         } catch (error) {
             console.error('Error loading local cache:', error);
-            return {};
+            this.cacheData = {};
+            return this.cacheData;
         }
     }
 


### PR DESCRIPTION
## Summary

- `localDataService`'s `raw_cache.json` fallback fires whenever Firestore has no recovery snapshot yet for today — a routine, expected state (e.g. every morning before the Garmin sync job has produced today's document), not an error.
- No build ships a `raw_cache.json` static asset, so the fetch either 404s or — on a host that rewrites unmatched paths for SPA routing (Firebase Hosting included) — resolves to `index.html` with `200 OK`. The old code JSON-parsed that HTML and logged `Error loading local cache: SyntaxError: Unexpected token '<', "<!doctype "... is not valid JSON`, even though the fallback correctly resolved to "no local cache" either way.
- `loadCacheData` now: skips the network request entirely outside dev (`import.meta.env.DEV`, since production never has this fixture to find); checks the response `content-type` before parsing, so an HTML SPA-fallback page is treated as an expected miss instead of a parse failure; and caches a miss (not just a hit), so repeated snapshot/date lookups stop re-fetching a request that can never succeed.
- No user-visible change to *why* a recovery snapshot is missing — that's still driven entirely by whether the Garmin sync job has written today's Firestore document. This only stops that ordinary condition from masquerading as a JSON parsing bug in the console.

## Validation

Results:
- `cd app && npm run check` (typecheck, lint, `vitest run`, workout catalog validation): pass — 161 test files / 1816 tests passed, 1 file / 86 tests skipped (pre-existing skips), 0 lint errors (2 pre-existing unrelated warnings).
- Added `app/src/services/localDataService.test.ts` covering: no fetch outside `DEV`; HTML SPA-fallback response treated as a silent miss (no `console.error`); miss is cached across repeated lookups; a real JSON fixture in `DEV` still loads correctly.

## Risk and reviewer guidance

Low risk: this only touches the dev-only local-cache fallback path inside `LocalDataService`, which is consulted after an authoritative Firestore read already misses (see `recoverySnapshotService.ts`). It changes logging/caching behavior on that fallback, not the Firestore read path, the Garmin sync pipeline, or any recommendation logic.

## Domain invariants

Not applicable — this change touches only client-side error handling/caching for a dev fixture fallback; no Firestore writes, date logic, credentials, or recommendation decision logic are involved.

## Screenshots or recordings

Not applicable — the change is a console-logging/caching fix with no visible UI change (the "recovery snapshot missing" UI state, when Garmin data genuinely hasn't synced yet, is unchanged).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_019YGhcgbydB2syhNrn9gih7)_