### PR TITLE
fix(ci): fix production-release concurrency deadlock

### DIFF
--- a/.github/workflows/deploy-firestore-indexes.yml
+++ b/.github/workflows/deploy-firestore-indexes.yml
@@ -6,6 +6,17 @@ name: Deploy Firestore Indexes
 on:
   workflow_dispatch:
   workflow_call:
+    inputs:
+      production_release_lock:
+        description: >-
+          Internal: set to true only by deploy-production.yml's call. Opts this call out of
+          the shared production-wide concurrency group below, since that caller already holds
+          it for the whole release -- requesting it again here would queue this job behind the
+          very run it's part of and deadlock. workflow_dispatch has no such input, so a
+          standalone run always falls through to the production-wide lock.
+        type: boolean
+        required: false
+        default: false
     secrets:
       GCP_PROJECT_ID:
         required: true
@@ -18,15 +29,19 @@ permissions:
   contents: read
   id-token: write
 
-# A standalone workflow_dispatch run joins the SAME group deploy-production.yml holds for a
-# whole release, so it queues behind an in-flight end-to-end release instead of deploying a
-# different SHA mid-release. A workflow_call invocation (i.e. from deploy-production.yml
-# itself) uses this workflow's own isolated group instead: that caller already holds the
+# A standalone workflow_dispatch run (production_release_lock defaults to false -- that input
+# doesn't exist under workflow_dispatch) joins the SAME group deploy-production.yml holds for
+# a whole release, so it queues behind an in-flight end-to-end release instead of deploying a
+# different SHA mid-release. deploy-production.yml's own call sets production_release_lock:
+# true and gets this workflow's isolated group instead: that caller already holds the
 # production-wide group for the run's whole duration, so requesting it again here would queue
-# this job behind the very run it's part of and deadlock.
+# this job behind the very run it's part of and deadlock. (github.event_name is NOT a usable
+# signal for this: inside a called reusable workflow it still reads as the caller's own
+# triggering event, e.g. workflow_dispatch, not "workflow_call" -- using it here previously
+# produced the exact deadlock this comment warns about.)
 concurrency:
   group: >-
-    ${{ github.event_name == 'workflow_call'
+    ${{ inputs.production_release_lock
       && format('deploy-firestore-indexes-{0}', github.repository)
       || format('deploy-production-{0}', github.repository) }}
   cancel-in-progress: false

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -51,6 +51,17 @@ on:
         type: boolean
         required: false
         default: false
+      production_release_lock:
+        description: >-
+          Internal: set to true only by deploy-production.yml's call (for both its rules and
+          hosting stages). Opts this call out of the shared production-wide concurrency group
+          below, since that caller already holds it for the whole release -- requesting it
+          again here would queue this job behind the very run it's part of and deadlock.
+          workflow_dispatch has no such input, so a standalone run always falls through to the
+          production-wide lock.
+        type: boolean
+        required: false
+        default: false
     secrets:
       GCP_PROJECT_ID:
         required: true
@@ -86,16 +97,20 @@ permissions:
 # check, then race to deploy -- the later one silently wins and clobbers the earlier release.
 # Queue instead of running concurrently; never cancel a deploy that's already underway.
 #
-# A standalone workflow_dispatch run joins the SAME group deploy-production.yml holds for a
-# whole release, so it queues behind an in-flight end-to-end release instead of deploying a
-# different SHA mid-release. A workflow_call invocation (i.e. from deploy-production.yml
-# itself, for both the rules and hosting stages) uses this workflow's own isolated group
-# instead: that caller already holds the production-wide group for the run's whole duration,
-# so requesting it again here would queue this job behind the very run it's part of and
-# deadlock.
+# A standalone workflow_dispatch run (production_release_lock defaults to false -- that input
+# doesn't exist under workflow_dispatch) joins the SAME group deploy-production.yml holds for
+# a whole release, so it queues behind an in-flight end-to-end release instead of deploying a
+# different SHA mid-release. deploy-production.yml's own calls (rules and hosting stages) set
+# production_release_lock: true and get this workflow's isolated group instead: that caller
+# already holds the production-wide group for the run's whole duration, so requesting it
+# again here would queue this job behind the very run it's part of and deadlock.
+# (github.event_name is NOT a usable signal for this: inside a called reusable workflow it
+# still reads as the caller's own triggering event, e.g. workflow_dispatch, not
+# "workflow_call" -- using it here previously produced the exact deadlock this comment warns
+# about.)
 concurrency:
   group: >-
-    ${{ github.event_name == 'workflow_call'
+    ${{ inputs.production_release_lock
       && format('deploy-frontend-{0}', github.repository)
       || format('deploy-production-{0}', github.repository) }}
   cancel-in-progress: false

--- a/.github/workflows/deploy-garmin-sync.yml
+++ b/.github/workflows/deploy-garmin-sync.yml
@@ -28,6 +28,17 @@ on:
         type: boolean
         required: false
         default: false
+      production_release_lock:
+        description: >-
+          Internal: set to true only by deploy-production.yml's call. Opts this call out of
+          the shared production-wide concurrency group below, since that caller already holds
+          it for the whole release -- requesting it again here would queue this job behind the
+          very run it's part of and deadlock. workflow_dispatch has no such input (there is
+          nothing above under `on.workflow_dispatch.inputs` to set it), so a standalone run
+          always falls through to the production-wide lock.
+        type: boolean
+        required: false
+        default: false
     secrets:
       GCP_PROJECT_ID:
         required: true
@@ -43,15 +54,19 @@ permissions:
 # Serialise both standalone deploys and calls from the end-to-end production release. A
 # second image/scheduler rollout must never overtake an in-flight rollout of another SHA.
 #
-# A standalone workflow_dispatch run joins the SAME group deploy-production.yml holds for a
-# whole release, so it queues behind an in-flight end-to-end release instead of deploying a
-# different SHA mid-release. A workflow_call invocation (i.e. from deploy-production.yml
-# itself) uses this workflow's own isolated group instead: that caller already holds the
+# A standalone workflow_dispatch run (production_release_lock defaults to false -- that input
+# doesn't exist under workflow_dispatch) joins the SAME group deploy-production.yml holds for
+# a whole release, so it queues behind an in-flight end-to-end release instead of deploying a
+# different SHA mid-release. deploy-production.yml's own call sets production_release_lock:
+# true and gets this workflow's isolated group instead: that caller already holds the
 # production-wide group for the run's whole duration, so requesting it again here would queue
-# this job behind the very run it's part of and deadlock.
+# this job behind the very run it's part of and deadlock. (github.event_name is NOT a usable
+# signal for this: inside a called reusable workflow it still reads as the caller's own
+# triggering event, e.g. workflow_dispatch, not "workflow_call" -- using it here previously
+# produced the exact deadlock this comment warns about.)
 concurrency:
   group: >-
-    ${{ github.event_name == 'workflow_call'
+    ${{ inputs.production_release_lock
       && format('deploy-garmin-sync-{0}', github.repository)
       || format('deploy-production-{0}', github.repository) }}
   cancel-in-progress: false

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -72,6 +72,7 @@ jobs:
     with:
       region: ${{ inputs.region }}
       run_smoke_test: ${{ inputs.run_garmin_sync_smoke_test }}
+      production_release_lock: true
     secrets:
       GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
       GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
@@ -84,6 +85,8 @@ jobs:
       contents: read
       id-token: write
     uses: ./.github/workflows/deploy-firestore-indexes.yml
+    with:
+      production_release_lock: true
     secrets:
       GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
       GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
@@ -100,6 +103,7 @@ jobs:
       deploy_hosting: false
       deploy_rules: true
       confirm_rules_drift: ${{ inputs.confirm_rules_drift }}
+      production_release_lock: true
     secrets:
       GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
       GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
@@ -116,6 +120,7 @@ jobs:
       deploy_hosting: true
       deploy_rules: false
       confirm_rules_drift: false
+      production_release_lock: true
     secrets:
       GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
       GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}


### PR DESCRIPTION
## Summary

- The first live **Deploy Production E2E** run ([32570614012](https://github.com/Szczepanov/adaptive-training-recommender/actions/runs/32570614012)) failed at "Deploy Garmin backend" before deploying anything: `Canceling since a deadlock was detected for concurrency group: 'deploy-production-Szczepanov/adaptive-training-recommender' between a top level workflow and 'Deploy Garmin backend'`.
- Root cause: the per-component concurrency groups added while addressing PR #187's review comments picked their group name with `github.event_name == 'workflow_call'`, assuming that context reads `'workflow_call'` inside a called reusable workflow. It doesn't — `github.event_name` inside a called workflow still reflects the *caller's* triggering event (`workflow_dispatch` here), so every called component resolved to the *same* group the caller already held for the whole release, and GitHub correctly detected the self-deadlock and canceled the run.
- Fix: distinguish caller vs. standalone with an explicit `production_release_lock` boolean input declared only under each workflow's `workflow_call.inputs` (absent from `workflow_dispatch`, so a standalone run always defaults to `false` and falls through to the shared production-wide lock as intended). `deploy-production.yml` now passes `production_release_lock: true` on all four deployment calls, resolving them to their own isolated concurrency group instead of the caller's — avoiding the deadlock while preserving the intended behavior (a standalone component dispatch still queues behind an in-flight end-to-end release).

## Validation

- [ ] `uv run pytest` (backend changes) — Not applicable, no Python changed.
- [ ] `uv run ruff check .` and `uv run mypy src/garmin_sync` (backend changes) — Not applicable.
- [ ] `cd app && npm run check` (frontend changes) — Not applicable, no frontend code changed.
- [ ] `cd app && npm run test:rules` (Firestore rules changes) — Not applicable.
- [ ] `cd app && npm run simulate:scenarios` (recommendation-engine changes) — Not applicable.
- [ ] `cd app && npm run visual:refresh` (material UI changes) — Not applicable.

Results:
- `python3 -c "import yaml; yaml.safe_load(open(f))"` on all four modified workflow files: pass — confirms valid YAML syntax (no `actionlint`/`zizmor` available in this environment to statically validate GitHub Actions expression syntax beyond that).
- Manual check: re-derived the actual `github` context behavior inside a called reusable workflow (the bug this PR fixes) against the real failure message from run 32570614012, and confirmed the new `inputs.production_release_lock`-based branch cannot collide with the caller's group under either trigger path — a standalone `workflow_dispatch` has no `production_release_lock` input to set, so it always evaluates false. This workflow itself cannot be dry-run outside GitHub Actions; correctness will be confirmed by re-running **Deploy Production E2E** after merge.

## Risk and reviewer guidance

Deployment-orchestration risk only (no application code touched). The change that needs closest review is the new `production_release_lock` input wiring in each of `deploy-garmin-sync.yml`, `deploy-firestore-indexes.yml`, and `deploy-frontend.yml`, plus the four `with:` blocks in `deploy-production.yml` that now set it — a mismatch there (e.g. a caller forgetting to pass `production_release_lock: true`) reproduces the exact deadlock this PR fixes. Re-running **Deploy Production E2E** after merge is the only way to confirm this end-to-end, since the GCP WIF provider rejects non-`main` refs.

## Domain invariants

Not applicable — CI/deployment workflow change only; no Firestore writes, calendar-date logic, credentials, or recommendation decision logic touched.

## Screenshots or recordings

Not applicable — deployment tooling only; no UI change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ky6ggeiwFLg4eGvJ1abXvp)_