### PR TITLE
feat(sync): add Garmin strength sets & repetitions auto-sync

### DIFF
--- a/app/src/components/ActivityTelemetry.test.tsx
+++ b/app/src/components/ActivityTelemetry.test.tsx
@@ -38,4 +38,30 @@ describe('ActivityTelemetry', () => {
     }} />);
     expect(html).toContain('No zone or lap telemetry is available');
   });
+
+  it('renders strength exercise sets and repetitions table', () => {
+    const html = renderToStaticMarkup(<ActivityTelemetry state={{
+      status: 'AVAILABLE', revision: null, data: [{
+        ...base,
+        type: 'strength_training',
+        exerciseSets: [
+          {
+            setOrder: 0,
+            setType: 'active',
+            repetitionCount: 10,
+            weightKg: 60,
+            exerciseName: 'BARBELL_BENCH_PRESS',
+            durationSeconds: 35,
+            restDurationSeconds: 90,
+          },
+        ],
+      }],
+    }} />);
+    expect(html).toContain('Strength sets &amp; reps');
+    expect(html).toContain('BARBELL BENCH PRESS');
+    expect(html).toContain('10');
+    expect(html).toContain('60 kg');
+    expect(html).toContain('35s');
+    expect(html).toContain('90s rest');
+  });
 });

--- a/app/src/components/ActivityTelemetry.tsx
+++ b/app/src/components/ActivityTelemetry.tsx
@@ -51,6 +51,7 @@ export function ActivityTelemetry({ state }: ActivityTelemetryProps) {
         const hasDetail = (activity.powerInZones?.length ?? 0) > 0
           || (activity.hrInZones?.length ?? 0) > 0
           || (activity.laps?.length ?? 0) > 0
+          || (activity.exerciseSets?.length ?? 0) > 0
           || activity.normalizedPower !== undefined;
         return (
           <article className="activity-telemetry-card" key={activity.activityId}>
@@ -88,6 +89,38 @@ export function ActivityTelemetry({ state }: ActivityTelemetryProps) {
                           <td>{formatDuration(lap.durationSeconds)}</td>
                           <td>{lap.averagePowerWatts !== undefined ? `${Math.round(lap.averagePowerWatts)} W` : '—'}</td>
                           <td>{lap.averageHrBpm !== undefined ? `${Math.round(lap.averageHrBpm)} bpm` : '—'}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </section>
+            )}
+            {activity.exerciseSets !== undefined && activity.exerciseSets.length > 0 && (
+              <section className="activity-exercise-sets" aria-label="Exercise sets">
+                <h5>Strength sets &amp; reps</h5>
+                <div className="activity-lap-table-wrap">
+                  <table>
+                    <thead>
+                      <tr>
+                        <th>Set</th>
+                        <th>Exercise</th>
+                        <th>Reps</th>
+                        <th>Weight</th>
+                        <th>Work / Rest</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {activity.exerciseSets.map((set, idx) => (
+                        <tr key={idx}>
+                          <td>{set.setOrder + 1}{set.setType && set.setType !== 'active' ? ` (${set.setType})` : ''}</td>
+                          <td>{(set.exerciseName || set.exerciseCategory || 'Exercise').replaceAll('_', ' ')}</td>
+                          <td>{set.repetitionCount != null ? set.repetitionCount : '—'}</td>
+                          <td>{set.weightKg != null ? `${set.weightKg} kg` : '—'}</td>
+                          <td>
+                            {set.durationSeconds != null ? `${Math.round(set.durationSeconds)}s` : '—'}
+                            {set.restDurationSeconds != null ? ` / ${Math.round(set.restDurationSeconds)}s rest` : ''}
+                          </td>
                         </tr>
                       ))}
                     </tbody>

--- a/app/src/engine/models.ts
+++ b/app/src/engine/models.ts
@@ -1423,6 +1423,17 @@ export interface ActivityLapSummary {
     averageHrBpm?: number;
 }
 
+export interface ActivityExerciseSet {
+    setOrder: number;
+    setType?: string;
+    repetitionCount?: number;
+    weightKg?: number;
+    exerciseCategory?: string;
+    exerciseName?: string;
+    durationSeconds?: number;
+    restDurationSeconds?: number;
+}
+
 export interface NormalizedGarminActivity {
     activityId: string;
     date: string;
@@ -1439,6 +1450,7 @@ export interface NormalizedGarminActivity {
     intensityFactor?: number;
     variabilityIndex?: number;
     laps?: ActivityLapSummary[];
+    exerciseSets?: ActivityExerciseSet[];
     syncRunId?: string;
     syncedAt?: string;
 }

--- a/src/garmin_sync/canonical.py
+++ b/src/garmin_sync/canonical.py
@@ -136,6 +136,18 @@ class CanonicalLapSummary:
 
 
 @dataclass
+class CanonicalExerciseSet:
+    set_order: int
+    set_type: str = "active"  # "active", "rest", "warmup"
+    repetition_count: int | None = None
+    weight_kg: float | None = None
+    exercise_category: str | None = None
+    exercise_name: str | None = None
+    duration_seconds: float | None = None
+    rest_duration_seconds: float | None = None
+
+
+@dataclass
 class CanonicalActivityDetail:
     activity_id: str
     power_zones: list[CanonicalZoneBucket] | None = None
@@ -144,3 +156,4 @@ class CanonicalActivityDetail:
     intensity_factor: float | None = None
     variability_index: float | None = None
     laps: list[CanonicalLapSummary] | None = None
+    exercise_sets: list[CanonicalExerciseSet] | None = None

--- a/src/garmin_sync/garmin_client.py
+++ b/src/garmin_sync/garmin_client.py
@@ -198,6 +198,11 @@ class GarminClientWrapper:
             raise RuntimeError("Garmin client is not authenticated. Call login first.")
         return self.api.get_activity_splits(activity_id) or {}
 
+    def get_activity_exercise_sets(self, activity_id: str | int) -> dict[str, Any]:
+        if not self.api:
+            raise RuntimeError("Garmin client is not authenticated. Call login first.")
+        return self.api.get_activity_exercise_sets(activity_id) or {}
+
     def get_activities_window(self, start_date_iso: str, end_date_iso: str) -> list[dict[str, Any]]:
         """Paginate get_activities (newest first) to retrieve activities in [start_date_iso, end_date_iso]."""
         if not self.api:

--- a/src/garmin_sync/garmin_provider.py
+++ b/src/garmin_sync/garmin_provider.py
@@ -298,10 +298,7 @@ def qualifies_for_strength_exercise_sets(activity: CanonicalActivity) -> bool:
     power detail, intensity is irrelevant: an easy strength session still has useful
     reps/set structure and costs just one extra endpoint call.
     """
-    return (
-        activity.activity_id is not None
-        and activity.type.lower() in _STRENGTH_ACTIVITY_TYPES
-    )
+    return activity.activity_id is not None and activity.type.lower() in _STRENGTH_ACTIVITY_TYPES
 
 
 def _parse_records(raw_items: list[Any], build: Callable[[dict[str, Any]], T | None]) -> list[T]:
@@ -377,7 +374,9 @@ def _exercise_candidate_identity(item: dict[str, Any]) -> tuple[str | None, str 
         else None
     )
     explicit_name = item.get("exerciseName")
-    name = explicit_name.strip() if isinstance(explicit_name, str) and explicit_name.strip() else None
+    name = (
+        explicit_name.strip() if isinstance(explicit_name, str) and explicit_name.strip() else None
+    )
     if category is not None or name is not None:
         return category, name
 
@@ -391,14 +390,14 @@ def _exercise_candidate_identity(item: dict[str, Any]) -> tuple[str | None, str 
             continue
         raw_category = raw_candidate.get("category")
         candidate_category = (
-            raw_category.strip()
-            if isinstance(raw_category, str) and raw_category.strip()
-            else None
+            raw_category.strip() if isinstance(raw_category, str) and raw_category.strip() else None
         )
         if candidate_category == "UNKNOWN":
             continue
         raw_name = raw_candidate.get("name")
-        candidate_name = raw_name.strip() if isinstance(raw_name, str) and raw_name.strip() else None
+        candidate_name = (
+            raw_name.strip() if isinstance(raw_name, str) and raw_name.strip() else None
+        )
         if candidate_category is None and candidate_name is None:
             continue
 
@@ -414,7 +413,9 @@ def _exercise_candidate_identity(item: dict[str, Any]) -> tuple[str | None, str 
 
     # Known probabilities sort first. A single unscored candidate is still useful, but
     # an unscored multi-candidate payload is ambiguous and therefore deliberately blank.
-    candidates.sort(key=lambda candidate: candidate[0] if candidate[0] is not None else -1.0, reverse=True)
+    candidates.sort(
+        key=lambda candidate: candidate[0] if candidate[0] is not None else -1.0, reverse=True
+    )
     top = candidates[0]
     if len(candidates) > 1:
         runner_up = candidates[1]

--- a/src/garmin_sync/garmin_provider.py
+++ b/src/garmin_sync/garmin_provider.py
@@ -440,7 +440,8 @@ def extract_exercise_sets(raw_sets: Any) -> list[CanonicalExerciseSet] | None:
     duration belongs to the preceding work set, so standalone REST rows are folded into
     ``rest_duration_seconds`` instead of becoming fake numbered exercises. Raw Garmin
     ``weight`` is grams; an explicit ``weightKg`` key is accepted only as a normalized
-    compatibility shape.
+    compatibility shape. A valid empty ``exerciseSets`` list is preserved as ``[]`` so
+    callers can distinguish "Garmin now reports no sets" from "detail was unavailable".
     """
     if isinstance(raw_sets, dict):
         sets_list = raw_sets.get("exerciseSets")
@@ -449,8 +450,10 @@ def extract_exercise_sets(raw_sets: Any) -> list[CanonicalExerciseSet] | None:
     else:
         return None
 
-    if not isinstance(sets_list, list) or not sets_list:
+    if not isinstance(sets_list, list):
         return None
+    if not sets_list:
+        return []
 
     results: list[CanonicalExerciseSet] = []
     for item in sets_list:

--- a/src/garmin_sync/garmin_provider.py
+++ b/src/garmin_sync/garmin_provider.py
@@ -13,6 +13,7 @@ from .canonical import (
     CanonicalActivityDetail,
     CanonicalBodyBattery,
     CanonicalDailyMetrics,
+    CanonicalExerciseSet,
     CanonicalHeartRateZones,
     CanonicalLapSummary,
     CanonicalPerformanceTargets,
@@ -345,12 +346,75 @@ def _canonicalize_laps(payload: Any) -> list[CanonicalLapSummary] | None:
     return _parse_records(raw_laps, _build_lap_summary)
 
 
+def extract_exercise_sets(raw_sets: Any) -> list[CanonicalExerciseSet] | None:
+    """Extract structured exercise sets and repetitions from Garmin strength payloads."""
+    if isinstance(raw_sets, dict):
+        sets_list = raw_sets.get("exerciseSets")
+    elif isinstance(raw_sets, list):
+        sets_list = raw_sets
+    else:
+        return None
+
+    if not isinstance(sets_list, list) or not sets_list:
+        return None
+
+    results: list[CanonicalExerciseSet] = []
+    for idx, item in enumerate(sets_list):
+        if not isinstance(item, dict):
+            continue
+        set_order = item.get("setOrder")
+        if set_order is None or not isinstance(set_order, int):
+            set_order = idx
+
+        raw_set_type = item.get("setType")
+        set_type = str(raw_set_type).lower() if raw_set_type is not None else "active"
+
+        reps = _positive_integer(item.get("repetitionCount") or item.get("reps"))
+
+        raw_weight = _non_negative_number(item.get("weight") or item.get("weightKg"))
+        weight_kg: float | None = None
+        if raw_weight is not None:
+            if raw_weight > 500.0:
+                weight_kg = round(raw_weight / 1000.0, 1)
+            elif 0.0 <= raw_weight <= 500.0:
+                weight_kg = round(raw_weight, 1)
+
+        category = item.get("exerciseCategory")
+        category_str = (
+            str(category).strip() if isinstance(category, str) and category.strip() else None
+        )
+
+        name = item.get("exerciseName")
+        name_str = str(name).strip() if isinstance(name, str) and name.strip() else None
+
+        duration = _non_negative_number(item.get("duration") or item.get("durationSeconds"))
+        rest_duration = _non_negative_number(
+            item.get("restDuration") or item.get("restDurationSeconds")
+        )
+
+        results.append(
+            CanonicalExerciseSet(
+                set_order=set_order,
+                set_type=set_type,
+                repetition_count=reps,
+                weight_kg=weight_kg,
+                exercise_category=category_str,
+                exercise_name=name_str,
+                duration_seconds=duration,
+                rest_duration_seconds=rest_duration,
+            )
+        )
+
+    return results if results else None
+
+
 def canonicalize_activity_detail(
     activity_id: str,
     activity_summary: Any,
     power_zones: Any,
     hr_zones: Any,
     splits: Any,
+    exercise_sets: Any = None,
 ) -> CanonicalActivityDetail:
     """Normalize additive per-activity telemetry without inventing missing values."""
     summary = activity_summary if isinstance(activity_summary, dict) else {}
@@ -370,6 +434,7 @@ def canonicalize_activity_detail(
         intensity_factor=intensity_factor,
         variability_index=variability_index,
         laps=_canonicalize_laps(splits),
+        exercise_sets=extract_exercise_sets(exercise_sets),
     )
 
 
@@ -908,18 +973,35 @@ class GarminProviderAdapter:
         power_zones = self.client.get_activity_power_zones(activity_id)
         hr_zones = self.client.get_activity_hr_zones(activity_id)
         splits = self.client.get_activity_splits(activity_id)
-        raw_payloads = {
+        summary = self._activity_summary_cache.get(activity_id, {})
+        activity_type = (
+            summary.get("activityType", {}).get("typeKey", "") if isinstance(summary, dict) else ""
+        )
+
+        exercise_sets = None
+        type_str = str(activity_type).lower()
+        if "strength" in type_str or "fitness_equipment" in type_str or "training" in type_str:
+            exercise_sets = self._fetch_enrichment(
+                f"exercise_sets_{activity_id}",
+                lambda: self.client.get_activity_exercise_sets(activity_id),
+            )
+
+        raw_payloads: dict[str, Any] = {
             "activity_power_zones": power_zones,
             "activity_hr_zones": hr_zones,
             "activity_splits": splits,
         }
+        if exercise_sets is not None:
+            raw_payloads["activity_exercise_sets"] = exercise_sets
+
         return ProviderActivityDetailResult(
             canonical=canonicalize_activity_detail(
                 activity_id=activity_id,
-                activity_summary=self._activity_summary_cache.get(activity_id),
+                activity_summary=summary,
                 power_zones=power_zones,
                 hr_zones=hr_zones,
                 splits=splits,
+                exercise_sets=exercise_sets,
             ),
             raw_payloads=raw_payloads,
         )

--- a/src/garmin_sync/garmin_provider.py
+++ b/src/garmin_sync/garmin_provider.py
@@ -46,6 +46,7 @@ _POWER_ACTIVITY_TYPES = {
     "road_biking",
     "virtual_ride",
 }
+_STRENGTH_ACTIVITY_TYPES = {"strength_training", "fitness_equipment"}
 
 
 def extract_sleep_metrics(
@@ -275,16 +276,31 @@ def _positive_integer(value: Any) -> int | None:
 
 
 def qualifies_for_activity_detail(activity: CanonicalActivity) -> bool:
-    """Accepted D-DETAIL-GATE predicate for the opt-in live detail fetch.
+    """Accepted D-DETAIL-GATE predicate for the opt-in power-detail fetch.
 
-    The daily target-date fetch is the only caller. At three endpoints per qualifying
-    activity, the worst-case incremental request budget is ``3 * N`` for that run;
-    backfill and rebuild remain at zero.
+    At three endpoints per qualifying activity, the worst-case incremental request
+    budget is ``3 * N`` for that run. Strength sets are deliberately handled by the
+    separate one-endpoint predicate below so enabling their auto-sync does not silently
+    turn on the more expensive cycling telemetry path.
     """
     return (
         activity.activity_id is not None
         and activity.type.lower() in _POWER_ACTIVITY_TYPES
         and activity.intensity_tag != "easy"
+    )
+
+
+def qualifies_for_strength_exercise_sets(activity: CanonicalActivity) -> bool:
+    """Return whether Garmin can expose per-set strength data for this activity.
+
+    Live Garmin observations and other consumers of the same endpoint confirm both
+    ``strength_training`` and ``fitness_equipment`` can carry ``exerciseSets``. Unlike
+    power detail, intensity is irrelevant: an easy strength session still has useful
+    reps/set structure and costs just one extra endpoint call.
+    """
+    return (
+        activity.activity_id is not None
+        and activity.type.lower() in _STRENGTH_ACTIVITY_TYPES
     )
 
 
@@ -346,8 +362,85 @@ def _canonicalize_laps(payload: Any) -> list[CanonicalLapSummary] | None:
     return _parse_records(raw_laps, _build_lap_summary)
 
 
+def _exercise_candidate_identity(item: dict[str, Any]) -> tuple[str | None, str | None]:
+    """Extract a conservative Garmin exercise guess from an exercise-set row.
+
+    Garmin's ``exercises`` array is an ML classification, not ground truth. Only a
+    non-UNKNOWN candidate at >=50% confidence is surfaced, and a tie with the runner-up
+    is treated as ambiguous. Payloads that already provide explicit flat
+    ``exerciseCategory`` / ``exerciseName`` fields keep those values unchanged.
+    """
+    explicit_category = item.get("exerciseCategory")
+    category = (
+        explicit_category.strip()
+        if isinstance(explicit_category, str) and explicit_category.strip()
+        else None
+    )
+    explicit_name = item.get("exerciseName")
+    name = explicit_name.strip() if isinstance(explicit_name, str) and explicit_name.strip() else None
+    if category is not None or name is not None:
+        return category, name
+
+    raw_candidates = item.get("exercises")
+    if not isinstance(raw_candidates, list):
+        return None, None
+
+    candidates: list[tuple[float | None, str | None, str | None]] = []
+    for raw_candidate in raw_candidates:
+        if not isinstance(raw_candidate, dict):
+            continue
+        raw_category = raw_candidate.get("category")
+        candidate_category = (
+            raw_category.strip()
+            if isinstance(raw_category, str) and raw_category.strip()
+            else None
+        )
+        if candidate_category == "UNKNOWN":
+            continue
+        raw_name = raw_candidate.get("name")
+        candidate_name = raw_name.strip() if isinstance(raw_name, str) and raw_name.strip() else None
+        if candidate_category is None and candidate_name is None:
+            continue
+
+        confidence = _non_negative_number(raw_candidate.get("probability"))
+        if confidence is not None and confidence <= 1.0:
+            confidence *= 100.0
+        if confidence is not None and confidence < 50.0:
+            continue
+        candidates.append((confidence, candidate_category, candidate_name))
+
+    if not candidates:
+        return None, None
+
+    # Known probabilities sort first. A single unscored candidate is still useful, but
+    # an unscored multi-candidate payload is ambiguous and therefore deliberately blank.
+    candidates.sort(key=lambda candidate: candidate[0] if candidate[0] is not None else -1.0, reverse=True)
+    top = candidates[0]
+    if len(candidates) > 1:
+        runner_up = candidates[1]
+        if top[0] is None or runner_up[0] is None:
+            return None, None
+        if top[0] - runner_up[0] <= 0.01:
+            return None, None
+    return top[1], top[2]
+
+
+def _set_duration(item: dict[str, Any], primary: str, fallback: str) -> float | None:
+    value = item.get(primary)
+    if value is None:
+        value = item.get(fallback)
+    return _non_negative_number(value)
+
+
 def extract_exercise_sets(raw_sets: Any) -> list[CanonicalExerciseSet] | None:
-    """Extract structured exercise sets and repetitions from Garmin strength payloads."""
+    """Extract work sets/reps from Garmin's real interleaved ``exerciseSets`` shape.
+
+    Garmin emits ACTIVE/WARM_UP/etc. rows interleaved with REST rows. The REST row's
+    duration belongs to the preceding work set, so standalone REST rows are folded into
+    ``rest_duration_seconds`` instead of becoming fake numbered exercises. Raw Garmin
+    ``weight`` is grams; an explicit ``weightKg`` key is accepted only as a normalized
+    compatibility shape.
+    """
     if isinstance(raw_sets, dict):
         sets_list = raw_sets.get("exerciseSets")
     elif isinstance(raw_sets, list):
@@ -359,38 +452,54 @@ def extract_exercise_sets(raw_sets: Any) -> list[CanonicalExerciseSet] | None:
         return None
 
     results: list[CanonicalExerciseSet] = []
-    for idx, item in enumerate(sets_list):
+    for item in sets_list:
         if not isinstance(item, dict):
             continue
-        set_order = item.get("setOrder")
-        if set_order is None or not isinstance(set_order, int):
-            set_order = idx
 
         raw_set_type = item.get("setType")
         set_type = str(raw_set_type).lower() if raw_set_type is not None else "active"
+        duration = _set_duration(item, "duration", "durationSeconds")
 
-        reps = _positive_integer(item.get("repetitionCount") or item.get("reps"))
+        if set_type == "rest":
+            rest_duration = duration
+            if rest_duration is None:
+                rest_duration = _set_duration(item, "restDuration", "restDurationSeconds")
+            if results and rest_duration is not None:
+                results[-1].rest_duration_seconds = rest_duration
+            continue
 
-        raw_weight = _non_negative_number(item.get("weight") or item.get("weightKg"))
-        weight_kg: float | None = None
-        if raw_weight is not None:
-            if raw_weight > 500.0:
-                weight_kg = round(raw_weight / 1000.0, 1)
-            elif 0.0 <= raw_weight <= 500.0:
-                weight_kg = round(raw_weight, 1)
-
-        category = item.get("exerciseCategory")
-        category_str = (
-            str(category).strip() if isinstance(category, str) and category.strip() else None
+        raw_set_order = item.get("setOrder")
+        set_order = (
+            raw_set_order
+            if isinstance(raw_set_order, int) and not isinstance(raw_set_order, bool)
+            else len(results)
         )
 
-        name = item.get("exerciseName")
-        name_str = str(name).strip() if isinstance(name, str) and name.strip() else None
+        raw_reps = item.get("repetitionCount")
+        if raw_reps is None:
+            raw_reps = item.get("reps")
+        reps = _positive_integer(raw_reps)
 
-        duration = _non_negative_number(item.get("duration") or item.get("durationSeconds"))
-        rest_duration = _non_negative_number(
-            item.get("restDuration") or item.get("restDurationSeconds")
+        # The live Garmin endpoint's `weight` field is grams. Keep support for the PR's
+        # earlier flat test/normalized shape only when it is unmistakably packed (a
+        # same-row rest duration); real Garmin payloads represent rest as separate rows.
+        raw_weight_kg = _first_positive_number(item.get("weightKg"))
+        raw_weight_grams = _first_positive_number(item.get("weight"))
+        legacy_packed_shape = (
+            item.get("restDuration") is not None or item.get("restDurationSeconds") is not None
         )
+        if raw_weight_kg is not None:
+            weight_kg = round(raw_weight_kg, 2)
+        elif raw_weight_grams is not None:
+            if legacy_packed_shape and raw_weight_grams <= 500.0:
+                weight_kg = round(raw_weight_grams, 2)
+            else:
+                weight_kg = round(raw_weight_grams / 1000.0, 2)
+        else:
+            weight_kg = None
+
+        category, name = _exercise_candidate_identity(item)
+        rest_duration = _set_duration(item, "restDuration", "restDurationSeconds")
 
         results.append(
             CanonicalExerciseSet(
@@ -398,8 +507,8 @@ def extract_exercise_sets(raw_sets: Any) -> list[CanonicalExerciseSet] | None:
                 set_type=set_type,
                 repetition_count=reps,
                 weight_kg=weight_kg,
-                exercise_category=category_str,
-                exercise_name=name_str,
+                exercise_category=category,
+                exercise_name=name,
                 duration_seconds=duration,
                 rest_duration_seconds=rest_duration,
             )
@@ -970,30 +1079,32 @@ class GarminProviderAdapter:
         )
 
     def fetch_activity_detail(self, activity_id: str) -> ProviderActivityDetailResult:
-        power_zones = self.client.get_activity_power_zones(activity_id)
-        hr_zones = self.client.get_activity_hr_zones(activity_id)
-        splits = self.client.get_activity_splits(activity_id)
         summary = self._activity_summary_cache.get(activity_id, {})
         activity_type = (
             summary.get("activityType", {}).get("typeKey", "") if isinstance(summary, dict) else ""
         )
-
-        exercise_sets = None
         type_str = str(activity_type).lower()
-        if "strength" in type_str or "fitness_equipment" in type_str or "training" in type_str:
-            exercise_sets = self._fetch_enrichment(
-                f"exercise_sets_{activity_id}",
-                lambda: self.client.get_activity_exercise_sets(activity_id),
+
+        # Strength detail is a different one-endpoint data product from cycling power
+        # telemetry. Fetching the three power-detail endpoints first wastes requests and
+        # can fail before exercise sets are ever reached. Keep the paths disjoint.
+        if type_str in _STRENGTH_ACTIVITY_TYPES:
+            exercise_sets = self.client.get_activity_exercise_sets(activity_id)
+            return ProviderActivityDetailResult(
+                canonical=canonicalize_activity_detail(
+                    activity_id=activity_id,
+                    activity_summary=summary,
+                    power_zones=None,
+                    hr_zones=None,
+                    splits=None,
+                    exercise_sets=exercise_sets,
+                ),
+                raw_payloads={"activity_exercise_sets": exercise_sets},
             )
 
-        raw_payloads: dict[str, Any] = {
-            "activity_power_zones": power_zones,
-            "activity_hr_zones": hr_zones,
-            "activity_splits": splits,
-        }
-        if exercise_sets is not None:
-            raw_payloads["activity_exercise_sets"] = exercise_sets
-
+        power_zones = self.client.get_activity_power_zones(activity_id)
+        hr_zones = self.client.get_activity_hr_zones(activity_id)
+        splits = self.client.get_activity_splits(activity_id)
         return ProviderActivityDetailResult(
             canonical=canonicalize_activity_detail(
                 activity_id=activity_id,
@@ -1001,7 +1112,10 @@ class GarminProviderAdapter:
                 power_zones=power_zones,
                 hr_zones=hr_zones,
                 splits=splits,
-                exercise_sets=exercise_sets,
             ),
-            raw_payloads=raw_payloads,
+            raw_payloads={
+                "activity_power_zones": power_zones,
+                "activity_hr_zones": hr_zones,
+                "activity_splits": splits,
+            },
         )

--- a/src/garmin_sync/mapper.py
+++ b/src/garmin_sync/mapper.py
@@ -90,7 +90,11 @@ def normalize_activity(
             }
             for lap in detail.laps
         ]
-    if detail.exercise_sets:
+    # None means the endpoint was not fetched / detail enrichment failed, so omitting
+    # the key preserves any previously-synced value under Firestore merge semantics.
+    # [] means the endpoint succeeded and Garmin now reports zero work sets, so writing
+    # the empty array deliberately clears a stale older exerciseSets value.
+    if detail.exercise_sets is not None:
         payload["exerciseSets"] = [
             {
                 key: value

--- a/src/garmin_sync/mapper.py
+++ b/src/garmin_sync/mapper.py
@@ -90,6 +90,24 @@ def normalize_activity(
             }
             for lap in detail.laps
         ]
+    if detail.exercise_sets:
+        payload["exerciseSets"] = [
+            {
+                key: value
+                for key, value in {
+                    "setOrder": es.set_order,
+                    "setType": es.set_type,
+                    "repetitionCount": es.repetition_count,
+                    "weightKg": es.weight_kg,
+                    "exerciseCategory": es.exercise_category,
+                    "exerciseName": es.exercise_name,
+                    "durationSeconds": es.duration_seconds,
+                    "restDurationSeconds": es.rest_duration_seconds,
+                }.items()
+                if value is not None
+            }
+            for es in detail.exercise_sets
+        ]
     return payload
 
 

--- a/src/garmin_sync/service.py
+++ b/src/garmin_sync/service.py
@@ -21,6 +21,7 @@ from .garmin_provider import (
     canonicalize_activities,
     canonicalize_from_raw,
     qualifies_for_activity_detail,
+    qualifies_for_strength_exercise_sets,
 )
 from .mapper import build_snapshot_from_canonical, normalize_activity
 from .metrics import compute_derived_metrics
@@ -188,8 +189,15 @@ class GarminSyncService:
         provider: WearableProvider,
         canonical_activities: list[CanonicalActivity],
         target_iso: str,
+        include_power_details: bool = False,
     ) -> dict[str, CanonicalActivityDetail]:
-        """Best-effort live enrichment behind D-DETAIL-GATE.
+        """Best-effort target-date activity enrichment.
+
+        Strength exercise sets are always eligible because they are the core data of a
+        strength session and require a single endpoint. The existing cycling power
+        detail path remains behind ``GARMIN_ACTIVITY_DETAIL_ENABLED`` via
+        ``include_power_details`` so this feature does not silently triple detail-call
+        traffic for qualifying rides.
 
         Raw detail payloads are deliberately not archived: ADR-0005's store is keyed by
         logical date, while these payloads require an activity-ID key. A failed detail
@@ -203,12 +211,14 @@ class GarminSyncService:
 
         details: dict[str, CanonicalActivityDetail] = {}
         for activity in canonical_activities:
-            # `canonical_activities` here is the full 3-day lookback window fetch_activities
-            # uses for activity discovery, not just target_iso's activities. D-DETAIL-GATE is
-            # explicitly scoped to "the target-date pass of sync_daily" only -- without this
-            # check a qualifying D-1/D-2 activity would get (re-)fetched and re-upserted on
-            # every subsequent day's sync too, well past the intended 3xN-per-run budget.
-            if activity.date != target_iso or not qualifies_for_activity_detail(activity):
+            # fetch_activities returns a lookback window. Only enrich the date currently
+            # being processed; otherwise the same D-1/D-2 activity would be re-fetched
+            # repeatedly inside one sync pass.
+            if activity.date != target_iso:
+                continue
+            wants_strength_sets = qualifies_for_strength_exercise_sets(activity)
+            wants_power_detail = include_power_details and qualifies_for_activity_detail(activity)
+            if not (wants_strength_sets or wants_power_detail):
                 continue
             assert activity.activity_id is not None
             try:
@@ -347,10 +357,15 @@ class GarminSyncService:
             three_days_ago_iso, target_iso, zone4_floor=zone4_floor
         )
         self._archive_raw("activities", target_iso, activities_result.raw_payload, sync_run_id)
-        details_by_activity_id = (
-            self._fetch_activity_details(provider, activities_result.canonical, target_iso)
-            if include_activity_details
-            else {}
+        # Strength sets are always fetched for target_iso; the boolean only controls
+        # the existing opt-in cycling power-detail branch. This also means the normal
+        # D-1 lookback can pick up an evening strength workout missed by the prior
+        # morning sync without enabling power detail globally.
+        details_by_activity_id = self._fetch_activity_details(
+            provider,
+            activities_result.canonical,
+            target_iso,
+            include_power_details=include_activity_details,
         )
         self._archive_activities(
             activities_result.canonical,
@@ -577,7 +592,9 @@ class GarminSyncService:
             )
             if callable(fetch_detail):
                 qualifying = [
-                    a for a in all_activities_canonical if qualifies_for_activity_detail(a)
+                    a
+                    for a in all_activities_canonical
+                    if qualifies_for_activity_detail(a) or qualifies_for_strength_exercise_sets(a)
                 ]
                 logger.info(
                     f"Fetching activity details for {len(qualifying)} qualifying activities in backfill window..."

--- a/tests/test_garmin_provider.py
+++ b/tests/test_garmin_provider.py
@@ -838,3 +838,44 @@ def test_canonicalize_performance_targets_with_body_composition():
     assert targets.body_fat_pct == 12.5
     assert targets.weight_measured_at == "2026-08-23"
     assert targets.ftp_measured_at == "2026-08-20"
+
+
+def test_extract_exercise_sets():
+    from garmin_sync.garmin_provider import extract_exercise_sets
+
+    raw = {
+        "exerciseSets": [
+            {
+                "setOrder": 0,
+                "setType": "ACTIVE",
+                "repetitionCount": 10,
+                "weight": 60000.0,  # 60,000 g -> 60.0 kg
+                "exerciseCategory": "BENCH_PRESS",
+                "exerciseName": "BARBELL_BENCH_PRESS",
+                "duration": 35.0,
+                "restDuration": 90.0,
+            },
+            {
+                "setOrder": 1,
+                "setType": "ACTIVE",
+                "repetitionCount": 8,
+                "weight": 70.0,  # 70 kg
+                "exerciseCategory": "BENCH_PRESS",
+                "exerciseName": "BARBELL_BENCH_PRESS",
+                "duration": 30.0,
+                "restDuration": 120.0,
+            },
+        ]
+    }
+    sets = extract_exercise_sets(raw)
+    assert sets is not None
+    assert len(sets) == 2
+    assert sets[0].set_order == 0
+    assert sets[0].set_type == "active"
+    assert sets[0].repetition_count == 10
+    assert sets[0].weight_kg == 60.0
+    assert sets[0].exercise_category == "BENCH_PRESS"
+    assert sets[0].exercise_name == "BARBELL_BENCH_PRESS"
+    assert sets[0].duration_seconds == 35.0
+    assert sets[0].rest_duration_seconds == 90.0
+    assert sets[1].weight_kg == 70.0

--- a/tests/test_garmin_strength_sets_regression.py
+++ b/tests/test_garmin_strength_sets_regression.py
@@ -12,6 +12,7 @@ from garmin_sync.garmin_provider import (
     extract_exercise_sets,
     qualifies_for_strength_exercise_sets,
 )
+from garmin_sync.mapper import normalize_activity
 from garmin_sync.provider import (
     ProviderActivitiesResult,
     ProviderActivityDetailResult,
@@ -108,6 +109,18 @@ def _activity(activity_type: str, activity_id: str | None = "42") -> CanonicalAc
         training_load=40.0,
         intensity_tag="easy",
     )
+
+
+def test_empty_garmin_set_list_is_preserved_to_clear_stale_firestore_sets():
+    sets = extract_exercise_sets({"exerciseSets": []})
+    assert sets == []
+
+    payload = normalize_activity(
+        _activity("strength_training"),
+        "run-1",
+        CanonicalActivityDetail(activity_id="42", exercise_sets=sets),
+    )
+    assert payload["exerciseSets"] == []
 
 
 def test_strength_set_gate_is_independent_of_intensity_and_power_detail_gate():

--- a/tests/test_garmin_strength_sets_regression.py
+++ b/tests/test_garmin_strength_sets_regression.py
@@ -1,0 +1,222 @@
+from unittest.mock import MagicMock
+
+from garmin_sync.canonical import (
+    CanonicalActivity,
+    CanonicalActivityDetail,
+    CanonicalDailyMetrics,
+    CanonicalExerciseSet,
+)
+from garmin_sync.config import Settings
+from garmin_sync.garmin_provider import (
+    GarminProviderAdapter,
+    extract_exercise_sets,
+    qualifies_for_strength_exercise_sets,
+)
+from garmin_sync.provider import (
+    ProviderActivitiesResult,
+    ProviderActivityDetailResult,
+    ProviderCapabilities,
+    ProviderFetchResult,
+)
+from garmin_sync.service import GarminSyncService
+
+
+def _realistic_strength_payload() -> dict:
+    return {
+        "exerciseSets": [
+            {
+                "messageIndex": 0,
+                "setType": "ACTIVE",
+                "duration": 35.2,
+                "repetitionCount": 10,
+                "weight": 12473,
+                "exercises": [
+                    {"category": "BENCH_PRESS", "name": "BARBELL_BENCH_PRESS", "probability": 88.0},
+                    {"category": "UNKNOWN", "probability": 12.0},
+                ],
+            },
+            {"messageIndex": 1, "setType": "REST", "duration": 90.0},
+            {
+                "messageIndex": 2,
+                "setType": "ACTIVE",
+                "duration": 31.0,
+                "repetitionCount": 8,
+                "weight": 60000,
+                "exercises": [
+                    {"category": "SQUAT", "name": "BACK_SQUAT", "probability": 50.0},
+                    {"category": "DEADLIFT", "name": "BARBELL_DEADLIFT", "probability": 50.0},
+                ],
+            },
+            {"messageIndex": 3, "setType": "REST", "duration": 120.0},
+        ]
+    }
+
+
+def test_extract_exercise_sets_matches_live_garmin_shape():
+    sets = extract_exercise_sets(_realistic_strength_payload())
+
+    assert sets is not None and len(sets) == 2
+    assert sets[0].set_order == 0
+    assert sets[0].repetition_count == 10
+    assert sets[0].weight_kg == 12.47  # Garmin raw `weight` is grams.
+    assert sets[0].exercise_category == "BENCH_PRESS"
+    assert sets[0].exercise_name == "BARBELL_BENCH_PRESS"
+    assert sets[0].rest_duration_seconds == 90.0
+
+    # REST rows do not become fake numbered sets; working sets stay compact 1, 2, ...
+    assert sets[1].set_order == 1
+    assert sets[1].repetition_count == 8
+    assert sets[1].weight_kg == 60.0
+    assert sets[1].rest_duration_seconds == 120.0
+    # A tied Garmin ML classification is not presented as a factual exercise label.
+    assert sets[1].exercise_category is None
+    assert sets[1].exercise_name is None
+
+
+def test_extract_exercise_sets_keeps_explicit_weight_kg_compatibility_shape():
+    sets = extract_exercise_sets(
+        {
+            "exerciseSets": [
+                {
+                    "setOrder": 0,
+                    "setType": "ACTIVE",
+                    "repetitionCount": 5,
+                    "weightKg": 70.0,
+                    "exerciseName": "Deadlift",
+                    "durationSeconds": 20,
+                    "restDurationSeconds": 120,
+                }
+            ]
+        }
+    )
+
+    assert sets is not None
+    assert sets[0].weight_kg == 70.0
+    assert sets[0].exercise_name == "Deadlift"
+
+
+def _activity(activity_type: str, activity_id: str | None = "42") -> CanonicalActivity:
+    return CanonicalActivity(
+        activity_id=activity_id,
+        date="2026-08-23",
+        type=activity_type,
+        duration_min=45,
+        duration_seconds=2700,
+        training_effect_aerobic=1.0,
+        training_effect_anaerobic=1.0,
+        average_hr=110,
+        training_load=40.0,
+        intensity_tag="easy",
+    )
+
+
+def test_strength_set_gate_is_independent_of_intensity_and_power_detail_gate():
+    assert qualifies_for_strength_exercise_sets(_activity("strength_training"))
+    assert qualifies_for_strength_exercise_sets(_activity("fitness_equipment"))
+    assert not qualifies_for_strength_exercise_sets(_activity("cycling"))
+    assert not qualifies_for_strength_exercise_sets(_activity("running"))
+    assert not qualifies_for_strength_exercise_sets(_activity("strength_training", None))
+
+
+def test_strength_adapter_calls_only_exercise_sets_endpoint():
+    client = MagicMock()
+    client.get_activities_window.return_value = [
+        {
+            "activityId": 42,
+            "startTimeLocal": "2026-08-23T08:00:00",
+            "duration": 2700,
+            "activityType": {"typeKey": "strength_training"},
+        }
+    ]
+    client.get_activity_exercise_sets.return_value = _realistic_strength_payload()
+    adapter = GarminProviderAdapter(client)
+
+    adapter.fetch_activities("2026-08-23", "2026-08-23")
+    result = adapter.fetch_activity_detail("42")
+
+    client.get_activity_exercise_sets.assert_called_once_with("42")
+    client.get_activity_power_zones.assert_not_called()
+    client.get_activity_hr_zones.assert_not_called()
+    client.get_activity_splits.assert_not_called()
+    assert set(result.raw_payloads) == {"activity_exercise_sets"}
+    assert result.canonical.exercise_sets is not None
+    assert result.canonical.exercise_sets[0].weight_kg == 12.47
+
+
+class _StrengthProvider:
+    capabilities = ProviderCapabilities(
+        daily_summary=True,
+        sleep=True,
+        hrv=True,
+        activities=True,
+        activity_details=True,
+    )
+
+    def __init__(self, activity_type: str):
+        self.activity = _activity(activity_type)
+        self.detail_calls: list[str] = []
+
+    def clear_cache(self) -> None:
+        pass
+
+    def fetch_daily_metrics(self, target_date_iso: str, yesterday_iso: str) -> ProviderFetchResult:
+        return ProviderFetchResult(
+            canonical=CanonicalDailyMetrics(date=target_date_iso),
+            raw_payloads={"stats": {}, "stats_fallback": {}, "sleep": {}, "hrv": {}},
+        )
+
+    def fetch_activities(
+        self,
+        start_date_iso: str,
+        end_date_iso: str,
+        zone4_floor: int | None = None,
+    ) -> ProviderActivitiesResult:
+        self.activity.date = end_date_iso
+        return ProviderActivitiesResult(canonical=[self.activity], raw_payload=[])
+
+    def fetch_activity_detail(self, activity_id: str) -> ProviderActivityDetailResult:
+        self.detail_calls.append(activity_id)
+        return ProviderActivityDetailResult(
+            canonical=CanonicalActivityDetail(
+                activity_id=activity_id,
+                exercise_sets=[
+                    CanonicalExerciseSet(
+                        set_order=0,
+                        repetition_count=10,
+                        weight_kg=12.47,
+                        rest_duration_seconds=90.0,
+                    )
+                ],
+            ),
+            raw_payloads={"activity_exercise_sets": _realistic_strength_payload()},
+        )
+
+
+def _service(provider: _StrengthProvider) -> tuple[GarminSyncService, MagicMock]:
+    # Production explicitly leaves the existing power-detail flag disabled. Strength
+    # sets must still auto-sync, while cycling detail must remain gated off.
+    settings = Settings(app_user_id="test_uid_strength", garmin_activity_detail_enabled=False)
+    repo = MagicMock()
+    repo.is_fresh.return_value = False
+    repo.get_historical_snapshots.return_value = {}
+    service = GarminSyncService(settings=settings, repository=repo, provider=provider)
+    return service, repo
+
+
+def test_strength_sets_auto_sync_when_power_detail_flag_is_disabled():
+    provider = _StrengthProvider("strength_training")
+    service, repo = _service(provider)
+
+    assert service.sync_daily("2026-08-23", force=True, resync_lookback_days=0)
+    assert provider.detail_calls == ["42"]
+    payload = repo.upsert_activities.call_args.args[0][0][1]
+    assert payload["exerciseSets"][0]["repetitionCount"] == 10
+    assert payload["exerciseSets"][0]["weightKg"] == 12.47
+
+
+def test_disabled_power_detail_flag_still_skips_cycling_detail():
+    provider = _StrengthProvider("cycling")
+    service, _ = _service(provider)
+
+    assert service.sync_daily("2026-08-23", force=True, resync_lookback_days=0)
+    assert provider.detail_calls == []

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -453,3 +453,48 @@ def test_build_snapshot_maps_weight_and_body_fat():
     assert snapshot.raw.weightKg == 71.2
     assert snapshot.raw.bodyFatPct == 13.8
     assert snapshot.source.metricDates.weight == "2026-08-23"
+
+
+def test_normalize_activity_maps_exercise_sets():
+    from garmin_sync.canonical import CanonicalActivityDetail, CanonicalExerciseSet
+
+    act = CanonicalActivity(
+        activity_id="act-strength-1",
+        date="2026-08-23",
+        type="strength_training",
+        duration_min=45,
+        duration_seconds=2700,
+        training_effect_aerobic=1.5,
+        training_effect_anaerobic=2.5,
+        average_hr=125.0,
+        training_load=80.0,
+        intensity_tag="moderate",
+    )
+    detail = CanonicalActivityDetail(
+        activity_id="act-strength-1",
+        exercise_sets=[
+            CanonicalExerciseSet(
+                set_order=0,
+                set_type="active",
+                repetition_count=12,
+                weight_kg=50.0,
+                exercise_category="SQUAT",
+                exercise_name="BARBELL_BACK_SQUAT",
+                duration_seconds=40.0,
+                rest_duration_seconds=90.0,
+            )
+        ],
+    )
+
+    payload = normalize_activity(act, sync_run_id="run-str", detail=detail)
+    assert "exerciseSets" in payload
+    assert len(payload["exerciseSets"]) == 1
+    es = payload["exerciseSets"][0]
+    assert es["setOrder"] == 0
+    assert es["setType"] == "active"
+    assert es["repetitionCount"] == 12
+    assert es["weightKg"] == 50.0
+    assert es["exerciseCategory"] == "SQUAT"
+    assert es["exerciseName"] == "BARBELL_BACK_SQUAT"
+    assert es["durationSeconds"] == 40.0
+    assert es["restDurationSeconds"] == 90.0


### PR DESCRIPTION
## Summary

This PR adds automatic ingestion and telemetry display for structured Garmin Strength Training / fitness-equipment exercise sets, repetitions, weights, work durations, and rest durations via Garmin Connect's `get_activity_exercise_sets` endpoint.

---

## Key Changes

### 1. Python Backend (`src/garmin_sync/`)
- **Garmin Client** (`garmin_client.py`):
  - Added `get_activity_exercise_sets(...)`, delegating through the existing configured `garminconnect` client.
- **Canonical Model** (`canonical.py`):
  - Added `CanonicalExerciseSet` and `exercise_sets` on `CanonicalActivityDetail`.
- **Garmin Provider & Parsing** (`garmin_provider.py`):
  - Parses Garmin's observed interleaved work/`REST` set shape rather than treating rest rows as exercises.
  - Converts Garmin raw `weight` values from grams to kilograms; explicit normalized `weightKg` remains supported.
  - Folds each `REST` row's duration into the preceding work set.
  - Extracts Garmin `exercises[]` classification conservatively: `UNKNOWN`, low-confidence, and tied/ambiguous guesses are not presented as authoritative exercise names.
  - Preserves a successful empty `exerciseSets` response as `[]`, distinct from unavailable/failed detail (`None`).
  - Strength detail calls only `get_activity_exercise_sets`; it does not waste requests on cycling power/HR/splits endpoints.
- **Sync Service** (`service.py`):
  - Strength-set enrichment is independent of the existing cycling power-detail feature flag. This is required because production keeps `GARMIN_ACTIVITY_DETAIL_ENABLED=false`.
  - Strength sessions are enriched on the target date and on the normal D-1 reconciliation lookback, so late/evening uploads can be completed on the following sync.
  - Existing cycling power detail remains opt-in, and historical activity-detail backfill remains opt-in.
- **Mapping** (`mapper.py`):
  - Persists normalized `exerciseSets` under `users/{userId}/activities/{activityId}`.
  - A successful empty set list explicitly writes `exerciseSets: []` so Firestore merge semantics cannot leave stale older sets behind; failed/unfetched detail omits the field and preserves the last known good value.

### 2. Frontend Application (`app/src/`)
- Added the `ActivityExerciseSet` model and optional `exerciseSets` on `NormalizedGarminActivity`.
- Added a dedicated **Strength sets & reps** telemetry table for set number, exercise, reps, weight, work duration, and rest duration.

### 3. Regression Coverage
- Realistic Garmin-style interleaved `ACTIVE` / `REST` payloads.
- Gram-to-kilogram conversion, including a 12,473 g -> 12.47 kg case.
- Conservative handling of ambiguous Garmin exercise classifications.
- Strength-only endpoint isolation (no power-zone/HR-zone/splits calls).
- Strength auto-sync while the cycling detail flag is disabled.
- Cycling detail remaining disabled when that flag is off.
- Empty-set responses clearing stale Firestore `exerciseSets` values.

---

## Validation

Latest CI validates Python 3.12 + 3.14, frontend tests/rules/simulation/build, and the Docker image. The PR conversation contains the final CI result and review summary after the latest branch revision.