### PR TITLE
docs(health-anomaly): address PR #174 review findings (HA6 docstrings + docs)

### DIFF
--- a/app/src/components/HealthAnomalyFollowupCard.tsx
+++ b/app/src/components/HealthAnomalyFollowupCard.tsx
@@ -39,6 +39,12 @@ interface HealthAnomalyFollowupFormProps {
     }) => Promise<void>;
 }
 
+/**
+ * Presentational HA6.1–HA6.3 follow-up form: best-explanation choice, optional symptom onset
+ * date, and optional respiratory test result/date. Pure props-in/callback-out so it can render
+ * without Firestore for the component test; {@link HealthAnomalyFollowupCard} wires it to the
+ * repository.
+ */
 export function HealthAnomalyFollowupForm({ candidate, existing, onSave }: HealthAnomalyFollowupFormProps) {
     const [explanation, setExplanation] = useState<HealthAnomalyOutcomeExplanation>(existing?.explanation ?? 'nothing_obvious');
     const [symptomOnsetDate, setSymptomOnsetDate] = useState(existing?.symptomOnset?.date ?? '');

--- a/app/src/engine/healthAnomalyOutcome.ts
+++ b/app/src/engine/healthAnomalyOutcome.ts
@@ -67,6 +67,15 @@ function isRealLocalDate(value: unknown): value is string {
         && date.getUTCDate() === day;
 }
 
+/**
+ * Validate and narrow a raw Firestore document (or candidate write payload) into a
+ * {@link HealthAnomalyEpisodeOutcome}.
+ *
+ * Mirrors the Firestore security rule's field-level checks so a malformed document is rejected
+ * client-side with the same shape it would be rejected server-side. When provided,
+ * `expectedUserId`/`expectedEpisodeId` additionally guard against a document read under the
+ * wrong owner or episode path.
+ */
 export function parseHealthAnomalyEpisodeOutcome(
     value: unknown,
     expectedUserId?: string,
@@ -119,6 +128,13 @@ export function parseHealthAnomalyEpisodeOutcome(
     return outcome;
 }
 
+/**
+ * Build a new-or-updated {@link HealthAnomalyEpisodeOutcome}, enforcing that episode/source
+ * identity and `createdAt` never change once `existing` is supplied. Only the conclusion
+ * (explanation, symptom onset, respiratory test, note) is allowed to evolve on an update; a
+ * caller attempting to move an outcome onto a different episode or assessment revision gets a
+ * thrown error rather than a silently reassigned record.
+ */
 export function buildHealthAnomalyEpisodeOutcome(input: {
     userId: string;
     episodeId: string;

--- a/app/src/services/healthAnomalyOutcomeService.ts
+++ b/app/src/services/healthAnomalyOutcomeService.ts
@@ -21,6 +21,14 @@ export interface HealthAnomalyFollowupCandidate {
     episodeDay: number;
 }
 
+/**
+ * Turn an assessment revision into a follow-up candidate, if the revision is actually eligible.
+ *
+ * Only a revision with a live episode qualifies. By default the first day of a new episode is
+ * excluded (`allowFirstEpisodeDay = false`) so today's own screen never prompts immediately;
+ * {@link findRecentHealthAnomalyFollowupCandidate} passes `true` for prior-day lookback, where a
+ * one-day episode is only ever seen in retrospect.
+ */
 export function followupCandidateFromRevision(
     revision: HealthAnomalyAssessmentRevision | null | undefined,
     allowFirstEpisodeDay = false,
@@ -63,13 +71,20 @@ export async function findRecentHealthAnomalyFollowupCandidate(
     return null;
 }
 
+/** Firestore-backed reader/writer for `users/{userId}/health_anomaly_outcomes/{episodeId}`. */
 export class HealthAnomalyOutcomeRepository {
+    /** Load and validate the existing outcome for an episode, or `null` if none was saved yet. */
     async get(userId: string, episodeId: string): Promise<HealthAnomalyEpisodeOutcome | null> {
         const snapshot = await getDoc(doc(getDb(), 'users', userId, 'health_anomaly_outcomes', episodeId));
         if (!snapshot.exists()) return null;
         return parseHealthAnomalyEpisodeOutcome(snapshot.data(), userId, episodeId);
     }
 
+    /**
+     * Transactionally create or update the outcome for `input.candidate.episodeId`, preserving
+     * the original `sourceAssessment` and `createdAt` on an update regardless of which later
+     * revision opened the edit form.
+     */
     async save(input: {
         userId: string;
         candidate: HealthAnomalyFollowupCandidate;

--- a/docs/architecture/health-anomaly-shadow.md
+++ b/docs/architecture/health-anomaly-shadow.md
@@ -1,6 +1,6 @@
 # Health anomaly shadow assessment architecture
 
-This document describes the implemented HA-B through HA-D evidence path from
+This document describes the implemented HA-B through HA-E evidence path from
 `docs/plans/health-anomaly-and-illness-risk-alerting.md`.
 
 ## Runtime boundary
@@ -47,7 +47,7 @@ The identity fingerprints the effective date, mode, evaluator/threshold versions
 canonical recovery/check-in/history content, and travel/persistence provenance. An exact retry
 reuses the same revision; a corrected/rebuilt source produces a different revision even when
 its external timestamp is unchanged. Outcome labels are intentionally not part of this
-revision and remain future HA6 work.
+revision; they live in a separate mutable document (see "Prospective outcome capture" below).
 
 Firestore permits owner reads and create-only revisions after structural validation. Updates
 and deletes are denied.
@@ -58,6 +58,45 @@ A non-normal assessment starts an episode. The next observed calendar day contin
 episode when the immediately previous assessment is non-normal. Residual persistence is
 carried forward only from a prior assessment that still had unexplained core evidence. The
 live evaluator never backdates an episode from future information.
+
+## Prospective outcome capture (HA6.1–HA6.3)
+
+Once a shadow episode exists, the athlete can later record what actually explained it. This is
+a distinct mutable record from the immutable assessment revision:
+
+`users/{userId}/health_anomaly_outcomes/{episodeId}`
+
+* `sourceAssessment` (`{date, revisionId}`) references the assessment revision that opened the
+  episode; Firestore requires the referenced revision to exist and its `assessment.episodeId`
+  to match the outcome document before any write is accepted.
+* `explanation` is one of a bounded retrospective vocabulary (illness symptoms, hard
+  training/recovery, poor sleep, alcohol, travel/jet lag, stress, heat/dehydration,
+  vaccination/medication, nothing obvious, other/not sure) and may change on a later update —
+  "nothing obvious" today can become "illness symptoms" tomorrow.
+* `symptomOnset` is an optional Warsaw-local day-precision date; absence remains unknown, never
+  "no symptoms".
+* `respiratoryTest` is an optional explicit positive/negative result plus test date, stored with
+  `source: 'user_reported'`; absence remains unknown, never a negative result.
+* `episodeId`, `sourceAssessment`, `createdAt` and `schemaVersion` are immutable after creation;
+  only `explanation`, `symptomOnset`, `respiratoryTest` and `note` may change on update.
+  Deletion is denied.
+
+Eligibility is deliberately not immediate: the app never prompts on the first day of a brand
+new episode. `findRecentHealthAnomalyFollowupCandidate` in
+`app/src/services/healthAnomalyOutcomeService.ts` offers a candidate only once a continuing
+episode reaches its second day, or — for a one-day episode — on a later day via a bounded
+prior-day lookback over already-persisted assessment revisions. No future data is fed back
+into the original assessment; only the separate outcome document is written or revised.
+
+The follow-up form (`HealthAnomalyFollowupCard`) is mounted only beside the existing shadow
+trace on the Detailed Data screen. It carries the same "evidence only, does not change your
+recommendation" framing as the shadow trace itself, and never renders the
+`possible illness or systemic stress` alert wording — that remains gated on the HA7 evidence
+decision.
+
+HA6.4 (a personal expected-response model built from these labels) is deliberately not part of
+this slice; it requires enough labelled real episodes per athlete before it can be evaluated
+without fitting sparse noise.
 
 ## Shadow diagnostics
 
@@ -102,7 +141,8 @@ same-day symptoms and 24/48/72-hour labels.
 
 ## Still not enabled
 
-HA-D does not add a Home alert, notification, illness probability, prospective outcome capture,
-or training gate. The next planned slice is HA-E / HA6 prospective follow-up labels. Visible
-wording still requires the HA7 evidence decision, and `tighten-v1` remains a later separate
-release decision.
+HA-E adds prospective outcome capture (HA6.1–HA6.3) but no Home alert, notification, illness
+probability, readiness weight, optimizer input, or training gate. HA6.4 personal
+expected-response modelling is deliberately deferred pending enough labelled real episodes.
+Visible wording still requires the HA7 evidence decision, and `tighten-v1` remains a later
+separate release decision.

--- a/docs/plans/health-anomaly-and-illness-risk-alerting.md
+++ b/docs/plans/health-anomaly-and-illness-risk-alerting.md
@@ -2,8 +2,8 @@
 
 * **Capability:** HA
 * **Status:** In progress
-* **Implementation status:** HA0/HA1 are merged via #162 (with validation follow-up #168); HA2–HA4 are on `main` after #166/#165 and follow-up fixes. HA5 shadow observability/replay exists on the unmerged `feat/health-anomaly-ha-d` branch but is not accepted until reconciled with current `main`, reviewed, and green in CI.
-* **Blocked by:** none for the already-merged HA0–HA4 shadow foundation. HA5 must land on current `main` before the prospective HA6 loop should become the operational focus. HA7 evidence gates any user-visible `possible illness or systemic stress` wording; HA9 training gating requires a separate release decision after visible-mode evidence.
+* **Implementation status:** HA0/HA1 are merged via #162 (with validation follow-up #168); HA2–HA4 are on `main` after #166/#165 and follow-up fixes. HA5 shadow observability/replay merged via #171, with the frontend-build secret-forwarding fix in #173; the full shadow foundation is on `main`. HA6.1–HA6.3 prospective outcome labels are implemented in PR #174 (`feat/health-anomaly-ha-e`), evidence-only and gated behind the same shadow surface.
+* **Blocked by:** none for the merged HA0–HA5 shadow foundation or for HA6.1–HA6.3. HA6.4 (personal expected-response modelling) remains blocked on accumulating enough labelled real episodes to evaluate without fitting sparse noise. HA7 evidence gates any user-visible `possible illness or systemic stress` wording; HA9 training gating requires a separate release decision after visible-mode evidence.
 * **Unlocks:** explainable pre-symptomatic physiological anomaly alerts; prospective athlete-specific calibration; later tighten-only health gating
 * **Decision:** [ADR-0025](../adr/0025-physiological-anomaly-and-possible-illness-signals.md)
 * **Research:** [2026-08-21 physiological anomaly and illness-risk review](../analysis/2026-08-21-physiological-anomaly-and-illness-risk-research.md)
@@ -751,7 +751,7 @@ Important: future symptoms are labels in the report, never live input to the day
 
 ## HA6 — prospective label loop and calibration
 
-**Status:** blocked operationally until HA5 lands on `main`; implementation can follow immediately, while release evidence necessarily accumulates over real use
+**Status:** HA6.1–HA6.3 implemented in PR #174 (`feat/health-anomaly-ha-e`), evidence-only, no Home surface. HA6.4 remains observation-only future work pending enough labelled real episodes; release evidence for HA7/HA9 necessarily accumulates over real use.
 
 ### HA6.1 Low-friction outcome capture
 
@@ -1079,19 +1079,19 @@ Keep implementation reviewable and protect production behavior.
 * policy `shadow-v1` explicit only;
 * append-only assessment revisions.
 
-### PR HA-D — shadow observability + replay — **in progress; not on `main`**
-
-Current branch: `feat/health-anomaly-ha-d`. Before merge, reconcile it with current `main`, resolve conflicts/drift, review the resulting diff, and use green repository CI as acceptance.
+### PR HA-D — shadow observability + replay — **merged (#171, CI fix #173)**
 
 * HA5;
 * DataView panel;
 * evidence script/report.
 
-### PR HA-E — prospective follow-up labels — **pending HA5 on `main`**
+### PR HA-E — prospective follow-up labels — **PR #174, `feat/health-anomaly-ha-e`**
 
-* HA6;
-* outcome capture;
-* no illness probability.
+* HA6.1–HA6.3 (outcome capture, symptom onset, optional respiratory test);
+* owner-scoped `health_anomaly_outcomes` Firestore rules with reference integrity to the immutable assessment revision;
+* follow-up form mounted only under the Detailed Data shadow surface;
+* no illness probability, no Home alert, no recommendation/training input;
+* HA6.4 deliberately deferred.
 
 ### PR HA-F — visible anomaly UX — **blocked by HA7**
 
@@ -1121,7 +1121,7 @@ For **shadow capability complete**:
 * real history can be replayed;
 * production recommendation behavior remains unchanged.
 
-The first five bullets are already satisfied on `main`; DataView/replay/runtime observability are the HA-D acceptance boundary. Do not call the shadow capability complete until HA-D is reconciled and merged.
+All eight bullets are satisfied on `main` now that HA-D is merged (#171, #173).
 
 For **visible capability complete**:
 
@@ -1143,15 +1143,12 @@ For **training integration complete**:
 
 ## Current continuation checklist
 
-The next agent should continue from the shipped HA0–HA4 foundation rather than recreating it:
+The next agent should continue from the shipped HA0–HA5 foundation and HA6.1–HA6.3 (PR #174) rather than recreating them:
 
 1. Read ADR-0025, ADR-0024, ADR-0010, this plan, and `docs/architecture/health-anomaly-shadow.md`.
-2. Reconcile `feat/health-anomaly-ha-d` with current `main`; do not merge the stale branch by force.
-3. Review the HA-D diff specifically for DataView shadow observability, runtime policy resolution, replay semantics, and evidence-script future-label isolation.
-4. Run the normal frontend, Firestore, simulation/policy-boundary, and repository CI gates; default `off` must preserve recommendation behavior.
-5. Merge HA-D only after the resulting branch is green and the evidence-only boundary remains intact.
-6. Explicitly enable `shadow-v1` only for the intended evidence-collection user/environment.
-7. Start HA6 prospective outcome labels after shadow assessments are actually being produced; keep labels outside immutable assessment revisions.
-8. Accumulate enough real episodes/healthy periods to report alert burden, confounder overlap, false alerts, and lead time honestly.
-9. Write the dated HA7 evidence review before any `visible-v1` cutover.
-10. Treat `tighten-v1` as a separate later release decision; health anomaly may only tighten, never relax, training decisions.
+2. Reconcile `feat/health-anomaly-ha-e` with current `main` and merge PR #174 once green; the HA6.1–HA6.3 outcome-capture surface stays evidence-only under Detailed Data.
+3. Explicitly enable `shadow-v1` only for the intended evidence-collection user/environment; HA6 follow-up prompts only appear once `shadow-v1` assessments are being produced for that user.
+4. Accumulate enough real episodes/healthy periods to report alert burden, confounder overlap, false alerts, and lead time honestly; HA6 outcome labels are the source for the context-explained and symptom-follow-up fractions HA7 needs.
+5. Start HA6.4 personal expected-response modelling only once enough labelled episodes exist per athlete to evaluate without fitting sparse noise.
+6. Write the dated HA7 evidence review before any `visible-v1` cutover.
+7. Treat `tighten-v1` as a separate later release decision; health anomaly may only tighten, never relax, training decisions.


### PR DESCRIPTION
## Summary

- Addresses the two pre-merge check warnings CodeRabbit raised on #174 ("No actionable comments were generated" — nothing inline to fix, but the automated description/docstring gates failed).
- Adds JSDoc to the new HA6 outcome parse/build/service/form entry points (`healthAnomalyOutcome.ts`, `healthAnomalyOutcomeService.ts`, `HealthAnomalyFollowupCard.tsx`) so docstring coverage on the functions CodeRabbit scoped to (15.38%, required 80%) matches the rest of the module.
- Documents HA6.1–HA6.3 prospective outcome capture in `docs/architecture/health-anomaly-shadow.md` (outcome model, Firestore rule shape, eligibility window, HA6.4 deferral) — previously this doc only described HA-B..HA-D.
- Updates `docs/plans/health-anomaly-and-illness-risk-alerting.md`: HA5 is now merged (#171, #173) rather than "unmerged", HA6.1–HA6.3 status reflects PR #174, the PR HA-D/HA-E roadmap entries, definition-of-done, and continuation checklist are brought in line with what's actually on `main` vs. in flight.
- No production code behavior changed — comments/JSDoc and Markdown docs only.

This targets `feat/health-anomaly-ha-e` (the #174 head branch) rather than `main`, so it can land into #174 before that PR merges.

## Validation

Results:
- `cd app && npm run check`: pass — 2018 tests passed / 124 skipped, typecheck clean, only 3 pre-existing unrelated ESLint warnings (unused eslint-disable directives in `App.tsx`, `useOverloadHistory.ts`, `performanceOutcomeRules.emulator.test.ts`), workout catalog validated (175 exercises / 37 workouts / 16 parameter binding sets / 25 authored session families).
- `cd app && npm run test:rules`: the new `healthAnomalyOutcomeRules.emulator.test.ts` (HA6) suite passes (5/5). Under this sandbox's default 10s hook timeout the Firestore emulator's `initializeTestEnvironment` intermittently exceeds the hook timeout for all six emulator suites, including the pre-existing, untouched `firestoreRules.emulator.test.ts` — confirmed environment-specific by re-running with `--hookTimeout=30000`, at which point all HA6 rules tests pass and only one unrelated pre-existing test (`firestoreRules.emulator.test.ts`'s subjective-drift-provenance case) hit its own 5s per-test timeout under load. Not a regression from this change.
- Manual check: read the full diff for #174 and confirmed the HA6 Firestore rule (`hasValidHealthAnomalyOutcome`) matches the documented immutability/reference-integrity claims.

## Risk and reviewer guidance

Low risk: this PR only adds comments/JSDoc to already-reviewed #174 code and updates two Markdown docs; it does not touch `firestore.rules`, the outcome model/service logic, or any UI behavior. Reviewers should mainly check that the new architecture-doc section for HA6 accurately describes the shipped rule/service shape.

## Domain invariants

- [x] Firestore writes remain user-scoped under `users/{APP_USER_ID}/...`; no `default_user` or top-level recovery snapshots were introduced — unchanged by this PR (no Firestore code touched).
- [x] Calendar-date logic uses `Europe/Warsaw`; completed `totalSteps` still means the previous calendar day (`D - 1`) — unchanged, no date logic touched.
- [x] No credentials, tokens, service-account files, or raw health payloads are included.
- [x] Recommendation decision logic changed: `POLICY_VERSION` was evaluated and relevant architecture/ADR documentation was updated — not applicable, no recommendation logic touched; documentation was updated to reflect already-shipped HA6.1–HA6.3 scope.

## Screenshots or recordings

Not applicable — doc/comment-only change with no rendered UI difference.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KJFk9rFLXbnSNn3ZYbrhvt)_