### PR TITLE
feat(app): open daily check-in as default first screen when pending

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -115,6 +115,7 @@ function App() {
       // and still exposes a Dashboard escape hatch if its own data source is unavailable.
       if (initialRouteUserIdRef.current !== requestUserId) {
         initialRouteUserIdRef.current = requestUserId;
+        lastRoutedDate.current = getLocalDateString();
         currentScreenRef.current = 'checkin';
         setScreen('checkin');
         setInitialRouteUserId(requestUserId);

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -234,6 +234,7 @@ function App() {
 
   const isWorkoutRunnerActive =
     (screen === 'sessions' || screen === 'testing') && activeStructuredSession?.state === 'in_progress';
+  const dailyViewDate = decisionInput?.date ?? getLocalDateString();
 
   return (
     <div className="app-container">
@@ -275,10 +276,11 @@ function App() {
           </div>
         )}
 
-      <main className="app-content" key={decisionInput?.date ?? getLocalDateString()}>
+      <main className="app-content">
         <Suspense fallback={<div className="loading-state">Loading...</div>}>
           {screen === 'home' && (
             <Home
+              key={dailyViewDate}
               userId={userId!}
               onNavigate={handleNavigate}
               onViewData={() => {
@@ -330,6 +332,7 @@ function App() {
 
           {screen === 'checkin' && (
             <DailyCheckin
+              key={dailyViewDate}
               userId={userId!}
               onNavigate={handleNavigate}
               onBack={() => handleNavigate('home')}

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -4,6 +4,7 @@ import './index.css';
 import { Home } from './components/Home';
 import type { PreparedSessionLaunch } from './components/session/SessionDestinationSheet';
 import { decisionComposer } from './engine/composer';
+import { hasCompletedSubjectiveCheckinForDecision } from './engine/checkinCompletion';
 import type { HealthAnomalyAssessmentRevision } from './engine/healthAnomalyModels';
 import type { DailyDecisionInput } from './engine/models';
 import type { SessionExecution, SessionIntent } from './sessions/models';
@@ -38,9 +39,14 @@ function App() {
   const [healthAnomalyShadowRevision, setHealthAnomalyShadowRevision] = useState<HealthAnomalyAssessmentRevision | null>(null);
   const [desktopSettingsOpen, setDesktopSettingsOpen] = useState(false);
   const [mobileMoreOpen, setMobileMoreOpen] = useState(false);
-  const hasResolvedInitialScreen = useRef(false);
-  const lastResolvedDate = useRef<string | null>(null);
-  const userNavigatedExplicitly = useRef(false);
+  const [initialRouteUserId, setInitialRouteUserId] = useState<string | null>(null);
+  const initialRouteUserIdRef = useRef<string | null>(null);
+  const lastRoutedDate = useRef<string | null>(null);
+  const decisionInputRequestRevision = useRef(0);
+  const activeUserIdRef = useRef<string | null>(userId);
+  const currentScreenRef = useRef<Screen>(screen);
+  activeUserIdRef.current = userId;
+  currentScreenRef.current = screen;
   // M3.4/M2.7 cutover: legacy Strength v1 remains a permanent read format, but it no longer
   // owns a second live runner. An already-open pre-cutover document is surfaced only so the
   // athlete can close it without losing its partial sets; all new execution uses SessionRunner.
@@ -52,52 +58,85 @@ function App() {
 
   const loadDecisionInput = useCallback(async () => {
     if (!userId) return;
+    const requestUserId = userId;
+    const requestRevision = ++decisionInputRequestRevision.current;
+
     try {
-      const input = await decisionComposer.composeDailyDecisionInput(userId);
+      const input = await decisionComposer.composeDailyDecisionInput(requestUserId);
+      if (
+        activeUserIdRef.current !== requestUserId
+        || decisionInputRequestRevision.current !== requestRevision
+      ) {
+        return;
+      }
+
       setDecisionInput(input);
 
-      // Check-in first routing: on initial boot or calendar day rollover, route to check-in if pending
-      const isNewDay = lastResolvedDate.current !== null && lastResolvedDate.current !== input.date;
-      if (!hasResolvedInitialScreen.current || isNewDay) {
-        hasResolvedInitialScreen.current = true;
-        lastResolvedDate.current = input.date;
-        const isCheckinIncomplete = !input.dataQuality.hasSubjectiveCheckin || !input.dataQuality.subjectiveCheckinComplete;
-        if (!userNavigatedExplicitly.current || isNewDay) {
-          if (isCheckinIncomplete) {
-            setScreen('checkin');
-          } else if (!userNavigatedExplicitly.current) {
-            setScreen('home');
-          }
-        }
+      // The initial route is resolved before the dashboard is allowed to mount, avoiding a
+      // flash (and unnecessary recommendation work) on Home before a pending check-in wins.
+      // On a later calendar day we only auto-route while the athlete is already on Home or
+      // Check-in, so a refresh can never eject an in-progress session or another workflow.
+      const needsInitialRoute = initialRouteUserIdRef.current !== requestUserId;
+      const needsDailyRoute = lastRoutedDate.current !== input.date;
+      const isSafeAutoRouteScreen = currentScreenRef.current === 'home' || currentScreenRef.current === 'checkin';
+      if (needsInitialRoute || (needsDailyRoute && isSafeAutoRouteScreen)) {
+        const nextScreen: Screen = hasCompletedSubjectiveCheckinForDecision(input) ? 'home' : 'checkin';
+        currentScreenRef.current = nextScreen;
+        setScreen(nextScreen);
+        initialRouteUserIdRef.current = requestUserId;
+        lastRoutedDate.current = input.date;
+        setInitialRouteUserId(requestUserId);
       }
 
       // HA-D evidence collection is deliberately fire-and-forget relative to readiness.
       // Only an explicit shadow-v1 runtime value reaches the HA service, and the result is
       // retained solely so the Detailed Data trace can update after immutable persistence.
-      void runConfiguredHealthAnomalyShadow(userId, input.date)
+      void runConfiguredHealthAnomalyShadow(requestUserId, input.date)
         .then(result => {
-          if (result) setHealthAnomalyShadowRevision(result.revision);
+          if (
+            result
+            && activeUserIdRef.current === requestUserId
+            && decisionInputRequestRevision.current === requestRevision
+          ) {
+            setHealthAnomalyShadowRevision(result.revision);
+          }
         })
         .catch(error => {
           console.error('Error collecting health anomaly shadow evidence:', error);
         });
     } catch (error) {
+      if (
+        activeUserIdRef.current !== requestUserId
+        || decisionInputRequestRevision.current !== requestRevision
+      ) {
+        return;
+      }
       console.error('Error loading decision input:', error);
+      // Fail open to Home if the first composition itself is unavailable. The app remains
+      // usable, while any later successful refresh can still apply today's route because
+      // lastRoutedDate intentionally remains unresolved.
+      if (initialRouteUserIdRef.current !== requestUserId) {
+        initialRouteUserIdRef.current = requestUserId;
+        currentScreenRef.current = 'home';
+        setScreen('home');
+        setInitialRouteUserId(requestUserId);
+      }
     }
   }, [userId]);
 
   useEffect(() => {
-    if (userId && authPhase === 'AUTHENTICATED') {
-      loadDecisionInput();
-    }
-  }, [userId, authPhase, loadDecisionInput]);
+    // Invalidate any outstanding decision composition before resetting identity-scoped UI.
+    // This prevents a slow response from the previous account (or an older same-account
+    // refresh) from replacing current decision data or driving navigation after the switch.
+    decisionInputRequestRevision.current += 1;
+    initialRouteUserIdRef.current = null;
+    lastRoutedDate.current = null;
+    setInitialRouteUserId(null);
+    setDecisionInput(null);
+    setHealthAnomalyShadowRevision(null);
 
-  useEffect(() => {
     // Clear synchronously on every identity change so a resolved session from a previous
     // account can never be shown, or acted on, under a newly signed-in userId.
-    hasResolvedInitialScreen.current = false;
-    lastResolvedDate.current = null;
-    userNavigatedExplicitly.current = false;
     setLegacyStrengthSessionId(null);
     setActiveStructuredSession(null);
     setActiveStructuredIntent(null);
@@ -128,15 +167,66 @@ function App() {
     return () => { cancelled = true; };
   }, [userId, authPhase]);
 
+  useEffect(() => {
+    if (userId && authPhase === 'AUTHENTICATED') {
+      void loadDecisionInput();
+    }
+  }, [userId, authPhase, loadDecisionInput]);
+
+  useEffect(() => {
+    if (!userId || authPhase !== 'AUTHENTICATED' || initialRouteUserId !== userId) return;
+
+    const refreshIfCalendarDayChanged = () => {
+      const isSafeAutoRouteScreen = currentScreenRef.current === 'home' || currentScreenRef.current === 'checkin';
+      if (isSafeAutoRouteScreen && lastRoutedDate.current !== getLocalDateString()) {
+        void loadDecisionInput();
+      }
+    };
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'visible') refreshIfCalendarDayChanged();
+    };
+
+    const intervalId = window.setInterval(refreshIfCalendarDayChanged, 60_000);
+    window.addEventListener('focus', refreshIfCalendarDayChanged);
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    return () => {
+      window.clearInterval(intervalId);
+      window.removeEventListener('focus', refreshIfCalendarDayChanged);
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+    };
+  }, [userId, authPhase, initialRouteUserId, loadDecisionInput]);
+
   if (authPhase !== 'AUTHENTICATED') {
     return <LoginScreen />;
   }
 
+  // Do not mount Home until today's completion state has chosen the first authenticated
+  // screen. Besides removing the visible Home→Check-in flash, this avoids generating or
+  // displaying a recommendation from incomplete subjective input before the check-in UI.
+  if (!userId || initialRouteUserId !== userId) {
+    return (
+      <div className="app-container">
+        <main className="app-content">
+          <div className="loading-state" role="status">Loading today&apos;s check-in status...</div>
+        </main>
+      </div>
+    );
+  }
+
   const handleNavigate = (newScreen: Screen) => {
-    userNavigatedExplicitly.current = true;
+    currentScreenRef.current = newScreen;
     setScreen(newScreen);
     setDesktopSettingsOpen(false);
     setMobileMoreOpen(false);
+
+    // If the app spent midnight/background time inside a non-routable workflow, re-evaluate
+    // the daily default as soon as the athlete next returns to Home or Check-in.
+    if (
+      (newScreen === 'home' || newScreen === 'checkin')
+      && lastRoutedDate.current !== getLocalDateString()
+    ) {
+      void loadDecisionInput();
+    }
   };
 
   const isWorkoutRunnerActive =
@@ -189,7 +279,7 @@ function App() {
               userId={userId!}
               onNavigate={handleNavigate}
               onViewData={() => {
-                loadDecisionInput();
+                void loadDecisionInput();
                 handleNavigate('data');
               }}
               onStartSession={async binding => {
@@ -313,7 +403,7 @@ function App() {
               userId={userId!}
               onNavigate={setScreen}
               onPlanChanged={() => {
-                loadDecisionInput();
+                void loadDecisionInput();
               }}
             />
           )}

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -45,8 +45,6 @@ function App() {
   const decisionInputRequestRevision = useRef(0);
   const activeUserIdRef = useRef<string | null>(userId);
   const currentScreenRef = useRef<Screen>(screen);
-  activeUserIdRef.current = userId;
-  currentScreenRef.current = screen;
   // M3.4/M2.7 cutover: legacy Strength v1 remains a permanent read format, but it no longer
   // owns a second live runner. An already-open pre-cutover document is surfaced only so the
   // athlete can close it without losing its partial sets; all new execution uses SessionRunner.
@@ -112,19 +110,24 @@ function App() {
         return;
       }
       console.error('Error loading decision input:', error);
-      // Fail open to Home if the first composition itself is unavailable. The app remains
-      // usable, while any later successful refresh can still apply today's route because
-      // lastRoutedDate intentionally remains unresolved.
+      // If the initial composition is unavailable we cannot prove today's check-in is
+      // complete, so fail toward Check-in. That screen reads the daily document directly
+      // and still exposes a Dashboard escape hatch if its own data source is unavailable.
       if (initialRouteUserIdRef.current !== requestUserId) {
         initialRouteUserIdRef.current = requestUserId;
-        currentScreenRef.current = 'home';
-        setScreen('home');
+        currentScreenRef.current = 'checkin';
+        setScreen('checkin');
         setInitialRouteUserId(requestUserId);
       }
     }
   }, [userId]);
 
   useEffect(() => {
+    // Keep the async identity guard in effect-space rather than mutating a ref during render.
+    // This effect is declared before the load effect below, so a newly authenticated identity
+    // is installed before its first decision composition starts.
+    activeUserIdRef.current = userId;
+
     // Invalidate any outstanding decision composition before resetting identity-scoped UI.
     // This prevents a slow response from the previous account (or an older same-account
     // refresh) from replacing current decision data or driving navigation after the switch.
@@ -401,7 +404,7 @@ function App() {
           {screen === 'plan' && (
             <PlanView
               userId={userId!}
-              onNavigate={setScreen}
+              onNavigate={handleNavigate}
               onPlanChanged={() => {
                 void loadDecisionInput();
               }}

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, lazy, Suspense } from 'react';
+import { useState, useEffect, useCallback, useRef, lazy, Suspense } from 'react';
 import './App.css';
 import './index.css';
 import { Home } from './components/Home';
@@ -38,6 +38,9 @@ function App() {
   const [healthAnomalyShadowRevision, setHealthAnomalyShadowRevision] = useState<HealthAnomalyAssessmentRevision | null>(null);
   const [desktopSettingsOpen, setDesktopSettingsOpen] = useState(false);
   const [mobileMoreOpen, setMobileMoreOpen] = useState(false);
+  const hasResolvedInitialScreen = useRef(false);
+  const lastResolvedDate = useRef<string | null>(null);
+  const userNavigatedExplicitly = useRef(false);
   // M3.4/M2.7 cutover: legacy Strength v1 remains a permanent read format, but it no longer
   // owns a second live runner. An already-open pre-cutover document is surfaced only so the
   // athlete can close it without losing its partial sets; all new execution uses SessionRunner.
@@ -52,6 +55,22 @@ function App() {
     try {
       const input = await decisionComposer.composeDailyDecisionInput(userId);
       setDecisionInput(input);
+
+      // Check-in first routing: on initial boot or calendar day rollover, route to check-in if pending
+      const isNewDay = lastResolvedDate.current !== null && lastResolvedDate.current !== input.date;
+      if (!hasResolvedInitialScreen.current || isNewDay) {
+        hasResolvedInitialScreen.current = true;
+        lastResolvedDate.current = input.date;
+        const isCheckinIncomplete = !input.dataQuality.hasSubjectiveCheckin || !input.dataQuality.subjectiveCheckinComplete;
+        if (!userNavigatedExplicitly.current || isNewDay) {
+          if (isCheckinIncomplete) {
+            setScreen('checkin');
+          } else if (!userNavigatedExplicitly.current) {
+            setScreen('home');
+          }
+        }
+      }
+
       // HA-D evidence collection is deliberately fire-and-forget relative to readiness.
       // Only an explicit shadow-v1 runtime value reaches the HA service, and the result is
       // retained solely so the Detailed Data trace can update after immutable persistence.
@@ -69,7 +88,6 @@ function App() {
 
   useEffect(() => {
     if (userId && authPhase === 'AUTHENTICATED') {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       loadDecisionInput();
     }
   }, [userId, authPhase, loadDecisionInput]);
@@ -77,6 +95,9 @@ function App() {
   useEffect(() => {
     // Clear synchronously on every identity change so a resolved session from a previous
     // account can never be shown, or acted on, under a newly signed-in userId.
+    hasResolvedInitialScreen.current = false;
+    lastResolvedDate.current = null;
+    userNavigatedExplicitly.current = false;
     setLegacyStrengthSessionId(null);
     setActiveStructuredSession(null);
     setActiveStructuredIntent(null);
@@ -112,6 +133,7 @@ function App() {
   }
 
   const handleNavigate = (newScreen: Screen) => {
+    userNavigatedExplicitly.current = true;
     setScreen(newScreen);
     setDesktopSettingsOpen(false);
     setMobileMoreOpen(false);
@@ -218,6 +240,7 @@ function App() {
               userId={userId!}
               onNavigate={handleNavigate}
               onBack={() => handleNavigate('home')}
+              onCheckinSaved={loadDecisionInput}
             />
           )}
 

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -275,7 +275,7 @@ function App() {
           </div>
         )}
 
-      <main className="app-content">
+      <main className="app-content" key={decisionInput?.date ?? getLocalDateString()}>
         <Suspense fallback={<div className="loading-state">Loading...</div>}>
           {screen === 'home' && (
             <Home

--- a/app/src/components/DailyCheckin.css
+++ b/app/src/components/DailyCheckin.css
@@ -61,6 +61,71 @@
   border: 1px solid rgba(255, 255, 255, 0.08);
 }
 
+/* Checkin Completed Banner */
+.checkin-completed-banner {
+  background: rgba(16, 185, 129, 0.1);
+  border: 1px solid rgba(16, 185, 129, 0.3);
+  border-radius: var(--radius-card, 14px);
+  padding: 0.9rem 1.1rem;
+  margin-bottom: 1.25rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.checkin-completed-content {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.checkin-completed-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: rgba(16, 185, 129, 0.2);
+  color: #34d399;
+  font-weight: 700;
+  font-size: 0.9rem;
+  flex-shrink: 0;
+}
+
+.checkin-completed-text strong {
+  display: block;
+  font-size: 0.9rem;
+  color: #6ee7b7;
+  margin-bottom: 0.15rem;
+}
+
+.checkin-completed-text p {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--text-secondary, #94a3b8);
+}
+
+.btn-view-plan-direct {
+  background: rgba(16, 185, 129, 0.18);
+  border: 1px solid rgba(16, 185, 129, 0.4);
+  color: #a7f3d0;
+  font-size: 0.85rem;
+  font-weight: 600;
+  padding: 0.45rem 0.9rem;
+  border-radius: var(--radius-control, 10px);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.btn-view-plan-direct:hover {
+  background: rgba(16, 185, 129, 0.3);
+  border-color: rgba(16, 185, 129, 0.6);
+}
+
 /* Followup Tissue Prompt */
 .followup-tissue-prompt {
   background: rgba(59, 130, 246, 0.12);

--- a/app/src/components/DailyCheckin.tsx
+++ b/app/src/components/DailyCheckin.tsx
@@ -8,6 +8,7 @@ import { EXERCISES } from '../workouts/exercises';
 import type { BodyRegion, DailySubjectiveCheckin, RegionTissueResponse, TissueResponseLevel } from '../engine/models';
 import type { HealthContextCheckin } from '../engine/healthAnomalyModels';
 import { BODY_REGIONS, TISSUE_LEVELS } from '../engine/models';
+import { isCompletedSubjectiveCheckin } from '../engine/checkinCompletion';
 import { getLocalDateString, addDaysToLocalDateString } from '../utils/localDate';
 import { getErrorMessage } from '../utils/errors';
 import type { Screen } from '../types/navigation';
@@ -19,7 +20,7 @@ interface DailyCheckinProps {
   userId: string;
   onNavigate: (screen: Screen) => void;
   onBack?: () => void;
-  onCheckinSaved?: () => void;
+  onCheckinSaved?: () => void | Promise<void>;
 }
 
 const REGION_LABELS: Record<BodyRegion, string> = {
@@ -412,7 +413,7 @@ export function DailyCheckin({ userId, onNavigate, onBack, onCheckinSaved }: Dai
 
       const result = await checkinService.upsertTodayCheckin(userId, checkinToSave);
       setCheckin(result);
-      if (onCheckinSaved) onCheckinSaved();
+      if (onCheckinSaved) await onCheckinSaved();
       onNavigate('home');
     } catch (err: unknown) {
       console.error('Unexpected error saving check-in:', err);
@@ -466,7 +467,7 @@ export function DailyCheckin({ userId, onNavigate, onBack, onCheckinSaved }: Dai
   const tissueResponses = Object.values(checkin.tissueResponses ?? {}).filter(
     (response): response is RegionTissueResponse => response !== undefined,
   );
-  const isAlreadySubmitted = Boolean(checkin.submittedAt || checkin.initialSubmittedAt);
+  const isAlreadySubmitted = isCompletedSubjectiveCheckin(checkin);
 
   return (
     <div className="checkin-container">

--- a/app/src/components/DailyCheckin.tsx
+++ b/app/src/components/DailyCheckin.tsx
@@ -19,6 +19,7 @@ interface DailyCheckinProps {
   userId: string;
   onNavigate: (screen: Screen) => void;
   onBack?: () => void;
+  onCheckinSaved?: () => void;
 }
 
 const REGION_LABELS: Record<BodyRegion, string> = {
@@ -107,7 +108,7 @@ const SCALES: ScaleConfig[] = [
   },
 ];
 
-export function DailyCheckin({ userId, onNavigate, onBack }: DailyCheckinProps) {
+export function DailyCheckin({ userId, onNavigate, onBack, onCheckinSaved }: DailyCheckinProps) {
   const [checkin, setCheckin] = useState<Partial<DailySubjectiveCheckin> | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -411,6 +412,7 @@ export function DailyCheckin({ userId, onNavigate, onBack }: DailyCheckinProps) 
 
       const result = await checkinService.upsertTodayCheckin(userId, checkinToSave);
       setCheckin(result);
+      if (onCheckinSaved) onCheckinSaved();
       onNavigate('home');
     } catch (err: unknown) {
       console.error('Unexpected error saving check-in:', err);
@@ -464,13 +466,19 @@ export function DailyCheckin({ userId, onNavigate, onBack }: DailyCheckinProps) 
   const tissueResponses = Object.values(checkin.tissueResponses ?? {}).filter(
     (response): response is RegionTissueResponse => response !== undefined,
   );
+  const isAlreadySubmitted = Boolean(checkin.submittedAt || checkin.initialSubmittedAt);
 
   return (
     <div className="checkin-container">
       <div className="checkin-header-bar">
         {onBack && (
-          <button type="button" className="back-btn" onClick={onBack} aria-label="Back">
-            ← Back
+          <button
+            type="button"
+            className="back-btn"
+            onClick={onBack}
+            aria-label={isAlreadySubmitted ? 'Back to Dashboard' : 'Skip to Dashboard'}
+          >
+            {isAlreadySubmitted ? '← Back to Dashboard' : '← Skip to Dashboard'}
           </button>
         )}
         <div className="checkin-title-group">
@@ -478,6 +486,25 @@ export function DailyCheckin({ userId, onNavigate, onBack }: DailyCheckinProps) 
           <span className="checkin-date-badge">Today · {checkin.date || getLocalDateString()}</span>
         </div>
       </div>
+
+      {isAlreadySubmitted && (
+        <aside className="checkin-completed-banner" role="status">
+          <div className="checkin-completed-content">
+            <span className="checkin-completed-icon">✓</span>
+            <div className="checkin-completed-text">
+              <strong>Today&apos;s check-in was submitted</strong>
+              <p>You can update your entries below anytime, or go straight to today&apos;s plan.</p>
+            </div>
+          </div>
+          <button
+            type="button"
+            className="btn-view-plan-direct"
+            onClick={onBack ?? (() => onNavigate('home'))}
+          >
+            View Today&apos;s Plan →
+          </button>
+        </aside>
+      )}
 
       {pendingFollowups.length > 0 && (
         <aside className="followup-tissue-prompt" aria-label="Yesterday reaction prompt">
@@ -869,7 +896,11 @@ export function DailyCheckin({ userId, onNavigate, onBack }: DailyCheckinProps) 
             className="btn-primary checkin-submit-btn"
             disabled={saving}
           >
-            {saving ? 'Saving check-in…' : "Save & see today's plan"}
+            {saving
+              ? 'Saving check-in…'
+              : isAlreadySubmitted
+              ? "Update & see today's plan"
+              : "Save & see today's plan"}
           </button>
         </div>
       </form>

--- a/app/src/engine/checkinCompletion.test.ts
+++ b/app/src/engine/checkinCompletion.test.ts
@@ -5,15 +5,15 @@ import {
 } from './checkinCompletion';
 
 describe('check-in completion semantics', () => {
-  it('does not treat a timestamped draft as completed', () => {
+  it('does not treat an incomplete draft as completed', () => {
     expect(isCompletedSubjectiveCheckin({
-      dataQuality: { isComplete: false, missingFields: ['readiness'] },
+      dataQuality: { isComplete: false },
     })).toBe(false);
   });
 
   it('treats validated complete check-ins as completed without relying on submission timestamps', () => {
     expect(isCompletedSubjectiveCheckin({
-      dataQuality: { isComplete: true, missingFields: [] },
+      dataQuality: { isComplete: true },
     })).toBe(true);
   });
 

--- a/app/src/engine/checkinCompletion.test.ts
+++ b/app/src/engine/checkinCompletion.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import {
+  hasCompletedSubjectiveCheckinForDecision,
+  isCompletedSubjectiveCheckin,
+} from './checkinCompletion';
+
+describe('check-in completion semantics', () => {
+  it('does not treat a timestamped draft as completed', () => {
+    expect(isCompletedSubjectiveCheckin({
+      dataQuality: { isComplete: false, missingFields: ['readiness'] },
+    })).toBe(false);
+  });
+
+  it('treats validated complete check-ins as completed without relying on submission timestamps', () => {
+    expect(isCompletedSubjectiveCheckin({
+      dataQuality: { isComplete: true, missingFields: [] },
+    })).toBe(true);
+  });
+
+  it('fails closed when decision-input completion flags disagree', () => {
+    expect(hasCompletedSubjectiveCheckinForDecision({
+      dataQuality: {
+        hasRecoverySnapshot: true,
+        hasSubjectiveCheckin: false,
+        subjectiveCheckinComplete: true,
+        profileReady: true,
+      },
+    })).toBe(false);
+  });
+
+  it('accepts a composed decision only when a complete subjective check-in exists', () => {
+    expect(hasCompletedSubjectiveCheckinForDecision({
+      dataQuality: {
+        hasRecoverySnapshot: true,
+        hasSubjectiveCheckin: true,
+        subjectiveCheckinComplete: true,
+        profileReady: true,
+      },
+    })).toBe(true);
+  });
+});

--- a/app/src/engine/checkinCompletion.ts
+++ b/app/src/engine/checkinCompletion.ts
@@ -1,5 +1,9 @@
 import type { DailyDecisionInput, DailySubjectiveCheckin } from './models';
 
+type SubjectiveCheckinCompletionView = {
+  dataQuality?: Pick<DailySubjectiveCheckin['dataQuality'], 'isComplete'>;
+};
+
 /**
  * Canonical UI completion predicate for a persisted or in-memory subjective check-in.
  *
@@ -8,9 +12,9 @@ import type { DailyDecisionInput, DailySubjectiveCheckin } from './models';
  * are complete. The validated data-quality flag is the authority used by the decision layer.
  */
 export function isCompletedSubjectiveCheckin(
-  checkin: Pick<DailySubjectiveCheckin, 'dataQuality'> | null | undefined,
+  checkin: SubjectiveCheckinCompletionView | null | undefined,
 ): boolean {
-  return checkin?.dataQuality.isComplete === true;
+  return checkin?.dataQuality?.isComplete === true;
 }
 
 /**

--- a/app/src/engine/checkinCompletion.ts
+++ b/app/src/engine/checkinCompletion.ts
@@ -1,0 +1,25 @@
+import type { DailyDecisionInput, DailySubjectiveCheckin } from './models';
+
+/**
+ * Canonical UI completion predicate for a persisted or in-memory subjective check-in.
+ *
+ * `submittedAt` is not a completion signal: draft check-ins are initialized with a timestamp
+ * and partial safety/follow-up writes may persist that draft before the six subjective scores
+ * are complete. The validated data-quality flag is the authority used by the decision layer.
+ */
+export function isCompletedSubjectiveCheckin(
+  checkin: Pick<DailySubjectiveCheckin, 'dataQuality'> | null | undefined,
+): boolean {
+  return checkin?.dataQuality.isComplete === true;
+}
+
+/**
+ * Decision-input equivalent of `isCompletedSubjectiveCheckin`. Requiring both flags keeps
+ * the routing predicate fail-closed if an inconsistent composed payload ever reports a
+ * complete check-in while also reporting that no subjective check-in exists.
+ */
+export function hasCompletedSubjectiveCheckinForDecision(
+  input: Pick<DailyDecisionInput, 'dataQuality'>,
+): boolean {
+  return input.dataQuality.hasSubjectiveCheckin && input.dataQuality.subjectiveCheckinComplete;
+}


### PR DESCRIPTION
## Summary
- Automatically routes to the **Morning Check-In** screen on app open when today's check-in is pending or incomplete, eliminating friction and boosting daily compliance.
- Automatically routes to **Home Dashboard** when today's check-in has already been completed for the current calendar day.
- Adds adaptive \← Skip to Dashboard\ / \← Back to Dashboard\ escape hatch navigation to prevent trapping athletes in a rush.
- Displays a status banner on revisitation if check-in was already completed with a direct \View Today's Plan →\ action.
- Submitting check-in immediately refreshes inputs and smoothly transitions to the Home Dashboard with today's training recommendation revealed.

## Verification
- Validated with \
pm run check\ (TypeScript compilation, ESLint, 201 test files / 2,052 Vitest unit tests, and workout catalog validation passed).