### PR TITLE
fix: close import-graph blind spots in OV1.4 architecture boundary test

### DIFF
--- a/app/src/observations/architecture.test.ts
+++ b/app/src/observations/architecture.test.ts
@@ -30,7 +30,15 @@ function productionFiles(directory = SRC_DIR): string[] {
 function resolveSpecifier(fromAbsolute: string, specifier: string): string | null {
     if (!specifier.startsWith('.')) return null;
     const base = resolve(dirname(fromAbsolute), specifier);
-    for (const candidate of [`${base}.ts`, `${base}.tsx`, join(base, 'index.ts'), join(base, 'index.tsx')]) {
+    // Some production files (e.g. engine/planSchedule.ts) import with an explicit `.ts`/`.tsx`
+    // suffix already baked into the specifier -- `resolve` preserves that suffix on `base`, so
+    // appending another extension or probing for an `index.ts` inside it would never match.
+    // Missing these edges would silently exempt those files' dependencies from the boundary
+    // checks below, so resolve the literal path first before falling back to extension probing.
+    const candidates = /\.tsx?$/.test(base)
+        ? [base]
+        : [`${base}.ts`, `${base}.tsx`, join(base, 'index.ts'), join(base, 'index.tsx')];
+    for (const candidate of candidates) {
         if (existsSync(candidate)) return relative(SRC_DIR, candidate).replaceAll('\\', '/');
     }
     return null;
@@ -62,6 +70,22 @@ function runtimeImportGraph(): Map<string, string[]> {
                             || clause.namedBindings.elements.some(element => !element.isTypeOnly)
                         ))
                     ));
+                if (hasValueBinding) {
+                    const target = resolveSpecifier(absolutePath, node.moduleSpecifier.text);
+                    if (target) edges.push(target);
+                }
+            }
+            // Re-export barrels (`export { x } from './y'`, `export * from './y'`) are a real
+            // runtime module dependency too -- missing this edge would let a boundary violation
+            // routed through a barrel file (e.g. engine/planningMode.ts) go undetected.
+            if (ts.isExportDeclaration(node) && node.moduleSpecifier && ts.isStringLiteral(node.moduleSpecifier)) {
+                const exportClause = node.exportClause;
+                const hasValueBinding = !node.isTypeOnly && (
+                    exportClause === undefined
+                    || (ts.isNamespaceExport(exportClause)
+                        ? true
+                        : exportClause.elements.some(element => !element.isTypeOnly))
+                );
                 if (hasValueBinding) {
                     const target = resolveSpecifier(absolutePath, node.moduleSpecifier.text);
                     if (target) edges.push(target);


### PR DESCRIPTION
## Summary

- Follow-up to #154 (merged), which added `app/src/observations/architecture.test.ts` — the "OV1.4" test enforcing the evidence-only boundary between OV/outcome runtime code and production optimizer/planner/rules/allocation modules.
- Reviewing that test's import-graph builder found two soundness gaps that let real runtime dependency edges go untracked, silently weakening the invariant the test claims to enforce.
- `resolveSpecifier` never matched relative specifiers that already carry an explicit `.ts`/`.tsx` suffix (e.g. `'./planSchedule.ts'`). That style is used in 30 production files, including `engine/planSchedule.ts` — one hop from the `engine/optimizer.ts` boundary module — so every one of its extension-qualified imports (`evergreenStrategy.ts`, `dataState.ts`, `models.ts`, `../workouts/event-plan.ts`, etc.) was dropped from the graph. Reachability computed from `engine/optimizer.ts` alone jumps from 28 to 48 modules once fixed.
- The AST visitor only inspected `ImportDeclaration` nodes, so re-export barrels (`export { x } from './y'`) were invisible to the graph even though the codebase already uses that pattern (e.g. `engine/planningMode.ts`, `src/workouts/index.ts`). A boundary violation routed through a barrel file would have slipped past the check undetected.
- No user-visible change: this only strengthens an internal test file; no `engine/`, persistence, or UI code touched.

## Validation

- [x] `cd app && npm run check` (frontend changes): pass — typecheck, lint (0 errors, 2 pre-existing unrelated warnings in `App.tsx`/`useOverloadHistory.ts`), full Vitest suite (165 files / 1832 tests passed, 1 skipped file / 86 skipped tests, unchanged from before), workout catalog validation (175 exercises, 37 workouts, 16 parameter binding sets, 25 authored session families).
- [x] Manual check: wrote a standalone probe comparing the old vs. fixed `resolveSpecifier`/graph-builder over the real `app/src` tree — reachability from `engine/optimizer.ts` grew from 28 to 48 modules, confirming the gap was real and not hypothetical (probe script removed before commit).
- [ ] `uv run pytest` — not applicable, no Python changes.
- [ ] `uv run ruff check .` and `uv run mypy src/garmin_sync` — not applicable, no Python changes.
- [ ] `cd app && npm run test:rules` — not applicable, no Firestore rules changes.
- [ ] `cd app && npm run simulate:scenarios` — not applicable, no recommendation-engine behavior changed (test-only fix).
- [ ] `cd app && npm run visual:refresh` — not applicable, no UI changes.

## Risk and reviewer guidance

Low risk: the change is confined to `app/src/observations/architecture.test.ts` (a Vitest-only, non-production file) and only widens what the boundary test can see — it cannot introduce a false positive on its own, and both boundary assertions still pass against the current codebase. Reviewers should double check the new `resolveSpecifier` candidate logic (extension-qualified specifiers resolve directly rather than being extension-probed again) and the added `ExportDeclaration` handling (type-only re-exports are still correctly excluded, mirroring the existing import-clause logic).

## Domain invariants

Not applicable — this PR only touches a test file under `app/src/observations/`; no Firestore paths, calendar-date logic, credentials, or `POLICY_VERSION`/recommendation decision logic are involved.

## Screenshots or recordings

Not applicable — no UI changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01B2WpMddpADpF2RKvttH5gD)_