### PR TITLE
fix: preserve active Garmin token during relink rollback; fix preset refresh masking

### DIFF
--- a/app/src/components/preferences/HealthRunYogaPresetSection.test.tsx
+++ b/app/src/components/preferences/HealthRunYogaPresetSection.test.tsx
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { HealthRunYogaPresetSection } from './HealthRunYogaPresetSection';
+import { derivePresetOutcome } from '../../utils/healthRunYogaPreset';
+
+// This repo has no interactive component-test harness (no @testing-library/react) --
+// markup-level smoke test below, matching the existing convention for sibling components
+// (GarminSyncNowButton.test.tsx). The outcome-selection logic that a review comment
+// flagged (a failed post-apply refresh must not overwrite a full/partial preset-save
+// message) is factored into the pure derivePresetOutcome() below and tested directly.
+
+function fulfilled(): PromiseFulfilledResult<undefined> {
+  return { status: 'fulfilled', value: undefined };
+}
+
+function rejected(reason: unknown): PromiseRejectedResult {
+  return { status: 'rejected', reason };
+}
+
+describe('HealthRunYogaPresetSection', () => {
+  it('renders the apply button by default', () => {
+    const html = renderToStaticMarkup(
+      <HealthRunYogaPresetSection userId="u1" onApplied={async () => {}} />,
+    );
+
+    expect(html).toContain('Apply Health + Running + Yoga');
+  });
+});
+
+describe('derivePresetOutcome', () => {
+  it('reports full success when both writes fulfill and the refresh also succeeds', () => {
+    const outcome = derivePresetOutcome([fulfilled(), fulfilled()], false);
+
+    expect(outcome.failed).toBe(false);
+    expect(outcome.text).toContain('applied');
+    expect(outcome.text).not.toContain('Reload');
+  });
+
+  it('tells the user to reload when both writes fulfill but the refresh fails', () => {
+    const outcome = derivePresetOutcome([fulfilled(), fulfilled()], true);
+
+    expect(outcome.failed).toBe(false);
+    expect(outcome.text).toContain('Reload');
+  });
+
+  it('reports a partial-save message when one write rejects, regardless of refresh outcome', () => {
+    const withRefreshOk = derivePresetOutcome([fulfilled(), rejected(new Error('boom'))], false);
+    const withRefreshFailed = derivePresetOutcome(
+      [fulfilled(), rejected(new Error('boom'))],
+      true,
+    );
+
+    for (const outcome of [withRefreshOk, withRefreshFailed]) {
+      expect(outcome.failed).toBe(true);
+      expect(outcome.text).toContain('only partly applied');
+      expect(outcome.text).toContain('boom');
+    }
+  });
+
+  it('reports full failure when both writes reject', () => {
+    const outcome = derivePresetOutcome(
+      [rejected(new Error('first')), rejected(new Error('second'))],
+      false,
+    );
+
+    expect(outcome.failed).toBe(true);
+    expect(outcome.text).toBe('first');
+  });
+
+  it('falls back to a generic message when the rejection carries no readable detail', () => {
+    const outcome = derivePresetOutcome([rejected(''), fulfilled()], false);
+
+    expect(outcome.failed).toBe(true);
+    expect(outcome.text).toContain('One preset save failed.');
+  });
+});

--- a/app/src/components/preferences/HealthRunYogaPresetSection.tsx
+++ b/app/src/components/preferences/HealthRunYogaPresetSection.tsx
@@ -2,16 +2,12 @@ import { useState } from 'react';
 import { preferencesService } from '../../services/preferencesService';
 import { trainingIntentProfileService } from '../../services/trainingIntentProfileService';
 import { getErrorMessage } from '../../utils/errors';
+import { derivePresetOutcome, type PresetMessage } from '../../utils/healthRunYogaPreset';
 
 interface HealthRunYogaPresetSectionProps {
   userId: string;
   onApplied: () => Promise<void>;
 }
-
-type PresetMessage = {
-  text: string;
-  failed: boolean;
-};
 
 export function HealthRunYogaPresetSection({ userId, onApplied }: HealthRunYogaPresetSectionProps) {
   const [saving, setSaving] = useState(false);
@@ -43,28 +39,19 @@ export function HealthRunYogaPresetSection({ userId, onApplied }: HealthRunYogaP
       ]);
 
       const fulfilledCount = results.filter((result) => result.status === 'fulfilled').length;
-      const rejected = results.find((result) => result.status === 'rejected');
 
+      // A refresh failure must not be reported as a preset-write failure: catch it
+      // separately so derivePresetOutcome still sees the real write outcome below.
+      let refreshFailed = false;
       if (fulfilledCount > 0) {
-        await onApplied();
+        try {
+          await onApplied();
+        } catch {
+          refreshFailed = true;
+        }
       }
 
-      if (rejected) {
-        const detail = getErrorMessage(rejected.reason) || 'One preset save failed.';
-        setMessage({
-          text:
-            fulfilledCount > 0
-              ? `The preset was only partly applied: ${detail} Reapply it to complete setup.`
-              : detail,
-          failed: true,
-        });
-        return;
-      }
-
-      setMessage({
-        text: 'Health + Running + Yoga preset applied. Review and save any further edits below.',
-        failed: false,
-      });
+      setMessage(derivePresetOutcome(results, refreshFailed));
     } catch (error: unknown) {
       setMessage({
         text: getErrorMessage(error) || 'Failed to apply preset.',

--- a/app/src/utils/healthRunYogaPreset.ts
+++ b/app/src/utils/healthRunYogaPreset.ts
@@ -1,0 +1,47 @@
+import { getErrorMessage } from './errors';
+
+export type PresetMessage = {
+  text: string;
+  failed: boolean;
+};
+
+/**
+ * Turn the two Health + Running + Yoga preset writes' settled results (plus whether the
+ * caller's post-apply refresh also failed) into the message shown to the user.
+ *
+ * A write failure always takes priority, since it is the thing the user must act on
+ * (reapply). A refresh failure only matters when both writes succeeded: it must not be
+ * reported as a preset failure -- the preset *did* apply -- and it must not silently
+ * overwrite the partial-save message either.
+ *
+ * Factored out of HealthRunYogaPresetSection so it's directly testable: this repo has no
+ * interactive component-test harness (no @testing-library/react), see
+ * GarminSyncNowButton.test.tsx / garminSyncStaleness.ts for the established pattern.
+ */
+export function derivePresetOutcome(
+  results: PromiseSettledResult<unknown>[],
+  refreshFailed: boolean,
+): PresetMessage {
+  const fulfilledCount = results.filter((result) => result.status === 'fulfilled').length;
+  const rejected = results.find(
+    (result): result is PromiseRejectedResult => result.status === 'rejected',
+  );
+
+  if (rejected) {
+    const detail = getErrorMessage(rejected.reason) || 'One preset save failed.';
+    return {
+      text:
+        fulfilledCount > 0
+          ? `The preset was only partly applied: ${detail} Reapply it to complete setup.`
+          : detail,
+      failed: true,
+    };
+  }
+
+  return {
+    text: refreshFailed
+      ? 'Health + Running + Yoga preset applied. Reload to see the latest settings.'
+      : 'Health + Running + Yoga preset applied. Review and save any further edits below.',
+    failed: false,
+  };
+}

--- a/src/garmin_sync/account_link.py
+++ b/src/garmin_sync/account_link.py
@@ -103,10 +103,16 @@ class GarminConnectionRepository:
         uid = data.get("userId")
         return str(uid) if uid else None
 
-    def assert_target_available(self, uid: str, identity_digest: str) -> None:
+    def assert_target_available(self, uid: str, identity_digest: str) -> str | None:
+        """Validate the target uid can accept this identity; return its current tokenObject.
+
+        The returned tokenObject (if any) is the previously-committed token path, so a
+        relink can stage its new upload separately and only remove this one after its own
+        commit succeeds.
+        """
         snapshot = self.db.collection("garminConnections").document(uid).get()
         if not snapshot.exists:
-            return
+            return None
         data = snapshot.to_dict() or {}
         existing_digest = data.get("identityDigest")
         if (
@@ -117,6 +123,8 @@ class GarminConnectionRepository:
             raise GarminLinkConflictError(
                 "This app account is already linked to a different Garmin account."
             )
+        token_object = data.get("tokenObject")
+        return str(token_object) if token_object else None
 
     def commit_link(
         self,
@@ -181,20 +189,37 @@ class GarminConnectionRepository:
 
         commit(transaction)
 
-    def list_active_user_ids(self) -> list[str]:
-        user_ids: list[str] = []
+    def list_active_connections(self) -> list[tuple[str, str | None]]:
+        """Return (uid, tokenObject) for every active Garmin connection.
+
+        tokenObject is whatever _finalize actually committed for that uid, not a
+        reconstructed canonical path, so scheduled sync always restores the token the
+        account-link transaction really wrote.
+        """
+        connections: list[tuple[str, str | None]] = []
+        seen: set[str] = set()
         for snapshot in self.db.collection("garminConnections").stream():
             data = snapshot.to_dict() or {}
             if data.get("status") != "active":
                 continue
             uid = data.get("userId") or snapshot.id
-            if uid and uid not in user_ids:
-                user_ids.append(str(uid))
-        return user_ids
+            if not uid or uid in seen:
+                continue
+            seen.add(uid)
+            token_object = data.get("tokenObject")
+            connections.append((str(uid), str(token_object) if token_object else None))
+        return connections
+
+    def list_active_user_ids(self) -> list[str]:
+        return [uid for uid, _ in self.list_active_connections()]
 
 
 def list_active_garmin_user_ids(db: Any = None) -> list[str]:
     return GarminConnectionRepository(db=db).list_active_user_ids()
+
+
+def list_active_garmin_connections(db: Any = None) -> list[tuple[str, str | None]]:
+    return GarminConnectionRepository(db=db).list_active_connections()
 
 
 def _garmin_identity(api: Garmin) -> tuple[str, str]:
@@ -343,8 +368,13 @@ class GarminAccountLinkService:
                 created_uid = target_uid
                 is_new_user = True
 
-            self.repository.assert_target_available(target_uid, identity_digest)
-            token_object = f"garmin/users/{target_uid}/garmin_tokens.json"
+            previous_token_object = self.repository.assert_target_available(
+                target_uid, identity_digest
+            )
+            # Stage every upload under a fresh, unique object name rather than the uid's
+            # canonical path: an active relink must never overwrite the token object that
+            # scheduled sync still reads until this new one is actually committed.
+            token_object = f"garmin/users/{target_uid}/garmin_tokens-{secrets.token_hex(8)}.json"
             if not GcsTokenStore(self.token_bucket, token_object).persist(token_path):
                 raise GarminLinkConfigurationError("Failed to persist Garmin session tokens.")
             uploaded_token_object = token_object
@@ -356,6 +386,11 @@ class GarminAccountLinkService:
                 token_object,
             )
             link_committed = True
+            if previous_token_object and previous_token_object != token_object:
+                # The new token is committed; the previous object is superseded and safe
+                # to remove. Scheduled sync restores whatever tokenObject Firestore has,
+                # so it never reads a path we're about to delete.
+                self._delete_token_object(previous_token_object)
             custom_token = firebase_auth.create_custom_token(target_uid)
             custom_token_text = (
                 custom_token.decode("utf-8")
@@ -392,6 +427,7 @@ __all__ = [
     "GarminLinkConfigurationError",
     "GarminLinkConflictError",
     "PendingLoginStore",
+    "list_active_garmin_connections",
     "list_active_garmin_user_ids",
     "GarminConnectAuthenticationError",
     "GarminConnectConnectionError",

--- a/src/garmin_sync/account_link.py
+++ b/src/garmin_sync/account_link.py
@@ -103,16 +103,16 @@ class GarminConnectionRepository:
         uid = data.get("userId")
         return str(uid) if uid else None
 
-    def assert_target_available(self, uid: str, identity_digest: str) -> str | None:
-        """Validate the target uid can accept this identity; return its current tokenObject.
+    def assert_target_available(self, uid: str, identity_digest: str) -> None:
+        """Fail fast if the target uid can't accept this identity, before uploading a token.
 
-        The returned tokenObject (if any) is the previously-committed token path, so a
-        relink can stage its new upload separately and only remove this one after its own
-        commit succeeds.
+        This is a pre-flight, non-transactional check only (so a doomed login doesn't pay
+        for an upload it can't use); commit_link() re-validates and is the actual guard,
+        since this read can be stale under concurrent relinks.
         """
         snapshot = self.db.collection("garminConnections").document(uid).get()
         if not snapshot.exists:
-            return None
+            return
         data = snapshot.to_dict() or {}
         existing_digest = data.get("identityDigest")
         if (
@@ -123,8 +123,6 @@ class GarminConnectionRepository:
             raise GarminLinkConflictError(
                 "This app account is already linked to a different Garmin account."
             )
-        token_object = data.get("tokenObject")
-        return str(token_object) if token_object else None
 
     def commit_link(
         self,
@@ -132,14 +130,22 @@ class GarminConnectionRepository:
         identity_digest: str,
         identity_kind: str,
         token_object: str,
-    ) -> None:
+    ) -> str | None:
+        """Commit the identity/connection mapping; return the tokenObject this replaced.
+
+        The previous tokenObject is read from inside this same transaction (not by a
+        separate pre-transaction call) so it's exactly the value this commit overwrites --
+        under concurrent relinks for the same account, Firestore's optimistic-concurrency
+        retry keeps that guarantee, so the caller can safely delete only that object and
+        never leak or race against a sibling transaction's own cleanup.
+        """
         identity_ref = self.db.collection("garminIdentities").document(identity_digest)
         connection_ref = self.db.collection("garminConnections").document(uid)
         transaction = self.db.transaction()
         server_timestamp = google_firestore.SERVER_TIMESTAMP
 
         @google_firestore.transactional
-        def commit(transaction_obj: Any) -> None:
+        def commit(transaction_obj: Any) -> str | None:
             identity_snapshot = identity_ref.get(transaction=transaction_obj)
             if identity_snapshot.exists:
                 identity_data = identity_snapshot.to_dict() or {}
@@ -150,6 +156,7 @@ class GarminConnectionRepository:
                     )
 
             connection_snapshot = connection_ref.get(transaction=transaction_obj)
+            previous_token_object: str | None = None
             if connection_snapshot.exists:
                 connection_data = connection_snapshot.to_dict() or {}
                 existing_digest = connection_data.get("identityDigest")
@@ -161,6 +168,10 @@ class GarminConnectionRepository:
                     raise GarminLinkConflictError(
                         "This app account is already linked to a different Garmin account."
                     )
+                existing_token_object = connection_data.get("tokenObject")
+                previous_token_object = (
+                    str(existing_token_object) if existing_token_object else None
+                )
 
             transaction_obj.set(
                 identity_ref,
@@ -186,8 +197,9 @@ class GarminConnectionRepository:
                 },
                 merge=True,
             )
+            return previous_token_object
 
-        commit(transaction)
+        return commit(transaction)
 
     def list_active_connections(self) -> list[tuple[str, str | None]]:
         """Return (uid, tokenObject) for every active Garmin connection.
@@ -368,9 +380,9 @@ class GarminAccountLinkService:
                 created_uid = target_uid
                 is_new_user = True
 
-            previous_token_object = self.repository.assert_target_available(
-                target_uid, identity_digest
-            )
+            # Pre-flight only (may be stale under concurrent relinks); commit_link() below
+            # re-validates transactionally and is the actual guard.
+            self.repository.assert_target_available(target_uid, identity_digest)
             # Stage every upload under a fresh, unique object name rather than the uid's
             # canonical path: an active relink must never overwrite the token object that
             # scheduled sync still reads until this new one is actually committed.
@@ -379,7 +391,11 @@ class GarminAccountLinkService:
                 raise GarminLinkConfigurationError("Failed to persist Garmin session tokens.")
             uploaded_token_object = token_object
 
-            self.repository.commit_link(
+            # previous_token_object is read from inside the same transaction that commits
+            # token_object, so it's exactly the value this commit overwrote -- safe to
+            # delete even under a concurrent relink for the same account (see
+            # commit_link()'s docstring).
+            previous_token_object = self.repository.commit_link(
                 target_uid,
                 identity_digest,
                 identity_kind,

--- a/src/garmin_sync/cli.py
+++ b/src/garmin_sync/cli.py
@@ -3,7 +3,7 @@ import logging
 import sys
 from collections.abc import Callable
 
-from .account_link import list_active_garmin_user_ids
+from .account_link import list_active_garmin_connections
 from .audit import format_report, run_audit
 from .config import load_settings, load_settings_for_user
 from .coordination import GarminExecutionLease
@@ -56,20 +56,20 @@ def _run_for_all_users(operation_name: str, operation: Callable[[GarminSyncServi
     Run/Scheduler records a partial failure.
     """
     try:
-        user_ids = list_active_garmin_user_ids()
+        connections = list_active_garmin_connections()
     except Exception as e:
         logger.error("%s linked-user discovery error: %s", operation_name, type(e).__name__)
         return 1
 
-    if not user_ids:
+    if not connections:
         logger.info("%s: no active Garmin links; nothing to do", operation_name)
         return 0
 
     failed_count = 0
-    for index, uid in enumerate(user_ids, start=1):
+    for index, (uid, token_object) in enumerate(connections, start=1):
         try:
-            logger.info("%s: starting linked user %d/%d", operation_name, index, len(user_ids))
-            settings = load_settings_for_user(uid)
+            logger.info("%s: starting linked user %d/%d", operation_name, index, len(connections))
+            settings = load_settings_for_user(uid, token_object=token_object)
             service = GarminSyncService(settings)
             if not _run_with_user_lease(operation_name, service, operation):
                 failed_count += 1
@@ -90,7 +90,7 @@ def _run_for_all_users(operation_name: str, operation: Callable[[GarminSyncServi
             "%s failed for %d/%d linked users",
             operation_name,
             failed_count,
-            len(user_ids),
+            len(connections),
         )
         return 1
     return 0

--- a/src/garmin_sync/config.py
+++ b/src/garmin_sync/config.py
@@ -151,12 +151,21 @@ def _scoped_for_user(settings: Settings) -> Settings:
     )
 
 
-def load_settings_for_user(user_id: str, env_file: str | None = None) -> Settings:
-    """Load token-only settings for one app user discovered from garminConnections."""
+def load_settings_for_user(
+    user_id: str, env_file: str | None = None, token_object: str | None = None
+) -> Settings:
+    """Load token-only settings for one app user discovered from garminConnections.
+
+    token_object, when given, is the tokenObject actually committed for this uid by the
+    account-link transaction and overrides the reconstructed canonical path -- a relink
+    may have staged its token under a different object name (see account_link._finalize).
+    """
     load_dotenv(dotenv_path=env_file)
     if not user_id or not user_id.strip():
         raise ValueError("Configuration error: linked Firebase user ID cannot be blank.")
     settings = _scoped_for_user(_load_base_settings(user_id))
+    if token_object:
+        settings = replace(settings, garmin_token_object=token_object)
     settings.validate()
     return settings
 

--- a/tests/test_account_link.py
+++ b/tests/test_account_link.py
@@ -225,8 +225,8 @@ def test_relink_commit_failure_preserves_active_token(
         def uid_for_identity(self, _identity_digest: str) -> None:
             return None
 
-        def assert_target_available(self, _uid: str, _identity_digest: str) -> str:
-            return "garmin/users/existing-uid/garmin_tokens-original.json"
+        def assert_target_available(self, _uid: str, _identity_digest: str) -> None:
+            return None
 
         def commit_link(
             self,
@@ -234,7 +234,10 @@ def test_relink_commit_failure_preserves_active_token(
             _identity_digest: str,
             _identity_kind: str,
             _token_object: str,
-        ) -> None:
+        ) -> str | None:
+            # A concurrent commit could have already replaced this uid's active token by
+            # the time this one is attempted; commit_link() itself still fails the link,
+            # so its (unused, since it raises) previous-token value never matters here.
             raise account_link_module.GarminLinkConflictError("conflicting link")
 
     class TokenStore:
@@ -282,14 +285,15 @@ def test_successful_relink_deletes_superseded_token(
     tmp_path: Path,
 ) -> None:
     """A successful relink commits the new staged token and only then removes the
-    now-superseded previous one."""
+    now-superseded previous one, using the value commit_link() itself just overwrote
+    (read atomically inside its transaction) rather than a pre-transaction snapshot."""
 
     class Repository:
         def uid_for_identity(self, _identity_digest: str) -> None:
             return None
 
-        def assert_target_available(self, _uid: str, _identity_digest: str) -> str:
-            return "garmin/users/existing-uid/garmin_tokens-original.json"
+        def assert_target_available(self, _uid: str, _identity_digest: str) -> None:
+            return None
 
         def commit_link(
             self,
@@ -297,8 +301,8 @@ def test_successful_relink_deletes_superseded_token(
             _identity_digest: str,
             _identity_kind: str,
             _token_object: str,
-        ) -> None:
-            return None
+        ) -> str | None:
+            return "garmin/users/existing-uid/garmin_tokens-original.json"
 
     class TokenStore:
         def __init__(self, _bucket: str, _object_name: str) -> None:
@@ -419,3 +423,78 @@ def test_custom_token_failure_after_commit_keeps_new_user_for_retry(
 
     assert repository.committed is True
     assert deleted_uids == []
+
+
+class _Snapshot:
+    def __init__(self, data: dict[str, Any] | None) -> None:
+        self._data = data
+        self.exists = data is not None
+
+    def to_dict(self) -> dict[str, Any] | None:
+        return dict(self._data) if self._data is not None else None
+
+
+class _Document:
+    def __init__(self, data: dict[str, Any] | None = None) -> None:
+        self.data = data
+
+    def get(self, transaction: Any = None) -> _Snapshot:
+        return _Snapshot(self.data)
+
+
+class _Collection:
+    def __init__(self) -> None:
+        self._documents: dict[str, _Document] = {}
+
+    def document(self, doc_id: str) -> _Document:
+        return self._documents.setdefault(doc_id, _Document())
+
+
+class _Transaction:
+    def set(self, doc_ref: _Document, payload: dict[str, Any], merge: bool = True) -> None:
+        assert merge is True
+        doc_ref.data = {**(doc_ref.data or {}), **payload}
+
+
+class _Db:
+    def __init__(self) -> None:
+        self._collections: dict[str, _Collection] = {}
+
+    def collection(self, name: str) -> _Collection:
+        return self._collections.setdefault(name, _Collection())
+
+    def transaction(self) -> _Transaction:
+        return _Transaction()
+
+
+def test_commit_link_returns_exactly_the_tokenObject_it_overwrote(monkeypatch: Any) -> None:
+    """Regression for a relink cleanup race: previous_token_object must come from inside
+    commit_link()'s own transaction, not a separate pre-transaction read, or a second
+    concurrent relink can delete a token a sibling commit just wrote instead of the one
+    it actually superseded -- leaking the sibling's staged object forever.
+
+    The fake transaction here runs the decorated body directly (no real retry machinery),
+    but that's enough: it proves each commit's returned "previous" value is read from
+    Firestore state at that exact commit, so sequential commits for the same uid chain
+    correctly regardless of how many callers are really racing.
+    """
+    monkeypatch.setattr(account_link_module.google_firestore, "transactional", lambda fn: fn)
+    db = _Db()
+    repository = account_link_module.GarminConnectionRepository(db=db)
+
+    first_previous = repository.commit_link(
+        "uid-1", "digest-1", "garmin_guid", "garmin/users/uid-1/garmin_tokens-aaa.json"
+    )
+    second_previous = repository.commit_link(
+        "uid-1", "digest-1", "garmin_guid", "garmin/users/uid-1/garmin_tokens-bbb.json"
+    )
+    third_previous = repository.commit_link(
+        "uid-1", "digest-1", "garmin_guid", "garmin/users/uid-1/garmin_tokens-ccc.json"
+    )
+
+    assert first_previous is None  # nothing committed yet for this uid
+    assert second_previous == "garmin/users/uid-1/garmin_tokens-aaa.json"
+    assert third_previous == "garmin/users/uid-1/garmin_tokens-bbb.json"
+    connection = db.collection("garminConnections").document("uid-1").data
+    assert connection is not None
+    assert connection["tokenObject"] == "garmin/users/uid-1/garmin_tokens-ccc.json"

--- a/tests/test_account_link.py
+++ b/tests/test_account_link.py
@@ -209,7 +209,137 @@ def test_link_commit_failure_removes_uploaded_token(
             "existing-uid",
         )
 
-    assert deleted_objects == ["garmin/users/existing-uid/garmin_tokens.json"]
+    assert len(deleted_objects) == 1
+    assert deleted_objects[0].startswith("garmin/users/existing-uid/garmin_tokens-")
+    assert deleted_objects[0].endswith(".json")
+
+
+def test_relink_commit_failure_preserves_active_token(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    """A failed relink must clean up only its own staged upload, never the active token
+    that scheduled sync still reads -- the two now live at different object names."""
+
+    class Repository:
+        def uid_for_identity(self, _identity_digest: str) -> None:
+            return None
+
+        def assert_target_available(self, _uid: str, _identity_digest: str) -> str:
+            return "garmin/users/existing-uid/garmin_tokens-original.json"
+
+        def commit_link(
+            self,
+            _uid: str,
+            _identity_digest: str,
+            _identity_kind: str,
+            _token_object: str,
+        ) -> None:
+            raise account_link_module.GarminLinkConflictError("conflicting link")
+
+    class TokenStore:
+        def __init__(self, _bucket: str, _object_name: str) -> None:
+            pass
+
+        def persist(self, _source: Path) -> bool:
+            return True
+
+    class FinalizableGarmin:
+        password = None
+
+        def connectapi(self, _path: str) -> dict[str, str]:
+            return {"garminGUID": "stable-guid"}
+
+    monkeypatch.setattr(account_link_module, "GcsTokenStore", TokenStore)
+    service = GarminAccountLinkService(
+        "bucket",
+        repository=Repository(),  # type: ignore[arg-type]
+    )
+    deleted_objects: list[str] = []
+    monkeypatch.setattr(service, "_delete_token_object", deleted_objects.append)
+
+    token_path = tmp_path / "tokens.json"
+    token_path.write_text("{}", encoding="utf-8")
+    temp_dir = tmp_path / "temporary"
+    temp_dir.mkdir()
+
+    with pytest.raises(account_link_module.GarminLinkConflictError, match="conflicting link"):
+        service._finalize(  # noqa: SLF001 - regression test for rollback boundary
+            FinalizableGarmin(),  # type: ignore[arg-type]
+            token_path,
+            temp_dir,
+            "existing-uid",
+        )
+
+    assert "garmin/users/existing-uid/garmin_tokens-original.json" not in deleted_objects
+    assert len(deleted_objects) == 1
+    assert deleted_objects[0].startswith("garmin/users/existing-uid/garmin_tokens-")
+    assert deleted_objects[0] != "garmin/users/existing-uid/garmin_tokens-original.json"
+
+
+def test_successful_relink_deletes_superseded_token(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    """A successful relink commits the new staged token and only then removes the
+    now-superseded previous one."""
+
+    class Repository:
+        def uid_for_identity(self, _identity_digest: str) -> None:
+            return None
+
+        def assert_target_available(self, _uid: str, _identity_digest: str) -> str:
+            return "garmin/users/existing-uid/garmin_tokens-original.json"
+
+        def commit_link(
+            self,
+            _uid: str,
+            _identity_digest: str,
+            _identity_kind: str,
+            _token_object: str,
+        ) -> None:
+            return None
+
+    class TokenStore:
+        def __init__(self, _bucket: str, _object_name: str) -> None:
+            pass
+
+        def persist(self, _source: Path) -> bool:
+            return True
+
+    class FinalizableGarmin:
+        password = None
+
+        def connectapi(self, _path: str) -> dict[str, str]:
+            return {"garminGUID": "stable-guid"}
+
+    monkeypatch.setattr(account_link_module, "GcsTokenStore", TokenStore)
+    monkeypatch.setattr(
+        account_link_module.firebase_auth,
+        "create_custom_token",
+        lambda _uid: b"token",
+    )
+    service = GarminAccountLinkService(
+        "bucket",
+        repository=Repository(),  # type: ignore[arg-type]
+    )
+    deleted_objects: list[str] = []
+    monkeypatch.setattr(service, "_delete_token_object", deleted_objects.append)
+
+    token_path = tmp_path / "tokens.json"
+    token_path.write_text("{}", encoding="utf-8")
+    temp_dir = tmp_path / "temporary"
+    temp_dir.mkdir()
+
+    result = service._finalize(  # noqa: SLF001 - regression test for rollback boundary
+        FinalizableGarmin(),  # type: ignore[arg-type]
+        token_path,
+        temp_dir,
+        "existing-uid",
+    )
+
+    assert result["status"] == "authenticated"
+    assert deleted_objects == ["garmin/users/existing-uid/garmin_tokens-original.json"]
 
 
 def test_custom_token_failure_after_commit_keeps_new_user_for_retry(

--- a/tests/test_multi_user_config.py
+++ b/tests/test_multi_user_config.py
@@ -82,6 +82,28 @@ def test_linked_user_settings_ignore_shared_token_path_overrides(
     assert settings.garmin_token_object == "garmin/users/linked-user/garmin_tokens.json"
 
 
+def test_linked_user_settings_use_committed_token_object_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GARMIN_TOKEN_STORE", "local")
+
+    settings = load_settings_for_user(
+        "linked-user", token_object="garmin/users/linked-user/garmin_tokens-abc123.json"
+    )
+
+    assert settings.garmin_token_object == "garmin/users/linked-user/garmin_tokens-abc123.json"
+
+
+def test_linked_user_settings_fall_back_to_canonical_object_without_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GARMIN_TOKEN_STORE", "local")
+
+    settings = load_settings_for_user("linked-user", token_object=None)
+
+    assert settings.garmin_token_object == "garmin/users/linked-user/garmin_tokens.json"
+
+
 def test_linked_user_settings_reject_default_uid(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("GARMIN_TOKEN_STORE", "local")
 


### PR DESCRIPTION
## Summary

Addresses the two review threads still unresolved on #180:

- **`src/garmin_sync/account_link.py`**: `_finalize()` overwrote the target uid's canonical token object (`garmin/users/{uid}/garmin_tokens.json`) *before* `commit_link()` ran. If the Firestore commit then failed on an active relink, rollback deleted that object — destroying the still-active token scheduled sync depended on, even though nothing about the link actually changed. Every upload is now staged under a fresh, unique object name; the previous token is only removed after its replacement successfully commits, and a failed commit only cleans up the newly staged (unused) object.
- Scheduled sync previously reconstructed the token's GCS path from a naming convention instead of reading what was actually committed. `GarminConnectionRepository` gains `list_active_connections()` (uid + committed `tokenObject`), `config.load_settings_for_user()` accepts an optional `token_object` override, and `cli.py`'s `_run_for_all_users()` passes the committed path through — so sync always restores the token the link transaction actually wrote.
- **`app/src/components/preferences/HealthRunYogaPresetSection.tsx`**: when both preset writes succeeded but the caller's post-apply `onApplied()` refresh failed, the refresh error fell into the outer `catch` and overwrote the real (success/partial-save) outcome with a generic "Failed to apply preset." message. The refresh is now caught separately; it only adds a "reload to see the latest settings" hint on top of the correct outcome. The outcome-selection logic is factored into `utils/healthRunYogaPreset.ts` (`derivePresetOutcome`) so it's directly unit-testable, per this repo's no-`@testing-library/react` convention.

No user-visible change for the common paths (new link, successful relink); this only changes rollback/restore behavior on failure paths.

## Validation

Results:
- `uv run pytest`: pass — all 240 tests, including 3 new regression tests in `tests/test_account_link.py` (relink commit-failure preserves the active token / doesn't touch it; successful relink removes the now-superseded one) and 2 in `tests/test_multi_user_config.py` (`token_object` override / fallback).
- `uv run ruff check .` and `uv run mypy src/garmin_sync`: pass.
- `cd app && npm run check` (typecheck + lint + vitest + workout catalog validation): pass — 0 errors, 2037 tests passed / 124 skipped, including a new `HealthRunYogaPresetSection.test.tsx` covering `derivePresetOutcome`'s write-success/write-failure/refresh-failure combinations.
- `cd app && npm run test:rules`: not applicable — no Firestore rules changes.
- `cd app && npm run simulate:scenarios`: not applicable — no recommendation-engine changes.
- `cd app && npm run visual:refresh`: not applicable — no visual/layout changes (message text only).

## Risk and reviewer guidance

Highest-risk area is `src/garmin_sync/account_link.py::_finalize` — it changes the token-object naming/cleanup contract for both new links and relinks. Reviewers should check: (1) a failed relink commit never deletes the pre-existing active token, (2) a successful relink does delete the now-superseded previous token (no orphaned objects piling up), (3) `cli.py`'s `_run_for_all_users` correctly resolves each uid's actual committed `tokenObject` rather than falling back to the canonical guess. Low risk elsewhere: the frontend change is message/state-handling only, no new writes or layout changes.

## Domain invariants

- [x] Firestore writes remain user-scoped under `users/{APP_USER_ID}/...`; no `default_user` or top-level recovery snapshots were introduced. Not touched by this change.
- [x] Calendar-date logic uses `Europe/Warsaw`; completed `totalSteps` still means the previous calendar day (`D - 1`). Not touched by this change.
- [x] No credentials, tokens, service-account files, or raw health payloads are included.
- [ ] Recommendation decision logic changed: not applicable — no engine/policy changes.

## Screenshots or recordings

Not applicable — no layout or visual change; the frontend fix only changes which status message text is shown after a refresh failure.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GhSK4rwmstZDnBBqdPYKzN)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Garmin relinking to preserve the active connection if the update fails.
  - Completed relinks now clean up outdated connection data safely.
  - Garmin connection discovery and synchronization now use the correct connection details.
  - Health, running, and yoga preset results now distinguish save failures from refresh failures and provide clearer messages.

- **Tests**
  - Added coverage for preset outcomes, Garmin relinking, and connection configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->