### PR TITLE
Fix CI type error blocking PR #181 (health-anomaly causality cleanup)

### DIFF
--- a/app/src/components/DailyCheckin.css
+++ b/app/src/components/DailyCheckin.css
@@ -83,6 +83,14 @@
   color: #cbd5e1;
 }
 
+.followup-tissue-prompt small {
+  display: block;
+  margin-top: 0.65rem;
+  color: var(--text-secondary, #94a3b8);
+  font-size: 0.72rem;
+  line-height: 1.35;
+}
+
 .followup-actions {
   display: flex;
   flex-wrap: wrap;
@@ -147,6 +155,13 @@
   color: var(--text-secondary, #94a3b8);
 }
 
+.checkin-helper-text {
+  margin: 0.8rem 0 0;
+  color: var(--text-secondary, #94a3b8);
+  font-size: 0.76rem;
+  line-height: 1.4;
+}
+
 /* Preset Quick-Fill Bar */
 .checkin-preset-bar {
   margin-bottom: 1rem;
@@ -191,6 +206,11 @@
   transition: border-color 0.2s;
 }
 
+.subjective-scale-row.status-unanswered {
+  border-style: dashed;
+  border-color: rgba(148, 163, 184, 0.28);
+}
+
 .subjective-scale-row:focus-within {
   border-color: rgba(56, 189, 248, 0.4);
 }
@@ -218,6 +238,11 @@
   border: 1px solid rgba(56, 189, 248, 0.25);
 }
 
+.scale-row-value-badge.status-unanswered {
+  background: rgba(148, 163, 184, 0.08);
+  border-color: rgba(148, 163, 184, 0.22);
+}
+
 .scale-row-value-badge.status-warning {
   background: rgba(245, 158, 11, 0.15);
   border-color: rgba(245, 158, 11, 0.35);
@@ -232,6 +257,10 @@
   font-size: 1rem;
   font-weight: 800;
   color: #38bdf8;
+}
+
+.scale-row-value-badge.status-unanswered .scale-value-number {
+  color: #94a3b8;
 }
 
 .scale-row-value-badge.status-warning .scale-value-number {
@@ -292,6 +321,11 @@
   transition: transform 0.15s ease;
 }
 
+.subjective-slider.status-unanswered::-webkit-slider-thumb {
+  background: #64748b;
+  box-shadow: none;
+}
+
 .subjective-slider.status-warning::-webkit-slider-thumb {
   background: #fbbf24;
   box-shadow: 0 2px 8px rgba(251, 191, 36, 0.5);
@@ -316,6 +350,11 @@
   border: none;
   box-shadow: 0 2px 8px rgba(56, 189, 248, 0.5);
   transition: transform 0.15s ease;
+}
+
+.subjective-slider.status-unanswered::-moz-range-thumb {
+  background: #64748b;
+  box-shadow: none;
 }
 
 .subjective-slider.status-warning::-moz-range-thumb {
@@ -595,6 +634,25 @@
   padding: 0 1rem 1rem 1rem;
 }
 
+.garmin-context-content[aria-label="Garmin context hidden"] {
+  display: block;
+  padding-top: 0.9rem;
+  color: var(--text-secondary, #94a3b8);
+}
+
+.garmin-context-content[aria-label="Garmin context hidden"] strong {
+  display: block;
+  margin-bottom: 0.3rem;
+  color: #cbd5e1;
+  font-size: 0.85rem;
+}
+
+.garmin-context-content[aria-label="Garmin context hidden"] p {
+  margin: 0;
+  font-size: 0.76rem;
+  line-height: 1.4;
+}
+
 .garmin-metric-pill {
   background: rgba(0, 0, 0, 0.25);
   border-radius: 8px;
@@ -602,6 +660,11 @@
   display: flex;
   flex-direction: column;
   gap: 0.1rem;
+}
+
+.garmin-metric-pill small {
+  color: var(--text-secondary, #94a3b8);
+  font-size: 0.68rem;
 }
 
 .pill-label {

--- a/app/src/components/DailyCheckin.tsx
+++ b/app/src/components/DailyCheckin.tsx
@@ -43,6 +43,13 @@ const TISSUE_LEVEL_LABELS: Record<TissueResponseLevel, string> = {
   severe: 'Severe',
 };
 
+const TISSUE_LEVEL_HELP: Record<TissueResponseLevel, string> = {
+  normal: 'No meaningful change; normal movement and function.',
+  mild: 'Noticeable stiffness/soreness, but normal walking and function.',
+  moderate: 'Persistent or function-changing response that should reduce load.',
+  severe: 'Marked pain/swelling/instability or meaningful loss of function.',
+};
+
 interface ScaleConfig {
   key: keyof Pick<DailySubjectiveCheckin, 'readiness' | 'sleepQuality' | 'fatigue' | 'soreness' | 'mentalStress' | 'motivation'>;
   label: string;
@@ -93,7 +100,7 @@ const SCALES: ScaleConfig[] = [
   },
   {
     key: 'motivation',
-    label: 'Motivation',
+    label: 'Motivation / Desire to Train',
     desc: 'How motivated are you to exercise?',
     lowLabel: '1 Low',
     highLabel: '10 High',
@@ -108,6 +115,7 @@ export function DailyCheckin({ userId, onNavigate, onBack }: DailyCheckinProps) 
   const [showGarminComparison, setShowGarminComparison] = useState(false);
   const [recoverySnapshot, setRecoverySnapshot] = useState<Awaited<ReturnType<typeof recoverySnapshotService.getRecoverySnapshotByDate>>>(null);
   const [pendingFollowups, setPendingFollowups] = useState<Array<{ region: BodyRegion; sessionRef?: RegionTissueResponse['sourceSessionRef'] }>>([]);
+  const [pendingTissueRegion, setPendingTissueRegion] = useState<BodyRegion | ''>('');
 
   const tissueSelectId = useId();
   const timeInputId = useId();
@@ -181,22 +189,29 @@ export function DailyCheckin({ userId, onNavigate, onBack }: DailyCheckinProps) 
         if (existing) {
           setCheckin(existing);
         } else {
-          // Initialize with neutral defaults
+          // Do not fabricate neutral subjective observations. Missing scores remain null so
+          // they cannot contaminate the athlete's longitudinal subjective baseline; the
+          // engine already has a neutral fallback for a deliberately partial safety check-in.
           setCheckin({
             userId,
             date: today,
-            readiness: 5,
-            sleepQuality: 5,
-            fatigue: 5,
-            soreness: 5,
-            mentalStress: 5,
-            motivation: 5,
+            readiness: null,
+            sleepQuality: null,
+            fatigue: null,
+            soreness: null,
+            mentalStress: null,
+            motivation: null,
             painOrInjury: false,
             illnessSymptoms: false,
+            healthContext: {
+              symptoms: { present: false },
+              alcoholDrinksLast24h: 0,
+              travelDisruption: 'none',
+            },
             unusuallyLimitedTime: false,
             alreadyTrainedToday: false,
             availability: {
-              timeAvailableMin: 60,
+              timeAvailableMin: null,
               preferredModalityToday: null,
               indoorOnly: false,
             },
@@ -245,16 +260,9 @@ export function DailyCheckin({ userId, onNavigate, onBack }: DailyCheckinProps) 
     });
   };
 
-  const handleBooleanToggle = (field: 'painOrInjury' | 'illnessSymptoms' | 'unusuallyLimitedTime' | 'alreadyTrainedToday') => {
+  const handleBooleanToggle = (field: 'painOrInjury' | 'illnessSymptoms' | 'alreadyTrainedToday') => {
     if (!checkin) return;
     const next = !checkin[field];
-    if (field === 'painOrInjury' && !next) {
-      // Clear tissueResponses when pain/injury is turned off
-      const cleared: Partial<DailySubjectiveCheckin> = { ...checkin, [field]: next };
-      delete cleared.tissueResponses;
-      setCheckin(cleared);
-      return;
-    }
     if (field === 'illnessSymptoms') {
       setCheckin({
         ...checkin,
@@ -268,6 +276,8 @@ export function DailyCheckin({ userId, onNavigate, onBack }: DailyCheckinProps) 
       });
       return;
     }
+    // The hard pain/injury flag and graded tissue observations are independent channels.
+    // Turning the hard flag off must not erase a valid mild/moderate tissue observation.
     setCheckin({ ...checkin, [field]: next });
   };
 
@@ -280,12 +290,17 @@ export function DailyCheckin({ userId, onNavigate, onBack }: DailyCheckinProps) 
     });
   };
 
-  const handleAddTissueRegion = (region: BodyRegion) => {
+  const handleAddTissueRegion = (region: BodyRegion, morningState: TissueResponseLevel) => {
     if (!checkin) return;
     const existing = checkin.tissueResponses ?? {};
     if (existing[region]) return;
-    const entry: RegionTissueResponse = { region, morningState: 'mild' };
-    setCheckin({ ...checkin, tissueResponses: { ...existing, [region]: entry } });
+    const entry: RegionTissueResponse = { region, morningState };
+    setCheckin({
+      ...checkin,
+      tissueResponses: { ...existing, [region]: entry },
+      ...(morningState === 'severe' ? { painOrInjury: true } : {}),
+    });
+    setPendingTissueRegion('');
   };
 
   const handleRemoveTissueRegion = (region: BodyRegion) => {
@@ -308,7 +323,11 @@ export function DailyCheckin({ userId, onNavigate, onBack }: DailyCheckinProps) 
       if (value === '') delete updated[field];
       else (updated as unknown as Record<string, unknown>)[field] = value;
     }
-    setCheckin({ ...checkin, tissueResponses: { ...checkin.tissueResponses, [region]: updated } });
+    setCheckin({
+      ...checkin,
+      tissueResponses: { ...checkin.tissueResponses, [region]: updated },
+      ...(value === 'severe' ? { painOrInjury: true } : {}),
+    });
   };
 
   const handleAnswerFollowup = async (
@@ -327,7 +346,9 @@ export function DailyCheckin({ userId, onNavigate, onBack }: DailyCheckinProps) 
     const updatedCheckin: Partial<DailySubjectiveCheckin> = {
       ...checkin,
       tissueResponses: currentResponses,
-      painOrInjury: level !== 'normal' ? true : checkin.painOrInjury,
+      // Mild/moderate already tighten the graded tissue policy. Only a severe response
+      // promotes the separate hard pain/injury flag that caps the plan at Mobility.
+      painOrInjury: level === 'severe' ? true : checkin.painOrInjury,
     };
     setCheckin(updatedCheckin);
     setPendingFollowups(prev => prev.filter(item => !(item.region === region && item.sessionRef?.id === sessionRef?.id && item.sessionRef?.kind === sessionRef?.kind)));
@@ -438,6 +459,12 @@ export function DailyCheckin({ userId, onNavigate, onBack }: DailyCheckinProps) 
     );
   }
 
+  const answeredSubjectiveCount = SCALES.filter(scale => typeof checkin[scale.key] === 'number').length;
+  const wearableRevealAllowed = Boolean(checkin.initialSubmittedAt && checkin.dataQuality?.isComplete);
+  const tissueResponses = Object.values(checkin.tissueResponses ?? {}).filter(
+    (response): response is RegionTissueResponse => response !== undefined,
+  );
+
   return (
     <div className="checkin-container">
       <div className="checkin-header-bar">
@@ -464,6 +491,7 @@ export function DailyCheckin({ userId, onNavigate, onBack }: DailyCheckinProps) 
                 key={lvl}
                 type="button"
                 className="btn-followup-pill"
+                title={TISSUE_LEVEL_HELP[lvl]}
                 onClick={() => void handleAnswerFollowup(pendingFollowups[0].region, lvl, pendingFollowups[0].sessionRef)}
               >
                 {TISSUE_LEVEL_LABELS[lvl]}
@@ -485,7 +513,7 @@ export function DailyCheckin({ userId, onNavigate, onBack }: DailyCheckinProps) 
         <section className="checkin-section" aria-label="Subjective state assessment">
           <div className="section-title-wrap">
             <h2>Subjective Recovery & State</h2>
-            <p>6 standard subjective dimensions scaled 1 to 10</p>
+            <p>Answer before viewing wearable data. {answeredSubjectiveCount}/6 scored; unanswered items remain missing rather than becoming artificial 5/10 values.</p>
           </div>
 
           <div className="checkin-preset-bar">
@@ -499,30 +527,32 @@ export function DailyCheckin({ userId, onNavigate, onBack }: DailyCheckinProps) 
           </div>
 
           <div className="scales-list">
-            {SCALES.map((scale) => {
-              const val = (checkin[scale.key] as number) ?? 5;
-              return (
-                <SubjectiveScaleRow
-                  key={scale.key}
-                  id={scale.key}
-                  label={scale.label}
-                  desc={scale.desc}
-                  value={val}
-                  lowLabel={scale.lowLabel}
-                  highLabel={scale.highLabel}
-                  isInverted={scale.isInverted}
-                  onChange={(nextVal) => handleScaleChange(scale.key, nextVal)}
-                />
-              );
-            })}
+            {SCALES.map((scale) => (
+              <SubjectiveScaleRow
+                key={scale.key}
+                id={scale.key}
+                label={scale.label}
+                desc={scale.desc}
+                value={(checkin[scale.key] as number | null | undefined) ?? null}
+                lowLabel={scale.lowLabel}
+                highLabel={scale.highLabel}
+                isInverted={scale.isInverted}
+                onChange={(nextVal) => handleScaleChange(scale.key, nextVal)}
+              />
+            ))}
           </div>
+          {answeredSubjectiveCount < SCALES.length && (
+            <p className="checkin-helper-text">
+              You can still save an incomplete check-in to report a safety issue. Only fully scored days enter the longitudinal subjective baseline.
+            </p>
+          )}
         </section>
 
         {/* Section 2: Health & Safety Flags */}
         <section className="checkin-section" aria-label="Health and safety status">
           <div className="section-title-wrap">
             <h2>Health & Safety</h2>
-            <p>Safety constraints that protect your recovery and tissue health</p>
+            <p>Hard safety flags are separate from graded local tissue response.</p>
           </div>
 
           <div className="boolean-options-grid">
@@ -534,8 +564,8 @@ export function DailyCheckin({ userId, onNavigate, onBack }: DailyCheckinProps) 
               />
               <span className="toggle-checkmark"></span>
               <div className="toggle-info">
-                <strong>Pain or Injury</strong>
-                <span>Active physical issue requiring load restriction</span>
+                <strong>Active Pain or Injury</strong>
+                <span>Hard safety flag for a current issue that should strongly restrict training</span>
               </div>
             </label>
 
@@ -548,20 +578,7 @@ export function DailyCheckin({ userId, onNavigate, onBack }: DailyCheckinProps) 
               <span className="toggle-checkmark"></span>
               <div className="toggle-info">
                 <strong>Illness Symptoms</strong>
-                <span>Feeling sick, feverish, or unwell</span>
-              </div>
-            </label>
-
-            <label className={`boolean-toggle-card ${checkin.unusuallyLimitedTime ? 'is-active' : ''}`}>
-              <input
-                type="checkbox"
-                checked={checkin.unusuallyLimitedTime || false}
-                onChange={() => handleBooleanToggle('unusuallyLimitedTime')}
-              />
-              <span className="toggle-checkmark"></span>
-              <div className="toggle-info">
-                <strong>Limited Time</strong>
-                <span>Have less time available than normal</span>
+                <span>Feeling sick, feverish, or systemically unwell</span>
               </div>
             </label>
 
@@ -582,115 +599,141 @@ export function DailyCheckin({ userId, onNavigate, onBack }: DailyCheckinProps) 
           <HealthContextSection
             value={checkin.healthContext}
             symptomsPresent={Boolean(checkin.illnessSymptoms)}
+            manualPhysiologyMissing={{
+              rhr: recoverySnapshot?.raw.restingHr == null,
+              hrv: recoverySnapshot?.raw.hrvOvernightAvg == null,
+              respiration: recoverySnapshot?.raw.respirationAvg == null,
+            }}
             onChange={handleHealthContextChange}
           />
 
-          {checkin.painOrInjury && (
-            <div className="tissue-response-expanded">
-              <div className="tissue-response-intro">
-                <h3>Affected Body Regions</h3>
-                <p>Pinpointing where and when helps calibrate safe session substitutions.</p>
-              </div>
-
-              <div className="form-group add-region-group">
-                <label htmlFor={tissueSelectId}>Add affected body area</label>
-                <select
-                  id={tissueSelectId}
-                  className="select-input"
-                  value=""
-                  onChange={(e) => {
-                    if (e.target.value) handleAddTissueRegion(e.target.value as BodyRegion);
-                  }}
-                >
-                  <option value="">Select an affected region…</option>
-                  {BODY_REGIONS.filter(region => !checkin.tissueResponses?.[region]).map(region => (
-                    <option key={region} value={region}>{REGION_LABELS[region]}</option>
-                  ))}
-                </select>
-              </div>
-
-              {Object.values(checkin.tissueResponses ?? {}).map(response => {
-                if (!response) return null;
-                const region = response.region;
-                return (
-                  <article className="tissue-region-card" key={region}>
-                    <div className="tissue-region-header">
-                      <strong>{REGION_LABELS[region]}</strong>
-                      <button
-                        type="button"
-                        className="tissue-region-remove"
-                        onClick={() => handleRemoveTissueRegion(region)}
-                        aria-label={`Remove ${REGION_LABELS[region]}`}
-                      >
-                        ✕ Remove
-                      </button>
-                    </div>
-
-                    <div className="tissue-region-fields">
-                      <div className="form-group">
-                        <label htmlFor={`${region}-morningState`}>This morning (resting/waking)</label>
-                        <select
-                          id={`${region}-morningState`}
-                          className="select-input"
-                          value={response.morningState}
-                          onChange={(e) => handleTissueFieldChange(region, 'morningState', e.target.value as TissueResponseLevel)}
-                        >
-                          {TISSUE_LEVELS.map(level => (
-                            <option key={level} value={level}>{TISSUE_LEVEL_LABELS[level]}</option>
-                          ))}
-                        </select>
-                      </div>
-
-                      <div className="form-group">
-                        <label htmlFor={`${region}-painDuringTraining`}>Pain during training (if any)</label>
-                        <select
-                          id={`${region}-painDuringTraining`}
-                          className="select-input"
-                          value={response.painDuringTraining ?? ''}
-                          onChange={(e) => handleTissueFieldChange(region, 'painDuringTraining', e.target.value as TissueResponseLevel | '')}
-                        >
-                          <option value="">Did not train / not applicable</option>
-                          {TISSUE_LEVELS.map(level => (
-                            <option key={level} value={level}>{TISSUE_LEVEL_LABELS[level]}</option>
-                          ))}
-                        </select>
-                      </div>
-
-                      <div className="form-group">
-                        <label htmlFor={`${region}-afterTrainingState`}>Right after training</label>
-                        <select
-                          id={`${region}-afterTrainingState`}
-                          className="select-input"
-                          value={response.afterTrainingState ?? ''}
-                          onChange={(e) => handleTissueFieldChange(region, 'afterTrainingState', e.target.value as TissueResponseLevel | '')}
-                        >
-                          <option value="">Did not train / not applicable</option>
-                          {TISSUE_LEVELS.map(level => (
-                            <option key={level} value={level}>{TISSUE_LEVEL_LABELS[level]}</option>
-                          ))}
-                        </select>
-                      </div>
-
-                      <div className="form-group">
-                        <label htmlFor={`${region}-nextMorningReaction`}>Reaction to yesterday&apos;s session</label>
-                        <select
-                          id={`${region}-nextMorningReaction`}
-                          className="select-input"
-                          value={response.nextMorningReaction ?? ''}
-                          onChange={(e) => handleTissueFieldChange(region, 'nextMorningReaction', e.target.value as TissueResponseLevel | '')}
-                        >
-                          <option value="">No session yesterday / not applicable</option>
-                          {TISSUE_LEVELS.map(level => (
-                            <option key={level} value={level}>{TISSUE_LEVEL_LABELS[level]}</option>
-                          ))}
-                        </select>
-                      </div>
-                    </div>
-                  </article>
-                );
-              })}
+          <div className="tissue-response-expanded" aria-label="Local tissue response">
+            <div className="tissue-response-intro">
+              <h3>Local Tissue Response</h3>
+              <p>
+                Report local stiffness, swelling/fullness, unusual tendon or calf soreness, or altered walking/stairs/squat even when you would not call it an injury. Local tissue response can tighten today&apos;s plan independently of Garmin readiness.
+              </p>
             </div>
-          )}
+
+            <div className="form-group add-region-group">
+              <label htmlFor={tissueSelectId}>Add body area to monitor</label>
+              <select
+                id={tissueSelectId}
+                className="select-input"
+                value={pendingTissueRegion}
+                onChange={(e) => setPendingTissueRegion(e.target.value as BodyRegion | '')}
+              >
+                <option value="">Select a region…</option>
+                {BODY_REGIONS.filter(region => !checkin.tissueResponses?.[region]).map(region => (
+                  <option key={region} value={region}>{REGION_LABELS[region]}</option>
+                ))}
+              </select>
+            </div>
+
+            {pendingTissueRegion && (
+              <div className="followup-tissue-prompt" aria-label={`Morning state for ${REGION_LABELS[pendingTissueRegion]}`}>
+                <p>How does your <strong>{REGION_LABELS[pendingTissueRegion]}</strong> feel this morning?</p>
+                <div className="followup-actions">
+                  {TISSUE_LEVELS.map(level => (
+                    <button
+                      key={level}
+                      type="button"
+                      className="btn-followup-pill"
+                      title={TISSUE_LEVEL_HELP[level]}
+                      onClick={() => handleAddTissueRegion(pendingTissueRegion, level)}
+                    >
+                      {TISSUE_LEVEL_LABELS[level]}
+                    </button>
+                  ))}
+                </div>
+                <small>Normal = no meaningful change · Mild = noticeable but normal function · Moderate = changes function/load · Severe = marked pain/swelling/instability or significant function loss</small>
+              </div>
+            )}
+
+            {tissueResponses.length === 0 && !pendingTissueRegion && (
+              <p className="checkin-helper-text">No local tissue issue reported today.</p>
+            )}
+
+            {tissueResponses.map(response => {
+              const region = response.region;
+              return (
+                <article className="tissue-region-card" key={region}>
+                  <div className="tissue-region-header">
+                    <strong>{REGION_LABELS[region]}</strong>
+                    <button
+                      type="button"
+                      className="tissue-region-remove"
+                      onClick={() => handleRemoveTissueRegion(region)}
+                      aria-label={`Remove ${REGION_LABELS[region]}`}
+                    >
+                      ✕ Remove
+                    </button>
+                  </div>
+
+                  <div className="tissue-region-fields">
+                    <div className="form-group">
+                      <label htmlFor={`${region}-morningState`}>This morning (resting/waking)</label>
+                      <select
+                        id={`${region}-morningState`}
+                        className="select-input"
+                        value={response.morningState}
+                        onChange={(e) => handleTissueFieldChange(region, 'morningState', e.target.value as TissueResponseLevel)}
+                      >
+                        {TISSUE_LEVELS.map(level => (
+                          <option key={level} value={level}>{TISSUE_LEVEL_LABELS[level]}</option>
+                        ))}
+                      </select>
+                    </div>
+
+                    <div className="form-group">
+                      <label htmlFor={`${region}-painDuringTraining`}>Pain during training (if any)</label>
+                      <select
+                        id={`${region}-painDuringTraining`}
+                        className="select-input"
+                        value={response.painDuringTraining ?? ''}
+                        onChange={(e) => handleTissueFieldChange(region, 'painDuringTraining', e.target.value as TissueResponseLevel | '')}
+                      >
+                        <option value="">Did not train / not applicable</option>
+                        {TISSUE_LEVELS.map(level => (
+                          <option key={level} value={level}>{TISSUE_LEVEL_LABELS[level]}</option>
+                        ))}
+                      </select>
+                    </div>
+
+                    <div className="form-group">
+                      <label htmlFor={`${region}-afterTrainingState`}>Right after training</label>
+                      <select
+                        id={`${region}-afterTrainingState`}
+                        className="select-input"
+                        value={response.afterTrainingState ?? ''}
+                        onChange={(e) => handleTissueFieldChange(region, 'afterTrainingState', e.target.value as TissueResponseLevel | '')}
+                      >
+                        <option value="">Did not train / not applicable</option>
+                        {TISSUE_LEVELS.map(level => (
+                          <option key={level} value={level}>{TISSUE_LEVEL_LABELS[level]}</option>
+                        ))}
+                      </select>
+                    </div>
+
+                    <div className="form-group">
+                      <label htmlFor={`${region}-nextMorningReaction`}>Reaction to yesterday&apos;s session</label>
+                      <select
+                        id={`${region}-nextMorningReaction`}
+                        className="select-input"
+                        value={response.nextMorningReaction ?? ''}
+                        onChange={(e) => handleTissueFieldChange(region, 'nextMorningReaction', e.target.value as TissueResponseLevel | '')}
+                      >
+                        <option value="">No session yesterday / not applicable</option>
+                        {TISSUE_LEVELS.map(level => (
+                          <option key={level} value={level}>{TISSUE_LEVEL_LABELS[level]}</option>
+                        ))}
+                      </select>
+                    </div>
+                  </div>
+                </article>
+              );
+            })}
+          </div>
         </section>
 
         {/* Section 3: Availability & Notes */}
@@ -708,8 +751,9 @@ export function DailyCheckin({ userId, onNavigate, onBack }: DailyCheckinProps) 
                 type="number"
                 min="0"
                 max="1440"
-                value={checkin.availability?.timeAvailableMin ?? 60}
-                onChange={(e) => handleAvailabilityChange('timeAvailableMin', Number(e.target.value))}
+                placeholder="e.g. 60"
+                value={checkin.availability?.timeAvailableMin ?? ''}
+                onChange={(e) => handleAvailabilityChange('timeAvailableMin', e.target.value === '' ? null : Number(e.target.value))}
                 className="number-input"
               />
             </div>
@@ -759,38 +803,55 @@ export function DailyCheckin({ userId, onNavigate, onBack }: DailyCheckinProps) 
           </div>
         </section>
 
-        {/* Section 4: Secondary Garmin Recovery Context Disclosure */}
+        {/* Objective values remain hidden until a complete subjective submission prevents anchoring. */}
         {recoverySnapshot && (
           <section className="checkin-garmin-disclosure">
-            <button
-              type="button"
-              className="garmin-context-toggle"
-              onClick={() => setShowGarminComparison(prev => !prev)}
-              aria-expanded={showGarminComparison}
-            >
-              <span>📊 Garmin Context ({recoverySnapshot.raw.sleepScore ? `Sleep ${recoverySnapshot.raw.sleepScore}` : 'Synced'})</span>
-              <span className="toggle-arrow">{showGarminComparison ? '▲' : '▼'}</span>
-            </button>
-
-            {showGarminComparison && (
-              <div className="garmin-context-content">
-                <div className="garmin-metric-pill">
-                  <span className="pill-label">Sleep Score</span>
-                  <span className="pill-val">{recoverySnapshot.raw.sleepScore ?? '--'}</span>
-                </div>
-                <div className="garmin-metric-pill">
-                  <span className="pill-label">Resting HR</span>
-                  <span className="pill-val">{recoverySnapshot.raw.restingHr ? `${recoverySnapshot.raw.restingHr} bpm` : '--'}</span>
-                </div>
-                <div className="garmin-metric-pill">
-                  <span className="pill-label">HRV Overnight</span>
-                  <span className="pill-val">{recoverySnapshot.raw.hrvOvernightAvg ? `${recoverySnapshot.raw.hrvOvernightAvg} ms` : '--'}</span>
-                </div>
-                <div className="garmin-metric-pill">
-                  <span className="pill-label">Body Battery</span>
-                  <span className="pill-val">{recoverySnapshot.raw.bodyBatteryWake ?? '--'} / 100</span>
-                </div>
+            {!wearableRevealAllowed ? (
+              <div className="garmin-context-content" aria-label="Garmin context hidden">
+                <strong>Garmin context hidden during first subjective check-in</strong>
+                <p>Complete and save the six subjective scores first. This keeps your self-report independent from wearable feedback.</p>
               </div>
+            ) : (
+              <>
+                <button
+                  type="button"
+                  className="garmin-context-toggle"
+                  onClick={() => setShowGarminComparison(prev => !prev)}
+                  aria-expanded={showGarminComparison}
+                >
+                  <span>📊 Garmin Context</span>
+                  <span className="toggle-arrow">{showGarminComparison ? '▲' : '▼'}</span>
+                </button>
+
+                {showGarminComparison && (
+                  <div className="garmin-context-content">
+                    <div className="garmin-metric-pill">
+                      <span className="pill-label">Sleep Score</span>
+                      <span className="pill-val">{recoverySnapshot.raw.sleepScore ?? '--'}</span>
+                      <small>7d {recoverySnapshot.derived.sleepScore7dAvg ?? '--'}</small>
+                    </div>
+                    <div className="garmin-metric-pill">
+                      <span className="pill-label">Resting HR</span>
+                      <span className="pill-val">{recoverySnapshot.raw.restingHr != null ? `${recoverySnapshot.raw.restingHr} bpm` : '--'}</span>
+                      <small>7d {recoverySnapshot.derived.restingHr7dAvg != null ? `${recoverySnapshot.derived.restingHr7dAvg} bpm` : '--'}</small>
+                    </div>
+                    <div className="garmin-metric-pill">
+                      <span className="pill-label">HRV Overnight</span>
+                      <span className="pill-val">{recoverySnapshot.raw.hrvOvernightAvg != null ? `${recoverySnapshot.raw.hrvOvernightAvg} ms` : '--'}</span>
+                      <small>7d {recoverySnapshot.derived.hrv7dAvg != null ? `${recoverySnapshot.derived.hrv7dAvg} ms` : '--'}</small>
+                    </div>
+                    <div className="garmin-metric-pill">
+                      <span className="pill-label">Respiration</span>
+                      <span className="pill-val">{recoverySnapshot.raw.respirationAvg != null ? `${recoverySnapshot.raw.respirationAvg} br/min` : '--'}</span>
+                      <small>7d {recoverySnapshot.derived.respiration7dAvg != null ? `${recoverySnapshot.derived.respiration7dAvg} br/min` : '--'}</small>
+                    </div>
+                    <div className="garmin-metric-pill">
+                      <span className="pill-label">Body Battery</span>
+                      <span className="pill-val">{recoverySnapshot.raw.bodyBatteryWake ?? '--'} / 100</span>
+                    </div>
+                  </div>
+                )}
+              </>
             )}
           </section>
         )}

--- a/app/src/components/HealthAnomalyShadowPanel.tsx
+++ b/app/src/components/HealthAnomalyShadowPanel.tsx
@@ -50,7 +50,7 @@ export function HealthAnomalyShadowTrace({ revision, decisionInput }: HealthAnom
           <div className="data-item"><span className="data-label">Revision:</span><span className="data-value">{revision.revisionId}</span></div>
           <div className="data-item"><span className="data-label">Computed:</span><span className="data-value">{revision.computedAt}</span></div>
           <div className="data-item"><span className="data-label">Episode:</span><span className="data-value">{assessment.episodeId ?? 'None'}{assessment.episodeDay ? ` · day ${assessment.episodeDay}` : ''}</span></div>
-          <div className="data-item"><span className="data-label">Unexplained persistence:</span><span className="data-value">{assessment.persistenceDays} day(s)</span></div>
+          <div className="data-item"><span className="data-label">Adverse physiology persistence:</span><span className="data-value">{assessment.persistenceDays} day(s)</span></div>
         </div>
 
         {assessment.coreSignals.map(signal => {

--- a/app/src/components/checkin/HealthContextSection.test.tsx
+++ b/app/src/components/checkin/HealthContextSection.test.tsx
@@ -3,7 +3,7 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { HealthContextSection } from './HealthContextSection';
 
 describe('HealthContextSection', () => {
-    it('renders a compact optional prompt without duplicating training, sleep, or stress questions', () => {
+    it('renders the requested default health context without duplicating training, sleep, or stress questions', () => {
         const html = renderToStaticMarkup(
             <HealthContextSection value={undefined} symptomsPresent={false} onChange={() => {}} />,
         );
@@ -13,14 +13,21 @@ describe('HealthContextSection', () => {
         expect(html).toContain('Travel / jet lag');
         expect(html).toContain('Heat / sauna');
         expect(html).toContain('Dehydration / fluid loss');
+        expect(html).toContain('Vaccination');
+        expect(html).toContain('Medication change');
         expect(html).toContain('Close sick contact');
+        expect(html).toContain('RHR higher than usual?');
+        expect(html).toContain('HRV lower than usual?');
+        expect(html).toContain('Respiration higher than usual?');
+        expect(html).toMatch(/<button[^>]*aria-pressed="true"[^>]*>None<\/button>/);
+        expect(html).toMatch(/aria-label="Travel disruption"[\s\S]*?<button[^>]*aria-pressed="true"[^>]*>No<\/button>/);
         expect(html).not.toContain('Hard training');
         expect(html).not.toContain('Poor sleep');
         expect(html).not.toContain('High stress');
         expect(html).not.toContain('health-context__symptoms');
     });
 
-    it('renders close sick contact as explicit yes/no choices while preserving unanswered state', () => {
+    it('renders contextual booleans as explicit unknown/no/yes tri-state choices', () => {
         const unanswered = renderToStaticMarkup(
             <HealthContextSection value={{}} symptomsPresent={false} onChange={() => {}} />,
         );
@@ -31,11 +38,30 @@ describe('HealthContextSection', () => {
             <HealthContextSection value={{ closeSickContact: true }} symptomsPresent={false} onChange={() => {}} />,
         );
 
-        expect(unanswered).toContain('aria-label="Close sick contact"');
-        expect(unanswered).toMatch(/<button[^>]*aria-pressed="false"[^>]*>No<\/button>/);
-        expect(unanswered).toMatch(/<button[^>]*aria-pressed="false"[^>]*>Yes<\/button>/);
-        expect(answeredNo).toMatch(/<button[^>]*aria-pressed="true"[^>]*>No<\/button>/);
-        expect(answeredYes).toMatch(/<button[^>]*aria-pressed="true"[^>]*>Yes<\/button>/);
+        expect(unanswered).toMatch(/aria-label="Close sick contact"[\s\S]*?<button[^>]*aria-pressed="true"[^>]*>Unknown<\/button>/);
+        expect(answeredNo).toMatch(/aria-label="Close sick contact"[\s\S]*?<button[^>]*aria-pressed="true"[^>]*>No<\/button>/);
+        expect(answeredYes).toMatch(/aria-label="Close sick contact"[\s\S]*?<button[^>]*aria-pressed="true"[^>]*>Yes<\/button>/);
+    });
+
+    it('keeps manual RHR, HRV, and respiration changes unknown until explicitly answered', () => {
+        const unanswered = renderToStaticMarkup(
+            <HealthContextSection value={{}} symptomsPresent={false} onChange={() => {}} />,
+        );
+        const changed = renderToStaticMarkup(
+            <HealthContextSection
+                value={{ subjectiveRhrHigher: true, subjectiveHrvLower: true, subjectiveRespirationHigher: false }}
+                symptomsPresent={false}
+                onChange={() => {}}
+            />,
+        );
+
+        expect(unanswered).toMatch(/aria-label="RHR higher than usual\?"[\s\S]*?<button[^>]*aria-pressed="true"[^>]*>Unknown<\/button>/);
+        expect(unanswered).toMatch(/aria-label="HRV lower than usual\?"[\s\S]*?<button[^>]*aria-pressed="true"[^>]*>Unknown<\/button>/);
+        expect(unanswered).toMatch(/aria-label="Respiration higher than usual\?"[\s\S]*?<button[^>]*aria-pressed="true"[^>]*>Unknown<\/button>/);
+        expect(changed).toContain('Context added');
+        expect(changed).toMatch(/aria-label="RHR higher than usual\?"[\s\S]*?<button[^>]*aria-pressed="true"[^>]*>Yes<\/button>/);
+        expect(changed).toMatch(/aria-label="HRV lower than usual\?"[\s\S]*?<button[^>]*aria-pressed="true"[^>]*>Yes<\/button>/);
+        expect(changed).toMatch(/aria-label="Respiration higher than usual\?"[\s\S]*?<button[^>]*aria-pressed="true"[^>]*>No<\/button>/);
     });
 
     it('shows selected context and a time-zone input when a shift is reported', () => {

--- a/app/src/components/checkin/HealthContextSection.test.tsx
+++ b/app/src/components/checkin/HealthContextSection.test.tsx
@@ -3,9 +3,14 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { HealthContextSection } from './HealthContextSection';
 
 describe('HealthContextSection', () => {
-    it('renders the requested default health context without duplicating training, sleep, or stress questions', () => {
+    it('renders requested health defaults without duplicating wearable questions when Garmin is present', () => {
         const html = renderToStaticMarkup(
-            <HealthContextSection value={undefined} symptomsPresent={false} onChange={() => {}} />,
+            <HealthContextSection
+                value={undefined}
+                symptomsPresent={false}
+                manualPhysiologyMissing={{ rhr: false, hrv: false, respiration: false }}
+                onChange={() => {}}
+            />,
         );
 
         expect(html).toContain('Anything unusual since yesterday?');
@@ -16,11 +21,11 @@ describe('HealthContextSection', () => {
         expect(html).toContain('Vaccination');
         expect(html).toContain('Medication change');
         expect(html).toContain('Close sick contact');
-        expect(html).toContain('RHR higher than usual?');
-        expect(html).toContain('HRV lower than usual?');
-        expect(html).toContain('Respiration higher than usual?');
         expect(html).toMatch(/<button[^>]*aria-pressed="true"[^>]*>None<\/button>/);
         expect(html).toMatch(/aria-label="Travel disruption"[\s\S]*?<button[^>]*aria-pressed="true"[^>]*>No<\/button>/);
+        expect(html).not.toContain('RHR higher than usual?');
+        expect(html).not.toContain('HRV lower than usual?');
+        expect(html).not.toContain('Respiration higher than usual?');
         expect(html).not.toContain('Hard training');
         expect(html).not.toContain('Poor sleep');
         expect(html).not.toContain('High stress');
@@ -43,25 +48,38 @@ describe('HealthContextSection', () => {
         expect(answeredYes).toMatch(/aria-label="Close sick contact"[\s\S]*?<button[^>]*aria-pressed="true"[^>]*>Yes<\/button>/);
     });
 
-    it('keeps manual RHR, HRV, and respiration changes unknown until explicitly answered', () => {
-        const unanswered = renderToStaticMarkup(
-            <HealthContextSection value={{}} symptomsPresent={false} onChange={() => {}} />,
-        );
-        const changed = renderToStaticMarkup(
+    it('only asks manual RHR, HRV, and respiration comparisons for missing objective signals', () => {
+        const html = renderToStaticMarkup(
             <HealthContextSection
-                value={{ subjectiveRhrHigher: true, subjectiveHrvLower: true, subjectiveRespirationHigher: false }}
+                value={{ manualRhrHigher: true, manualRespirationHigher: false }}
                 symptomsPresent={false}
+                manualPhysiologyMissing={{ rhr: true, hrv: false, respiration: true }}
                 onChange={() => {}}
             />,
         );
 
-        expect(unanswered).toMatch(/aria-label="RHR higher than usual\?"[\s\S]*?<button[^>]*aria-pressed="true"[^>]*>Unknown<\/button>/);
-        expect(unanswered).toMatch(/aria-label="HRV lower than usual\?"[\s\S]*?<button[^>]*aria-pressed="true"[^>]*>Unknown<\/button>/);
-        expect(unanswered).toMatch(/aria-label="Respiration higher than usual\?"[\s\S]*?<button[^>]*aria-pressed="true"[^>]*>Unknown<\/button>/);
-        expect(changed).toContain('Context added');
-        expect(changed).toMatch(/aria-label="RHR higher than usual\?"[\s\S]*?<button[^>]*aria-pressed="true"[^>]*>Yes<\/button>/);
-        expect(changed).toMatch(/aria-label="HRV lower than usual\?"[\s\S]*?<button[^>]*aria-pressed="true"[^>]*>Yes<\/button>/);
-        expect(changed).toMatch(/aria-label="Respiration higher than usual\?"[\s\S]*?<button[^>]*aria-pressed="true"[^>]*>No<\/button>/);
+        expect(html).toContain('Manual physiology fallback');
+        expect(html).toContain('RHR higher than usual?');
+        expect(html).not.toContain('HRV lower than usual?');
+        expect(html).toContain('Respiration higher than usual?');
+        expect(html).toMatch(/aria-label="RHR higher than usual\?"[\s\S]*?<button[^>]*aria-pressed="true"[^>]*>Yes<\/button>/);
+        expect(html).toMatch(/aria-label="Respiration higher than usual\?"[\s\S]*?<button[^>]*aria-pressed="true"[^>]*>No<\/button>/);
+        expect(html).toContain('Context added');
+    });
+
+    it('keeps missing manual physiology unknown until explicitly answered', () => {
+        const html = renderToStaticMarkup(
+            <HealthContextSection
+                value={{}}
+                symptomsPresent={false}
+                manualPhysiologyMissing={{ rhr: true, hrv: true, respiration: true }}
+                onChange={() => {}}
+            />,
+        );
+
+        expect(html).toMatch(/aria-label="RHR higher than usual\?"[\s\S]*?<button[^>]*aria-pressed="true"[^>]*>Unknown<\/button>/);
+        expect(html).toMatch(/aria-label="HRV lower than usual\?"[\s\S]*?<button[^>]*aria-pressed="true"[^>]*>Unknown<\/button>/);
+        expect(html).toMatch(/aria-label="Respiration higher than usual\?"[\s\S]*?<button[^>]*aria-pressed="true"[^>]*>Unknown<\/button>/);
     });
 
     it('shows selected context and a time-zone input when a shift is reported', () => {

--- a/app/src/components/checkin/HealthContextSection.test.tsx
+++ b/app/src/components/checkin/HealthContextSection.test.tsx
@@ -8,7 +8,6 @@ describe('HealthContextSection', () => {
             <HealthContextSection
                 value={undefined}
                 symptomsPresent={false}
-                manualPhysiologyMissing={{ rhr: true, hrv: true, respiration: true }}
                 onChange={() => {}}
             />,
         );

--- a/app/src/components/checkin/HealthContextSection.test.tsx
+++ b/app/src/components/checkin/HealthContextSection.test.tsx
@@ -13,10 +13,29 @@ describe('HealthContextSection', () => {
         expect(html).toContain('Travel / jet lag');
         expect(html).toContain('Heat / sauna');
         expect(html).toContain('Dehydration / fluid loss');
+        expect(html).toContain('Close sick contact');
         expect(html).not.toContain('Hard training');
         expect(html).not.toContain('Poor sleep');
         expect(html).not.toContain('High stress');
         expect(html).not.toContain('health-context__symptoms');
+    });
+
+    it('renders close sick contact as explicit yes/no choices while preserving unanswered state', () => {
+        const unanswered = renderToStaticMarkup(
+            <HealthContextSection value={{}} symptomsPresent={false} onChange={() => {}} />,
+        );
+        const answeredNo = renderToStaticMarkup(
+            <HealthContextSection value={{ closeSickContact: false }} symptomsPresent={false} onChange={() => {}} />,
+        );
+        const answeredYes = renderToStaticMarkup(
+            <HealthContextSection value={{ closeSickContact: true }} symptomsPresent={false} onChange={() => {}} />,
+        );
+
+        expect(unanswered).toContain('aria-label="Close sick contact"');
+        expect(unanswered).toMatch(/<button[^>]*aria-pressed="false"[^>]*>No<\/button>/);
+        expect(unanswered).toMatch(/<button[^>]*aria-pressed="false"[^>]*>Yes<\/button>/);
+        expect(answeredNo).toMatch(/<button[^>]*aria-pressed="true"[^>]*>No<\/button>/);
+        expect(answeredYes).toMatch(/<button[^>]*aria-pressed="true"[^>]*>Yes<\/button>/);
     });
 
     it('shows selected context and a time-zone input when a shift is reported', () => {

--- a/app/src/components/checkin/HealthContextSection.test.tsx
+++ b/app/src/components/checkin/HealthContextSection.test.tsx
@@ -3,12 +3,12 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { HealthContextSection } from './HealthContextSection';
 
 describe('HealthContextSection', () => {
-    it('renders requested health defaults without duplicating wearable questions when Garmin is present', () => {
+    it('defaults contextual health flags to No and does not ask manual physiology questions', () => {
         const html = renderToStaticMarkup(
             <HealthContextSection
                 value={undefined}
                 symptomsPresent={false}
-                manualPhysiologyMissing={{ rhr: false, hrv: false, respiration: false }}
+                manualPhysiologyMissing={{ rhr: true, hrv: true, respiration: true }}
                 onChange={() => {}}
             />,
         );
@@ -23,63 +23,44 @@ describe('HealthContextSection', () => {
         expect(html).toContain('Close sick contact');
         expect(html).toMatch(/<button[^>]*aria-pressed="true"[^>]*>None<\/button>/);
         expect(html).toMatch(/aria-label="Travel disruption"[\s\S]*?<button[^>]*aria-pressed="true"[^>]*>No<\/button>/);
+        for (const label of ['Heat / sauna', 'Dehydration / fluid loss', 'Vaccination', 'Medication change', 'Close sick contact']) {
+            const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            expect(html).toMatch(new RegExp(`aria-label="${escaped}"[\\s\\S]*?<button[^>]*aria-pressed="true"[^>]*>No<\\/button>`));
+        }
+        expect(html).not.toContain('Unknown');
+        expect(html).not.toContain('Manual physiology fallback');
         expect(html).not.toContain('RHR higher than usual?');
         expect(html).not.toContain('HRV lower than usual?');
         expect(html).not.toContain('Respiration higher than usual?');
-        expect(html).not.toContain('Hard training');
-        expect(html).not.toContain('Poor sleep');
-        expect(html).not.toContain('High stress');
         expect(html).not.toContain('health-context__symptoms');
     });
 
-    it('renders contextual booleans as explicit unknown/no/yes tri-state choices', () => {
-        const unanswered = renderToStaticMarkup(
-            <HealthContextSection value={{}} symptomsPresent={false} onChange={() => {}} />,
+    it('treats legacy null contextual values as the new No default', () => {
+        const html = renderToStaticMarkup(
+            <HealthContextSection
+                value={{
+                    unusualHeatOrSauna: null,
+                    dehydrationOrFluidLoss: null,
+                    recentVaccination: null,
+                    medicationChange: null,
+                    closeSickContact: null,
+                }}
+                symptomsPresent={false}
+                onChange={() => {}}
+            />,
         );
-        const answeredNo = renderToStaticMarkup(
-            <HealthContextSection value={{ closeSickContact: false }} symptomsPresent={false} onChange={() => {}} />,
-        );
-        const answeredYes = renderToStaticMarkup(
+
+        expect(html).not.toContain('Unknown');
+        expect(html).toMatch(/aria-label="Close sick contact"[\s\S]*?<button[^>]*aria-pressed="true"[^>]*>No<\/button>/);
+    });
+
+    it('shows a Yes selection and context badge when a contextual flag is reported', () => {
+        const html = renderToStaticMarkup(
             <HealthContextSection value={{ closeSickContact: true }} symptomsPresent={false} onChange={() => {}} />,
         );
 
-        expect(unanswered).toMatch(/aria-label="Close sick contact"[\s\S]*?<button[^>]*aria-pressed="true"[^>]*>Unknown<\/button>/);
-        expect(answeredNo).toMatch(/aria-label="Close sick contact"[\s\S]*?<button[^>]*aria-pressed="true"[^>]*>No<\/button>/);
-        expect(answeredYes).toMatch(/aria-label="Close sick contact"[\s\S]*?<button[^>]*aria-pressed="true"[^>]*>Yes<\/button>/);
-    });
-
-    it('only asks manual RHR, HRV, and respiration comparisons for missing objective signals', () => {
-        const html = renderToStaticMarkup(
-            <HealthContextSection
-                value={{ manualRhrHigher: true, manualRespirationHigher: false }}
-                symptomsPresent={false}
-                manualPhysiologyMissing={{ rhr: true, hrv: false, respiration: true }}
-                onChange={() => {}}
-            />,
-        );
-
-        expect(html).toContain('Manual physiology fallback');
-        expect(html).toContain('RHR higher than usual?');
-        expect(html).not.toContain('HRV lower than usual?');
-        expect(html).toContain('Respiration higher than usual?');
-        expect(html).toMatch(/aria-label="RHR higher than usual\?"[\s\S]*?<button[^>]*aria-pressed="true"[^>]*>Yes<\/button>/);
-        expect(html).toMatch(/aria-label="Respiration higher than usual\?"[\s\S]*?<button[^>]*aria-pressed="true"[^>]*>No<\/button>/);
+        expect(html).toMatch(/aria-label="Close sick contact"[\s\S]*?<button[^>]*aria-pressed="true"[^>]*>Yes<\/button>/);
         expect(html).toContain('Context added');
-    });
-
-    it('keeps missing manual physiology unknown until explicitly answered', () => {
-        const html = renderToStaticMarkup(
-            <HealthContextSection
-                value={{}}
-                symptomsPresent={false}
-                manualPhysiologyMissing={{ rhr: true, hrv: true, respiration: true }}
-                onChange={() => {}}
-            />,
-        );
-
-        expect(html).toMatch(/aria-label="RHR higher than usual\?"[\s\S]*?<button[^>]*aria-pressed="true"[^>]*>Unknown<\/button>/);
-        expect(html).toMatch(/aria-label="HRV lower than usual\?"[\s\S]*?<button[^>]*aria-pressed="true"[^>]*>Unknown<\/button>/);
-        expect(html).toMatch(/aria-label="Respiration higher than usual\?"[\s\S]*?<button[^>]*aria-pressed="true"[^>]*>Unknown<\/button>/);
     });
 
     it('shows selected context and a time-zone input when a shift is reported', () => {

--- a/app/src/components/checkin/HealthContextSection.tsx
+++ b/app/src/components/checkin/HealthContextSection.tsx
@@ -19,15 +19,19 @@ const TRAVEL_OPTIONS: Array<{ value: NonNullable<HealthContextCheckin['travelDis
 ];
 
 const CONTEXT_TOGGLES: Array<{
-    key: 'unusualHeatOrSauna' | 'dehydrationOrFluidLoss' | 'recentVaccination' | 'medicationChange' | 'closeSickContact';
+    key: 'unusualHeatOrSauna' | 'dehydrationOrFluidLoss' | 'recentVaccination' | 'medicationChange';
     label: string;
 }> = [
     { key: 'unusualHeatOrSauna', label: 'Heat / sauna' },
     { key: 'dehydrationOrFluidLoss', label: 'Dehydration / fluid loss' },
     { key: 'recentVaccination', label: 'Vaccination' },
     { key: 'medicationChange', label: 'Medication change' },
-    { key: 'closeSickContact', label: 'Close sick contact' },
 ];
+
+const SICK_CONTACT_OPTIONS = [
+    { value: false, label: 'No' },
+    { value: true, label: 'Yes' },
+] as const;
 
 const ONSETS = [
     ['today', 'Today'],
@@ -174,6 +178,23 @@ export function HealthContextSection({ value, symptomsPresent, onChange }: Healt
                             {item.label}
                         </button>
                     ))}
+                </div>
+
+                <div className="health-context__row">
+                    <span className="health-context__label">Close sick contact</span>
+                    <div className="health-context__chips" role="group" aria-label="Close sick contact">
+                        {SICK_CONTACT_OPTIONS.map(option => (
+                            <button
+                                key={String(option.value)}
+                                type="button"
+                                className={`health-context__chip ${context.closeSickContact === option.value ? 'is-selected' : ''}`}
+                                aria-pressed={context.closeSickContact === option.value}
+                                onClick={() => update({ closeSickContact: option.value })}
+                            >
+                                {option.label}
+                            </button>
+                        ))}
+                    </div>
                 </div>
 
                 <label className="health-context__other">

--- a/app/src/components/checkin/HealthContextSection.tsx
+++ b/app/src/components/checkin/HealthContextSection.tsx
@@ -9,6 +9,15 @@ import './HealthContextSection.css';
 interface HealthContextSectionProps {
     value?: HealthContextCheckin;
     symptomsPresent: boolean;
+    /**
+     * Deprecated no-op kept only while this PR is stacked on #179, whose DailyCheckin caller
+     * still supplies the old missingness object. No manual physiology reaches UI or engine state.
+     */
+    manualPhysiologyMissing?: {
+        rhr: boolean;
+        hrv: boolean;
+        respiration: boolean;
+    };
     onChange: (next: HealthContextCheckin) => void;
 }
 

--- a/app/src/components/checkin/HealthContextSection.tsx
+++ b/app/src/components/checkin/HealthContextSection.tsx
@@ -8,7 +8,10 @@ import './HealthContextSection.css';
 interface HealthContextSectionProps {
     value?: HealthContextCheckin;
     symptomsPresent: boolean;
-    /** Manual physiology is only useful when the matching objective daily value is missing. */
+    /**
+     * Kept temporarily for caller compatibility. Physiology direction is no longer asked
+     * manually; Garmin-derived core signals are the only authority.
+     */
     manualPhysiologyMissing?: {
         rhr: boolean;
         hrv: boolean;
@@ -32,14 +35,7 @@ const CONTEXT_QUESTIONS = [
     { key: 'closeSickContact', label: 'Close sick contact' },
 ] as const;
 
-const MANUAL_PHYSIOLOGY_QUESTIONS = [
-    { key: 'manualRhrHigher', signal: 'rhr', label: 'RHR higher than usual?' },
-    { key: 'manualHrvLower', signal: 'hrv', label: 'HRV lower than usual?' },
-    { key: 'manualRespirationHigher', signal: 'respiration', label: 'Respiration higher than usual?' },
-] as const;
-
-const TRI_STATE_OPTIONS = [
-    { value: null, label: 'Unknown' },
+const YES_NO_OPTIONS = [
     { value: false, label: 'No' },
     { value: true, label: 'Yes' },
 ] as const;
@@ -78,16 +74,12 @@ function hasUnusualContext(value: HealthContextCheckin | undefined, symptomsPres
         || value.recentVaccination === true
         || value.medicationChange === true
         || value.closeSickContact === true
-        || value.manualRhrHigher === true
-        || value.manualHrvLower === true
-        || value.manualRespirationHigher === true
         || Boolean(value.otherDisruption?.trim());
 }
 
 export function HealthContextSection({
     value,
     symptomsPresent,
-    manualPhysiologyMissing = { rhr: false, hrv: false, respiration: false },
     onChange,
 }: HealthContextSectionProps) {
     const context: HealthContextCheckin = {
@@ -95,11 +87,15 @@ export function HealthContextSection({
         travelDisruption: 'none',
         symptoms: { present: symptomsPresent },
         ...value,
+        unusualHeatOrSauna: value?.unusualHeatOrSauna ?? false,
+        dehydrationOrFluidLoss: value?.dehydrationOrFluidLoss ?? false,
+        recentVaccination: value?.recentVaccination ?? false,
+        medicationChange: value?.medicationChange ?? false,
+        closeSickContact: value?.closeSickContact ?? false,
         ...(value?.symptoms ? { symptoms: value.symptoms } : {}),
     };
     const update = (patch: Partial<HealthContextCheckin>) => onChange({ ...context, ...patch });
     const symptoms = context.symptoms ?? { present: symptomsPresent };
-    const manualQuestions = MANUAL_PHYSIOLOGY_QUESTIONS.filter(item => manualPhysiologyMissing[item.signal]);
 
     const updateSymptoms = (patch: Partial<NonNullable<HealthContextCheckin['symptoms']>>) => {
         onChange({
@@ -127,7 +123,7 @@ export function HealthContextSection({
             <summary className="health-context__summary">
                 <span>
                     <strong>Anything unusual since yesterday?</strong>
-                    <small>Symptoms default to No; alcohol to 0; travel to none. Other items remain Unknown until answered.</small>
+                    <small>Symptoms and contextual flags default to No; alcohol to 0; travel to none.</small>
                 </span>
                 {unusual && <span className="health-context__badge">Context added</span>}
             </summary>
@@ -190,10 +186,8 @@ export function HealthContextSection({
                     <div className="health-context__row" key={item.key}>
                         <span className="health-context__label">{item.label}</span>
                         <div className="health-context__chips" role="group" aria-label={item.label}>
-                            {TRI_STATE_OPTIONS.map(option => {
-                                const selected = option.value === null
-                                    ? context[item.key] == null
-                                    : context[item.key] === option.value;
+                            {YES_NO_OPTIONS.map(option => {
+                                const selected = context[item.key] === option.value;
                                 return (
                                     <button
                                         key={String(option.value)}
@@ -209,39 +203,6 @@ export function HealthContextSection({
                         </div>
                     </div>
                 ))}
-
-                {manualQuestions.length > 0 && (
-                    <>
-                        <div className="health-context__row">
-                            <span className="health-context__label">Manual physiology fallback</span>
-                            <small>Only shown where today&apos;s Garmin value is missing. Use another measurement/source if you know the direction; otherwise leave Unknown.</small>
-                        </div>
-
-                        {manualQuestions.map(item => (
-                            <div className="health-context__row" key={item.key}>
-                                <span className="health-context__label">{item.label}</span>
-                                <div className="health-context__chips" role="group" aria-label={item.label}>
-                                    {TRI_STATE_OPTIONS.map(option => {
-                                        const selected = option.value === null
-                                            ? context[item.key] == null
-                                            : context[item.key] === option.value;
-                                        return (
-                                            <button
-                                                key={String(option.value)}
-                                                type="button"
-                                                className={`health-context__chip ${selected ? 'is-selected' : ''}`}
-                                                aria-pressed={selected}
-                                                onClick={() => update({ [item.key]: option.value })}
-                                            >
-                                                {option.label}
-                                            </button>
-                                        );
-                                    })}
-                                </div>
-                            </div>
-                        ))}
-                    </>
-                )}
 
                 <label className="health-context__other">
                     Other disruption (optional)

--- a/app/src/components/checkin/HealthContextSection.tsx
+++ b/app/src/components/checkin/HealthContextSection.tsx
@@ -2,21 +2,13 @@ import type {
     HealthContextCheckin,
     HealthSymptomType,
 } from '../../engine/healthAnomalyModels';
+import { normalizeHealthContext } from '../../engine/healthContextDefaults';
 import { HEALTH_OTHER_DISRUPTION_MAX_LENGTH } from '../../engine/healthContextValidation';
 import './HealthContextSection.css';
 
 interface HealthContextSectionProps {
     value?: HealthContextCheckin;
     symptomsPresent: boolean;
-    /**
-     * Kept temporarily for caller compatibility. Physiology direction is no longer asked
-     * manually; Garmin-derived core signals are the only authority.
-     */
-    manualPhysiologyMissing?: {
-        rhr: boolean;
-        hrv: boolean;
-        respiration: boolean;
-    };
     onChange: (next: HealthContextCheckin) => void;
 }
 
@@ -82,18 +74,7 @@ export function HealthContextSection({
     symptomsPresent,
     onChange,
 }: HealthContextSectionProps) {
-    const context: HealthContextCheckin = {
-        alcoholDrinksLast24h: 0,
-        travelDisruption: 'none',
-        symptoms: { present: symptomsPresent },
-        ...value,
-        unusualHeatOrSauna: value?.unusualHeatOrSauna ?? false,
-        dehydrationOrFluidLoss: value?.dehydrationOrFluidLoss ?? false,
-        recentVaccination: value?.recentVaccination ?? false,
-        medicationChange: value?.medicationChange ?? false,
-        closeSickContact: value?.closeSickContact ?? false,
-        ...(value?.symptoms ? { symptoms: value.symptoms } : {}),
-    };
+    const context = normalizeHealthContext(value, symptomsPresent);
     const update = (patch: Partial<HealthContextCheckin>) => onChange({ ...context, ...patch });
     const symptoms = context.symptoms ?? { present: symptomsPresent };
 

--- a/app/src/components/checkin/HealthContextSection.tsx
+++ b/app/src/components/checkin/HealthContextSection.tsx
@@ -8,6 +8,12 @@ import './HealthContextSection.css';
 interface HealthContextSectionProps {
     value?: HealthContextCheckin;
     symptomsPresent: boolean;
+    /** Manual physiology is only useful when the matching objective daily value is missing. */
+    manualPhysiologyMissing?: {
+        rhr: boolean;
+        hrv: boolean;
+        respiration: boolean;
+    };
     onChange: (next: HealthContextCheckin) => void;
 }
 
@@ -26,10 +32,10 @@ const CONTEXT_QUESTIONS = [
     { key: 'closeSickContact', label: 'Close sick contact' },
 ] as const;
 
-const SUBJECTIVE_CHANGE_QUESTIONS = [
-    { key: 'subjectiveRhrHigher', label: 'RHR higher than usual?' },
-    { key: 'subjectiveHrvLower', label: 'HRV lower than usual?' },
-    { key: 'subjectiveRespirationHigher', label: 'Respiration higher than usual?' },
+const MANUAL_PHYSIOLOGY_QUESTIONS = [
+    { key: 'manualRhrHigher', signal: 'rhr', label: 'RHR higher than usual?' },
+    { key: 'manualHrvLower', signal: 'hrv', label: 'HRV lower than usual?' },
+    { key: 'manualRespirationHigher', signal: 'respiration', label: 'Respiration higher than usual?' },
 ] as const;
 
 const TRI_STATE_OPTIONS = [
@@ -72,13 +78,18 @@ function hasUnusualContext(value: HealthContextCheckin | undefined, symptomsPres
         || value.recentVaccination === true
         || value.medicationChange === true
         || value.closeSickContact === true
-        || value.subjectiveRhrHigher === true
-        || value.subjectiveHrvLower === true
-        || value.subjectiveRespirationHigher === true
+        || value.manualRhrHigher === true
+        || value.manualHrvLower === true
+        || value.manualRespirationHigher === true
         || Boolean(value.otherDisruption?.trim());
 }
 
-export function HealthContextSection({ value, symptomsPresent, onChange }: HealthContextSectionProps) {
+export function HealthContextSection({
+    value,
+    symptomsPresent,
+    manualPhysiologyMissing = { rhr: false, hrv: false, respiration: false },
+    onChange,
+}: HealthContextSectionProps) {
     const context: HealthContextCheckin = {
         alcoholDrinksLast24h: 0,
         travelDisruption: 'none',
@@ -88,6 +99,7 @@ export function HealthContextSection({ value, symptomsPresent, onChange }: Healt
     };
     const update = (patch: Partial<HealthContextCheckin>) => onChange({ ...context, ...patch });
     const symptoms = context.symptoms ?? { present: symptomsPresent };
+    const manualQuestions = MANUAL_PHYSIOLOGY_QUESTIONS.filter(item => manualPhysiologyMissing[item.signal]);
 
     const updateSymptoms = (patch: Partial<NonNullable<HealthContextCheckin['symptoms']>>) => {
         onChange({
@@ -198,34 +210,38 @@ export function HealthContextSection({ value, symptomsPresent, onChange }: Healt
                     </div>
                 ))}
 
-                <div className="health-context__row">
-                    <span className="health-context__label">Wearable changes vs usual</span>
-                    <small>Manual context only; objective Garmin signals remain authoritative.</small>
-                </div>
-
-                {SUBJECTIVE_CHANGE_QUESTIONS.map(item => (
-                    <div className="health-context__row" key={item.key}>
-                        <span className="health-context__label">{item.label}</span>
-                        <div className="health-context__chips" role="group" aria-label={item.label}>
-                            {TRI_STATE_OPTIONS.map(option => {
-                                const selected = option.value === null
-                                    ? context[item.key] == null
-                                    : context[item.key] === option.value;
-                                return (
-                                    <button
-                                        key={String(option.value)}
-                                        type="button"
-                                        className={`health-context__chip ${selected ? 'is-selected' : ''}`}
-                                        aria-pressed={selected}
-                                        onClick={() => update({ [item.key]: option.value })}
-                                    >
-                                        {option.label}
-                                    </button>
-                                );
-                            })}
+                {manualQuestions.length > 0 && (
+                    <>
+                        <div className="health-context__row">
+                            <span className="health-context__label">Manual physiology fallback</span>
+                            <small>Only shown where today&apos;s Garmin value is missing. Use another measurement/source if you know the direction; otherwise leave Unknown.</small>
                         </div>
-                    </div>
-                ))}
+
+                        {manualQuestions.map(item => (
+                            <div className="health-context__row" key={item.key}>
+                                <span className="health-context__label">{item.label}</span>
+                                <div className="health-context__chips" role="group" aria-label={item.label}>
+                                    {TRI_STATE_OPTIONS.map(option => {
+                                        const selected = option.value === null
+                                            ? context[item.key] == null
+                                            : context[item.key] === option.value;
+                                        return (
+                                            <button
+                                                key={String(option.value)}
+                                                type="button"
+                                                className={`health-context__chip ${selected ? 'is-selected' : ''}`}
+                                                aria-pressed={selected}
+                                                onClick={() => update({ [item.key]: option.value })}
+                                            >
+                                                {option.label}
+                                            </button>
+                                        );
+                                    })}
+                                </div>
+                            </div>
+                        ))}
+                    </>
+                )}
 
                 <label className="health-context__other">
                     Other disruption (optional)

--- a/app/src/components/checkin/HealthContextSection.tsx
+++ b/app/src/components/checkin/HealthContextSection.tsx
@@ -18,17 +18,22 @@ const TRAVEL_OPTIONS: Array<{ value: NonNullable<HealthContextCheckin['travelDis
     { value: 'late_arrival_or_disrupted_sleep', label: 'Late arrival' },
 ];
 
-const CONTEXT_TOGGLES: Array<{
-    key: 'unusualHeatOrSauna' | 'dehydrationOrFluidLoss' | 'recentVaccination' | 'medicationChange';
-    label: string;
-}> = [
+const CONTEXT_QUESTIONS = [
     { key: 'unusualHeatOrSauna', label: 'Heat / sauna' },
     { key: 'dehydrationOrFluidLoss', label: 'Dehydration / fluid loss' },
     { key: 'recentVaccination', label: 'Vaccination' },
     { key: 'medicationChange', label: 'Medication change' },
-];
+    { key: 'closeSickContact', label: 'Close sick contact' },
+] as const;
 
-const SICK_CONTACT_OPTIONS = [
+const SUBJECTIVE_CHANGE_QUESTIONS = [
+    { key: 'subjectiveRhrHigher', label: 'RHR higher than usual?' },
+    { key: 'subjectiveHrvLower', label: 'HRV lower than usual?' },
+    { key: 'subjectiveRespirationHigher', label: 'Respiration higher than usual?' },
+] as const;
+
+const TRI_STATE_OPTIONS = [
+    { value: null, label: 'Unknown' },
     { value: false, label: 'No' },
     { value: true, label: 'Yes' },
 ] as const;
@@ -67,11 +72,20 @@ function hasUnusualContext(value: HealthContextCheckin | undefined, symptomsPres
         || value.recentVaccination === true
         || value.medicationChange === true
         || value.closeSickContact === true
+        || value.subjectiveRhrHigher === true
+        || value.subjectiveHrvLower === true
+        || value.subjectiveRespirationHigher === true
         || Boolean(value.otherDisruption?.trim());
 }
 
 export function HealthContextSection({ value, symptomsPresent, onChange }: HealthContextSectionProps) {
-    const context = value ?? {};
+    const context: HealthContextCheckin = {
+        alcoholDrinksLast24h: 0,
+        travelDisruption: 'none',
+        symptoms: { present: symptomsPresent },
+        ...value,
+        ...(value?.symptoms ? { symptoms: value.symptoms } : {}),
+    };
     const update = (patch: Partial<HealthContextCheckin>) => onChange({ ...context, ...patch });
     const symptoms = context.symptoms ?? { present: symptomsPresent };
 
@@ -84,12 +98,6 @@ export function HealthContextSection({ value, symptomsPresent, onChange }: Healt
                 ...patch,
             },
         });
-    };
-
-    const toggleContextFlag = (key: typeof CONTEXT_TOGGLES[number]['key']) => {
-        // Null is the explicit "answered/cleared" representation accepted by the persistence
-        // contract; unlike `undefined`, it is safe to send through Firestore merge writes.
-        update({ [key]: context[key] === true ? null : true });
     };
 
     const toggleSymptomType = (type: HealthSymptomType) => {
@@ -166,36 +174,58 @@ export function HealthContextSection({ value, symptomsPresent, onChange }: Healt
                     )}
                 </div>
 
-                <div className="health-context__toggle-grid" aria-label="Other unusual context">
-                    {CONTEXT_TOGGLES.map(item => (
-                        <button
-                            key={item.key}
-                            type="button"
-                            className={`health-context__toggle ${context[item.key] === true ? 'is-selected' : ''}`}
-                            aria-pressed={context[item.key] === true}
-                            onClick={() => toggleContextFlag(item.key)}
-                        >
-                            {item.label}
-                        </button>
-                    ))}
-                </div>
+                {CONTEXT_QUESTIONS.map(item => (
+                    <div className="health-context__row" key={item.key}>
+                        <span className="health-context__label">{item.label}</span>
+                        <div className="health-context__chips" role="group" aria-label={item.label}>
+                            {TRI_STATE_OPTIONS.map(option => {
+                                const selected = option.value === null
+                                    ? context[item.key] == null
+                                    : context[item.key] === option.value;
+                                return (
+                                    <button
+                                        key={String(option.value)}
+                                        type="button"
+                                        className={`health-context__chip ${selected ? 'is-selected' : ''}`}
+                                        aria-pressed={selected}
+                                        onClick={() => update({ [item.key]: option.value })}
+                                    >
+                                        {option.label}
+                                    </button>
+                                );
+                            })}
+                        </div>
+                    </div>
+                ))}
 
                 <div className="health-context__row">
-                    <span className="health-context__label">Close sick contact</span>
-                    <div className="health-context__chips" role="group" aria-label="Close sick contact">
-                        {SICK_CONTACT_OPTIONS.map(option => (
-                            <button
-                                key={String(option.value)}
-                                type="button"
-                                className={`health-context__chip ${context.closeSickContact === option.value ? 'is-selected' : ''}`}
-                                aria-pressed={context.closeSickContact === option.value}
-                                onClick={() => update({ closeSickContact: option.value })}
-                            >
-                                {option.label}
-                            </button>
-                        ))}
-                    </div>
+                    <span className="health-context__label">Wearable changes vs usual</span>
+                    <small>Manual context only; objective Garmin signals remain authoritative.</small>
                 </div>
+
+                {SUBJECTIVE_CHANGE_QUESTIONS.map(item => (
+                    <div className="health-context__row" key={item.key}>
+                        <span className="health-context__label">{item.label}</span>
+                        <div className="health-context__chips" role="group" aria-label={item.label}>
+                            {TRI_STATE_OPTIONS.map(option => {
+                                const selected = option.value === null
+                                    ? context[item.key] == null
+                                    : context[item.key] === option.value;
+                                return (
+                                    <button
+                                        key={String(option.value)}
+                                        type="button"
+                                        className={`health-context__chip ${selected ? 'is-selected' : ''}`}
+                                        aria-pressed={selected}
+                                        onClick={() => update({ [item.key]: option.value })}
+                                    >
+                                        {option.label}
+                                    </button>
+                                );
+                            })}
+                        </div>
+                    </div>
+                ))}
 
                 <label className="health-context__other">
                     Other disruption (optional)

--- a/app/src/components/checkin/HealthContextSection.tsx
+++ b/app/src/components/checkin/HealthContextSection.tsx
@@ -115,7 +115,7 @@ export function HealthContextSection({ value, symptomsPresent, onChange }: Healt
             <summary className="health-context__summary">
                 <span>
                     <strong>Anything unusual since yesterday?</strong>
-                    <small>Optional context that can explain recovery changes</small>
+                    <small>Symptoms default to No; alcohol to 0; travel to none. Other items remain Unknown until answered.</small>
                 </span>
                 {unusual && <span className="health-context__badge">Context added</span>}
             </summary>

--- a/app/src/components/checkin/SubjectiveScaleRow.test.tsx
+++ b/app/src/components/checkin/SubjectiveScaleRow.test.tsx
@@ -23,6 +23,7 @@ describe('SubjectiveScaleRow', () => {
     expect(html).toContain('10 Exhausted');
     expect(html).toContain('4');
     expect(html).toContain('status-normal');
+    expect(html).toContain('data-answered="true"');
   });
 
   it('renders warning status for elevated inverted scale value', () => {
@@ -59,5 +60,26 @@ describe('SubjectiveScaleRow', () => {
     expect(html).toContain('min="1"');
     expect(html).toContain('max="10"');
     expect(html).toContain('status-normal');
+  });
+
+  it('keeps an unanswered midpoint visually and semantically distinct from a real 5/10', () => {
+    const html = renderToStaticMarkup(
+      <SubjectiveScaleRow
+        id="readiness"
+        label="Overall Readiness"
+        value={null}
+        lowLabel="1 Not ready"
+        highLabel="10 Fully ready"
+        onChange={() => {}}
+      />
+    );
+
+    expect(html).toContain('status-unanswered');
+    expect(html).toContain('data-answered="false"');
+    expect(html).toContain('not set');
+    expect(html).toContain('aria-valuetext="Not answered"');
+    // Range inputs still need a renderable thumb position, but 5 is not reported as an answer.
+    expect(html).toContain('value="5"');
+    expect(html).not.toContain('aria-valuenow="5"');
   });
 });

--- a/app/src/components/checkin/SubjectiveScaleRow.tsx
+++ b/app/src/components/checkin/SubjectiveScaleRow.tsx
@@ -4,7 +4,7 @@ export interface SubjectiveScaleRowProps {
   id: string;
   label: string;
   desc?: string;
-  value: number;
+  value: number | null;
   lowLabel: string;
   highLabel: string;
   isInverted?: boolean;
@@ -21,20 +21,34 @@ export const SubjectiveScaleRow: React.FC<SubjectiveScaleRowProps> = ({
   isInverted = false,
   onChange,
 }) => {
-  // Severity-based accents: amber for warning, red for severe, neutral blue for normal/good
-  const isSevere = isInverted ? value >= 8 : value <= 3;
-  const isWarning = isInverted ? value >= 6 && value < 8 : value === 4;
-  const severityClass = isSevere ? 'status-severe' : isWarning ? 'status-warning' : 'status-normal';
+  const sliderValue = value ?? 5;
+  // An unanswered scale is deliberately distinct from a real midpoint score. The engine can
+  // still use its neutral fallback for a partial safety-only check-in, while subjective
+  // baseline history only matures from explicitly scored days.
+  const severityClass = value === null
+    ? 'status-unanswered'
+    : isInverted
+      ? value >= 8 ? 'status-severe' : value >= 6 ? 'status-warning' : 'status-normal'
+      : value <= 3 ? 'status-severe' : value === 4 ? 'status-warning' : 'status-normal';
 
   return (
-    <div className={`subjective-scale-row ${severityClass}`} data-scale={id}>
+    <div className={`subjective-scale-row ${severityClass}`} data-scale={id} data-answered={value !== null}>
       <div className="scale-row-header">
         <label htmlFor={`slider-${id}`} className="scale-row-label">
           {label}
         </label>
         <div className={`scale-row-value-badge ${severityClass}`} aria-live="polite">
-          <span className="scale-value-number">{value}</span>
-          <span className="scale-value-max">/10</span>
+          {value === null ? (
+            <>
+              <span className="scale-value-number">—</span>
+              <span className="scale-value-max">not set</span>
+            </>
+          ) : (
+            <>
+              <span className="scale-value-number">{value}</span>
+              <span className="scale-value-max">/10</span>
+            </>
+          )}
         </div>
       </div>
 
@@ -45,12 +59,18 @@ export const SubjectiveScaleRow: React.FC<SubjectiveScaleRowProps> = ({
           min="1"
           max="10"
           step="1"
-          value={value}
+          value={sliderValue}
+          onPointerDown={() => {
+            // Clicking the untouched midpoint should count as an explicit answer even when
+            // the thumb does not move and the browser therefore emits no change event.
+            if (value === null) onChange(sliderValue);
+          }}
           onChange={(e) => onChange(Number(e.target.value))}
           className={`subjective-slider ${severityClass}`}
           aria-valuemin={1}
           aria-valuemax={10}
-          aria-valuenow={value}
+          aria-valuenow={value ?? undefined}
+          aria-valuetext={value === null ? 'Not answered' : `${value} out of 10`}
           aria-label={label}
           aria-description={desc}
         />

--- a/app/src/engine/healthAnomaly.ts
+++ b/app/src/engine/healthAnomaly.ts
@@ -205,13 +205,11 @@ function isAdverseEvidence(evidence: CoreSignalEvidence): boolean {
     return evidence.direction === 'high';
 }
 
-function hasHardTraining(snapshot: HealthAnomalyInput['recoverySnapshot']): boolean {
-    const raw = snapshot?.raw;
-    return !!raw && (
-        (raw.yesterdayTraining?.hardActivityCount ?? 0) > 0
-        || raw.yesterdayTraining?.primaryActivity?.intensityTag === 'hard'
-        || (raw.todayTraining?.hardActivityCount ?? 0) > 0
-        || raw.todayTraining?.primaryActivity?.intensityTag === 'hard'
+function hasPriorHardTraining(snapshot: HealthAnomalyInput['recoverySnapshot']): boolean {
+    const yesterday = snapshot?.raw.yesterdayTraining;
+    return !!yesterday && (
+        (yesterday.hardActivityCount ?? 0) > 0
+        || yesterday.primaryActivity?.intensityTag === 'hard'
     );
 }
 
@@ -230,13 +228,14 @@ function resolveExplanations(input: HealthAnomalyInput): ContextExplanation[] {
     const snapshot = input.recoverySnapshot;
     const checkin = input.subjectiveCheckin;
     const health = checkin?.healthContext;
-    const immediateHardTraining = hasHardTraining(snapshot);
+    const priorHardTraining = hasPriorHardTraining(snapshot);
 
-    if (immediateHardTraining) {
-        addExplanation(explanations, 'hard_training', 'strong', ['rhr', 'hrv'], ['RECENT_HARD_SESSION']);
-        addExplanation(explanations, 'hard_training', 'weak', ['respiration'], ['RECENT_HARD_SESSION']);
-    } else if (input.last3DaysHardSessionsCount > 0) {
-        addExplanation(explanations, 'hard_training', 'moderate', ['rhr', 'hrv'], ['HARD_SESSION_WITHIN_3D']);
+    // Morning RHR/HRV/respiration precede any activity performed later today. Do not use
+    // todayTraining, or an aggregate whose temporal membership is not explicit, to explain
+    // those measurements after a later Garmin re-sync.
+    if (priorHardTraining) {
+        addExplanation(explanations, 'hard_training', 'strong', ['rhr', 'hrv'], ['YESTERDAY_HARD_SESSION']);
+        addExplanation(explanations, 'hard_training', 'weak', ['respiration'], ['YESTERDAY_HARD_SESSION']);
     }
 
     const objectivePoorSleep = (snapshot?.raw.sleepScore ?? 100) < 60
@@ -297,26 +296,10 @@ function resolveExplanations(input: HealthAnomalyInput): ContextExplanation[] {
     return explanations;
 }
 
-function manualSupport(
-    value: boolean | null | undefined,
-    objectiveAvailable: boolean,
-): Pick<SupportingSignalEvidence, 'status' | 'value'> {
-    // Manual comparison is a fallback only. If the corresponding objective signal is present,
-    // the manual answer is deliberately suppressed rather than double-counted.
-    if (objectiveAvailable) return { status: 'unavailable', value: null };
-    return {
-        status: value === true ? 'supportive' : value === false ? 'normal' : 'unavailable',
-        value: value ?? null,
-    };
-}
-
 function deriveSupportingSignals(input: HealthAnomalyInput): SupportingSignalEvidence[] {
     const snapshot = input.recoverySnapshot;
     const checkin = input.subjectiveCheckin;
     const health = checkin?.healthContext;
-    const rhrManual = manualSupport(health?.manualRhrHigher, snapshot?.raw.restingHr != null);
-    const hrvManual = manualSupport(health?.manualHrvLower, snapshot?.raw.hrvOvernightAvg != null);
-    const respirationManual = manualSupport(health?.manualRespirationHigher, snapshot?.raw.respirationAvg != null);
     const derived: SupportingSignalEvidence[] = [
         {
             code: 'GARMIN_SLEEP_SCORE',
@@ -343,9 +326,6 @@ function deriveSupportingSignals(input: HealthAnomalyInput): SupportingSignalEvi
             status: health?.closeSickContact === true ? 'supportive' : health?.closeSickContact === false ? 'normal' : 'unavailable',
             value: health?.closeSickContact ?? null,
         },
-        { code: 'MANUAL_RHR_HIGHER', ...rhrManual },
-        { code: 'MANUAL_HRV_LOWER', ...hrvManual },
-        { code: 'MANUAL_RESPIRATION_HIGHER', ...respirationManual },
     ];
     const byCode = new Map<string, SupportingSignalEvidence>();
     for (const signal of derived) byCode.set(signal.code, signal);
@@ -435,8 +415,9 @@ function rationaleFacts(
 
 /**
  * HA3 pure evaluator. Supporting Garmin composites never increase evidence level or satisfy the
- * multi-signal requirement; only adverse core channels can do that. Context explains observed
- * physiology but never deletes it from the trace.
+ * multi-signal requirement; only adverse core channels can do that. Context qualifies the
+ * interpretation of observed physiology but never deletes the abnormal measurement or resets
+ * its consecutive physiological persistence.
  */
 export function evaluatePhysiologicalAnomaly(
     input: HealthAnomalyInput,
@@ -461,12 +442,12 @@ export function evaluatePhysiologicalAnomaly(
     const symptomsReported = input.subjectiveCheckin?.healthContext?.symptoms?.present === true
         || input.subjectiveCheckin?.illnessSymptoms === true;
     const priorDaysAreContiguous = isAdjacentDate(input.persistence.previousAssessmentDate, input.date);
-    const priorUnexplainedDays = priorDaysAreContiguous
+    const priorAdverseDays = priorDaysAreContiguous
         && Number.isFinite(input.persistence.unexplainedPersistenceDays)
         ? Math.max(0, Math.floor(input.persistence.unexplainedPersistenceDays))
         : 0;
-    const persistenceDays = unexplained.length > 0
-        ? priorUnexplainedDays + 1
+    const persistenceDays = adverseAnomalies.length > 0
+        ? priorAdverseDays + 1
         : 0;
 
     let state: PhysiologicalAnomalyAssessment['state'];

--- a/app/src/engine/healthAnomaly.ts
+++ b/app/src/engine/healthAnomaly.ts
@@ -297,10 +297,26 @@ function resolveExplanations(input: HealthAnomalyInput): ContextExplanation[] {
     return explanations;
 }
 
+function manualSupport(
+    value: boolean | null | undefined,
+    objectiveAvailable: boolean,
+): Pick<SupportingSignalEvidence, 'status' | 'value'> {
+    // Manual comparison is a fallback only. If the corresponding objective signal is present,
+    // the manual answer is deliberately suppressed rather than double-counted.
+    if (objectiveAvailable) return { status: 'unavailable', value: null };
+    return {
+        status: value === true ? 'supportive' : value === false ? 'normal' : 'unavailable',
+        value: value ?? null,
+    };
+}
+
 function deriveSupportingSignals(input: HealthAnomalyInput): SupportingSignalEvidence[] {
     const snapshot = input.recoverySnapshot;
     const checkin = input.subjectiveCheckin;
     const health = checkin?.healthContext;
+    const rhrManual = manualSupport(health?.manualRhrHigher, snapshot?.raw.restingHr != null);
+    const hrvManual = manualSupport(health?.manualHrvLower, snapshot?.raw.hrvOvernightAvg != null);
+    const respirationManual = manualSupport(health?.manualRespirationHigher, snapshot?.raw.respirationAvg != null);
     const derived: SupportingSignalEvidence[] = [
         {
             code: 'GARMIN_SLEEP_SCORE',
@@ -327,21 +343,9 @@ function deriveSupportingSignals(input: HealthAnomalyInput): SupportingSignalEvi
             status: health?.closeSickContact === true ? 'supportive' : health?.closeSickContact === false ? 'normal' : 'unavailable',
             value: health?.closeSickContact ?? null,
         },
-        {
-            code: 'SUBJECTIVE_RHR_HIGHER',
-            status: health?.subjectiveRhrHigher === true ? 'supportive' : health?.subjectiveRhrHigher === false ? 'normal' : 'unavailable',
-            value: health?.subjectiveRhrHigher ?? null,
-        },
-        {
-            code: 'SUBJECTIVE_HRV_LOWER',
-            status: health?.subjectiveHrvLower === true ? 'supportive' : health?.subjectiveHrvLower === false ? 'normal' : 'unavailable',
-            value: health?.subjectiveHrvLower ?? null,
-        },
-        {
-            code: 'SUBJECTIVE_RESPIRATION_HIGHER',
-            status: health?.subjectiveRespirationHigher === true ? 'supportive' : health?.subjectiveRespirationHigher === false ? 'normal' : 'unavailable',
-            value: health?.subjectiveRespirationHigher ?? null,
-        },
+        { code: 'MANUAL_RHR_HIGHER', ...rhrManual },
+        { code: 'MANUAL_HRV_LOWER', ...hrvManual },
+        { code: 'MANUAL_RESPIRATION_HIGHER', ...respirationManual },
     ];
     const byCode = new Map<string, SupportingSignalEvidence>();
     for (const signal of derived) byCode.set(signal.code, signal);

--- a/app/src/engine/healthAnomaly.ts
+++ b/app/src/engine/healthAnomaly.ts
@@ -230,12 +230,14 @@ function resolveExplanations(input: HealthAnomalyInput): ContextExplanation[] {
     const health = checkin?.healthContext;
     const priorHardTraining = hasPriorHardTraining(snapshot);
 
-    // Morning RHR/HRV/respiration precede any activity performed later today. Do not use
-    // todayTraining, or an aggregate whose temporal membership is not explicit, to explain
-    // those measurements after a later Garmin re-sync.
+    // Morning RHR/HRV/respiration precede any activity performed later today. `todayTraining`
+    // is therefore never explanatory. The backend defines last3DaysHardSessionsCount as D-1
+    // through D-3 only, so that aggregate is causally safe for a weaker prior-load context.
     if (priorHardTraining) {
         addExplanation(explanations, 'hard_training', 'strong', ['rhr', 'hrv'], ['YESTERDAY_HARD_SESSION']);
         addExplanation(explanations, 'hard_training', 'weak', ['respiration'], ['YESTERDAY_HARD_SESSION']);
+    } else if (input.last3DaysHardSessionsCount > 0) {
+        addExplanation(explanations, 'hard_training', 'moderate', ['rhr', 'hrv'], ['HARD_SESSION_WITHIN_3D']);
     }
 
     const objectivePoorSleep = (snapshot?.raw.sleepScore ?? 100) < 60

--- a/app/src/engine/healthAnomaly.ts
+++ b/app/src/engine/healthAnomaly.ts
@@ -174,7 +174,7 @@ function categorizeSignal(
         direction = 'low';
     } else if (deviation >= thresholds.strongDeviation) {
         // Retain unusually-high HRV as out-of-range telemetry without treating it as an
-        // adverse illness vote. isAdverseEvidence deliberately excludes two_sided HRV.
+        // adverse illness vote. isAdverseCoreSignalEvidence deliberately excludes two_sided HRV.
         status = 'strong_anomaly';
         direction = 'two_sided';
     } else if (deviation >= thresholds.moderateDeviation) {
@@ -199,7 +199,8 @@ function isAnomaly(evidence: CoreSignalEvidence): boolean {
     return evidence.status === 'moderate_anomaly' || evidence.status === 'strong_anomaly';
 }
 
-function isAdverseEvidence(evidence: CoreSignalEvidence): boolean {
+/** Canonical adverse-core classifier shared by evaluation and persistence composition. */
+export function isAdverseCoreSignalEvidence(evidence: CoreSignalEvidence): boolean {
     if (!isAnomaly(evidence)) return false;
     if (evidence.signal === 'hrv') return evidence.direction === 'low';
     return evidence.direction === 'high';
@@ -350,7 +351,7 @@ function strongestCoverage(
 }
 
 function evidenceLevel(coreSignals: readonly CoreSignalEvidence[]): PhysiologicalAnomalyAssessment['evidenceLevel'] {
-    const adverse = coreSignals.filter(isAdverseEvidence);
+    const adverse = coreSignals.filter(isAdverseCoreSignalEvidence);
     if (adverse.length === 0) return 'none';
     const strongCount = adverse.filter(item => item.status === 'strong_anomaly').length;
     if (adverse.length >= 2 && strongCount >= 1) return 'high';
@@ -434,7 +435,7 @@ export function evaluatePhysiologicalAnomaly(
         .filter((quality): quality is CoreSignalDataQuality => quality !== null);
     const supportingSignals = deriveSupportingSignals(input);
     const explanations = resolveExplanations(input);
-    const adverseAnomalies = coreSignals.filter(isAdverseEvidence);
+    const adverseAnomalies = coreSignals.filter(isAdverseCoreSignalEvidence);
     const unexplained = adverseAnomalies.filter(
         evidence => strongestCoverage(evidence.signal, explanations) !== 'strong',
     );

--- a/app/src/engine/healthAnomaly.ts
+++ b/app/src/engine/healthAnomaly.ts
@@ -327,6 +327,21 @@ function deriveSupportingSignals(input: HealthAnomalyInput): SupportingSignalEvi
             status: health?.closeSickContact === true ? 'supportive' : health?.closeSickContact === false ? 'normal' : 'unavailable',
             value: health?.closeSickContact ?? null,
         },
+        {
+            code: 'SUBJECTIVE_RHR_HIGHER',
+            status: health?.subjectiveRhrHigher === true ? 'supportive' : health?.subjectiveRhrHigher === false ? 'normal' : 'unavailable',
+            value: health?.subjectiveRhrHigher ?? null,
+        },
+        {
+            code: 'SUBJECTIVE_HRV_LOWER',
+            status: health?.subjectiveHrvLower === true ? 'supportive' : health?.subjectiveHrvLower === false ? 'normal' : 'unavailable',
+            value: health?.subjectiveHrvLower ?? null,
+        },
+        {
+            code: 'SUBJECTIVE_RESPIRATION_HIGHER',
+            status: health?.subjectiveRespirationHigher === true ? 'supportive' : health?.subjectiveRespirationHigher === false ? 'normal' : 'unavailable',
+            value: health?.subjectiveRespirationHigher ?? null,
+        },
     ];
     const byCode = new Map<string, SupportingSignalEvidence>();
     for (const signal of derived) byCode.set(signal.code, signal);

--- a/app/src/engine/healthAnomalyAdverseClassifier.test.ts
+++ b/app/src/engine/healthAnomalyAdverseClassifier.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { isAdverseCoreSignalEvidence } from './healthAnomaly';
+import type { CoreSignalEvidence, HealthCoreSignal } from './healthAnomalyModels';
+
+function evidence(
+    signal: HealthCoreSignal,
+    status: CoreSignalEvidence['status'],
+    direction: CoreSignalEvidence['direction'],
+): CoreSignalEvidence {
+    return {
+        signal,
+        status,
+        direction,
+        currentValue: 1,
+        baselineValue: 1,
+        scaleValue: 1,
+        standardizedDeviation: status === 'normal' ? 0 : 2,
+        estimator: 'mean-stdev-28d',
+        baselineVersion: 'test',
+    };
+}
+
+describe('isAdverseCoreSignalEvidence', () => {
+    it('treats elevated RHR and respiration plus low HRV as adverse core physiology', () => {
+        expect(isAdverseCoreSignalEvidence(evidence('rhr', 'moderate_anomaly', 'high'))).toBe(true);
+        expect(isAdverseCoreSignalEvidence(evidence('respiration', 'strong_anomaly', 'high'))).toBe(true);
+        expect(isAdverseCoreSignalEvidence(evidence('hrv', 'moderate_anomaly', 'low'))).toBe(true);
+    });
+
+    it('does not promote high HRV or normal signals into an adverse illness vote', () => {
+        expect(isAdverseCoreSignalEvidence(evidence('hrv', 'strong_anomaly', 'two_sided'))).toBe(false);
+        expect(isAdverseCoreSignalEvidence(evidence('rhr', 'normal', null))).toBe(false);
+        expect(isAdverseCoreSignalEvidence(evidence('respiration', 'normal', null))).toBe(false);
+    });
+});

--- a/app/src/engine/healthAnomalyAdverseClassifier.test.ts
+++ b/app/src/engine/healthAnomalyAdverseClassifier.test.ts
@@ -16,7 +16,7 @@ function evidence(
         scaleValue: 1,
         standardizedDeviation: status === 'normal' ? 0 : 2,
         estimator: 'mean-stdev-28d',
-        baselineVersion: 'test',
+        baselineVersion: 5,
     };
 }
 

--- a/app/src/engine/healthAnomalyEvaluator.test.ts
+++ b/app/src/engine/healthAnomalyEvaluator.test.ts
@@ -295,19 +295,38 @@ describe('evaluatePhysiologicalAnomaly HA3', () => {
         expect(result.state).toBe('normal');
     });
 
-    it('keeps manual RHR, HRV, and respiration changes as supporting evidence only', () => {
+    it('uses manual physiology as supporting evidence only when the matching Garmin values are missing', () => {
+        const missingSnapshot = snapshot({ restingHr: null, hrvOvernightAvg: null, respirationAvg: null });
         const result = evaluate(featureSet(), {
+            recoverySnapshot: missingSnapshot,
             subjectiveCheckin: checkin({
                 healthContext: {
-                    subjectiveRhrHigher: true,
-                    subjectiveHrvLower: true,
-                    subjectiveRespirationHigher: true,
+                    manualRhrHigher: true,
+                    manualHrvLower: true,
+                    manualRespirationHigher: true,
                 },
             }),
         });
-        expect(result.supportingSignals).toContainEqual(expect.objectContaining({ code: 'SUBJECTIVE_RHR_HIGHER', status: 'supportive', value: true }));
-        expect(result.supportingSignals).toContainEqual(expect.objectContaining({ code: 'SUBJECTIVE_HRV_LOWER', status: 'supportive', value: true }));
-        expect(result.supportingSignals).toContainEqual(expect.objectContaining({ code: 'SUBJECTIVE_RESPIRATION_HIGHER', status: 'supportive', value: true }));
+        expect(result.supportingSignals).toContainEqual(expect.objectContaining({ code: 'MANUAL_RHR_HIGHER', status: 'supportive', value: true }));
+        expect(result.supportingSignals).toContainEqual(expect.objectContaining({ code: 'MANUAL_HRV_LOWER', status: 'supportive', value: true }));
+        expect(result.supportingSignals).toContainEqual(expect.objectContaining({ code: 'MANUAL_RESPIRATION_HIGHER', status: 'supportive', value: true }));
+        expect(result.evidenceLevel).toBe('none');
+        expect(result.state).toBe('normal');
+    });
+
+    it('suppresses manual physiology when the matching Garmin values are available', () => {
+        const result = evaluate(featureSet(), {
+            subjectiveCheckin: checkin({
+                healthContext: {
+                    manualRhrHigher: true,
+                    manualHrvLower: true,
+                    manualRespirationHigher: true,
+                },
+            }),
+        });
+        expect(result.supportingSignals).toContainEqual(expect.objectContaining({ code: 'MANUAL_RHR_HIGHER', status: 'unavailable', value: null }));
+        expect(result.supportingSignals).toContainEqual(expect.objectContaining({ code: 'MANUAL_HRV_LOWER', status: 'unavailable', value: null }));
+        expect(result.supportingSignals).toContainEqual(expect.objectContaining({ code: 'MANUAL_RESPIRATION_HIGHER', status: 'unavailable', value: null }));
         expect(result.evidenceLevel).toBe('none');
         expect(result.state).toBe('normal');
     });

--- a/app/src/engine/healthAnomalyEvaluator.test.ts
+++ b/app/src/engine/healthAnomalyEvaluator.test.ts
@@ -295,6 +295,23 @@ describe('evaluatePhysiologicalAnomaly HA3', () => {
         expect(result.state).toBe('normal');
     });
 
+    it('keeps manual RHR, HRV, and respiration changes as supporting evidence only', () => {
+        const result = evaluate(featureSet(), {
+            subjectiveCheckin: checkin({
+                healthContext: {
+                    subjectiveRhrHigher: true,
+                    subjectiveHrvLower: true,
+                    subjectiveRespirationHigher: true,
+                },
+            }),
+        });
+        expect(result.supportingSignals).toContainEqual(expect.objectContaining({ code: 'SUBJECTIVE_RHR_HIGHER', status: 'supportive', value: true }));
+        expect(result.supportingSignals).toContainEqual(expect.objectContaining({ code: 'SUBJECTIVE_HRV_LOWER', status: 'supportive', value: true }));
+        expect(result.supportingSignals).toContainEqual(expect.objectContaining({ code: 'SUBJECTIVE_RESPIRATION_HIGHER', status: 'supportive', value: true }));
+        expect(result.evidenceLevel).toBe('none');
+        expect(result.state).toBe('normal');
+    });
+
     it('retains unusually high HRV as two-sided out-of-range telemetry without treating it as adverse', () => {
         const result = evaluate(featureSet(0, 0, 3));
         expect(result.coreSignals.find(item => item.signal === 'hrv')).toMatchObject({

--- a/app/src/engine/healthAnomalyEvaluator.test.ts
+++ b/app/src/engine/healthAnomalyEvaluator.test.ts
@@ -164,21 +164,36 @@ describe('evaluatePhysiologicalAnomaly HA3', () => {
         expect(evaluate(featureSet()).state).toBe('normal');
     });
 
-    it('treats one high RHR after an immediate hard session as explained, never possible illness', () => {
+    it('treats one high RHR after a prior hard session as explained, never possible illness', () => {
         const hard = snapshot({
             yesterdayTraining: { hardActivityCount: 1, primaryActivity: { activityId: 1, type: 'cycling', durationMin: 60, trainingEffect: 4, intensityTag: 'hard' } },
         });
         const result = evaluate(featureSet(3, 0, 0), { recoverySnapshot: hard, last3DaysHardSessionsCount: 1 });
         expect(result.state).toBe('explained_recovery_strain');
         expect(result.unexplainedEvidence).toEqual([]);
+        expect(result.persistenceDays).toBe(1);
     });
 
-    it('explains RHR-up + HRV-down after hard training when respiration is normal', () => {
+    it('explains RHR-up + HRV-down after prior hard training when respiration is normal', () => {
         const hard = snapshot({
             yesterdayTraining: { hardActivityCount: 1, primaryActivity: { activityId: 1, type: 'cycling', durationMin: 60, trainingEffect: 4, intensityTag: 'hard' } },
         });
         expect(evaluate(featureSet(3, 0, -2), { recoverySnapshot: hard, last3DaysHardSessionsCount: 1 }).state)
             .toBe('explained_recovery_strain');
+    });
+
+    it('does not let same-day hard training retroactively explain morning physiology', () => {
+        const afterWorkoutResync = snapshot({
+            todayTraining: { hardActivityCount: 1, primaryActivity: { activityId: 2, type: 'cycling', durationMin: 75, trainingEffect: 4.2, intensityTag: 'hard' } },
+            last3DaysHardSessionsCount: 1,
+        });
+        const result = evaluate(featureSet(3, 0, 0), {
+            recoverySnapshot: afterWorkoutResync,
+            last3DaysHardSessionsCount: 1,
+        });
+        expect(result.state).toBe('watch_unexplained');
+        expect(result.unexplainedEvidence).toEqual(['rhr:strong_anomaly:high']);
+        expect(result.explanations.some(item => item.kind === 'hard_training')).toBe(false);
     });
 
     it('creates an unexplained watch for a first-day multi-signal adverse pattern', () => {
@@ -202,6 +217,26 @@ describe('evaluatePhysiologicalAnomaly HA3', () => {
         expect(result.persistenceDays).toBe(2);
         expect(result.episodeId).toBe('health-anomaly:2026-08-20');
         expect(result.episodeDay).toBe(2);
+    });
+
+    it('preserves adverse physiology persistence when strong context explains the signal', () => {
+        const hard = snapshot({
+            yesterdayTraining: { hardActivityCount: 1, primaryActivity: { activityId: 1, type: 'cycling', durationMin: 60, trainingEffect: 4, intensityTag: 'hard' } },
+        });
+        const result = evaluate(featureSet(3, 0, 0), {
+            recoverySnapshot: hard,
+            persistence: {
+                previousState: 'explained_recovery_strain',
+                previousEpisodeId: 'health-anomaly:2026-08-20',
+                previousEpisodeDay: 1,
+                previousAssessmentDate: '2026-08-20',
+                unexplainedPersistenceDays: 1,
+            },
+        });
+        expect(result.state).toBe('explained_recovery_strain');
+        expect(result.unexplainedEvidence).toEqual([]);
+        expect(result.persistenceDays).toBe(2);
+        expect(result.rationale.facts).toContainEqual({ code: 'PERSISTENCE', value: 2, unit: 'days' });
     });
 
     it('resets persistence across a non-adjacent gap instead of carrying the prior count forward', () => {
@@ -295,38 +330,10 @@ describe('evaluatePhysiologicalAnomaly HA3', () => {
         expect(result.state).toBe('normal');
     });
 
-    it('uses manual physiology as supporting evidence only when the matching Garmin values are missing', () => {
+    it('never emits manual physiology supporting signals, even when Garmin core values are missing', () => {
         const missingSnapshot = snapshot({ restingHr: null, hrvOvernightAvg: null, respirationAvg: null });
-        const result = evaluate(featureSet(), {
-            recoverySnapshot: missingSnapshot,
-            subjectiveCheckin: checkin({
-                healthContext: {
-                    manualRhrHigher: true,
-                    manualHrvLower: true,
-                    manualRespirationHigher: true,
-                },
-            }),
-        });
-        expect(result.supportingSignals).toContainEqual(expect.objectContaining({ code: 'MANUAL_RHR_HIGHER', status: 'supportive', value: true }));
-        expect(result.supportingSignals).toContainEqual(expect.objectContaining({ code: 'MANUAL_HRV_LOWER', status: 'supportive', value: true }));
-        expect(result.supportingSignals).toContainEqual(expect.objectContaining({ code: 'MANUAL_RESPIRATION_HIGHER', status: 'supportive', value: true }));
-        expect(result.evidenceLevel).toBe('none');
-        expect(result.state).toBe('normal');
-    });
-
-    it('suppresses manual physiology when the matching Garmin values are available', () => {
-        const result = evaluate(featureSet(), {
-            subjectiveCheckin: checkin({
-                healthContext: {
-                    manualRhrHigher: true,
-                    manualHrvLower: true,
-                    manualRespirationHigher: true,
-                },
-            }),
-        });
-        expect(result.supportingSignals).toContainEqual(expect.objectContaining({ code: 'MANUAL_RHR_HIGHER', status: 'unavailable', value: null }));
-        expect(result.supportingSignals).toContainEqual(expect.objectContaining({ code: 'MANUAL_HRV_LOWER', status: 'unavailable', value: null }));
-        expect(result.supportingSignals).toContainEqual(expect.objectContaining({ code: 'MANUAL_RESPIRATION_HIGHER', status: 'unavailable', value: null }));
+        const result = evaluate(featureSet(), { recoverySnapshot: missingSnapshot });
+        expect(result.supportingSignals.some(item => item.code.startsWith('MANUAL_'))).toBe(false);
         expect(result.evidenceLevel).toBe('none');
         expect(result.state).toBe('normal');
     });

--- a/app/src/engine/healthAnomalyEvaluator.test.ts
+++ b/app/src/engine/healthAnomalyEvaluator.test.ts
@@ -185,15 +185,27 @@ describe('evaluatePhysiologicalAnomaly HA3', () => {
     it('does not let same-day hard training retroactively explain morning physiology', () => {
         const afterWorkoutResync = snapshot({
             todayTraining: { hardActivityCount: 1, primaryActivity: { activityId: 2, type: 'cycling', durationMin: 75, trainingEffect: 4.2, intensityTag: 'hard' } },
-            last3DaysHardSessionsCount: 1,
+            // Backend semantics intentionally exclude today from this D-1..D-3 count.
+            last3DaysHardSessionsCount: 0,
         });
         const result = evaluate(featureSet(3, 0, 0), {
             recoverySnapshot: afterWorkoutResync,
-            last3DaysHardSessionsCount: 1,
+            last3DaysHardSessionsCount: 0,
         });
         expect(result.state).toBe('watch_unexplained');
         expect(result.unexplainedEvidence).toEqual(['rhr:strong_anomaly:high']);
         expect(result.explanations.some(item => item.kind === 'hard_training')).toBe(false);
+    });
+
+    it('retains the causally safe D-1 to D-3 aggregate as moderate prior-training context', () => {
+        const result = evaluate(featureSet(3, 0, 0), { last3DaysHardSessionsCount: 1 });
+        expect(result.state).toBe('watch_unexplained');
+        expect(result.explanations).toContainEqual(expect.objectContaining({
+            kind: 'hard_training',
+            strength: 'moderate',
+            evidence: ['HARD_SESSION_WITHIN_3D'],
+        }));
+        expect(result.unexplainedEvidence).toEqual(['rhr:strong_anomaly:high']);
     });
 
     it('creates an unexplained watch for a first-day multi-signal adverse pattern', () => {

--- a/app/src/engine/healthAnomalyModels.ts
+++ b/app/src/engine/healthAnomalyModels.ts
@@ -24,6 +24,10 @@ export interface HealthContextCheckin {
     recentVaccination?: boolean | null;
     medicationChange?: boolean | null;
     closeSickContact?: boolean | null;
+    /** Manual comparison with the athlete's usual wearable pattern. Null/omitted means unknown. */
+    subjectiveRhrHigher?: boolean | null;
+    subjectiveHrvLower?: boolean | null;
+    subjectiveRespirationHigher?: boolean | null;
     /** Opaque user content. Never use the text itself as evaluator evidence. */
     otherDisruption?: string | null;
     symptoms?: HealthSymptomsCheckin;

--- a/app/src/engine/healthAnomalyModels.ts
+++ b/app/src/engine/healthAnomalyModels.ts
@@ -24,10 +24,14 @@ export interface HealthContextCheckin {
     recentVaccination?: boolean | null;
     medicationChange?: boolean | null;
     closeSickContact?: boolean | null;
-    /** Manual comparison with the athlete's usual wearable pattern. Null/omitted means unknown. */
-    subjectiveRhrHigher?: boolean | null;
-    subjectiveHrvLower?: boolean | null;
-    subjectiveRespirationHigher?: boolean | null;
+    /**
+     * Manual physiology fallback used only when the corresponding objective daily signal is
+     * unavailable. These are user-observed comparisons, not subjective sensations and never
+     * replace or override an available Garmin core signal. Null/omitted means unknown.
+     */
+    manualRhrHigher?: boolean | null;
+    manualHrvLower?: boolean | null;
+    manualRespirationHigher?: boolean | null;
     /** Opaque user content. Never use the text itself as evaluator evidence. */
     otherDisruption?: string | null;
     symptoms?: HealthSymptomsCheckin;

--- a/app/src/engine/healthAnomalyModels.ts
+++ b/app/src/engine/healthAnomalyModels.ts
@@ -24,14 +24,6 @@ export interface HealthContextCheckin {
     recentVaccination?: boolean | null;
     medicationChange?: boolean | null;
     closeSickContact?: boolean | null;
-    /**
-     * Manual physiology fallback used only when the corresponding objective daily signal is
-     * unavailable. These are user-observed comparisons, not subjective sensations and never
-     * replace or override an available Garmin core signal. Null/omitted means unknown.
-     */
-    manualRhrHigher?: boolean | null;
-    manualHrvLower?: boolean | null;
-    manualRespirationHigher?: boolean | null;
     /** Opaque user content. Never use the text itself as evaluator evidence. */
     otherDisruption?: string | null;
     symptoms?: HealthSymptomsCheckin;
@@ -209,6 +201,7 @@ export interface HealthAnomalyPersistenceInput {
     previousEpisodeId: string | null;
     previousEpisodeDay: number | null;
     previousAssessmentDate?: string | null;
+    /** Legacy name: this counter now preserves consecutive adverse core physiology even when context is strong. */
     unexplainedPersistenceDays: number;
 }
 

--- a/app/src/engine/healthContextContract.test.ts
+++ b/app/src/engine/healthContextContract.test.ts
@@ -94,28 +94,28 @@ describe('HA1 validateCheckin migration contract', () => {
         expect(stale.errors.some(error => error.field === 'healthContext.symptoms.onset')).toBe(true);
     });
 
-    it('accepts tri-state subjective physiology changes and preserves explicit false', () => {
+    it('accepts tri-state manual physiology fallback and preserves explicit false', () => {
         const result = validateCheckin(writePayload({
             healthContext: {
-                subjectiveRhrHigher: true,
-                subjectiveHrvLower: false,
-                subjectiveRespirationHigher: null,
+                manualRhrHigher: true,
+                manualHrvLower: false,
+                manualRespirationHigher: null,
             },
         }));
         expect(result.isValid).toBe(true);
         expect(result.data?.healthContext).toMatchObject({
-            subjectiveRhrHigher: true,
-            subjectiveHrvLower: false,
-            subjectiveRespirationHigher: null,
+            manualRhrHigher: true,
+            manualHrvLower: false,
+            manualRespirationHigher: null,
         });
     });
 
-    it('rejects malformed subjective physiology changes', () => {
+    it('rejects malformed manual physiology fallback', () => {
         const result = validateCheckin(writePayload({
-            healthContext: { subjectiveRhrHigher: 'yes' },
+            healthContext: { manualRhrHigher: 'yes' },
         }));
         expect(result.isValid).toBe(false);
-        expect(result.errors.some(error => error.field === 'healthContext.subjectiveRhrHigher')).toBe(true);
+        expect(result.errors.some(error => error.field === 'healthContext.manualRhrHigher')).toBe(true);
     });
 
     it('rejects non-finite and out-of-range timezone shifts', () => {
@@ -166,20 +166,20 @@ describe('HA1 parseSubjectiveCheckin migration contract', () => {
         expect(parsed.data.illnessSymptoms).toBe(false);
     });
 
-    it('parses subjective physiology changes without converting unknown to normal', () => {
+    it('parses manual physiology fallback without converting unknown to normal', () => {
         const parsed = parseSubjectiveCheckin(storedPayload({
             healthContext: {
-                subjectiveRhrHigher: false,
-                subjectiveHrvLower: true,
-                subjectiveRespirationHigher: null,
+                manualRhrHigher: false,
+                manualHrvLower: true,
+                manualRespirationHigher: null,
             },
         }), PATH, 'u1', DATE);
         expect(parsed.status).toBe('AVAILABLE');
         if (parsed.status !== 'AVAILABLE') throw new Error('expected available');
         expect(parsed.data.healthContext).toMatchObject({
-            subjectiveRhrHigher: false,
-            subjectiveHrvLower: true,
-            subjectiveRespirationHigher: null,
+            manualRhrHigher: false,
+            manualHrvLower: true,
+            manualRespirationHigher: null,
         });
     });
 

--- a/app/src/engine/healthContextContract.test.ts
+++ b/app/src/engine/healthContextContract.test.ts
@@ -94,6 +94,30 @@ describe('HA1 validateCheckin migration contract', () => {
         expect(stale.errors.some(error => error.field === 'healthContext.symptoms.onset')).toBe(true);
     });
 
+    it('accepts tri-state subjective physiology changes and preserves explicit false', () => {
+        const result = validateCheckin(writePayload({
+            healthContext: {
+                subjectiveRhrHigher: true,
+                subjectiveHrvLower: false,
+                subjectiveRespirationHigher: null,
+            },
+        }));
+        expect(result.isValid).toBe(true);
+        expect(result.data?.healthContext).toMatchObject({
+            subjectiveRhrHigher: true,
+            subjectiveHrvLower: false,
+            subjectiveRespirationHigher: null,
+        });
+    });
+
+    it('rejects malformed subjective physiology changes', () => {
+        const result = validateCheckin(writePayload({
+            healthContext: { subjectiveRhrHigher: 'yes' },
+        }));
+        expect(result.isValid).toBe(false);
+        expect(result.errors.some(error => error.field === 'healthContext.subjectiveRhrHigher')).toBe(true);
+    });
+
     it('rejects non-finite and out-of-range timezone shifts', () => {
         for (const value of [14.1, -14.1, Number.POSITIVE_INFINITY, Number.NaN]) {
             const result = validateCheckin(writePayload({ healthContext: { timezoneShiftHours: value } }));
@@ -140,6 +164,23 @@ describe('HA1 parseSubjectiveCheckin migration contract', () => {
         expect(parsed.status).toBe('AVAILABLE');
         if (parsed.status !== 'AVAILABLE') throw new Error('expected available');
         expect(parsed.data.illnessSymptoms).toBe(false);
+    });
+
+    it('parses subjective physiology changes without converting unknown to normal', () => {
+        const parsed = parseSubjectiveCheckin(storedPayload({
+            healthContext: {
+                subjectiveRhrHigher: false,
+                subjectiveHrvLower: true,
+                subjectiveRespirationHigher: null,
+            },
+        }), PATH, 'u1', DATE);
+        expect(parsed.status).toBe('AVAILABLE');
+        if (parsed.status !== 'AVAILABLE') throw new Error('expected available');
+        expect(parsed.data.healthContext).toMatchObject({
+            subjectiveRhrHigher: false,
+            subjectiveHrvLower: true,
+            subjectiveRespirationHigher: null,
+        });
     });
 
     it('rejects stale nested details and invalid timezone ranges on read', () => {

--- a/app/src/engine/healthContextContract.test.ts
+++ b/app/src/engine/healthContextContract.test.ts
@@ -94,7 +94,24 @@ describe('HA1 validateCheckin migration contract', () => {
         expect(stale.errors.some(error => error.field === 'healthContext.symptoms.onset')).toBe(true);
     });
 
-    it('accepts tri-state manual physiology fallback and preserves explicit false', () => {
+    it('defaults ordinary contextual flags to explicit false when the context block exists', () => {
+        const result = validateCheckin(writePayload({
+            healthContext: {
+                unusualHeatOrSauna: null,
+                closeSickContact: true,
+            },
+        }));
+        expect(result.isValid).toBe(true);
+        expect(result.data?.healthContext).toMatchObject({
+            unusualHeatOrSauna: false,
+            dehydrationOrFluidLoss: false,
+            recentVaccination: false,
+            medicationChange: false,
+            closeSickContact: true,
+        });
+    });
+
+    it('accepts legacy manual physiology fields but strips them from canonical check-in data', () => {
         const result = validateCheckin(writePayload({
             healthContext: {
                 manualRhrHigher: true,
@@ -103,14 +120,12 @@ describe('HA1 validateCheckin migration contract', () => {
             },
         }));
         expect(result.isValid).toBe(true);
-        expect(result.data?.healthContext).toMatchObject({
-            manualRhrHigher: true,
-            manualHrvLower: false,
-            manualRespirationHigher: null,
-        });
+        expect(result.data?.healthContext).not.toHaveProperty('manualRhrHigher');
+        expect(result.data?.healthContext).not.toHaveProperty('manualHrvLower');
+        expect(result.data?.healthContext).not.toHaveProperty('manualRespirationHigher');
     });
 
-    it('rejects malformed manual physiology fallback', () => {
+    it('rejects malformed legacy manual physiology fields', () => {
         const result = validateCheckin(writePayload({
             healthContext: { manualRhrHigher: 'yes' },
         }));
@@ -166,7 +181,22 @@ describe('HA1 parseSubjectiveCheckin migration contract', () => {
         expect(parsed.data.illnessSymptoms).toBe(false);
     });
 
-    it('parses manual physiology fallback without converting unknown to normal', () => {
+    it('normalizes absent/null contextual flags to No on persisted health-context documents', () => {
+        const parsed = parseSubjectiveCheckin(storedPayload({
+            healthContext: { closeSickContact: null },
+        }), PATH, 'u1', DATE);
+        expect(parsed.status).toBe('AVAILABLE');
+        if (parsed.status !== 'AVAILABLE') throw new Error('expected available');
+        expect(parsed.data.healthContext).toMatchObject({
+            unusualHeatOrSauna: false,
+            dehydrationOrFluidLoss: false,
+            recentVaccination: false,
+            medicationChange: false,
+            closeSickContact: false,
+        });
+    });
+
+    it('strips legacy manual physiology so missing Garmin stays objectively unavailable', () => {
         const parsed = parseSubjectiveCheckin(storedPayload({
             healthContext: {
                 manualRhrHigher: false,
@@ -176,11 +206,9 @@ describe('HA1 parseSubjectiveCheckin migration contract', () => {
         }), PATH, 'u1', DATE);
         expect(parsed.status).toBe('AVAILABLE');
         if (parsed.status !== 'AVAILABLE') throw new Error('expected available');
-        expect(parsed.data.healthContext).toMatchObject({
-            manualRhrHigher: false,
-            manualHrvLower: true,
-            manualRespirationHigher: null,
-        });
+        expect(parsed.data.healthContext).not.toHaveProperty('manualRhrHigher');
+        expect(parsed.data.healthContext).not.toHaveProperty('manualHrvLower');
+        expect(parsed.data.healthContext).not.toHaveProperty('manualRespirationHigher');
     });
 
     it('rejects stale nested details and invalid timezone ranges on read', () => {

--- a/app/src/engine/healthContextDefaults.test.ts
+++ b/app/src/engine/healthContextDefaults.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import { createDefaultHealthContext, normalizeHealthContext } from './healthContextDefaults';
+import { validateCheckin } from './validation';
+
+describe('canonical health-context defaults', () => {
+    it('uses one explicit product default set for newly reported context', () => {
+        expect(createDefaultHealthContext()).toEqual({
+            alcoholDrinksLast24h: 0,
+            travelDisruption: 'none',
+            unusualHeatOrSauna: false,
+            dehydrationOrFluidLoss: false,
+            recentVaccination: false,
+            medicationChange: false,
+            closeSickContact: false,
+            symptoms: { present: false },
+        });
+    });
+
+    it('normalizes legacy null contextual booleans to No while retaining positive answers', () => {
+        expect(normalizeHealthContext({
+            unusualHeatOrSauna: null,
+            dehydrationOrFluidLoss: true,
+            recentVaccination: null,
+            medicationChange: false,
+            closeSickContact: null,
+        })).toMatchObject({
+            alcoholDrinksLast24h: 0,
+            travelDisruption: 'none',
+            unusualHeatOrSauna: false,
+            dehydrationOrFluidLoss: true,
+            recentVaccination: false,
+            medicationChange: false,
+            closeSickContact: false,
+            symptoms: { present: false },
+        });
+    });
+
+    it('migrates a legacy top-level illness flag into nested symptoms when the old context lacked symptoms', () => {
+        const result = validateCheckin({
+            userId: 'u1',
+            date: '2026-08-21',
+            readiness: 7,
+            sleepQuality: 7,
+            fatigue: 4,
+            soreness: 3,
+            mentalStress: 4,
+            motivation: 8,
+            painOrInjury: false,
+            illnessSymptoms: true,
+            unusuallyLimitedTime: false,
+            alreadyTrainedToday: false,
+            availability: { timeAvailableMin: 60, preferredModalityToday: null, indoorOnly: false },
+            notes: null,
+            healthContext: { closeSickContact: false },
+        });
+
+        expect(result.isValid).toBe(true);
+        expect(result.data?.illnessSymptoms).toBe(true);
+        expect(result.data?.healthContext?.symptoms).toEqual({ present: true });
+        expect(result.data?.healthContext?.closeSickContact).toBe(false);
+    });
+
+    it('keeps explicitly supplied nested symptoms authoritative over the legacy flag', () => {
+        const result = validateCheckin({
+            userId: 'u1',
+            date: '2026-08-21',
+            readiness: 7,
+            sleepQuality: 7,
+            fatigue: 4,
+            soreness: 3,
+            mentalStress: 4,
+            motivation: 8,
+            painOrInjury: false,
+            illnessSymptoms: true,
+            unusuallyLimitedTime: false,
+            alreadyTrainedToday: false,
+            availability: { timeAvailableMin: 60, preferredModalityToday: null, indoorOnly: false },
+            notes: null,
+            healthContext: { symptoms: { present: false } },
+        });
+
+        expect(result.isValid).toBe(true);
+        expect(result.data?.illnessSymptoms).toBe(false);
+        expect(result.data?.healthContext?.symptoms).toEqual({ present: false });
+    });
+});

--- a/app/src/engine/healthContextDefaults.ts
+++ b/app/src/engine/healthContextDefaults.ts
@@ -1,0 +1,42 @@
+import type { HealthContextCheckin } from './healthAnomalyModels';
+
+/**
+ * Canonical defaults for a newly reported health-context block. Historical check-ins that
+ * have no healthContext at all stay historically absent; callers opt into these defaults
+ * only when creating or normalizing an actual block.
+ */
+export function createDefaultHealthContext(symptomsPresent = false): HealthContextCheckin {
+    return {
+        alcoholDrinksLast24h: 0,
+        travelDisruption: 'none',
+        unusualHeatOrSauna: false,
+        dehydrationOrFluidLoss: false,
+        recentVaccination: false,
+        medicationChange: false,
+        closeSickContact: false,
+        symptoms: { present: symptomsPresent },
+    };
+}
+
+/**
+ * Normalize an existing/supplied context onto the product defaults. Legacy null/omitted
+ * yes/no values become explicit false only once a health-context block exists.
+ */
+export function normalizeHealthContext(
+    value: HealthContextCheckin | undefined,
+    symptomsPresent = value?.symptoms?.present ?? false,
+): HealthContextCheckin {
+    const defaults = createDefaultHealthContext(symptomsPresent);
+    return {
+        ...defaults,
+        ...value,
+        unusualHeatOrSauna: value?.unusualHeatOrSauna === true,
+        dehydrationOrFluidLoss: value?.dehydrationOrFluidLoss === true,
+        recentVaccination: value?.recentVaccination === true,
+        medicationChange: value?.medicationChange === true,
+        closeSickContact: value?.closeSickContact === true,
+        symptoms: value?.symptoms
+            ? { ...value.symptoms, present: symptomsPresent }
+            : { present: symptomsPresent },
+    };
+}

--- a/app/src/engine/healthContextValidation.ts
+++ b/app/src/engine/healthContextValidation.ts
@@ -3,6 +3,7 @@ import type {
     HealthSymptomsCheckin,
     HealthSymptomType,
 } from './healthAnomalyModels';
+import { normalizeHealthContext } from './healthContextDefaults';
 
 export const HEALTH_OTHER_DISRUPTION_MAX_LENGTH = 500;
 
@@ -35,9 +36,9 @@ const HEALTH_CONTEXT_KEYS = new Set([
     'recentVaccination',
     'medicationChange',
     'closeSickContact',
-    // Legacy keys remain accepted at the boundary so already-written documents do not
-    // become invalid. They are intentionally stripped from validated data: RHR/HRV/
-    // respiration direction is calculated from Garmin history, never from check-in input.
+    // Legacy keys remain accepted at the raw boundary so already-written documents do not
+    // become invalid. They are intentionally absent from HealthContextCheckin and stripped
+    // from validated canonical data: physiology direction comes only from Garmin.
     'manualRhrHigher',
     'manualHrvLower',
     'manualRespirationHigher',
@@ -153,8 +154,8 @@ function validateSymptoms(
 
 /**
  * Shared app-side contract for the optional check-in health context. Malformed supplied
- * fields fail closed. Once the block exists, ordinary contextual yes/no questions normalize
- * missing/null legacy values to explicit false because their product default is No.
+ * fields fail closed. A completely absent historical block stays absent; once a block
+ * exists, canonical product defaults are materialized by normalizeHealthContext().
  */
 export function validateHealthContext(raw: unknown): HealthContextValidationResult {
     if (raw === undefined) return { isValid: true, data: undefined, errors: [] };
@@ -232,21 +233,22 @@ export function validateHealthContext(raw: unknown): HealthContextValidationResu
     const symptoms = validateSymptoms(raw.symptoms, errors);
     if (errors.length > 0) return { isValid: false, errors };
 
-    const data: HealthContextCheckin = {
+    const supplied: HealthContextCheckin = {
         ...(typeof raw.alcoholDrinksLast24h === 'number' ? { alcoholDrinksLast24h: raw.alcoholDrinksLast24h as 0 | 1 | 2 | 3 } : {}),
         ...(isOneOf(raw.travelDisruption, HEALTH_TRAVEL_DISRUPTIONS) ? { travelDisruption: raw.travelDisruption } : {}),
         ...(raw.timezoneShiftHours === null || typeof raw.timezoneShiftHours === 'number' ? { timezoneShiftHours: raw.timezoneShiftHours as number | null } : {}),
-        unusualHeatOrSauna: raw.unusualHeatOrSauna === true,
-        dehydrationOrFluidLoss: raw.dehydrationOrFluidLoss === true,
-        recentVaccination: raw.recentVaccination === true,
-        medicationChange: raw.medicationChange === true,
-        closeSickContact: raw.closeSickContact === true,
-        // Do not carry legacy manual physiology into canonical validated data. If a Garmin
-        // current value/baseline is missing, the objective channel remains unavailable.
+        ...(raw.unusualHeatOrSauna === null || typeof raw.unusualHeatOrSauna === 'boolean' ? { unusualHeatOrSauna: raw.unusualHeatOrSauna as boolean | null } : {}),
+        ...(raw.dehydrationOrFluidLoss === null || typeof raw.dehydrationOrFluidLoss === 'boolean' ? { dehydrationOrFluidLoss: raw.dehydrationOrFluidLoss as boolean | null } : {}),
+        ...(raw.recentVaccination === null || typeof raw.recentVaccination === 'boolean' ? { recentVaccination: raw.recentVaccination as boolean | null } : {}),
+        ...(raw.medicationChange === null || typeof raw.medicationChange === 'boolean' ? { medicationChange: raw.medicationChange as boolean | null } : {}),
+        ...(raw.closeSickContact === null || typeof raw.closeSickContact === 'boolean' ? { closeSickContact: raw.closeSickContact as boolean | null } : {}),
         ...(raw.otherDisruption === null || typeof raw.otherDisruption === 'string' ? { otherDisruption: raw.otherDisruption } : {}),
         ...(symptoms ? { symptoms } : {}),
     };
 
+    // Legacy manual physiology keys were validated above only for migration compatibility;
+    // they are intentionally not represented in supplied/canonical data.
+    const data = normalizeHealthContext(supplied, symptoms?.present ?? false);
     return { isValid: true, data, errors: [] };
 }
 

--- a/app/src/engine/healthContextValidation.ts
+++ b/app/src/engine/healthContextValidation.ts
@@ -35,8 +35,9 @@ const HEALTH_CONTEXT_KEYS = new Set([
     'recentVaccination',
     'medicationChange',
     'closeSickContact',
-    // Legacy keys remain readable so already-written documents do not become invalid.
-    // New UI code no longer asks or writes these; Garmin core signals are authoritative.
+    // Legacy keys remain accepted at the boundary so already-written documents do not
+    // become invalid. They are intentionally stripped from validated data: RHR/HRV/
+    // respiration direction is calculated from Garmin history, never from check-in input.
     'manualRhrHigher',
     'manualHrvLower',
     'manualRespirationHigher',
@@ -240,11 +241,8 @@ export function validateHealthContext(raw: unknown): HealthContextValidationResu
         recentVaccination: raw.recentVaccination === true,
         medicationChange: raw.medicationChange === true,
         closeSickContact: raw.closeSickContact === true,
-        // Preserve legacy manual fields on read/write for migration compatibility only.
-        // Decision logic no longer needs new manual physiology input from the check-in UI.
-        ...(raw.manualRhrHigher === null || typeof raw.manualRhrHigher === 'boolean' ? { manualRhrHigher: raw.manualRhrHigher } : {}),
-        ...(raw.manualHrvLower === null || typeof raw.manualHrvLower === 'boolean' ? { manualHrvLower: raw.manualHrvLower } : {}),
-        ...(raw.manualRespirationHigher === null || typeof raw.manualRespirationHigher === 'boolean' ? { manualRespirationHigher: raw.manualRespirationHigher } : {}),
+        // Do not carry legacy manual physiology into canonical validated data. If a Garmin
+        // current value/baseline is missing, the objective channel remains unavailable.
         ...(raw.otherDisruption === null || typeof raw.otherDisruption === 'string' ? { otherDisruption: raw.otherDisruption } : {}),
         ...(symptoms ? { symptoms } : {}),
     };

--- a/app/src/engine/healthContextValidation.ts
+++ b/app/src/engine/healthContextValidation.ts
@@ -35,6 +35,8 @@ const HEALTH_CONTEXT_KEYS = new Set([
     'recentVaccination',
     'medicationChange',
     'closeSickContact',
+    // Legacy keys remain readable so already-written documents do not become invalid.
+    // New UI code no longer asks or writes these; Garmin core signals are authoritative.
     'manualRhrHigher',
     'manualHrvLower',
     'manualRespirationHigher',
@@ -149,8 +151,9 @@ function validateSymptoms(
 }
 
 /**
- * Shared app-side contract for the optional check-in health context. This is deliberately
- * strict about malformed supplied fields while treating an omitted block as unknown.
+ * Shared app-side contract for the optional check-in health context. Malformed supplied
+ * fields fail closed. Once the block exists, ordinary contextual yes/no questions normalize
+ * missing/null legacy values to explicit false because their product default is No.
  */
 export function validateHealthContext(raw: unknown): HealthContextValidationResult {
     if (raw === undefined) return { isValid: true, data: undefined, errors: [] };
@@ -232,11 +235,13 @@ export function validateHealthContext(raw: unknown): HealthContextValidationResu
         ...(typeof raw.alcoholDrinksLast24h === 'number' ? { alcoholDrinksLast24h: raw.alcoholDrinksLast24h as 0 | 1 | 2 | 3 } : {}),
         ...(isOneOf(raw.travelDisruption, HEALTH_TRAVEL_DISRUPTIONS) ? { travelDisruption: raw.travelDisruption } : {}),
         ...(raw.timezoneShiftHours === null || typeof raw.timezoneShiftHours === 'number' ? { timezoneShiftHours: raw.timezoneShiftHours as number | null } : {}),
-        ...(raw.unusualHeatOrSauna === null || typeof raw.unusualHeatOrSauna === 'boolean' ? { unusualHeatOrSauna: raw.unusualHeatOrSauna } : {}),
-        ...(raw.dehydrationOrFluidLoss === null || typeof raw.dehydrationOrFluidLoss === 'boolean' ? { dehydrationOrFluidLoss: raw.dehydrationOrFluidLoss } : {}),
-        ...(raw.recentVaccination === null || typeof raw.recentVaccination === 'boolean' ? { recentVaccination: raw.recentVaccination } : {}),
-        ...(raw.medicationChange === null || typeof raw.medicationChange === 'boolean' ? { medicationChange: raw.medicationChange } : {}),
-        ...(raw.closeSickContact === null || typeof raw.closeSickContact === 'boolean' ? { closeSickContact: raw.closeSickContact } : {}),
+        unusualHeatOrSauna: raw.unusualHeatOrSauna === true,
+        dehydrationOrFluidLoss: raw.dehydrationOrFluidLoss === true,
+        recentVaccination: raw.recentVaccination === true,
+        medicationChange: raw.medicationChange === true,
+        closeSickContact: raw.closeSickContact === true,
+        // Preserve legacy manual fields on read/write for migration compatibility only.
+        // Decision logic no longer needs new manual physiology input from the check-in UI.
         ...(raw.manualRhrHigher === null || typeof raw.manualRhrHigher === 'boolean' ? { manualRhrHigher: raw.manualRhrHigher } : {}),
         ...(raw.manualHrvLower === null || typeof raw.manualHrvLower === 'boolean' ? { manualHrvLower: raw.manualHrvLower } : {}),
         ...(raw.manualRespirationHigher === null || typeof raw.manualRespirationHigher === 'boolean' ? { manualRespirationHigher: raw.manualRespirationHigher } : {}),

--- a/app/src/engine/healthContextValidation.ts
+++ b/app/src/engine/healthContextValidation.ts
@@ -35,6 +35,9 @@ const HEALTH_CONTEXT_KEYS = new Set([
     'recentVaccination',
     'medicationChange',
     'closeSickContact',
+    'subjectiveRhrHigher',
+    'subjectiveHrvLower',
+    'subjectiveRespirationHigher',
     'otherDisruption',
     'symptoms',
 ]);
@@ -203,6 +206,9 @@ export function validateHealthContext(raw: unknown): HealthContextValidationResu
         'recentVaccination',
         'medicationChange',
         'closeSickContact',
+        'subjectiveRhrHigher',
+        'subjectiveHrvLower',
+        'subjectiveRespirationHigher',
     ] as const) {
         if (!isNullableBoolean(raw[field])) {
             errors.push({ field: `healthContext.${field}`, message: `${field} must be boolean, null, or omitted`, value: raw[field] });
@@ -231,6 +237,9 @@ export function validateHealthContext(raw: unknown): HealthContextValidationResu
         ...(raw.recentVaccination === null || typeof raw.recentVaccination === 'boolean' ? { recentVaccination: raw.recentVaccination } : {}),
         ...(raw.medicationChange === null || typeof raw.medicationChange === 'boolean' ? { medicationChange: raw.medicationChange } : {}),
         ...(raw.closeSickContact === null || typeof raw.closeSickContact === 'boolean' ? { closeSickContact: raw.closeSickContact } : {}),
+        ...(raw.subjectiveRhrHigher === null || typeof raw.subjectiveRhrHigher === 'boolean' ? { subjectiveRhrHigher: raw.subjectiveRhrHigher } : {}),
+        ...(raw.subjectiveHrvLower === null || typeof raw.subjectiveHrvLower === 'boolean' ? { subjectiveHrvLower: raw.subjectiveHrvLower } : {}),
+        ...(raw.subjectiveRespirationHigher === null || typeof raw.subjectiveRespirationHigher === 'boolean' ? { subjectiveRespirationHigher: raw.subjectiveRespirationHigher } : {}),
         ...(raw.otherDisruption === null || typeof raw.otherDisruption === 'string' ? { otherDisruption: raw.otherDisruption } : {}),
         ...(symptoms ? { symptoms } : {}),
     };

--- a/app/src/engine/healthContextValidation.ts
+++ b/app/src/engine/healthContextValidation.ts
@@ -35,9 +35,9 @@ const HEALTH_CONTEXT_KEYS = new Set([
     'recentVaccination',
     'medicationChange',
     'closeSickContact',
-    'subjectiveRhrHigher',
-    'subjectiveHrvLower',
-    'subjectiveRespirationHigher',
+    'manualRhrHigher',
+    'manualHrvLower',
+    'manualRespirationHigher',
     'otherDisruption',
     'symptoms',
 ]);
@@ -206,9 +206,9 @@ export function validateHealthContext(raw: unknown): HealthContextValidationResu
         'recentVaccination',
         'medicationChange',
         'closeSickContact',
-        'subjectiveRhrHigher',
-        'subjectiveHrvLower',
-        'subjectiveRespirationHigher',
+        'manualRhrHigher',
+        'manualHrvLower',
+        'manualRespirationHigher',
     ] as const) {
         if (!isNullableBoolean(raw[field])) {
             errors.push({ field: `healthContext.${field}`, message: `${field} must be boolean, null, or omitted`, value: raw[field] });
@@ -237,9 +237,9 @@ export function validateHealthContext(raw: unknown): HealthContextValidationResu
         ...(raw.recentVaccination === null || typeof raw.recentVaccination === 'boolean' ? { recentVaccination: raw.recentVaccination } : {}),
         ...(raw.medicationChange === null || typeof raw.medicationChange === 'boolean' ? { medicationChange: raw.medicationChange } : {}),
         ...(raw.closeSickContact === null || typeof raw.closeSickContact === 'boolean' ? { closeSickContact: raw.closeSickContact } : {}),
-        ...(raw.subjectiveRhrHigher === null || typeof raw.subjectiveRhrHigher === 'boolean' ? { subjectiveRhrHigher: raw.subjectiveRhrHigher } : {}),
-        ...(raw.subjectiveHrvLower === null || typeof raw.subjectiveHrvLower === 'boolean' ? { subjectiveHrvLower: raw.subjectiveHrvLower } : {}),
-        ...(raw.subjectiveRespirationHigher === null || typeof raw.subjectiveRespirationHigher === 'boolean' ? { subjectiveRespirationHigher: raw.subjectiveRespirationHigher } : {}),
+        ...(raw.manualRhrHigher === null || typeof raw.manualRhrHigher === 'boolean' ? { manualRhrHigher: raw.manualRhrHigher } : {}),
+        ...(raw.manualHrvLower === null || typeof raw.manualHrvLower === 'boolean' ? { manualHrvLower: raw.manualHrvLower } : {}),
+        ...(raw.manualRespirationHigher === null || typeof raw.manualRespirationHigher === 'boolean' ? { manualRespirationHigher: raw.manualRespirationHigher } : {}),
         ...(raw.otherDisruption === null || typeof raw.otherDisruption === 'string' ? { otherDisruption: raw.otherDisruption } : {}),
         ...(symptoms ? { symptoms } : {}),
     };

--- a/app/src/engine/validation.ts
+++ b/app/src/engine/validation.ts
@@ -10,6 +10,14 @@ import {
 
 export * from './validationCore';
 
+function rawNestedSymptomsWereSupplied(value: unknown): boolean {
+    return typeof value === 'object'
+        && value !== null
+        && !Array.isArray(value)
+        && Object.prototype.hasOwnProperty.call(value, 'symptoms')
+        && (value as Record<string, unknown>).symptoms !== undefined;
+}
+
 /**
  * HA1 compatibility wrapper around the repository's established check-in validator.
  *
@@ -34,16 +42,35 @@ export function validateCheckin(raw: unknown): ValidationResult<DailySubjectiveC
         return { isValid: false, errors: healthContextResult.errors };
     }
 
-    const healthContext = healthContextResult.data;
-    if (!healthContext) return coreResult;
+    const validatedHealthContext = healthContextResult.data;
+    if (!validatedHealthContext) return coreResult;
+
+    const nestedSymptomsSupplied = rawNestedSymptomsWereSupplied(rawRecord.healthContext);
+    const legacyIllnessSymptoms = typeof rawRecord.illnessSymptoms === 'boolean'
+        ? rawRecord.illnessSymptoms
+        : false;
+
+    // A legacy record may already have a health-context map from an earlier schema while
+    // still carrying illness truth only in the top-level compatibility flag. The canonical
+    // default constructor materializes symptoms:false for any supplied context block; do not
+    // let that newly materialized default overwrite historical truth. If nested symptoms
+    // were absent in the raw document, migrate the legacy boolean into the canonical nested
+    // shape. Once raw nested symptoms exist, they remain authoritative.
+    const healthContext = nestedSymptomsSupplied
+        ? validatedHealthContext
+        : {
+            ...validatedHealthContext,
+            symptoms: { present: legacyIllnessSymptoms },
+        };
 
     const illnessSymptoms = resolveLegacyIllnessSymptoms(rawRecord.illnessSymptoms, healthContext);
     let dataQuality = coreResult.data.dataQuality;
 
-    // A context-only write with `symptoms.present` has answered the same safety question as
-    // the legacy boolean. Do not mark the check-in incomplete merely because the redundant
-    // compatibility field was omitted by that caller.
-    if (healthContext.symptoms && rawRecord.illnessSymptoms === undefined
+    // A context-only write with an explicitly supplied `symptoms.present` has answered the
+    // same safety question as the legacy boolean. Do not mark the check-in incomplete merely
+    // because the redundant compatibility field was omitted by that caller. A defaulted
+    // nested value created during migration is not treated as an explicit answer.
+    if (nestedSymptomsSupplied && healthContext.symptoms && rawRecord.illnessSymptoms === undefined
         && dataQuality.missingFields.includes('illnessSymptoms')) {
         const missingFields = dataQuality.missingFields.filter(field => field !== 'illnessSymptoms');
         dataQuality = { isComplete: missingFields.length === 0, missingFields };

--- a/app/src/services/checkinHealthContext.test.ts
+++ b/app/src/services/checkinHealthContext.test.ts
@@ -45,7 +45,7 @@ describe('CheckinService HA1 health-context persistence', () => {
         firestore.deleteField.mockReturnValue(DELETE_FIELD_SENTINEL);
     });
 
-    it('persists a context-only symptom report with explicit No contextual defaults', async () => {
+    it('persists a context-only symptom report with canonical contextual defaults', async () => {
         const input = { ...baseCheckin, healthContext: { symptoms: { present: true as const } } };
         delete input.illnessSymptoms;
         const result = await new CheckinService().upsertCheckin('u1', input);
@@ -54,6 +54,8 @@ describe('CheckinService HA1 health-context persistence', () => {
         const payload = firestore.setDoc.mock.calls[0][1] as Record<string, unknown>;
         expect(payload.illnessSymptoms).toBe(true);
         const context = payload.healthContext as Record<string, unknown>;
+        expect(context.alcoholDrinksLast24h).toBe(0);
+        expect(context.travelDisruption).toBe('none');
         expect(context.unusualHeatOrSauna).toBe(false);
         expect(context.dehydrationOrFluidLoss).toBe(false);
         expect(context.recentVaccination).toBe(false);
@@ -75,7 +77,7 @@ describe('CheckinService HA1 health-context persistence', () => {
         expect(firestore.setDoc.mock.calls[0][2]).toEqual({ merge: true });
     });
 
-    it('normalizes supplied context to explicit No flags while deleting unrelated omitted keys', async () => {
+    it('normalizes any supplied context block to the canonical product defaults', async () => {
         await new CheckinService().upsertCheckin('u1', {
             ...baseCheckin,
             healthContext: {
@@ -87,13 +89,19 @@ describe('CheckinService HA1 health-context persistence', () => {
         const payload = firestore.setDoc.mock.calls[0][1] as {
             healthContext: Record<string, unknown>;
         };
+        expect(payload.healthContext.alcoholDrinksLast24h).toBe(0);
+        expect(payload.healthContext.travelDisruption).toBe('none');
         expect(payload.healthContext.unusualHeatOrSauna).toBe(false);
         expect(payload.healthContext.dehydrationOrFluidLoss).toBe(false);
         expect(payload.healthContext.recentVaccination).toBe(false);
         expect(payload.healthContext.medicationChange).toBe(false);
         expect(payload.healthContext.closeSickContact).toBe(false);
-        expect(payload.healthContext.alcoholDrinksLast24h).toBe(DELETE_FIELD_SENTINEL);
-        expect(payload.healthContext.symptoms).toBe(DELETE_FIELD_SENTINEL);
+        expect(payload.healthContext.symptoms).toEqual({
+            present: false,
+            onset: DELETE_FIELD_SENTINEL,
+            severity: DELETE_FIELD_SENTINEL,
+            types: DELETE_FIELD_SENTINEL,
+        });
     });
 
     it('explicitly clears stale nested symptom details when present becomes false', async () => {

--- a/app/src/services/checkinHealthContext.test.ts
+++ b/app/src/services/checkinHealthContext.test.ts
@@ -45,7 +45,7 @@ describe('CheckinService HA1 health-context persistence', () => {
         firestore.deleteField.mockReturnValue(DELETE_FIELD_SENTINEL);
     });
 
-    it('persists a context-only symptom report with the derived legacy compatibility flag', async () => {
+    it('persists a context-only symptom report with explicit No contextual defaults', async () => {
         const input = { ...baseCheckin, healthContext: { symptoms: { present: true as const } } };
         delete input.illnessSymptoms;
         const result = await new CheckinService().upsertCheckin('u1', input);
@@ -54,7 +54,11 @@ describe('CheckinService HA1 health-context persistence', () => {
         const payload = firestore.setDoc.mock.calls[0][1] as Record<string, unknown>;
         expect(payload.illnessSymptoms).toBe(true);
         const context = payload.healthContext as Record<string, unknown>;
-        expect(context.closeSickContact).toBe(DELETE_FIELD_SENTINEL);
+        expect(context.unusualHeatOrSauna).toBe(false);
+        expect(context.dehydrationOrFluidLoss).toBe(false);
+        expect(context.recentVaccination).toBe(false);
+        expect(context.medicationChange).toBe(false);
+        expect(context.closeSickContact).toBe(false);
         expect(context.symptoms).toEqual({
             present: true,
             onset: DELETE_FIELD_SENTINEL,
@@ -71,7 +75,7 @@ describe('CheckinService HA1 health-context persistence', () => {
         expect(firestore.setDoc.mock.calls[0][2]).toEqual({ merge: true });
     });
 
-    it('deletes omitted context keys instead of retaining stale merge values', async () => {
+    it('normalizes supplied context to explicit No flags while deleting unrelated omitted keys', async () => {
         await new CheckinService().upsertCheckin('u1', {
             ...baseCheckin,
             healthContext: {
@@ -83,8 +87,11 @@ describe('CheckinService HA1 health-context persistence', () => {
         const payload = firestore.setDoc.mock.calls[0][1] as {
             healthContext: Record<string, unknown>;
         };
+        expect(payload.healthContext.unusualHeatOrSauna).toBe(false);
+        expect(payload.healthContext.dehydrationOrFluidLoss).toBe(false);
+        expect(payload.healthContext.recentVaccination).toBe(false);
+        expect(payload.healthContext.medicationChange).toBe(false);
         expect(payload.healthContext.closeSickContact).toBe(false);
-        expect(payload.healthContext.recentVaccination).toBeNull();
         expect(payload.healthContext.alcoholDrinksLast24h).toBe(DELETE_FIELD_SENTINEL);
         expect(payload.healthContext.symptoms).toBe(DELETE_FIELD_SENTINEL);
     });

--- a/app/src/services/healthAnomalyCausality.test.ts
+++ b/app/src/services/healthAnomalyCausality.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { DataState } from '../engine/dataState';
+import type {
+    CoreSignalEvidence,
+    HealthAnomalyAssessmentRevision,
+    PhysiologicalAnomalyAssessment,
+} from '../engine/healthAnomalyModels';
+import type { DailyRecoverySnapshot, DailySubjectiveCheckin } from '../engine/models';
+import { HealthAnomalyService } from './healthAnomalyService';
+
+function available<T>(data: T, revision = 'rev'): DataState<T> {
+    return { status: 'AVAILABLE', data, revision };
+}
+
+function snapshot(date: string, rhr: number): DailyRecoverySnapshot {
+    return {
+        userId: 'u1',
+        date,
+        source: { garminSyncedAt: `${date}T06:00:00Z`, sourceSchemaVersion: 3, timezone: 'Europe/Warsaw' },
+        raw: {
+            sleepScore: 85,
+            sleepDurationSec: 8 * 3600,
+            restingHr: rhr,
+            hrvOvernightAvg: 60,
+            hrvStatus: null,
+            respirationAvg: 14,
+            bodyBatteryWake: 70,
+            bodyBatteryChange: 35,
+            totalSteps: 8000,
+            last3DaysHardSessionsCount: 0,
+            yesterdayTraining: null,
+            todayTraining: null,
+        },
+        derived: {
+            baselineComputationVersion: 5,
+            sleepScore7dAvg: 85,
+            sleepScore28dAvg: 84,
+            restingHr7dAvg: 50,
+            restingHr28dAvg: 50,
+            hrv7dAvg: 60,
+            hrv28dAvg: 60,
+            respiration7dAvg: 14,
+            respiration28dAvg: 14,
+            hrv28dStdev: 5,
+            restingHr28dStdev: 2,
+            sleepScore28dStdev: 5,
+            respiration28dMad: 0.5,
+            restingHr28dMedian: 50,
+            restingHr28dMad: 2,
+            hrv28dMedian: 60,
+            hrv28dMad: 5,
+            deltas: {
+                sleepScoreVs7d: 0,
+                sleepScoreVs28d: 1,
+                restingHrVs7d: rhr - 50,
+                restingHrVs28d: rhr - 50,
+                hrvVs7d: 0,
+                hrvVs28d: 0,
+                respirationVs7d: 0,
+                respirationVs28d: 0,
+            },
+        },
+        dataQuality: {
+            sleepScoreAvailable: true,
+            restingHrAvailable: true,
+            hrvAvailable: true,
+            baseline7dReady: true,
+            baseline28dReady: true,
+        },
+    } as DailyRecoverySnapshot;
+}
+
+function checkin(date: string): DailySubjectiveCheckin {
+    return {
+        userId: 'u1',
+        date,
+        readiness: 8,
+        sleepQuality: 8,
+        fatigue: 2,
+        soreness: 2,
+        mentalStress: 2,
+        motivation: 8,
+        painOrInjury: false,
+        illnessSymptoms: false,
+        unusuallyLimitedTime: false,
+        alreadyTrainedToday: false,
+        availability: { timeAvailableMin: 60, preferredModalityToday: null, indoorOnly: false },
+        notes: null,
+        submittedAt: `${date}T06:05:00Z`,
+        dataQuality: { isComplete: true, missingFields: [] },
+        schemaVersion: 1,
+        createdAt: `${date}T06:05:00Z`,
+        updatedAt: `${date}T06:05:00Z`,
+    };
+}
+
+function adverseRhr(): CoreSignalEvidence {
+    return {
+        signal: 'rhr',
+        status: 'strong_anomaly',
+        direction: 'high',
+        currentValue: 56,
+        baselineValue: 50,
+        scaleValue: 2,
+        standardizedDeviation: 3,
+        estimator: 'mean-stdev-28d',
+        baselineVersion: 5,
+    };
+}
+
+function previousAssessment(): HealthAnomalyAssessmentRevision {
+    const assessment: PhysiologicalAnomalyAssessment = {
+        state: 'explained_recovery_strain',
+        evidenceLevel: 'moderate',
+        coreSignals: [
+            adverseRhr(),
+            { ...adverseRhr(), signal: 'respiration', status: 'normal', direction: null, standardizedDeviation: 0 },
+            { ...adverseRhr(), signal: 'hrv', status: 'normal', direction: null, standardizedDeviation: 0 },
+        ],
+        supportingSignals: [],
+        explanations: [{ kind: 'hard_training', strength: 'strong', explainsSignals: ['rhr', 'hrv'], evidence: ['YESTERDAY_HARD_SESSION'] }],
+        unexplainedEvidence: [],
+        persistenceDays: 2,
+        episodeId: 'health-anomaly:2026-08-19',
+        episodeDay: 2,
+        dataQuality: [],
+        rationale: { facts: [], explanations: ['HARD_TRAINING'], cautions: ['NOT_A_DIAGNOSIS'] },
+        policyVersion: 'health-anomaly/ha3-v1',
+        thresholdPolicyVersion: 'health-anomaly-thresholds/shadow-candidate-v1',
+        mode: 'shadow-v1',
+    };
+    return {
+        userId: 'u1',
+        date: '2026-08-20',
+        revisionId: 'ha-prev',
+        idempotencyKey: 'prev',
+        computedAt: '2026-08-20T06:30:00Z',
+        policyVersion: 'health-anomaly/ha3-v1',
+        thresholdPolicy: {
+            policyVersion: 'health-anomaly-thresholds/shadow-candidate-v1',
+            moderateDeviation: 1.5,
+            strongDeviation: 2.5,
+            minimumCoreSignalsForMultiSignal: 2,
+            persistenceDaysForEscalation: 2,
+            minimumHistoryCount: 14,
+            minimumRecentDayCoverage: 4 / 7,
+            maxBaselineAgeDays: 3,
+            estimatorBySignal: { rhr: 'mean-stdev-28d', respiration: 'median-mad-28d', hrv: 'log-mean-stdev-28d' },
+        },
+        mode: 'shadow-v1',
+        source: {
+            timezone: 'Europe/Warsaw',
+            recoverySnapshotRevision: 'snapshot-prev',
+            checkinRevision: 'checkin-prev',
+            historyWindowStart: '2026-07-23',
+            historyWindowEndExclusive: '2026-08-20',
+            historySnapshotRevisions: [],
+            travelContextRevision: null,
+            persistenceLookbackStart: '2026-08-19',
+        },
+        assessment,
+        schemaVersion: 1,
+    };
+}
+
+describe('HealthAnomalyService causality and persistence', () => {
+    it('carries adverse physiology persistence through a prior strongly explained day', async () => {
+        const current = snapshot('2026-08-21', 56);
+        const history = Array.from({ length: 20 }, (_, index) => {
+            const day = String(index + 1).padStart(2, '0');
+            return snapshot(`2026-08-${day}`, 48 + (index % 5));
+        });
+        const recovery = {
+            getRecoverySnapshotState: vi.fn().mockResolvedValue(available(current, 'current')),
+            getRecoverySnapshotsInRangeState: vi.fn().mockResolvedValue(available(history, 'history')),
+        };
+        const checkins = { getCheckinState: vi.fn().mockResolvedValue(available(checkin('2026-08-21'), 'checkin')) };
+        const blocks = { getBlocksInRangeState: vi.fn().mockResolvedValue({ status: 'MISSING' }) };
+        const persisted: HealthAnomalyAssessmentRevision[] = [];
+        const store = {
+            getLatestForDate: vi.fn().mockResolvedValue(previousAssessment()),
+            persistImmutable: vi.fn().mockImplementation(async (value: HealthAnomalyAssessmentRevision) => {
+                persisted.push(value);
+                return value;
+            }),
+        };
+        const service = new HealthAnomalyService(recovery as never, checkins as never, blocks as never, store as never);
+
+        const result = await service.assessAndPersist('u1', '2026-08-21', 'shadow-v1');
+
+        expect(result).not.toBeNull();
+        expect(result?.assessment.coreSignals.find(signal => signal.signal === 'rhr')?.direction).toBe('high');
+        expect(result?.assessment.persistenceDays).toBe(3);
+        expect(result?.assessment.episodeId).toBe('health-anomaly:2026-08-19');
+        expect(persisted).toHaveLength(1);
+    });
+});

--- a/app/src/services/healthAnomalyService.ts
+++ b/app/src/services/healthAnomalyService.ts
@@ -1,6 +1,7 @@
 import type { DataState } from '../engine/dataState';
 import {
     evaluatePhysiologicalAnomaly,
+    isAdverseCoreSignalEvidence,
     SHADOW_V1_HEALTH_ANOMALY_THRESHOLDS,
 } from '../engine/healthAnomaly';
 import { HEALTH_ANOMALY_BASELINE_WINDOW_DAYS, mapRecoverySnapshotToHealthAnomalyFeatures } from '../engine/healthAnomalyFeatures';
@@ -38,15 +39,6 @@ export interface HealthAnomalyServiceResult {
 
 function availableData<T>(state: DataState<T>): T | null {
     return state.status === 'AVAILABLE' ? state.data : null;
-}
-
-function hasAdverseCorePhysiology(assessment: PhysiologicalAnomalyAssessment): boolean {
-    return assessment.coreSignals.some(evidence => {
-        const anomalous = evidence.status === 'moderate_anomaly' || evidence.status === 'strong_anomaly';
-        if (!anomalous) return false;
-        if (evidence.signal === 'hrv') return evidence.direction === 'low';
-        return evidence.direction === 'high';
-    });
 }
 
 /**
@@ -139,7 +131,8 @@ export class HealthAnomalyService {
                 // Preserve consecutive abnormal physiology even when the prior day had a
                 // strong competing explanation. Context may qualify interpretation, but it
                 // must not reset the physiological trace.
-                unexplainedPersistenceDays: previousAssessment && hasAdverseCorePhysiology(previousAssessment.assessment)
+                unexplainedPersistenceDays: previousAssessment
+                    && previousAssessment.assessment.coreSignals.some(isAdverseCoreSignalEvidence)
                     ? previousAssessment.assessment.persistenceDays
                     : 0,
             },

--- a/app/src/services/healthAnomalyService.ts
+++ b/app/src/services/healthAnomalyService.ts
@@ -40,6 +40,15 @@ function availableData<T>(state: DataState<T>): T | null {
     return state.status === 'AVAILABLE' ? state.data : null;
 }
 
+function hasAdverseCorePhysiology(assessment: PhysiologicalAnomalyAssessment): boolean {
+    return assessment.coreSignals.some(evidence => {
+        const anomalous = evidence.status === 'moderate_anomaly' || evidence.status === 'strong_anomaly';
+        if (!anomalous) return false;
+        if (evidence.signal === 'hrv') return evidence.direction === 'low';
+        return evidence.direction === 'high';
+    });
+}
+
 /**
  * Keep the parser/store revision when available for debugging, but bind the immutable HA
  * identity to the exact canonical content as well. A corrected/rebuilt document therefore
@@ -127,7 +136,10 @@ export class HealthAnomalyService {
                 previousEpisodeId: previousAssessment?.assessment.episodeId ?? null,
                 previousEpisodeDay: previousAssessment?.assessment.episodeDay ?? null,
                 previousAssessmentDate: previousAssessment?.date ?? null,
-                unexplainedPersistenceDays: previousAssessment && previousAssessment.assessment.unexplainedEvidence.length > 0
+                // Preserve consecutive abnormal physiology even when the prior day had a
+                // strong competing explanation. Context may qualify interpretation, but it
+                // must not reset the physiological trace.
+                unexplainedPersistenceDays: previousAssessment && hasAdverseCorePhysiology(previousAssessment.assessment)
                     ? previousAssessment.assessment.persistenceDays
                     : 0,
             },

--- a/docs/plans/health-anomaly-causality-cleanup.md
+++ b/docs/plans/health-anomaly-causality-cleanup.md
@@ -1,46 +1,42 @@
 # Health anomaly causality and canonicalization cleanup
 
+## Status
+
+Implementation complete on PR #181; full CI validation is the remaining gate. The PR is stacked on #179 (`fix/close-sick-contact-tristate`) so its normal base does not match the repository's `pull_request -> main` CI filter. For integration validation, #181 may be pointed at `main` temporarily and then restored to the stacked base.
+
 ## Context
 
-This plan is a follow-up to PR #179. It is intentionally stacked on `fix/close-sick-contact-tristate` so the follow-up architecture work is isolated from the morning check-in redesign.
+This is a follow-up to PR #179. It is intentionally stacked on `fix/close-sick-contact-tristate` so the follow-up architecture work is isolated from the morning check-in redesign.
 
-## Goals
+## Implemented goals
 
-1. Make Garmin-derived RHR/HRV/respiration the only canonical physiology source.
-2. Prevent same-day training from retroactively explaining overnight/morning physiology.
-3. Centralize health-context defaults so UI, persistence, validation, and evaluator semantics cannot drift.
-4. Keep physiological anomalies visible even when a strong contextual explanation exists; context changes interpretation, not whether the abnormal measurement occurred.
-5. Preserve backward compatibility for old persisted documents without letting legacy fields enter canonical decision input.
+1. Garmin-derived RHR/HRV/respiration are the only canonical physiology source.
+2. Same-day training cannot retroactively explain overnight/morning physiology.
+3. Health-context defaults have one shared constructor/normalizer used by UI and validation/persistence semantics.
+4. Strong context changes interpretation without deleting the observed abnormal core signal or resetting its consecutive physiological persistence.
+5. Old persisted manual-physiology keys remain readable at the raw migration boundary but are stripped before canonical decision input.
+6. Legacy top-level `illnessSymptoms` truth is migrated into nested symptoms when an old context block did not yet contain nested symptom state.
 
-## Non-goals in this PR
+## Implemented details
 
-The following ideas remain shadow/follow-up work because they change detection policy or require ingestion/schema evidence beyond this cleanup:
+### Canonical physiology authority
 
-- episode closing hysteresis
-- persistent single-core-signal escalation
-- new core signals such as skin temperature
-- device/source-specific respiration provenance migration
-- health-context attestation analytics
+- Removed manual RHR/HRV/respiration fields from `HealthContextCheckin`.
+- Removed `manualSupport()` and all `MANUAL_*` evaluator supporting signals.
+- Legacy manual keys are accepted only by raw health-context validation so existing Firestore documents do not become invalid; they are not emitted into canonical health-context data.
+- Missing Garmin current values/baselines remain unavailable rather than falling back to athlete guesses.
+- The stacked #179 caller still passes an old `manualPhysiologyMissing` prop into `HealthContextSection`; #181 keeps this as an explicitly deprecated no-op shim only to avoid a risky whole-file replacement of the large `DailyCheckin.tsx`. It has no UI, persistence, or evaluator behavior and should be deleted after the stack is flattened/when that caller can be edited safely.
 
-## Implementation sequence
+### Temporal causality
 
-### 1. Remove manual physiology from canonical paths
+- `todayTraining` is never used to explain morning RHR/HRV/respiration.
+- Explicit hard training yesterday remains a strong RHR/HRV explanation and weak respiration explanation.
+- `last3DaysHardSessionsCount` remains a moderate RHR/HRV context because the backend defines it as D-1 through D-3 only; today's activities are explicitly excluded during snapshot construction.
+- Regression coverage proves a same-day hard activity added by a later Garmin sync cannot erase an abnormal morning RHR signal.
 
-- Remove manual RHR/HRV/respiration fields from `HealthContextCheckin`.
-- Remove manual physiology props/UI compatibility plumbing.
-- Remove `manualSupport()` and `MANUAL_*` supporting signals from the evaluator.
-- Continue accepting legacy manual keys at the raw validation boundary only so old Firestore documents remain readable; strip them from validated canonical output.
-- Add regression tests proving legacy keys are ignored and missing Garmin physiology remains unavailable.
+### Canonical health-context defaults
 
-### 2. Fix temporal causality
-
-- Treat only prior-day/relevant pre-measurement training as an explanation of morning RHR/HRV/respiration.
-- Explicitly exclude `todayTraining` from the morning physiological explanation path.
-- Add a regression test where an abnormal morning signal remains unexplained after a hard same-day activity appears in a later Garmin sync.
-
-### 3. Canonicalize health-context defaults
-
-Create one shared default constructor/normalizer with:
+`createDefaultHealthContext()` / `normalizeHealthContext()` define:
 
 - symptoms: `false`
 - alcohol: `0`
@@ -51,14 +47,17 @@ Create one shared default constructor/normalizer with:
 - medication change: `false`
 - close sick contact: `false`
 
-Use it for new check-ins, UI normalization, and validation of supplied health-context blocks. Historical documents with no health-context block remain historically absent rather than being silently rewritten.
+The UI consumes the shared normalizer. Any supplied health-context block is normalized before canonical persistence, so new/supplied records store explicit product defaults. A completely absent historical health-context block remains absent instead of being rewritten as an asserted historical negative.
 
-### 4. Preserve anomaly evidence under contextual explanations
+When a legacy document has `illnessSymptoms: true` but its old context map never contained nested `symptoms`, validation migrates that true value into canonical `healthContext.symptoms.present`. Once nested symptoms are explicitly present in raw data, they remain authoritative.
 
-- Keep adverse core signals in the unexplained/persistence trace instead of deleting them solely because a contextual explanation is `strong`.
-- Record strong context as competing/explanatory evidence.
-- Preserve `explained_recovery_strain` as an interpretation state when all adverse signals have strong contextual coverage, while retaining the underlying physiological evidence for traceability and persistence analysis.
-- Add tests showing vaccination/training/poor sleep cannot erase a measured anomaly from the trace.
+### Context versus physiology
+
+- Core abnormal measurements remain present in `coreSignals` regardless of explanatory context.
+- `unexplainedEvidence` continues to mean the current residual lacking strong contextual coverage.
+- `persistenceDays` now tracks consecutive adverse core physiology, including days interpreted as `explained_recovery_strain`.
+- Service composition seeds persistence from prior adverse core evidence rather than from `unexplainedEvidence.length`, so a strongly explained prior day cannot reset the physiological trace.
+- The developer trace label is now `Adverse physiology persistence` to match this contract.
 
 ## Safety invariants
 
@@ -66,25 +65,30 @@ Use it for new check-ins, UI normalization, and validation of supplied health-co
 - Context never fabricates a physiological anomaly.
 - Context never deletes an observed abnormal core signal.
 - Same-day post-measurement training cannot explain morning physiology.
-- Historical missing context is not rewritten as an asserted historical negative.
+- The D-1..D-3 hard-session aggregate remains usable because ingestion explicitly excludes today.
+- Historical absence of a whole health-context block is not rewritten as an asserted historical negative.
 - Supporting Garmin composites do not count as independent core votes.
 - Local tissue restrictions remain independent of health-anomaly interpretation.
 
-## Test plan
+## Regression coverage added/updated
 
-- health-context validation/parser migration tests
-- UI default-constructor tests
-- evaluator manual-signal removal tests
-- same-day causality regression
-- contextual-explanation trace/persistence regressions
-- full frontend CI, Firestore rules, simulations, Python suites, dependency audits, Docker build
+- canonical health-context default constructor and null normalization
+- legacy illness-to-nested-symptom migration
+- legacy manual-physiology acceptance + canonical stripping
+- no `MANUAL_*` evaluator signals when Garmin physiology is missing
+- same-day training causal-leak regression
+- safe D-1..D-3 aggregate context regression
+- adverse physiology persistence under strong contextual explanation
+- service-level persistence across a prior `explained_recovery_strain` assessment
+- health-context persistence of explicit product defaults
 
-## Follow-up experiments
+## Follow-up experiments / separate changes
 
-After this cleanup is stable, evaluate in shadow mode:
+These are intentionally not mixed into this cleanup because they change detection policy or require additional ingestion/schema evidence:
 
 1. two-normal-day hysteresis before closing an established episode
 2. `one strong core signal + >=3 days persistence` as an alternate escalation route
 3. exact respiration/device provenance and baseline segmentation on device/source changes
 4. optional health-context attestation timestamp for calibration analytics
 5. skin-temperature deviation as an additional candidate signal if Garmin provenance is reliable
+6. remove the stacked caller's deprecated no-op `manualPhysiologyMissing` prop once `DailyCheckin.tsx` can be edited safely after #179 is flattened

--- a/docs/plans/health-anomaly-causality-cleanup.md
+++ b/docs/plans/health-anomaly-causality-cleanup.md
@@ -1,0 +1,90 @@
+# Health anomaly causality and canonicalization cleanup
+
+## Context
+
+This plan is a follow-up to PR #179. It is intentionally stacked on `fix/close-sick-contact-tristate` so the follow-up architecture work is isolated from the morning check-in redesign.
+
+## Goals
+
+1. Make Garmin-derived RHR/HRV/respiration the only canonical physiology source.
+2. Prevent same-day training from retroactively explaining overnight/morning physiology.
+3. Centralize health-context defaults so UI, persistence, validation, and evaluator semantics cannot drift.
+4. Keep physiological anomalies visible even when a strong contextual explanation exists; context changes interpretation, not whether the abnormal measurement occurred.
+5. Preserve backward compatibility for old persisted documents without letting legacy fields enter canonical decision input.
+
+## Non-goals in this PR
+
+The following ideas remain shadow/follow-up work because they change detection policy or require ingestion/schema evidence beyond this cleanup:
+
+- episode closing hysteresis
+- persistent single-core-signal escalation
+- new core signals such as skin temperature
+- device/source-specific respiration provenance migration
+- health-context attestation analytics
+
+## Implementation sequence
+
+### 1. Remove manual physiology from canonical paths
+
+- Remove manual RHR/HRV/respiration fields from `HealthContextCheckin`.
+- Remove manual physiology props/UI compatibility plumbing.
+- Remove `manualSupport()` and `MANUAL_*` supporting signals from the evaluator.
+- Continue accepting legacy manual keys at the raw validation boundary only so old Firestore documents remain readable; strip them from validated canonical output.
+- Add regression tests proving legacy keys are ignored and missing Garmin physiology remains unavailable.
+
+### 2. Fix temporal causality
+
+- Treat only prior-day/relevant pre-measurement training as an explanation of morning RHR/HRV/respiration.
+- Explicitly exclude `todayTraining` from the morning physiological explanation path.
+- Add a regression test where an abnormal morning signal remains unexplained after a hard same-day activity appears in a later Garmin sync.
+
+### 3. Canonicalize health-context defaults
+
+Create one shared default constructor/normalizer with:
+
+- symptoms: `false`
+- alcohol: `0`
+- travel: `none`
+- heat/sauna: `false`
+- dehydration/fluid loss: `false`
+- vaccination: `false`
+- medication change: `false`
+- close sick contact: `false`
+
+Use it for new check-ins, UI normalization, and validation of supplied health-context blocks. Historical documents with no health-context block remain historically absent rather than being silently rewritten.
+
+### 4. Preserve anomaly evidence under contextual explanations
+
+- Keep adverse core signals in the unexplained/persistence trace instead of deleting them solely because a contextual explanation is `strong`.
+- Record strong context as competing/explanatory evidence.
+- Preserve `explained_recovery_strain` as an interpretation state when all adverse signals have strong contextual coverage, while retaining the underlying physiological evidence for traceability and persistence analysis.
+- Add tests showing vaccination/training/poor sleep cannot erase a measured anomaly from the trace.
+
+## Safety invariants
+
+- Missing Garmin data never becomes normal.
+- Context never fabricates a physiological anomaly.
+- Context never deletes an observed abnormal core signal.
+- Same-day post-measurement training cannot explain morning physiology.
+- Historical missing context is not rewritten as an asserted historical negative.
+- Supporting Garmin composites do not count as independent core votes.
+- Local tissue restrictions remain independent of health-anomaly interpretation.
+
+## Test plan
+
+- health-context validation/parser migration tests
+- UI default-constructor tests
+- evaluator manual-signal removal tests
+- same-day causality regression
+- contextual-explanation trace/persistence regressions
+- full frontend CI, Firestore rules, simulations, Python suites, dependency audits, Docker build
+
+## Follow-up experiments
+
+After this cleanup is stable, evaluate in shadow mode:
+
+1. two-normal-day hysteresis before closing an established episode
+2. `one strong core signal + >=3 days persistence` as an alternate escalation route
+3. exact respiration/device provenance and baseline segmentation on device/source changes
+4. optional health-context attestation timestamp for calibration analytics
+5. skin-temperature deviation as an additional candidate signal if Garmin provenance is reliable

--- a/docs/plans/health-anomaly-causality-cleanup.md
+++ b/docs/plans/health-anomaly-causality-cleanup.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Implementation complete on PR #181; full CI validation is the remaining gate. The PR is stacked on #179 (`fix/close-sick-contact-tristate`) so its normal base does not match the repository's `pull_request -> main` CI filter. For integration validation, #181 may be pointed at `main` temporarily and then restored to the stacked base.
+Implementation complete on PR #181. Full integration CI passed in pipeline #1035 against `main + #179 + #181`; the PR was then restored to its stacked #179 base (`fix/close-sick-contact-tristate`) so the follow-up remains isolated from the morning check-in redesign.
 
 ## Context
 


### PR DESCRIPTION
## Summary

- Fixes the `Frontend Build & Firestore Rules` CI failure on #181: `tsc -b` failed with `error TS2322: Type 'string' is not assignable to type 'number'` in `app/src/engine/healthAnomalyAdverseClassifier.test.ts(19,9)`.
- `CoreSignalEvidence.baselineVersion` is typed `number | null`, but the new test's `evidence()` helper passed the string literal `'test'`. Changed it to `5`, matching the numeric convention already used for `baselineVersion` in every other `CoreSignalEvidence` fixture in this codebase (e.g. `healthAnomalyEvaluator.test.ts`, `healthAnomalyPersistence.test.ts`, `healthAnomalyCausality.test.ts`).
- Built on top of #181's branch (`refactor/health-anomaly-causality-cleanup`), so this PR carries the same content as #181 plus this one-line test fix. It exists to unblock CI on #181 — merge/cherry-pick this fix onto #181's branch, or merge this PR instead of #181, whichever is preferred.

## Validation

Results:
- `cd app && npx tsc -b`: pass
- `cd app && npm run check` (typecheck + lint + vitest + workout catalog validation): pass — 0 errors, 3 pre-existing unrelated ESLint warnings, 2031 tests passed / 124 skipped
- `cd app && npm run build`: pass

## Risk and reviewer guidance

Single-line change confined to a test fixture; no production code touched. No behavioral risk.

## Domain invariants

Not applicable — this is a test-only type fix with no changes to Firestore paths, calendar-date logic, credentials, or recommendation decision logic.

## Screenshots or recordings

Not applicable — test-only change, no UI impact.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NmjWLRb5mJDkFLohPaAzw5)_