### PR TITLE
feat: add HA6 prospective health-anomaly outcome labels

### DIFF
--- a/app/firestore.rules
+++ b/app/firestore.rules
@@ -259,11 +259,6 @@ service cloud.firestore {
     }
 
     function hasValidSubjectiveHealthFields(data) {
-      // Mirrors the app parser's precedence (parseSubjectiveCheckin): a rich symptoms
-      // block is authoritative and makes the legacy flag optional, but if it's absent
-      // the legacy flag is the only illness signal and must be a real boolean. Without
-      // this, a write could satisfy the rule with neither field present, then get
-      // permanently rejected as invalid on every subsequent read.
       return (('illnessSymptoms' in data)
           ? data.illnessSymptoms is bool
           : (('healthContext' in data) && (data.healthContext is map) && ('symptoms' in data.healthContext)))
@@ -1242,9 +1237,59 @@ service cloud.firestore {
       allow update, delete: if false;
     }
 
+    function hasValidHealthAnomalyOutcome(userId, episodeId) {
+      let data = request.resource.data;
+      let sourceAssessment = data.sourceAssessment;
+      let symptomOnset = data.symptomOnset;
+      let respiratoryTest = data.respiratoryTest;
+      let assessmentPath = /databases/$(database)/documents/users/$(userId)/health_anomaly_assessments/$(sourceAssessment.date)/revisions/$(sourceAssessment.revisionId);
+      return hasOwnedUserId(userId)
+        && data.keys().hasOnly(['userId', 'episodeId', 'sourceAssessment', 'explanation', 'symptomOnset', 'respiratoryTest', 'note', 'createdAt', 'updatedAt', 'schemaVersion'])
+        && data.keys().hasAll(['userId', 'episodeId', 'sourceAssessment', 'explanation', 'symptomOnset', 'respiratoryTest', 'note', 'createdAt', 'updatedAt', 'schemaVersion'])
+        && data.episodeId == episodeId
+        && data.episodeId is string && data.episodeId.size() > 0 && data.episodeId.size() <= 160
+        && sourceAssessment is map
+        && sourceAssessment.keys().hasOnly(['date', 'revisionId'])
+        && sourceAssessment.keys().hasAll(['date', 'revisionId'])
+        && isValidActivityDate(sourceAssessment.date)
+        && sourceAssessment.revisionId is string && sourceAssessment.revisionId.matches('^ha-[0-9a-f]{16}$')
+        && exists(assessmentPath)
+        && get(assessmentPath).data.assessment.episodeId == episodeId
+        && data.explanation in ['illness_symptoms', 'hard_training_recovery', 'poor_sleep', 'alcohol', 'travel_jetlag', 'stress', 'heat_dehydration', 'vaccination_medication', 'nothing_obvious', 'other_not_sure']
+        && (symptomOnset == null || (
+          symptomOnset is map
+          && symptomOnset.keys().hasOnly(['date', 'precision'])
+          && symptomOnset.keys().hasAll(['date', 'precision'])
+          && isValidActivityDate(symptomOnset.date)
+          && symptomOnset.precision == 'day'
+        ))
+        && (respiratoryTest == null || (
+          respiratoryTest is map
+          && respiratoryTest.keys().hasOnly(['result', 'testedOn', 'source'])
+          && respiratoryTest.keys().hasAll(['result', 'testedOn', 'source'])
+          && respiratoryTest.result in ['positive', 'negative']
+          && isValidActivityDate(respiratoryTest.testedOn)
+          && respiratoryTest.source == 'user_reported'
+        ))
+        && (data.note == null || (data.note is string && data.note.size() <= 2000))
+        && data.createdAt is string && data.createdAt.size() > 0
+        && data.updatedAt is string && data.updatedAt.size() > 0
+        && data.schemaVersion == 1;
+    }
+
+    match /users/{userId}/health_anomaly_outcomes/{episodeId} {
+      allow read: if isOwner(userId);
+      allow create: if hasValidHealthAnomalyOutcome(userId, episodeId);
+      allow update: if hasValidHealthAnomalyOutcome(userId, episodeId)
+        && keepsOwnership(userId)
+        && request.resource.data.episodeId == resource.data.episodeId
+        && request.resource.data.sourceAssessment == resource.data.sourceAssessment
+        && request.resource.data.createdAt == resource.data.createdAt
+        && request.resource.data.schemaVersion == resource.data.schemaVersion;
+      allow delete: if false;
+    }
+
     // --- OV5.1: immutable outcome-evaluation criteria and lifecycle.
-    // Metric bindings are embedded in the revision document so activation freezes the
-    // exact bounded criteria atomically with the revision hash.
     function outcomeEvaluationHeadAfterRevision(userId, evaluationId, revision) {
       let headPath = /databases/$(database)/documents/users/$(userId)/outcome_evaluations/$(evaluationId);
       let head = getAfter(headPath).data;
@@ -1257,9 +1302,6 @@ service cloud.firestore {
       return next.id == evaluationId && next.revision == revision && next.status == 'draft';
     }
 
-    // Activation must target the current head revision -- otherwise an earlier draft left
-    // behind by a later createDraftRevision could be activated after the fact, producing two
-    // revisions of the same evaluation both in 'active' status.
     function isHeadOutcomeEvaluationRevision(userId, evaluationId, revision) {
       let headPath = /databases/$(database)/documents/users/$(userId)/outcome_evaluations/$(evaluationId);
       return exists(headPath) && get(headPath).data.currentRevision == revision;

--- a/app/src/components/HealthAnomalyFollowupCard.css
+++ b/app/src/components/HealthAnomalyFollowupCard.css
@@ -1,0 +1,41 @@
+.ha-followup-form {
+  display: grid;
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.ha-followup-field {
+  display: grid;
+  gap: 6px;
+}
+
+.ha-followup-field label {
+  font-weight: 600;
+}
+
+.ha-followup-field select,
+.ha-followup-field input,
+.ha-followup-field textarea,
+.ha-followup-form button {
+  min-height: 44px;
+  font: inherit;
+}
+
+.ha-followup-field select,
+.ha-followup-field input,
+.ha-followup-field textarea {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.ha-followup-field textarea {
+  min-height: 72px;
+  resize: vertical;
+}
+
+.ha-followup-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}

--- a/app/src/components/HealthAnomalyFollowupCard.test.tsx
+++ b/app/src/components/HealthAnomalyFollowupCard.test.tsx
@@ -1,0 +1,44 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import { HealthAnomalyFollowupForm } from './HealthAnomalyFollowupCard';
+
+const candidate = {
+    episodeId: 'health-anomaly:2026-08-20',
+    sourceAssessment: { date: '2026-08-20', revisionId: 'ha-1234567890abcdef' },
+    episodeDay: 2,
+};
+
+describe('HealthAnomalyFollowupForm', () => {
+    it('renders every HA6 explanation choice without turning the form into an alert', () => {
+        const html = renderToStaticMarkup(
+            <HealthAnomalyFollowupForm candidate={candidate} existing={null} onSave={vi.fn()} />,
+        );
+        expect(html).toContain('Recovery follow-up (shadow)');
+        expect(html).toContain('I developed illness symptoms');
+        expect(html).toContain('Hard training / recovery');
+        expect(html).toContain('Nothing obvious');
+        expect(html).toContain('Other / not sure');
+        expect(html).toContain('does not change your recommendation');
+        expect(html).not.toContain('Possible illness or other systemic stress');
+    });
+
+    it('renders an existing symptom/test label for later editing', () => {
+        const html = renderToStaticMarkup(
+            <HealthAnomalyFollowupForm
+                candidate={candidate}
+                existing={{
+                    userId: 'u1', episodeId: candidate.episodeId, sourceAssessment: candidate.sourceAssessment,
+                    explanation: 'illness_symptoms',
+                    symptomOnset: { date: '2026-08-21', precision: 'day' },
+                    respiratoryTest: { result: 'positive', testedOn: '2026-08-21', source: 'user_reported' },
+                    note: 'Later symptoms', createdAt: '2026-08-21T06:00:00Z', updatedAt: '2026-08-21T18:00:00Z', schemaVersion: 1,
+                }}
+                onSave={vi.fn()}
+            />,
+        );
+        expect(html).toContain('Approximate symptom onset date');
+        expect(html).toContain('value="2026-08-21"');
+        expect(html).toContain('Update follow-up');
+        expect(html).toContain('Later symptoms');
+    });
+});

--- a/app/src/components/HealthAnomalyFollowupCard.tsx
+++ b/app/src/components/HealthAnomalyFollowupCard.tsx
@@ -1,0 +1,217 @@
+import { useEffect, useState } from 'react';
+import type { HealthAnomalyAssessmentRevision } from '../engine/healthAnomalyModels';
+import {
+    HEALTH_ANOMALY_OUTCOME_EXPLANATIONS,
+    type HealthAnomalyEpisodeOutcome,
+    type HealthAnomalyOutcomeExplanation,
+    type HealthAnomalyRespiratoryTestResult,
+} from '../engine/healthAnomalyOutcome';
+import {
+    findRecentHealthAnomalyFollowupCandidate,
+    healthAnomalyOutcomeRepository,
+    type HealthAnomalyFollowupCandidate,
+} from '../services/healthAnomalyOutcomeService';
+import { getLocalDateString } from '../utils/localDate';
+import './HealthAnomalyFollowupCard.css';
+
+const EXPLANATION_LABELS: Record<HealthAnomalyOutcomeExplanation, string> = {
+    illness_symptoms: 'I developed illness symptoms',
+    hard_training_recovery: 'Hard training / recovery',
+    poor_sleep: 'Poor sleep',
+    alcohol: 'Alcohol',
+    travel_jetlag: 'Travel / jet lag',
+    stress: 'Stress',
+    heat_dehydration: 'Heat / dehydration',
+    vaccination_medication: 'Vaccination / medication',
+    nothing_obvious: 'Nothing obvious',
+    other_not_sure: 'Other / not sure',
+};
+
+interface HealthAnomalyFollowupFormProps {
+    candidate: HealthAnomalyFollowupCandidate;
+    existing: HealthAnomalyEpisodeOutcome | null;
+    onSave: (input: {
+        explanation: HealthAnomalyOutcomeExplanation;
+        symptomOnsetDate: string | null;
+        testResult: HealthAnomalyRespiratoryTestResult | null;
+        testedOn: string | null;
+        note: string | null;
+    }) => Promise<void>;
+}
+
+export function HealthAnomalyFollowupForm({ candidate, existing, onSave }: HealthAnomalyFollowupFormProps) {
+    const [explanation, setExplanation] = useState<HealthAnomalyOutcomeExplanation>(existing?.explanation ?? 'nothing_obvious');
+    const [symptomOnsetDate, setSymptomOnsetDate] = useState(existing?.symptomOnset?.date ?? '');
+    const [testResult, setTestResult] = useState<HealthAnomalyRespiratoryTestResult | ''>(existing?.respiratoryTest?.result ?? '');
+    const [testedOn, setTestedOn] = useState(existing?.respiratoryTest?.testedOn ?? getLocalDateString());
+    const [note, setNote] = useState(existing?.note ?? '');
+    const [saving, setSaving] = useState(false);
+    const [saved, setSaved] = useState(false);
+    const [error, setError] = useState(false);
+
+    const submit = async () => {
+        setSaving(true);
+        setSaved(false);
+        setError(false);
+        try {
+            await onSave({
+                explanation,
+                symptomOnsetDate: symptomOnsetDate || null,
+                testResult: testResult || null,
+                testedOn: testResult ? (testedOn || getLocalDateString()) : null,
+                note: note.trim() || null,
+            });
+            setSaved(true);
+        } catch {
+            setError(true);
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    return (
+        <div className="data-section" data-testid="health-anomaly-followup">
+            <h3>Recovery follow-up (shadow)</h3>
+            <p className="data-state-notice">
+                Evidence only. This answer can be updated later and does not change your recommendation.
+            </p>
+            <p>Episode day {candidate.episodeDay}. What best explains the unusual recovery signals in retrospect?</p>
+
+            <div className="ha-followup-form">
+                <div className="ha-followup-field">
+                    <label htmlFor="ha-followup-explanation">Best explanation</label>
+                    <select
+                        id="ha-followup-explanation"
+                        value={explanation}
+                        onChange={event => setExplanation(event.target.value as HealthAnomalyOutcomeExplanation)}
+                    >
+                        {HEALTH_ANOMALY_OUTCOME_EXPLANATIONS.map(value => (
+                            <option key={value} value={value}>{EXPLANATION_LABELS[value]}</option>
+                        ))}
+                    </select>
+                </div>
+
+                {(explanation === 'illness_symptoms' || !!existing?.symptomOnset) && (
+                    <div className="ha-followup-field">
+                        <label htmlFor="ha-followup-onset">Approximate symptom onset date</label>
+                        <input
+                            id="ha-followup-onset"
+                            type="date"
+                            value={symptomOnsetDate}
+                            onChange={event => setSymptomOnsetDate(event.target.value)}
+                        />
+                    </div>
+                )}
+
+                <div className="ha-followup-field">
+                    <label htmlFor="ha-followup-test">Optional respiratory test</label>
+                    <select
+                        id="ha-followup-test"
+                        value={testResult}
+                        onChange={event => setTestResult(event.target.value as HealthAnomalyRespiratoryTestResult | '')}
+                    >
+                        <option value="">No result recorded / unknown</option>
+                        <option value="positive">Positive</option>
+                        <option value="negative">Negative</option>
+                    </select>
+                </div>
+
+                {testResult && (
+                    <div className="ha-followup-field">
+                        <label htmlFor="ha-followup-tested-on">Test date</label>
+                        <input
+                            id="ha-followup-tested-on"
+                            type="date"
+                            value={testedOn}
+                            onChange={event => setTestedOn(event.target.value)}
+                        />
+                    </div>
+                )}
+
+                <div className="ha-followup-field">
+                    <label htmlFor="ha-followup-note">Optional note</label>
+                    <textarea
+                        id="ha-followup-note"
+                        maxLength={2000}
+                        value={note}
+                        onChange={event => setNote(event.target.value)}
+                    />
+                </div>
+
+                <div className="ha-followup-actions">
+                    <button type="button" onClick={() => void submit()} disabled={saving}>
+                        {saving ? 'Saving…' : existing ? 'Update follow-up' : 'Save follow-up'}
+                    </button>
+                    {saved && <span role="status">Saved.</span>}
+                    {error && <span role="alert">Could not save the follow-up.</span>}
+                </div>
+            </div>
+        </div>
+    );
+}
+
+interface HealthAnomalyFollowupCardProps {
+    userId: string;
+    date: string;
+    currentRevision?: HealthAnomalyAssessmentRevision | null;
+}
+
+/**
+ * Shadow-era HA6 surface. It intentionally lives on Detailed Data rather than Home: HA7 still
+ * owns any visible anomaly/possible-illness alert semantics. This card only collects a later
+ * retrospective label for an episode that the shadow evaluator already persisted.
+ */
+export function HealthAnomalyFollowupCard({ userId, date, currentRevision }: HealthAnomalyFollowupCardProps) {
+    const [candidate, setCandidate] = useState<HealthAnomalyFollowupCandidate | null>(null);
+    const [existing, setExisting] = useState<HealthAnomalyEpisodeOutcome | null>(null);
+    const [loaded, setLoaded] = useState(false);
+
+    useEffect(() => {
+        let cancelled = false;
+        setLoaded(false);
+        findRecentHealthAnomalyFollowupCandidate(userId, date, currentRevision)
+            .then(async value => {
+                if (cancelled) return;
+                setCandidate(value);
+                if (!value) {
+                    setExisting(null);
+                    setLoaded(true);
+                    return;
+                }
+                const outcome = await healthAnomalyOutcomeRepository.get(userId, value.episodeId);
+                if (cancelled) return;
+                setExisting(outcome);
+                setLoaded(true);
+            })
+            .catch(() => {
+                if (!cancelled) {
+                    setCandidate(null);
+                    setExisting(null);
+                    setLoaded(true);
+                }
+            });
+        return () => { cancelled = true; };
+    }, [userId, date, currentRevision]);
+
+    if (!loaded || !candidate) return null;
+
+    return (
+        <HealthAnomalyFollowupForm
+            candidate={candidate}
+            existing={existing}
+            onSave={async input => {
+                const saved = await healthAnomalyOutcomeRepository.save({
+                    userId,
+                    candidate,
+                    explanation: input.explanation,
+                    symptomOnset: input.symptomOnsetDate ? { date: input.symptomOnsetDate, precision: 'day' } : null,
+                    respiratoryTest: input.testResult && input.testedOn
+                        ? { result: input.testResult, testedOn: input.testedOn, source: 'user_reported' }
+                        : null,
+                    note: input.note,
+                });
+                setExisting(saved);
+            }}
+        />
+    );
+}

--- a/app/src/components/HealthAnomalyFollowupCard.tsx
+++ b/app/src/components/HealthAnomalyFollowupCard.tsx
@@ -39,6 +39,12 @@ interface HealthAnomalyFollowupFormProps {
     }) => Promise<void>;
 }
 
+/**
+ * Presentational HA6.1–HA6.3 follow-up form: best-explanation choice, optional symptom onset
+ * date, and optional respiratory test result/date. Pure props-in/callback-out so it can render
+ * without Firestore for the component test; {@link HealthAnomalyFollowupCard} wires it to the
+ * repository.
+ */
 export function HealthAnomalyFollowupForm({ candidate, existing, onSave }: HealthAnomalyFollowupFormProps) {
     const [explanation, setExplanation] = useState<HealthAnomalyOutcomeExplanation>(existing?.explanation ?? 'nothing_obvious');
     const [symptomOnsetDate, setSymptomOnsetDate] = useState(existing?.symptomOnset?.date ?? '');

--- a/app/src/components/HealthAnomalyShadowPanel.tsx
+++ b/app/src/components/HealthAnomalyShadowPanel.tsx
@@ -3,6 +3,7 @@ import type { DailyDecisionInput } from '../engine/models';
 import type { HealthAnomalyAssessmentRevision } from '../engine/healthAnomalyModels';
 import { healthAnomalyAssessmentRepository } from '../services/healthAnomalyPersistence';
 import { configuredHealthAnomalyShadowPolicy } from '../services/healthAnomalyRuntime';
+import { HealthAnomalyFollowupCard } from './HealthAnomalyFollowupCard';
 import { selectHealthAnomalyLoadState, selectHealthAnomalyShadowRevision } from './healthAnomalyShadowView';
 import type { HealthAnomalyLoadResult } from './healthAnomalyShadowView';
 
@@ -149,7 +150,12 @@ export function HealthAnomalyShadowPanel({ userId, decisionInput, liveRevision }
   const loadState = selectHealthAnomalyLoadState(userId, date, loadResult);
   const revisionForDate = selectHealthAnomalyShadowRevision(userId, date, liveRevision, persistedRevision);
   if (revisionForDate) {
-    return <div className="data-view-container"><HealthAnomalyShadowTrace revision={revisionForDate} decisionInput={decisionInput} /></div>;
+    return (
+      <div className="data-view-container">
+        <HealthAnomalyShadowTrace revision={revisionForDate} decisionInput={decisionInput} />
+        <HealthAnomalyFollowupCard userId={userId} date={date} currentRevision={revisionForDate} />
+      </div>
+    );
   }
   if (loadState === 'loading' || loadState === 'ready') {
     return <div className="data-view-container"><div className="data-section"><h3>Health anomaly (shadow)</h3><p>Loading shadow assessment…</p></div></div>;

--- a/app/src/emulator/healthAnomalyOutcomeRules.emulator.test.ts
+++ b/app/src/emulator/healthAnomalyOutcomeRules.emulator.test.ts
@@ -1,0 +1,118 @@
+import { readFileSync } from 'node:fs';
+import { afterAll, afterEach, beforeAll, describe, it } from 'vitest';
+import {
+    assertFails,
+    assertSucceeds,
+    initializeTestEnvironment,
+    type RulesTestEnvironment,
+} from '@firebase/rules-unit-testing';
+import { deleteDoc, doc, getDoc, setDoc, updateDoc } from 'firebase/firestore';
+
+const emulatorDescribe = process.env.FIRESTORE_EMULATOR_HOST ? describe : describe.skip;
+let testEnvironment: RulesTestEnvironment;
+
+const ownerId = 'athlete-health-anomaly-outcome';
+const otherId = 'other-health-anomaly-outcome';
+const episodeId = 'health-anomaly:2026-08-20';
+const assessmentDate = '2026-08-20';
+const revisionId = 'ha-1234567890abcdef';
+const assessmentPath = `users/${ownerId}/health_anomaly_assessments/${assessmentDate}/revisions/${revisionId}`;
+const outcomePath = `users/${ownerId}/health_anomaly_outcomes/${episodeId}`;
+
+function outcome() {
+    return {
+        userId: ownerId,
+        episodeId,
+        sourceAssessment: { date: assessmentDate, revisionId },
+        explanation: 'nothing_obvious',
+        symptomOnset: null,
+        respiratoryTest: null,
+        note: null,
+        createdAt: '2026-08-21T06:30:00.000Z',
+        updatedAt: '2026-08-21T06:30:00.000Z',
+        schemaVersion: 1,
+    };
+}
+
+async function seedAssessment(): Promise<void> {
+    await testEnvironment.withSecurityRulesDisabled(async context => {
+        await setDoc(doc(context.firestore(), assessmentPath), {
+            userId: ownerId,
+            date: assessmentDate,
+            revisionId,
+            assessment: { episodeId },
+        });
+    });
+}
+
+emulatorDescribe('Health anomaly prospective outcome rules (HA6)', () => {
+    beforeAll(async () => {
+        testEnvironment = await initializeTestEnvironment({
+            projectId: 'demo-adaptive-training-health-anomaly-outcomes',
+            firestore: { rules: readFileSync('firestore.rules', 'utf8') },
+        });
+    });
+
+    afterEach(async () => {
+        await testEnvironment.clearFirestore();
+    });
+
+    afterAll(async () => {
+        await testEnvironment.cleanup();
+    });
+
+    it('allows the owner to create, read and later revise the mutable conclusion', async () => {
+        await seedAssessment();
+        const db = testEnvironment.authenticatedContext(ownerId).firestore();
+        await assertSucceeds(setDoc(doc(db, outcomePath), outcome()));
+        await assertSucceeds(getDoc(doc(db, outcomePath)));
+        await assertSucceeds(updateDoc(doc(db, outcomePath), {
+            explanation: 'illness_symptoms',
+            symptomOnset: { date: '2026-08-21', precision: 'day' },
+            respiratoryTest: { result: 'positive', testedOn: '2026-08-21', source: 'user_reported' },
+            updatedAt: '2026-08-21T18:00:00.000Z',
+        }));
+    });
+
+    it('rejects cross-user access and deletion', async () => {
+        await seedAssessment();
+        const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+        await assertSucceeds(setDoc(doc(ownerDb, outcomePath), outcome()));
+
+        const otherDb = testEnvironment.authenticatedContext(otherId).firestore();
+        await assertFails(getDoc(doc(otherDb, outcomePath)));
+        await assertFails(setDoc(doc(otherDb, outcomePath), { ...outcome(), userId: otherId }));
+        await assertFails(deleteDoc(doc(ownerDb, outcomePath)));
+    });
+
+    it('requires a real referenced assessment whose episode identity matches', async () => {
+        const db = testEnvironment.authenticatedContext(ownerId).firestore();
+        await assertFails(setDoc(doc(db, outcomePath), outcome()));
+
+        await seedAssessment();
+        await assertFails(setDoc(doc(db, `users/${ownerId}/health_anomaly_outcomes/different-episode`), {
+            ...outcome(), episodeId: 'different-episode',
+        }));
+    });
+
+    it('keeps episode/source identity and createdAt immutable while allowing conclusions to change', async () => {
+        await seedAssessment();
+        const db = testEnvironment.authenticatedContext(ownerId).firestore();
+        await assertSucceeds(setDoc(doc(db, outcomePath), outcome()));
+        await assertFails(updateDoc(doc(db, outcomePath), { sourceAssessment: { date: assessmentDate, revisionId: 'ha-fedcba0987654321' } }));
+        await assertFails(updateDoc(doc(db, outcomePath), { createdAt: '2026-08-22T00:00:00.000Z' }));
+        await assertFails(updateDoc(doc(db, outcomePath), { episodeId: 'different-episode' }));
+    });
+
+    it('rejects malformed explanation, onset and respiratory-test labels', async () => {
+        await seedAssessment();
+        const db = testEnvironment.authenticatedContext(ownerId).firestore();
+        await assertFails(setDoc(doc(db, outcomePath), { ...outcome(), explanation: 'diagnosed_flu' }));
+        await assertFails(setDoc(doc(db, outcomePath), {
+            ...outcome(), symptomOnset: { date: '2026-02-31', precision: 'day' },
+        }));
+        await assertFails(setDoc(doc(db, outcomePath), {
+            ...outcome(), respiratoryTest: { result: 'unknown', testedOn: '2026-08-21', source: 'user_reported' },
+        }));
+    });
+});

--- a/app/src/engine/healthAnomalyOutcome.test.ts
+++ b/app/src/engine/healthAnomalyOutcome.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import {
+    buildHealthAnomalyEpisodeOutcome,
+    parseHealthAnomalyEpisodeOutcome,
+    type HealthAnomalyEpisodeOutcome,
+} from './healthAnomalyOutcome';
+
+const sourceAssessment = { date: '2026-08-20', revisionId: 'ha-1234567890abcdef' };
+
+function existing(): HealthAnomalyEpisodeOutcome {
+    return buildHealthAnomalyEpisodeOutcome({
+        userId: 'u1',
+        episodeId: 'health-anomaly:2026-08-20',
+        sourceAssessment,
+        explanation: 'nothing_obvious',
+        now: '2026-08-21T06:00:00.000Z',
+    });
+}
+
+describe('HealthAnomalyEpisodeOutcome (HA6)', () => {
+    it('treats an absent respiratory test as unknown rather than negative', () => {
+        const result = existing();
+        expect(result.respiratoryTest).toBeNull();
+    });
+
+    it('allows the explanation to evolve without rewriting immutable episode/source identity', () => {
+        const prior = existing();
+        const updated = buildHealthAnomalyEpisodeOutcome({
+            userId: prior.userId,
+            episodeId: prior.episodeId,
+            sourceAssessment: prior.sourceAssessment,
+            explanation: 'illness_symptoms',
+            symptomOnset: { date: '2026-08-21', precision: 'day' },
+            respiratoryTest: { result: 'positive', testedOn: '2026-08-21', source: 'user_reported' },
+            note: 'Symptoms appeared after waking.',
+            now: '2026-08-21T18:00:00.000Z',
+            existing: prior,
+        });
+
+        expect(updated.createdAt).toBe(prior.createdAt);
+        expect(updated.updatedAt).not.toBe(prior.updatedAt);
+        expect(updated.sourceAssessment).toEqual(prior.sourceAssessment);
+        expect(updated.explanation).toBe('illness_symptoms');
+        expect(updated.symptomOnset?.date).toBe('2026-08-21');
+        expect(updated.respiratoryTest?.result).toBe('positive');
+    });
+
+    it('rejects an attempted source reassignment during an update', () => {
+        const prior = existing();
+        expect(() => buildHealthAnomalyEpisodeOutcome({
+            userId: prior.userId,
+            episodeId: prior.episodeId,
+            sourceAssessment: { ...prior.sourceAssessment, date: '2026-08-19' },
+            explanation: 'poor_sleep',
+            now: '2026-08-21T18:00:00.000Z',
+            existing: prior,
+        })).toThrow(/immutable identity/i);
+    });
+
+    it('rejects malformed dates, enums and path-unsafe episode ids', () => {
+        const base = existing();
+        expect(() => parseHealthAnomalyEpisodeOutcome({ ...base, episodeId: 'bad/id' })).toThrow(/episodeId/);
+        expect(() => parseHealthAnomalyEpisodeOutcome({ ...base, explanation: 'diagnosed_flu' })).toThrow(/explanation/);
+        expect(() => parseHealthAnomalyEpisodeOutcome({
+            ...base,
+            symptomOnset: { date: '2026-02-31', precision: 'day' },
+        })).toThrow(/onset/);
+        expect(() => parseHealthAnomalyEpisodeOutcome({
+            ...base,
+            respiratoryTest: { result: 'unknown', testedOn: '2026-08-21', source: 'user_reported' },
+        })).toThrow(/respiratory test/);
+    });
+
+    it('bounds free text and trims an empty note to null', () => {
+        const empty = buildHealthAnomalyEpisodeOutcome({
+            userId: 'u1', episodeId: 'episode-1', sourceAssessment,
+            explanation: 'other_not_sure', note: '   ', now: '2026-08-21T06:00:00.000Z',
+        });
+        expect(empty.note).toBeNull();
+        expect(() => parseHealthAnomalyEpisodeOutcome({ ...empty, note: 'x'.repeat(2001) })).toThrow(/note/);
+    });
+});

--- a/app/src/engine/healthAnomalyOutcome.ts
+++ b/app/src/engine/healthAnomalyOutcome.ts
@@ -1,0 +1,154 @@
+export const HEALTH_ANOMALY_OUTCOME_EXPLANATIONS = [
+    'illness_symptoms',
+    'hard_training_recovery',
+    'poor_sleep',
+    'alcohol',
+    'travel_jetlag',
+    'stress',
+    'heat_dehydration',
+    'vaccination_medication',
+    'nothing_obvious',
+    'other_not_sure',
+] as const;
+
+export type HealthAnomalyOutcomeExplanation = typeof HEALTH_ANOMALY_OUTCOME_EXPLANATIONS[number];
+export type HealthAnomalyRespiratoryTestResult = 'positive' | 'negative';
+
+export interface HealthAnomalySymptomOnsetLabel {
+    /** Approximate Warsaw-local onset date; day precision is sufficient for HA6 lead-time analysis. */
+    date: string;
+    precision: 'day';
+}
+
+export interface HealthAnomalyRespiratoryTestLabel {
+    /** Absence of this object is unknown, never a negative test. */
+    result: HealthAnomalyRespiratoryTestResult;
+    testedOn: string;
+    source: 'user_reported';
+}
+
+/**
+ * Mutable prospective outcome label for one immutable health-anomaly episode.
+ *
+ * The assessment revision remains untouched. A later answer can change as the episode becomes
+ * clearer (for example nothing_obvious -> illness_symptoms), while source identity and createdAt
+ * stay fixed. HA6 labels are evidence only and have no recommendation authority.
+ */
+export interface HealthAnomalyEpisodeOutcome {
+    userId: string;
+    episodeId: string;
+    sourceAssessment: {
+        date: string;
+        revisionId: string;
+    };
+    explanation: HealthAnomalyOutcomeExplanation;
+    symptomOnset: HealthAnomalySymptomOnsetLabel | null;
+    respiratoryTest: HealthAnomalyRespiratoryTestLabel | null;
+    note: string | null;
+    createdAt: string;
+    updatedAt: string;
+    schemaVersion: 1;
+}
+
+const LOCAL_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const REVISION_ID_RE = /^ha-[0-9a-f]{16}$/;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+    return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isRealLocalDate(value: unknown): value is string {
+    if (typeof value !== 'string' || !LOCAL_DATE_RE.test(value)) return false;
+    const [year, month, day] = value.split('-').map(Number);
+    const instant = Date.UTC(year, month - 1, day);
+    const date = new Date(instant);
+    return date.getUTCFullYear() === year
+        && date.getUTCMonth() === month - 1
+        && date.getUTCDate() === day;
+}
+
+export function parseHealthAnomalyEpisodeOutcome(
+    value: unknown,
+    expectedUserId?: string,
+    expectedEpisodeId?: string,
+): HealthAnomalyEpisodeOutcome {
+    if (!isPlainObject(value)) throw new Error('Health anomaly outcome must be an object');
+    const outcome = value as unknown as HealthAnomalyEpisodeOutcome;
+
+    if (outcome.schemaVersion !== 1) throw new Error('Unsupported health anomaly outcome schemaVersion');
+    if (typeof outcome.userId !== 'string' || outcome.userId.length === 0) throw new Error('Invalid health anomaly outcome userId');
+    if (expectedUserId && outcome.userId !== expectedUserId) throw new Error('Health anomaly outcome ownership mismatch');
+    if (typeof outcome.episodeId !== 'string' || outcome.episodeId.length === 0 || outcome.episodeId.length > 160 || outcome.episodeId.includes('/')) {
+        throw new Error('Invalid health anomaly outcome episodeId');
+    }
+    if (expectedEpisodeId && outcome.episodeId !== expectedEpisodeId) throw new Error('Health anomaly outcome episode mismatch');
+
+    if (!isPlainObject(outcome.sourceAssessment)
+        || !isRealLocalDate(outcome.sourceAssessment.date)
+        || typeof outcome.sourceAssessment.revisionId !== 'string'
+        || !REVISION_ID_RE.test(outcome.sourceAssessment.revisionId)) {
+        throw new Error('Invalid health anomaly outcome source assessment');
+    }
+    if (!(HEALTH_ANOMALY_OUTCOME_EXPLANATIONS as readonly string[]).includes(outcome.explanation)) {
+        throw new Error('Invalid health anomaly outcome explanation');
+    }
+
+    if (outcome.symptomOnset !== null) {
+        if (!isPlainObject(outcome.symptomOnset)
+            || outcome.symptomOnset.precision !== 'day'
+            || !isRealLocalDate(outcome.symptomOnset.date)) {
+            throw new Error('Invalid health anomaly symptom onset');
+        }
+    }
+
+    if (outcome.respiratoryTest !== null) {
+        if (!isPlainObject(outcome.respiratoryTest)
+            || !['positive', 'negative'].includes(outcome.respiratoryTest.result)
+            || !isRealLocalDate(outcome.respiratoryTest.testedOn)
+            || outcome.respiratoryTest.source !== 'user_reported') {
+            throw new Error('Invalid health anomaly respiratory test label');
+        }
+    }
+
+    if (outcome.note !== null && (typeof outcome.note !== 'string' || outcome.note.length > 2000)) {
+        throw new Error('Invalid health anomaly outcome note');
+    }
+    if (typeof outcome.createdAt !== 'string' || outcome.createdAt.length === 0) throw new Error('Invalid health anomaly outcome createdAt');
+    if (typeof outcome.updatedAt !== 'string' || outcome.updatedAt.length === 0) throw new Error('Invalid health anomaly outcome updatedAt');
+
+    return outcome;
+}
+
+export function buildHealthAnomalyEpisodeOutcome(input: {
+    userId: string;
+    episodeId: string;
+    sourceAssessment: HealthAnomalyEpisodeOutcome['sourceAssessment'];
+    explanation: HealthAnomalyOutcomeExplanation;
+    symptomOnset?: HealthAnomalySymptomOnsetLabel | null;
+    respiratoryTest?: HealthAnomalyRespiratoryTestLabel | null;
+    note?: string | null;
+    now: string;
+    existing?: HealthAnomalyEpisodeOutcome | null;
+}): HealthAnomalyEpisodeOutcome {
+    if (input.existing) {
+        if (input.existing.userId !== input.userId
+            || input.existing.episodeId !== input.episodeId
+            || input.existing.sourceAssessment.date !== input.sourceAssessment.date
+            || input.existing.sourceAssessment.revisionId !== input.sourceAssessment.revisionId) {
+            throw new Error('Health anomaly outcome immutable identity cannot change');
+        }
+    }
+
+    return parseHealthAnomalyEpisodeOutcome({
+        userId: input.userId,
+        episodeId: input.episodeId,
+        sourceAssessment: input.sourceAssessment,
+        explanation: input.explanation,
+        symptomOnset: input.symptomOnset ?? null,
+        respiratoryTest: input.respiratoryTest ?? null,
+        note: input.note?.trim() || null,
+        createdAt: input.existing?.createdAt ?? input.now,
+        updatedAt: input.now,
+        schemaVersion: 1,
+    }, input.userId, input.episodeId);
+}

--- a/app/src/engine/healthAnomalyOutcome.ts
+++ b/app/src/engine/healthAnomalyOutcome.ts
@@ -67,6 +67,15 @@ function isRealLocalDate(value: unknown): value is string {
         && date.getUTCDate() === day;
 }
 
+/**
+ * Validate and narrow a raw Firestore document (or candidate write payload) into a
+ * {@link HealthAnomalyEpisodeOutcome}.
+ *
+ * Mirrors the Firestore security rule's field-level checks so a malformed document is rejected
+ * client-side with the same shape it would be rejected server-side. When provided,
+ * `expectedUserId`/`expectedEpisodeId` additionally guard against a document read under the
+ * wrong owner or episode path.
+ */
 export function parseHealthAnomalyEpisodeOutcome(
     value: unknown,
     expectedUserId?: string,
@@ -119,6 +128,13 @@ export function parseHealthAnomalyEpisodeOutcome(
     return outcome;
 }
 
+/**
+ * Build a new-or-updated {@link HealthAnomalyEpisodeOutcome}, enforcing that episode/source
+ * identity and `createdAt` never change once `existing` is supplied. Only the conclusion
+ * (explanation, symptom onset, respiratory test, note) is allowed to evolve on an update; a
+ * caller attempting to move an outcome onto a different episode or assessment revision gets a
+ * thrown error rather than a silently reassigned record.
+ */
 export function buildHealthAnomalyEpisodeOutcome(input: {
     userId: string;
     episodeId: string;

--- a/app/src/services/healthAnomalyOutcomeService.test.ts
+++ b/app/src/services/healthAnomalyOutcomeService.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { HealthAnomalyAssessmentRevision } from '../engine/healthAnomalyModels';
+
+const firestore = vi.hoisted(() => ({
+    doc: vi.fn(),
+    getDoc: vi.fn(),
+    runTransaction: vi.fn(),
+}));
+const assessmentRepo = vi.hoisted(() => ({ getLatestForDate: vi.fn() }));
+vi.mock('firebase/firestore', () => firestore);
+vi.mock('../firebase', () => ({ getDb: vi.fn(() => ({})) }));
+vi.mock('./healthAnomalyPersistence', () => ({ healthAnomalyAssessmentRepository: assessmentRepo }));
+
+import {
+    findRecentHealthAnomalyFollowupCandidate,
+    followupCandidateFromRevision,
+    HealthAnomalyOutcomeRepository,
+} from './healthAnomalyOutcomeService';
+
+function revision(date: string, episodeDay: number | null): HealthAnomalyAssessmentRevision {
+    return {
+        userId: 'u1', date,
+        revisionId: 'ha-1234567890abcdef',
+        idempotencyKey: `${date}:1234567890abcdef`,
+        computedAt: `${date}T06:00:00.000Z`,
+        policyVersion: 'health-anomaly/ha3-v1',
+        thresholdPolicy: {
+            policyVersion: 'health-anomaly-thresholds/shadow-candidate-v1',
+            moderateDeviation: 1.5, strongDeviation: 2.5,
+            minimumCoreSignalsForMultiSignal: 2, persistenceDaysForEscalation: 2,
+            minimumHistoryCount: 14, minimumRecentDayCoverage: 4 / 7, maxBaselineAgeDays: 3,
+            estimatorBySignal: { rhr: 'mean-stdev-28d', respiration: 'median-mad-28d', hrv: 'log-mean-stdev-28d' },
+        },
+        mode: 'shadow-v1',
+        source: {
+            timezone: 'Europe/Warsaw', recoverySnapshotRevision: null, checkinRevision: null,
+            historyWindowStart: '2026-07-24', historyWindowEndExclusive: date,
+            historySnapshotRevisions: [], travelContextRevision: null, persistenceLookbackStart: '2026-08-19',
+        },
+        assessment: {
+            state: episodeDay ? 'watch_unexplained' : 'normal', evidenceLevel: episodeDay ? 'moderate' : 'none',
+            coreSignals: [], supportingSignals: [], explanations: [], unexplainedEvidence: [], persistenceDays: episodeDay ?? 0,
+            episodeId: episodeDay ? 'health-anomaly:2026-08-20' : null,
+            episodeDay, dataQuality: [], rationale: { facts: [], explanations: [], cautions: [] },
+            policyVersion: 'health-anomaly/ha3-v1', thresholdPolicyVersion: 'health-anomaly-thresholds/shadow-candidate-v1', mode: 'shadow-v1',
+        },
+        schemaVersion: 1,
+    };
+}
+
+describe('HA6 follow-up candidate selection', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('does not prompt on the first day of a new episode', () => {
+        expect(followupCandidateFromRevision(revision('2026-08-21', 1))).toBeNull();
+    });
+
+    it('prompts on episode day 2+', () => {
+        expect(followupCandidateFromRevision(revision('2026-08-21', 2))?.episodeDay).toBe(2);
+    });
+
+    it('recovers a one-day episode on a later day using bounded prior-day reads', async () => {
+        assessmentRepo.getLatestForDate
+            .mockResolvedValueOnce(revision('2026-08-20', 1));
+        const candidate = await findRecentHealthAnomalyFollowupCandidate('u1', '2026-08-21', revision('2026-08-21', null));
+        expect(candidate?.episodeId).toBe('health-anomaly:2026-08-20');
+        expect(assessmentRepo.getLatestForDate).toHaveBeenCalledWith('u1', '2026-08-20');
+    });
+});
+
+describe('HealthAnomalyOutcomeRepository', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('creates a separate mutable outcome document for an episode', async () => {
+        firestore.doc.mockReturnValue({ path: 'outcome' });
+        const transaction = {
+            get: vi.fn().mockResolvedValue({ exists: () => false }),
+            set: vi.fn(),
+        };
+        firestore.runTransaction.mockImplementation(async (_db: unknown, callback: (tx: typeof transaction) => unknown) => callback(transaction));
+        const candidate = followupCandidateFromRevision(revision('2026-08-21', 2))!;
+
+        const result = await new HealthAnomalyOutcomeRepository().save({
+            userId: 'u1', candidate, explanation: 'nothing_obvious', now: '2026-08-21T18:00:00.000Z',
+        });
+        expect(result.episodeId).toBe(candidate.episodeId);
+        expect(result.respiratoryTest).toBeNull();
+        expect(transaction.set).toHaveBeenCalledWith({ path: 'outcome' }, result);
+    });
+
+    it('updates the conclusion while preserving the original assessment identity and createdAt', async () => {
+        firestore.doc.mockReturnValue({ path: 'outcome' });
+        const existing = {
+            userId: 'u1', episodeId: 'health-anomaly:2026-08-20',
+            sourceAssessment: { date: '2026-08-20', revisionId: 'ha-1234567890abcdef' },
+            explanation: 'nothing_obvious', symptomOnset: null, respiratoryTest: null, note: null,
+            createdAt: '2026-08-21T06:00:00.000Z', updatedAt: '2026-08-21T06:00:00.000Z', schemaVersion: 1,
+        } as const;
+        const transaction = {
+            get: vi.fn().mockResolvedValue({ exists: () => true, data: () => existing }),
+            set: vi.fn(),
+        };
+        firestore.runTransaction.mockImplementation(async (_db: unknown, callback: (tx: typeof transaction) => unknown) => callback(transaction));
+        const candidate = { episodeId: existing.episodeId, sourceAssessment: { date: '2026-08-21', revisionId: 'ha-fedcba0987654321' }, episodeDay: 2 };
+
+        const result = await new HealthAnomalyOutcomeRepository().save({
+            userId: 'u1', candidate, explanation: 'illness_symptoms',
+            symptomOnset: { date: '2026-08-21', precision: 'day' },
+            now: '2026-08-21T18:00:00.000Z',
+        });
+        expect(result.sourceAssessment).toEqual(existing.sourceAssessment);
+        expect(result.createdAt).toBe(existing.createdAt);
+        expect(result.explanation).toBe('illness_symptoms');
+    });
+});

--- a/app/src/services/healthAnomalyOutcomeService.ts
+++ b/app/src/services/healthAnomalyOutcomeService.ts
@@ -1,0 +1,107 @@
+import { doc, getDoc, runTransaction } from 'firebase/firestore';
+import { getDb } from '../firebase';
+import {
+    buildHealthAnomalyEpisodeOutcome,
+    parseHealthAnomalyEpisodeOutcome,
+    type HealthAnomalyEpisodeOutcome,
+    type HealthAnomalyOutcomeExplanation,
+    type HealthAnomalyRespiratoryTestLabel,
+    type HealthAnomalySymptomOnsetLabel,
+} from '../engine/healthAnomalyOutcome';
+import type { HealthAnomalyAssessmentRevision } from '../engine/healthAnomalyModels';
+import { addDaysToLocalDateString } from '../utils/localDate';
+import { healthAnomalyAssessmentRepository } from './healthAnomalyPersistence';
+
+export interface HealthAnomalyFollowupCandidate {
+    episodeId: string;
+    sourceAssessment: {
+        date: string;
+        revisionId: string;
+    };
+    episodeDay: number;
+}
+
+export function followupCandidateFromRevision(
+    revision: HealthAnomalyAssessmentRevision | null | undefined,
+    allowFirstEpisodeDay = false,
+): HealthAnomalyFollowupCandidate | null {
+    const episodeId = revision?.assessment.episodeId;
+    const episodeDay = revision?.assessment.episodeDay;
+    if (!revision || !episodeId || !episodeDay) return null;
+    if (!allowFirstEpisodeDay && episodeDay < 2) return null;
+    return {
+        episodeId,
+        sourceAssessment: { date: revision.date, revisionId: revision.revisionId },
+        episodeDay,
+    };
+}
+
+/**
+ * Find a recent episode only when the user opens the shadow evidence surface.
+ *
+ * Today's first anomaly day is deliberately not a prompt: HA6 says ask later. A continuing
+ * episode becomes eligible from day 2. A one-day episode becomes eligible on a later day via
+ * the bounded prior-day lookback, without future data entering the original assessment.
+ */
+export async function findRecentHealthAnomalyFollowupCandidate(
+    userId: string,
+    throughDate: string,
+    currentRevision?: HealthAnomalyAssessmentRevision | null,
+    lookbackDays = 3,
+): Promise<HealthAnomalyFollowupCandidate | null> {
+    const current = currentRevision?.date === throughDate
+        ? followupCandidateFromRevision(currentRevision, false)
+        : null;
+    if (current) return current;
+
+    for (let offset = 1; offset <= lookbackDays; offset += 1) {
+        const date = addDaysToLocalDateString(throughDate, -offset);
+        const revision = await healthAnomalyAssessmentRepository.getLatestForDate(userId, date);
+        const candidate = followupCandidateFromRevision(revision, true);
+        if (candidate) return candidate;
+    }
+    return null;
+}
+
+export class HealthAnomalyOutcomeRepository {
+    async get(userId: string, episodeId: string): Promise<HealthAnomalyEpisodeOutcome | null> {
+        const snapshot = await getDoc(doc(getDb(), 'users', userId, 'health_anomaly_outcomes', episodeId));
+        if (!snapshot.exists()) return null;
+        return parseHealthAnomalyEpisodeOutcome(snapshot.data(), userId, episodeId);
+    }
+
+    async save(input: {
+        userId: string;
+        candidate: HealthAnomalyFollowupCandidate;
+        explanation: HealthAnomalyOutcomeExplanation;
+        symptomOnset?: HealthAnomalySymptomOnsetLabel | null;
+        respiratoryTest?: HealthAnomalyRespiratoryTestLabel | null;
+        note?: string | null;
+        now?: string;
+    }): Promise<HealthAnomalyEpisodeOutcome> {
+        const ref = doc(getDb(), 'users', input.userId, 'health_anomaly_outcomes', input.candidate.episodeId);
+        return runTransaction(getDb(), async transaction => {
+            const snapshot = await transaction.get(ref);
+            const existing = snapshot.exists()
+                ? parseHealthAnomalyEpisodeOutcome(snapshot.data(), input.userId, input.candidate.episodeId)
+                : null;
+            const outcome = buildHealthAnomalyEpisodeOutcome({
+                userId: input.userId,
+                episodeId: input.candidate.episodeId,
+                // Once the episode has a label, keep its original assessment reference even
+                // if a later episode day is the revision that opened the edit form.
+                sourceAssessment: existing?.sourceAssessment ?? input.candidate.sourceAssessment,
+                explanation: input.explanation,
+                symptomOnset: input.symptomOnset ?? null,
+                respiratoryTest: input.respiratoryTest ?? null,
+                note: input.note ?? null,
+                now: input.now ?? new Date().toISOString(),
+                existing,
+            });
+            transaction.set(ref, outcome);
+            return outcome;
+        });
+    }
+}
+
+export const healthAnomalyOutcomeRepository = new HealthAnomalyOutcomeRepository();

--- a/app/src/services/healthAnomalyOutcomeService.ts
+++ b/app/src/services/healthAnomalyOutcomeService.ts
@@ -21,6 +21,14 @@ export interface HealthAnomalyFollowupCandidate {
     episodeDay: number;
 }
 
+/**
+ * Turn an assessment revision into a follow-up candidate, if the revision is actually eligible.
+ *
+ * Only a revision with a live episode qualifies. By default the first day of a new episode is
+ * excluded (`allowFirstEpisodeDay = false`) so today's own screen never prompts immediately;
+ * {@link findRecentHealthAnomalyFollowupCandidate} passes `true` for prior-day lookback, where a
+ * one-day episode is only ever seen in retrospect.
+ */
 export function followupCandidateFromRevision(
     revision: HealthAnomalyAssessmentRevision | null | undefined,
     allowFirstEpisodeDay = false,
@@ -63,13 +71,20 @@ export async function findRecentHealthAnomalyFollowupCandidate(
     return null;
 }
 
+/** Firestore-backed reader/writer for `users/{userId}/health_anomaly_outcomes/{episodeId}`. */
 export class HealthAnomalyOutcomeRepository {
+    /** Load and validate the existing outcome for an episode, or `null` if none was saved yet. */
     async get(userId: string, episodeId: string): Promise<HealthAnomalyEpisodeOutcome | null> {
         const snapshot = await getDoc(doc(getDb(), 'users', userId, 'health_anomaly_outcomes', episodeId));
         if (!snapshot.exists()) return null;
         return parseHealthAnomalyEpisodeOutcome(snapshot.data(), userId, episodeId);
     }
 
+    /**
+     * Transactionally create or update the outcome for `input.candidate.episodeId`, preserving
+     * the original `sourceAssessment` and `createdAt` on an update regardless of which later
+     * revision opened the edit form.
+     */
     async save(input: {
         userId: string;
         candidate: HealthAnomalyFollowupCandidate;

--- a/docs/architecture/health-anomaly-shadow.md
+++ b/docs/architecture/health-anomaly-shadow.md
@@ -1,6 +1,6 @@
 # Health anomaly shadow assessment architecture
 
-This document describes the implemented HA-B through HA-D evidence path from
+This document describes the implemented HA-B through HA-E evidence path from
 `docs/plans/health-anomaly-and-illness-risk-alerting.md`.
 
 ## Runtime boundary
@@ -47,7 +47,7 @@ The identity fingerprints the effective date, mode, evaluator/threshold versions
 canonical recovery/check-in/history content, and travel/persistence provenance. An exact retry
 reuses the same revision; a corrected/rebuilt source produces a different revision even when
 its external timestamp is unchanged. Outcome labels are intentionally not part of this
-revision and remain future HA6 work.
+revision; they live in a separate mutable document (see "Prospective outcome capture" below).
 
 Firestore permits owner reads and create-only revisions after structural validation. Updates
 and deletes are denied.
@@ -58,6 +58,45 @@ A non-normal assessment starts an episode. The next observed calendar day contin
 episode when the immediately previous assessment is non-normal. Residual persistence is
 carried forward only from a prior assessment that still had unexplained core evidence. The
 live evaluator never backdates an episode from future information.
+
+## Prospective outcome capture (HA6.1–HA6.3)
+
+Once a shadow episode exists, the athlete can later record what actually explained it. This is
+a distinct mutable record from the immutable assessment revision:
+
+`users/{userId}/health_anomaly_outcomes/{episodeId}`
+
+* `sourceAssessment` (`{date, revisionId}`) references the assessment revision that opened the
+  episode; Firestore requires the referenced revision to exist and its `assessment.episodeId`
+  to match the outcome document before any write is accepted.
+* `explanation` is one of a bounded retrospective vocabulary (illness symptoms, hard
+  training/recovery, poor sleep, alcohol, travel/jet lag, stress, heat/dehydration,
+  vaccination/medication, nothing obvious, other/not sure) and may change on a later update —
+  "nothing obvious" today can become "illness symptoms" tomorrow.
+* `symptomOnset` is an optional Warsaw-local day-precision date; absence remains unknown, never
+  "no symptoms".
+* `respiratoryTest` is an optional explicit positive/negative result plus test date, stored with
+  `source: 'user_reported'`; absence remains unknown, never a negative result.
+* `episodeId`, `sourceAssessment`, `createdAt` and `schemaVersion` are immutable after creation;
+  only `explanation`, `symptomOnset`, `respiratoryTest` and `note` may change on update.
+  Deletion is denied.
+
+Eligibility is deliberately not immediate: the app never prompts on the first day of a brand
+new episode. `findRecentHealthAnomalyFollowupCandidate` in
+`app/src/services/healthAnomalyOutcomeService.ts` offers a candidate only once a continuing
+episode reaches its second day, or — for a one-day episode — on a later day via a bounded
+prior-day lookback over already-persisted assessment revisions. No future data is fed back
+into the original assessment; only the separate outcome document is written or revised.
+
+The follow-up form (`HealthAnomalyFollowupCard`) is mounted only beside the existing shadow
+trace on the Detailed Data screen. It carries the same "evidence only, does not change your
+recommendation" framing as the shadow trace itself, and never renders the
+`possible illness or systemic stress` alert wording — that remains gated on the HA7 evidence
+decision.
+
+HA6.4 (a personal expected-response model built from these labels) is deliberately not part of
+this slice; it requires enough labelled real episodes per athlete before it can be evaluated
+without fitting sparse noise.
 
 ## Shadow diagnostics
 
@@ -102,7 +141,8 @@ same-day symptoms and 24/48/72-hour labels.
 
 ## Still not enabled
 
-HA-D does not add a Home alert, notification, illness probability, prospective outcome capture,
-or training gate. The next planned slice is HA-E / HA6 prospective follow-up labels. Visible
-wording still requires the HA7 evidence decision, and `tighten-v1` remains a later separate
-release decision.
+HA-E adds prospective outcome capture (HA6.1–HA6.3) but no Home alert, notification, illness
+probability, readiness weight, optimizer input, or training gate. HA6.4 personal
+expected-response modelling is deliberately deferred pending enough labelled real episodes.
+Visible wording still requires the HA7 evidence decision, and `tighten-v1` remains a later
+separate release decision.

--- a/docs/plans/health-anomaly-and-illness-risk-alerting.md
+++ b/docs/plans/health-anomaly-and-illness-risk-alerting.md
@@ -2,8 +2,8 @@
 
 * **Capability:** HA
 * **Status:** In progress
-* **Implementation status:** HA0/HA1 are merged via #162 (with validation follow-up #168); HA2–HA4 are on `main` after #166/#165 and follow-up fixes. HA5 shadow observability/replay exists on the unmerged `feat/health-anomaly-ha-d` branch but is not accepted until reconciled with current `main`, reviewed, and green in CI.
-* **Blocked by:** none for the already-merged HA0–HA4 shadow foundation. HA5 must land on current `main` before the prospective HA6 loop should become the operational focus. HA7 evidence gates any user-visible `possible illness or systemic stress` wording; HA9 training gating requires a separate release decision after visible-mode evidence.
+* **Implementation status:** HA0/HA1 are merged via #162 (with validation follow-up #168); HA2–HA4 are on `main` after #166/#165 and follow-up fixes. HA5 shadow observability/replay merged via #171, with the frontend-build secret-forwarding fix in #173; the full shadow foundation is on `main`. HA6.1–HA6.3 prospective outcome labels are implemented in PR #174 (`feat/health-anomaly-ha-e`), evidence-only and gated behind the same shadow surface.
+* **Blocked by:** none for the merged HA0–HA5 shadow foundation or for HA6.1–HA6.3. HA6.4 (personal expected-response modelling) remains blocked on accumulating enough labelled real episodes to evaluate without fitting sparse noise. HA7 evidence gates any user-visible `possible illness or systemic stress` wording; HA9 training gating requires a separate release decision after visible-mode evidence.
 * **Unlocks:** explainable pre-symptomatic physiological anomaly alerts; prospective athlete-specific calibration; later tighten-only health gating
 * **Decision:** [ADR-0025](../adr/0025-physiological-anomaly-and-possible-illness-signals.md)
 * **Research:** [2026-08-21 physiological anomaly and illness-risk review](../analysis/2026-08-21-physiological-anomaly-and-illness-risk-research.md)
@@ -751,7 +751,7 @@ Important: future symptoms are labels in the report, never live input to the day
 
 ## HA6 — prospective label loop and calibration
 
-**Status:** blocked operationally until HA5 lands on `main`; implementation can follow immediately, while release evidence necessarily accumulates over real use
+**Status:** HA6.1–HA6.3 implemented in PR #174 (`feat/health-anomaly-ha-e`), evidence-only, no Home surface. HA6.4 remains observation-only future work pending enough labelled real episodes; release evidence for HA7/HA9 necessarily accumulates over real use.
 
 ### HA6.1 Low-friction outcome capture
 
@@ -1079,19 +1079,19 @@ Keep implementation reviewable and protect production behavior.
 * policy `shadow-v1` explicit only;
 * append-only assessment revisions.
 
-### PR HA-D — shadow observability + replay — **in progress; not on `main`**
-
-Current branch: `feat/health-anomaly-ha-d`. Before merge, reconcile it with current `main`, resolve conflicts/drift, review the resulting diff, and use green repository CI as acceptance.
+### PR HA-D — shadow observability + replay — **merged (#171, CI fix #173)**
 
 * HA5;
 * DataView panel;
 * evidence script/report.
 
-### PR HA-E — prospective follow-up labels — **pending HA5 on `main`**
+### PR HA-E — prospective follow-up labels — **PR #174, `feat/health-anomaly-ha-e`**
 
-* HA6;
-* outcome capture;
-* no illness probability.
+* HA6.1–HA6.3 (outcome capture, symptom onset, optional respiratory test);
+* owner-scoped `health_anomaly_outcomes` Firestore rules with reference integrity to the immutable assessment revision;
+* follow-up form mounted only under the Detailed Data shadow surface;
+* no illness probability, no Home alert, no recommendation/training input;
+* HA6.4 deliberately deferred.
 
 ### PR HA-F — visible anomaly UX — **blocked by HA7**
 
@@ -1121,7 +1121,7 @@ For **shadow capability complete**:
 * real history can be replayed;
 * production recommendation behavior remains unchanged.
 
-The first five bullets are already satisfied on `main`; DataView/replay/runtime observability are the HA-D acceptance boundary. Do not call the shadow capability complete until HA-D is reconciled and merged.
+All eight bullets are satisfied on `main` now that HA-D is merged (#171, #173).
 
 For **visible capability complete**:
 
@@ -1143,15 +1143,12 @@ For **training integration complete**:
 
 ## Current continuation checklist
 
-The next agent should continue from the shipped HA0–HA4 foundation rather than recreating it:
+The next agent should continue from the shipped HA0–HA5 foundation and HA6.1–HA6.3 (PR #174) rather than recreating them:
 
 1. Read ADR-0025, ADR-0024, ADR-0010, this plan, and `docs/architecture/health-anomaly-shadow.md`.
-2. Reconcile `feat/health-anomaly-ha-d` with current `main`; do not merge the stale branch by force.
-3. Review the HA-D diff specifically for DataView shadow observability, runtime policy resolution, replay semantics, and evidence-script future-label isolation.
-4. Run the normal frontend, Firestore, simulation/policy-boundary, and repository CI gates; default `off` must preserve recommendation behavior.
-5. Merge HA-D only after the resulting branch is green and the evidence-only boundary remains intact.
-6. Explicitly enable `shadow-v1` only for the intended evidence-collection user/environment.
-7. Start HA6 prospective outcome labels after shadow assessments are actually being produced; keep labels outside immutable assessment revisions.
-8. Accumulate enough real episodes/healthy periods to report alert burden, confounder overlap, false alerts, and lead time honestly.
-9. Write the dated HA7 evidence review before any `visible-v1` cutover.
-10. Treat `tighten-v1` as a separate later release decision; health anomaly may only tighten, never relax, training decisions.
+2. Reconcile `feat/health-anomaly-ha-e` with current `main` and merge PR #174 once green; the HA6.1–HA6.3 outcome-capture surface stays evidence-only under Detailed Data.
+3. Explicitly enable `shadow-v1` only for the intended evidence-collection user/environment; HA6 follow-up prompts only appear once `shadow-v1` assessments are being produced for that user.
+4. Accumulate enough real episodes/healthy periods to report alert burden, confounder overlap, false alerts, and lead time honestly; HA6 outcome labels are the source for the context-explained and symptom-follow-up fractions HA7 needs.
+5. Start HA6.4 personal expected-response modelling only once enough labelled episodes exist per athlete to evaluate without fitting sparse noise.
+6. Write the dated HA7 evidence review before any `visible-v1` cutover.
+7. Treat `tighten-v1` as a separate later release decision; health anomaly may only tighten, never relax, training decisions.


### PR DESCRIPTION
## Summary

Implements HA-E / HA6.1–HA6.3 on top of merged HA-D (#171), while keeping the capability evidence-only.

### HA6.1 — episode outcome capture
- adds a dedicated `health_anomaly_outcomes/{episodeId}` record rather than mutating immutable HA assessment revisions or overloading daily check-in context;
- captures the plan's bounded retrospective explanation vocabulary;
- allows the conclusion to evolve later while episode/source identity and `createdAt` remain immutable;
- prompts only later: continuing episodes become eligible from day 2, while a one-day episode can be picked up by a bounded prior-day lookback.

### HA6.2 — symptom onset
- optional Warsaw-local approximate onset date with day precision;
- absence remains unknown.

### HA6.3 — optional respiratory test
- optional explicit positive/negative result plus test date;
- no stored result means unknown, never negative;
- stored as a distinct `user_reported` label source.

### Persistence / security
- owner-scoped Firestore rules for `health_anomaly_outcomes`;
- every outcome must reference an existing immutable assessment revision whose episode id matches the outcome document;
- update may change conclusion/onset/test/note only; episode identity, source assessment, schema and creation time are immutable;
- deletion denied;
- emulator coverage for ownership, reference integrity, mutable conclusion, immutable identity, malformed labels and deletion denial.

### UI / release boundary
- follow-up form is mounted only under the existing Detailed Data **shadow** surface;
- no Home alert, notification, illness probability, readiness weight, optimizer input or training gate;
- no `possible illness or systemic stress` visible alert wording is introduced;
- HA7 still owns visible alert release semantics, and HA9 remains separately gated.

## Deliberately not included

HA6.4 personal expected-response modelling. That remains dependent on enough labelled personal history to evaluate without fitting sparse noise.

## Verification

CI is the acceptance source. The branch adds unit/component/emulator tests and does not intentionally change recommendation policy or `POLICY_VERSION`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a health-anomaly follow-up card for recording explanations, symptom onset, respiratory-test results, and notes.
  * Follow-up records can be created, edited, and saved with loading, cancellation, and error states.
  * Added eligibility detection for recent health-anomaly episodes, including recovery follow-ups.
  * Added validation to ensure outcome records are complete, consistent, and securely associated with the correct episode.

* **Bug Fixes**
  * Prevented unauthorized access, deletion, or modification of health-anomaly outcomes.
  * Preserved original episode identity and creation details when records are updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->