### PR TITLE
Fix slider pointerUp fallback to primary-button releases (addresses #179 review comment)

### DIFF
--- a/app/src/components/checkin/SubjectiveScaleRow.tsx
+++ b/app/src/components/checkin/SubjectiveScaleRow.tsx
@@ -60,10 +60,11 @@ export const SubjectiveScaleRow: React.FC<SubjectiveScaleRowProps> = ({
           max="10"
           step="1"
           value={sliderValue}
-          onPointerDown={() => {
-            // Clicking the untouched midpoint should count as an explicit answer even when
-            // the thumb does not move and the browser therefore emits no change event.
-            if (value === null) onChange(sliderValue);
+          onPointerUp={(event) => {
+            // Keep the neutral thumb position purely visual until the athlete completes an
+            // interaction. Pointer-down can precede a drag, so recording 5 there briefly
+            // fabricates a midpoint observation before the intended value is chosen.
+            if (value === null) onChange(Number(event.currentTarget.value));
           }}
           onChange={(e) => onChange(Number(e.target.value))}
           className={`subjective-slider ${severityClass}`}

--- a/app/src/components/checkin/SubjectiveScaleRow.tsx
+++ b/app/src/components/checkin/SubjectiveScaleRow.tsx
@@ -63,8 +63,12 @@ export const SubjectiveScaleRow: React.FC<SubjectiveScaleRowProps> = ({
           onPointerUp={(event) => {
             // Keep the neutral thumb position purely visual until the athlete completes an
             // interaction. Pointer-down can precede a drag, so recording 5 there briefly
-            // fabricates a midpoint observation before the intended value is chosen.
-            if (value === null) onChange(Number(event.currentTarget.value));
+            // fabricates a midpoint observation before the intended value is chosen. Only a
+            // primary-button release should count as the athlete's answer; an auxiliary or
+            // secondary-button release must not fabricate a value either.
+            if (value === null && event.isPrimary && event.button === 0) {
+              onChange(Number(event.currentTarget.value));
+            }
           }}
           onChange={(e) => onChange(Number(e.target.value))}
           className={`subjective-slider ${severityClass}`}


### PR DESCRIPTION
## Summary

- Addresses the CodeRabbit review comment on #179: `SubjectiveScaleRow`'s `onPointerUp` handler recorded the fallback midpoint value for *any* pointer release on an unanswered slider, including an auxiliary or secondary mouse-button release — fabricating an unintended 5/10 answer.
- Guards the fallback so only a primary-button release (`event.isPrimary && event.button === 0`) is treated as the athlete's explicit answer.
- Built on top of #179's branch (`fix/close-sick-contact-tristate`), so this PR carries the same content as #179 plus this one-file fix — merge this instead of #179, or cherry-pick the fix commit onto #179's branch, whichever is preferred.
- No user-visible change to correctly-answered sliders; only prevents a spurious auto-answer on non-primary pointer releases.

## Validation

Results:
- `cd app && npx tsc -b`: pass
- `cd app && npm run check` (typecheck + lint + vitest + workout catalog validation): pass — 0 errors, 3 pre-existing unrelated ESLint warnings, 2031 tests passed / 124 skipped
- Manual check: `SubjectiveScaleRow.test.tsx` (SSR-rendered, doesn't exercise pointer events) passes unchanged; reviewed the guard against the W3C Pointer Events spec cited in the review comment.

## Risk and reviewer guidance

Single-file, narrowly-scoped guard on an existing conditional; no production behavior changes for primary-button interactions (mouse left-click, touch, pen). Low risk.

## Domain invariants

Not applicable — no Firestore paths, calendar-date logic, credentials, or recommendation decision logic touched.

## Screenshots or recordings

Not applicable — behavioral guard on pointer-event handling, not a visual change.

---

### Merge-order check (per user request)

Verified against `main`: PR #181 (merged via #183) was built stacked on top of #179's branch and, when retargeted and merged straight into `main`, already carried all of #179's substantive changes (`createDefaultHealthContext`, `closeSickContact` tri-state defaults, `HealthContextSection`, etc. are all present on `main`). Diffing #179's branch against current `main` shows only one remaining file — this slider pointer-event fix — was not yet on `main`. So despite #181/#183 landing ahead of #179, nothing from #179 was lost; this PR closes that last gap.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JeSdHhA8p9YTEq9ky6uDbv)_