### PR TITLE
fix(ci): forward VITE_HEALTH_ANOMALY_POLICY secret into frontend build

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -122,6 +122,12 @@ jobs:
           VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
           VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
           VITE_FIREBASE_MEASUREMENT_ID: ${{ secrets.VITE_FIREBASE_MEASUREMENT_ID }}
+          # HA-D developer evidence collection (see app/.env.example). Forwarding the repo
+          # secret here is required -- Vite only inlines VITE_* vars present in the build-time
+          # environment, and a missing value fails closed to 'off' by design
+          # (resolveConfiguredHealthAnomalyShadowPolicy), so without this line the secret being
+          # set has no effect on the deployed build.
+          VITE_HEALTH_ANOMALY_POLICY: ${{ secrets.VITE_HEALTH_ANOMALY_POLICY }}
           VITE_GIT_SHA: ${{ github.sha }}
           VITE_GIT_DIRTY: "false"
         run: npm run build


### PR DESCRIPTION
## Summary

- The `deploy-frontend.yml` "Build frontend" step only forwarded the Firebase secrets into `npm run build`'s environment — it never referenced `secrets.VITE_HEALTH_ANOMALY_POLICY`.
- Vite only inlines `import.meta.env.VITE_*` variables present in the process environment at build time. With the variable absent, `configuredHealthAnomalyShadowPolicy()` reads `undefined`, and `resolveConfiguredHealthAnomalyShadowPolicy` fails closed to `'off'` by design (a missing value must never silently opt someone into shadow collection).
- Net effect: setting the `VITE_HEALTH_ANOMALY_POLICY` repo secret to `shadow-v1` had no effect on the deployed build — production was shipping HA shadow mode off regardless.
- Fix: forward `secrets.VITE_HEALTH_ANOMALY_POLICY` into the build step's `env:` block, same as the existing Firebase secrets.

## Validation

- [x] YAML syntax: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-frontend.yml'))"` — pass.
- [ ] `cd app && npm run check` — not applicable; this change touches only `.github/workflows/deploy-frontend.yml`, no app source.
- [ ] Manual check: not run against a live deploy (requires GitHub Actions secrets/GCP access outside this session). Next scheduled `deploy-frontend` run with `deploy_hosting: true` will exercise the corrected env forwarding; expect `HealthAnomalyShadowPanel` to appear on the Data screen in the deployed build if `VITE_HEALTH_ANOMALY_POLICY=shadow-v1` is set as a repo secret.

## Risk and reviewer guidance

Low risk: single-line addition to an existing `env:` block in a manually-dispatched (`workflow_dispatch`) deploy workflow; no code path changes, no effect on any other secret or step. Worth double-checking that `VITE_HEALTH_ANOMALY_POLICY` is actually the secret name configured in the repo (Settings → Secrets and variables → Actions) — if the secret doesn't exist, this resolves to an empty string, which still fails closed to `'off'` (same current behavior), so there's no risk of silently going the other way.

## Domain invariants

Not applicable — CI workflow change only; no Firestore, date-logic, or recommendation-policy code touched.

## Screenshots or recordings

Not applicable — no UI change in this PR; enables an existing dev-only shadow panel to actually receive its intended build-time configuration on the next deploy.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015R3HwzgTcpy3qEBsBhCqet)_