### PR TITLE
docs: reconcile docs/plans status per post-HA-D audit

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -60,8 +60,9 @@ Among capability plans, Garmin per-activity telemetry (G) and Mobile UX/UI (UX) 
 **implemented**; Strength session logging (S) is **In progress (default-off)** with all
 numbered code delivered; Multidomain sessions (M) is **In progress** with M0–M5.3
 complete; Performance outcome validation (OV) is **In progress** with the engineering
-stack through OV6.1 merged; Health anomaly alerting (HA) is **In progress** with HA0–HA4
-on `main` and HA5 shadow observability/replay still unmerged.
+stack through OV6.1 merged; Health anomaly alerting (HA) is **In progress** with HA0–HA5
+on `main` (HA5 shadow observability/replay merged via #171) and HA6.1–HA6.3 prospective
+outcome labels the next unblocked slice.
 
 For Multidomain delivery, the 2026-08-19 evidence-first cutline chain from
 [`2026-08-19-product-scope-cutline-review.md`](../analysis/2026-08-19-product-scope-cutline-review.md),
@@ -83,10 +84,12 @@ selection authority.
 HA is the canonical plan for physiological-anomaly/possible-illness evidence. HA-A/#162
 landed the fail-closed policy contract plus optional check-in context; #166/#165 and follow-up
 fixes put the anomaly-grade feature mapping, pure evaluator, explanations, persistence,
-episode continuity and composition boundary on `main`. HA5 exists on
-`feat/health-anomaly-ha-d` but is not accepted until reconciled with current `main`, reviewed,
-and green in CI. User-visible wording remains gated by HA7 evidence, and tighten-only training
-integration remains a separate later release decision.
+episode continuity and composition boundary on `main`. HA-D/#171 landed HA5 shadow
+observability/replay on `main` on 2026-08-21. HA6.1–HA6.3 prospective outcome labels are now
+the next unblocked implementation slice; HA6.4's personal expected-response model additionally
+needs enough labelled personal history to evaluate without fitting sparse noise. User-visible
+wording remains gated by HA7 evidence, and tighten-only training integration remains a separate
+later release decision.
 
 The Phase 0–5 task boards are historical implementation records; the
 [follow-up analysis](../analysis/2026-08-09-phase-0-5-completion-review.md) records
@@ -117,7 +120,7 @@ all-`Ready` table became unusable.
 | M | [Multidomain session authoring, execution & evidence](./multidomain-session-authoring-execution-and-evidence.md) | **In progress** | M8.1 | M6 still requires an explicit real-use trigger; repeated-testing implementation has transferred to OV and is not an M blocker/task; M8.2 needs real history and only independently justified M6/OV evidence if required; M9 needs its own named triggers | source-neutral authored sessions, safe mixed-dose execution and occurrence-linked response; specialized field work remains usage-triggered, while repeated testing/progress is owned by OV |
 | UX | [Mobile UX/UI redesign](./mobile_ux_implementation_plan.md) | **Implemented** | none | none | mobile-first daily decision flow, single-page rapid check-in, state-first Home layout, unblocked recommendation, 44px+ touch targets, and mobile layout tokens |
 | OV | [Performance outcome validation & goal-progress loop](./performance-outcome-validation.md) | **In progress** | OV7 operational evidence; OV4.4/OV6.2 only when their triggers are met | OV7 follows the event/block timeline; OV4.4 needs close-spaced repeats; OV6.2 needs repeated report use; OV8 needs multiple prospective blocks | sole implementation/status owner of repeated testing/progress; engineering through OV6.1 is merged (#154/#155/#163/#164/#169), with production selection authority still explicitly excluded |
-| HA | [Health anomaly and possible-illness alerting](./health-anomaly-and-illness-risk-alerting.md) | **In progress** | HA5 reconciliation/PR; HA6 after HA5 is on `main` | HA5 branch is not yet accepted on current `main`; HA7 needs real replay/prospective evidence; HA8/HA9 remain release-gated | explainable physiological-anomaly evidence with structured confounders; HA0–HA4 are on `main`, visible illness wording and training changes remain gated |
+| HA | [Health anomaly and possible-illness alerting](./health-anomaly-and-illness-risk-alerting.md) | **In progress** | HA6.1–HA6.3 prospective outcome labels | HA6.4 needs enough labelled personal history; HA7 needs real replay/prospective evidence; HA8/HA9 remain release-gated | explainable physiological-anomaly evidence with structured confounders; HA0–HA5 are on `main` (HA5 via #171), visible illness wording and training changes remain gated |
 
 Rows G, S, M, UX, OV, and HA are **not phases**. They are capability/surface plans whose work items are
 prefixed `G*`, `S*`, `M*`, `UX*`, `OV*`, `HA*` precisely so they cannot be mistaken for the `Phase 0`–`9`

--- a/docs/plans/health-anomaly-and-illness-risk-alerting.md
+++ b/docs/plans/health-anomaly-and-illness-risk-alerting.md
@@ -2,8 +2,8 @@
 
 * **Capability:** HA
 * **Status:** In progress
-* **Implementation status:** HA0/HA1 are merged via #162 (with validation follow-up #168); HA2–HA4 are on `main` after #166/#165 and follow-up fixes. HA5 shadow observability/replay exists on the unmerged `feat/health-anomaly-ha-d` branch but is not accepted until reconciled with current `main`, reviewed, and green in CI.
-* **Blocked by:** none for the already-merged HA0–HA4 shadow foundation. HA5 must land on current `main` before the prospective HA6 loop should become the operational focus. HA7 evidence gates any user-visible `possible illness or systemic stress` wording; HA9 training gating requires a separate release decision after visible-mode evidence.
+* **Implementation status:** HA0/HA1 are merged via #162 (with validation follow-up #168); HA2–HA4 are on `main` after #166/#165 and follow-up fixes. HA5 shadow observability/replay merged to `main` via PR #171 (HA-D) on 2026-08-21.
+* **Blocked by:** none for the shipped HA0–HA5 shadow foundation. HA6.1–HA6.3 (prospective outcome labels) are the current unblocked implementation slice; HA6.4 additionally needs enough labelled personal history to evaluate without fitting sparse noise. HA7 evidence gates any user-visible `possible illness or systemic stress` wording; HA9 training gating requires a separate release decision after visible-mode evidence.
 * **Unlocks:** explainable pre-symptomatic physiological anomaly alerts; prospective athlete-specific calibration; later tighten-only health gating
 * **Decision:** [ADR-0025](../adr/0025-physiological-anomaly-and-possible-illness-signals.md)
 * **Research:** [2026-08-21 physiological anomaly and illness-risk review](../analysis/2026-08-21-physiological-anomaly-and-illness-risk-research.md)
@@ -695,7 +695,7 @@ Acceptance criteria:
 
 ## HA5 — shadow mode and developer observability
 
-**Status:** in progress off `main`; implemented on `feat/health-anomaly-ha-d`, but not accepted until reconciled with current `main`, reviewed, and green in CI
+**Status:** complete on `main` (PR #171, 2026-08-21)
 
 ### HA5.1 Enable explicit shadow computation
 
@@ -751,7 +751,7 @@ Important: future symptoms are labels in the report, never live input to the day
 
 ## HA6 — prospective label loop and calibration
 
-**Status:** blocked operationally until HA5 lands on `main`; implementation can follow immediately, while release evidence necessarily accumulates over real use
+**Status:** HA6.1–HA6.3 are startable now that HA5 is on `main`; release evidence necessarily accumulates over real use. HA6.4 remains gated on enough labelled personal history existing, not merely on HA5 landing.
 
 ### HA6.1 Low-friction outcome capture
 
@@ -1079,15 +1079,13 @@ Keep implementation reviewable and protect production behavior.
 * policy `shadow-v1` explicit only;
 * append-only assessment revisions.
 
-### PR HA-D — shadow observability + replay — **in progress; not on `main`**
-
-Current branch: `feat/health-anomaly-ha-d`. Before merge, reconcile it with current `main`, resolve conflicts/drift, review the resulting diff, and use green repository CI as acceptance.
+### PR HA-D — shadow observability + replay — **merged 2026-08-21 (#171)**
 
 * HA5;
 * DataView panel;
 * evidence script/report.
 
-### PR HA-E — prospective follow-up labels — **pending HA5 on `main`**
+### PR HA-E — prospective follow-up labels — **startable now (HA5 is on `main`)**
 
 * HA6;
 * outcome capture;
@@ -1121,7 +1119,7 @@ For **shadow capability complete**:
 * real history can be replayed;
 * production recommendation behavior remains unchanged.
 
-The first five bullets are already satisfied on `main`; DataView/replay/runtime observability are the HA-D acceptance boundary. Do not call the shadow capability complete until HA-D is reconciled and merged.
+All bullets are now satisfied on `main` (HA-D merged via PR #171, 2026-08-21). The shadow capability is complete; the current work is the HA6 prospective label loop.
 
 For **visible capability complete**:
 
@@ -1143,15 +1141,11 @@ For **training integration complete**:
 
 ## Current continuation checklist
 
-The next agent should continue from the shipped HA0–HA4 foundation rather than recreating it:
+The next agent should continue from the shipped HA0–HA5 foundation rather than recreating it:
 
 1. Read ADR-0025, ADR-0024, ADR-0010, this plan, and `docs/architecture/health-anomaly-shadow.md`.
-2. Reconcile `feat/health-anomaly-ha-d` with current `main`; do not merge the stale branch by force.
-3. Review the HA-D diff specifically for DataView shadow observability, runtime policy resolution, replay semantics, and evidence-script future-label isolation.
-4. Run the normal frontend, Firestore, simulation/policy-boundary, and repository CI gates; default `off` must preserve recommendation behavior.
-5. Merge HA-D only after the resulting branch is green and the evidence-only boundary remains intact.
-6. Explicitly enable `shadow-v1` only for the intended evidence-collection user/environment.
-7. Start HA6 prospective outcome labels after shadow assessments are actually being produced; keep labels outside immutable assessment revisions.
-8. Accumulate enough real episodes/healthy periods to report alert burden, confounder overlap, false alerts, and lead time honestly.
-9. Write the dated HA7 evidence review before any `visible-v1` cutover.
-10. Treat `tighten-v1` as a separate later release decision; health anomaly may only tighten, never relax, training decisions.
+2. Explicitly enable `shadow-v1` only for the intended evidence-collection user/environment, if not already enabled.
+3. Implement HA6.1–HA6.3 prospective outcome labels now that shadow assessments are being produced; keep labels outside immutable assessment revisions.
+4. Accumulate enough real episodes/healthy periods to report alert burden, confounder overlap, false alerts, and lead time honestly.
+5. Write the dated HA7 evidence review before any `visible-v1` cutover.
+6. Treat `tighten-v1` as a separate later release decision; health anomaly may only tighten, never relax, training decisions.

--- a/docs/plans/multidomain-session-authoring-execution-and-evidence.md
+++ b/docs/plans/multidomain-session-authoring-execution-and-evidence.md
@@ -804,6 +804,22 @@ only after completion.
 - `useSessionRunner.ts` completes the 1RM derivation loop on session finish via `preferencesService.applyOneRepMaxDerivations`.
 - Non-Strength and general sessions route through `SessionRunner`. The v1 Strength runner and global resume banner are maintained alongside `SessionRunner` during the transition period.
 
+**Residual cutover debt (2026-08-21).** Parity being reached does not mean the dual-runner
+state is closed. `app/src/App.tsx` still maintains two live execution lifecycles: the
+`strength` route uses `StrengthSessionRunner` + `strengthSessionService` +
+`activeStrengthSession`, while structured/testing routes use the generic `SessionRunner` +
+`sessionExecutionService` + `activeStructuredSession`. `app/src/components/StrengthSessionRunner.tsx`
+remains present. This is genuine residual implementation debt, not stale prose — see
+[2026-08-21 post-HA-D plan reconciliation, R4](../analysis/2026-08-21-post-ha-d-plan-reconciliation.md#r4--the-legacy-strength-runner-is-genuine-residual-implementation-debt).
+The retirement is scoped as its own cutover PR, preserving the permanent Strength-v1 history
+read compatibility model while routing new Strength execution through the generic runner.
+Before removing `StrengthSessionRunner`, explicitly cover: a catalog Strength recommendation
+starting through the generic runner; in-progress resume after reload; RIR/RPE/velocity-loss/
+technical gauges remaining available; last comparable set context remaining visible;
+completion still applying derived 1RM writeback; Strength-v1 historical records remaining
+readable through the compatibility read model; and no second active-session banner/lifecycle
+remaining.
+
 ### M3.5 `[x]` Bounded exercise/drill facet vocabulary
 
 **Outcome (2026-08-18).** `ExerciseDefinition.facets` provides a bounded optional vocabulary for

--- a/docs/plans/phase-9-subjective-baselines.md
+++ b/docs/plans/phase-9-subjective-baselines.md
@@ -517,7 +517,7 @@ evidence. Writing code is not what closes this task.
 - [x] `npm run check` and `npm run test:rules` pass.
 - [x] `npm run simulate:diff` reports no changed pre-existing baseline scenario (9.5 fixtures appear as `[NEW SCENARIO]`).
 - [x] `check-policy-drift.mjs` passes — **no `POLICY_VERSION` bump while the live default is `'off'`**.
-- [ ] A history-leak regression proves date `D` never contributes to the baseline used for decision `D`.
+- [x] A history-leak regression proves date `D` never contributes to the baseline used for decision `D` (`subjectiveBaseline.test.ts` — `excludes a check-in dated exactly asOfDate (D-SUBJHIST)`, plus a future-date exclusion case).
 - [ ] The property test proving drift can only tighten passes.
 - [ ] Every 9.5 fixture has the intended variance/absolute-mode properties.
 - [x] The slow-drifter fixture is detectable by at least one measured drift candidate without noisy-stationary becoming pathologically restrictive; failure is valid evidence against the candidate.


### PR DESCRIPTION
## Summary

- Follow-up to #172's dated `docs/analysis/2026-08-21-post-ha-d-plan-reconciliation.md` audit, which flagged that `docs/plans/` was left stale after PR #171 (HA-D) merged.
- Reconciles the four living plan files the audit itemized in its "Follow-up documentation reconciliation" section, so `main` doesn't carry a window where the dated audit and the living plans disagree.
- No runtime, Firestore, recommendation-policy or deployment behavior changes — documentation only.

## Changes

- `docs/plans/README.md`: HA5 recorded as merged via #171; HA6.1–HA6.3 recorded as the next unblocked slice; HA table row updated to match.
- `docs/plans/health-anomaly-and-illness-risk-alerting.md`: HA5/PR HA-D flipped from "in progress/unmerged" to complete/merged (#171, 2026-08-21); HA6/PR HA-E retargeted from "blocked on HA5" to startable; "shadow capability complete" and the continuation checklist updated to match the shipped state.
- `docs/plans/phase-9-subjective-baselines.md`: checked off the D-SUBJHIST history-leak acceptance item — already proved by the existing `subjectiveBaseline.test.ts` regression (`excludes a check-in dated exactly asOfDate (D-SUBJHIST)` plus a future-date exclusion case).
- `docs/plans/multidomain-session-authoring-execution-and-evidence.md`: made the residual `StrengthSessionRunner`/`SessionRunner` dual-runner state explicit under M3.4, pointing at the audit's R4 finding and its pre-removal verification checklist for the future cutover PR.

## Validation

- [x] `uv run pre-commit run` on the four changed files — passes (trailing whitespace/EOF/secret-scan hooks; no lint/test hooks apply to markdown).
- [ ] `cd app && npm run check` — not run; no `app/` source changed.
- [ ] `uv run pytest` — not run; no Python source changed.

## Risk and reviewer guidance

Documentation only. Worth double-checking the HA5/HA6 status claims against PR #171's actual merged content, and the D-SUBJHIST checkbox against `subjectiveBaseline.test.ts`, since this PR is asserting those as already-true facts rather than proposing new behavior.

## Domain invariants

Not applicable — documentation-only change, no code touched.

## Screenshots or recordings

Not applicable — no UI change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WwEWE4z8AFfUem4jN4fVLP)_