### PR TITLE
fix(observations): stabilize OV2 emulator suite and close rule gaps

### DIFF
--- a/app/firestore.rules
+++ b/app/firestore.rules
@@ -1039,6 +1039,8 @@ service cloud.firestore {
         && comparison.required is list && comparison.required.size() <= 16 && comparison.required.hasOnly(dimensions)
         && comparison.seriesDefining is list && comparison.seriesDefining.size() <= 16 && comparison.seriesDefining.hasOnly(comparison.required)
         && comparison.contextOnly is list && comparison.contextOnly.size() <= 16 && comparison.contextOnly.hasOnly(comparison.required)
+        && !comparison.seriesDefining.hasAny(comparison.contextOnly)
+        && comparison.required.size() <= comparison.seriesDefining.size() + comparison.contextOnly.size()
         && comparison.canonicalizationVersion is string && comparison.canonicalizationVersion.size() > 0 && comparison.canonicalizationVersion.size() <= 64
         && familiarization is map
         && familiarization.keys().hasOnly(['required', 'minimumExposures'])
@@ -1085,6 +1087,8 @@ service cloud.firestore {
         && request.resource.data.purpose == resource.data.purpose
         && (('scheduledDate' in request.resource.data) == ('scheduledDate' in resource.data))
         && (!('scheduledDate' in resource.data) || request.resource.data.scheduledDate == resource.data.scheduledDate)
+        && (!('startedAt' in resource.data) || request.resource.data.startedAt == resource.data.startedAt)
+        && (!('completedAt' in resource.data) || request.resource.data.completedAt == resource.data.completedAt)
         && (
           request.resource.data.state == resource.data.state
           || (resource.data.state == 'scheduled' && request.resource.data.state in ['in_progress', 'abandoned'])
@@ -1120,6 +1124,7 @@ service cloud.firestore {
         && data.observationKey == observationKey
         && data.assessmentAttemptId is string && data.assessmentAttemptId.size() > 0 && data.assessmentAttemptId.size() <= 160
         && hasKnownOutcomeMetric(data.metricId)
+        && data.observationKey == data.assessmentAttemptId + ':' + data.metricId
         && data.headRevision is int && data.headRevision >= 1
         && data.createdAt is string && data.createdAt.size() > 0
         && data.updatedAt is string && data.updatedAt.size() > 0;

--- a/app/src/emulator/performanceOutcomeRules.emulator.test.ts
+++ b/app/src/emulator/performanceOutcomeRules.emulator.test.ts
@@ -30,7 +30,7 @@ function validProtocol() {
         comparisonContext: {
             required: ['power_source_id', 'duration_seconds', 'warmup_revision'],
             seriesDefining: ['power_source_id', 'duration_seconds', 'warmup_revision'],
-            contextOnly: [],
+            contextOnly: [] as string[],
             canonicalizationVersion: 'comparison-series-v1',
         },
         familiarization: { required: true, minimumExposures: 1 },
@@ -117,7 +117,13 @@ async function writeInitialObservation() {
 emulatorDescribe('Performance outcome Firestore rules (OV2.4)', () => {
     beforeAll(async () => {
         testEnvironment = await initializeTestEnvironment({
-            projectId: 'demo-adaptive-training',
+            // Isolated from firestoreRules.emulator.test.ts's project: vitest runs emulator
+            // test files in parallel by default, and both suites call clearFirestore() in
+            // their own afterEach. Sharing one emulator project let one file's
+            // clearFirestore() wipe documents mid-transaction in the other, producing
+            // intermittent "evaluation error" / PERMISSION_DENIED failures in CI even
+            // though the rules themselves were correct.
+            projectId: 'demo-adaptive-training-ov2',
             firestore: { rules: readFileSync('firestore.rules', 'utf8') },
         });
     });
@@ -147,6 +153,27 @@ emulatorDescribe('Performance outcome Firestore rules (OV2.4)', () => {
         ));
     });
 
+    it('rejects a protocol comparisonContext that double-classifies or drops a required dimension', async () => {
+        const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+        const overlapping = validProtocol();
+        overlapping.comparisonContext = {
+            ...overlapping.comparisonContext,
+            required: ['power_source_id', 'duration_seconds', 'warmup_revision'],
+            seriesDefining: ['power_source_id', 'duration_seconds'],
+            contextOnly: ['duration_seconds', 'warmup_revision'],
+        };
+        await assertFails(setDoc(doc(ownerDb, protocolRevisionPath), overlapping));
+
+        const uncovered = validProtocol();
+        uncovered.comparisonContext = {
+            ...uncovered.comparisonContext,
+            required: ['power_source_id', 'duration_seconds', 'warmup_revision'],
+            seriesDefining: ['power_source_id'],
+            contextOnly: ['duration_seconds'],
+        };
+        await assertFails(setDoc(doc(ownerDb, protocolRevisionPath), uncovered));
+    });
+
     it('allows a valid manual observation only when revision 1 and the head are created atomically', async () => {
         const ownerDb = await seedProtocolAndAttempt();
         await assertFails(setDoc(doc(ownerDb, revision1Path), validRevision(1)));
@@ -156,6 +183,14 @@ emulatorDescribe('Performance outcome Firestore rules (OV2.4)', () => {
         batch.set(doc(ownerDb, revision1Path), validRevision(1));
         batch.set(doc(ownerDb, observationPath), validHead(1));
         await assertSucceeds(batch.commit());
+    });
+
+    it('rejects an observation head whose observationKey does not match its own assessmentAttemptId/metricId', async () => {
+        const ownerDb = await seedProtocolAndAttempt();
+        const batch = writeBatch(ownerDb);
+        batch.set(doc(ownerDb, revision1Path), validRevision(1));
+        batch.set(doc(ownerDb, observationPath), { ...validHead(1), assessmentAttemptId: 'attempt-9' });
+        await assertFails(batch.commit());
     });
 
     it('rejects malformed observation units and unknown fields', async () => {
@@ -208,6 +243,29 @@ emulatorDescribe('Performance outcome Firestore rules (OV2.4)', () => {
             state: 'in_progress', startedAt: '2026-08-21T06:00:00.000Z',
         }));
         await assertFails(updateDoc(doc(ownerDb, attemptPath), { purpose: 'post_block' }));
+    });
+
+    it('rejects rewriting startedAt/completedAt provenance timestamps on an assessment attempt', async () => {
+        const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+        await assertSucceeds(setDoc(doc(ownerDb, protocolRevisionPath), validProtocol()));
+        await assertSucceeds(setDoc(doc(ownerDb, attemptPath), {
+            id: attemptId,
+            protocolRef: { id: protocolId, revision: 1 },
+            state: 'in_progress',
+            purpose: 'baseline',
+            startedAt: '2026-08-21T06:00:00.000Z',
+        }));
+        // Rewriting startedAt while state stays in_progress must fail, even though the shape
+        // is otherwise valid.
+        await assertFails(updateDoc(doc(ownerDb, attemptPath), { startedAt: '1999-01-01T00:00:00.000Z' }));
+        // A legitimate transition may add completedAt, but not also back-date startedAt.
+        await assertFails(updateDoc(doc(ownerDb, attemptPath), {
+            state: 'completed', startedAt: '1999-01-01T00:00:00.000Z', completedAt: '2026-08-21T06:25:00.000Z',
+        }));
+        await assertSucceeds(updateDoc(doc(ownerDb, attemptPath), {
+            state: 'completed', completedAt: '2026-08-21T06:25:00.000Z',
+        }));
+        await assertFails(updateDoc(doc(ownerDb, attemptPath), { completedAt: '1999-01-01T00:00:00.000Z' }));
     });
 
     it('stores ecological competition evidence without protocol-only benchmark fields', async () => {

--- a/app/src/services/assessmentAttemptService.ts
+++ b/app/src/services/assessmentAttemptService.ts
@@ -1,4 +1,4 @@
-import { doc, getDoc, setDoc, updateDoc, type Firestore } from 'firebase/firestore';
+import { doc, getDoc, runTransaction, setDoc, type Firestore } from 'firebase/firestore';
 import { getDb } from '../firebase';
 import type { AssessmentAttempt } from '../observations/models';
 import { assertValidAssessmentAttempt } from '../observations/validation';
@@ -33,35 +33,51 @@ export class AssessmentAttemptService {
     }
 
     async startAttempt(userId: string, attemptId: string, startedAt: string): Promise<void> {
-        const current = await this.requireAttempt(userId, attemptId);
-        if (current.state !== 'scheduled') throw new Error(`Cannot start assessment from ${current.state}`);
-        const next: AssessmentAttempt = { ...current, state: 'in_progress', startedAt };
-        assertValidAssessmentAttempt(next);
-        await updateDoc(this.attemptRef(userId, attemptId), { state: 'in_progress', startedAt });
+        await this.transitionAttempt(userId, attemptId, current => {
+            if (current.state !== 'scheduled') throw new Error(`Cannot start assessment from ${current.state}`);
+            return { ...current, state: 'in_progress', startedAt };
+        });
     }
 
     async completeAttempt(userId: string, attemptId: string, completedAt: string): Promise<void> {
-        const current = await this.requireAttempt(userId, attemptId);
-        if (current.state !== 'in_progress') throw new Error(`Cannot complete assessment from ${current.state}`);
-        const next: AssessmentAttempt = { ...current, state: 'completed', completedAt };
-        assertValidAssessmentAttempt(next);
-        await updateDoc(this.attemptRef(userId, attemptId), { state: 'completed', completedAt });
+        await this.transitionAttempt(userId, attemptId, current => {
+            if (current.state !== 'in_progress') throw new Error(`Cannot complete assessment from ${current.state}`);
+            return { ...current, state: 'completed', completedAt };
+        });
     }
 
     async abandonAttempt(userId: string, attemptId: string): Promise<void> {
-        const current = await this.requireAttempt(userId, attemptId);
-        if (current.state !== 'scheduled' && current.state !== 'in_progress') {
-            throw new Error(`Cannot abandon assessment from ${current.state}`);
-        }
-        const next: AssessmentAttempt = { ...current, state: 'abandoned' };
-        assertValidAssessmentAttempt(next);
-        await updateDoc(this.attemptRef(userId, attemptId), { state: 'abandoned' });
+        await this.transitionAttempt(userId, attemptId, current => {
+            if (current.state !== 'scheduled' && current.state !== 'in_progress') {
+                throw new Error(`Cannot abandon assessment from ${current.state}`);
+            }
+            return { ...current, state: 'abandoned' };
+        });
     }
 
-    private async requireAttempt(userId: string, attemptId: string): Promise<AssessmentAttempt> {
-        const attempt = await this.getAttempt(userId, attemptId);
-        if (!attempt) throw new Error(`Assessment attempt ${attemptId} does not exist`);
-        return attempt;
+    /**
+     * Reads and rewrites the attempt inside a transaction so two concurrent transitions on the
+     * same attempt (e.g. two starts racing) can't both observe the pre-transition state and
+     * silently clobber each other's fields; the loser fails/retries via Firestore's transaction
+     * conflict handling instead.
+     */
+    private async transitionAttempt(
+        userId: string,
+        attemptId: string,
+        transition: (current: AssessmentAttempt) => AssessmentAttempt,
+    ): Promise<void> {
+        const ref = this.attemptRef(userId, attemptId);
+        await runTransaction(this.db, async transaction => {
+            const snapshot = await transaction.get(ref);
+            if (!snapshot.exists()) throw new Error(`Assessment attempt ${attemptId} does not exist`);
+            const current = snapshot.data() as AssessmentAttempt;
+            assertValidAssessmentAttempt(current);
+            if (current.id !== attemptId) throw new Error(`Assessment attempt path mismatch for ${attemptId}`);
+
+            const next = transition(current);
+            assertValidAssessmentAttempt(next);
+            transaction.set(ref, next);
+        });
     }
 }
 

--- a/app/src/services/observationPersistenceServices.test.ts
+++ b/app/src/services/observationPersistenceServices.test.ts
@@ -191,16 +191,17 @@ describe('OV2 persistence services', () => {
         expect(firestore.doc.mock.calls.at(-1)?.slice(-2)).toEqual(['revisions', '2']);
     });
 
-    it('enforces assessment state transitions before issuing Firestore updates', async () => {
-        firestore.getDoc.mockResolvedValueOnce(snapshot(attempt));
+    it('enforces assessment state transitions before issuing Firestore writes', async () => {
+        firestore.transaction.get.mockResolvedValueOnce(snapshot(attempt));
         const service = new AssessmentAttemptService({} as never);
         await service.startAttempt('u1', 'attempt-1', '2026-08-22T06:00:00.000Z');
-        expect(firestore.updateDoc).toHaveBeenCalledWith(expect.anything(), {
+        expect(firestore.transaction.set).toHaveBeenCalledWith(expect.anything(), {
+            ...attempt,
             state: 'in_progress',
             startedAt: '2026-08-22T06:00:00.000Z',
         });
 
-        firestore.getDoc.mockResolvedValueOnce(snapshot({ ...attempt, state: 'completed', startedAt: '2026-08-22T06:00:00Z', completedAt: '2026-08-22T07:00:00Z' }));
+        firestore.transaction.get.mockResolvedValueOnce(snapshot({ ...attempt, state: 'completed', startedAt: '2026-08-22T06:00:00Z', completedAt: '2026-08-22T07:00:00Z' }));
         await expect(service.startAttempt('u1', 'attempt-1', '2026-08-22T08:00:00Z')).rejects.toThrow(/Cannot start assessment from completed/);
     });
 


### PR DESCRIPTION
Review/fix pass on #155.

## Summary

- Root-caused and fixed the failing "Frontend Build & Firestore Rules" CI job on #155: `performanceOutcomeRules.emulator.test.ts` shared a Firestore emulator project id with `firestoreRules.emulator.test.ts`. Vitest runs emulator test files in parallel by default, and both suites call `clearFirestore()` in their own `afterEach`, so one file's cleanup could wipe documents mid-transaction in the other — producing the intermittent `PERMISSION_DENIED` / "evaluation error" failures seen on CI. Confirmed by running the new suite standalone (passed) vs. alongside the other file (failed non-deterministically, including a different manifestation each run). Fix: give the new suite its own emulator project id.
- While verifying, found and closed three real gaps in the new OV2 `firestore.rules`, each backed by a new emulator test that fails without the fix (verified by reverting the rules and re-running):
  - `hasValidMeasurementProtocol` didn't enforce that every required comparison dimension is classified into exactly one of `seriesDefining`/`contextOnly`, unlike the parallel TS validator (`assertValidMeasurementProtocol`). A protocol violating that invariant could be written through the rules and would then become permanently unreadable through the app (`getRevision()` re-validates on every read and throws).
  - `hasValidObservationHead` never checked `observationKey` against `assessmentAttemptId + ':' + metricId`, unlike the sibling revision-document rule that already enforces this.
  - `hasValidAssessmentAttemptTransition` allowed `startedAt`/`completedAt` to be silently rewritten on update as long as `state` itself didn't change, undermining the immutable-provenance intent of those timestamps.
- Fixed a matching race in `AssessmentAttemptService`: `startAttempt`/`completeAttempt`/`abandonAttempt` read-then-wrote via plain `getDoc`/`updateDoc`, so two concurrent transitions on the same attempt could both pass their client-side state check and clobber each other. Reworked into a single transactional helper, matching the pattern `MetricObservationService` already uses for its correction workflow. Updated the matching unit test to assert against the transaction mock instead of `updateDoc`.

No behavior outside OV2 persistence is touched.

## Validation

- [x] `cd app && npm run test:rules` — pass; 97/97 (added 3 new tests). Ran twice for stability, and reverted just `firestore.rules` to confirm the 3 new tests fail without the fix (regression net verified).
- [x] `cd app && npm run check` — pass (typecheck, lint, `vitest run` 1849 passed/97 skipped, workout catalog validation).
- [x] `cd app && npm run build` — pass.
- [ ] `uv run pytest` / `uv run ruff check .` / `uv run mypy src/garmin_sync` — not applicable, no Python files touched.
- [ ] `cd app && npm run simulate:scenarios` — not applicable, no recommendation-engine changes.
- [ ] `cd app && npm run visual:refresh` — not applicable, no UI changes.

## Risk and reviewer guidance

Low risk: additive rule constraints and a read-then-write → transactional refactor confined to the OV2 collections this PR itself introduces (not yet used elsewhere in the app). Reviewer should double check the `comparison.required.size() <= comparison.seriesDefining.size() + comparison.contextOnly.size()` coverage check in `firestore.rules` — Firestore's rules dialect doesn't support the CEL `.all()` macro or `list + list` concatenation (both errored in the emulator), so full "every required dimension is classified" coverage is approximated via a size comparison rather than an explicit membership check. Combined with the existing `hasOnly()` subset checks and the new disjointness check, this is exact as long as `seriesDefining`/`contextOnly` don't contain duplicate entries (not independently enforced at the rules layer, same as before this change).

## Domain invariants

- [x] Firestore writes remain user-scoped under `users/{APP_USER_ID}/...`; no `default_user` or top-level collections were introduced — all changes are within the existing `users/{userId}/...` OV2 collections from #155.
- [ ] Calendar-date logic — not applicable, no date-computation changes.
- [x] No credentials, tokens, service-account files, or raw health payloads are included.
- [ ] Recommendation decision logic — not applicable, OV2 persistence only; no `POLICY_VERSION`-relevant changes.

## Screenshots or recordings

Not applicable — backend/rules/test changes only, no UI.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AHLQ7EdmZDXPtfLHn6PcMT)_