### PR TITLE
feat: add performance outcome validation contracts

### DIFF
--- a/app/src/observations/architecture.test.ts
+++ b/app/src/observations/architecture.test.ts
@@ -1,0 +1,130 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import * as ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+const OBSERVATIONS_DIR = dirname(fileURLToPath(import.meta.url));
+const SRC_DIR = dirname(OBSERVATIONS_DIR);
+
+const SELECTION_PREFIXES = [
+    'engine/optimizer',
+    'engine/planner',
+    'engine/rules',
+    'engine/weeklyAllocation',
+    'engine/evergreenPlanning',
+    'engine/sequenceSearch',
+] as const;
+
+function productionFiles(directory = SRC_DIR): string[] {
+    return readdirSync(directory, { withFileTypes: true })
+        .flatMap(entry => {
+            const absolutePath = join(directory, entry.name);
+            if (entry.isDirectory()) return productionFiles(absolutePath);
+            if (!entry.isFile() || !/\.tsx?$/.test(entry.name) || /\.test\.tsx?$/.test(entry.name)) return [];
+            return [absolutePath];
+        })
+        .sort();
+}
+
+function resolveSpecifier(fromAbsolute: string, specifier: string): string | null {
+    if (!specifier.startsWith('.')) return null;
+    const base = resolve(dirname(fromAbsolute), specifier);
+    for (const candidate of [`${base}.ts`, `${base}.tsx`, join(base, 'index.ts'), join(base, 'index.tsx')]) {
+        if (existsSync(candidate)) return relative(SRC_DIR, candidate).replaceAll('\\', '/');
+    }
+    return null;
+}
+
+function runtimeImportGraph(): Map<string, string[]> {
+    const graph = new Map<string, string[]>();
+
+    for (const absolutePath of productionFiles()) {
+        const fileName = relative(SRC_DIR, absolutePath).replaceAll('\\', '/');
+        const source = ts.createSourceFile(
+            fileName,
+            readFileSync(absolutePath, 'utf8'),
+            ts.ScriptTarget.Latest,
+            true,
+            fileName.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+        );
+        const edges: string[] = [];
+
+        const visit = (node: ts.Node): void => {
+            if (ts.isImportDeclaration(node) && ts.isStringLiteral(node.moduleSpecifier)) {
+                const clause = node.importClause;
+                const typeOnlyDeclaration = clause?.isTypeOnly === true;
+                const hasValueBinding = !clause
+                    || (!typeOnlyDeclaration && (
+                        clause.name !== undefined
+                        || (clause.namedBindings !== undefined && (
+                            ts.isNamespaceImport(clause.namedBindings)
+                            || clause.namedBindings.elements.some(element => !element.isTypeOnly)
+                        ))
+                    ));
+                if (hasValueBinding) {
+                    const target = resolveSpecifier(absolutePath, node.moduleSpecifier.text);
+                    if (target) edges.push(target);
+                }
+            }
+            ts.forEachChild(node, visit);
+        };
+
+        visit(source);
+        graph.set(fileName, edges);
+    }
+
+    return graph;
+}
+
+function reachableFrom(graph: Map<string, string[]>, start: string): Set<string> {
+    const reachable = new Set<string>();
+    const queue = [...(graph.get(start) ?? [])];
+    while (queue.length > 0) {
+        const module = queue.pop()!;
+        if (reachable.has(module)) continue;
+        reachable.add(module);
+        queue.push(...(graph.get(module) ?? []));
+    }
+    return reachable;
+}
+
+function isSelectionModule(path: string): boolean {
+    return SELECTION_PREFIXES.some(prefix => path.startsWith(prefix));
+}
+
+function isOutcomeEvidenceModule(path: string): boolean {
+    return path.startsWith('observations/') || path.startsWith('outcomes/');
+}
+
+describe('Performance outcome evidence architecture boundary (OV1.4)', () => {
+    const graph = runtimeImportGraph();
+
+    it('observation evidence cannot reach production selection/ranking modules at runtime', () => {
+        const observationModules = Array.from(graph.keys()).filter(path => path.startsWith('observations/'));
+        expect(observationModules.length).toBeGreaterThan(0);
+
+        for (const module of observationModules) {
+            for (const dependency of reachableFrom(graph, module)) {
+                expect(
+                    isSelectionModule(dependency),
+                    `Evidence module "${module}" must not reach production selection module "${dependency}"`,
+                ).toBe(false);
+            }
+        }
+    });
+
+    it('production selection/ranking cannot consume OV outcome evidence at runtime, directly or transitively', () => {
+        const selectionModules = Array.from(graph.keys()).filter(isSelectionModule);
+        expect(selectionModules.length).toBeGreaterThan(0);
+
+        for (const module of selectionModules) {
+            for (const dependency of reachableFrom(graph, module)) {
+                expect(
+                    isOutcomeEvidenceModule(dependency),
+                    `Selection module "${module}" must not reach evidence-only module "${dependency}" without a separate ADR/ship decision`,
+                ).toBe(false);
+            }
+        }
+    });
+});

--- a/app/src/observations/comparability.test.ts
+++ b/app/src/observations/comparability.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest';
+import type { ComparisonContext, ComparisonSeries, MeasurementProtocol } from './models';
+import {
+    areComparisonSeriesComparable,
+    buildComparisonSeries,
+    COMPARISON_CANONICALIZATION_V1,
+} from './comparability';
+import { assertValidMeasurementProtocol } from './protocols';
+
+function protocol(overrides: Partial<MeasurementProtocol> = {}): MeasurementProtocol {
+    return {
+        id: 'cycling-20m-tt',
+        revision: 1,
+        title: 'Cycling 20-minute TT',
+        intent: 'testing',
+        metricIds: ['cycling_tt_20m_mean_power_w'],
+        instructions: [{ id: 'main', text: 'Complete the declared 20-minute protocol.' }],
+        comparisonContext: {
+            required: ['power_source_id', 'bike_setup_id', 'duration_seconds', 'warmup_revision', 'feedback_rule', 'weather_note'],
+            seriesDefining: ['power_source_id', 'bike_setup_id', 'duration_seconds', 'warmup_revision', 'feedback_rule'],
+            contextOnly: ['weather_note'],
+            canonicalizationVersion: COMPARISON_CANONICALIZATION_V1,
+        },
+        familiarization: { required: true, minimumExposures: 1 },
+        burden: 'high',
+        expectedRecoveryHours: 24,
+        invalidationRules: ['Interrupted effort'],
+        createdAt: '2026-08-21T00:00:00.000Z',
+        ...overrides,
+    };
+}
+
+const baseContext: ComparisonContext = {
+    power_source_id: 'Favero-Assioma-Duo',
+    bike_setup_id: 'Road Bike A',
+    duration_seconds: 1200,
+    warmup_revision: 'WU-1',
+    feedback_rule: 'Power Visible',
+    weather_note: 'Indoor, fan on',
+};
+
+describe('OV1 protocol validation and comparable series', () => {
+    it('canonicalizes equivalent repeats identically regardless of input key order or identifier case/whitespace', async () => {
+        const a = await buildComparisonSeries('cycling_tt_20m_mean_power_w', 'W', protocol(), baseContext);
+        const b = await buildComparisonSeries('cycling_tt_20m_mean_power_w', 'W', protocol(), {
+            weather_note: 'Different contextual wording is allowed',
+            feedback_rule: ' power visible ',
+            warmup_revision: 'wu-1',
+            duration_seconds: 1200,
+            bike_setup_id: ' road bike a ',
+            power_source_id: 'FAVERO-ASSIOMA-DUO',
+        });
+        expect(a.key).toBe(b.key);
+        expect(a.key).toMatch(/^[0-9a-f]{64}$/);
+        expect(areComparisonSeriesComparable(a, b)).toBe(true);
+    });
+
+    it('creates a new series when a series-defining device/setup dimension changes', async () => {
+        const baseline = await buildComparisonSeries('cycling_tt_20m_mean_power_w', 'W', protocol(), baseContext);
+        const changedDevice = await buildComparisonSeries('cycling_tt_20m_mean_power_w', 'W', protocol(), {
+            ...baseContext,
+            power_source_id: 'Kickr-v7',
+        });
+        expect(changedDevice.key).not.toBe(baseline.key);
+        expect(areComparisonSeriesComparable(baseline, changedDevice)).toBe(false);
+    });
+
+    it('creates a new series when a material warm-up revision changes', async () => {
+        const baseline = await buildComparisonSeries('cycling_tt_20m_mean_power_w', 'W', protocol(), baseContext);
+        const changedWarmup = await buildComparisonSeries('cycling_tt_20m_mean_power_w', 'W', protocol(), {
+            ...baseContext,
+            warmup_revision: 'WU-2',
+        });
+        expect(changedWarmup.key).not.toBe(baseline.key);
+    });
+
+    it('does not split a series for context-only note changes', async () => {
+        const baseline = await buildComparisonSeries('cycling_tt_20m_mean_power_w', 'W', protocol(), baseContext);
+        const differentWeather = await buildComparisonSeries('cycling_tt_20m_mean_power_w', 'W', protocol(), {
+            ...baseContext,
+            weather_note: 'Rain outside; test remained indoors',
+        });
+        expect(differentWeather.key).toBe(baseline.key);
+    });
+
+    it('keeps protocol revision and canonicalization version explicit in comparability', async () => {
+        const revision1 = await buildComparisonSeries('cycling_tt_20m_mean_power_w', 'W', protocol(), baseContext);
+        const revision2 = await buildComparisonSeries('cycling_tt_20m_mean_power_w', 'W', protocol({ revision: 2 }), baseContext);
+        expect(revision2.key).not.toBe(revision1.key);
+
+        const sameKeyOldPolicy: ComparisonSeries = {
+            ...revision1,
+            canonicalizationVersion: 'comparison-series-v0',
+        };
+        expect(areComparisonSeriesComparable(revision1, sameKeyOldPolicy)).toBe(false);
+    });
+
+    it('fails on unit mismatch, undeclared metrics and missing required context', async () => {
+        await expect(buildComparisonSeries('cycling_tt_20m_mean_power_w', 'kW', protocol(), baseContext))
+            .rejects.toThrow(/requires unit W/);
+        await expect(buildComparisonSeries('cycling_tt_4m_mean_power_w', 'W', protocol(), baseContext))
+            .rejects.toThrow(/not declared by protocol/);
+        const missingDevice: ComparisonContext = {
+            bike_setup_id: 'Road Bike A',
+            duration_seconds: 1200,
+            warmup_revision: 'WU-1',
+            feedback_rule: 'Power Visible',
+            weather_note: 'Indoor, fan on',
+        };
+        await expect(buildComparisonSeries('cycling_tt_20m_mean_power_w', 'W', protocol(), missingDevice))
+            .rejects.toThrow(/Missing required comparison dimension: power_source_id/);
+    });
+
+    it('rejects malformed comparison partitions', () => {
+        const overlap = protocol({
+            comparisonContext: {
+                required: ['power_source_id'],
+                seriesDefining: ['power_source_id'],
+                contextOnly: ['power_source_id'],
+                canonicalizationVersion: COMPARISON_CANONICALIZATION_V1,
+            },
+        });
+        expect(() => assertValidMeasurementProtocol(overlap)).toThrow(/cannot be both series-defining and context-only/);
+
+        const unclassifiedRequired = protocol({
+            comparisonContext: {
+                required: ['power_source_id', 'weather_note'],
+                seriesDefining: ['power_source_id'],
+                contextOnly: [],
+                canonicalizationVersion: COMPARISON_CANONICALIZATION_V1,
+            },
+        });
+        expect(() => assertValidMeasurementProtocol(unclassifiedRequired)).toThrow(/must be classified/);
+    });
+
+    it('rejects unsupported canonicalization versions rather than silently re-keying old evidence', async () => {
+        await expect(buildComparisonSeries(
+            'cycling_tt_20m_mean_power_w',
+            'W',
+            protocol({
+                comparisonContext: {
+                    ...protocol().comparisonContext,
+                    canonicalizationVersion: 'comparison-series-v2',
+                },
+            }),
+            baseContext,
+        )).rejects.toThrow(/Unsupported comparison canonicalization version/);
+    });
+});

--- a/app/src/observations/comparability.ts
+++ b/app/src/observations/comparability.ts
@@ -1,0 +1,122 @@
+import type {
+    ComparisonContext,
+    ComparisonContextValue,
+    ComparisonDimension,
+    ComparisonSeries,
+    MeasurementProtocol,
+} from './models';
+import { assertMetricUnit } from './registry';
+import {
+    assertComparisonDimensionValue,
+    assertValidMeasurementProtocol,
+    getComparisonDimensionDefinition,
+} from './protocols';
+
+export const COMPARISON_CANONICALIZATION_V1 = 'comparison-series-v1';
+
+interface CanonicalDimensionValue {
+    id: ComparisonDimension;
+    value: string | number | boolean;
+}
+
+interface CanonicalComparisonPayload {
+    metricId: string;
+    protocolId: string;
+    protocolRevision: number;
+    canonicalizationVersion: string;
+    dimensions: readonly CanonicalDimensionValue[];
+}
+
+function normalizeDimensionValue(id: ComparisonDimension, value: ComparisonContextValue): string | number | boolean {
+    assertComparisonDimensionValue(id, value);
+    const definition = getComparisonDimensionDefinition(id);
+    if (definition.valueKind === 'identifier') return (value as string).trim().toLowerCase();
+    if (definition.valueKind === 'text') return (value as string).trim();
+    return value as number | boolean;
+}
+
+function assertSupportedCanonicalizationVersion(version: string): void {
+    if (version !== COMPARISON_CANONICALIZATION_V1) {
+        throw new Error(`Unsupported comparison canonicalization version: ${version}`);
+    }
+}
+
+function stableDimensionOrder(a: ComparisonDimension, b: ComparisonDimension): number {
+    if (a < b) return -1;
+    if (a > b) return 1;
+    return 0;
+}
+
+function canonicalPayload(
+    metricId: string,
+    protocol: MeasurementProtocol,
+    context: ComparisonContext,
+): CanonicalComparisonPayload {
+    assertValidMeasurementProtocol(protocol);
+    assertSupportedCanonicalizationVersion(protocol.comparisonContext.canonicalizationVersion);
+
+    if (!protocol.metricIds.includes(metricId)) {
+        throw new Error(`Metric ${metricId} is not declared by protocol ${protocol.id}@${protocol.revision}`);
+    }
+
+    for (const dimension of protocol.comparisonContext.required) {
+        const value = context[dimension];
+        if (value === undefined) {
+            throw new Error(`Missing required comparison dimension: ${dimension}`);
+        }
+        assertComparisonDimensionValue(dimension, value);
+    }
+
+    const dimensions = [...protocol.comparisonContext.seriesDefining]
+        .sort(stableDimensionOrder)
+        .map(id => ({ id, value: normalizeDimensionValue(id, context[id]!) }));
+
+    return {
+        metricId,
+        protocolId: protocol.id,
+        protocolRevision: protocol.revision,
+        canonicalizationVersion: protocol.comparisonContext.canonicalizationVersion,
+        dimensions,
+    };
+}
+
+export function canonicalComparisonSeriesJson(
+    metricId: string,
+    unit: string,
+    protocol: MeasurementProtocol,
+    context: ComparisonContext,
+): string {
+    assertMetricUnit(metricId, unit);
+    return JSON.stringify(canonicalPayload(metricId, protocol, context));
+}
+
+async function sha256Hex(value: string): Promise<string> {
+    const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(value));
+    return Array.from(new Uint8Array(digest))
+        .map(byte => byte.toString(16).padStart(2, '0'))
+        .join('');
+}
+
+export async function buildComparisonSeries(
+    metricId: string,
+    unit: string,
+    protocol: MeasurementProtocol,
+    context: ComparisonContext,
+): Promise<ComparisonSeries> {
+    const payload = canonicalComparisonSeriesJson(metricId, unit, protocol, context);
+    return {
+        metricId,
+        protocolId: protocol.id,
+        protocolRevision: protocol.revision,
+        canonicalizationVersion: protocol.comparisonContext.canonicalizationVersion,
+        key: await sha256Hex(payload),
+    };
+}
+
+export function areComparisonSeriesComparable(a: ComparisonSeries, b: ComparisonSeries): boolean {
+    return a.metricId === b.metricId
+        && a.protocolId === b.protocolId
+        && a.protocolRevision === b.protocolRevision
+        && a.canonicalizationVersion === b.canonicalizationVersion
+        && a.key === b.key;
+}

--- a/app/src/observations/models.ts
+++ b/app/src/observations/models.ts
@@ -1,0 +1,98 @@
+export type EvidencePlane = 'decision' | 'process_response' | 'outcome';
+
+export type ObservationIntent = 'training' | 'testing' | 'competition';
+
+export type OutcomeRole = 'primary' | 'secondary' | 'context';
+
+export type MetricDirection =
+    | 'higher_is_better'
+    | 'lower_is_better'
+    | 'target_range'
+    | 'context_only';
+
+export type MetricDomain = 'cycling' | 'running' | 'field' | 'strength' | 'general';
+
+export interface MetricDefinition {
+    id: string;
+    displayName: string;
+    domain: MetricDomain;
+    unit: string;
+    direction: MetricDirection;
+    valueKind: 'scalar';
+    description: string;
+}
+
+/**
+ * V1 comparison context is intentionally cycling-first. Add dimensions only when a real
+ * protocol needs them; do not turn this into a speculative cross-sport taxonomy.
+ */
+export type ComparisonDimension =
+    | 'power_source_id'
+    | 'bike_setup_id'
+    | 'test_environment'
+    | 'course_or_trainer_id'
+    | 'duration_seconds'
+    | 'start_mode'
+    | 'warmup_revision'
+    | 'feedback_rule'
+    | 'weather_note';
+
+export type ComparisonContextValue = string | number | boolean;
+
+export type ComparisonContext = Readonly<Partial<Record<ComparisonDimension, ComparisonContextValue>>>;
+
+/**
+ * Measurement protocols describe evidence collection. They deliberately do not introduce a
+ * second executable-workout language; the existing session runner remains the execution
+ * authority once testing workflow integration lands in OV3.
+ */
+export interface ProtocolInstruction {
+    id: string;
+    text: string;
+}
+
+export interface MeasurementProtocol {
+    id: string;
+    revision: number;
+    title: string;
+    intent: 'testing';
+    metricIds: readonly string[];
+    instructions: readonly ProtocolInstruction[];
+    warmupRef?: string;
+    comparisonContext: {
+        required: readonly ComparisonDimension[];
+        seriesDefining: readonly ComparisonDimension[];
+        contextOnly: readonly ComparisonDimension[];
+        canonicalizationVersion: string;
+    };
+    familiarization: {
+        required: boolean;
+        minimumExposures: number;
+    };
+    burden: 'low' | 'moderate' | 'high';
+    expectedRecoveryHours?: number;
+    invalidationRules: readonly string[];
+    createdAt: string;
+}
+
+export interface ComparisonSeries {
+    metricId: string;
+    protocolId: string;
+    protocolRevision: number;
+    canonicalizationVersion: string;
+    key: string;
+}
+
+export type ReliabilitySource =
+    | 'literature_reference'
+    | 'personal_repeatability'
+    | 'manual';
+
+export interface ReliabilityEstimate {
+    source: ReliabilitySource;
+    statistic: 'cv_pct' | 'typical_error_pct' | 'typical_error_abs' | 'sem_abs';
+    value: number;
+    reference?: string;
+    contextNote?: string;
+    estimatedAt?: string;
+}

--- a/app/src/observations/protocols.ts
+++ b/app/src/observations/protocols.ts
@@ -1,0 +1,140 @@
+import type {
+    ComparisonContextValue,
+    ComparisonDimension,
+    MeasurementProtocol,
+} from './models';
+import { getMetricDefinition } from './registry';
+
+export type ComparisonDimensionValueKind = 'identifier' | 'number' | 'boolean' | 'text';
+
+export interface ComparisonDimensionDefinition {
+    id: ComparisonDimension;
+    valueKind: ComparisonDimensionValueKind;
+    description: string;
+}
+
+const DIMENSIONS = [
+    { id: 'power_source_id', valueKind: 'identifier', description: 'Primary power meter or trainer identity.' },
+    { id: 'bike_setup_id', valueKind: 'identifier', description: 'Bike/setup identity when material to the protocol.' },
+    { id: 'test_environment', valueKind: 'identifier', description: 'Indoor/outdoor or another protocol-declared environment identity.' },
+    { id: 'course_or_trainer_id', valueKind: 'identifier', description: 'Controlled course or indoor trainer/setup identity.' },
+    { id: 'duration_seconds', valueKind: 'number', description: 'Protocol effort duration in seconds.' },
+    { id: 'start_mode', valueKind: 'identifier', description: 'Declared start rule such as standing or rolling.' },
+    { id: 'warmup_revision', valueKind: 'identifier', description: 'Warm-up prescription revision.' },
+    { id: 'feedback_rule', valueKind: 'identifier', description: 'Feedback/pacing information allowed during the test.' },
+    { id: 'weather_note', valueKind: 'text', description: 'Contextual weather note when weather is not series-defining.' },
+] as const satisfies readonly ComparisonDimensionDefinition[];
+
+const DIMENSION_BY_ID = new Map<ComparisonDimension, ComparisonDimensionDefinition>(
+    DIMENSIONS.map(dimension => [dimension.id, dimension] as const),
+);
+
+export function getComparisonDimensionDefinition(id: ComparisonDimension): ComparisonDimensionDefinition {
+    const dimension = DIMENSION_BY_ID.get(id);
+    if (!dimension) throw new Error(`Unsupported comparison dimension: ${id}`);
+    return dimension;
+}
+
+export function assertComparisonDimensionValue(id: ComparisonDimension, value: ComparisonContextValue): void {
+    const definition = getComparisonDimensionDefinition(id);
+    switch (definition.valueKind) {
+        case 'identifier':
+        case 'text':
+            if (typeof value !== 'string' || value.trim().length === 0) {
+                throw new Error(`Comparison dimension ${id} requires a non-empty string`);
+            }
+            return;
+        case 'number':
+            if (typeof value !== 'number' || !Number.isFinite(value)) {
+                throw new Error(`Comparison dimension ${id} requires a finite number`);
+            }
+            return;
+        case 'boolean':
+            if (typeof value !== 'boolean') {
+                throw new Error(`Comparison dimension ${id} requires a boolean`);
+            }
+            return;
+    }
+}
+
+function assertUniqueDimensions(label: string, dimensions: readonly ComparisonDimension[]): void {
+    if (new Set(dimensions).size !== dimensions.length) {
+        throw new Error(`${label} contains duplicate comparison dimensions`);
+    }
+}
+
+function assertUniqueStrings(label: string, values: readonly string[]): void {
+    if (new Set(values).size !== values.length) throw new Error(`${label} contains duplicate values`);
+}
+
+/**
+ * Runtime contract validation for immutable protocol revisions. Persistence immutability lands
+ * in OV2; this validator pins the revision shape and comparison partition before any storage
+ * path exists.
+ */
+export function assertValidMeasurementProtocol(protocol: MeasurementProtocol): void {
+    if (protocol.id.trim().length === 0) throw new Error('Measurement protocol id is required');
+    if (!Number.isInteger(protocol.revision) || protocol.revision < 1) {
+        throw new Error('Measurement protocol revision must be a positive integer');
+    }
+    if (protocol.title.trim().length === 0) throw new Error('Measurement protocol title is required');
+    if (protocol.intent !== 'testing') throw new Error('Measurement protocol intent must be testing');
+    if (protocol.metricIds.length === 0) throw new Error('Measurement protocol must declare at least one metric');
+    assertUniqueStrings('Measurement protocol metricIds', protocol.metricIds);
+    protocol.metricIds.forEach(getMetricDefinition);
+
+    const instructionIds = protocol.instructions.map(instruction => instruction.id);
+    assertUniqueStrings('Measurement protocol instruction ids', instructionIds);
+    for (const instruction of protocol.instructions) {
+        if (instruction.id.trim().length === 0 || instruction.text.trim().length === 0) {
+            throw new Error('Protocol instructions require non-empty id and text');
+        }
+    }
+
+    const { required, seriesDefining, contextOnly, canonicalizationVersion } = protocol.comparisonContext;
+    assertUniqueDimensions('required', required);
+    assertUniqueDimensions('seriesDefining', seriesDefining);
+    assertUniqueDimensions('contextOnly', contextOnly);
+    if (canonicalizationVersion.trim().length === 0) throw new Error('canonicalizationVersion is required');
+
+    const requiredSet = new Set(required);
+    const seriesSet = new Set(seriesDefining);
+    const contextSet = new Set(contextOnly);
+
+    for (const dimension of [...required, ...seriesDefining, ...contextOnly]) {
+        getComparisonDimensionDefinition(dimension);
+    }
+    for (const dimension of seriesDefining) {
+        if (!requiredSet.has(dimension)) {
+            throw new Error(`Series-defining dimension ${dimension} must also be required`);
+        }
+        if (contextSet.has(dimension)) {
+            throw new Error(`Comparison dimension ${dimension} cannot be both series-defining and context-only`);
+        }
+    }
+    for (const dimension of contextOnly) {
+        if (!requiredSet.has(dimension)) {
+            throw new Error(`Context-only dimension ${dimension} must also be required`);
+        }
+    }
+    for (const dimension of required) {
+        if (!seriesSet.has(dimension) && !contextSet.has(dimension)) {
+            throw new Error(`Required comparison dimension ${dimension} must be classified as series-defining or context-only`);
+        }
+    }
+
+    if (!Number.isInteger(protocol.familiarization.minimumExposures) || protocol.familiarization.minimumExposures < 0) {
+        throw new Error('Familiarization minimumExposures must be a non-negative integer');
+    }
+    if (protocol.familiarization.required && protocol.familiarization.minimumExposures < 1) {
+        throw new Error('A required familiarization needs at least one minimum exposure');
+    }
+    if (protocol.expectedRecoveryHours !== undefined
+        && (!Number.isFinite(protocol.expectedRecoveryHours) || protocol.expectedRecoveryHours < 0)) {
+        throw new Error('expectedRecoveryHours must be a finite non-negative number');
+    }
+}
+
+export function measurementProtocolRef(protocol: MeasurementProtocol): { id: string; revision: number } {
+    return { id: protocol.id, revision: protocol.revision };
+}

--- a/app/src/observations/registry.test.ts
+++ b/app/src/observations/registry.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import {
+    assertMetricAllowedForOutcomeRole,
+    assertMetricUnit,
+    getMetricDefinition,
+    listMetricDefinitions,
+} from './registry';
+
+describe('OV1 metric registry', () => {
+    it('ships only the bounded cycling-first v1 registry', () => {
+        expect(listMetricDefinitions().map(metric => metric.id)).toEqual([
+            'cycling_tt_20m_mean_power_w',
+            'cycling_tt_4m_mean_power_w',
+            'cycling_submax_mean_hr_bpm',
+            'cycling_submax_rpe',
+        ]);
+        expect(getMetricDefinition('cycling_tt_20m_mean_power_w').direction).toBe('higher_is_better');
+    });
+
+    it('requires the metric exact unit', () => {
+        expect(assertMetricUnit('cycling_tt_20m_mean_power_w', 'W').unit).toBe('W');
+        expect(() => assertMetricUnit('cycling_tt_20m_mean_power_w', 'kW')).toThrow(/requires unit W/);
+    });
+
+    it('fails closed for unsupported metric ids', () => {
+        expect(() => getMetricDefinition('cycling_magic_fitness_score')).toThrow(/Unsupported metric id/);
+    });
+
+    it('does not allow context-only evidence to be promoted to a primary or secondary outcome', () => {
+        expect(() => assertMetricAllowedForOutcomeRole('cycling_submax_mean_hr_bpm', 'primary'))
+            .toThrow(/Context-only metric/);
+        expect(() => assertMetricAllowedForOutcomeRole('cycling_submax_rpe', 'secondary'))
+            .toThrow(/Context-only metric/);
+        expect(assertMetricAllowedForOutcomeRole('cycling_submax_rpe', 'context').direction).toBe('context_only');
+    });
+});

--- a/app/src/observations/registry.ts
+++ b/app/src/observations/registry.ts
@@ -1,0 +1,72 @@
+import type { MetricDefinition, OutcomeRole } from './models';
+
+const METRICS = [
+    {
+        id: 'cycling_tt_20m_mean_power_w',
+        displayName: '20-minute TT mean power',
+        domain: 'cycling',
+        unit: 'W',
+        direction: 'higher_is_better',
+        valueKind: 'scalar',
+        description: 'Raw mean power from a protocol-locked 20-minute cycling time trial. This is not FTP.',
+    },
+    {
+        id: 'cycling_tt_4m_mean_power_w',
+        displayName: '4-minute TT mean power',
+        domain: 'cycling',
+        unit: 'W',
+        direction: 'higher_is_better',
+        valueKind: 'scalar',
+        description: 'Raw mean power from a protocol-locked 4-minute cycling time trial.',
+    },
+    {
+        id: 'cycling_submax_mean_hr_bpm',
+        displayName: 'Submaximal mean heart rate',
+        domain: 'cycling',
+        unit: 'bpm',
+        direction: 'context_only',
+        valueKind: 'scalar',
+        description: 'Mean heart rate from a declared submaximal cycling protocol; contextual evidence in v1.',
+    },
+    {
+        id: 'cycling_submax_rpe',
+        displayName: 'Submaximal RPE',
+        domain: 'cycling',
+        unit: 'rpe',
+        direction: 'context_only',
+        valueKind: 'scalar',
+        description: 'Session/perceived exertion recorded for a declared submaximal cycling protocol; contextual evidence in v1.',
+    },
+] as const satisfies readonly MetricDefinition[];
+
+const METRIC_BY_ID = new Map<string, MetricDefinition>(METRICS.map(metric => [metric.id, metric] as const));
+
+export function listMetricDefinitions(): readonly MetricDefinition[] {
+    return METRICS;
+}
+
+export function getMetricDefinition(metricId: string): MetricDefinition {
+    const metric = METRIC_BY_ID.get(metricId);
+    if (!metric) throw new Error(`Unsupported metric id: ${metricId}`);
+    return metric;
+}
+
+export function assertMetricUnit(metricId: string, unit: string): MetricDefinition {
+    const metric = getMetricDefinition(metricId);
+    if (metric.unit !== unit) {
+        throw new Error(`Metric ${metricId} requires unit ${metric.unit}; received ${unit}`);
+    }
+    return metric;
+}
+
+/**
+ * OV1 boundary used by later OutcomeEvaluationSpec validation. Context metrics remain useful
+ * evidence, but they cannot silently become primary/secondary performance outcomes.
+ */
+export function assertMetricAllowedForOutcomeRole(metricId: string, role: OutcomeRole): MetricDefinition {
+    const metric = getMetricDefinition(metricId);
+    if (role !== 'context' && metric.direction === 'context_only') {
+        throw new Error(`Context-only metric ${metricId} cannot be bound as ${role}`);
+    }
+    return metric;
+}

--- a/app/src/observations/reliability.test.ts
+++ b/app/src/observations/reliability.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import type { ReliabilityEstimate } from './models';
+import { assertValidReliabilityEstimate, reliabilityEvidenceLabel } from './reliability';
+
+describe('OV1 reliability provenance', () => {
+    it('keeps literature, personal repeatability and manual evidence visibly distinct', () => {
+        const literature: ReliabilityEstimate = {
+            source: 'literature_reference',
+            statistic: 'cv_pct',
+            value: 2.1,
+            reference: 'Reviewed protocol-specific source',
+        };
+        const personal: ReliabilityEstimate = {
+            source: 'personal_repeatability',
+            statistic: 'typical_error_abs',
+            value: 6,
+            contextNote: 'Close-spaced comparable repeat trials',
+        };
+        const manual: ReliabilityEstimate = {
+            source: 'manual',
+            statistic: 'sem_abs',
+            value: 5,
+        };
+
+        expect(reliabilityEvidenceLabel(literature)).toBe('reference_level');
+        expect(reliabilityEvidenceLabel(personal)).toBe('personal');
+        expect(reliabilityEvidenceLabel(manual)).toBe('manual');
+    });
+
+    it('rejects negative, non-finite and empty-provenance values', () => {
+        expect(() => assertValidReliabilityEstimate({
+            source: 'manual', statistic: 'typical_error_abs', value: -1,
+        })).toThrow(/finite non-negative/);
+        expect(() => assertValidReliabilityEstimate({
+            source: 'manual', statistic: 'typical_error_abs', value: Number.NaN,
+        })).toThrow(/finite non-negative/);
+        expect(() => assertValidReliabilityEstimate({
+            source: 'literature_reference', statistic: 'cv_pct', value: 2, reference: '   ',
+        })).toThrow(/reference must be non-empty/);
+    });
+});

--- a/app/src/observations/reliability.ts
+++ b/app/src/observations/reliability.ts
@@ -1,0 +1,23 @@
+import type { ReliabilityEstimate } from './models';
+
+/**
+ * Reliability metadata is evidence provenance, not a probability model. Keep the source and
+ * statistic explicit so later progress policy never has to infer what a bare number meant.
+ */
+export function assertValidReliabilityEstimate(estimate: ReliabilityEstimate): void {
+    if (!Number.isFinite(estimate.value) || estimate.value < 0) {
+        throw new Error('Reliability estimate value must be a finite non-negative number');
+    }
+    if (estimate.reference !== undefined && estimate.reference.trim().length === 0) {
+        throw new Error('Reliability reference must be non-empty when provided');
+    }
+    if (estimate.contextNote !== undefined && estimate.contextNote.trim().length === 0) {
+        throw new Error('Reliability context note must be non-empty when provided');
+    }
+}
+
+export function reliabilityEvidenceLabel(estimate: ReliabilityEstimate): 'reference_level' | 'personal' | 'manual' {
+    if (estimate.source === 'literature_reference') return 'reference_level';
+    if (estimate.source === 'personal_repeatability') return 'personal';
+    return 'manual';
+}


### PR DESCRIPTION
## Scope

Implements the first code slice of `docs/plans/performance-outcome-validation.md` (PR A / OV contracts), with no persistence, UI, progress labels, block verdicts, or recommendation-policy changes.

### Included
- OV evidence vocabulary: decision / process-response / outcome planes; training / testing / competition intents; primary / secondary / context roles.
- Bounded cycling-first metric registry with exact units and context-only role protection.
- Measurement protocol contracts and validation for required, series-defining, and context-only dimensions.
- Versioned comparison-series canonicalization (`comparison-series-v1`) using stable dimension ordering and SHA-256, matching the repository's existing immutable-content hash convention.
- Explicit reliability provenance (`literature_reference`, `personal_repeatability`, `manual`) without converting statistics into unsupported probabilities.
- Architecture tests enforcing the evidence-only boundary in both directions: OV/outcome runtime code cannot reach optimizer/planner/rules/allocation modules, and production selection cannot reach OV/outcome runtime evidence without a later ADR/ship decision.
- Unit tests for exact metric registry, units, context-only binding, protocol partitions, material setup changes, context-only changes, protocol revisions, canonicalization-version mismatch, missing context, and reliability provenance.

### Deliberately excluded by the approved plan
- Firestore observation/protocol persistence (PR B / OV2)
- testing runner integration (PR C / OV3)
- progress derivation (PR D / OV4)
- outcome evaluation specs/block reports (PR E / OV5–OV6.1)
- UI (later usage-triggered PR)

The plan index on `main` already records that the M7 repeated-testing trigger fired on 2026-08-21 and delegates implementation to OV.

## Safety / architecture
- No files under `engine/`, persistence/services, Firestore rules, or UI were changed.
- Raw 20-minute mean power remains a raw metric and is explicitly not called FTP.
- No recommendation semantics or Phase 9.0 selector behavior are changed.

## Verification
The branch diff is one commit ahead of current `main` and contains exactly nine new `app/src/observations/*` files. Local execution is unavailable in the current tool runtime (outbound DNS to GitHub is blocked), so repository CI is the executable verification source for `npm run check` / build rather than an unverified local claim.