### PR TITLE
fix(ops): grant frontend deployer read access to garmin-account-link

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -8,8 +8,10 @@ name: Deploy Frontend & Firestore Rules
 # secret this workflow reads below.
 #
 # Deliberately a SEPARATE identity from garmin-sync's github-deployer: github-frontend-deployer
-# holds only roles/firebasehosting.admin and roles/firebaserules.admin, nothing about Cloud
-# Run, Artifact Registry, or Cloud Scheduler, and vice versa -- see docs/ops/frontend-deployment.md.
+# holds only roles/firebasehosting.admin and roles/firebaserules.admin at the project level,
+# plus roles/run.viewer scoped to just the garmin-account-link Cloud Run service (Hosting
+# needs that to validate firebase.json's rewrite to it) -- nothing about Artifact Registry or
+# Cloud Scheduler, and vice versa -- see docs/ops/frontend-deployment.md.
 #
 # Firestore indexes are deliberately out of scope here too, same as the local
 # `npm run firestore:rules:deploy` procedure this mirrors (docs/ops/firestore-rules-deployment.md)

--- a/docs/ops/frontend-deployment.md
+++ b/docs/ops/frontend-deployment.md
@@ -21,10 +21,17 @@ here) are two different service accounts, both provisioned by the same one-time
 `docs/ops/setup-workload-identity.sh`, both trusting the same Workload Identity Pool/Provider
 (restricted to this repo's `main` branch -- a run from any other branch or a fork can't
 authenticate as either at all). `github-frontend-deployer` only ever holds
-`roles/firebasehosting.admin` and `roles/firebaserules.admin` -- nothing about Cloud Run,
-Artifact Registry, Cloud Scheduler, or general Firestore data/index access. A workflow file
-compromised or added later in this repo therefore can't use it to reach garmin-sync's
+`roles/firebasehosting.admin` and `roles/firebaserules.admin` at the project level -- nothing
+about Artifact Registry, Cloud Scheduler, or general Firestore data/index access. A workflow
+file compromised or added later in this repo therefore can't use it to reach garmin-sync's
 infrastructure, or vice versa: each identity can only touch the one surface it's scoped to.
+
+The one narrow exception: `app/firebase.json` rewrites `/api/garmin/**` to the
+`garmin-account-link` Cloud Run service, and Firebase Hosting needs `run.services.get` on that
+service to validate the rewrite when finalizing a deploy. `setup-workload-identity.sh` grants
+`github-frontend-deployer` `roles/run.viewer` scoped to that single Cloud Run service (a
+resource-level IAM binding, not a project-level one) -- it still can't see or touch any other
+Cloud Run service.
 
 ## One-time setup
 
@@ -37,6 +44,11 @@ export GCP_PROJECT=adaptive-training-recommender   # your Firebase/GCP project i
 export GITHUB_REPO=OWNER/REPO                       # e.g. Szczepanov/adaptive-training-recommender
 bash docs/ops/setup-workload-identity.sh
 ```
+
+The `garmin-account-link` Cloud Run service binding above only applies if that service has
+already been deployed (run **Deploy Garmin Sync** first). If it hasn't, the script prints a
+`NOTE:` and skips that one binding -- rerun the script (idempotent) after deploying Garmin
+Sync so `github-frontend-deployer` gets the read access it needs.
 
 Add the printed `GCP_FRONTEND_DEPLOYER_SA_EMAIL` as a repo secret (alongside
 `GCP_PROJECT_ID` and `GCP_WORKLOAD_IDENTITY_PROVIDER`, already added if you set up

--- a/docs/ops/setup-workload-identity.sh
+++ b/docs/ops/setup-workload-identity.sh
@@ -166,6 +166,22 @@ for ROLE in \
     --condition=None >/dev/null
 done
 
+# app/firebase.json rewrites /api/garmin/** to the garmin-account-link Cloud Run service.
+# Finalizing a Hosting version that references it calls run.services.get on that service, so
+# github-frontend-deployer needs read access there -- but only there. Bind roles/run.viewer on
+# the single Cloud Run service (not the project) so this identity still can't see or touch any
+# other Cloud Run service, preserving the isolation from github-deployer described above.
+if gcloud run services describe garmin-account-link --region="${REGION}" >/dev/null 2>&1; then
+  gcloud run services add-iam-policy-binding garmin-account-link \
+    --region="${REGION}" \
+    --member="serviceAccount:${FRONTEND_DEPLOYER_SA_EMAIL}" \
+    --role="roles/run.viewer" >/dev/null
+else
+  echo "NOTE: garmin-account-link Cloud Run service not found in ${REGION} yet -- run" >&2
+  echo "      'Deploy Garmin Sync' first, then rerun this script to grant" >&2
+  echo "      github-frontend-deployer read access to it (required for Hosting deploys)." >&2
+fi
+
 gcloud iam service-accounts add-iam-policy-binding "${FRONTEND_DEPLOYER_SA_EMAIL}" \
   --role="roles/iam.workloadIdentityUser" \
   --member="principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL_ID}/attribute.repository/${GITHUB_REPO}"


### PR DESCRIPTION
## Summary

- `Deploy Frontend & Firestore Rules` (run [32568180636](https://github.com/Szczepanov/adaptive-training-recommender/actions/runs/32568180636)) fails at `firebase deploy --only hosting` with `HTTP Error: 403, Permission 'run.services.get' denied on resource 'namespaces/***/services/garmin-account-link'`.
- Root cause: `app/firebase.json` now rewrites `/api/garmin/**` to the `garmin-account-link` Cloud Run service (added by the self-service Garmin accounts feature). Firebase Hosting calls `run.services.get` on that service to validate the rewrite when finalizing a version, but `github-frontend-deployer` was deliberately scoped to hold nothing Cloud-Run-related.
- Fix: `docs/ops/setup-workload-identity.sh` now grants `github-frontend-deployer` `roles/run.viewer` scoped to just the single `garmin-account-link` Cloud Run service (a resource-level IAM binding, not project-level), so it can validate the rewrite without gaining visibility into any other Cloud Run service. Updated `docs/ops/frontend-deployment.md` and the inline comment in `deploy-frontend.yml` to describe this narrow exception.
- Operational impact: this is a no-op until the repo owner reruns `docs/ops/setup-workload-identity.sh` against the real GCP project (the script is idempotent and already prints a `NOTE:` if `garmin-account-link` hasn't been deployed yet — deploy Garmin Sync first, then rerun).

## Validation

- [x] `bash -n docs/ops/setup-workload-identity.sh`: pass (syntax only — this script isn't exercised by CI and requires real `gcloud`/GCP credentials to run for real)
- [ ] `cd app && npm run check` — not applicable, no `app/` code changed
- [ ] `uv run pytest` — not applicable, no Python code changed

## Risk and reviewer guidance

- Low risk: the only executable change is a new, idempotent, resource-scoped IAM binding gated behind an existence check on the target Cloud Run service; nothing project-wide is granted and no existing bindings are touched.
- Reviewers should confirm `roles/run.viewer` (not something broader) is the right predefined role for `run.services.get`, and that scoping it to the single service via `gcloud run services add-iam-policy-binding` (rather than `gcloud projects add-iam-policy-binding`) is the intended way to preserve the isolation this repo documents between `github-deployer` and `github-frontend-deployer`.
- This change has no effect until someone with GCP IAM admin rights reruns `docs/ops/setup-workload-identity.sh`.

## Domain invariants

Not applicable — ops/IAM setup script and documentation change only; no Firestore writes, date logic, or recommendation-engine code touched.

## Screenshots or recordings

Not applicable — no UI change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SLDrDL3PGbASaxfFYD2e24)_