### PR TITLE
Improve daily check-in signal quality and tissue monitoring

### DIFF
--- a/app/src/components/checkin/SubjectiveScaleRow.tsx
+++ b/app/src/components/checkin/SubjectiveScaleRow.tsx
@@ -60,10 +60,11 @@ export const SubjectiveScaleRow: React.FC<SubjectiveScaleRowProps> = ({
           max="10"
           step="1"
           value={sliderValue}
-          onPointerDown={() => {
-            // Clicking the untouched midpoint should count as an explicit answer even when
-            // the thumb does not move and the browser therefore emits no change event.
-            if (value === null) onChange(sliderValue);
+          onPointerUp={(event) => {
+            // Keep the neutral thumb position purely visual until the athlete completes an
+            // interaction. Pointer-down can precede a drag, so recording 5 there briefly
+            // fabricates a midpoint observation before the intended value is chosen.
+            if (value === null) onChange(Number(event.currentTarget.value));
           }}
           onChange={(e) => onChange(Number(e.target.value))}
           className={`subjective-slider ${severityClass}`}


### PR DESCRIPTION
## Summary
- stop fabricating neutral 5/10 subjective scores; unanswered values stay `null`
- retain the one-tap typical preset for low-friction complete reporting
- blind Garmin metrics until the first complete subjective submission, then show current + 7d recovery context
- separate graded local tissue response from the hard pain/injury flag
- keep mild/moderate tissue issues in the existing graded injury policy; only severe tissue response promotes the hard pain/injury flag
- make local tissue monitoring available even when the athlete would not call the sensation an injury, and preserve tissue data when the hard flag is cleared
- default symptoms to **No**, alcohol to **0**, travel to **none**
- default **heat/sauna, dehydration/fluid loss, vaccination, medication change, and close sick contact to No**
- remove manual RHR/HRV/respiration questions from the check-in
- calculate RHR-high, HRV-low, and respiration-high states only from Garmin objective data against the athlete's personal history/baseline
- accept old manual-physiology fields only at the migration boundary, then strip them before canonical decision input so they cannot substitute for missing Garmin data
- remove the redundant limited-time toggle; explicit available minutes are the single authority and start unanswered
- add UI, validation/parser, evaluator, and missing-state regression coverage

## Signal architecture
The check-in separates four channels:
1. **Subjective wellness** — readiness, sleep quality, fatigue, soreness, stress, motivation/desire to train.
2. **Local tissue response** — graded normal/mild/moderate/severe by body region, including next-morning response.
3. **Systemic/context** — symptoms, sick contact, alcohol, travel, heat/dehydration, vaccination, medication change.
4. **Objective physiology** — Garmin RHR, HRV, respiration and supporting composites.

## Correct defaults
- Symptoms: **No**
- Alcohol: **0**
- Travel: **none**
- Heat / sauna: **No**
- Dehydration / fluid loss: **No**
- Vaccination: **No**
- Medication change: **No**
- Close sick contact: **No**
- Subjective scales: **unanswered**, never silently 5/10
- Time available: **unanswered**, never silently 60 min

## Garmin-derived physiology
RHR, HRV and respiration are not check-in questions. The existing health-anomaly feature path reads Garmin daily values and compares them with the athlete's prior 28-day history. The evaluator uses signal-specific estimators/directions:
- RHR: high is adverse; mean/stdev 28d candidate
- HRV: low is adverse; log-mean/stdev 28d candidate
- Respiration: high is adverse; median/MAD 28d candidate

If the current Garmin value or sufficient baseline is missing, the objective channel remains **unavailable**. The app does not ask the athlete to guess it.

## Safety / decision behavior
- incomplete check-ins can still carry pain, illness, and tissue-safety information
- only fully scored subjective days mature the longitudinal subjective baseline
- mild/moderate tissue observations use the graded tissue policy without automatically activating the hard pain/injury gate
- severe tissue observations promote the hard pain/injury flag
- local tissue data is retained when the hard pain flag is cleared
- Garmin data cannot clear a local tissue restriction
- old manual physiology fields are ignored by canonical decision input

## Testing
Latest CI is running for the corrected head. The prior full branch run passed frontend lint/tests/coverage/build, Firestore rules, simulations, Python 3.12/3.14 suites, dependency audits, and Docker build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Scale responses are now recorded when the slider interaction ends, using the value selected by the user.
  * Removed unintended midpoint responses when beginning to interact with an unanswered scale.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->