### PR TITLE
⚡ Bolt: Memoize derived goal state in Goals component

### DIFF
--- a/app/src/components/Goals.tsx
+++ b/app/src/components/Goals.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { goalService } from '../services/goalService';
 import type { UserGoal, GoalCategory, GoalDomain, GoalStatus, UserEvent } from '../engine/models';
 import { deriveGoalCategory, deriveEventPriority, getDaysToEvent, goalToUserEvent, evaluatePeriodizationPhase } from '../engine/periodization';
@@ -122,29 +122,30 @@ export function Goals({ userId }: GoalsProps) {
     }
   };
 
-  // Derive Periodization State directly from canonical engine output
-  const activeUserEvents = goals
+  // ⚡ Bolt Performance Optimization:
+  // Memoize derived goal arrays and periodization state to prevent O(N) recalculations on every render.
+  const activeUserEvents = useMemo(() => goals
     .filter(g => g.status === 'active')
     .map(goalToUserEvent)
-    .filter((e): e is UserEvent => e !== null);
+    .filter((e): e is UserEvent => e !== null), [goals]);
 
-  const periodizationResult = evaluatePeriodizationPhase(activeUserEvents, getLocalDateString());
+  const periodizationResult = useMemo(() => evaluatePeriodizationPhase(activeUserEvents, getLocalDateString()), [activeUserEvents]);
   const focusEvent = periodizationResult.focusEvent;
   const daysToFocusEvent = periodizationResult.daysToEvent;
   const currentPhaseName = periodizationResult.phase.phaseName;
 
-  const filteredGoals = goals.filter(goal => {
+  const filteredGoals = useMemo(() => goals.filter(goal => {
     if (filter === 'all') return true;
     if (filter === 'active') return goal.status === 'active';
     if (filter === 'archived') return goal.status === 'archived';
     return true;
-  });
+  }), [goals, filter]);
 
-  const goalsByCategory = filteredGoals.reduce((acc, goal) => {
+  const goalsByCategory = useMemo(() => filteredGoals.reduce((acc, goal) => {
     if (!acc[goal.category]) acc[goal.category] = [];
     acc[goal.category].push(goal);
     return acc;
-  }, {} as Record<GoalCategory, UserGoalWithId[]>);
+  }, {} as Record<GoalCategory, UserGoalWithId[]>), [filteredGoals]);
 
   const renderStars = (priority: number) => {
     return Array.from({ length: 5 }, (_, i) => (

--- a/app/src/components/Goals.tsx
+++ b/app/src/components/Goals.tsx
@@ -122,14 +122,20 @@ export function Goals({ userId }: GoalsProps) {
     }
   };
 
-  // ⚡ Bolt Performance Optimization:
-  // Memoize derived goal arrays and periodization state to prevent O(N) recalculations on every render.
+  // Memoize derived goal arrays and periodization state to avoid repeated O(N) work.
   const activeUserEvents = useMemo(() => goals
     .filter(g => g.status === 'active')
     .map(goalToUserEvent)
     .filter((e): e is UserEvent => e !== null), [goals]);
 
-  const periodizationResult = useMemo(() => evaluatePeriodizationPhase(activeUserEvents, getLocalDateString()), [activeUserEvents]);
+  // Keep date-dependent derivations tied to the current render date. Without `today` in the
+  // dependency list, a component that remains mounted across midnight can keep yesterday's
+  // periodization result until the active-event array changes.
+  const today = getLocalDateString();
+  const periodizationResult = useMemo(
+    () => evaluatePeriodizationPhase(activeUserEvents, today),
+    [activeUserEvents, today],
+  );
   const focusEvent = periodizationResult.focusEvent;
   const daysToFocusEvent = periodizationResult.daysToEvent;
   const currentPhaseName = periodizationResult.phase.phaseName;
@@ -225,7 +231,7 @@ export function Goals({ userId }: GoalsProps) {
                       {goal.eventCategory && goal.targetDate && (
                         <span className="event-badge">
                           🏁 {EVENT_CATEGORY_LABELS[goal.eventCategory]} · {(() => {
-                            const days = getDaysToEvent(goal.targetDate, getLocalDateString());
+                            const days = getDaysToEvent(goal.targetDate, today);
                             return days >= 0 ? `in ${days}d` : `${Math.abs(days)}d ago`;
                           })()}
                         </span>


### PR DESCRIPTION
💡 What: Wrapped `activeUserEvents`, `periodizationResult`, `filteredGoals`, and `goalsByCategory` array/object derivation logic in React `useMemo` hooks.
🎯 Why: To prevent O(N) recalculations on every single React render in the Goals component, especially since things like `goalsByCategory` involve looping and reducing arrays that only need to change when `goals` or `filter` values change.
📊 Impact: Expected to reduce CPU overhead during routine React re-renders in the Goals component, especially for users with a large history of goals.
🔬 Measurement: Verify by running `cd app && npm run test` and `cd app && npm run lint`. No regressions observed in Vitest test suite.

---
*PR created automatically by Jules for task [12164748635984836583](https://jules.google.com/task/12164748635984836583) started by @Szczepanov*