### PR TITLE
docs: address CodeRabbit review comments on PR #159

### DIFF
--- a/docs/adr/0025-physiological-anomaly-and-possible-illness-signals.md
+++ b/docs/adr/0025-physiological-anomaly-and-possible-illness-signals.md
@@ -87,6 +87,34 @@ Estimator details remain governed by ADR-0024. In particular:
 
 Thresholds, weights and persistence windows are versioned policy, not physiological facts.
 
+#### Deterministic coverage rules
+
+`evaluatePhysiologicalAnomaly` must apply the following minimum-data rules before it scores any
+channel, so that `watch_unexplained` and `possible_illness_or_systemic_stress` never rest on
+data the evaluator effectively fabricated:
+
+* **Minimum observations** — each channel requires a baseline window with at least the
+  observation count ADR-0024 defines for its estimator (for example the v3+ respiration
+  median/MAD minimum). Fewer observations produces `CoreSignalEvidence.status = 'unavailable'`
+  for that channel, never `'normal'`.
+* **Baseline age** — a baseline older than its policy-defined refresh window is treated as stale
+  and downgrades the channel to `unavailable` rather than being scored against a stale
+  reference.
+* **Missing or failed-quality current value** — a missing, non-finite, or quality-flagged
+  current value produces `unavailable` for that channel. `unavailable` is evidence-neutral: it
+  must not be interpreted as `normal` and must not silently drop out of the multi-signal count.
+* **Evidence required for `watch_unexplained`** — at least one core channel at
+  `moderate_anomaly` or stronger with `status != 'unavailable'`, and no explanation strong
+  enough to cover it.
+* **Evidence required for `possible_illness_or_systemic_stress`** — at least
+  `HealthAnomalyThresholdPolicy.minimumCoreSignalsForMultiSignal` independently scored core
+  channels (not `unavailable`, not explained away) at `moderate_anomaly` or stronger,
+  persisting for at least `persistenceDaysForEscalation` observed days per §8. A single-channel
+  anomaly, however strong, cannot alone reach `possible_illness_or_systemic_stress`.
+* Exact minimum-observation counts, baseline windows, and
+  `minimumCoreSignalsForMultiSignal`/`persistenceDaysForEscalation` values are versioned policy
+  calibrated in shadow replay (§9's evidence gates), not fixed by this ADR.
+
 ### 3. Garmin composite metrics are supporting/context signals, not independent votes
 
 Sleep Score, Body Battery, Garmin stress, HRV Status and Training Readiness share upstream
@@ -101,6 +129,20 @@ They may be used to:
 
 They must not manufacture high illness confidence by double-counting shared HRV/sleep/stress
 inputs.
+
+#### The bound on `supportingSignals`
+
+`supportingSignals` are explanatory/contextual only. They:
+
+* may adjust `explanations` and user-facing rationale;
+* must not raise `evidenceLevel`;
+* must not count toward `minimumCoreSignalsForMultiSignal`;
+* must not independently trigger a transition to `possible_illness_or_systemic_stress`.
+
+Only `coreSignals` (RHR, respiration, HRV) can satisfy the multi-signal qualification for
+`possible_illness_or_systemic_stress`. A future revision that wants a supporting signal to
+contribute a bounded amount of evidence requires a versioned, explicitly capped contribution
+defined in a follow-up ADR/policy revision, not an implicit weight inside the evaluator.
 
 ### 4. Known alternative explanations are first-class structured inputs
 
@@ -206,6 +248,38 @@ type HealthAnomalyPolicy =
 
 Production begins at `off`; implementation/replay explicitly opts into `shadow-v1`.
 
+#### Privacy, retention and access controls
+
+`shadow-v1` persistence is still collection of sensitive health and behavioral data and is
+governed by these controls from the moment it is enabled, not only at `visible-v1`:
+
+* **Purpose limitation and consent** — health-anomaly data is collected only to compute and
+  explain this athlete's own assessment. No cross-user aggregation, model training on other
+  users, or secondary use without separate explicit consent.
+* **Field minimization** — only the fields listed in this ADR and the implementation plan (core
+  signal values, structured explanations, optional check-in context, symptom detail, outcome
+  label) may be persisted. Do not persist raw wearable payloads beyond what §11 requires for
+  replay.
+* **Free-text bounds and redaction** — `otherDisruption` and any free-text note is
+  length-bounded, stored as opaque user content, excluded from server logs/telemetry, and never
+  used as evaluator input beyond presence/absence.
+* **Retention and deletion** — assessment revisions, check-in context and outcome labels follow
+  the repository's existing user-data retention/deletion path (ADR-0002 user scoping);
+  deleting a user's data deletes health-anomaly records with it. A default retention window is
+  set as versioned policy, not left unbounded.
+* **Authorized access** — reads are scoped to the owning user via existing Firestore
+  user-isolation rules (ADR-0002); no service role reads across users outside an explicit,
+  audited operational need.
+* **Export minimization** — the HA5.3 replay/evidence tooling reads only the fields it needs
+  and must not bulk-dump raw check-in free text or cross-user data.
+* **Logging redaction** — application/error logs must not include raw symptom text, free-text
+  disruption notes, or other identifiable health context; log structured codes/enums only.
+* **Outcome labels are stored separately from the live assessment record.** A follow-up label
+  (§12) is a distinct, separately timestamped append/update event, never a mutation of the
+  original assessment revision, and it must never be read by the live evaluator or by
+  point-in-time replay of an earlier date — only by later analysis/calibration tooling that is
+  explicitly reading history.
+
 ### 10. Training integration, when eventually enabled, is tighten-only
 
 A future validated high-confidence state may suppress/defer hard or maximal work.
@@ -234,10 +308,27 @@ Persist enough provenance to reconstruct why an assessment occurred:
 * symptoms;
 * persistence/episode state;
 * state transitions;
-* eventual follow-up label when available.
+* eventual follow-up label when available;
+* **source-level replay inputs**, specifically:
+  * the source record's date/timestamp for every input used (Garmin recovery-snapshot date,
+    check-in date, and any revision/sync identifier those records carry);
+  * the evaluation timezone (`Europe/Warsaw` local date, per repository convention);
+  * the exact evaluation window boundaries used per channel (baseline window start/end,
+    persistence-lookback window);
+  * the exact estimator inputs — which estimator/version produced each baseline and scale, and
+    the raw sample count/coverage that estimator consumed.
+
+Assessment time, values and policy versions alone do not identify which observations were used.
+Late Garmin syncs, corrected samples, local-date changes, or baseline backfills can silently
+change what a naive recomputation sees, so the source-level fields above must be persisted
+independently of any aggregate revision number.
 
 Same-day recomputation must follow the append-only revision principles from ADR-0010 rather
-than overwriting the history that produced an earlier alert.
+than overwriting the history that produced an earlier alert. Reuse ADR-0010's immutable
+revision fields where they directly apply, but do not rely on ADR-0010's aggregate decision
+revision alone to reconstruct which source observations fed a given assessment — persist the
+source-level identifiers above so an assessment stays deterministically replayable regardless of
+what happens to unrelated decision state.
 
 ### 12. Prospectively learn the athlete's alternative explanations and outcomes
 
@@ -301,11 +392,54 @@ truthful and not excessively noisy. At minimum report:
 A generic `unusual physiology` message can be released on weaker evidence than a `possible
 illness` interpretation because it makes a narrower claim.
 
+#### Numeric gate and ownership
+
+* **Minimum observation window:** at least 60 observed days per candidate policy, with all
+  three core channels reaching non-`unavailable` coverage on at least 80% of those days.
+* **Minimum episode count:** at least 5 distinct anomaly episodes (`watch_unexplained` or
+  stronger) in the report window; fewer means shadow mode continues rather than cutting over on
+  an underpowered sample.
+* **Noise bound:** unexplained-alert rate on days the athlete retrospectively reports healthy
+  must not exceed a stated versioned ceiling (candidate starting point: no more than 1
+  unexplained `watch_unexplained`-or-stronger alert per 10 observed healthy days). The exact
+  ceiling is fixed as calibrated policy in the HA7 report, not invented ad hoc at cutover time.
+* **Confidence requirement:** the reported truthfulness metrics (context-explained fraction,
+  symptom-follow-up fraction, per-signal/multi-signal alert counts) must be stable across at
+  least two non-overlapping observation windows before cutover, not a single window.
+* **Decision owner:** the engineering owner recorded in this ADR's `Deciders` field approves the
+  HA7 report and the cutover; no cutover ships without that sign-off recorded in the report.
+* **Rollback condition:** if post-cutover monitoring shows the unexplained-alert rate or
+  context-explained fraction regressing beyond the HA7 report's stated bounds for 14
+  consecutive observed days, the policy selector reverts to `shadow-v1` and a new HA7-style
+  report is required before re-attempting `visible-v1`.
+
 ### `visible-v1` -> `tighten-v1`
 
 Requires evidence that the new gate improves safety/decision quality without causing an
 unacceptable rate of unnecessary hard-session suppression. Report actual recommendation
 flips and athlete outcomes. Synthetic scenarios alone cannot authorize this cutover.
+
+#### Numeric gate and ownership
+
+* **Minimum observation window:** at least 90 observed days in `visible-v1` with recorded
+  athlete-facing alerts, covering at least 3 distinct anomaly episodes with a recorded outcome
+  label (§12/HA6).
+* **Confidence requirement:** report actual recommendation flips (how often the gate would have
+  changed the training recommendation) and their outcomes; unnecessary hard-session suppression
+  (episodes later explained as non-illness) must not exceed a stated versioned ceiling
+  (candidate starting point: no more than 1 in 5 suppressions retrospectively found
+  unnecessary).
+* **Decision owner:** the same named engineering owner as the `visible-v1` cutover; requires a
+  fresh, dated report specific to the training-gate decision — the `shadow-v1 -> visible-v1`
+  report cannot be reused.
+* **Rollback condition:** if `tighten-v1` produces recommendation flips later judged
+  unnecessary at a rate exceeding the stated ceiling over any rolling 30-day window, the policy
+  selector reverts to `visible-v1` immediately and a corrective report is required before
+  re-attempting `tighten-v1`.
+
+The candidate numeric ceilings above are starting points for the HA7 report to confirm or
+tighten with real data, not final physiological truths; they replace subjective phrases like
+"not excessively noisy" or "unacceptable rate" with a reproducible ship/no-ship decision.
 
 ---
 

--- a/docs/analysis/2026-08-21-physiological-anomaly-and-illness-risk-research.md
+++ b/docs/analysis/2026-08-21-physiological-anomaly-and-illness-risk-research.md
@@ -48,7 +48,7 @@ That default-off decision remains correct for the **training strain score**. Thi
 
 ### Known training stress
 
-`EngineObjectiveInput.last_3_days_hard_sessions_count`, `yesterday_training`, `today_training`, per-activity telemetry and completed-session cost already let the system distinguish an athlete who unexpectedly deteriorated from an athlete who completed a hard session that plausibly explains next-morning autonomic suppression.
+`EngineObjectiveInput.last_3_days_hard_sessions_count`, `yesterday_training`, `today_training`, per-activity telemetry and completed-session cost already provide context for a separate evaluator to distinguish unexpected deterioration from the expected response to a hard session. The current engine does not itself make that comparison: `evaluateReadinessAndSafetyEnvelope` applies recent hard-session context as a strain penalty, but it does not compare the observed response with an activity-matched expected response or produce a causal explanation — that attribution is the capability this document and ADR-0025 propose.
 
 This is important because intense exercise is a documented source of false-positive infection alerts.
 
@@ -173,15 +173,35 @@ Examples:
 
 ## Evidence hierarchy for the app
 
-The evaluator should distinguish **independent physiological channels** from **context/composites**.
+The evaluator should distinguish **distinct candidate physiological channels** from
+**context/composites**.
 
 ### Core anomaly channels
 
-These are the strongest first-pass independent channels available in the repository:
+These are the strongest first-pass distinct candidate channels available in the repository.
+"Distinct" is a claim about the physiological concept each channel targets, not a proven
+statistical independence claim: some wearable methods estimate respiration rate from
+heartbeat-interval variability via respiratory sinus arrhythmia, so RHR/HRV and
+device-estimated respiration can be correlated rather than independent, depending on how the
+device derives respiration. Do not label them "independent channels" until that is checked for
+the device data actually used.
 
 1. **RHR** — adverse direction: higher than personal baseline.
 2. **Respiration rate** — adverse direction: higher than personal baseline.
 3. **HRV** — adverse pattern usually lower than personal baseline, but ADR-0024 correctly warns that unusually high HRV can also be abnormal; use a two-sided personal-normality model internally and treat the common low-HRV direction as the illness/recovery feature.
+
+Before using channel agreement as evidence for `possible_illness_or_systemic_stress`, the
+evaluator requires:
+
+* **device-specific signal validation** — confirm how the connected device derives respiration
+  rate (direct sensor vs. HRV-derived) so the evaluator knows whether RHR/HRV and respiration
+  can share a common source signal;
+* **within-person correlation checks** — measure this athlete's own historical RHR/HRV/
+  respiration correlation during replay rather than assuming population-level independence;
+* **a cap or adjustment for correlated evidence** — when two channels are found to be
+  correlated for a given device/athlete, their joint agreement contributes less than two fully
+  independent channels' worth of evidence toward `minimumCoreSignalsForMultiSignal`
+  (ADR-0025 §2).
 
 The system should require adequate baseline coverage and data quality before scoring any channel.
 
@@ -319,6 +339,22 @@ A shadow/replay report should measure at least:
 * how often a proposed alert would have suppressed a hard session;
 * whether the alert adds information beyond the existing readiness recommendation;
 * per-policy confusion matrices once enough labelled episodes exist.
+
+Outcome labels must match what the validation claim actually needs. A missing reported symptom
+does not establish that a day was healthy — the JMIR Formative Research prospective study cited
+above only tested users after a positive alert, treated un-acted alerts as negative by default,
+and still reported a PPV of only 4-10% in that population. Reusing "no reported symptom = healthy
+day" the same way would inherit that bias. The report must therefore:
+
+* use **separate outcome labels** rather than one healthy/sick axis: lab-confirmed infection,
+  other respiratory illness, self-reported symptoms without confirmation, explicit confounder
+  (hard training/alcohol/travel/sleep/stress/heat/dehydration), and unknown/no follow-up;
+* give **alert and non-alert periods the same observation and testing opportunity** — do not
+  compare a heavily-followed-up alert period against a passively-observed non-alert period;
+* **freeze baselines and policy inputs at assessment time** during replay, so a later baseline
+  recompute cannot retroactively change what an earlier date's assessment would have shown;
+* **not authorize `possible_illness_or_systemic_stress`** from symptom-follow-up metrics alone —
+  require it alongside the data-quality and multi-signal-persistence evidence from ADR-0025 §2.
 
 Synthetic scenarios are useful for threshold behavior but cannot authorize user-facing `possible illness` wording on their own.
 

--- a/docs/plans/health-anomaly-and-illness-risk-alerting.md
+++ b/docs/plans/health-anomaly-and-illness-risk-alerting.md
@@ -91,6 +91,22 @@ export type HealthAnomalyPolicy =
 Normal production behavior stays `off` until the shadow implementation lands and the feature
 is intentionally enabled for evidence collection.
 
+#### Fail-closed policy resolution
+
+Runtime resolution of `HealthAnomalyPolicy` must be fail-closed:
+
+* accept only the four exact enum string values (`'off' | 'shadow-v1' | 'visible-v1' |
+  'tighten-v1'`); reject anything else rather than coercing or guessing;
+* a missing configuration value resolves to `'off'`;
+* an invalid/unrecognized string value resolves to `'off'`;
+* a configuration read failure (feature-flag store unavailable, malformed remote config, etc.)
+  resolves to `'off'`;
+* every non-`'off'` mode requires an explicit, valid configured value — there is no implicit
+  upgrade path from missing/invalid configuration into a more visible mode.
+
+HA0.1 unit tests must cover all four valid values plus the missing/invalid/read-failure cases
+above, asserting each degrades to `'off'`.
+
 ---
 
 ## Canonical data contracts
@@ -335,12 +351,49 @@ When the user turns illness symptoms on, optionally reveal:
 
 `illnessSymptoms` remains the compatibility flag consumed by existing code.
 
+#### Migration and validation contract
+
+This single contract applies consistently in `validateCheckin`, `parseSubjectiveCheckin`, and
+`app/firestore.rules` — not just in the UI:
+
+* **Precedence when both fields are present.** `healthContext.symptoms.present` is the
+  authoritative source once supplied; it wins over any independently-written `illnessSymptoms`
+  value on the same write.
+  * `symptoms.present === true` sets `illnessSymptoms = true`.
+  * `symptoms.present === false` sets `illnessSymptoms = false` (explicit clear).
+  * `healthContext.symptoms` omitted entirely leaves the legacy `illnessSymptoms` field
+    untouched — omission is not the same as `present: false`.
+* **Allowed nested combinations.** `onset`, `severity` and `types` are only meaningful, and
+  only accepted, when `symptoms.present === true`. When `present === false` or `symptoms` is
+  absent, `onset`/`severity`/`types` must be absent or `null`; a write that sets them alongside
+  `present: false` (or without `present`) is an invalid nested state and is rejected.
+* **Finite `timezoneShiftHours` bounds.** When supplied, `timezoneShiftHours` must be a finite
+  number in `[-14, 14]` (covering real-world UTC offsets); `null`/omitted means unknown.
+  Values outside that range or non-finite values are rejected.
+* **Firestore rules enforce the same shape**, not only ownership/date: reject documents where
+  `healthContext.symptoms.present` is `false`/absent but onset/severity/types are set, and
+  reject `timezoneShiftHours` outside `[-14, 14]`. Rules validation is best-effort mirroring of
+  `validateCheckin`; the app-side validator remains the primary gate.
+
 Acceptance criteria:
 
-* a legacy check-in behaves exactly as before;
+* a legacy check-in (no `healthContext`) behaves exactly as before;
 * new context round-trips through persistence;
-* clearing `symptoms.present` updates `illnessSymptoms` consistently;
-* no context field is required to submit a check-in.
+* clearing `symptoms.present` (`true -> false`) updates `illnessSymptoms` consistently and
+  clears/rejects any now-invalid nested onset/severity/types;
+* no context field is required to submit a check-in;
+* `validateCheckin`, `parseSubjectiveCheckin` and `app/firestore.rules` agree on the contract
+  above.
+
+Required tests (`validateCheckin`, `parseSubjectiveCheckin`, and `test:rules`):
+
+* legacy-only — only `illnessSymptoms` set, no `healthContext`;
+* context-only — `healthContext.symptoms.present` set, no legacy `illnessSymptoms` on the write;
+* conflicting — both fields present with different values, confirms `healthContext` wins;
+* clear-flow — `present: true` followed by `present: false`, confirms `illnessSymptoms` clears
+  and stale onset/severity/types are rejected or cleared;
+* invalid-range — `timezoneShiftHours` outside `[-14, 14]` or non-finite is rejected;
+* invalid-nested-state — onset/severity/types set while `present` is `false`/absent is rejected.
 
 ---
 
@@ -397,6 +450,16 @@ Per signal record:
 
 The evaluator must be able to say `unavailable`. One missing signal must not be interpreted as
 normal.
+
+**Zero-scale behavior must be deterministic.** When a channel's scale (MAD/stdev) is zero or
+below a documented near-zero epsilon, the default is `status = 'unavailable'` — never a
+standardized deviation computed by dividing by (near-)zero. A specific non-escalating fallback
+(for example, treating an exactly-zero-variance history as `'normal'` when history count is
+otherwise sufficient and the current value equals the baseline exactly) is only permitted when
+it is explicitly documented in the policy and covered by a unit test proving it cannot produce
+`moderate_anomaly`/`strong_anomaly`/infinite evidence from zero variance. Every threshold policy
+must pass a test asserting zero/near-zero scale never yields `moderate_anomaly`, `strong_anomaly`,
+or an infinite/NaN standardized deviation.
 
 Acceptance criteria:
 
@@ -572,6 +635,34 @@ Persist:
 * whether an alert was actually shown;
 * optional outcome label added later as a separate append/update event according to existing
   journal conventions.
+
+#### Immutable, replayable identity
+
+Do not rely on a generic revision primitive's numeric counter or timestamp alone. Define:
+
+* **`revisionId`** — derived from an immutable source-revision identifier or a normalized input
+  fingerprint (a stable hash of the exact source snapshot/check-in identifiers, baseline
+  versions and policy version that produced the assessment), not a wall-clock timestamp.
+  Timestamps alone cannot distinguish "recomputed with the same inputs" from "recomputed after
+  a late sync changed the inputs."
+* **Idempotency key** — deterministic from `(effective local date, source snapshot/check-in
+  revisions, policy version, baseline/threshold policy version, mode)`. Recomputing with an
+  unchanged key must not create a duplicate revision; recomputing with a changed key (a source
+  revision changed) creates a new revision per ADR-0010's append-only principle.
+* **Immutable threshold values** — each policy version resolves to a fixed, immutable set of
+  `HealthAnomalyThresholdPolicy` values at compute time; a later change to the *current* policy
+  version must not retroactively alter what an already-persisted revision recorded as its
+  effective thresholds.
+* **Outcome labels stay outside the immutable revision.** A later follow-up label (HA6) is
+  written as a separate append/update event referencing the assessment/episode, never as a
+  mutation of the assessment revision that produced the original alert (see ADR-0025's privacy
+  section on keeping outcome labels separate from live scoring/replay).
+* **Late and out-of-order updates.** A late Garmin sync, corrected sample, or backfilled
+  baseline that changes a source revision after the original assessment was computed produces a
+  *new* revision under the same `{date}` with a new `revisionId`/idempotency key; it does not
+  overwrite the earlier revision. The episode-identity logic (HA4.2) treats a late-arriving
+  revision using the source data's effective date, not the recompute wall-clock time, and must
+  not use future information to backdate an episode's start.
 
 ### HA4.2 Episode identity
 
@@ -911,7 +1002,9 @@ At minimum:
 6. symptoms true + normal wearables -> `symptoms_reported`;
 7. symptoms true + perfect-looking readiness -> still symptoms state;
 8. missing respiration -> evaluator does not fabricate normal respiration;
-9. zero MAD/scale -> signal unavailable or policy-defined safe fallback, never infinite evidence;
+9. zero/near-zero MAD/scale -> signal `unavailable` by default, or an explicitly documented
+   non-escalating fallback per HA2.4, but never `moderate_anomaly`/`strong_anomaly` or infinite
+   evidence;
 10. alcohol explains RHR/HRV but not automatically all respiration evidence;
 11. travel + poor sleep can explain more than travel alone;
 12. correlated Garmin composites cannot independently escalate state;


### PR DESCRIPTION
## Summary

Addresses all 12 CodeRabbit review comments on #159 by tightening the design docs before implementation begins:

- `docs/adr/0025-physiological-anomaly-and-possible-illness-signals.md` — deterministic coverage/minimum-observation rules for `evaluatePhysiologicalAnomaly`, an explicit bound on `supportingSignals` (explanatory-only, cannot escalate), a privacy/retention/access-control subsection, source-level replay provenance (independent of ADR-0010's aggregate revision), and numeric cutover gates with named decision ownership and rollback conditions for `shadow-v1 -> visible-v1 -> tighten-v1`.
- `docs/analysis/2026-08-21-physiological-anomaly-and-illness-risk-research.md` — corrected the training-context capability claim so it doesn't overstate current engine behavior, stopped calling RHR/respiration/HRV "independent" without a dependence check, and defined a separate outcome-label taxonomy with matched observation windows and frozen replay baselines.
- `docs/plans/health-anomaly-and-illness-risk-alerting.md` — fail-closed `HealthAnomalyPolicy` resolution, a full `healthContext`/`illnessSymptoms` migration and validation contract applied consistently across `validateCheckin`/`parseSubjectiveCheckin`/`firestore.rules`, an immutable/replayable assessment identity (revision fingerprint, idempotency key, immutable thresholds, outcome labels kept out of the immutable revision), and deterministic zero/near-zero-scale handling.

This PR is stacked on `docs/physiological-anomaly-alerts` (the head of #159) so merging it here folds the fixes into #159.

No behavior change: this remains documentation-only. It changes no engine code, scoring weights, Firestore schema, or UI.

## Validation

- [ ] `uv run pytest` (backend changes) — not applicable, docs-only change
- [ ] `uv run ruff check .` and `uv run mypy src/garmin_sync` (backend changes) — not applicable, docs-only change
- [ ] `cd app && npm run check` (frontend changes) — not applicable, docs-only change
- [ ] `cd app && npm run test:rules` (Firestore rules changes) — not applicable, no rules changed
- [ ] `cd app && npm run simulate:scenarios` (recommendation-engine changes) — not applicable, no engine code changed
- [ ] `cd app && npm run visual:refresh` (material UI changes) — not applicable, no UI changed

Manual check: reviewed the diff against each of the 12 CodeRabbit findings on #159 and confirmed each is addressed in the relevant document section.

## Risk and reviewer guidance

Low risk: documentation-only change, no code/schema/UI touched. Reviewers should confirm the new coverage/privacy/provenance/cutover-gate language in ADR-0025 stays consistent with the implementation plan's HA0–HA10 sections, since a few numeric ceilings (noise bound, minimum episode counts) are proposed starting points for the eventual HA7 evidence report rather than final values.

## Domain invariants

Not applicable — documentation-only change; no Firestore writes, date logic, credentials, or recommendation decision logic were touched.

## Screenshots or recordings

Not applicable — documentation-only change, no UI affected.


---
_Generated by [Claude Code](https://claude.ai/code/session_01V2QmWQTjX7x1o1DXC4R5or)_