### PR TITLE
feat(sync): add Garmin sleep stage architecture telemetry

### DIFF
--- a/app/src/components/DailyCheckin.tsx
+++ b/app/src/components/DailyCheckin.tsx
@@ -849,6 +849,24 @@ export function DailyCheckin({ userId, onNavigate, onBack }: DailyCheckinProps) 
                       <span className="pill-label">Body Battery</span>
                       <span className="pill-val">{recoverySnapshot.raw.bodyBatteryWake ?? '--'} / 100</span>
                     </div>
+                    {recoverySnapshot.raw.deepSleepSec != null && (
+                      <div className="garmin-metric-pill">
+                        <span className="pill-label">Deep Sleep</span>
+                        <span className="pill-val">{Math.round(recoverySnapshot.raw.deepSleepSec / 60)} min</span>
+                        {recoverySnapshot.raw.sleepDurationSec ? (
+                          <small>{Math.round((recoverySnapshot.raw.deepSleepSec / recoverySnapshot.raw.sleepDurationSec) * 100)}% of total</small>
+                        ) : null}
+                      </div>
+                    )}
+                    {recoverySnapshot.raw.remSleepSec != null && (
+                      <div className="garmin-metric-pill">
+                        <span className="pill-label">REM Sleep</span>
+                        <span className="pill-val">{Math.round(recoverySnapshot.raw.remSleepSec / 60)} min</span>
+                        {recoverySnapshot.raw.sleepDurationSec ? (
+                          <small>{Math.round((recoverySnapshot.raw.remSleepSec / recoverySnapshot.raw.sleepDurationSec) * 100)}% of total</small>
+                        ) : null}
+                      </div>
+                    )}
                   </div>
                 )}
               </>

--- a/app/src/components/DataView.tsx
+++ b/app/src/components/DataView.tsx
@@ -58,6 +58,12 @@ function formatCandidateDelta(value: number | null | undefined): string {
   return value > 0 ? `+${value}` : String(value);
 }
 
+function formatSleepStageMinutes(seconds: number | null | undefined): string {
+  return typeof seconds === 'number' && Number.isFinite(seconds)
+    ? `${Math.round(seconds / 60)}m`
+    : 'N/A';
+}
+
 function formatCandidateBaseline(
   median7d: number | null | undefined,
   median28d: number | null | undefined,
@@ -202,7 +208,7 @@ export function DataView({ decisionInput, userId, initialTab = 'recovery' }: Dat
             <div className="data-item">
               <span className="data-label">Sleep Stages (Deep / REM / Light / Awake):</span>
               <span className="data-value">
-                {Math.round((recoverySnapshot.raw.deepSleepSec ?? 0) / 60)}m / {Math.round((recoverySnapshot.raw.remSleepSec ?? 0) / 60)}m / {Math.round((recoverySnapshot.raw.lightSleepSec ?? 0) / 60)}m / {Math.round((recoverySnapshot.raw.awakeSleepSec ?? 0) / 60)}m
+                {formatSleepStageMinutes(recoverySnapshot.raw.deepSleepSec)} / {formatSleepStageMinutes(recoverySnapshot.raw.remSleepSec)} / {formatSleepStageMinutes(recoverySnapshot.raw.lightSleepSec)} / {formatSleepStageMinutes(recoverySnapshot.raw.awakeSleepSec)}
               </span>
             </div>
           )}

--- a/app/src/components/DataView.tsx
+++ b/app/src/components/DataView.tsx
@@ -166,6 +166,20 @@ export function DataView({ decisionInput, userId, initialTab = 'recovery' }: Dat
               }
             </span>
           </div>
+          {recoverySnapshot?.raw.deepSleepSec != null && (
+            <div className="data-item">
+              <span className="data-label">Sleep Stages (Deep / REM / Light / Awake):</span>
+              <span className="data-value">
+                {Math.round((recoverySnapshot.raw.deepSleepSec ?? 0) / 60)}m / {Math.round((recoverySnapshot.raw.remSleepSec ?? 0) / 60)}m / {Math.round((recoverySnapshot.raw.lightSleepSec ?? 0) / 60)}m / {Math.round((recoverySnapshot.raw.awakeSleepSec ?? 0) / 60)}m
+              </span>
+            </div>
+          )}
+          {recoverySnapshot?.raw.restlessMomentsCount != null && (
+            <div className="data-item">
+              <span className="data-label">Restless Moments:</span>
+              <span className="data-value">{recoverySnapshot.raw.restlessMomentsCount}</span>
+            </div>
+          )}
           <div className="data-item">
             <span className="data-label">Resting HR:</span>
             <span className="data-value">{recoverySnapshot?.raw.restingHr ?? 'N/A'}</span>

--- a/app/src/engine/models.ts
+++ b/app/src/engine/models.ts
@@ -856,6 +856,11 @@ export interface DailyRecoverySnapshot {
     raw: {
         sleepScore: number | null;
         sleepDurationSec: number | null;
+        deepSleepSec?: number | null;
+        remSleepSec?: number | null;
+        lightSleepSec?: number | null;
+        awakeSleepSec?: number | null;
+        restlessMomentsCount?: number | null;
         restingHr: number | null;
         hrvOvernightAvg: number | null;
         hrvStatus: string | null;

--- a/src/garmin_sync/canonical.py
+++ b/src/garmin_sync/canonical.py
@@ -82,6 +82,11 @@ class CanonicalDailyMetrics:
     sleep_score: float | None = None
     sleep_duration_seconds: int | None = None
     sleep_date: str | None = None
+    deep_sleep_seconds: int | None = None
+    rem_sleep_seconds: int | None = None
+    light_sleep_seconds: int | None = None
+    awake_sleep_seconds: int | None = None
+    restless_moments_count: int | None = None
     respiration_rate_brpm: float | None = None
     body_battery_wake: float | None = None
     body_battery_wake_date: str | None = None

--- a/src/garmin_sync/garmin_provider.py
+++ b/src/garmin_sync/garmin_provider.py
@@ -46,13 +46,23 @@ _POWER_ACTIVITY_TYPES = {
 
 
 def extract_sleep_metrics(
-    sleep_obj: dict[str, Any],
-) -> tuple[int | float | None, int | None, float | None]:
-    """Extract (sleep_score, sleep_sec, avg_resp) from a raw Garmin sleep response.
+    sleep_obj: dict[str, Any] | None,
+) -> tuple[
+    int | float | None,
+    int | None,
+    float | None,
+    int | None,
+    int | None,
+    int | None,
+    int | None,
+    int | None,
+]:
+    """Extract (sleep_score, sleep_sec, avg_resp, deep_sec, rem_sec, light_sec, awake_sec, restless_count)
+    from a raw Garmin sleep response.
     Handles both known Garmin response shapes (nested dailySleepDTO.sleepScores.overall
     and top-level overallSleepScore)."""
     if not sleep_obj:
-        return None, None, None
+        return None, None, None, None, None, None, None, None
 
     daily_sleep = sleep_obj.get("dailySleepDTO", {})
     scores = daily_sleep.get("sleepScores", {}) or sleep_obj.get("overallSleepScore", {})
@@ -70,7 +80,22 @@ def extract_sleep_metrics(
         "averageRespirationValue"
     )
 
-    return sleep_score, sleep_sec, avg_resp
+    deep_sec = daily_sleep.get("deepSleepSeconds")
+    rem_sec = daily_sleep.get("remSleepSeconds")
+    light_sec = daily_sleep.get("lightSleepSeconds")
+    awake_sec = daily_sleep.get("awakeSleepSeconds")
+    restless_count = daily_sleep.get("restlessMomentsCount")
+
+    return (
+        sleep_score,
+        sleep_sec,
+        avg_resp,
+        deep_sec if isinstance(deep_sec, int) else None,
+        rem_sec if isinstance(rem_sec, int) else None,
+        light_sec if isinstance(light_sec, int) else None,
+        awake_sec if isinstance(awake_sec, int) else None,
+        restless_count if isinstance(restless_count, int) else None,
+    )
 
 
 def _sleep_window_gmt_ms(
@@ -497,13 +522,38 @@ def canonicalize_from_raw(
         steps_date = target_date_iso
 
     # Sleep
-    sleep_score, sleep_sec, avg_resp = extract_sleep_metrics(sleep_today)
+    (
+        sleep_score,
+        sleep_sec,
+        avg_resp,
+        deep_sec,
+        rem_sec,
+        light_sec,
+        awake_sec,
+        restless_count,
+    ) = extract_sleep_metrics(sleep_today)
     sleep_date = target_date_iso
     used_sleep_fallback = False
     if sleep_score is None and sleep_fallback:
-        fb_score, fb_sec, fb_resp = extract_sleep_metrics(sleep_fallback)
+        (
+            fb_score,
+            fb_sec,
+            fb_resp,
+            fb_deep,
+            fb_rem,
+            fb_light,
+            fb_awake,
+            fb_restless,
+        ) = extract_sleep_metrics(sleep_fallback)
         if fb_score is not None:
             sleep_score, sleep_sec, avg_resp = fb_score, fb_sec, fb_resp
+            deep_sec, rem_sec, light_sec, awake_sec, restless_count = (
+                fb_deep,
+                fb_rem,
+                fb_light,
+                fb_awake,
+                fb_restless,
+            )
             sleep_date = yesterday_iso
             used_sleep_fallback = True
 
@@ -536,6 +586,11 @@ def canonicalize_from_raw(
         sleep_score=sleep_score,
         sleep_duration_seconds=sleep_sec,
         sleep_date=sleep_date if sleep_score is not None else None,
+        deep_sleep_seconds=deep_sec,
+        rem_sleep_seconds=rem_sec,
+        light_sleep_seconds=light_sec,
+        awake_sleep_seconds=awake_sec,
+        restless_moments_count=restless_count,
         respiration_rate_brpm=avg_resp,
         body_battery_wake=bb_wake,
         body_battery_wake_date=bb_wake_date if bb_wake is not None else None,

--- a/src/garmin_sync/garmin_provider.py
+++ b/src/garmin_sync/garmin_provider.py
@@ -45,6 +45,13 @@ _POWER_ACTIVITY_TYPES = {
 }
 
 
+def _optional_non_negative_int(value: Any) -> int | None:
+    """Accept Garmin count/duration fields only when they are real non-negative ints."""
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return None
+    return value
+
+
 def extract_sleep_metrics(
     sleep_obj: dict[str, Any] | None,
 ) -> tuple[
@@ -60,12 +67,15 @@ def extract_sleep_metrics(
     """Extract (sleep_score, sleep_sec, avg_resp, deep_sec, rem_sec, light_sec, awake_sec, restless_count)
     from a raw Garmin sleep response.
     Handles both known Garmin response shapes (nested dailySleepDTO.sleepScores.overall
-    and top-level overallSleepScore)."""
+    and top-level overallSleepScore), and tolerates stage/restlessness fields appearing
+    either in dailySleepDTO or at the response root."""
     if not sleep_obj:
         return None, None, None, None, None, None, None, None
 
-    daily_sleep = sleep_obj.get("dailySleepDTO", {})
-    scores = daily_sleep.get("sleepScores", {}) or sleep_obj.get("overallSleepScore", {})
+    raw_daily_sleep = sleep_obj.get("dailySleepDTO")
+    daily_sleep = raw_daily_sleep if isinstance(raw_daily_sleep, dict) else {}
+    raw_scores = daily_sleep.get("sleepScores") or sleep_obj.get("overallSleepScore")
+    scores = raw_scores if isinstance(raw_scores, dict) else {}
 
     sleep_score = (
         scores.get("overall", {}).get("value")
@@ -80,21 +90,25 @@ def extract_sleep_metrics(
         "averageRespirationValue"
     )
 
-    deep_sec = daily_sleep.get("deepSleepSeconds")
-    rem_sec = daily_sleep.get("remSleepSeconds")
-    light_sec = daily_sleep.get("lightSleepSeconds")
-    awake_sec = daily_sleep.get("awakeSleepSeconds")
-    restless_count = daily_sleep.get("restlessMomentsCount")
+    def sleep_int(field: str) -> int | None:
+        nested = _optional_non_negative_int(daily_sleep.get(field))
+        return nested if nested is not None else _optional_non_negative_int(sleep_obj.get(field))
+
+    deep_sec = sleep_int("deepSleepSeconds")
+    rem_sec = sleep_int("remSleepSeconds")
+    light_sec = sleep_int("lightSleepSeconds")
+    awake_sec = sleep_int("awakeSleepSeconds")
+    restless_count = sleep_int("restlessMomentsCount")
 
     return (
         sleep_score,
         sleep_sec,
         avg_resp,
-        deep_sec if isinstance(deep_sec, int) else None,
-        rem_sec if isinstance(rem_sec, int) else None,
-        light_sec if isinstance(light_sec, int) else None,
-        awake_sec if isinstance(awake_sec, int) else None,
-        restless_count if isinstance(restless_count, int) else None,
+        deep_sec,
+        rem_sec,
+        light_sec,
+        awake_sec,
+        restless_count,
     )
 
 

--- a/src/garmin_sync/mapper.py
+++ b/src/garmin_sync/mapper.py
@@ -219,6 +219,11 @@ def _build_raw_metrics(
     return RawMetrics(
         sleepScore=canonical.sleep_score,
         sleepDurationSec=canonical.sleep_duration_seconds,
+        deepSleepSec=canonical.deep_sleep_seconds,
+        remSleepSec=canonical.rem_sleep_seconds,
+        lightSleepSec=canonical.light_sleep_seconds,
+        awakeSleepSec=canonical.awake_sleep_seconds,
+        restlessMomentsCount=canonical.restless_moments_count,
         restingHr=canonical.resting_heart_rate_bpm,
         hrvOvernightAvg=canonical.hrv_overnight_avg_ms,
         hrvStatus=canonical.hrv_status,

--- a/src/garmin_sync/models.py
+++ b/src/garmin_sync/models.py
@@ -143,6 +143,11 @@ class HeartRateZonesSummary:
 class RawMetrics:
     sleepScore: int | float | None = None
     sleepDurationSec: int | None = None
+    deepSleepSec: int | None = None
+    remSleepSec: int | None = None
+    lightSleepSec: int | None = None
+    awakeSleepSec: int | None = None
+    restlessMomentsCount: int | None = None
     restingHr: int | float | None = None
     hrvOvernightAvg: int | float | None = None
     hrvStatus: str | None = None

--- a/tests/test_garmin_provider.py
+++ b/tests/test_garmin_provider.py
@@ -182,11 +182,19 @@ def test_canonicalize_from_raw_fallback_consistency():
 
 def test_extract_sleep_metrics_handles_nested_and_fallback_shapes():
     nested = {
-        "dailySleepDTO": {"sleepScores": {"overall": {"value": 90}}, "sleepTimeSeconds": 25000}
+        "dailySleepDTO": {
+            "sleepScores": {"overall": {"value": 90}},
+            "sleepTimeSeconds": 25000,
+            "deepSleepSeconds": 5400,
+            "remSleepSeconds": 6000,
+            "lightSleepSeconds": 12000,
+            "awakeSleepSeconds": 1600,
+            "restlessMomentsCount": 15,
+        }
     }
-    assert extract_sleep_metrics(nested) == (90, 25000, None)
-    assert extract_sleep_metrics({}) == (None, None, None)
-    assert extract_sleep_metrics(None) == (None, None, None)
+    assert extract_sleep_metrics(nested) == (90, 25000, None, 5400, 6000, 12000, 1600, 15)
+    assert extract_sleep_metrics({}) == (None, None, None, None, None, None, None, None)
+    assert extract_sleep_metrics(None) == (None, None, None, None, None, None, None, None)
 
 
 # --- Respiration precision (finer than dailySleepDTO.averageRespirationValue) ----

--- a/tests/test_garmin_sleep_stage_telemetry.py
+++ b/tests/test_garmin_sleep_stage_telemetry.py
@@ -1,0 +1,62 @@
+from garmin_sync.garmin_provider import extract_sleep_metrics
+
+
+def test_extract_sleep_metrics_reads_top_level_restless_count():
+    payload = {
+        "dailySleepDTO": {
+            "sleepScores": {"overall": {"value": 91}},
+            "sleepTimeSeconds": 27_000,
+            "deepSleepSeconds": 5_400,
+            "remSleepSeconds": 6_000,
+            "lightSleepSeconds": 14_000,
+            "awakeSleepSeconds": 1_600,
+        },
+        "restlessMomentsCount": 17,
+    }
+
+    assert extract_sleep_metrics(payload) == (
+        91,
+        27_000,
+        None,
+        5_400,
+        6_000,
+        14_000,
+        1_600,
+        17,
+    )
+
+
+def test_extract_sleep_metrics_prefers_nested_count_when_both_shapes_exist():
+    payload = {
+        "dailySleepDTO": {
+            "sleepScores": {"overall": {"value": 84}},
+            "restlessMomentsCount": 8,
+        },
+        "restlessMomentsCount": 99,
+    }
+
+    assert extract_sleep_metrics(payload)[-1] == 8
+
+
+def test_extract_sleep_metrics_degrades_on_malformed_sleep_dto_and_invalid_counts():
+    payload = {
+        "dailySleepDTO": "unexpected-shape",
+        "overallSleepScore": {"value": 88},
+        "totalSleepSeconds": 25_200,
+        "deepSleepSeconds": -1,
+        "remSleepSeconds": True,
+        "lightSleepSeconds": 13_000,
+        "awakeSleepSeconds": 0,
+        "restlessMomentsCount": False,
+    }
+
+    assert extract_sleep_metrics(payload) == (
+        88,
+        25_200,
+        None,
+        None,
+        None,
+        13_000,
+        0,
+        None,
+    )

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -432,3 +432,30 @@ def test_build_snapshot_metric_enrichment_fields_absent_when_no_canonical_data()
     assert snapshot.raw.bodyBatteryChange is None
     assert snapshot.dataQuality.stressAvailable is False
     assert snapshot.source.metricDates.stress is None
+
+
+def test_build_snapshot_maps_sleep_stages():
+    canonical = CanonicalDailyMetrics(
+        date="2026-08-23",
+        sleep_score=85,
+        sleep_duration_seconds=28800,
+        deep_sleep_seconds=5400,
+        rem_sleep_seconds=6400,
+        light_sleep_seconds=15000,
+        awake_sleep_seconds=2000,
+        restless_moments_count=12,
+    )
+
+    snapshot = build_snapshot_from_canonical(
+        user_id="test_uid",
+        target_date_iso="2026-08-23",
+        canonical=canonical,
+        canonical_activities=[],
+        derived_metrics=DerivedMetrics(),
+    )
+
+    assert snapshot.raw.deepSleepSec == 5400
+    assert snapshot.raw.remSleepSec == 6400
+    assert snapshot.raw.lightSleepSec == 15000
+    assert snapshot.raw.awakeSleepSec == 2000
+    assert snapshot.raw.restlessMomentsCount == 12


### PR DESCRIPTION
## Summary

This PR introduces full sleep stage architecture telemetry (Deep sleep, REM sleep, Light sleep, Awake duration, and Restless moments count) from Garmin Connect into the adaptive training recommender ecosystem.

---

## Key Changes

### 1. Python Backend (`src/garmin_sync/`)
- **Canonical Model** (`canonical.py`):
  - Added `deep_sleep_seconds`, `rem_sleep_seconds`, `light_sleep_seconds`, `awake_sleep_seconds`, and `restless_moments_count` to `CanonicalDailyMetrics`.
- **Garmin Provider & Parsing** (`garmin_provider.py`):
  - Updated `extract_sleep_metrics` and `canonicalize_from_raw` to defensively extract all sleep stage durations and restlessness counts from `dailySleepDTO`.
- **Snapshot Mapper & Storage** (`mapper.py`, `models.py`):
  - Mapped canonical sleep stage metrics into `DailyRecoverySnapshot.raw` (`deepSleepSec`, `remSleepSec`, `lightSleepSec`, `awakeSleepSec`, `restlessMomentsCount`).

### 2. Frontend Application & Engine (`app/src/`)
- **Engine Recovery Model** (`app/src/engine/models.ts`):
  - Extended `DailyRecoverySnapshot.raw` with optional `deepSleepSec`, `remSleepSec`, `lightSleepSec`, `awakeSleepSec`, and `restlessMomentsCount`.
- **Check-in & Recovery Inspection UI** (`DailyCheckin.tsx`, `DataView.tsx`):
  - Added Deep Sleep and REM Sleep metric pills to the check-in recovery comparison panel (with % of total sleep duration).
  - Added full sleep stage duration breakdown (`Deep / REM / Light / Awake`) and restless moments counter to `DataView.tsx` raw metrics.

---

## Verification & Test Results

- **Python Backend**:
  - `uv run pytest`: **252 passed** in 8.43s
  - `uv run ruff check .`: **Passed**
  - `uv run mypy src/garmin_sync`: **Success: no issues found in 22 source files**
- **Frontend App**:
  - `npm run typecheck`: **Clean compile (0 errors)**
  - `npm run lint`: **0 errors**
  - `npm test`: **2,037 passed, 0 failed** across 199 test files
  - `npm run validate:workouts`: **Validated 175 exercises, 37 workouts, 16 parameter binding sets, 25 authored families**
  - `npm run simulate:diff`: **No semantic differences found against committed baseline**
  - `npm run build`: **Production build succeeded**
