### PR TITLE
ci: add end-to-end production deployment pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: [ main ]
   workflow_call:
+    secrets:
+      # Optional: push/pull_request triggers already see the repo's full secret set directly,
+      # so this only matters for a workflow_call caller (deploy-production.yml), which must
+      # pass it explicitly instead of `secrets: inherit`. Frontend-build's own env fixes every
+      # other Firebase value to a build/test-only placeholder, so only the API key is real.
+      VITE_FIREBASE_API_KEY:
+        required: false
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,16 @@ jobs:
         run: npm run validate:workouts
 
       - name: Check engine policy version drift
-        run: node scripts/check-policy-drift.mjs ${{ github.event.pull_request.base.sha || github.event.before }}
+        shell: bash
+        run: |
+          BASE_SHA="${{ github.event.pull_request.base.sha || github.event.before }}"
+          # workflow_call inherits the caller event. A production workflow_dispatch has
+          # neither pull_request.base.sha nor push.before, so compare the release commit to
+          # its first parent instead of silently skipping the policy-version gate.
+          if [ -z "${BASE_SHA}" ] || [ "${BASE_SHA}" = "0000000000000000000000000000000000000000" ]; then
+            BASE_SHA="$(git rev-parse HEAD^)"
+          fi
+          node scripts/check-policy-drift.mjs "${BASE_SHA}"
 
       - name: Run frontend test suite
         run: npm test

--- a/.github/workflows/deploy-firestore-indexes.yml
+++ b/.github/workflows/deploy-firestore-indexes.yml
@@ -18,8 +18,17 @@ permissions:
   contents: read
   id-token: write
 
+# A standalone workflow_dispatch run joins the SAME group deploy-production.yml holds for a
+# whole release, so it queues behind an in-flight end-to-end release instead of deploying a
+# different SHA mid-release. A workflow_call invocation (i.e. from deploy-production.yml
+# itself) uses this workflow's own isolated group instead: that caller already holds the
+# production-wide group for the run's whole duration, so requesting it again here would queue
+# this job behind the very run it's part of and deadlock.
 concurrency:
-  group: deploy-firestore-indexes-${{ github.repository }}
+  group: >-
+    ${{ github.event_name == 'workflow_call'
+      && format('deploy-firestore-indexes-{0}', github.repository)
+      || format('deploy-production-{0}', github.repository) }}
   cancel-in-progress: false
 
 env:

--- a/.github/workflows/deploy-firestore-indexes.yml
+++ b/.github/workflows/deploy-firestore-indexes.yml
@@ -1,0 +1,94 @@
+name: Deploy Firestore Indexes
+
+# Firestore index construction is asynchronous. Keep indexes as a separate deployment unit
+# from rules/Hosting so the production E2E release can wait until every composite index is
+# READY before exposing a frontend that may depend on it.
+on:
+  workflow_dispatch:
+  workflow_call:
+    secrets:
+      GCP_PROJECT_ID:
+        required: true
+      GCP_WORKLOAD_IDENTITY_PROVIDER:
+        required: true
+      GCP_FRONTEND_DEPLOYER_SA_EMAIL:
+        required: true
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: deploy-firestore-indexes-${{ github.repository }}
+  cancel-in-progress: false
+
+env:
+  GCP_PROJECT: ${{ secrets.GCP_PROJECT_ID }}
+  CLOUDSDK_CORE_PROJECT: ${{ secrets.GCP_PROJECT_ID }}
+
+jobs:
+  deploy:
+    name: Deploy and wait for indexes
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: app
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Authenticate to GCP (Workload Identity Federation, no key)
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_FRONTEND_DEPLOYER_SA_EMAIL }}
+
+      - uses: google-github-actions/setup-gcloud@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: app/package-lock.json
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      # Deliberately do not pass --force. The pipeline may add/update repository-owned indexes,
+      # but it must not silently delete a production index that exists outside the file. Such a
+      # cleanup remains an explicit operator action after reviewing the difference.
+      - name: Deploy Firestore indexes
+        run: |
+          npm exec --no -- firebase deploy --only firestore:indexes \
+            --project "${GCP_PROJECT}" --non-interactive
+
+      # firebase deploy returns after index creation has been requested, not necessarily after
+      # the indexes are usable. Block the client rollout until all composite indexes settle.
+      - name: Wait for composite indexes to become ready
+        run: |
+          DEADLINE=$((SECONDS + 1200))
+          while true; do
+            STATES="$(gcloud firestore indexes composite list \
+              --database='(default)' --format='value(state)')"
+
+            if grep -qx 'NEEDS_REPAIR' <<<"${STATES}"; then
+              echo "At least one Firestore composite index is in NEEDS_REPAIR." >&2
+              gcloud firestore indexes composite list --database='(default)'
+              exit 1
+            fi
+
+            if ! grep -qx 'CREATING' <<<"${STATES}"; then
+              echo "All Firestore composite indexes are READY."
+              break
+            fi
+
+            if (( SECONDS >= DEADLINE )); then
+              echo "Timed out waiting for Firestore composite indexes to become READY." >&2
+              gcloud firestore indexes composite list --database='(default)'
+              exit 1
+            fi
+
+            sleep 10
+          done

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -85,8 +85,19 @@ permissions:
 # A second manual run started before the first finishes could both pass the Firestore drift
 # check, then race to deploy -- the later one silently wins and clobbers the earlier release.
 # Queue instead of running concurrently; never cancel a deploy that's already underway.
+#
+# A standalone workflow_dispatch run joins the SAME group deploy-production.yml holds for a
+# whole release, so it queues behind an in-flight end-to-end release instead of deploying a
+# different SHA mid-release. A workflow_call invocation (i.e. from deploy-production.yml
+# itself, for both the rules and hosting stages) uses this workflow's own isolated group
+# instead: that caller already holds the production-wide group for the run's whole duration,
+# so requesting it again here would queue this job behind the very run it's part of and
+# deadlock.
 concurrency:
-  group: deploy-frontend-${{ github.repository }}
+  group: >-
+    ${{ github.event_name == 'workflow_call'
+      && format('deploy-frontend-{0}', github.repository)
+      || format('deploy-production-{0}', github.repository) }}
   cancel-in-progress: false
 
 env:
@@ -140,6 +151,34 @@ jobs:
 
       - name: Install Node dependencies
         run: npm ci
+
+      # The project-ID check below only catches a Firebase project mismatch. It says nothing
+      # about the other values app/src/firebase.ts reads -- a missing API key, auth domain, or
+      # app ID still produces a successful static build whose Firebase client silently fails at
+      # runtime, and neither the Hosting nor the rewrite smoke check below would catch that
+      # (they only exercise static assets and the Cloud Run rewrite, not Firebase client init).
+      - name: Validate Firebase build configuration is complete
+        if: ${{ inputs.deploy_hosting }}
+        env:
+          VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY }}
+          VITE_FIREBASE_AUTH_DOMAIN: ${{ secrets.VITE_FIREBASE_AUTH_DOMAIN }}
+          VITE_FIREBASE_STORAGE_BUCKET: ${{ secrets.VITE_FIREBASE_STORAGE_BUCKET }}
+          VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
+          VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
+          VITE_FIREBASE_MEASUREMENT_ID: ${{ secrets.VITE_FIREBASE_MEASUREMENT_ID }}
+        run: |
+          missing=""
+          for var in VITE_FIREBASE_API_KEY VITE_FIREBASE_AUTH_DOMAIN VITE_FIREBASE_STORAGE_BUCKET \
+                     VITE_FIREBASE_MESSAGING_SENDER_ID VITE_FIREBASE_APP_ID VITE_FIREBASE_MEASUREMENT_ID; do
+            if [ -z "${!var}" ]; then
+              missing="${missing} ${var}"
+            fi
+          done
+          if [ -n "${missing}" ]; then
+            echo "Missing required Firebase build configuration:${missing}" >&2
+            echo "app/src/firebase.ts needs all of these set to produce a working runtime Firebase config -- refusing to build." >&2
+            exit 1
+          fi
 
       # Firebase project ID and GCP project ID are the same string for this project (see
       # docs/ops/cloud-run-deployment.md), but they're two independently-set secrets --

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -8,9 +8,10 @@ name: Deploy Frontend & Firestore Rules
 # secret this workflow reads below.
 #
 # Deliberately a SEPARATE identity from garmin-sync's github-deployer: github-frontend-deployer
-# holds only Firebase Hosting/Rules plus the dedicated Firestore index role used by the
-# separate deploy-firestore-indexes.yml workflow; it has nothing about Cloud Run, Artifact
-# Registry, or Cloud Scheduler -- see docs/ops/frontend-deployment.md.
+# holds Firebase Hosting/Rules plus the dedicated Firestore index role used by the separate
+# deploy-firestore-indexes.yml workflow, and roles/run.viewer scoped only to the
+# garmin-account-link service so Hosting can validate its rewrite. It has nothing about
+# Artifact Registry or Cloud Scheduler -- see docs/ops/frontend-deployment.md.
 #
 # Firestore indexes remain a separate deployment unit because index construction is
 # asynchronous and needs its own readiness gate. The production E2E workflow calls that unit

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -57,18 +57,21 @@ on:
         required: true
       GCP_FRONTEND_DEPLOYER_SA_EMAIL:
         required: true
+      # Build-time Firebase values are optional at the reusable-workflow boundary so a
+      # rules-only call does not depend on unrelated Hosting configuration. Hosting calls
+      # still fail safely if their required build values are absent or point at another project.
       VITE_FIREBASE_API_KEY:
-        required: true
+        required: false
       VITE_FIREBASE_AUTH_DOMAIN:
-        required: true
+        required: false
       VITE_FIREBASE_PROJECT_ID:
-        required: true
+        required: false
       VITE_FIREBASE_STORAGE_BUCKET:
-        required: true
+        required: false
       VITE_FIREBASE_MESSAGING_SENDER_ID:
-        required: true
+        required: false
       VITE_FIREBASE_APP_ID:
-        required: true
+        required: false
       VITE_FIREBASE_MEASUREMENT_ID:
         required: false
       VITE_HEALTH_ANOMALY_POLICY:

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -8,12 +8,13 @@ name: Deploy Frontend & Firestore Rules
 # secret this workflow reads below.
 #
 # Deliberately a SEPARATE identity from garmin-sync's github-deployer: github-frontend-deployer
-# holds only roles/firebasehosting.admin and roles/firebaserules.admin, nothing about Cloud
-# Run, Artifact Registry, or Cloud Scheduler, and vice versa -- see docs/ops/frontend-deployment.md.
+# holds only Firebase Hosting/Rules plus the dedicated Firestore index role used by the
+# separate deploy-firestore-indexes.yml workflow; it has nothing about Cloud Run, Artifact
+# Registry, or Cloud Scheduler -- see docs/ops/frontend-deployment.md.
 #
-# Firestore indexes are deliberately out of scope here too, same as the local
-# `npm run firestore:rules:deploy` procedure this mirrors (docs/ops/firestore-rules-deployment.md)
-# -- use `make deploy-indexes` locally for those.
+# Firestore indexes remain a separate deployment unit because index construction is
+# asynchronous and needs its own readiness gate. The production E2E workflow calls that unit
+# before this workflow's rules/hosting stages.
 on:
   workflow_dispatch:
     inputs:
@@ -32,6 +33,46 @@ on:
         type: boolean
         required: true
         default: false
+  workflow_call:
+    inputs:
+      deploy_hosting:
+        description: "Build and deploy the web app to Firebase Hosting"
+        type: boolean
+        required: false
+        default: true
+      deploy_rules:
+        description: "Deploy app/firestore.rules"
+        type: boolean
+        required: false
+        default: true
+      confirm_rules_drift:
+        description: "Reviewed Firestore rules drift may be replaced with the repository version"
+        type: boolean
+        required: false
+        default: false
+    secrets:
+      GCP_PROJECT_ID:
+        required: true
+      GCP_WORKLOAD_IDENTITY_PROVIDER:
+        required: true
+      GCP_FRONTEND_DEPLOYER_SA_EMAIL:
+        required: true
+      VITE_FIREBASE_API_KEY:
+        required: true
+      VITE_FIREBASE_AUTH_DOMAIN:
+        required: true
+      VITE_FIREBASE_PROJECT_ID:
+        required: true
+      VITE_FIREBASE_STORAGE_BUCKET:
+        required: true
+      VITE_FIREBASE_MESSAGING_SENDER_ID:
+        required: true
+      VITE_FIREBASE_APP_ID:
+        required: true
+      VITE_FIREBASE_MEASUREMENT_ID:
+        required: false
+      VITE_HEALTH_ANOMALY_POLICY:
+        required: false
 
 permissions:
   contents: read
@@ -138,6 +179,28 @@ jobs:
       - name: Deploy to Firebase Hosting
         if: ${{ inputs.deploy_hosting }}
         run: npm exec --no -- firebase deploy --only hosting --project "${GCP_PROJECT}" --non-interactive
+
+      - name: Smoke test Firebase Hosting
+        if: ${{ inputs.deploy_hosting }}
+        run: |
+          curl --fail --silent --show-error --retry 5 --retry-delay 3 --retry-all-errors \
+            "https://${GCP_PROJECT}.web.app/" >/dev/null
+
+      # GET /api/garmin/login is intentionally unsupported by the account-link service. A
+      # backend-shaped 404 therefore proves the Hosting rewrite reached Cloud Run without
+      # submitting credentials or consuming a login-rate-limit attempt.
+      - name: Smoke test Hosting to Garmin API rewrite
+        if: ${{ inputs.deploy_hosting }}
+        run: |
+          BODY_FILE="$(mktemp)"
+          STATUS="$(curl --silent --show-error --retry 5 --retry-delay 3 --retry-all-errors \
+            --output "${BODY_FILE}" --write-out '%{http_code}' \
+            "https://${GCP_PROJECT}.web.app/api/garmin/login")"
+          if [ "${STATUS}" != "404" ] || ! grep -q '"error":"not_found"' "${BODY_FILE}"; then
+            echo "Expected Cloud Run JSON 404 through Firebase Hosting rewrite; got HTTP ${STATUS}." >&2
+            cat "${BODY_FILE}" >&2
+            exit 1
+          fi
 
       # Default path remains fail-closed: unexpected drift stops the run before any rules
       # deployment. This is the safe choice for ordinary frontend/rules deploys.

--- a/.github/workflows/deploy-garmin-sync.yml
+++ b/.github/workflows/deploy-garmin-sync.yml
@@ -16,10 +16,35 @@ on:
         type: boolean
         required: true
         default: false
+  workflow_call:
+    inputs:
+      region:
+        description: "GCP region"
+        type: string
+        required: false
+        default: "europe-central2"
+      run_smoke_test:
+        description: "Execute the garmin-sync Job once and wait, after deploying"
+        type: boolean
+        required: false
+        default: false
+    secrets:
+      GCP_PROJECT_ID:
+        required: true
+      GCP_WORKLOAD_IDENTITY_PROVIDER:
+        required: true
+      GCP_DEPLOYER_SA_EMAIL:
+        required: true
 
 permissions:
   contents: read
   id-token: write
+
+# Serialise both standalone deploys and calls from the end-to-end production release. A
+# second image/scheduler rollout must never overtake an in-flight rollout of another SHA.
+concurrency:
+  group: deploy-garmin-sync-${{ github.repository }}
+  cancel-in-progress: false
 
 env:
   GCP_PROJECT: ${{ secrets.GCP_PROJECT_ID }}
@@ -144,6 +169,19 @@ jobs:
             --schedule="*/3 * * * *" --time-zone="Europe/Warsaw" \
             --uri="https://run.googleapis.com/v2/projects/${GCP_PROJECT}/locations/${REGION}/jobs/garmin-manual-sync:run" \
             --http-method=POST --oauth-service-account-email="${SCHEDULER_SA_EMAIL}"
+
+      # This is credential-free and safe on every deploy. It catches a container that pushed
+      # successfully but cannot actually start under the Cloud Run runtime configuration.
+      - name: Smoke test account-link service health
+        run: |
+          SERVICE_URL="$(gcloud run services describe garmin-account-link \
+            --region="${REGION}" --format='value(status.url)')"
+          if [ -z "${SERVICE_URL}" ]; then
+            echo "Cloud Run did not return a URL for garmin-account-link." >&2
+            exit 1
+          fi
+          curl --fail --silent --show-error --retry 5 --retry-delay 3 --retry-all-errors \
+            "${SERVICE_URL}/health"
 
       - name: Smoke test garmin-sync
         if: inputs.run_smoke_test

--- a/.github/workflows/deploy-garmin-sync.yml
+++ b/.github/workflows/deploy-garmin-sync.yml
@@ -42,8 +42,18 @@ permissions:
 
 # Serialise both standalone deploys and calls from the end-to-end production release. A
 # second image/scheduler rollout must never overtake an in-flight rollout of another SHA.
+#
+# A standalone workflow_dispatch run joins the SAME group deploy-production.yml holds for a
+# whole release, so it queues behind an in-flight end-to-end release instead of deploying a
+# different SHA mid-release. A workflow_call invocation (i.e. from deploy-production.yml
+# itself) uses this workflow's own isolated group instead: that caller already holds the
+# production-wide group for the run's whole duration, so requesting it again here would queue
+# this job behind the very run it's part of and deadlock.
 concurrency:
-  group: deploy-garmin-sync-${{ github.repository }}
+  group: >-
+    ${{ github.event_name == 'workflow_call'
+      && format('deploy-garmin-sync-{0}', github.repository)
+      || format('deploy-production-{0}', github.repository) }}
   cancel-in-progress: false
 
 env:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -25,14 +25,19 @@ on:
         required: true
         default: false
 
-# Called deployment workflows cannot elevate permissions above their caller. Keep the release
-# capable of WIF while each reusable workflow still narrows its own permissions explicitly.
+# Called deployment workflows cannot elevate permissions above their caller. id-token: write is
+# only granted per-job below, to the four deployment callers that actually need WIF -- not at
+# workflow scope, which would also hand it to preflight and release-summary.
 permissions:
   contents: read
-  id-token: write
 
 # Queue whole releases. Component workflows have their own concurrency groups as a second
-# line of defence against someone starting a standalone component deployment at the same time.
+# line of defence against someone starting a standalone component deployment at the same time --
+# but a standalone dispatch of a component workflow also joins this same production-wide group
+# (see each component workflow's own concurrency block), so it queues behind an in-flight
+# end-to-end release instead of racing it onto a different SHA. Never copy this group into a
+# reusable workflow's own workflow_call path: this caller run already holds it for the whole
+# release, so a called job requesting the same group would queue behind itself and deadlock.
 concurrency:
   group: deploy-production-${{ github.repository }}
   cancel-in-progress: false
@@ -54,42 +59,75 @@ jobs:
     name: Full CI release gate
     needs: preflight
     uses: ./.github/workflows/ci.yml
-    secrets: inherit
+    secrets:
+      VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY }}
 
   deploy-garmin:
     name: Deploy Garmin backend
     needs: validate
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/deploy-garmin-sync.yml
     with:
       region: ${{ inputs.region }}
       run_smoke_test: ${{ inputs.run_garmin_sync_smoke_test }}
-    secrets: inherit
+    secrets:
+      GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      GCP_DEPLOYER_SA_EMAIL: ${{ secrets.GCP_DEPLOYER_SA_EMAIL }}
 
   deploy-indexes:
     name: Deploy Firestore indexes
     needs: deploy-garmin
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/deploy-firestore-indexes.yml
-    secrets: inherit
+    secrets:
+      GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      GCP_FRONTEND_DEPLOYER_SA_EMAIL: ${{ secrets.GCP_FRONTEND_DEPLOYER_SA_EMAIL }}
 
   deploy-rules:
     name: Deploy Firestore rules
     needs: deploy-indexes
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/deploy-frontend.yml
     with:
       deploy_hosting: false
       deploy_rules: true
       confirm_rules_drift: ${{ inputs.confirm_rules_drift }}
-    secrets: inherit
+    secrets:
+      GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      GCP_FRONTEND_DEPLOYER_SA_EMAIL: ${{ secrets.GCP_FRONTEND_DEPLOYER_SA_EMAIL }}
 
   deploy-hosting:
     name: Deploy frontend last
     needs: deploy-rules
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/deploy-frontend.yml
     with:
       deploy_hosting: true
       deploy_rules: false
       confirm_rules_drift: false
-    secrets: inherit
+    secrets:
+      GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      GCP_FRONTEND_DEPLOYER_SA_EMAIL: ${{ secrets.GCP_FRONTEND_DEPLOYER_SA_EMAIL }}
+      VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY }}
+      VITE_FIREBASE_AUTH_DOMAIN: ${{ secrets.VITE_FIREBASE_AUTH_DOMAIN }}
+      VITE_FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}
+      VITE_FIREBASE_STORAGE_BUCKET: ${{ secrets.VITE_FIREBASE_STORAGE_BUCKET }}
+      VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
+      VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
+      VITE_FIREBASE_MEASUREMENT_ID: ${{ secrets.VITE_FIREBASE_MEASUREMENT_ID }}
+      VITE_HEALTH_ANOMALY_POLICY: ${{ secrets.VITE_HEALTH_ANOMALY_POLICY }}
 
   release-summary:
     name: Release summary
@@ -97,12 +135,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Record promoted revision
+        env:
+          # inputs.region is dispatcher-controlled. Pass it through env and print the
+          # variable rather than interpolating the expression into the run script directly --
+          # a `${{ }}` expansion inside `run:` is substituted into the shell source verbatim
+          # before the shell ever runs it, so a region value like `$(...)` would execute as a
+          # command in this job, which inherits id-token: write.
+          RELEASE_REGION: ${{ inputs.region }}
         run: |
           {
             echo "## Production release complete"
             echo
             echo "- Commit: \`${GITHUB_SHA}\`"
-            echo "- Region: \`${{ inputs.region }}\`"
+            printf '%s\n' "- Region: \`${RELEASE_REGION}\`"
             echo "- Garmin backend, Firestore indexes/rules, and Firebase Hosting all completed."
             echo "- Hosting smoke checks verified the site and the Hosting -> Cloud Run API rewrite."
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,108 @@
+name: Deploy Production E2E
+
+# One production release = one Git SHA, validated once and promoted in dependency order:
+#   CI -> Garmin backend/jobs/schedulers -> Firestore indexes -> Firestore rules -> Hosting.
+#
+# This intentionally remains workflow_dispatch rather than deploying every main push. Rules
+# drift is a production safety gate that sometimes requires an explicit human acknowledgement;
+# a partially reviewed rules change must never become an unattended release side effect.
+on:
+  workflow_dispatch:
+    inputs:
+      region:
+        description: "GCP region for Garmin Cloud Run/Scheduler resources"
+        type: string
+        required: true
+        default: "europe-central2"
+      confirm_rules_drift:
+        description: "I reviewed Firestore rules drift and intend to replace production with the repo version"
+        type: boolean
+        required: true
+        default: false
+      run_garmin_sync_smoke_test:
+        description: "Also execute the live garmin-sync job once after backend deployment"
+        type: boolean
+        required: true
+        default: false
+
+# Called deployment workflows cannot elevate permissions above their caller. Keep the release
+# capable of WIF while each reusable workflow still narrows its own permissions explicitly.
+permissions:
+  contents: read
+  id-token: write
+
+# Queue whole releases. Component workflows have their own concurrency groups as a second
+# line of defence against someone starting a standalone component deployment at the same time.
+concurrency:
+  group: deploy-production-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  preflight:
+    name: Production ref guard
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require main branch
+        run: |
+          if [ "${GITHUB_REF}" != "refs/heads/main" ]; then
+            echo "Production Workload Identity Federation is restricted to refs/heads/main." >&2
+            echo "Re-run this workflow with main selected in the Run workflow branch picker." >&2
+            exit 1
+          fi
+
+  validate:
+    name: Full CI release gate
+    needs: preflight
+    uses: ./.github/workflows/ci.yml
+    secrets: inherit
+
+  deploy-garmin:
+    name: Deploy Garmin backend
+    needs: validate
+    uses: ./.github/workflows/deploy-garmin-sync.yml
+    with:
+      region: ${{ inputs.region }}
+      run_smoke_test: ${{ inputs.run_garmin_sync_smoke_test }}
+    secrets: inherit
+
+  deploy-indexes:
+    name: Deploy Firestore indexes
+    needs: deploy-garmin
+    uses: ./.github/workflows/deploy-firestore-indexes.yml
+    secrets: inherit
+
+  deploy-rules:
+    name: Deploy Firestore rules
+    needs: deploy-indexes
+    uses: ./.github/workflows/deploy-frontend.yml
+    with:
+      deploy_hosting: false
+      deploy_rules: true
+      confirm_rules_drift: ${{ inputs.confirm_rules_drift }}
+    secrets: inherit
+
+  deploy-hosting:
+    name: Deploy frontend last
+    needs: deploy-rules
+    uses: ./.github/workflows/deploy-frontend.yml
+    with:
+      deploy_hosting: true
+      deploy_rules: false
+      confirm_rules_drift: false
+    secrets: inherit
+
+  release-summary:
+    name: Release summary
+    needs: deploy-hosting
+    runs-on: ubuntu-latest
+    steps:
+      - name: Record promoted revision
+        run: |
+          {
+            echo "## Production release complete"
+            echo
+            echo "- Commit: \`${GITHUB_SHA}\`"
+            echo "- Region: \`${{ inputs.region }}\`"
+            echo "- Garmin backend, Firestore indexes/rules, and Firebase Hosting all completed."
+            echo "- Hosting smoke checks verified the site and the Hosting -> Cloud Run API rewrite."
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/docs/ops/frontend-deployment.md
+++ b/docs/ops/frontend-deployment.md
@@ -1,109 +1,92 @@
-# Frontend & Firestore Rules Deployment (GitHub Actions)
+# Frontend, Firestore Rules & Indexes Deployment (GitHub Actions)
 
-Deploys the web app (`app/`) to Firebase Hosting and/or `app/firestore.rules` to Cloud
-Firestore, entirely from the GitHub web UI -- no local machine or `gcloud`/`firebase` CLI
-needed. This is the **`Deploy Frontend & Firestore Rules`** workflow
-(`.github/workflows/deploy-frontend.yml`), triggered as `workflow_dispatch` (works fine from a
-phone/tablet browser).
+For ordinary production promotion use **Deploy Production E2E** and follow
+[`production-deployment.md`](./production-deployment.md). It validates and promotes one `main`
+Git SHA in dependency order: Garmin backend -> Firestore indexes -> Firestore rules ->
+Firebase Hosting.
 
-It authenticates the same way `deploy-garmin-sync.yml` does -- **Workload Identity
-Federation**: no service-account JSON key is ever stored as a secret, only a provider resource
-name and a service-account email GitHub proves it's allowed to impersonate for that one run.
+The component workflows documented here remain available for targeted recovery or deliberately
+scoped deployments:
 
-Firestore **indexes** are out of scope here, same as the local `npm run firestore:rules:deploy`
-procedure this mirrors -- use `make deploy-indexes` locally for those (rare enough not to need
-its own CI path yet).
+- **Deploy Frontend & Firestore Rules** (`.github/workflows/deploy-frontend.yml`)
+- **Deploy Firestore Indexes** (`.github/workflows/deploy-firestore-indexes.yml`)
 
-## Design: a separate identity from garmin-sync's
+Both authenticate with **Workload Identity Federation**. No service-account JSON key is stored
+in GitHub.
 
-`github-deployer` (used by `deploy-garmin-sync.yml`) and `github-frontend-deployer` (used
-here) are two different service accounts, both provisioned by the same one-time
-`docs/ops/setup-workload-identity.sh`, both trusting the same Workload Identity Pool/Provider
-(restricted to this repo's `main` branch -- a run from any other branch or a fork can't
-authenticate as either at all). `github-frontend-deployer` only ever holds
-`roles/firebasehosting.admin` and `roles/firebaserules.admin` -- nothing about Cloud Run,
-Artifact Registry, Cloud Scheduler, or general Firestore data/index access. A workflow file
-compromised or added later in this repo therefore can't use it to reach garmin-sync's
-infrastructure, or vice versa: each identity can only touch the one surface it's scoped to.
+## Deployment identities
 
-## One-time setup
+`github-deployer` is reserved for Garmin Cloud Run, Artifact Registry and Cloud Scheduler.
+`github-frontend-deployer` is separate and is limited to the Firebase/Firestore deployment
+surface used here:
 
-If you've already run `docs/ops/setup-workload-identity.sh` for `deploy-garmin-sync.yml`,
-rerun it (idempotent -- it only fills in what's missing, including the new
-`github-frontend-deployer` identity this workflow needs):
+- `roles/firebasehosting.admin`
+- `roles/firebaserules.admin`
+- `roles/datastore.indexAdmin`
+- `roles/serviceusage.serviceUsageConsumer`
+
+Both identities trust the same WIF provider, whose condition is restricted to this repository's
+`main` branch. A feature branch or fork cannot authenticate as either deployment identity.
+
+After the E2E/index pipeline is merged, rerun the idempotent setup script once so the existing
+frontend deployer receives its Firestore index role:
 
 ```bash
-export GCP_PROJECT=adaptive-training-recommender   # your Firebase/GCP project id
-export GITHUB_REPO=OWNER/REPO                       # e.g. Szczepanov/adaptive-training-recommender
+export GCP_PROJECT=adaptive-training-recommender
+export GITHUB_REPO=Szczepanov/adaptive-training-recommender
 bash docs/ops/setup-workload-identity.sh
 ```
 
-Add the printed `GCP_FRONTEND_DEPLOYER_SA_EMAIL` as a repo secret (alongside
-`GCP_PROJECT_ID` and `GCP_WORKLOAD_IDENTITY_PROVIDER`, already added if you set up
-`deploy-garmin-sync.yml` -- both workflows share those two).
+The script prints the required repository secrets. Hosting builds also need the production
+Firebase web config (`VITE_FIREBASE_*`). Those values are client configuration embedded in the
+bundle, not a service-account credential. `VITE_HEALTH_ANOMALY_POLICY` is optional and fails
+closed to `off` when absent.
 
-You also need your **production Firebase web app config** as repo secrets -- this is the
-public client-side config embedded in the built bundle (not a credential), found in the
-Firebase console under Project settings -> General -> Your apps:
+## Frontend and Firestore rules
 
-| Secret | Value |
-|---|---|
-| `VITE_FIREBASE_API_KEY` | from the Firebase console |
-| `VITE_FIREBASE_AUTH_DOMAIN` | from the Firebase console |
-| `VITE_FIREBASE_PROJECT_ID` | from the Firebase console |
-| `VITE_FIREBASE_STORAGE_BUCKET` | from the Firebase console |
-| `VITE_FIREBASE_MESSAGING_SENDER_ID` | from the Firebase console |
-| `VITE_FIREBASE_APP_ID` | from the Firebase console |
-| `VITE_FIREBASE_MEASUREMENT_ID` | optional, only if you use Analytics |
+Run **Deploy Frontend & Firestore Rules** when you intentionally need only Hosting, only rules,
+or both. Its inputs are:
 
-These are the same values your local `.env` (gitignored) already has, if you've deployed the
-frontend from a local machine before.
+- `deploy_hosting` — runs the production frontend build and deploys Firebase Hosting.
+- `deploy_rules` — runs the Firestore rules safety/deployment flow.
+- `confirm_rules_drift` — defaults to `false`; set it only after reviewing an intentional
+  production-vs-repository rules mismatch.
 
-## Deploy
+The rules path remains fail-closed by default. With no acknowledgement, unexpected production
+drift stops the run before changing rules. With `confirm_rules_drift: true`, only that expected
+pre-deployment mismatch is acknowledged; the deployment script still saves rollback metadata,
+runs the mandatory Firestore emulator suite, deploys only rules, and verifies the deployed
+source hash against `app/firestore.rules`.
 
-Run the **Deploy Frontend & Firestore Rules** workflow (Actions tab -> select it -> Run
-workflow). It has three inputs:
+Hosting deploys are followed by two smoke checks: the Firebase Hosting root must be reachable,
+and the `/api/garmin/**` Hosting rewrite must reach the Cloud Run account-link backend. The
+rewrite probe uses a credential-free unsupported GET path and expects the backend's JSON 404,
+so it does not submit Garmin credentials or consume a login-rate-limit attempt.
 
-* `deploy_hosting` -- runs `npm run build` (which runs the full `npm run check`: typecheck,
-  lint, unit tests, workout-catalog validation -- never deploys a build that hasn't passed
-  those) then `firebase deploy --only hosting`.
-* `deploy_rules` -- runs the Firestore rules safety/deployment flow.
-* `confirm_rules_drift` -- defaults to `false`. Leave it off for ordinary runs. If the
-  deployed production rules differ from `app/firestore.rules`, the run stops before changing
-  production. Turn it on only after reviewing the mismatch and intentionally choosing the
-  repository version as the next production ruleset.
+For a normal release, do not run Hosting before new backend/index/rules dependencies are ready;
+use **Deploy Production E2E**, which always cuts Hosting last.
 
-For an intentional rules change, `confirm_rules_drift: true` acknowledges only the expected
-pre-deployment mismatch. It does **not** bypass the rest of the safety flow: the existing
-rules deployment script still saves the active ruleset for rollback, runs the mandatory
-Firestore emulator tests, deploys only `firestore:rules`, reads production back, and fails if
-the deployed source hash does not exactly match `app/firestore.rules`.
+## Firestore indexes
 
-This gives a phone-only recovery path for legitimate drift without weakening the default:
+Run **Deploy Firestore Indexes** for an index-only production change. It deploys
+`app/firestore.indexes.json` and then waits for composite-index construction to finish.
 
-1. Run with `deploy_rules: true` and `confirm_rules_drift: false` first.
-2. If the drift gate fails, review the production-vs-repository difference in Firebase/GitHub.
-3. If the repository version is the intended reviewed version, rerun with
-   `confirm_rules_drift: true`.
+The Firebase CLI can return while index construction is still asynchronous, so the workflow
+polls Firestore until no composite index is `CREATING`. `NEEDS_REPAIR` fails immediately and a
+20-minute readiness timeout also fails the run.
 
-Turn either deployment target off to deploy just one side -- e.g. `deploy_rules: false` for a
-frontend-only change, or `deploy_hosting: false` to ship a reviewed rules change without also
-cutting a new Hosting release.
+The workflow deliberately omits `--force`. It may add/update repository-owned indexes but does
+not silently opt into deleting a production index that is present remotely but absent from the
+repository. Treat index deletion as a separate reviewed operator action.
 
-## Rollback stays local
+## Rollback
 
-`deploy_rules` uploads its rollback backup JSON as a workflow run artifact (the runner itself
-is thrown away after the job, and the local procedure's `app/artifacts/firestore-rules-rollbacks/`
-is gitignored) -- download it from the run's **Artifacts** section if you ever need it. Rolling
-back is still a deliberate local operation, unchanged from
-[`firestore-rules-deployment.md`](./firestore-rules-deployment.md#rollback): download the
-backup, then from `app/` with `gcloud auth application-default login` done once,
+Rules deployment uploads its rollback backup JSON to the workflow run's **Artifacts** section.
+For a rules rollback, download it and follow
+[`firestore-rules-deployment.md`](./firestore-rules-deployment.md#rollback).
 
-```bash
-npm run firestore:rules:rollback -- --backup <downloaded-file>.json --confirm
-```
+Firebase Hosting keeps release history; roll traffic back from the Firebase console to a prior
+Hosting release when needed.
 
-Hosting releases don't need this: Firebase Hosting keeps prior releases browsable in the
-console, and rolling back (Hosting -> your site -> release history -> **Rollback** on any
-prior release) repoints traffic to it directly -- no separate backup file to manage. There is
-no `firebase hosting:rollback` CLI command; the console is the only supported way to do this.
+Indexes are not automatically deleted by the pipeline. Review query impact before correcting
+or removing an index.

--- a/docs/ops/frontend-deployment.md
+++ b/docs/ops/frontend-deployment.md
@@ -25,17 +25,29 @@ surface used here:
 - `roles/datastore.indexAdmin`
 - `roles/serviceusage.serviceUsageConsumer`
 
+There is one narrow Cloud Run exception inherited from the existing Hosting deployment path:
+`app/firebase.json` rewrites `/api/garmin/**` to `garmin-account-link`, and Firebase Hosting
+needs `run.services.get` on that service while finalizing the Hosting release.
+`setup-workload-identity.sh` therefore grants `github-frontend-deployer` `roles/run.viewer`
+**only on that single Cloud Run service**, not at project level. It still cannot deploy or
+modify Cloud Run and cannot inspect unrelated services.
+
 Both identities trust the same WIF provider, whose condition is restricted to this repository's
 `main` branch. A feature branch or fork cannot authenticate as either deployment identity.
 
 After the E2E/index pipeline is merged, rerun the idempotent setup script once so the existing
-frontend deployer receives its Firestore index role:
+frontend deployer receives its Firestore index role and the scoped Cloud Run viewer binding:
 
 ```bash
 export GCP_PROJECT=adaptive-training-recommender
 export GITHUB_REPO=Szczepanov/adaptive-training-recommender
 bash docs/ops/setup-workload-identity.sh
 ```
+
+The `garmin-account-link` binding is applied only when that service already exists. If it has
+not been deployed yet, the script prints a `NOTE:`; run **Deploy Garmin Sync** first and rerun
+the setup script afterward. In the normal E2E setup this is a one-time bootstrap concern, not
+a per-release step.
 
 The script prints the required repository secrets. Hosting builds also need the production
 Firebase web config (`VITE_FIREBASE_*`). Those values are client configuration embedded in the

--- a/docs/ops/production-deployment.md
+++ b/docs/ops/production-deployment.md
@@ -1,0 +1,114 @@
+# End-to-End Production Deployment
+
+The recommended way to promote a repository revision to production is the GitHub Actions
+**Deploy Production E2E** workflow (`.github/workflows/deploy-production.yml`). It releases one
+`main` commit through the full validation and deployment chain without relying on a local
+machine.
+
+The release is intentionally manual (`workflow_dispatch`). Firestore security rules already
+have a fail-closed production-drift gate that can require an explicit operator acknowledgement;
+a merge to `main` must not silently turn that acknowledgement into an unattended deployment.
+
+## Release order and safety model
+
+A production run promotes one Git SHA in dependency order:
+
+1. **Full CI release gate** — Python 3.12/3.14 tests, lint/type checks, frontend tests and
+   Firestore rules emulator suite, simulations, production frontend build, dependency audits,
+   and Docker build.
+2. **Garmin backend** — build and push the SHA-tagged image, deploy `garmin-account-link`, the
+   three Cloud Run Jobs and their Scheduler jobs, then verify the account-link `/health`
+   endpoint. The optional live `garmin-sync` execution remains opt-in because it calls Garmin.
+3. **Firestore indexes** — deploy `app/firestore.indexes.json` and wait until every composite
+   index is usable. A `NEEDS_REPAIR` state or a 20-minute readiness timeout fails the release.
+4. **Firestore security rules** — run the existing drift/backup/emulator/deploy/hash-verification
+   sequence. Unexpected drift fails closed by default.
+5. **Firebase Hosting** — build with production Firebase configuration, deploy the frontend,
+   verify the Hosting URL, then verify the `/api/garmin/**` Hosting rewrite reaches the Cloud
+   Run account-link service.
+
+Hosting is deliberately last. A new client therefore cannot be exposed before the server-side
+Garmin API, indexes and security rules it may depend on are live.
+
+The top-level release and every mutable component workflow use non-cancelling concurrency
+groups. A second release queues rather than overtaking a deployment already in progress.
+
+## One-time setup change
+
+The existing Workload Identity Federation design remains in place and remains restricted to
+this repository's `main` branch. Re-run the idempotent setup script once after this pipeline is
+merged:
+
+```bash
+export GCP_PROJECT=adaptive-training-recommender
+export GITHUB_REPO=Szczepanov/adaptive-training-recommender
+bash docs/ops/setup-workload-identity.sh
+```
+
+This adds `roles/datastore.indexAdmin` to `github-frontend-deployer`, which is the predefined
+Firestore index-management role used by the new index deployment unit. No service-account key
+is created or stored.
+
+The repository secrets printed by the setup script plus the existing `VITE_FIREBASE_*` build
+configuration are consumed by the component workflows. `VITE_HEALTH_ANOMALY_POLICY` remains
+optional and fails closed to `off` when absent.
+
+## Running a production release
+
+From GitHub:
+
+1. Open **Actions** -> **Deploy Production E2E** -> **Run workflow**.
+2. Select the `main` branch. The workflow also checks this explicitly before any deployment;
+   the WIF provider itself rejects other refs as a second guard.
+3. Keep `region` at `europe-central2` unless the deployed Garmin resources were intentionally
+   moved.
+4. Leave `confirm_rules_drift` off for the first attempt.
+5. Leave `run_garmin_sync_smoke_test` off for an ordinary release. The account-link service
+   still receives a credential-free health check on every backend deployment.
+
+If the rules stage stops because production differs from `app/firestore.rules`, review the
+mismatch. If the repository version is the intended reviewed production ruleset, rerun the
+same `main` release with `confirm_rules_drift: true`. That acknowledgement bypasses only the
+pre-deployment mismatch stop; rollback backup creation, emulator tests, deployment and
+post-deploy source-hash verification still run.
+
+## Firestore index behavior
+
+The index workflow deliberately does **not** pass Firebase CLI `--force`. It may add or update
+repository-owned indexes, but it will not silently opt into deleting a remote-only production
+index. Remove obsolete production indexes only as a separate reviewed operator action.
+
+Firebase accepts index creation asynchronously, so a successful CLI invocation alone is not a
+release-ready signal. The workflow polls composite-index state and blocks the rules/Hosting
+stages until creation settles.
+
+## Targeted recovery workflows
+
+The component workflows remain manually runnable when a full release is unnecessary:
+
+- **Deploy Garmin Sync** — backend/jobs/schedulers only.
+- **Deploy Firestore Indexes** — indexes only, including readiness wait.
+- **Deploy Frontend & Firestore Rules** — Hosting and/or rules only.
+
+Use these for recovery or a deliberately scoped operational change. Normal production
+promotion should use **Deploy Production E2E** so ordering and single-SHA traceability are
+preserved.
+
+## Failure and rollback
+
+A failed stage stops every dependent later stage. For example, index or rules failure means no
+new Hosting release is cut.
+
+- **Garmin backend:** redeploy the previous known-good Git SHA through the backend workflow or
+  restore the previous Cloud Run image revision/job spec according to
+  `cloud-run-deployment.md`.
+- **Firestore rules:** the rules deployment uploads its pre-change rollback metadata as a
+  workflow artifact. Follow `firestore-rules-deployment.md` for the deliberate rollback
+  command.
+- **Firestore indexes:** index deletion is not automated by this pipeline. Correct or remove a
+  failed/obsolete index only after reviewing the production query impact.
+- **Firebase Hosting:** use Firebase Hosting release history to roll traffic back to a previous
+  release.
+
+The E2E workflow is a deployment orchestrator, not a substitute for the component runbooks;
+those remain authoritative for component-specific recovery details.

--- a/docs/ops/setup-workload-identity.sh
+++ b/docs/ops/setup-workload-identity.sh
@@ -170,6 +170,22 @@ for ROLE in \
     --condition=None >/dev/null
 done
 
+# app/firebase.json rewrites /api/garmin/** to the garmin-account-link Cloud Run service.
+# Finalizing a Hosting version that references it calls run.services.get on that service, so
+# github-frontend-deployer needs read access there -- but only there. Bind roles/run.viewer on
+# the single Cloud Run service (not the project) so this identity still can't see or touch any
+# other Cloud Run service, preserving the isolation from github-deployer described above.
+if gcloud run services describe garmin-account-link --region="${REGION}" >/dev/null 2>&1; then
+  gcloud run services add-iam-policy-binding garmin-account-link \
+    --region="${REGION}" \
+    --member="serviceAccount:${FRONTEND_DEPLOYER_SA_EMAIL}" \
+    --role="roles/run.viewer" >/dev/null
+else
+  echo "NOTE: garmin-account-link Cloud Run service not found in ${REGION} yet -- run" >&2
+  echo "      'Deploy Garmin Sync' first, then rerun this script to grant" >&2
+  echo "      github-frontend-deployer read access to it (required for Hosting deploys)." >&2
+fi
+
 gcloud iam service-accounts add-iam-policy-binding "${FRONTEND_DEPLOYER_SA_EMAIL}" \
   --role="roles/iam.workloadIdentityUser" \
   --member="principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL_ID}/attribute.repository/${GITHUB_REPO}"

--- a/docs/ops/setup-workload-identity.sh
+++ b/docs/ops/setup-workload-identity.sh
@@ -153,12 +153,16 @@ gcloud iam service-accounts add-iam-policy-binding "${DEPLOYER_SA_EMAIL}" \
 echo "==> Creating github-frontend-deployer"
 if ! gcloud iam service-accounts describe "${FRONTEND_DEPLOYER_SA_EMAIL}" >/dev/null 2>&1; then
   gcloud iam service-accounts create "${FRONTEND_DEPLOYER_SA_NAME}" \
-    --display-name="GitHub Actions frontend/rules deploy identity (WIF, no key)"
+    --display-name="GitHub Actions frontend/rules/index deploy identity (WIF, no key)"
 fi
 
+# datastore.indexAdmin is the predefined least-privilege role for creating, updating,
+# listing and deleting Firestore indexes. The index workflow itself deliberately omits
+# --force, so it never opts into destructive removal of remote-only indexes automatically.
 for ROLE in \
   roles/firebasehosting.admin \
   roles/firebaserules.admin \
+  roles/datastore.indexAdmin \
   roles/serviceusage.serviceUsageConsumer \
 ; do
   gcloud projects add-iam-policy-binding "${GCP_PROJECT}" \
@@ -185,7 +189,7 @@ Setup complete. Add these GitHub repository secrets:
 Garmin usernames, passwords, MFA secrets and APP_USER_IDS are intentionally NOT
 GitHub secrets anymore. Users establish their own Garmin link from the web app.
 
-For "Deploy Frontend & Firestore Rules" also configure the Firebase web app values:
+For Firebase Hosting/Rules also configure the Firebase web app values:
 
   VITE_FIREBASE_API_KEY
   VITE_FIREBASE_AUTH_DOMAIN
@@ -194,7 +198,9 @@ For "Deploy Frontend & Firestore Rules" also configure the Firebase web app valu
   VITE_FIREBASE_MESSAGING_SENDER_ID
   VITE_FIREBASE_APP_ID
   VITE_FIREBASE_MEASUREMENT_ID (optional)
+  VITE_HEALTH_ANOMALY_POLICY (optional; defaults fail-closed to off)
 
-Then run "Deploy Garmin Sync" followed by "Deploy Frontend & Firestore Rules".
+Recommended production path: run "Deploy Production E2E" from main. The standalone
+Garmin, Firestore-index and Frontend/Rules workflows remain available for targeted recovery.
 ==============================================================================
 EOF


### PR DESCRIPTION
## Summary

- Adds **Deploy Production E2E**, a single manual production release workflow that gates one `main` SHA on the full existing CI suite and promotes it in dependency order: Garmin backend/jobs/schedulers -> Firestore indexes -> Firestore rules -> Firebase Hosting.
- Refactors the existing CI, Garmin deploy, and frontend/rules deploy workflows into reusable workflow units while preserving their standalone `workflow_dispatch` recovery paths and adding non-cancelling deployment concurrency.
- Adds a dedicated Firestore index deployment unit that waits for composite indexes to become usable before client rollout and deliberately avoids destructive `--force` reconciliation.
- Adds production smoke checks for the Cloud Run account-link `/health` endpoint, Firebase Hosting, and the Hosting -> Cloud Run `/api/garmin/**` rewrite. Hosting is cut last so a new client cannot precede its server/data dependencies.
- Preserves the existing fail-closed Firestore rules drift acknowledgement rather than auto-deploying on every `main` merge; documents the E2E release/rollback path in `docs/ops/production-deployment.md`.

## Validation

GitHub Actions **CI Pipeline #1074** (`32568581412`) completed successfully on this PR head.

- [x] `uv run pytest` — passed on Python 3.12 and 3.14 with coverage generation.
- [x] `uv run ruff check .` and `uv run mypy src/garmin_sync` — passed on both Python matrices; formatting and pre-commit checks also passed.
- [x] `cd app && npm run check` equivalent CI gates — lint, workout validation and frontend test suite passed.
- [x] `cd app && npm run test:rules` — Firestore emulator suite passed.
- [x] `cd app && npm run simulate:scenarios` — scenarios and committed-baseline gate passed; semantic diff reporting completed successfully.
- [x] Production frontend build and Node dependency audit passed.
- [x] Docker image build passed.
- [x] The modified policy-version drift check passed on the PR path.

Focused validation:
- Compared `feat/e2e-production-deployment` against `main`: branch is cleanly ahead from `1503c350b973ef15ed34e6de697d4b19d6300d52`; change set is limited to GitHub Actions and deployment runbooks/setup.
- GitHub accepted and executed the modified workflow configuration, including the reusable-CI changes.
- The E2E workflow itself cannot be exercised against production from this feature branch by design: the GCP WIF provider rejects non-`main` refs. The first live end-to-end invocation therefore necessarily occurs after merge.

## Risk and reviewer guidance

Moderate operational risk because this introduces the production orchestrator, but it composes the existing deployment procedures instead of replacing their safety logic.

Please focus review on:
- dependency ordering in `.github/workflows/deploy-production.yml`;
- reusable-workflow inputs/secrets and deployment concurrency;
- the Firestore index readiness gate in `deploy-firestore-indexes.yml`;
- smoke checks in the Garmin/frontend workflows.

One post-merge setup action is required before the first E2E release: rerun `docs/ops/setup-workload-identity.sh` (idempotent) so `github-frontend-deployer` receives `roles/datastore.indexAdmin`.

Rules drift remains fail-closed. If a reviewed repository rules change differs from production, the first release attempt with `confirm_rules_drift: false` stops before Hosting; rerun with the acknowledgement only after reviewing that difference.

Index deployment intentionally omits `--force`, so a remote-only production index is not silently deleted. The readiness gate waits up to 20 minutes and fails on `NEEDS_REPAIR`.

## Domain invariants

- [x] No credentials, tokens, service-account files, or raw health payloads are included; deployment continues to use keyless Workload Identity Federation.
- Firestore write scoping, Warsaw calendar-date semantics, training data models, and recommendation decision logic are untouched.
- `POLICY_VERSION` does not change because no decision-affecting engine code changes.

## Screenshots or recordings

Not applicable — deployment/operations tooling only; no UI change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a consolidated, manually triggered production deployment workflow covering backend, Firestore indexes, rules, and frontend hosting.
  * Added reusable deployment workflows with configurable regions, smoke tests, and deployment options.
  * Added automated health and hosting smoke checks, including Firestore index readiness validation.

* **Documentation**
  * Updated production deployment and Workload Identity setup guidance.
  * Documented deployment ordering, safety controls, recovery workflows, and rollback considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->