### PR TITLE
fix: grant github-deployer write access to the Garmin token bucket

### DIFF
--- a/docs/ops/setup-workload-identity.sh
+++ b/docs/ops/setup-workload-identity.sh
@@ -167,6 +167,15 @@ gcloud iam service-accounts add-iam-policy-binding "${DEPLOYER_SA_EMAIL}" \
   --role="roles/iam.workloadIdentityUser" \
   --member="principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL_ID}/attribute.repository/${GITHUB_REPO}"
 
+# garmin-token-bootstrap.yml authenticates as github-deployer too (it's the only WIF
+# identity granted to this repo) and uploads the bootstrapped token straight to this
+# bucket -- without this it gets a 403 on upload that GcsTokenStore.persist() used to
+# swallow silently. Bucket-scoped, matching how garmin-sync-job's own access to this
+# bucket (above) is scoped rather than a project-wide storage role.
+echo "==> Allowing github-deployer to upload the bootstrapped token to the token bucket"
+gcloud storage buckets add-iam-policy-binding "gs://${TOKEN_BUCKET}" \
+  --member="serviceAccount:${DEPLOYER_SA_EMAIL}" --role="roles/storage.objectAdmin" >/dev/null
+
 echo "==> Creating github-frontend-deployer service account (skipping if it already exists)"
 if ! gcloud iam service-accounts describe "${FRONTEND_DEPLOYER_SA_EMAIL}" >/dev/null 2>&1; then
   gcloud iam service-accounts create "${FRONTEND_DEPLOYER_SA_NAME}" \

--- a/scripts/bootstrap_garmin_tokens.py
+++ b/scripts/bootstrap_garmin_tokens.py
@@ -56,7 +56,14 @@ def bootstrap(bucket_name: str | None = None, object_name: str = "garmin/garmin_
 
     print(f"Uploading token file to gs://{bucket}/{object_name}...")
     gcs_store = GcsTokenStore(bucket_name=bucket, object_name=object_name)
-    gcs_store.persist(local_file)
+    if not gcs_store.persist(local_file):
+        raise RuntimeError(
+            f"Upload to gs://{bucket}/{object_name} failed -- see the 'Failed to upload "
+            "token file to GCS' error above for the underlying cause (a missing IAM binding "
+            "on the token bucket for the identity running this script is the usual one). "
+            "Login succeeded and tokens were saved locally, but the Cloud Run job still has "
+            "no token to read until this upload succeeds."
+        )
     print("Token bootstrap completed successfully!")
 
 

--- a/src/garmin_sync/token_store.py
+++ b/src/garmin_sync/token_store.py
@@ -69,8 +69,8 @@ class TokenStore(Protocol):
         """Restore single token JSON file to destination path. Return True if restored successfully."""
         ...
 
-    def persist(self, source: Path) -> None:
-        """Persist refreshed token JSON file from local path to storage backend."""
+    def persist(self, source: Path) -> bool:
+        """Persist refreshed token JSON file from local path to storage backend. Return True if persisted successfully."""
         ...
 
 
@@ -94,11 +94,11 @@ class LocalTokenStore:
         logger.info(f"Restored tokens from local store file '{self.storage_file}'.")
         return True
 
-    def persist(self, source: Path) -> None:
+    def persist(self, source: Path) -> bool:
         source_path = Path(source).expanduser().resolve()
         if not source_path.exists() or source_path.is_dir():
             logger.warning(f"Source token file '{source_path}' does not exist. Nothing to persist.")
-            return
+            return False
 
         if source_path != self.storage_file:
             self.storage_file.parent.mkdir(parents=True, exist_ok=True)
@@ -106,6 +106,7 @@ class LocalTokenStore:
 
         _set_secure_permissions(self.storage_file)
         logger.info(f"Persisted tokens to local store file '{self.storage_file}'.")
+        return True
 
 
 class GcsTokenStore:
@@ -150,23 +151,23 @@ class GcsTokenStore:
             _set_secure_permissions(dest_path)
             logger.info(f"Restored GCS token file to '{dest_path}'.")
             return True
-        except Exception:
-            logger.warning("Failed to restore token file from GCS.")
+        except Exception as e:
+            logger.warning(f"Failed to restore token file from GCS: {type(e).__name__}: {e}")
             return False
 
-    def persist(self, source: Path) -> None:
+    def persist(self, source: Path) -> bool:
         source_path = Path(source).expanduser().resolve()
         if not source_path.exists() or source_path.is_dir():
             logger.warning(
                 f"Source token file '{source_path}' does not exist. Skipping GCS upload."
             )
-            return
+            return False
 
         try:
             from google.cloud import storage  # type: ignore[attr-defined]
         except ImportError:
             logger.error("google-cloud-storage is required for GcsTokenStore.")
-            return
+            return False
 
         try:
             client = storage.Client()
@@ -177,8 +178,16 @@ class GcsTokenStore:
             logger.info(
                 f"Successfully persisted refreshed token file to gs://{self.bucket_name}/{self.object_name}."
             )
-        except Exception:
-            logger.error("Failed to upload token file to GCS.")
+            return True
+        except Exception as e:
+            # Surface the real cause (e.g. a 403 from a missing IAM binding on the token
+            # bucket) instead of swallowing it -- callers that must know upload succeeded
+            # (see bootstrap_garmin_tokens.py) rely on both this message and the return value.
+            logger.error(
+                f"Failed to upload token file to gs://{self.bucket_name}/{self.object_name}: "
+                f"{type(e).__name__}: {e}"
+            )
+            return False
 
 
 def create_token_store(

--- a/tests/test_bootstrap_garmin_tokens.py
+++ b/tests/test_bootstrap_garmin_tokens.py
@@ -1,3 +1,7 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import bootstrap_garmin_tokens
 import pyotp
 import pytest
 from bootstrap_garmin_tokens import _mfa_prompt
@@ -48,3 +52,46 @@ def test_mfa_prompt_falls_back_to_input_when_neither_is_set(
     prompt = _mfa_prompt()
 
     assert prompt() == "654321"
+
+
+class _StubGarminClientWrapper:
+    """Login succeeds and writes a token file, without touching the real Garmin API."""
+
+    def __init__(self, **_kwargs) -> None:
+        pass
+
+    def login_with_tokens_or_credentials(self, token_path: Path) -> None:
+        token_path = Path(token_path)
+        token_path.parent.mkdir(parents=True, exist_ok=True)
+        token_path.write_text("{}")
+
+
+class _StubGcsTokenStoreUploadFails:
+    """Mirrors a GcsTokenStore.persist() that ran into e.g. a 403 from a missing IAM
+    binding -- returns False rather than raising, same as the real implementation."""
+
+    def __init__(self, bucket_name: str, object_name: str) -> None:
+        self.bucket_name = bucket_name
+        self.object_name = object_name
+
+    def persist(self, source: Path) -> bool:
+        return False
+
+
+def test_bootstrap_raises_when_gcs_upload_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A failed upload must fail the script loudly (see token_store.py's persist()) instead
+    of printing 'Token bootstrap completed successfully!' with no token actually in GCS."""
+    settings = SimpleNamespace(
+        garmin_token_path=str(tmp_path / "tokens.json"),
+        garmin_email="user@example.com",
+        garmin_password="secret",
+        garmin_token_bucket=None,
+    )
+    monkeypatch.setattr(bootstrap_garmin_tokens, "load_settings", lambda: settings)
+    monkeypatch.setattr(bootstrap_garmin_tokens, "GarminClientWrapper", _StubGarminClientWrapper)
+    monkeypatch.setattr(bootstrap_garmin_tokens, "GcsTokenStore", _StubGcsTokenStoreUploadFails)
+
+    with pytest.raises(RuntimeError, match="Upload to gs://my-bucket"):
+        bootstrap_garmin_tokens.bootstrap(bucket_name="my-bucket")

--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -1,6 +1,8 @@
+from pathlib import Path
+
 import pytest
 
-from garmin_sync.token_store import GcsTokenStore
+from garmin_sync.token_store import GcsTokenStore, LocalTokenStore
 
 
 @pytest.mark.parametrize(
@@ -9,3 +11,18 @@ from garmin_sync.token_store import GcsTokenStore
 def test_gcs_token_store_rejects_traversing_object_names(object_name: str) -> None:
     with pytest.raises(ValueError, match="non-traversing"):
         GcsTokenStore(bucket_name="bucket", object_name=object_name)
+
+
+def test_local_token_store_persist_returns_true_on_success(tmp_path: Path) -> None:
+    source = tmp_path / "source.json"
+    source.write_text("{}")
+    store = LocalTokenStore(local_path=tmp_path / "store" / "tokens.json")
+
+    assert store.persist(source) is True
+    assert store.storage_file.exists()
+
+
+def test_local_token_store_persist_returns_false_when_source_missing(tmp_path: Path) -> None:
+    store = LocalTokenStore(local_path=tmp_path / "store" / "tokens.json")
+
+    assert store.persist(tmp_path / "missing.json") is False


### PR DESCRIPTION
## Summary

- Root cause of the `garmin-sync` Cloud Run job failing with `GarminConnectAuthenticationError` on every run: `garmin-token-bootstrap.yml` authenticates as `github-deployer`, but `setup-workload-identity.sh` only ever granted `garmin-sync-job` (the Cloud Run runtime SA) `storage.objectAdmin` on the token bucket — `github-deployer` had no access to it, so the bootstrap workflow's GCS upload was silently failing on every run.
- The failure was invisible: `GcsTokenStore.persist()` swallowed the upload exception and logged only a bare `"Failed to upload token file to GCS."` with no underlying cause, and `bootstrap_garmin_tokens.py` never checked whether `persist()` actually succeeded before printing `"Token bootstrap completed successfully!"` — so the bootstrap workflow went green with no token ever reaching the bucket.
- Fixes:
  - `docs/ops/setup-workload-identity.sh`: grant `github-deployer` `storage.objectAdmin` on the token bucket (bucket-scoped, mirroring `garmin-sync-job`'s own grant).
  - `src/garmin_sync/token_store.py`: `persist()` now returns `bool` and logs the real exception (`type(e).__name__: e`) instead of swallowing it, for both `LocalTokenStore` and `GcsTokenStore` (and `GcsTokenStore.restore()`'s error log was fixed the same way).
  - `scripts/bootstrap_garmin_tokens.py`: raises (failing the workflow) when the GCS upload didn't actually succeed, instead of always printing success.
- Operational impact: an operator who already ran `setup-workload-identity.sh` needs to re-run it (idempotent) or apply the new `gcloud storage buckets add-iam-policy-binding` command by hand once, then re-run **Garmin Token Bootstrap**.

## Validation

Results:
- `uv run pytest`: pass (all 130 tests, including 3 new tests covering `persist()`'s new return value and the bootstrap script's new failure path)
- `uv run ruff check .`: pass
- `uv run ruff format --check .`: pass
- `uv run mypy src/garmin_sync`: pass, no issues
- `bash -n docs/ops/setup-workload-identity.sh`: syntax OK
- `cd app && npm run check`: not applicable — no frontend files changed

## Risk and reviewer guidance

- The `persist()` signature change (`-> None` to `-> bool`) is backward compatible: every existing caller in `service.py` already discards the return value, so their control flow is unchanged. Only `bootstrap_garmin_tokens.py` was updated to actually check it.
- `docs/ops/setup-workload-identity.sh` is a one-time/idempotent infra script, not applied automatically by CI — the IAM grant only takes effect once someone re-runs it (or the equivalent `gcloud` command) against the live GCP project. This PR alone does not fix the currently-broken deployment; it needs that one manual step afterward.
- Worth double-checking the chosen role (`roles/storage.objectAdmin`, matching the existing `garmin-sync-job` grant) is the intended level of access for `github-deployer` on this bucket, rather than a narrower `objectCreator`.

## Domain invariants

- Not applicable — Firestore writes and calendar-date logic (`APP_USER_ID` scoping, `Europe/Warsaw`, `D - 1` semantics) untouched by this change.
- [x] No credentials, tokens, service-account files, or raw health payloads are included — verified; only IAM role names and error-handling code changed.
- Not applicable — no recommendation/policy logic touched.

## Screenshots or recordings

Not applicable — infra/backend fix, no UI change.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01CKpBREoWhgnLV7uRx6VScC)_