### PR TITLE
fix(health-context): close Firestore rules/parser gap on illnessSymptoms

### DIFF
--- a/app/firestore.rules
+++ b/app/firestore.rules
@@ -274,7 +274,14 @@ service cloud.firestore {
     }
 
     function hasValidSubjectiveHealthFields(data) {
-      return (!('illnessSymptoms' in data) || data.illnessSymptoms is bool)
+      // Mirrors the app parser's precedence (parseSubjectiveCheckin): a rich symptoms
+      // block is authoritative and makes the legacy flag optional, but if it's absent
+      // the legacy flag is the only illness signal and must be a real boolean. Without
+      // this, a write could satisfy the rule with neither field present, then get
+      // permanently rejected as invalid on every subsequent read.
+      return (('illnessSymptoms' in data)
+          ? data.illnessSymptoms is bool
+          : (('healthContext' in data) && (data.healthContext is map) && ('symptoms' in data.healthContext)))
         && (!('healthContext' in data) || hasValidHealthContext(data.healthContext));
     }
 

--- a/app/src/emulator/healthContextRules.emulator.test.ts
+++ b/app/src/emulator/healthContextRules.emulator.test.ts
@@ -131,6 +131,15 @@ emulatorDescribe('Daily subjective check-in health-context rules (HA1)', () => {
         }
     });
 
+    it('rejects a write with neither the legacy illness flag nor a rich symptoms block', async () => {
+        const db = testEnvironment.authenticatedContext(ownerId).firestore();
+        await assertFails(setDoc(doc(db, checkinPath), contextOnlyCheckin()));
+        await assertFails(setDoc(doc(db, checkinPath), {
+            ...contextOnlyCheckin(),
+            healthContext: { travelDisruption: 'none' },
+        }));
+    });
+
     it('rejects malformed supplied context fields while keeping every context field optional', async () => {
         const db = testEnvironment.authenticatedContext(ownerId).firestore();
         await assertSucceeds(setDoc(doc(db, checkinPath), baseCheckin()));

--- a/app/src/persistence/parsers/decisionInputs.ts
+++ b/app/src/persistence/parsers/decisionInputs.ts
@@ -73,12 +73,12 @@ export function parseSubjectiveCheckin(raw: unknown, documentPath: string, userI
     if (!['painOrInjury', 'unusuallyLimitedTime', 'alreadyTrainedToday'].every(field => typeof raw[field] === 'boolean')) {
         return issue(documentPath, 'invalid-safety-flag');
     }
-    if (raw.illnessSymptoms !== undefined && typeof raw.illnessSymptoms !== 'boolean') {
-        return issue(documentPath, 'invalid-safety-flag', 'illnessSymptoms');
-    }
-    // Legacy documents must still carry their compatibility flag. The only accepted
-    // context-only exception is a rich symptoms block whose `present` value is authoritative.
-    if (!richSymptomsSupplied && typeof raw.illnessSymptoms !== 'boolean') {
+    // Legacy documents must still carry their compatibility flag as a real boolean. The
+    // only accepted context-only exception is an omitted flag alongside a rich symptoms
+    // block, whose `present` value is authoritative (HA1 precedence).
+    const illnessSymptomsValid = typeof raw.illnessSymptoms === 'boolean'
+        || (raw.illnessSymptoms === undefined && richSymptomsSupplied);
+    if (!illnessSymptomsValid) {
         return issue(documentPath, 'invalid-safety-flag', 'illnessSymptoms');
     }
     if (!hasNullableNumbers(raw, ['readiness', 'sleepQuality', 'fatigue', 'soreness', 'mentalStress', 'motivation'])


### PR DESCRIPTION
## Summary

Follow-up review/fix from #162 (HA-A health anomaly contracts and check-in context), which merged while this review was in progress. That merge included its own fix for the `isOneOf()` type-narrowing bug that was failing `tsc` in CI, so this PR only carries the one remaining gap found during review:

- `firestore.rules`: `hasValidSubjectiveHealthFields()` allowed a create/update with **neither** `illnessSymptoms` nor a rich `healthContext.symptoms` block present. Such a write passes the security rule but is then permanently rejected as `invalid-safety-flag` by `parseSubjectiveCheckin` on every subsequent read — a document that's writable but unreadable. The rule now enforces exactly what the parser requires (legacy flag as a real boolean, or a rich symptoms block when the flag is omitted), with a new emulator regression test covering the previously-permitted gap.
- `decisionInputs.ts`: simplified two sequential, overlapping `illnessSymptoms` validity checks (the first fully subsumed by the second) into one condition mirroring the rule's precedence — no behavior change.

No user-visible change; this is validation/rules-only.

## Validation

Results:
- `cd app && npm run check` (typecheck, lint, unit tests, workout catalog validation): pass — 1903 tests passed, 105 skipped, 0 lint errors.
- `cd app && npm run build`: pass.
- `cd app && npm run test:rules` (Firestore rules emulator suite, including the new regression test): pass — 105/105.
- `cd app && npm run simulate:scenarios && npm run simulate:diff`: pass — no semantic differences vs. committed baseline.
- [ ] `uv run pytest` / `ruff` / `mypy` — not run; no Python files touched by this diff.
- [ ] `npm run visual:refresh` — not applicable; no UI-visible change.

## Risk and reviewer guidance

Low risk: the Firestore rule change is stricter than before (closes a gap, doesn't widen access), so please double-check the new emulator test covers the intended before/after behavior. Existing tests were unaffected since none relied on the previously-permitted gap.

## Domain invariants

- [x] Firestore writes remain user-scoped under `users/{APP_USER_ID}/...`; unaffected by this change.
- Not applicable — no calendar-date logic touched.
- [x] No credentials, tokens, service-account files, or raw health payloads are included.
- Not applicable — no recommendation decision logic (`POLICY_VERSION`) changed; this is contract/rules validation only.

## Screenshots or recordings

Not applicable — no UI-visible change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UN283ipQcd7H93Aeg3STVp)_