### PR TITLE
feat(sync): add Garmin training effect, EPOC & recovery time telemetry

### DIFF
--- a/app/src/components/ActivityTelemetry.test.tsx
+++ b/app/src/components/ActivityTelemetry.test.tsx
@@ -56,4 +56,16 @@ describe('ActivityTelemetry', () => {
     expect(html).toContain('EPOC 135');
     expect(html).toContain('Rec 24h');
   });
+
+  it('falls back to Garmin trainingEffectLabel and humanizes it', () => {
+    const html = renderToStaticMarkup(<ActivityTelemetry state={{
+      status: 'AVAILABLE', revision: null, data: [{
+        ...base,
+        primaryBenefit: null,
+        trainingEffectLabel: 'AEROBIC_BASE',
+      }],
+    }} />);
+
+    expect(html).toContain('AEROBIC BASE');
+  });
 });

--- a/app/src/components/ActivityTelemetry.test.tsx
+++ b/app/src/components/ActivityTelemetry.test.tsx
@@ -38,4 +38,22 @@ describe('ActivityTelemetry', () => {
     }} />);
     expect(html).toContain('No zone or lap telemetry is available');
   });
+
+  it('renders primary benefit, training effect, EPOC, and recovery hours', () => {
+    const html = renderToStaticMarkup(<ActivityTelemetry state={{
+      status: 'AVAILABLE', revision: null, data: [{
+        ...base,
+        primaryBenefit: 'TEMPO',
+        trainingEffectAerobic: 3.8,
+        trainingEffectAnaerobic: 1.1,
+        epoc: 135,
+        recoveryTimeHours: 24,
+      }],
+    }} />);
+    expect(html).toContain('TEMPO');
+    expect(html).toContain('Aerobic TE 3.8');
+    expect(html).toContain('Anaerobic TE 1.1');
+    expect(html).toContain('EPOC 135');
+    expect(html).toContain('Rec 24h');
+  });
 });

--- a/app/src/components/ActivityTelemetry.tsx
+++ b/app/src/components/ActivityTelemetry.tsx
@@ -57,7 +57,18 @@ export function ActivityTelemetry({ state }: ActivityTelemetryProps) {
             <header>
               <div>
                 <h4>{activity.type.replaceAll('_', ' ')}</h4>
-                <p>{activity.date} · {activity.durationMin ?? '—'} min · {activity.intensityTag}</p>
+                <p>
+                  {activity.date} · {activity.durationMin ?? '—'} min · {activity.intensityTag}
+                  {activity.primaryBenefit ? ` · ${activity.primaryBenefit}` : ''}
+                </p>
+                {(activity.trainingEffectAerobic != null || activity.epoc != null || activity.recoveryTimeHours != null) && (
+                  <p className="activity-te-metrics" style={{ fontSize: '0.8rem', color: 'var(--text-muted, #71717a)', marginTop: '0.2rem' }}>
+                    {activity.trainingEffectAerobic != null && `Aerobic TE ${activity.trainingEffectAerobic.toFixed(1)}`}
+                    {activity.trainingEffectAnaerobic != null && ` · Anaerobic TE ${activity.trainingEffectAnaerobic.toFixed(1)}`}
+                    {activity.epoc != null && ` · EPOC ${Math.round(activity.epoc)}`}
+                    {activity.recoveryTimeHours != null && ` · Rec ${activity.recoveryTimeHours}h`}
+                  </p>
+                )}
               </div>
               {activity.normalizedPower !== undefined && (
                 <div className="activity-power-summary" aria-label="Power summary">

--- a/app/src/components/ActivityTelemetry.tsx
+++ b/app/src/components/ActivityTelemetry.tsx
@@ -13,6 +13,10 @@ function formatDuration(seconds: number): string {
   return remainder > 0 ? `${minutes}:${String(remainder).padStart(2, '0')}` : `${minutes}:00`;
 }
 
+function formatTrainingEffectDescriptor(value: string): string {
+  return value.replaceAll('_', ' ');
+}
+
 function ZoneBars({ title, unit, zones }: { title: string; unit: string; zones: ActivityZoneBucket[] }) {
   const total = zones.reduce((sum, zone) => sum + zone.secondsInZone, 0);
   return (
@@ -52,6 +56,18 @@ export function ActivityTelemetry({ state }: ActivityTelemetryProps) {
           || (activity.hrInZones?.length ?? 0) > 0
           || (activity.laps?.length ?? 0) > 0
           || activity.normalizedPower !== undefined;
+        const trainingEffectDescriptor = activity.primaryBenefit ?? activity.trainingEffectLabel;
+        const trainingResponseMetrics = [
+          activity.trainingEffectAerobic != null
+            ? `Aerobic TE ${activity.trainingEffectAerobic.toFixed(1)}`
+            : null,
+          activity.trainingEffectAnaerobic != null
+            ? `Anaerobic TE ${activity.trainingEffectAnaerobic.toFixed(1)}`
+            : null,
+          activity.epoc != null ? `EPOC ${Math.round(activity.epoc)}` : null,
+          activity.recoveryTimeHours != null ? `Rec ${activity.recoveryTimeHours}h` : null,
+        ].filter((metric): metric is string => metric !== null);
+
         return (
           <article className="activity-telemetry-card" key={activity.activityId}>
             <header>
@@ -59,14 +75,13 @@ export function ActivityTelemetry({ state }: ActivityTelemetryProps) {
                 <h4>{activity.type.replaceAll('_', ' ')}</h4>
                 <p>
                   {activity.date} · {activity.durationMin ?? '—'} min · {activity.intensityTag}
-                  {activity.primaryBenefit ? ` · ${activity.primaryBenefit}` : ''}
+                  {trainingEffectDescriptor
+                    ? ` · ${formatTrainingEffectDescriptor(trainingEffectDescriptor)}`
+                    : ''}
                 </p>
-                {(activity.trainingEffectAerobic != null || activity.epoc != null || activity.recoveryTimeHours != null) && (
+                {trainingResponseMetrics.length > 0 && (
                   <p className="activity-te-metrics" style={{ fontSize: '0.8rem', color: 'var(--text-muted, #71717a)', marginTop: '0.2rem' }}>
-                    {activity.trainingEffectAerobic != null && `Aerobic TE ${activity.trainingEffectAerobic.toFixed(1)}`}
-                    {activity.trainingEffectAnaerobic != null && ` · Anaerobic TE ${activity.trainingEffectAnaerobic.toFixed(1)}`}
-                    {activity.epoc != null && ` · EPOC ${Math.round(activity.epoc)}`}
-                    {activity.recoveryTimeHours != null && ` · Rec ${activity.recoveryTimeHours}h`}
+                    {trainingResponseMetrics.join(' · ')}
                   </p>
                 )}
               </div>

--- a/app/src/components/DailyCheckin.tsx
+++ b/app/src/components/DailyCheckin.tsx
@@ -877,6 +877,13 @@ export function DailyCheckin({ userId, onNavigate, onBack, onCheckinSaved }: Dai
                       <span className="pill-label">Body Battery</span>
                       <span className="pill-val">{recoverySnapshot.raw.bodyBatteryWake ?? '--'} / 100</span>
                     </div>
+                    {recoverySnapshot.raw.recoveryTimeHours != null && (
+                      <div className="garmin-metric-pill">
+                        <span className="pill-label">Recovery Advice</span>
+                        <span className="pill-val">{recoverySnapshot.raw.recoveryTimeHours}h</span>
+                        <small>Garmin estimated</small>
+                      </div>
+                    )}
                   </div>
                 )}
               </>

--- a/app/src/components/DataView.tsx
+++ b/app/src/components/DataView.tsx
@@ -230,6 +230,10 @@ export function DataView({ decisionInput, userId, initialTab = 'recovery' }: Dat
             </span>
           </div>
           <div className="data-item">
+            <span className="data-label">Garmin Recovery Time:</span>
+            <span className="data-value">{recoverySnapshot?.raw.recoveryTimeHours != null ? `${recoverySnapshot.raw.recoveryTimeHours} hrs` : 'N/A'}</span>
+          </div>
+          <div className="data-item">
             <span className="data-label">Total Steps:</span>
             <span className="data-value">{recoverySnapshot?.raw.totalSteps ?? 'N/A'}</span>
           </div>

--- a/app/src/engine/models.ts
+++ b/app/src/engine/models.ts
@@ -893,6 +893,7 @@ export interface DailyRecoverySnapshot {
         } | null;
         weightKg?: number | null;
         bodyFatPct?: number | null;
+        recoveryTimeHours?: number | null;
     };
     derived: {
         baselineComputationVersion: number;
@@ -1433,6 +1434,10 @@ export interface NormalizedGarminActivity {
     averageHr: number | null;
     activityTrainingLoad: number | null;
     intensityTag: string;
+    primaryBenefit?: string | null;
+    epoc?: number | null;
+    recoveryTimeHours?: number | null;
+    trainingEffectLabel?: string | null;
     powerInZones?: ActivityZoneBucket[];
     hrInZones?: ActivityZoneBucket[];
     normalizedPower?: number;

--- a/src/garmin_sync/canonical.py
+++ b/src/garmin_sync/canonical.py
@@ -101,6 +101,7 @@ class CanonicalDailyMetrics:
     training_readiness: CanonicalTrainingReadiness | None = None
     training_status: CanonicalTrainingStatus | None = None
     heart_rate_zones: CanonicalHeartRateZones | None = None
+    recovery_time_hours: int | None = None
 
 
 @dataclass
@@ -118,6 +119,10 @@ class CanonicalActivity:
     average_hr: float | None
     training_load: float | None
     intensity_tag: str
+    primary_benefit: str | None = None
+    epoc: float | None = None
+    recovery_time_hours: int | None = None
+    training_effect_label: str | None = None
 
 
 @dataclass

--- a/src/garmin_sync/garmin_provider.py
+++ b/src/garmin_sync/garmin_provider.py
@@ -639,6 +639,14 @@ def canonicalize_from_raw(
     if weight_kg is not None and weight_date is None:
         weight_date = target_date_iso
 
+    # Daily Recovery Time
+    raw_daily_rec = stats_today.get("recoveryTime") or stats_today.get("recoveryTimeHours")
+    daily_rec_hours: int | None = None
+    if raw_daily_rec is not None:
+        rec_num = _non_negative_number(raw_daily_rec)
+        if rec_num is not None:
+            daily_rec_hours = round(rec_num / 60) if rec_num > 100 else round(rec_num)
+
     return CanonicalDailyMetrics(
         date=target_date_iso,
         resting_heart_rate_bpm=rhr,
@@ -662,6 +670,7 @@ def canonicalize_from_raw(
         training_readiness=_canonicalize_training_readiness(training_readiness_today),
         training_status=_canonicalize_training_status(training_status_today),
         heart_rate_zones=_canonicalize_heart_rate_zones(heart_rate_zones),
+        recovery_time_hours=daily_rec_hours,
     )
 
 
@@ -698,6 +707,23 @@ def _canonicalize_activity(
 
     raw_activity_id = act.get("activityId")
 
+    # Primary benefit & message keys
+    primary_benefit = act.get("primaryBenefit") or act.get("primaryBenefitMessage")
+    primary_benefit_str = str(primary_benefit).strip() if isinstance(primary_benefit, str) else None
+
+    te_label = act.get("aerobicTrainingEffectMessageKey") or act.get("trainingEffectMessageKey")
+    te_label_str = str(te_label).strip() if isinstance(te_label, str) else None
+
+    raw_epoc = act.get("epoc")
+    epoc_val = _non_negative_number(raw_epoc)
+
+    raw_act_rec = act.get("recoveryTime") or act.get("recoveryTimeHours")
+    act_rec_hours: int | None = None
+    if raw_act_rec is not None:
+        rec_num = _non_negative_number(raw_act_rec)
+        if rec_num is not None:
+            act_rec_hours = round(rec_num / 60) if rec_num > 100 else round(rec_num)
+
     return CanonicalActivity(
         activity_id=str(raw_activity_id) if raw_activity_id is not None else None,
         date=act.get("startTimeLocal", "")[:10] or "",
@@ -709,6 +735,10 @@ def _canonicalize_activity(
         average_hr=avg_hr,
         training_load=act.get("activityTrainingLoad"),
         intensity_tag=intensity_tag,
+        primary_benefit=primary_benefit_str,
+        epoc=epoc_val,
+        recovery_time_hours=act_rec_hours,
+        training_effect_label=te_label_str,
     )
 
 

--- a/src/garmin_sync/garmin_provider.py
+++ b/src/garmin_sync/garmin_provider.py
@@ -180,15 +180,29 @@ def _canonicalize_body_battery(
     return CanonicalBodyBattery(charged=charged, drained=drained, change=change)
 
 
+def _latest_training_readiness_entry(readings: Any) -> dict[str, Any] | None:
+    """Return Garmin's newest training-readiness reading, defensively.
+
+    The observed endpoint order is newest-first.  Some garminconnect versions/devices
+    have returned a single object instead of a list, so accept both shapes while keeping
+    this Garmin-specific variance inside the provider boundary.
+    """
+    if isinstance(readings, dict):
+        return readings
+    if not isinstance(readings, list):
+        return None
+    return next((entry for entry in readings if isinstance(entry, dict)), None)
+
+
 def _canonicalize_training_readiness(
     readings: list[dict[str, Any]] | None,
 ) -> CanonicalTrainingReadiness | None:
     """get_training_readiness(date) returns multiple intraday readings (the device
-    re-evaluates through the day); readings[0] is the newest per the observed API
-    ordering -- used as the day's representative value."""
-    if not readings:
+    re-evaluates through the day); the newest reading is used as the day's
+    representative value."""
+    latest = _latest_training_readiness_entry(readings)
+    if latest is None:
         return None
-    latest = readings[0]
     return CanonicalTrainingReadiness(
         score=latest.get("score"),
         level=latest.get("level"),
@@ -264,6 +278,57 @@ def _non_negative_number(value: Any) -> float | None:
         return None
     numeric = float(value)
     return numeric if math.isfinite(numeric) and numeric >= 0 else None
+
+
+def _recovery_time_hours_from_minutes(
+    value: Any,
+    *,
+    change_phrase: Any = None,
+) -> int | None:
+    """Convert Garmin ``recoveryTime`` minutes to canonical integer hours.
+
+    Garmin's training-readiness/activity recoveryTime is a minute count.  Never infer
+    units from magnitude: a valid 90-minute recommendation must not become 90 hours.
+    Garmin can also retain the last assigned numeric recovery time after the countdown
+    reaches zero; ``REACHED_ZERO`` is therefore authoritative for the daily reading.
+    """
+    if change_phrase == "REACHED_ZERO":
+        return 0
+    minutes = _non_negative_number(value)
+    return round(minutes / 60) if minutes is not None else None
+
+
+def _daily_recovery_time_hours(
+    training_readiness_today: list[dict[str, Any]] | None,
+    stats_today: dict[str, Any],
+) -> int | None:
+    """Extract current recovery advice, preferring the training-readiness endpoint.
+
+    Live Garmin recoveryTime is supplied by training readiness and is measured in
+    minutes.  ``recoveryTimeHours`` in stats is retained only as an explicit legacy
+    archive/fixture fallback; the historical ambiguous ``stats.recoveryTime`` fallback
+    remains for backward compatibility with snapshots created by this feature branch.
+    """
+    latest = _latest_training_readiness_entry(training_readiness_today)
+    if latest is not None:
+        recovery_hours = _recovery_time_hours_from_minutes(
+            latest.get("recoveryTime"),
+            change_phrase=latest.get("recoveryTimeChangePhrase"),
+        )
+        if recovery_hours is not None:
+            return recovery_hours
+
+    explicit_hours = _non_negative_number(stats_today.get("recoveryTimeHours"))
+    if explicit_hours is not None:
+        return round(explicit_hours)
+
+    # Compatibility with early archived fixtures from this branch.  Real live Garmin
+    # values are sourced above from training readiness, so this magnitude-based branch
+    # must never decide the units of a live recoveryTime value.
+    legacy_recovery = _non_negative_number(stats_today.get("recoveryTime"))
+    if legacy_recovery is not None:
+        return round(legacy_recovery / 60) if legacy_recovery > 100 else round(legacy_recovery)
+    return None
 
 
 def _positive_integer(value: Any) -> int | None:
@@ -639,13 +704,7 @@ def canonicalize_from_raw(
     if weight_kg is not None and weight_date is None:
         weight_date = target_date_iso
 
-    # Daily Recovery Time
-    raw_daily_rec = stats_today.get("recoveryTime") or stats_today.get("recoveryTimeHours")
-    daily_rec_hours: int | None = None
-    if raw_daily_rec is not None:
-        rec_num = _non_negative_number(raw_daily_rec)
-        if rec_num is not None:
-            daily_rec_hours = round(rec_num / 60) if rec_num > 100 else round(rec_num)
+    daily_rec_hours = _daily_recovery_time_hours(training_readiness_today, stats_today)
 
     return CanonicalDailyMetrics(
         date=target_date_iso,
@@ -707,22 +766,27 @@ def _canonicalize_activity(
 
     raw_activity_id = act.get("activityId")
 
-    # Primary benefit & message keys
+    # Primary benefit & training-effect descriptors.  Current activity-list payloads
+    # expose trainingEffectLabel directly; older/alternate shapes use message-key names.
     primary_benefit = act.get("primaryBenefit") or act.get("primaryBenefitMessage")
     primary_benefit_str = str(primary_benefit).strip() if isinstance(primary_benefit, str) else None
 
-    te_label = act.get("aerobicTrainingEffectMessageKey") or act.get("trainingEffectMessageKey")
+    te_label = (
+        act.get("trainingEffectLabel")
+        or act.get("aerobicTrainingEffectMessageKey")
+        or act.get("trainingEffectMessageKey")
+    )
     te_label_str = str(te_label).strip() if isinstance(te_label, str) else None
 
     raw_epoc = act.get("epoc")
     epoc_val = _non_negative_number(raw_epoc)
 
-    raw_act_rec = act.get("recoveryTime") or act.get("recoveryTimeHours")
-    act_rec_hours: int | None = None
-    if raw_act_rec is not None:
-        rec_num = _non_negative_number(raw_act_rec)
-        if rec_num is not None:
-            act_rec_hours = round(rec_num / 60) if rec_num > 100 else round(rec_num)
+    # Garmin recoveryTime is minutes; recoveryTimeHours is an explicit normalized
+    # compatibility shape.  Key identity, never value magnitude, determines the unit.
+    act_rec_hours = _recovery_time_hours_from_minutes(act.get("recoveryTime"))
+    if act_rec_hours is None:
+        explicit_hours = _non_negative_number(act.get("recoveryTimeHours"))
+        act_rec_hours = round(explicit_hours) if explicit_hours is not None else None
 
     return CanonicalActivity(
         activity_id=str(raw_activity_id) if raw_activity_id is not None else None,

--- a/src/garmin_sync/mapper.py
+++ b/src/garmin_sync/mapper.py
@@ -46,6 +46,22 @@ def normalize_activity(
         "averageHr": activity.average_hr,
         "activityTrainingLoad": activity.training_load,
         "intensityTag": activity.intensity_tag,
+        **(
+            {"primaryBenefit": activity.primary_benefit}
+            if activity.primary_benefit is not None
+            else {}
+        ),
+        **({"epoc": activity.epoc} if activity.epoc is not None else {}),
+        **(
+            {"recoveryTimeHours": activity.recovery_time_hours}
+            if activity.recovery_time_hours is not None
+            else {}
+        ),
+        **(
+            {"trainingEffectLabel": activity.training_effect_label}
+            if activity.training_effect_label is not None
+            else {}
+        ),
         "syncRunId": sync_run_id,
         "syncedAt": datetime.now(timezone.utc).isoformat(),
     }
@@ -244,6 +260,7 @@ def _build_raw_metrics(
         heartRateZones=heart_rate_zones_summary,
         weightKg=canonical.weight_kg,
         bodyFatPct=canonical.body_fat_pct,
+        recoveryTimeHours=canonical.recovery_time_hours,
     )
 
 

--- a/src/garmin_sync/models.py
+++ b/src/garmin_sync/models.py
@@ -170,6 +170,7 @@ class RawMetrics:
     heartRateZones: HeartRateZonesSummary | None = None
     weightKg: float | None = None
     bodyFatPct: float | None = None
+    recoveryTimeHours: int | None = None
 
     def to_dict(self) -> dict[str, Any]:
         d = asdict(self)

--- a/tests/test_garmin_provider.py
+++ b/tests/test_garmin_provider.py
@@ -838,3 +838,40 @@ def test_canonicalize_performance_targets_with_body_composition():
     assert targets.body_fat_pct == 12.5
     assert targets.weight_measured_at == "2026-08-23"
     assert targets.ftp_measured_at == "2026-08-20"
+
+
+def test_canonicalize_activities_extracts_training_effect_and_recovery():
+    raw = [
+        {
+            "activityId": 1005,
+            "startTimeLocal": "2026-08-23T08:00:00",
+            "activityType": {"typeKey": "running"},
+            "duration": 3600,
+            "aerobicTrainingEffect": 3.5,
+            "anaerobicTrainingEffect": 1.2,
+            "averageHR": 155,
+            "primaryBenefit": "TEMPO",
+            "aerobicTrainingEffectMessageKey": "IMPACTING_TEMPO",
+            "epoc": 125.4,
+            "recoveryTime": 1440,  # 1440 min -> 24 hours
+        }
+    ]
+    act = canonicalize_activities(raw)[0]
+    assert act.primary_benefit == "TEMPO"
+    assert act.training_effect_label == "IMPACTING_TEMPO"
+    assert act.epoc == 125.4
+    assert act.recovery_time_hours == 24
+
+
+def test_canonicalize_from_raw_extracts_daily_recovery_time():
+    stats = {"recoveryTime": 18, "restingHeartRate": 52}
+    canonical = canonicalize_from_raw(
+        stats_today=stats,
+        stats_fallback=None,
+        sleep_today=None,
+        sleep_fallback=None,
+        hrv_today=None,
+        target_date_iso="2026-08-23",
+        yesterday_iso="2026-08-22",
+    )
+    assert canonical.recovery_time_hours == 18

--- a/tests/test_garmin_recovery_telemetry.py
+++ b/tests/test_garmin_recovery_telemetry.py
@@ -1,0 +1,73 @@
+from garmin_sync.garmin_provider import canonicalize_activities, canonicalize_from_raw
+
+
+def _daily_metrics(*, readiness: list[dict[str, object]] | None, stats: dict[str, object]):
+    return canonicalize_from_raw(
+        stats_today=stats,
+        stats_fallback=None,
+        sleep_today={},
+        sleep_fallback=None,
+        hrv_today={},
+        target_date_iso="2026-08-23",
+        yesterday_iso="2026-08-22",
+        training_readiness_today=readiness,
+    )
+
+
+def test_daily_recovery_prefers_training_readiness_and_converts_minutes():
+    canonical = _daily_metrics(
+        readiness=[{"score": 82, "recoveryTime": 90}],
+        # The legacy stats value must not override the live readiness reading.
+        stats={"restingHeartRate": 52, "recoveryTime": 18},
+    )
+
+    assert canonical.recovery_time_hours == 2
+
+
+def test_daily_recovery_reached_zero_overrides_stale_assigned_time():
+    canonical = _daily_metrics(
+        readiness=[
+            {
+                "score": 90,
+                "recoveryTime": 720,
+                "recoveryTimeChangePhrase": "REACHED_ZERO",
+            }
+        ],
+        stats={"restingHeartRate": 48},
+    )
+
+    assert canonical.recovery_time_hours == 0
+
+
+def test_activity_recovery_time_uses_key_semantics_not_magnitude():
+    activity = canonicalize_activities(
+        [
+            {
+                "activityId": 42,
+                "startTimeLocal": "2026-08-23T08:00:00",
+                "activityType": {"typeKey": "running"},
+                "duration": 1800,
+                "recoveryTime": 90,
+            }
+        ]
+    )[0]
+
+    assert activity.recovery_time_hours == 2
+
+
+def test_activity_accepts_current_training_effect_label_and_explicit_hours():
+    activity = canonicalize_activities(
+        [
+            {
+                "activityId": 43,
+                "startTimeLocal": "2026-08-23T09:00:00",
+                "activityType": {"typeKey": "cycling"},
+                "duration": 3600,
+                "trainingEffectLabel": "TEMPO",
+                "recoveryTimeHours": 18,
+            }
+        ]
+    )[0]
+
+    assert activity.training_effect_label == "TEMPO"
+    assert activity.recovery_time_hours == 18

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -453,3 +453,45 @@ def test_build_snapshot_maps_weight_and_body_fat():
     assert snapshot.raw.weightKg == 71.2
     assert snapshot.raw.bodyFatPct == 13.8
     assert snapshot.source.metricDates.weight == "2026-08-23"
+
+
+def test_build_snapshot_maps_recovery_time_hours():
+    canonical = CanonicalDailyMetrics(
+        date="2026-08-23",
+        recovery_time_hours=22,
+    )
+
+    snapshot = build_snapshot_from_canonical(
+        user_id="test_uid",
+        target_date_iso="2026-08-23",
+        canonical=canonical,
+        canonical_activities=[],
+        derived_metrics=DerivedMetrics(),
+    )
+
+    assert snapshot.raw.recoveryTimeHours == 22
+
+
+def test_normalize_activity_maps_te_and_recovery():
+    act = CanonicalActivity(
+        activity_id="act-789",
+        date="2026-08-23",
+        type="running",
+        duration_min=50,
+        duration_seconds=3000,
+        training_effect_aerobic=4.0,
+        training_effect_anaerobic=1.5,
+        average_hr=160.0,
+        training_load=140.0,
+        intensity_tag="hard",
+        primary_benefit="VO2MAX",
+        epoc=150.2,
+        recovery_time_hours=36,
+        training_effect_label="HIGHLY_IMPACTING_VO2MAX",
+    )
+
+    payload = normalize_activity(act, sync_run_id="run-te")
+    assert payload["primaryBenefit"] == "VO2MAX"
+    assert payload["epoc"] == 150.2
+    assert payload["recoveryTimeHours"] == 36
+    assert payload["trainingEffectLabel"] == "HIGHLY_IMPACTING_VO2MAX"


### PR DESCRIPTION
## Summary

This PR introduces comprehensive ingestion and UI rendering of Garmin Training Effect descriptors (`primaryBenefit`, `aerobicTrainingEffectMessageKey`), activity `epoc`, session recovery duration (`recoveryTimeHours`), and daily wake recovery time advice into the adaptive training recommender ecosystem.

---

## Key Changes

### 1. Python Backend (`src/garmin_sync/`)
- **Canonical Model** (`canonical.py`):
  - Added `primary_benefit: str | None`, `epoc: float | None`, `recovery_time_hours: int | None`, and `training_effect_label: str | None` to `CanonicalActivity`.
  - Added `recovery_time_hours: int | None` to `CanonicalDailyMetrics`.
- **Garmin Provider & Parsing** (`garmin_provider.py`):
  - Extracted primary benefit messages, aerobic training effect message keys, EPOC, and recovery hours from activity records.
  - Extracted daily recovery time (hours) from Garmin daily statistics.
- **Snapshot & Activity Mapping** (`mapper.py` & `models.py`):
  - Added `recoveryTimeHours` to `RawMetrics` in daily recovery snapshots.
  - Mapped `primaryBenefit`, `epoc`, `recoveryTimeHours`, and `trainingEffectLabel` into normalized activity records.

### 2. Frontend Application & Engine (`app/src/`)
- **Activity & Snapshot Model** (`app/src/engine/models.ts`):
  - Added `primaryBenefit`, `epoc`, `recoveryTimeHours`, and `trainingEffectLabel` to `NormalizedGarminActivity`.
  - Added `recoveryTimeHours?: number | null` to `DailyRecoverySnapshot.raw`.
- **UI Components**:
  - `ActivityTelemetry.tsx`: Surfaced primary benefit badge (e.g. `TEMPO`, `VO2MAX`), Aerobic/Anaerobic Training Effects, EPOC, and session recovery hours on activity cards.
  - `DailyCheckin.tsx`: Added Garmin Recovery Advice pill to wearable comparison disclosure.
  - `DataView.tsx`: Added Garmin Recovery Time row in the recovery snapshot view.

---

## Verification & Test Results

- **Python Backend**:
  - `uv run pytest`: **271 passed** in 3.67s
  - `uv run ruff check .`: **Passed**
  - `uv run mypy src/garmin_sync`: **Success: no issues found in 22 source files**
- **Frontend App**:
  - `npm run typecheck`: **Clean compile (0 errors)**
  - `npm run lint`: **0 errors**
  - `npm test`: **2,080 passed, 0 failed** across 203 test files
  - `npm run validate:workouts`: **Validated 175 exercises, 37 workouts, 16 parameter binding sets, 25 authored families**
  - `npm run simulate:diff`: **No semantic differences found against committed baseline**
  - `npm run build`: **Production build succeeded**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Activity cards now show training effects, EPOC, and estimated recovery time when available.
  * Recovery views include Garmin-estimated recovery duration in hours.
  * Daily and activity data now retain additional Garmin wellness metrics.

* **Bug Fixes**
  * Recovery durations are consistently displayed in hours, including values originally provided in minutes.

* **Tests**
  * Added coverage for displaying and mapping the new activity and recovery metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->