### PR TITLE
feat(garmin): automated 56-day backfill on link and auto-sync on login

### DIFF
--- a/app/firestore.rules
+++ b/app/firestore.rules
@@ -918,10 +918,12 @@ service cloud.firestore {
     function hasValidGarminSyncRequest(userId) {
       let data = request.resource.data;
       return hasOwnedUserId(userId)
-        && data.keys().hasOnly(['userId', 'status', 'requestedAt', 'completedAt', 'error'])
+        && data.keys().hasOnly(['userId', 'status', 'requestedAt', 'completedAt', 'error', 'requestType', 'days'])
         && data.keys().hasAll(['userId', 'status', 'requestedAt'])
         && data.status == 'pending'
         && data.requestedAt is string
+        && (!('requestType' in data) || data.requestType in ['sync', 'initial_backfill', 'backfill'])
+        && (!('days' in data) || (data.days is int && data.days >= 1 && data.days <= 365))
         && (!('completedAt' in data) || data.completedAt == null)
         && (!('error' in data) || data.error == null);
     }

--- a/app/src/components/GarminSyncNowButton.test.tsx
+++ b/app/src/components/GarminSyncNowButton.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { GarminSyncNowButton, isAwaitedManualSyncTerminal } from './GarminSyncNowButton';
+import { GarminSyncNowButton } from './GarminSyncNowButton';
+import { isAwaitedSyncTerminal } from '../utils/garminSyncRequestState';
 import { isSyncRequestStale, STALE_AFTER_MS } from '../utils/garminSyncStaleness';
 import type { GarminSyncRequest } from '../services/garminSyncRequestService';
 
@@ -27,7 +28,7 @@ describe('GarminSyncNowButton', () => {
     });
 });
 
-describe('isAwaitedManualSyncTerminal', () => {
+describe('isAwaitedSyncTerminal', () => {
     const requestedAt = '2026-08-21T06:00:00.000Z';
     const base = (overrides: Partial<GarminSyncRequest> = {}): GarminSyncRequest => ({
         userId: 'u1',
@@ -38,7 +39,7 @@ describe('isAwaitedManualSyncTerminal', () => {
 
     it('ignores terminal snapshots for an older shared-document request', () => {
         expect(
-            isAwaitedManualSyncTerminal(
+            isAwaitedSyncTerminal(
                 base({ status: 'completed', requestedAt: '2026-08-21T05:00:00.000Z' }),
                 requestedAt
             )
@@ -46,14 +47,14 @@ describe('isAwaitedManualSyncTerminal', () => {
     });
 
     it('waits while the matching request is pending or processing', () => {
-        expect(isAwaitedManualSyncTerminal(base({ status: 'pending' }), requestedAt)).toBe(false);
-        expect(isAwaitedManualSyncTerminal(base({ status: 'processing' }), requestedAt)).toBe(false);
+        expect(isAwaitedSyncTerminal(base({ status: 'pending' }), requestedAt)).toBe(false);
+        expect(isAwaitedSyncTerminal(base({ status: 'processing' }), requestedAt)).toBe(false);
     });
 
     it('resolves only a terminal snapshot for the exact request', () => {
-        expect(isAwaitedManualSyncTerminal(base({ status: 'completed' }), requestedAt)).toBe(true);
-        expect(isAwaitedManualSyncTerminal(base({ status: 'failed' }), requestedAt)).toBe(true);
-        expect(isAwaitedManualSyncTerminal(base({ status: 'completed' }), null)).toBe(false);
+        expect(isAwaitedSyncTerminal(base({ status: 'completed' }), requestedAt)).toBe(true);
+        expect(isAwaitedSyncTerminal(base({ status: 'failed' }), requestedAt)).toBe(true);
+        expect(isAwaitedSyncTerminal(base({ status: 'completed' }), null)).toBe(false);
     });
 });
 

--- a/app/src/components/GarminSyncNowButton.test.tsx
+++ b/app/src/components/GarminSyncNowButton.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { GarminSyncNowButton } from './GarminSyncNowButton';
+import { GarminSyncNowButton, isAwaitedManualSyncTerminal } from './GarminSyncNowButton';
 import { isSyncRequestStale, STALE_AFTER_MS } from '../utils/garminSyncStaleness';
 import type { GarminSyncRequest } from '../services/garminSyncRequestService';
 
@@ -8,15 +8,13 @@ import type { GarminSyncRequest } from '../services/garminSyncRequestService';
 // markup-level smoke test, matching the existing convention for sibling components
 // (ManualSessionBuilder.test.tsx, SessionJsonImport.test.tsx). subscribeToRequest is a
 // useEffect, which react-dom/server never runs, so this only exercises the button's
-// default (no outstanding request) render; garminSyncRequestService.test.ts and
-// test_sync_service.py cover the request/poll behavior itself. The stale-request
-// detection is the one piece of state-transition logic worth its own interactive test
-// (per review), so it's factored into the pure isSyncRequestStale() below instead of
-// buried in the component, and tested directly here without rendering anything.
+// default (no outstanding request) render. State-transition rules are kept in pure
+// helpers and tested directly below.
 vi.mock('../services/garminSyncRequestService', () => ({
     garminSyncRequestService: {
         subscribeToRequest: vi.fn(() => vi.fn()),
-        requestSync: vi.fn(async () => {}),
+        requestSync: vi.fn(async () => '2026-08-21T06:00:00.000Z'),
+        getRequest: vi.fn(async () => null),
     },
 }));
 
@@ -26,6 +24,36 @@ describe('GarminSyncNowButton', () => {
 
         expect(html).toContain('Sync now');
         expect(html).not.toContain('disabled');
+    });
+});
+
+describe('isAwaitedManualSyncTerminal', () => {
+    const requestedAt = '2026-08-21T06:00:00.000Z';
+    const base = (overrides: Partial<GarminSyncRequest> = {}): GarminSyncRequest => ({
+        userId: 'u1',
+        status: 'pending',
+        requestedAt,
+        ...overrides,
+    });
+
+    it('ignores terminal snapshots for an older shared-document request', () => {
+        expect(
+            isAwaitedManualSyncTerminal(
+                base({ status: 'completed', requestedAt: '2026-08-21T05:00:00.000Z' }),
+                requestedAt
+            )
+        ).toBe(false);
+    });
+
+    it('waits while the matching request is pending or processing', () => {
+        expect(isAwaitedManualSyncTerminal(base({ status: 'pending' }), requestedAt)).toBe(false);
+        expect(isAwaitedManualSyncTerminal(base({ status: 'processing' }), requestedAt)).toBe(false);
+    });
+
+    it('resolves only a terminal snapshot for the exact request', () => {
+        expect(isAwaitedManualSyncTerminal(base({ status: 'completed' }), requestedAt)).toBe(true);
+        expect(isAwaitedManualSyncTerminal(base({ status: 'failed' }), requestedAt)).toBe(true);
+        expect(isAwaitedManualSyncTerminal(base({ status: 'completed' }), null)).toBe(false);
     });
 });
 
@@ -52,7 +80,7 @@ describe('isSyncRequestStale', () => {
         expect(isSyncRequestStale(baseRequest({ status: 'processing' }), requestedAtMs + STALE_AFTER_MS - 1)).toBe(false);
     });
 
-    it('goes stale once pending or processing exceeds the threshold', () => {
+    it('goes stale once pending or ordinary processing exceeds the threshold', () => {
         expect(isSyncRequestStale(baseRequest({ status: 'pending' }), requestedAtMs + STALE_AFTER_MS + 1)).toBe(true);
         expect(isSyncRequestStale(baseRequest({ status: 'processing' }), requestedAtMs + STALE_AFTER_MS + 1)).toBe(true);
     });

--- a/app/src/components/GarminSyncNowButton.tsx
+++ b/app/src/components/GarminSyncNowButton.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { garminSyncRequestService, type GarminSyncRequest } from '../services/garminSyncRequestService';
+import { isAwaitedSyncTerminal } from '../utils/garminSyncRequestState';
 import { isSyncRequestStale, isSyncRequestInFlight } from '../utils/garminSyncStaleness';
 import './GarminSyncNowButton.css';
 
@@ -8,21 +9,6 @@ export interface GarminSyncNowButtonProps {
     /** Called once a request this button made or joined finishes (successfully or not),
      * so the caller can reload whatever data the sync may have just refreshed. */
     onSynced?: () => void;
-}
-
-/** Only a terminal snapshot for the exact request returned by requestSync() resolves
- * this button's awaiting state. A stale terminal snapshot from the shared fixed-id
- * document must not be mistaken for completion of the request being queued now. */
-export function isAwaitedManualSyncTerminal(
-    request: GarminSyncRequest | null,
-    awaitingRequestedAt: string | null
-): boolean {
-    return (
-        !!awaitingRequestedAt &&
-        !!request &&
-        request.requestedAt === awaitingRequestedAt &&
-        !isSyncRequestInFlight(request)
-    );
 }
 
 /**
@@ -53,7 +39,7 @@ export function GarminSyncNowButton({ userId, onSynced }: GarminSyncNowButtonPro
             userId,
             (next) => {
                 setRequest(next);
-                if (isAwaitedManualSyncTerminal(next, awaitingRequestedAtRef.current)) {
+                if (isAwaitedSyncTerminal(next, awaitingRequestedAtRef.current)) {
                     awaitingRequestedAtRef.current = null;
                     onSyncedRef.current?.();
                 }
@@ -92,7 +78,7 @@ export function GarminSyncNowButton({ userId, onSynced }: GarminSyncNowButtonPro
                 const current = await garminSyncRequestService.getRequest(userId);
                 if (
                     awaitingRequestedAtRef.current === requestedAt &&
-                    isAwaitedManualSyncTerminal(current, requestedAt)
+                    isAwaitedSyncTerminal(current, requestedAt)
                 ) {
                     awaitingRequestedAtRef.current = null;
                     onSyncedRef.current?.();

--- a/app/src/components/GarminSyncNowButton.tsx
+++ b/app/src/components/GarminSyncNowButton.tsx
@@ -5,9 +5,24 @@ import './GarminSyncNowButton.css';
 
 export interface GarminSyncNowButtonProps {
     userId: string;
-    /** Called once a request this button made finishes (successfully or not), so the
-     * caller can reload whatever data the sync may have just refreshed. */
+    /** Called once a request this button made or joined finishes (successfully or not),
+     * so the caller can reload whatever data the sync may have just refreshed. */
     onSynced?: () => void;
+}
+
+/** Only a terminal snapshot for the exact request returned by requestSync() resolves
+ * this button's awaiting state. A stale terminal snapshot from the shared fixed-id
+ * document must not be mistaken for completion of the request being queued now. */
+export function isAwaitedManualSyncTerminal(
+    request: GarminSyncRequest | null,
+    awaitingRequestedAt: string | null
+): boolean {
+    return (
+        !!awaitingRequestedAt &&
+        !!request &&
+        request.requestedAt === awaitingRequestedAt &&
+        !isSyncRequestInFlight(request)
+    );
 }
 
 /**
@@ -21,7 +36,16 @@ export function GarminSyncNowButton({ userId, onSynced }: GarminSyncNowButtonPro
     const [triggering, setTriggering] = useState(false);
     const [localError, setLocalError] = useState<string | null>(null);
     const [now, setNow] = useState(() => Date.now());
-    const awaitingOwnRequest = useRef(false);
+    const awaitingRequestedAtRef = useRef<string | null>(null);
+    const onSyncedRef = useRef(onSynced);
+
+    useEffect(() => {
+        onSyncedRef.current = onSynced;
+    }, [onSynced]);
+
+    useEffect(() => {
+        awaitingRequestedAtRef.current = null;
+    }, [userId]);
 
     useEffect(() => {
         if (!userId) return;
@@ -29,15 +53,14 @@ export function GarminSyncNowButton({ userId, onSynced }: GarminSyncNowButtonPro
             userId,
             (next) => {
                 setRequest(next);
-                if (awaitingOwnRequest.current && next && !isSyncRequestInFlight(next)) {
-                    awaitingOwnRequest.current = false;
-                    onSynced?.();
+                if (isAwaitedManualSyncTerminal(next, awaitingRequestedAtRef.current)) {
+                    awaitingRequestedAtRef.current = null;
+                    onSyncedRef.current?.();
                 }
             },
             (err) => console.error('[GarminSyncNowButton] Subscription error:', err)
         );
         return unsubscribe;
-        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [userId]);
 
     const isInFlight = isSyncRequestInFlight(request);
@@ -57,13 +80,32 @@ export function GarminSyncNowButton({ userId, onSynced }: GarminSyncNowButtonPro
     const handleClick = useCallback(async () => {
         setTriggering(true);
         setLocalError(null);
-        awaitingOwnRequest.current = true;
         try {
-            await garminSyncRequestService.requestSync(userId);
+            const requestedAt = await garminSyncRequestService.requestSync(userId);
+            awaitingRequestedAtRef.current = requestedAt;
+
+            // A request we join can finish between requestSync() resolving and the
+            // awaiting timestamp being installed above. The realtime listener may have
+            // already emitted that terminal snapshot while nothing was awaited, so do
+            // one reconciliation read after installing the correlation key.
+            try {
+                const current = await garminSyncRequestService.getRequest(userId);
+                if (
+                    awaitingRequestedAtRef.current === requestedAt &&
+                    isAwaitedManualSyncTerminal(current, requestedAt)
+                ) {
+                    awaitingRequestedAtRef.current = null;
+                    onSyncedRef.current?.();
+                }
+            } catch (err) {
+                // The realtime subscription remains the primary completion path; a
+                // transient read failure is not a failed sync request.
+                console.warn('[GarminSyncNowButton] Failed to reconcile sync state:', err);
+            }
         } catch (err) {
             console.error('Failed to request Garmin sync:', err);
             setLocalError('Could not request sync — try again.');
-            awaitingOwnRequest.current = false;
+            awaitingRequestedAtRef.current = null;
         } finally {
             setTriggering(false);
         }

--- a/app/src/components/Home.tsx
+++ b/app/src/components/Home.tsx
@@ -43,6 +43,7 @@ import { MinimumSafetyCheckin } from './MinimumSafetyCheckin';
 import { WeekAheadStrip } from './WeekAheadStrip';
 import { LaterDayFollowupCard, type LaterDayFollowupTarget } from './session/LaterDayFollowupCard';
 import { GarminSyncNowButton } from './GarminSyncNowButton';
+import { useAutoGarminSync } from '../hooks/useAutoGarminSync';
 import {
   canGenerateNormalRecommendation,
   createProvisionalSafetyRecommendation,
@@ -638,6 +639,12 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
   useEffect(() => {
     loadDashboardData();
   }, [loadDashboardData]);
+
+  useAutoGarminSync({
+    userId,
+    decisionInput,
+    onSynced: loadDashboardData,
+  });
 
   useEffect(() => {
     setTodaysJournalEntry(null);

--- a/app/src/hooks/useAutoGarminSync.test.ts
+++ b/app/src/hooks/useAutoGarminSync.test.ts
@@ -1,13 +1,23 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { garminSyncRequestService } from '../services/garminSyncRequestService';
-import { useAutoGarminSync } from './useAutoGarminSync';
+import { useAutoGarminSync, isAwaitedSyncComplete } from './useAutoGarminSync';
+import type { GarminSyncRequest } from '../services/garminSyncRequestService';
 
 vi.mock('../services/garminSyncRequestService', () => ({
     garminSyncRequestService: {
         subscribeToRequest: vi.fn(),
-        requestSync: vi.fn(async () => {}),
+        requestSync: vi.fn(async () => '2026-08-23T06:00:00.000Z'),
     },
 }));
+
+function request(overrides: Partial<GarminSyncRequest> = {}): GarminSyncRequest {
+    return {
+        userId: 'user-1',
+        status: 'pending',
+        requestedAt: '2026-08-23T06:00:00.000Z',
+        ...overrides,
+    };
+}
 
 describe('useAutoGarminSync', () => {
     beforeEach(() => {
@@ -24,5 +34,48 @@ describe('useAutoGarminSync', () => {
 
         expect(garminSyncRequestService.subscribeToRequest).toBeDefined();
         expect(garminSyncRequestService.requestSync).toBeDefined();
+    });
+});
+
+// Regression coverage for the completion-correlation fix: an auto-triggered sync
+// must only be reported "synced" for the exact request this hook queued reaching
+// 'completed', not for any other update to the shared garmin_sync_requests/latest
+// doc it happens to observe (a stale already-terminal snapshot, a still in-flight
+// update, or a failed outcome).
+describe('isAwaitedSyncComplete', () => {
+    const OUR_REQUESTED_AT = '2026-08-23T06:00:00.000Z';
+
+    it('ignores an initial snapshot that is already completed for a different (older) request', () => {
+        // This is the exact bug CodeRabbit flagged: if the doc already holds a
+        // completed request when the subscription attaches -- before requestSync()'s
+        // own write has landed -- the old boolean "not in-flight" check would fire
+        // onSynced immediately for someone else's finished sync.
+        const staleCompleted = request({ status: 'completed', requestedAt: '2026-08-23T05:00:00.000Z' });
+        expect(isAwaitedSyncComplete(staleCompleted, OUR_REQUESTED_AT)).toBe(false);
+    });
+
+    it('ignores pending/processing updates for our own request', () => {
+        expect(isAwaitedSyncComplete(request({ status: 'pending', requestedAt: OUR_REQUESTED_AT }), OUR_REQUESTED_AT)).toBe(
+            false
+        );
+        expect(
+            isAwaitedSyncComplete(request({ status: 'processing', requestedAt: OUR_REQUESTED_AT }), OUR_REQUESTED_AT)
+        ).toBe(false);
+    });
+
+    it('does not treat a failed outcome for our own request as success', () => {
+        expect(isAwaitedSyncComplete(request({ status: 'failed', requestedAt: OUR_REQUESTED_AT }), OUR_REQUESTED_AT)).toBe(
+            false
+        );
+    });
+
+    it('reports completion once our own request reaches completed', () => {
+        expect(
+            isAwaitedSyncComplete(request({ status: 'completed', requestedAt: OUR_REQUESTED_AT }), OUR_REQUESTED_AT)
+        ).toBe(true);
+    });
+
+    it('ignores updates when nothing is currently awaited', () => {
+        expect(isAwaitedSyncComplete(request({ status: 'completed', requestedAt: OUR_REQUESTED_AT }), null)).toBe(false);
     });
 });

--- a/app/src/hooks/useAutoGarminSync.test.ts
+++ b/app/src/hooks/useAutoGarminSync.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { garminSyncRequestService } from '../services/garminSyncRequestService';
+import { useAutoGarminSync } from './useAutoGarminSync';
+
+vi.mock('../services/garminSyncRequestService', () => ({
+    garminSyncRequestService: {
+        subscribeToRequest: vi.fn(),
+        requestSync: vi.fn(async () => {}),
+    },
+}));
+
+describe('useAutoGarminSync', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('exports useAutoGarminSync function', () => {
+        expect(typeof useAutoGarminSync).toBe('function');
+    });
+
+    it('subscribes to garminSyncRequestService when userId is provided', () => {
+        const unsubscribe = vi.fn();
+        vi.mocked(garminSyncRequestService.subscribeToRequest).mockReturnValue(unsubscribe);
+
+        expect(garminSyncRequestService.subscribeToRequest).toBeDefined();
+        expect(garminSyncRequestService.requestSync).toBeDefined();
+    });
+});

--- a/app/src/hooks/useAutoGarminSync.test.ts
+++ b/app/src/hooks/useAutoGarminSync.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { garminSyncRequestService } from '../services/garminSyncRequestService';
-import { getAwaitedSyncOutcome, useAutoGarminSync, isAwaitedSyncComplete } from './useAutoGarminSync';
+import { getAwaitedSyncOutcome, isAwaitedSyncComplete } from '../utils/garminSyncRequestState';
+import { useAutoGarminSync } from './useAutoGarminSync';
 import type { GarminSyncRequest } from '../services/garminSyncRequestService';
 
 vi.mock('../services/garminSyncRequestService', () => ({

--- a/app/src/hooks/useAutoGarminSync.test.ts
+++ b/app/src/hooks/useAutoGarminSync.test.ts
@@ -1,12 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { garminSyncRequestService } from '../services/garminSyncRequestService';
-import { useAutoGarminSync, isAwaitedSyncComplete } from './useAutoGarminSync';
+import { getAwaitedSyncOutcome, useAutoGarminSync, isAwaitedSyncComplete } from './useAutoGarminSync';
 import type { GarminSyncRequest } from '../services/garminSyncRequestService';
 
 vi.mock('../services/garminSyncRequestService', () => ({
     garminSyncRequestService: {
         subscribeToRequest: vi.fn(),
         requestSync: vi.fn(async () => '2026-08-23T06:00:00.000Z'),
+        getRequest: vi.fn(async () => null),
     },
 }));
 
@@ -28,54 +29,49 @@ describe('useAutoGarminSync', () => {
         expect(typeof useAutoGarminSync).toBe('function');
     });
 
-    it('subscribes to garminSyncRequestService when userId is provided', () => {
+    it('exposes the sync request service methods used by the hook', () => {
         const unsubscribe = vi.fn();
         vi.mocked(garminSyncRequestService.subscribeToRequest).mockReturnValue(unsubscribe);
 
         expect(garminSyncRequestService.subscribeToRequest).toBeDefined();
         expect(garminSyncRequestService.requestSync).toBeDefined();
+        expect(garminSyncRequestService.getRequest).toBeDefined();
     });
 });
 
-// Regression coverage for the completion-correlation fix: an auto-triggered sync
-// must only be reported "synced" for the exact request this hook queued reaching
-// 'completed', not for any other update to the shared garmin_sync_requests/latest
-// doc it happens to observe (a stale already-terminal snapshot, a still in-flight
-// update, or a failed outcome).
-describe('isAwaitedSyncComplete', () => {
+// Regression coverage for completion correlation: an auto-triggered sync must only
+// be reported "synced" for the exact request this hook queued/joined reaching
+// 'completed', not for any other update to garmin_sync_requests/latest.
+describe('awaited sync outcome', () => {
     const OUR_REQUESTED_AT = '2026-08-23T06:00:00.000Z';
 
-    it('ignores an initial snapshot that is already completed for a different (older) request', () => {
-        // This is the exact bug CodeRabbit flagged: if the doc already holds a
-        // completed request when the subscription attaches -- before requestSync()'s
-        // own write has landed -- the old boolean "not in-flight" check would fire
-        // onSynced immediately for someone else's finished sync.
+    it('ignores an initial snapshot that is already completed for a different request', () => {
         const staleCompleted = request({ status: 'completed', requestedAt: '2026-08-23T05:00:00.000Z' });
+        expect(getAwaitedSyncOutcome(staleCompleted, OUR_REQUESTED_AT)).toBeNull();
         expect(isAwaitedSyncComplete(staleCompleted, OUR_REQUESTED_AT)).toBe(false);
     });
 
     it('ignores pending/processing updates for our own request', () => {
-        expect(isAwaitedSyncComplete(request({ status: 'pending', requestedAt: OUR_REQUESTED_AT }), OUR_REQUESTED_AT)).toBe(
-            false
-        );
+        expect(getAwaitedSyncOutcome(request({ status: 'pending', requestedAt: OUR_REQUESTED_AT }), OUR_REQUESTED_AT)).toBeNull();
         expect(
-            isAwaitedSyncComplete(request({ status: 'processing', requestedAt: OUR_REQUESTED_AT }), OUR_REQUESTED_AT)
-        ).toBe(false);
+            getAwaitedSyncOutcome(request({ status: 'processing', requestedAt: OUR_REQUESTED_AT }), OUR_REQUESTED_AT)
+        ).toBeNull();
     });
 
-    it('does not treat a failed outcome for our own request as success', () => {
-        expect(isAwaitedSyncComplete(request({ status: 'failed', requestedAt: OUR_REQUESTED_AT }), OUR_REQUESTED_AT)).toBe(
-            false
-        );
+    it('classifies a failed outcome for our own request without treating it as success', () => {
+        const failed = request({ status: 'failed', requestedAt: OUR_REQUESTED_AT });
+        expect(getAwaitedSyncOutcome(failed, OUR_REQUESTED_AT)).toBe('failed');
+        expect(isAwaitedSyncComplete(failed, OUR_REQUESTED_AT)).toBe(false);
     });
 
     it('reports completion once our own request reaches completed', () => {
-        expect(
-            isAwaitedSyncComplete(request({ status: 'completed', requestedAt: OUR_REQUESTED_AT }), OUR_REQUESTED_AT)
-        ).toBe(true);
+        const completed = request({ status: 'completed', requestedAt: OUR_REQUESTED_AT });
+        expect(getAwaitedSyncOutcome(completed, OUR_REQUESTED_AT)).toBe('completed');
+        expect(isAwaitedSyncComplete(completed, OUR_REQUESTED_AT)).toBe(true);
     });
 
     it('ignores updates when nothing is currently awaited', () => {
+        expect(getAwaitedSyncOutcome(request({ status: 'completed', requestedAt: OUR_REQUESTED_AT }), null)).toBeNull();
         expect(isAwaitedSyncComplete(request({ status: 'completed', requestedAt: OUR_REQUESTED_AT }), null)).toBe(false);
     });
 });

--- a/app/src/hooks/useAutoGarminSync.ts
+++ b/app/src/hooks/useAutoGarminSync.ts
@@ -1,0 +1,76 @@
+import { useEffect, useRef } from 'react';
+import type { DailyDecisionInput } from '../engine/models';
+import { garminSyncRequestService } from '../services/garminSyncRequestService';
+import { isRecoverySnapshotStale, isSyncRequestInFlight } from '../utils/garminSyncStaleness';
+
+export interface UseAutoGarminSyncOptions {
+    userId: string | null | undefined;
+    decisionInput: DailyDecisionInput | null;
+    onSynced?: () => void;
+    enabled?: boolean;
+}
+
+/**
+ * Automatically checks whether today's Garmin recovery snapshot has been ingested
+ * and is up-to-date upon login or dashboard load.
+ *
+ * If the snapshot for decisionInput.date is missing, incomplete, or older than 60 minutes,
+ * an automated sync request is queued (matching manual "Sync Now" behavior) and onSynced
+ * is invoked when the ingestion completes.
+ */
+export function useAutoGarminSync({
+    userId,
+    decisionInput,
+    onSynced,
+    enabled = true,
+}: UseAutoGarminSyncOptions): void {
+    const hasTriggeredForDateRef = useRef<string | null>(null);
+    const awaitingSyncRef = useRef<boolean>(false);
+    const onSyncedRef = useRef(onSynced);
+
+    useEffect(() => {
+        onSyncedRef.current = onSynced;
+    }, [onSynced]);
+
+    // Reset the auto-trigger tracker when the user identity changes
+    useEffect(() => {
+        hasTriggeredForDateRef.current = null;
+        awaitingSyncRef.current = false;
+    }, [userId]);
+
+    // Subscribe to sync request state changes to notify caller when our sync finishes
+    useEffect(() => {
+        if (!userId || !enabled) return;
+
+        const unsubscribe = garminSyncRequestService.subscribeToRequest(
+            userId,
+            (request) => {
+                if (awaitingSyncRef.current && request && !isSyncRequestInFlight(request)) {
+                    awaitingSyncRef.current = false;
+                    onSyncedRef.current?.();
+                }
+            },
+            (err) => console.error('[useAutoGarminSync] Subscription error:', err)
+        );
+
+        return unsubscribe;
+    }, [userId, enabled]);
+
+    // Check staleness and trigger sync if needed
+    useEffect(() => {
+        if (!enabled || !userId || !decisionInput) return;
+
+        const targetDate = decisionInput.date;
+        if (hasTriggeredForDateRef.current === targetDate) return;
+
+        const isStale = isRecoverySnapshotStale(decisionInput.recoverySnapshot, targetDate);
+        if (isStale) {
+            hasTriggeredForDateRef.current = targetDate;
+            awaitingSyncRef.current = true;
+            garminSyncRequestService.requestSync(userId).catch((err) => {
+                console.warn('[useAutoGarminSync] Failed to request auto sync:', err);
+                awaitingSyncRef.current = false;
+            });
+        }
+    }, [userId, decisionInput, enabled]);
+}

--- a/app/src/hooks/useAutoGarminSync.ts
+++ b/app/src/hooks/useAutoGarminSync.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import type { DailyDecisionInput } from '../engine/models';
-import { garminSyncRequestService, type GarminSyncRequest } from '../services/garminSyncRequestService';
+import { garminSyncRequestService } from '../services/garminSyncRequestService';
+import { getAwaitedSyncOutcome } from '../utils/garminSyncRequestState';
 import { isRecoverySnapshotStale } from '../utils/garminSyncStaleness';
 
 export interface UseAutoGarminSyncOptions {
@@ -10,40 +11,9 @@ export interface UseAutoGarminSyncOptions {
     enabled?: boolean;
 }
 
-type AwaitedSyncOutcome = 'completed' | 'failed' | null;
-
 interface ActiveTriggerContext {
     userId: string;
     targetDate: string;
-}
-
-/**
- * Classify a subscription/read snapshot only when it belongs to the exact request
- * this hook is awaiting. This lets both the realtime listener and the post-request
- * reconciliation read share the same correlation rules.
- */
-export function getAwaitedSyncOutcome(
-    request: GarminSyncRequest | null,
-    awaitingRequestedAt: string | null
-): AwaitedSyncOutcome {
-    if (!awaitingRequestedAt || !request || request.requestedAt !== awaitingRequestedAt) {
-        return null;
-    }
-    if (request.status === 'completed' || request.status === 'failed') {
-        return request.status;
-    }
-    return null;
-}
-
-/**
- * Pure predicate kept for focused regression tests and callers that only care about
- * successful completion.
- */
-export function isAwaitedSyncComplete(
-    request: GarminSyncRequest | null,
-    awaitingRequestedAt: string | null
-): boolean {
-    return getAwaitedSyncOutcome(request, awaitingRequestedAt) === 'completed';
 }
 
 /**

--- a/app/src/hooks/useAutoGarminSync.ts
+++ b/app/src/hooks/useAutoGarminSync.ts
@@ -1,13 +1,36 @@
 import { useEffect, useRef } from 'react';
 import type { DailyDecisionInput } from '../engine/models';
-import { garminSyncRequestService } from '../services/garminSyncRequestService';
-import { isRecoverySnapshotStale, isSyncRequestInFlight } from '../utils/garminSyncStaleness';
+import { garminSyncRequestService, type GarminSyncRequest } from '../services/garminSyncRequestService';
+import { isRecoverySnapshotStale } from '../utils/garminSyncStaleness';
 
 export interface UseAutoGarminSyncOptions {
     userId: string | null | undefined;
     decisionInput: DailyDecisionInput | null;
     onSynced?: () => void;
     enabled?: boolean;
+}
+
+/**
+ * Pure predicate behind the completion subscription below, extracted so it's
+ * testable without a render harness (this repo has no interactive component-test
+ * harness -- see GarminSyncNowButton.test.tsx / garminSyncStaleness.ts).
+ *
+ * `awaitingRequestedAt` is the `requestedAt` of the specific request this hook
+ * queued (see requestSync()'s docstring). A snapshot only counts as "our sync
+ * finished" when it's that same request AND it reached 'completed' -- an update
+ * that matches the identifier but is still 'pending'/'processing', or that
+ * terminated as 'failed', must not fire onSynced.
+ */
+export function isAwaitedSyncComplete(
+    request: GarminSyncRequest | null,
+    awaitingRequestedAt: string | null
+): boolean {
+    return (
+        !!awaitingRequestedAt &&
+        !!request &&
+        request.requestedAt === awaitingRequestedAt &&
+        request.status === 'completed'
+    );
 }
 
 /**
@@ -25,7 +48,11 @@ export function useAutoGarminSync({
     enabled = true,
 }: UseAutoGarminSyncOptions): void {
     const hasTriggeredForDateRef = useRef<string | null>(null);
-    const awaitingSyncRef = useRef<boolean>(false);
+    // requestedAt of the specific request *this hook* queued, so the completion
+    // subscription below can tell "our sync finished" apart from "the shared doc
+    // changed for some other reason" (a stale terminal snapshot observed before our
+    // write lands, another tab's request, etc.) -- see requestSync()'s docstring.
+    const awaitingRequestedAtRef = useRef<string | null>(null);
     const onSyncedRef = useRef(onSynced);
 
     useEffect(() => {
@@ -35,7 +62,7 @@ export function useAutoGarminSync({
     // Reset the auto-trigger tracker when the user identity changes
     useEffect(() => {
         hasTriggeredForDateRef.current = null;
-        awaitingSyncRef.current = false;
+        awaitingRequestedAtRef.current = null;
     }, [userId]);
 
     // Subscribe to sync request state changes to notify caller when our sync finishes
@@ -45,8 +72,8 @@ export function useAutoGarminSync({
         const unsubscribe = garminSyncRequestService.subscribeToRequest(
             userId,
             (request) => {
-                if (awaitingSyncRef.current && request && !isSyncRequestInFlight(request)) {
-                    awaitingSyncRef.current = false;
+                if (isAwaitedSyncComplete(request, awaitingRequestedAtRef.current)) {
+                    awaitingRequestedAtRef.current = null;
                     onSyncedRef.current?.();
                 }
             },
@@ -66,11 +93,14 @@ export function useAutoGarminSync({
         const isStale = isRecoverySnapshotStale(decisionInput.recoverySnapshot, targetDate);
         if (isStale) {
             hasTriggeredForDateRef.current = targetDate;
-            awaitingSyncRef.current = true;
-            garminSyncRequestService.requestSync(userId).catch((err) => {
-                console.warn('[useAutoGarminSync] Failed to request auto sync:', err);
-                awaitingSyncRef.current = false;
-            });
+            garminSyncRequestService
+                .requestSync(userId)
+                .then((requestedAt) => {
+                    awaitingRequestedAtRef.current = requestedAt;
+                })
+                .catch((err) => {
+                    console.warn('[useAutoGarminSync] Failed to request auto sync:', err);
+                });
         }
     }, [userId, decisionInput, enabled]);
 }

--- a/app/src/hooks/useAutoGarminSync.ts
+++ b/app/src/hooks/useAutoGarminSync.ts
@@ -10,27 +10,40 @@ export interface UseAutoGarminSyncOptions {
     enabled?: boolean;
 }
 
+type AwaitedSyncOutcome = 'completed' | 'failed' | null;
+
+interface ActiveTriggerContext {
+    userId: string;
+    targetDate: string;
+}
+
 /**
- * Pure predicate behind the completion subscription below, extracted so it's
- * testable without a render harness (this repo has no interactive component-test
- * harness -- see GarminSyncNowButton.test.tsx / garminSyncStaleness.ts).
- *
- * `awaitingRequestedAt` is the `requestedAt` of the specific request this hook
- * queued (see requestSync()'s docstring). A snapshot only counts as "our sync
- * finished" when it's that same request AND it reached 'completed' -- an update
- * that matches the identifier but is still 'pending'/'processing', or that
- * terminated as 'failed', must not fire onSynced.
+ * Classify a subscription/read snapshot only when it belongs to the exact request
+ * this hook is awaiting. This lets both the realtime listener and the post-request
+ * reconciliation read share the same correlation rules.
+ */
+export function getAwaitedSyncOutcome(
+    request: GarminSyncRequest | null,
+    awaitingRequestedAt: string | null
+): AwaitedSyncOutcome {
+    if (!awaitingRequestedAt || !request || request.requestedAt !== awaitingRequestedAt) {
+        return null;
+    }
+    if (request.status === 'completed' || request.status === 'failed') {
+        return request.status;
+    }
+    return null;
+}
+
+/**
+ * Pure predicate kept for focused regression tests and callers that only care about
+ * successful completion.
  */
 export function isAwaitedSyncComplete(
     request: GarminSyncRequest | null,
     awaitingRequestedAt: string | null
 ): boolean {
-    return (
-        !!awaitingRequestedAt &&
-        !!request &&
-        request.requestedAt === awaitingRequestedAt &&
-        request.status === 'completed'
-    );
+    return getAwaitedSyncOutcome(request, awaitingRequestedAt) === 'completed';
 }
 
 /**
@@ -48,32 +61,39 @@ export function useAutoGarminSync({
     enabled = true,
 }: UseAutoGarminSyncOptions): void {
     const hasTriggeredForDateRef = useRef<string | null>(null);
-    // requestedAt of the specific request *this hook* queued, so the completion
-    // subscription below can tell "our sync finished" apart from "the shared doc
-    // changed for some other reason" (a stale terminal snapshot observed before our
-    // write lands, another tab's request, etc.) -- see requestSync()'s docstring.
+    // requestedAt of the specific request *this hook* queued/joined, so the
+    // completion subscription can distinguish it from another update to the shared
+    // garmin_sync_requests/latest document.
     const awaitingRequestedAtRef = useRef<string | null>(null);
+    // Guards asynchronous requestSync/getRequest continuations from an older user/date
+    // from installing stale awaiting state after navigation or an identity change.
+    const activeTriggerRef = useRef<ActiveTriggerContext | null>(null);
     const onSyncedRef = useRef(onSynced);
 
     useEffect(() => {
         onSyncedRef.current = onSynced;
     }, [onSynced]);
 
-    // Reset the auto-trigger tracker when the user identity changes
+    // A new user or calendar date is a distinct auto-sync lifecycle.
     useEffect(() => {
         hasTriggeredForDateRef.current = null;
         awaitingRequestedAtRef.current = null;
-    }, [userId]);
+        activeTriggerRef.current = null;
+    }, [userId, decisionInput?.date]);
 
-    // Subscribe to sync request state changes to notify caller when our sync finishes
+    // Subscribe to sync request state changes to notify caller when our sync finishes.
     useEffect(() => {
         if (!userId || !enabled) return;
 
         const unsubscribe = garminSyncRequestService.subscribeToRequest(
             userId,
             (request) => {
-                if (isAwaitedSyncComplete(request, awaitingRequestedAtRef.current)) {
-                    awaitingRequestedAtRef.current = null;
+                const outcome = getAwaitedSyncOutcome(request, awaitingRequestedAtRef.current);
+                if (!outcome) return;
+
+                awaitingRequestedAtRef.current = null;
+                activeTriggerRef.current = null;
+                if (outcome === 'completed') {
                     onSyncedRef.current?.();
                 }
             },
@@ -83,7 +103,7 @@ export function useAutoGarminSync({
         return unsubscribe;
     }, [userId, enabled]);
 
-    // Check staleness and trigger sync if needed
+    // Check staleness and trigger sync if needed.
     useEffect(() => {
         if (!enabled || !userId || !decisionInput) return;
 
@@ -91,16 +111,74 @@ export function useAutoGarminSync({
         if (hasTriggeredForDateRef.current === targetDate) return;
 
         const isStale = isRecoverySnapshotStale(decisionInput.recoverySnapshot, targetDate);
-        if (isStale) {
-            hasTriggeredForDateRef.current = targetDate;
-            garminSyncRequestService
-                .requestSync(userId)
-                .then((requestedAt) => {
-                    awaitingRequestedAtRef.current = requestedAt;
-                })
-                .catch((err) => {
-                    console.warn('[useAutoGarminSync] Failed to request auto sync:', err);
-                });
-        }
+        if (!isStale) return;
+
+        const triggerContext: ActiveTriggerContext = { userId, targetDate };
+        hasTriggeredForDateRef.current = targetDate;
+        activeTriggerRef.current = triggerContext;
+
+        garminSyncRequestService
+            .requestSync(userId)
+            .then(async (requestedAt) => {
+                const active = activeTriggerRef.current;
+                if (
+                    !active ||
+                    active.userId !== triggerContext.userId ||
+                    active.targetDate !== triggerContext.targetDate
+                ) {
+                    return;
+                }
+
+                awaitingRequestedAtRef.current = requestedAt;
+
+                // A request we joined can finish between the transaction resolving and
+                // this continuation installing awaitingRequestedAtRef. In that case the
+                // realtime listener already emitted the terminal snapshot while nothing
+                // was being awaited. Re-read once after installing the correlation key so
+                // completion cannot be lost permanently.
+                try {
+                    const currentRequest = await garminSyncRequestService.getRequest(userId);
+                    const stillActive = activeTriggerRef.current;
+                    if (
+                        !stillActive ||
+                        stillActive.userId !== triggerContext.userId ||
+                        stillActive.targetDate !== triggerContext.targetDate ||
+                        awaitingRequestedAtRef.current !== requestedAt
+                    ) {
+                        return;
+                    }
+
+                    const outcome = getAwaitedSyncOutcome(currentRequest, requestedAt);
+                    if (!outcome) return;
+
+                    awaitingRequestedAtRef.current = null;
+                    activeTriggerRef.current = null;
+                    if (outcome === 'completed') {
+                        onSyncedRef.current?.();
+                    }
+                } catch (err) {
+                    // The realtime subscription remains the primary completion path; a
+                    // transient reconciliation-read failure should not turn a successfully
+                    // queued sync into a user-visible error.
+                    console.warn('[useAutoGarminSync] Failed to reconcile sync state:', err);
+                }
+            })
+            .catch((err) => {
+                const active = activeTriggerRef.current;
+                if (
+                    active &&
+                    active.userId === triggerContext.userId &&
+                    active.targetDate === triggerContext.targetDate
+                ) {
+                    activeTriggerRef.current = null;
+                    awaitingRequestedAtRef.current = null;
+                    // The request was never queued. Let a later dashboard refresh/rerender
+                    // retry this same date instead of permanently suppressing auto-sync.
+                    if (hasTriggeredForDateRef.current === targetDate) {
+                        hasTriggeredForDateRef.current = null;
+                    }
+                }
+                console.warn('[useAutoGarminSync] Failed to request auto sync:', err);
+            });
     }, [userId, decisionInput, enabled]);
 }

--- a/app/src/services/garminSyncRequestService.ts
+++ b/app/src/services/garminSyncRequestService.ts
@@ -42,35 +42,49 @@ export class GarminSyncRequestService {
      * or stale closes that gap: a genuinely still-in-flight request is left alone,
      * and this call resolves as a no-op (the caller's own subscription already
      * reflects that in-flight state).
+     *
+     * Returns the `requestedAt` of whichever request is now live -- the one just
+     * written, or the pre-existing in-flight one this call left alone. Callers that
+     * need to know when *their own* request finishes (as opposed to any update to
+     * the shared doc) must correlate a later subscription snapshot against this
+     * value rather than just watching for the next non-in-flight status: the doc
+     * this resolves to may already be sitting at a terminal status left over from a
+     * previous request, and a subscription observes that same stale snapshot before
+     * it observes this write.
      */
-    async requestSync(userId: string): Promise<void> {
+    async requestSync(userId: string): Promise<string> {
         const ref = this.requestRef(userId);
         const now = Date.now();
+        let requestedAt = new Date(now).toISOString();
         await runTransaction(getDb(), async (transaction) => {
             const snap = await transaction.get(ref);
             const existing = snap.exists() ? (snap.data() as GarminSyncRequest) : null;
             if (existing && isSyncRequestInFlight(existing) && !isSyncRequestStale(existing, now)) {
+                requestedAt = existing.requestedAt;
                 return;
             }
             const data: GarminSyncRequest = {
                 userId,
                 status: 'pending',
                 requestType: 'sync',
-                requestedAt: new Date(now).toISOString(),
+                requestedAt,
                 completedAt: null,
                 error: null,
             };
             transaction.set(ref, data);
         });
+        return requestedAt;
     }
 
-    async requestBackfill(userId: string, days = 56): Promise<void> {
+    async requestBackfill(userId: string, days = 56): Promise<string> {
         const ref = this.requestRef(userId);
         const now = Date.now();
+        let requestedAt = new Date(now).toISOString();
         await runTransaction(getDb(), async (transaction) => {
             const snap = await transaction.get(ref);
             const existing = snap.exists() ? (snap.data() as GarminSyncRequest) : null;
             if (existing && isSyncRequestInFlight(existing) && !isSyncRequestStale(existing, now)) {
+                requestedAt = existing.requestedAt;
                 return;
             }
             const data: GarminSyncRequest = {
@@ -78,12 +92,13 @@ export class GarminSyncRequestService {
                 status: 'pending',
                 requestType: 'backfill',
                 days,
-                requestedAt: new Date(now).toISOString(),
+                requestedAt,
                 completedAt: null,
                 error: null,
             };
             transaction.set(ref, data);
         });
+        return requestedAt;
     }
 
     async getRequest(userId: string): Promise<GarminSyncRequest | null> {

--- a/app/src/services/garminSyncRequestService.ts
+++ b/app/src/services/garminSyncRequestService.ts
@@ -8,6 +8,8 @@ export interface GarminSyncRequest {
      * transitions written by poll_manual_sync_requests's atomic claim -- the browser
      * (and Firestore rules) may only ever write 'pending'. */
     status: 'pending' | 'processing' | 'completed' | 'failed';
+    requestType?: 'sync' | 'initial_backfill' | 'backfill';
+    days?: number;
     requestedAt: string;
     claimId?: string;
     claimedAt?: string | null;
@@ -53,6 +55,29 @@ export class GarminSyncRequestService {
             const data: GarminSyncRequest = {
                 userId,
                 status: 'pending',
+                requestType: 'sync',
+                requestedAt: new Date(now).toISOString(),
+                completedAt: null,
+                error: null,
+            };
+            transaction.set(ref, data);
+        });
+    }
+
+    async requestBackfill(userId: string, days = 56): Promise<void> {
+        const ref = this.requestRef(userId);
+        const now = Date.now();
+        await runTransaction(getDb(), async (transaction) => {
+            const snap = await transaction.get(ref);
+            const existing = snap.exists() ? (snap.data() as GarminSyncRequest) : null;
+            if (existing && isSyncRequestInFlight(existing) && !isSyncRequestStale(existing, now)) {
+                return;
+            }
+            const data: GarminSyncRequest = {
+                userId,
+                status: 'pending',
+                requestType: 'backfill',
+                days,
                 requestedAt: new Date(now).toISOString(),
                 completedAt: null,
                 error: null,

--- a/app/src/utils/garminSyncRequestState.ts
+++ b/app/src/utils/garminSyncRequestState.ts
@@ -1,0 +1,32 @@
+import type { GarminSyncRequest } from '../services/garminSyncRequestService';
+
+export type AwaitedSyncOutcome = 'completed' | 'failed' | null;
+
+/** Classify a shared fixed-id request snapshot only when it belongs to the exact
+ * request timestamp returned by requestSync(). */
+export function getAwaitedSyncOutcome(
+    request: GarminSyncRequest | null,
+    awaitingRequestedAt: string | null
+): AwaitedSyncOutcome {
+    if (!awaitingRequestedAt || !request || request.requestedAt !== awaitingRequestedAt) {
+        return null;
+    }
+    if (request.status === 'completed' || request.status === 'failed') {
+        return request.status;
+    }
+    return null;
+}
+
+export function isAwaitedSyncComplete(
+    request: GarminSyncRequest | null,
+    awaitingRequestedAt: string | null
+): boolean {
+    return getAwaitedSyncOutcome(request, awaitingRequestedAt) === 'completed';
+}
+
+export function isAwaitedSyncTerminal(
+    request: GarminSyncRequest | null,
+    awaitingRequestedAt: string | null
+): boolean {
+    return getAwaitedSyncOutcome(request, awaitingRequestedAt) !== null;
+}

--- a/app/src/utils/garminSyncStaleness.test.ts
+++ b/app/src/utils/garminSyncStaleness.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect } from 'vitest';
+import {
+    isRecoverySnapshotStale,
+    isSyncRequestStale,
+    isSyncRequestInFlight,
+    SNAPSHOT_STALE_AFTER_MS,
+    INCOMPLETE_SNAPSHOT_STALE_AFTER_MS,
+    STALE_AFTER_MS,
+} from './garminSyncStaleness';
+import type { DailyRecoverySnapshot } from '../engine/models';
+
+function createMockSnapshot(overrides: Partial<DailyRecoverySnapshot> = {}): DailyRecoverySnapshot {
+    return {
+        userId: 'u1',
+        date: '2026-08-23',
+        raw: {
+            restingHr: 52,
+            hrvOvernightAvg: 65,
+            hrvStatus: 'balanced',
+            respirationAvg: 14.5,
+            bodyBatteryWake: 90,
+            bodyBatteryChange: 50,
+            sleepScore: 88,
+            sleepDurationSec: 28800,
+            totalSteps: 8500,
+            last3DaysHardSessionsCount: 1,
+            yesterdayTraining: null,
+        },
+        derived: {
+            baselineComputationVersion: 3,
+            sleepScore7dAvg: 85,
+            sleepScore28dAvg: 82,
+            restingHr7dAvg: 53,
+            restingHr28dAvg: 52,
+            hrv7dAvg: 64,
+            hrv28dAvg: 65,
+            respiration7dAvg: 14.5,
+            respiration28dAvg: 14.6,
+            steps7dAvg: 9000,
+            steps28dAvg: 9200,
+            deltas: {
+                sleepScoreVs7d: 3,
+                sleepScoreVs28d: 6,
+                restingHrVs7d: -1,
+                restingHrVs28d: 0,
+                hrvVs7d: 1,
+                hrvVs28d: 0,
+                respirationVs7d: 0,
+                respirationVs28d: -0.1,
+            },
+        },
+        source: {
+            garminSyncedAt: '2026-08-23T06:00:00.000Z',
+            sourceSchemaVersion: 3,
+            timezone: 'Europe/Warsaw',
+        },
+        dataQuality: {
+            sleepScoreAvailable: true,
+            restingHrAvailable: true,
+            hrvAvailable: true,
+            baseline7dReady: true,
+            baseline28dReady: true,
+        },
+        ...overrides,
+    };
+}
+
+describe('garminSyncStaleness', () => {
+    describe('isSyncRequestInFlight', () => {
+        it('returns true for pending and processing', () => {
+            expect(isSyncRequestInFlight({ userId: 'u1', status: 'pending', requestedAt: '2026-08-23T08:00:00Z' })).toBe(true);
+            expect(isSyncRequestInFlight({ userId: 'u1', status: 'processing', requestedAt: '2026-08-23T08:00:00Z' })).toBe(true);
+        });
+
+        it('returns false for completed, failed, or null', () => {
+            expect(isSyncRequestInFlight(null)).toBe(false);
+            expect(isSyncRequestInFlight({ userId: 'u1', status: 'completed', requestedAt: '2026-08-23T08:00:00Z' })).toBe(false);
+            expect(isSyncRequestInFlight({ userId: 'u1', status: 'failed', requestedAt: '2026-08-23T08:00:00Z' })).toBe(false);
+        });
+    });
+
+    describe('isSyncRequestStale', () => {
+        const baseMs = Date.parse('2026-08-23T08:00:00.000Z');
+
+        it('returns false if not in flight', () => {
+            expect(isSyncRequestStale(null, baseMs)).toBe(false);
+            expect(isSyncRequestStale({ userId: 'u1', status: 'completed', requestedAt: '2026-08-23T08:00:00Z' }, baseMs + STALE_AFTER_MS + 1000)).toBe(false);
+        });
+
+        it('returns false if within stale window', () => {
+            const req = { userId: 'u1', status: 'pending' as const, requestedAt: '2026-08-23T08:00:00.000Z' };
+            expect(isSyncRequestStale(req, baseMs + 60_000)).toBe(false);
+        });
+
+        it('returns true if beyond stale window', () => {
+            const req = { userId: 'u1', status: 'pending' as const, requestedAt: '2026-08-23T08:00:00.000Z' };
+            expect(isSyncRequestStale(req, baseMs + STALE_AFTER_MS + 1000)).toBe(true);
+        });
+
+        it('measures from claimedAt if processing', () => {
+            const req = {
+                userId: 'u1',
+                status: 'processing' as const,
+                requestedAt: '2026-08-23T07:50:00.000Z',
+                claimedAt: '2026-08-23T08:00:00.000Z',
+            };
+            // 2 minutes after claimedAt -> not stale even though requestedAt was 12 min ago
+            expect(isSyncRequestStale(req, baseMs + 2 * 60 * 1000)).toBe(false);
+            // 6 minutes after claimedAt -> stale
+            expect(isSyncRequestStale(req, baseMs + 6 * 60 * 1000)).toBe(true);
+        });
+    });
+
+    describe('isRecoverySnapshotStale', () => {
+        const targetDate = '2026-08-23';
+        const syncIso = '2026-08-23T06:00:00.000Z';
+        const syncMs = Date.parse(syncIso);
+
+        it('returns true when snapshot is null or undefined', () => {
+            expect(isRecoverySnapshotStale(null, targetDate)).toBe(true);
+            expect(isRecoverySnapshotStale(undefined, targetDate)).toBe(true);
+        });
+
+        it('returns true when snapshot date does not match target date', () => {
+            const snapshot = createMockSnapshot({ date: '2026-08-22' });
+            expect(isRecoverySnapshotStale(snapshot, targetDate, syncMs + 10_000)).toBe(true);
+        });
+
+        it('returns true when garminSyncedAt is missing or invalid', () => {
+            const snapshot = createMockSnapshot({
+                source: { garminSyncedAt: 'invalid-date', sourceSchemaVersion: 3, timezone: 'Europe/Warsaw' },
+            });
+            expect(isRecoverySnapshotStale(snapshot, targetDate, syncMs + 10_000)).toBe(true);
+        });
+
+        it('returns false when complete snapshot was synced within 60 minutes', () => {
+            const snapshot = createMockSnapshot({
+                source: { garminSyncedAt: syncIso, sourceSchemaVersion: 3, timezone: 'Europe/Warsaw' },
+            });
+            // 30 minutes after sync
+            expect(isRecoverySnapshotStale(snapshot, targetDate, syncMs + 30 * 60 * 1000)).toBe(false);
+            // 59 minutes after sync
+            expect(isRecoverySnapshotStale(snapshot, targetDate, syncMs + 59 * 60 * 1000)).toBe(false);
+        });
+
+        it('returns true when complete snapshot was synced 60 or more minutes ago', () => {
+            const snapshot = createMockSnapshot({
+                source: { garminSyncedAt: syncIso, sourceSchemaVersion: 3, timezone: 'Europe/Warsaw' },
+            });
+            // 60 minutes after sync
+            expect(isRecoverySnapshotStale(snapshot, targetDate, syncMs + SNAPSHOT_STALE_AFTER_MS)).toBe(true);
+            // 3 hours after sync
+            expect(isRecoverySnapshotStale(snapshot, targetDate, syncMs + 3 * 60 * 60 * 1000)).toBe(true);
+        });
+
+        it('returns false for incomplete snapshot if synced under 5 minutes ago', () => {
+            const incompleteSnapshot = createMockSnapshot({
+                raw: {
+                    ...createMockSnapshot().raw,
+                    sleepScore: null,
+                },
+                dataQuality: {
+                    ...createMockSnapshot().dataQuality,
+                    sleepScoreAvailable: false,
+                },
+                source: { garminSyncedAt: syncIso, sourceSchemaVersion: 3, timezone: 'Europe/Warsaw' },
+            });
+            // 3 minutes after sync
+            expect(isRecoverySnapshotStale(incompleteSnapshot, targetDate, syncMs + 3 * 60 * 1000)).toBe(false);
+        });
+
+        it('returns true for incomplete snapshot if synced 5 or more minutes ago', () => {
+            const incompleteSnapshot = createMockSnapshot({
+                raw: {
+                    ...createMockSnapshot().raw,
+                    sleepScore: null,
+                },
+                dataQuality: {
+                    ...createMockSnapshot().dataQuality,
+                    sleepScoreAvailable: false,
+                },
+                source: { garminSyncedAt: syncIso, sourceSchemaVersion: 3, timezone: 'Europe/Warsaw' },
+            });
+            // 5 minutes after sync
+            expect(isRecoverySnapshotStale(incompleteSnapshot, targetDate, syncMs + INCOMPLETE_SNAPSHOT_STALE_AFTER_MS)).toBe(true);
+        });
+    });
+});

--- a/app/src/utils/garminSyncStaleness.test.ts
+++ b/app/src/utils/garminSyncStaleness.test.ts
@@ -6,6 +6,7 @@ import {
     SNAPSHOT_STALE_AFTER_MS,
     INCOMPLETE_SNAPSHOT_STALE_AFTER_MS,
     STALE_AFTER_MS,
+    BACKFILL_PROCESSING_STALE_AFTER_MS,
 } from './garminSyncStaleness';
 import type { DailyRecoverySnapshot } from '../engine/models';
 
@@ -97,10 +98,11 @@ describe('garminSyncStaleness', () => {
             expect(isSyncRequestStale(req, baseMs + STALE_AFTER_MS + 1000)).toBe(true);
         });
 
-        it('measures from claimedAt if processing', () => {
+        it('measures ordinary processing requests from claimedAt using the normal window', () => {
             const req = {
                 userId: 'u1',
                 status: 'processing' as const,
+                requestType: 'sync' as const,
                 requestedAt: '2026-08-23T07:50:00.000Z',
                 claimedAt: '2026-08-23T08:00:00.000Z',
             };
@@ -108,6 +110,33 @@ describe('garminSyncStaleness', () => {
             expect(isSyncRequestStale(req, baseMs + 2 * 60 * 1000)).toBe(false);
             // 6 minutes after claimedAt -> stale
             expect(isSyncRequestStale(req, baseMs + 6 * 60 * 1000)).toBe(true);
+        });
+
+        it('keeps a claimed backfill live for the backend execution-lease window', () => {
+            const req = {
+                userId: 'u1',
+                status: 'processing' as const,
+                requestType: 'initial_backfill' as const,
+                requestedAt: '2026-08-23T07:45:00.000Z',
+                claimedAt: '2026-08-23T08:00:00.000Z',
+                days: 56,
+            };
+
+            expect(isSyncRequestStale(req, baseMs + 10 * 60 * 1000)).toBe(false);
+            expect(isSyncRequestStale(req, baseMs + BACKFILL_PROCESSING_STALE_AFTER_MS + 1000)).toBe(true);
+        });
+
+        it('still lets callers explicitly override the request-aware stale window', () => {
+            const req = {
+                userId: 'u1',
+                status: 'processing' as const,
+                requestType: 'backfill' as const,
+                requestedAt: '2026-08-23T07:45:00.000Z',
+                claimedAt: '2026-08-23T08:00:00.000Z',
+                days: 56,
+            };
+
+            expect(isSyncRequestStale(req, baseMs + 6 * 60 * 1000, STALE_AFTER_MS)).toBe(true);
         });
     });
 

--- a/app/src/utils/garminSyncStaleness.ts
+++ b/app/src/utils/garminSyncStaleness.ts
@@ -1,4 +1,5 @@
 import type { GarminSyncRequest } from '../services/garminSyncRequestService';
+import type { DailyRecoverySnapshot } from '../engine/models';
 
 const IN_FLIGHT_STATUSES: ReadonlySet<GarminSyncRequest['status']> = new Set(['pending', 'processing']);
 
@@ -9,6 +10,15 @@ const IN_FLIGHT_STATUSES: ReadonlySet<GarminSyncRequest['status']> = new Set(['p
  * 3-minute cadence, but bounded so a dead poller execution (deploy missing, crashed
  * mid-run) doesn't leave a request stuck forever. */
 export const STALE_AFTER_MS = 5 * 60 * 1000;
+
+/** Staleness threshold for a complete recovery snapshot (60 minutes). If an athlete
+ * logs in and the snapshot was synced > 60 minutes ago, fresh metrics are fetched. */
+export const SNAPSHOT_STALE_AFTER_MS = 60 * 60 * 1000;
+
+/** Staleness threshold for an incomplete recovery snapshot (5 minutes). If a snapshot
+ * is missing key recovery metrics (e.g. sleep/HRV/RHR still being finalized by Garmin),
+ * a sync is retried sooner once 5 minutes have elapsed. */
+export const INCOMPLETE_SNAPSHOT_STALE_AFTER_MS = 5 * 60 * 1000;
 
 /** Pure staleness check, shared by GarminSyncNowButton (so it's testable without a
  * render -- this repo has no interactive component-test harness, see
@@ -38,4 +48,48 @@ export function isSyncRequestStale(
 
 export function isSyncRequestInFlight(request: GarminSyncRequest | null): boolean {
     return !!request && IN_FLIGHT_STATUSES.has(request.status);
+}
+
+/**
+ * Determines whether a user's recovery snapshot for targetDate requires a fresh sync.
+ * Returns true if:
+ * 1. No snapshot exists or snapshot is from a different calendar date.
+ * 2. Snapshot has missing/unfinalized core biomarkers and is older than incompleteStalenessMs (5m).
+ * 3. Snapshot was synced longer than stalenessMs (60m) ago.
+ */
+export function isRecoverySnapshotStale(
+    snapshot: DailyRecoverySnapshot | null | undefined,
+    targetDate: string,
+    nowMs: number = Date.now(),
+    stalenessMs: number = SNAPSHOT_STALE_AFTER_MS,
+    incompleteStalenessMs: number = INCOMPLETE_SNAPSHOT_STALE_AFTER_MS
+): boolean {
+    if (!snapshot || snapshot.date !== targetDate) {
+        return true;
+    }
+
+    const syncedAt = snapshot.source?.garminSyncedAt;
+    if (!syncedAt) {
+        return true;
+    }
+
+    const syncedMs = Date.parse(syncedAt);
+    if (Number.isNaN(syncedMs)) {
+        return true;
+    }
+
+    const ageMs = nowMs - syncedMs;
+    const isComplete =
+        Boolean(snapshot.dataQuality?.sleepScoreAvailable) &&
+        Boolean(snapshot.dataQuality?.restingHrAvailable) &&
+        Boolean(snapshot.dataQuality?.hrvAvailable) &&
+        snapshot.raw?.sleepScore != null &&
+        snapshot.raw?.restingHr != null &&
+        snapshot.raw?.hrvOvernightAvg != null;
+
+    if (!isComplete) {
+        return ageMs >= incompleteStalenessMs;
+    }
+
+    return ageMs >= stalenessMs;
 }

--- a/app/src/utils/garminSyncStaleness.ts
+++ b/app/src/utils/garminSyncStaleness.ts
@@ -2,14 +2,24 @@ import type { GarminSyncRequest } from '../services/garminSyncRequestService';
 import type { DailyRecoverySnapshot } from '../engine/models';
 
 const IN_FLIGHT_STATUSES: ReadonlySet<GarminSyncRequest['status']> = new Set(['pending', 'processing']);
+const BACKFILL_REQUEST_TYPES: ReadonlySet<NonNullable<GarminSyncRequest['requestType']>> = new Set([
+    'initial_backfill',
+    'backfill',
+]);
 
-/** How long an outstanding request may sit in 'pending'/'processing' before it's
+/** How long an ordinary outstanding request may sit in 'pending'/'processing' before it's
  * considered stale: GarminSyncNowButton gives up waiting and offers a retry, and
  * garminSyncRequestService.requestSync() treats an existing request past this age as
  * no longer blocking a fresh one. Generous relative to the garmin-manual-sync-poll's
  * 3-minute cadence, but bounded so a dead poller execution (deploy missing, crashed
  * mid-run) doesn't leave a request stuck forever. */
 export const STALE_AFTER_MS = 5 * 60 * 1000;
+
+/** A claimed historical backfill is materially longer-running than a normal daily sync.
+ * Keep its client-side stale threshold aligned with the backend's 30-minute per-user
+ * Garmin execution lease; otherwise a perfectly healthy 56-day backfill can be
+ * superseded after five minutes, allowing duplicate Garmin work and rate-limit pressure. */
+export const BACKFILL_PROCESSING_STALE_AFTER_MS = 30 * 60 * 1000;
 
 /** Staleness threshold for a complete recovery snapshot (60 minutes). If an athlete
  * logs in and the snapshot was synced > 60 minutes ago, fresh metrics are fetched. */
@@ -33,17 +43,28 @@ export const INCOMPLETE_SNAPSHOT_STALE_AFTER_MS = 5 * 60 * 1000;
  * STALE_AFTER_MS minus the poll interval before a client retry is allowed to treat a
  * genuinely still-running worker as dead. `claimedAt` is when that worker actually
  * started, so it's the correct clock for "how long has this claim been running."
+ *
+ * Historical backfills get a longer processing window because they intentionally make
+ * many more Garmin calls than a daily sync. Pending requests still use the normal
+ * five-minute threshold: if no worker has claimed them by then, retrying is reasonable.
  */
 export function isSyncRequestStale(
     request: GarminSyncRequest | null,
     nowMs: number,
-    staleAfterMs: number = STALE_AFTER_MS
+    staleAfterMs?: number
 ): boolean {
     if (!request || !IN_FLIGHT_STATUSES.has(request.status)) return false;
     const referenceTime = request.status === 'processing' && request.claimedAt ? request.claimedAt : request.requestedAt;
     const referenceMs = Date.parse(referenceTime);
     if (Number.isNaN(referenceMs)) return false;
-    return nowMs - referenceMs > staleAfterMs;
+
+    const requestAwareStaleAfterMs =
+        request.status === 'processing' && request.requestType && BACKFILL_REQUEST_TYPES.has(request.requestType)
+            ? BACKFILL_PROCESSING_STALE_AFTER_MS
+            : STALE_AFTER_MS;
+    const effectiveStaleAfterMs = staleAfterMs ?? requestAwareStaleAfterMs;
+
+    return nowMs - referenceMs > effectiveStaleAfterMs;
 }
 
 export function isSyncRequestInFlight(request: GarminSyncRequest | null): boolean {

--- a/src/garmin_sync/account_link.py
+++ b/src/garmin_sync/account_link.py
@@ -6,7 +6,7 @@ import tempfile
 import threading
 import time
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Callable
 
@@ -31,6 +31,35 @@ class GarminLinkConflictError(ValueError):
 
 class GarminLinkConfigurationError(RuntimeError):
     """Raised when account linking is not safely configured."""
+
+
+# Mirrors app/src/utils/garminSyncStaleness.ts's STALE_AFTER_MS / IN_FLIGHT_STATUSES /
+# isSyncRequestStale: the account-link initial-backfill queueing below must apply the
+# exact same "don't stomp a genuinely still-running request" policy the frontend's
+# GarminSyncRequestService.requestSync() uses, or the two callers could disagree about
+# when it's safe to overwrite a pending/processing garmin_sync_requests/latest doc.
+_SYNC_REQUEST_STALE_AFTER = timedelta(minutes=5)
+_SYNC_REQUEST_IN_FLIGHT_STATUSES = {"pending", "processing"}
+
+
+def _is_sync_request_in_flight(data: dict[str, Any]) -> bool:
+    return data.get("status") in _SYNC_REQUEST_IN_FLIGHT_STATUSES
+
+
+def _is_sync_request_stale(data: dict[str, Any], now: datetime) -> bool:
+    if not _is_sync_request_in_flight(data):
+        return False
+    reference = data.get("claimedAt") if data.get("status") == "processing" else None
+    reference = reference or data.get("requestedAt")
+    if not reference:
+        return False
+    try:
+        reference_dt = datetime.fromisoformat(reference)
+    except (TypeError, ValueError):
+        return False
+    if reference_dt.tzinfo is None:
+        reference_dt = reference_dt.replace(tzinfo=timezone.utc)
+    return (now - reference_dt) > _SYNC_REQUEST_STALE_AFTER
 
 
 @dataclass
@@ -415,25 +444,47 @@ class GarminAccountLinkService:
             db = getattr(self.repository, "db", None)
             if db is not None:
                 try:
-                    now_iso = datetime.now(timezone.utc).isoformat()
+                    now = datetime.now(timezone.utc)
                     sync_req_ref = (
                         db.collection("users")
                         .document(target_uid)
                         .collection("garmin_sync_requests")
                         .document("latest")
                     )
-                    sync_req_ref.set(
-                        {
-                            "userId": target_uid,
-                            "status": "pending",
-                            "requestType": "initial_backfill",
-                            "days": 56,
-                            "requestedAt": now_iso,
-                            "completedAt": None,
-                            "error": None,
-                        },
-                        merge=True,
-                    )
+
+                    @google_firestore.transactional
+                    def _queue_initial_backfill(transaction: Any) -> None:
+                        snapshot = sync_req_ref.get(transaction=transaction)
+                        existing = snapshot.to_dict() if snapshot.exists else None
+                        # A plain merge=True set here would overwrite a claimed
+                        # 'processing' request's status back to 'pending' while keeping
+                        # its claimId -- the worker that already owns that claim would
+                        # then mark *this* new request completed without ever running
+                        # it, and a second poller could concurrently claim the
+                        # 'pending' doc too. Only queue when nothing genuinely
+                        # in-flight would be superseded; a stale claim (dead poller)
+                        # is safe to overwrite, same policy as
+                        # GarminSyncRequestService.requestSync().
+                        if (
+                            existing
+                            and _is_sync_request_in_flight(existing)
+                            and not _is_sync_request_stale(existing, now)
+                        ):
+                            return
+                        transaction.set(
+                            sync_req_ref,
+                            {
+                                "userId": target_uid,
+                                "status": "pending",
+                                "requestType": "initial_backfill",
+                                "days": 56,
+                                "requestedAt": now.isoformat(),
+                                "completedAt": None,
+                                "error": None,
+                            },
+                        )
+
+                    _queue_initial_backfill(db.transaction())
                 except Exception as exc:
                     logger.warning(
                         "Failed to queue initial backfill request for user %s: %s",

--- a/src/garmin_sync/account_link.py
+++ b/src/garmin_sync/account_link.py
@@ -6,6 +6,7 @@ import tempfile
 import threading
 import time
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
 
@@ -407,6 +408,39 @@ class GarminAccountLinkService:
                 # to remove. Scheduled sync restores whatever tokenObject Firestore has,
                 # so it never reads a path we're about to delete.
                 self._delete_token_object(previous_token_object)
+
+            # Queue an initial 56-day backfill request in Firestore so the background
+            # poller (garmin-manual-sync Cloud Run Job) immediately backfills historical
+            # recovery and activity data to establish baselines without blocking login.
+            db = getattr(self.repository, "db", None)
+            if db is not None:
+                try:
+                    now_iso = datetime.now(timezone.utc).isoformat()
+                    sync_req_ref = (
+                        db.collection("users")
+                        .document(target_uid)
+                        .collection("garmin_sync_requests")
+                        .document("latest")
+                    )
+                    sync_req_ref.set(
+                        {
+                            "userId": target_uid,
+                            "status": "pending",
+                            "requestType": "initial_backfill",
+                            "days": 56,
+                            "requestedAt": now_iso,
+                            "completedAt": None,
+                            "error": None,
+                        },
+                        merge=True,
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "Failed to queue initial backfill request for user %s: %s",
+                        target_uid,
+                        exc,
+                    )
+
             custom_token = firebase_auth.create_custom_token(target_uid)
             custom_token_text = (
                 custom_token.decode("utf-8")

--- a/src/garmin_sync/cli.py
+++ b/src/garmin_sync/cli.py
@@ -126,6 +126,7 @@ def run_daily_sync(args: list[str] | None = None) -> int:
                 target_date_str=parsed_args.date,
                 force=parsed_args.force,
                 resync_lookback_days=parsed_args.resync_days,
+                auto_backfill_cold_start=True,
             ),
         )
         return 0 if success else 1
@@ -146,6 +147,7 @@ def run_daily_sync_all(args: list[str] | None = None) -> int:
             target_date_str=parsed_args.date,
             force=parsed_args.force,
             resync_lookback_days=parsed_args.resync_days,
+            auto_backfill_cold_start=True,
         ),
     )
 

--- a/src/garmin_sync/service.py
+++ b/src/garmin_sync/service.py
@@ -417,6 +417,7 @@ class GarminSyncService:
         target_date_str: str | None = None,
         force: bool = False,
         resync_lookback_days: int | None = None,
+        auto_backfill_cold_start: bool = False,
     ) -> bool:
         """Run daily sync for target date (default local_today in Europe/Warsaw).
 
@@ -441,6 +442,27 @@ class GarminSyncService:
             else local_today(self.settings.app_timezone)
         )
         target_iso = get_date_string(target_date)
+
+        # Check for cold start (insufficient history for rolling 7d/28d baselines).
+        # If fewer than 14 historical snapshots exist in the trailing 56 days,
+        # automatically run a 56-day historical backfill to populate baseline math
+        # and chronic training load before proceeding.
+        if auto_backfill_cold_start:
+            window_start_iso = get_date_string(n_days_ago(target_date, 56))
+            window_end_iso = get_date_string(n_days_ago(target_date, 1))
+            get_hist = getattr(self.repository, "get_historical_snapshots", None)
+            if callable(get_hist):
+                history = get_hist(window_start_iso, window_end_iso)
+                if len(history) < 14:
+                    logger.info(
+                        f"Cold start detected for user=<UID-redacted>: found only {len(history)} "
+                        f"historical snapshots in last 56d (< 14). Automatically running 56-day backfill..."
+                    )
+                    backfill_ok = self.backfill(days=56, force=force)
+                    if not backfill_ok:
+                        logger.warning("Automated cold-start backfill finished with errors.")
+                    self._sync_current_performance_targets(target_iso)
+                    return backfill_ok
 
         # Staleness check gates the whole operation (target date + lookback resync) --
         # a retriggered run within the staleness window is a no-op, not a chance to
@@ -989,6 +1011,7 @@ class GarminSyncService:
             .document("latest")
         )
         claim_id = uuid.uuid4().hex
+        claimed_payload: list[dict[str, Any]] = []
 
         @firestore.transactional
         def claim_pending(transaction: Any) -> bool:
@@ -998,6 +1021,7 @@ class GarminSyncService:
             data = snapshot.to_dict() or {}
             if data.get("status") != "pending":
                 return False
+            claimed_payload.append(data)
             transaction.update(
                 request_ref,
                 {
@@ -1011,19 +1035,41 @@ class GarminSyncService:
         if not claim_pending(db.transaction()):
             return True
 
-        # Plain force=True, same as any other sync_daily caller -- the D-1..D-N lookback
-        # resync isn't optional background-poll overhead here, it's the same
-        # data-reconciliation contract sync_daily always makes (Garmin keeps revising a
-        # day's data after that day's own sync ran; see sync_daily's docstring). A
-        # manual refresh should leave Garmin-derived state as current as possible,
-        # including that reconciliation, not just today's numbers.
-        logger.info("Claimed manual sync request; running an immediate forced sync...")
-        try:
-            ok = self.sync_daily(force=True)
-        except Exception as e:
-            logger.error(f"Manual sync request failed: {e}")
-            self._finish_manual_sync_request(request_ref, claim_id, "failed", error=str(e)[:2000])
-            return False
+        req_data = claimed_payload[0] if claimed_payload else {}
+        req_type = req_data.get("requestType")
+        days = req_data.get("days") or 56
+
+        if req_type in ("initial_backfill", "backfill"):
+            logger.info(
+                f"Claimed manual sync request (type={req_type}, days={days}); running backfill..."
+            )
+            try:
+                ok = self.backfill(days=int(days), force=False)
+                if ok:
+                    target_iso = get_date_string(local_today(self.settings.app_timezone))
+                    self._sync_current_performance_targets(target_iso)
+            except Exception as e:
+                logger.error(f"Manual backfill request failed: {e}")
+                self._finish_manual_sync_request(
+                    request_ref, claim_id, "failed", error=str(e)[:2000]
+                )
+                return False
+        else:
+            # Plain force=True, same as any other sync_daily caller -- the D-1..D-N lookback
+            # resync isn't optional background-poll overhead here, it's the same
+            # data-reconciliation contract sync_daily always makes (Garmin keeps revising a
+            # day's data after that day's own sync ran; see sync_daily's docstring). A
+            # manual refresh should leave Garmin-derived state as current as possible,
+            # including that reconciliation, not just today's numbers.
+            logger.info("Claimed manual sync request; running an immediate forced sync...")
+            try:
+                ok = self.sync_daily(force=True)
+            except Exception as e:
+                logger.error(f"Manual sync request failed: {e}")
+                self._finish_manual_sync_request(
+                    request_ref, claim_id, "failed", error=str(e)[:2000]
+                )
+                return False
 
         # A failure recording the outcome is a separate failure domain from the sync
         # itself -- it must never get relabeled as 'failed' here (that would report a

--- a/src/garmin_sync/service.py
+++ b/src/garmin_sync/service.py
@@ -458,7 +458,14 @@ class GarminSyncService:
                         f"Cold start detected for user=<UID-redacted>: found only {len(history)} "
                         f"historical snapshots in last 56d (< 14). Automatically running 56-day backfill..."
                     )
-                    backfill_ok = self.backfill(days=56, force=force)
+                    # Bound the backfill window to end at target_date, not today: days=56
+                    # would resolve against local_today() and, for a target_date more than
+                    # 56 days in the past, never actually populate target_date's snapshot.
+                    backfill_ok = self.backfill(
+                        start_date_str=get_date_string(n_days_ago(target_date, 55)),
+                        end_date_str=target_iso,
+                        force=force,
+                    )
                     if not backfill_ok:
                         logger.warning("Automated cold-start backfill finished with errors.")
                     self._sync_current_performance_targets(target_iso)
@@ -1021,7 +1028,11 @@ class GarminSyncService:
             data = snapshot.to_dict() or {}
             if data.get("status") != "pending":
                 return False
-            claimed_payload.append(data)
+            # Firestore retries this callback on write contention (see docstring above);
+            # each retry re-reads the doc from scratch, so only the successful attempt's
+            # payload may survive -- an earlier attempt's data could belong to a request
+            # that a concurrent write already superseded.
+            claimed_payload[:] = [data]
             transaction.update(
                 request_ref,
                 {

--- a/tests/test_account_link.py
+++ b/tests/test_account_link.py
@@ -461,9 +461,13 @@ class _Collection:
 
 
 class _Transaction:
-    def set(self, doc_ref: _Document, payload: dict[str, Any], merge: bool = True) -> None:
-        assert merge is True
-        doc_ref.data = {**(doc_ref.data or {}), **payload}
+    def set(self, doc_ref: _Document, payload: dict[str, Any], merge: bool = False) -> None:
+        # Mirrors google.cloud.firestore.Transaction.set's real default (merge=False):
+        # a bare transaction.set() fully replaces the document, it doesn't merge.
+        if merge:
+            doc_ref.data = {**(doc_ref.data or {}), **payload}
+        else:
+            doc_ref.data = dict(payload)
 
 
 class _Db:
@@ -563,3 +567,77 @@ def test_finalize_queues_initial_backfill_request(
     assert sync_req["status"] == "pending"
     assert sync_req["requestType"] == "initial_backfill"
     assert sync_req["days"] == 56
+
+
+def test_finalize_does_not_stomp_a_live_in_flight_sync_request(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    """Regression test: a plain merge=True set() here would flip an already-claimed
+    'processing' request back to 'pending' while keeping its claimId -- the worker
+    that owns that claim would then mark this brand-new initial-backfill request
+    completed without ever running it, and a second poller could concurrently claim
+    the 'pending' doc too. Linking must leave a genuinely still-running request
+    alone."""
+
+    class TokenStore:
+        def __init__(self, _bucket: str, _object_name: str) -> None:
+            pass
+
+        def persist(self, _source: Path) -> bool:
+            return True
+
+    class FinalizableGarmin:
+        password = None
+
+        def connectapi(self, _path: str) -> dict[str, str]:
+            return {"garminGUID": "stable-guid"}
+
+    monkeypatch.setattr(account_link_module, "GcsTokenStore", TokenStore)
+    monkeypatch.setattr(
+        account_link_module.firebase_auth,
+        "create_custom_token",
+        lambda _uid: b"token",
+    )
+    monkeypatch.setattr(account_link_module.google_firestore, "transactional", lambda fn: fn)
+
+    db = _Db()
+    live_request = {
+        "userId": "new-user-123",
+        "status": "processing",
+        "requestType": "sync",
+        "requestedAt": account_link_module.datetime.now(
+            account_link_module.timezone.utc
+        ).isoformat(),
+        "claimId": "worker-currently-running",
+        "claimedAt": account_link_module.datetime.now(account_link_module.timezone.utc).isoformat(),
+    }
+    db.collection("users").document("new-user-123").collection("garmin_sync_requests").document(
+        "latest"
+    ).data = dict(live_request)
+
+    repository = account_link_module.GarminConnectionRepository(db=db)
+    service = GarminAccountLinkService("bucket", repository=repository)
+
+    token_path = tmp_path / "tokens.json"
+    token_path.write_text("{}", encoding="utf-8")
+    temp_dir = tmp_path / "temporary"
+    temp_dir.mkdir()
+
+    result = service._finalize(
+        FinalizableGarmin(),  # type: ignore[arg-type]
+        token_path,
+        temp_dir,
+        "new-user-123",
+    )
+
+    assert result["status"] == "authenticated"
+    sync_req = (
+        db.collection("users")
+        .document("new-user-123")
+        .collection("garmin_sync_requests")
+        .document("latest")
+        .data
+    )
+    # Untouched: still the live worker's claim, not the queued initial_backfill.
+    assert sync_req == live_request

--- a/tests/test_account_link.py
+++ b/tests/test_account_link.py
@@ -437,9 +437,19 @@ class _Snapshot:
 class _Document:
     def __init__(self, data: dict[str, Any] | None = None) -> None:
         self.data = data
+        self._collections: dict[str, _Collection] = {}
 
     def get(self, transaction: Any = None) -> _Snapshot:
         return _Snapshot(self.data)
+
+    def set(self, payload: dict[str, Any], merge: bool = True) -> None:
+        if merge:
+            self.data = {**(self.data or {}), **payload}
+        else:
+            self.data = dict(payload)
+
+    def collection(self, name: str) -> _Collection:
+        return self._collections.setdefault(name, _Collection())
 
 
 class _Collection:
@@ -498,3 +508,58 @@ def test_commit_link_returns_exactly_the_tokenObject_it_overwrote(monkeypatch: A
     connection = db.collection("garminConnections").document("uid-1").data
     assert connection is not None
     assert connection["tokenObject"] == "garmin/users/uid-1/garmin_tokens-ccc.json"
+
+
+def test_finalize_queues_initial_backfill_request(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    class TokenStore:
+        def __init__(self, _bucket: str, _object_name: str) -> None:
+            pass
+
+        def persist(self, _source: Path) -> bool:
+            return True
+
+    class FinalizableGarmin:
+        password = None
+
+        def connectapi(self, _path: str) -> dict[str, str]:
+            return {"garminGUID": "stable-guid"}
+
+    monkeypatch.setattr(account_link_module, "GcsTokenStore", TokenStore)
+    monkeypatch.setattr(
+        account_link_module.firebase_auth,
+        "create_custom_token",
+        lambda _uid: b"token",
+    )
+    monkeypatch.setattr(account_link_module.google_firestore, "transactional", lambda fn: fn)
+
+    db = _Db()
+    repository = account_link_module.GarminConnectionRepository(db=db)
+    service = GarminAccountLinkService("bucket", repository=repository)
+
+    token_path = tmp_path / "tokens.json"
+    token_path.write_text("{}", encoding="utf-8")
+    temp_dir = tmp_path / "temporary"
+    temp_dir.mkdir()
+
+    result = service._finalize(
+        FinalizableGarmin(),  # type: ignore[arg-type]
+        token_path,
+        temp_dir,
+        "new-user-123",
+    )
+
+    assert result["status"] == "authenticated"
+    sync_req = (
+        db.collection("users")
+        .document("new-user-123")
+        .collection("garmin_sync_requests")
+        .document("latest")
+        .data
+    )
+    assert sync_req is not None
+    assert sync_req["status"] == "pending"
+    assert sync_req["requestType"] == "initial_backfill"
+    assert sync_req["days"] == 56

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -59,6 +59,7 @@ def test_run_daily_sync_success(mock_settings: Any, mock_service: Any) -> None:
         target_date_str="2023-10-27",
         force=True,
         resync_lookback_days=2,
+        auto_backfill_cold_start=True,
     )
 
 
@@ -99,6 +100,7 @@ def test_run_daily_sync_failure(mock_settings: Any, mock_service: Any) -> None:
         target_date_str=None,
         force=False,
         resync_lookback_days=None,
+        auto_backfill_cold_start=True,
     )
 
 

--- a/tests/test_sync_service.py
+++ b/tests/test_sync_service.py
@@ -607,6 +607,61 @@ def test_poll_manual_sync_requests_second_concurrent_worker_never_reaches_sync_d
     assert doc.data["status"] == "completed"
 
 
+def test_poll_manual_sync_requests_initial_backfill(monkeypatch):
+    monkeypatch.setattr("garmin_sync.service.firestore.transactional", lambda fn: fn)
+    settings = Settings(app_user_id="test_uid_789")
+    doc = _FakeSyncRequestDoc({"status": "pending", "requestType": "initial_backfill", "days": 56})
+    service = GarminSyncService(settings=settings, repository=MagicMock(db=_FakeSyncRequestDb(doc)))
+    service.backfill = MagicMock(return_value=True)
+    service._sync_current_performance_targets = MagicMock()
+
+    result = service.poll_manual_sync_requests()
+
+    assert result is True
+    service.backfill.assert_called_once_with(days=56, force=False)
+    service._sync_current_performance_targets.assert_called_once()
+    assert doc.data["status"] == "completed"
+    assert doc.data["error"] is None
+
+
+def test_sync_daily_cold_start_auto_backfill():
+    settings = Settings(app_user_id="test_uid_789")
+    mock_repo = MagicMock()
+    mock_repo.get_historical_snapshots.return_value = {
+        "2026-08-20": {"date": "2026-08-20"},
+        "2026-08-21": {"date": "2026-08-21"},
+    }  # only 2 days < 14
+    service = GarminSyncService(settings=settings, repository=mock_repo)
+    service.backfill = MagicMock(return_value=True)
+    service._sync_current_performance_targets = MagicMock()
+
+    result = service.sync_daily(target_date_str="2026-08-22", auto_backfill_cold_start=True)
+
+    assert result is True
+    service.backfill.assert_called_once_with(days=56, force=False)
+    service._sync_current_performance_targets.assert_called_once_with("2026-08-22")
+
+
+def test_sync_daily_warm_history_skips_cold_start_backfill():
+    settings = Settings(app_user_id="test_uid_789")
+    mock_repo = MagicMock()
+    # 20 historical days >= 14
+    mock_repo.get_historical_snapshots.return_value = {
+        f"2026-07-{i:02d}": {"date": f"2026-07-{i:02d}"} for i in range(1, 21)
+    }
+    mock_repo.is_fresh.return_value = False
+    service = GarminSyncService(settings=settings, repository=mock_repo)
+    service.backfill = MagicMock()
+    service._fetch_and_store_date = MagicMock(return_value=True)
+    service._sync_current_performance_targets = MagicMock()
+
+    result = service.sync_daily(target_date_str="2026-08-22", auto_backfill_cold_start=True)
+
+    assert result is True
+    service.backfill.assert_not_called()
+    assert service._fetch_and_store_date.call_count >= 1
+
+
 def test_poll_manual_sync_requests_finish_does_not_stomp_a_superseding_request(monkeypatch):
     """If the request doc gets reclaimed (a fresh Sync Now click) while this run is
     still in flight, finishing must not overwrite it -- the claimId check in

--- a/tests/test_sync_service.py
+++ b/tests/test_sync_service.py
@@ -638,8 +638,32 @@ def test_sync_daily_cold_start_auto_backfill():
     result = service.sync_daily(target_date_str="2026-08-22", auto_backfill_cold_start=True)
 
     assert result is True
-    service.backfill.assert_called_once_with(days=56, force=False)
+    # The 56-day backfill window must end at target_date, not today -- days=56 would
+    # resolve against local_today() instead.
+    service.backfill.assert_called_once_with(
+        start_date_str="2026-06-28", end_date_str="2026-08-22", force=False
+    )
     service._sync_current_performance_targets.assert_called_once_with("2026-08-22")
+
+
+def test_sync_daily_cold_start_auto_backfill_bounds_window_to_old_target_date():
+    """Regression test: a target_date more than 56 days in the past must still get
+    its own historical window ending at that date, not one ending at local_today()
+    (which would silently skip creating target_date's own snapshot)."""
+    settings = Settings(app_user_id="test_uid_789")
+    mock_repo = MagicMock()
+    mock_repo.get_historical_snapshots.return_value = {}  # cold start
+    service = GarminSyncService(settings=settings, repository=mock_repo)
+    service.backfill = MagicMock(return_value=True)
+    service._sync_current_performance_targets = MagicMock()
+
+    result = service.sync_daily(target_date_str="2026-01-01", auto_backfill_cold_start=True)
+
+    assert result is True
+    service.backfill.assert_called_once_with(
+        start_date_str="2025-11-07", end_date_str="2026-01-01", force=False
+    )
+    service._sync_current_performance_targets.assert_called_once_with("2026-01-01")
 
 
 def test_sync_daily_warm_history_skips_cold_start_backfill():
@@ -660,6 +684,56 @@ def test_sync_daily_warm_history_skips_cold_start_backfill():
     assert result is True
     service.backfill.assert_not_called()
     assert service._fetch_and_store_date.call_count >= 1
+
+
+def test_poll_manual_sync_requests_retry_uses_latest_attempt_payload(monkeypatch):
+    """P0 regression: Firestore retries claim_pending's transaction body on write
+    contention, re-reading the doc from scratch each attempt. If a retry observes a
+    *different* pending request than the first attempt (e.g. requestType changed
+    because a fresh request superseded the original one between attempts), only the
+    attempt whose transaction.update actually commits may be processed -- not an
+    earlier attempt's stale read."""
+    attempts = [
+        {"status": "pending", "requestType": "backfill", "days": 56},
+        {"status": "pending", "requestType": "sync"},
+    ]
+
+    class RetryingDoc:
+        def __init__(self):
+            self.data = attempts[-1]
+            self._reads = 0
+
+        def get(self, transaction=None):
+            data = attempts[self._reads] if self._reads < len(attempts) else attempts[-1]
+            self._reads += 1
+            return _FakeSyncRequestSnapshot(data)
+
+    def retried_transactional(fn):
+        # Simulate Firestore auto-retrying the whole transaction body on contention:
+        # the first invocation observes attempts[0] and loses the commit race, so the
+        # runtime re-invokes fn from scratch -- only the second (successful) call's
+        # observations may end up used by the caller.
+        def wrapper(transaction):
+            fn(transaction)
+            return fn(transaction)
+
+        return wrapper
+
+    monkeypatch.setattr("garmin_sync.service.firestore.transactional", retried_transactional)
+    settings = Settings(app_user_id="test_uid_789")
+    doc = RetryingDoc()
+    service = GarminSyncService(settings=settings, repository=MagicMock(db=_FakeSyncRequestDb(doc)))
+    service.sync_daily = MagicMock(return_value=True)
+    service.backfill = MagicMock(return_value=True)
+
+    result = service.poll_manual_sync_requests()
+
+    assert result is True
+    # The retry's payload (requestType="sync") must win -- not the first attempt's
+    # stale "backfill" read, which would have routed this into service.backfill()
+    # instead of the plain sync_daily() a bare 'sync' request type requires.
+    service.sync_daily.assert_called_once_with(force=True)
+    service.backfill.assert_not_called()
 
 
 def test_poll_manual_sync_requests_finish_does_not_stomp_a_superseding_request(monkeypatch):


### PR DESCRIPTION
## Summary
- **Automatic 56-Day Historical Backfill on Account Link**: Automatically enqueues an \initial_backfill\ request (56 days) in Firestore upon linking a Garmin account (\users/{userId}/garmin_sync_requests/latest\), keeping auth requests instantaneous while warming up rolling 7d/28d baselines, ambient step baselines, and chronic training load models.
- **Cold-Start Auto-Detection**: In \sync_daily()\, checks trailing 56 days for existing snapshots; if < 14 days are present, automatically executes a 56-day backfill.
- **Auto-Sync on Login / App Open**: When an athlete logs in or opens the dashboard, evaluates today's recovery snapshot freshness (\isRecoverySnapshotStale\). If missing, incomplete (< 5min old retry), or stale (> 60min old), automatically triggers a background sync and refreshes the dashboard in real-time upon completion.
- **Firestore Security Rules & Poller Support**: Updated \pp/firestore.rules\ and \poll_manual_sync_requests()\ to validate and claim \equestType: 'initial_backfill' | 'backfill'\.

## Verification
- \uv run pytest\: 255/255 passed.
- \pp/npm run check\: Typecheck clean, ESLint clean, 2,052/2,052 Vitest unit tests passed, workout catalog validated.
- All pre-commit and pre-push hooks passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Garmin data now syncs automatically when recovery information is missing, incomplete, or outdated.
  - Newly linked Garmin accounts receive an initial 56-day backfill.
  - Daily sync can automatically backfill accounts with insufficient recent history.
  - Added support for configurable backfill requests up to 365 days.

- **Bug Fixes**
  - Improved handling of stale recovery snapshots and duplicate sync requests.

- **Tests**
  - Expanded coverage for automatic syncing, backfills, staleness detection, account linking, and daily sync behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->