### PR TITLE
Move Sync Now button out of a collapsed disclosure

### DIFF
--- a/app/src/components/Home.css
+++ b/app/src/components/Home.css
@@ -94,7 +94,7 @@
   margin: 0;
 }
 
-.card-header-actions {
+.today-status-header-actions {
   display: flex;
   align-items: center;
   gap: 0.5rem;
@@ -1086,8 +1086,10 @@
 /* Today Status Hero & Direct Biomarkers */
 .today-status-header {
   display: flex;
+  flex-wrap: wrap;
   justify-content: space-between;
   align-items: center;
+  gap: 0.5rem;
   margin-bottom: 1rem;
 }
 

--- a/app/src/components/Home.tsx
+++ b/app/src/components/Home.tsx
@@ -908,11 +908,14 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
                     : 'Ready to train'}
                 </h3>
               </div>
-              {activeRec && (
-                <span className={`status-badge mode-${activeRec.mode}`}>
-                  {MODE_LABELS[activeRec.mode]}
-                </span>
-              )}
+              <div className="today-status-header-actions">
+                {activeRec && (
+                  <span className={`status-badge mode-${activeRec.mode}`}>
+                    {MODE_LABELS[activeRec.mode]}
+                  </span>
+                )}
+                <GarminSyncNowButton userId={userId} onSynced={loadDashboardData} />
+              </div>
             </div>
 
             {/* Direct Biomarker Chips */}
@@ -1180,16 +1183,13 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
             <div className="dashboard-card">
               <div className="card-header">
                 <h3>Today's Recovery</h3>
-                <div className="card-header-actions">
-                  {decisionInput?.recoverySnapshot ? (
-                    <span className="status-badge status-normal">
-                      Sleep {decisionInput.recoverySnapshot.raw.sleepScore ?? '--'} · HRV {decisionInput.recoverySnapshot.raw.hrvOvernightAvg ?? '--'}ms
-                    </span>
-                  ) : (
-                    <span className="status-badge warning">No Data</span>
-                  )}
-                  <GarminSyncNowButton userId={userId} onSynced={loadDashboardData} />
-                </div>
+                {decisionInput?.recoverySnapshot ? (
+                  <span className="status-badge status-normal">
+                    Sleep {decisionInput.recoverySnapshot.raw.sleepScore ?? '--'} · HRV {decisionInput.recoverySnapshot.raw.hrvOvernightAvg ?? '--'}ms
+                  </span>
+                ) : (
+                  <span className="status-badge warning">No Data</span>
+                )}
               </div>
 
               {decisionInput?.recoverySnapshot ? (


### PR DESCRIPTION
## Summary

- Follow-up to #147: after deploying, the **🔄 Sync now** button was reported as not findable on the live app.
- Root cause: it landed inside the "Today's Recovery" card, which lives inside the sidebar's collapsed-by-default `<details>` disclosure ("More insights & history ›") — invisible on page load, defeating the point of a quick "I'm up early, sync now" action.
- Moved the button into the always-visible "Today's Readiness" summary card at the top of the Home screen's main column, next to the training-mode badge. Removed the now-duplicate button from the sidebar card rather than showing it in two places.
- Minor CSS: `.today-status-header` gets `flex-wrap: wrap` and a small gap so it doesn't crowd on narrow viewports now that it carries an extra element.

## Validation

- [x] `cd app && npm run check` (typecheck, lint, vitest, workout-catalog validation): pass — 1832 tests passed (the 2 lint warnings shown are pre-existing/unrelated, from `App.tsx` and `useOverloadHistory.ts`).
- [ ] `uv run pytest` / `ruff` / `mypy` — not applicable, no Python files touched.
- [ ] `cd app && npm run test:rules` — not applicable, no Firestore rules touched.
- [ ] `cd app && npm run simulate:scenarios` — not applicable, no recommendation-engine logic changed.
- [ ] `cd app && npm run visual:refresh` — not run; same sandbox constraint as #147 (no local dev server / credentials available here to capture a live screenshot).

## Risk and reviewer guidance

- Pure frontend layout change — no data model, rules, or backend changes. Low risk.
- Worth a quick look at the "Today's Readiness" card on a narrow viewport once deployed, to confirm the mode badge + button don't crowd the headline text awkwardly (added `flex-wrap` as a precaution, not verified against a live render in this sandbox).

## Domain invariants

- [ ] Firestore writes remain user-scoped — not applicable, no Firestore code touched.
- [ ] Calendar-date logic — not applicable.
- [x] No credentials, tokens, service-account files, or raw health payloads included.
- [ ] Recommendation decision logic changed — not applicable.

## Screenshots or recordings

Not applicable — no local dev server / Garmin credentials available in this sandbox to capture a live screenshot.


---
_Generated by [Claude Code](https://claude.ai/code/session_013A2ewqMPo7mcZJ68H5bKfL)_