### PR TITLE
✍️ Scribe: Add missing ADR-0024 and ADR-0025 to README index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -75,6 +75,8 @@ Architectural choices, system invariants, and technical trade-offs are documente
 * [**ADR-0021: Strength Session Logging & Intensity Gauges**](./adr/0021-strength-session-logging-and-intensity-gauges.md) — *Accepted.* Durable raw strength-session logging, gauge semantics, safe estimated-1RM write-back, and the evidence gate before logged work can affect engine cost or stimulus.
 * [**ADR-0022: Zone-Derived Completed-Training Credit Is a Measured Candidate**](./adr/0022-zone-derived-completed-training-credit.md) — *Accepted.* A direct power-zone-share candidate may be measured inside the existing evidence tier, but production remains on TE pending a later evidence-backed activation decision.
 * [**ADR-0023: Multidomain Session Authoring, Execution, and Evidence**](./adr/0023-multidomain-session-authoring-execution-and-evidence.md) — *Accepted.* Source-neutral session definition, occurrence authority, subcollection performed entries, D-MSNAP content-addressed snapshots, D-MCHOICE bounded option sets, and single tissue authority linkage.
+* [**ADR-0024: Metric-Specific Biometric Baseline Estimators**](./adr/0024-biometric-baseline-estimator-policy.md) — *Accepted.* Metric-specific robust location/scale estimators (median/MAD vs mean/stdev) justified by replay evidence.
+* [**ADR-0025: Physiological Anomaly and Possible-Illness Signals**](./adr/0025-physiological-anomaly-and-possible-illness-signals.md) — *Accepted.* Defines a separate health-anomaly capability, independent of training strain, using respiration/RHR/HRV to detect pre-symptomatic patterns.
 
 ---
 


### PR DESCRIPTION
* **📄 What:** The documentation was improved by adding missing references for `ADR-0024` and `ADR-0025` to the main `docs/README.md` file's ADR index.
* **⚠️ Problem:** The `docs/README.md` file acts as the main index for all the documentation, including Architecture Decision Records. However, `ADR-0024` and `ADR-0025` were created in `docs/adr/` but never added to this main directory index, causing incomplete documentation coverage.
* **📚 Source of truth:** The presence of `docs/adr/0024-biometric-baseline-estimator-policy.md` and `docs/adr/0025-physiological-anomaly-and-possible-illness-signals.md` directly.
* **✅ Verification:** Used grep to verify the actual ADR files against what was in the `docs/README.md`. Also verified using `make check` that all CI checks remain green.
* **🎯 Impact:** Readers of the documentation, primarily other contributors/agents, benefit from a complete and accurate list of all accepted architectural decisions without having to manually scour the `docs/adr` directory.
* **🔒 Governance:** Product scope, authority, privacy, licensing, and operational limits remain completely unchanged. This is purely a documentation consistency fix aligning the README with the existing ADRs.

---
*PR created automatically by Jules for task [7147071018467978449](https://jules.google.com/task/7147071018467978449) started by @Szczepanov*