### PR TITLE
chore(ci): tidy up CI/CD workflow action-version drift

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -127,7 +127,7 @@ jobs:
       run:
         working-directory: app
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false # this job never needs to push; don't leave the token in git config
 
@@ -138,7 +138,7 @@ jobs:
           exit 1
 
       - name: Authenticate to GCP (Workload Identity Federation, no key)
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_FRONTEND_DEPLOYER_SA_EMAIL }}
@@ -147,10 +147,10 @@ jobs:
       # scripts/check-firestore-rules-drift.mjs calls to read the deployed ruleset via the
       # Firebase Rules REST API -- it picks up the WIF credentials the auth step just wrote to
       # GOOGLE_APPLICATION_CREDENTIALS as Application Default Credentials automatically.
-      - uses: google-github-actions/setup-gcloud@v2
+      - uses: google-github-actions/setup-gcloud@v3
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "22"
           cache: "npm"
@@ -159,7 +159,7 @@ jobs:
       # Only firestore:rules:deploy needs this (it runs the emulator suite before deploying),
       # but it's cheap enough to always install rather than condition on deploy_rules.
       - name: Set up Java for Firestore Emulator
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "21"
@@ -287,7 +287,7 @@ jobs:
       # deliberate operation, same as before this workflow existed).
       - name: Upload Firestore rules rollback backup
         if: always() && inputs.deploy_rules
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: firestore-rules-rollback-backup
           path: app/artifacts/firestore-rules-rollbacks/


### PR DESCRIPTION
## Summary

- `deploy-frontend.yml` had fallen behind the rest of `.github/workflows` on shared-action versions: it was still pinned to `actions/checkout@v4`, `google-github-actions/auth@v2`, `google-github-actions/setup-gcloud@v2`, `actions/setup-node@v4`, `actions/setup-java@v4`, and `actions/upload-artifact@v4`, while `ci.yml`, `deploy-garmin-sync.yml`, and `deploy-firestore-indexes.yml` had already moved to `@v7`/`@v3`/`@v7`/`@v5`/`@v7` respectively for the same actions.
- Bumped `deploy-frontend.yml`'s pins to match what every other workflow in the repo already runs, so a single action now resolves to exactly one major version across all five workflow files.
- No inputs, `with:` blocks, or step behavior changed — only the version tag moved forward to match what's already running elsewhere in this repo's own CI.

## Validation

- [ ] `uv run pytest` (backend changes) — Not applicable, no Python changed.
- [ ] `uv run ruff check .` and `uv run mypy src/garmin_sync` (backend changes) — Not applicable.
- [ ] `cd app && npm run check` (frontend changes) — Not applicable, no frontend code changed.
- [ ] `cd app && npm run test:rules` (Firestore rules changes) — Not applicable.
- [ ] `cd app && npm run simulate:scenarios` (recommendation-engine changes) — Not applicable.
- [ ] `cd app && npm run visual:refresh` (material UI changes) — Not applicable.

Results:
- `python3 -c "import yaml; yaml.safe_load(open(f))"` on all five workflow files: pass.
- `grep -nE "uses: [a-zA-Z].*@v[0-9]" .github/workflows/*.yml` before/after: confirmed every shared action (`actions/checkout`, `actions/setup-node`, `actions/setup-java`, `actions/upload-artifact`, `google-github-actions/auth`, `google-github-actions/setup-gcloud`) now resolves to exactly one version repo-wide.
- No `actionlint`/`zizmor` available in this environment to statically validate GitHub Actions syntax beyond YAML parsing; this workflow cannot be dry-run outside GitHub Actions. Since only version tags changed (no inputs/behavior), risk is limited to the pinned actions' own v4→v7/v2→v3/v4→v5 changelogs, which the repo's other workflows already exercise successfully.

## Risk and reviewer guidance

Low risk: pure version-pin alignment, no logic changed in `deploy-frontend.yml`, and every bumped-to version is already running successfully elsewhere in this repo's CI (`ci.yml` uses `checkout@v7`/`setup-node@v7`/`setup-java@v5`/`upload-artifact@v7`; `deploy-garmin-sync.yml` and `deploy-firestore-indexes.yml` use `checkout@v7`, `google-github-actions/auth@v3`, `google-github-actions/setup-gcloud@v3`). Reviewer should confirm the next `deploy-frontend.yml` dispatch (Hosting or rules-only) still passes with the bumped actions.

## Domain invariants

Not applicable — CI/CD workflow version-pin change only; no Firestore writes, calendar-date logic, credentials, or recommendation decision logic touched.

## Screenshots or recordings

Not applicable — deployment tooling only; no UI change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ky6ggeiwFLg4eGvJ1abXvp)_