### PR TITLE
feat(sync): add shoe & equipment mileage tracking auto-sync

### DIFF
--- a/app/firestore.rules
+++ b/app/firestore.rules
@@ -564,6 +564,11 @@ service cloud.firestore {
       allow write: if false;
     }
 
+    match /users/{userId}/gear/{gearId} {
+      allow read: if isOwner(userId);
+      allow write: if false;
+    }
+
     function isStrengthSessionDocument(sessionId) {
       return request.resource.data.sessionId == sessionId;
     }

--- a/app/src/components/preferences/PerformanceSections.tsx
+++ b/app/src/components/preferences/PerformanceSections.tsx
@@ -220,6 +220,77 @@ export function PerformanceSections({
           })}
         </div>
       </div>
+
+      {preferences.gearTracker?.items && preferences.gearTracker.items.length > 0 && (
+        <div className="preference-section">
+          <h2>Shoes & Equipment Mileage</h2>
+          <p className="preference-desc">
+            Garmin gear records monitor cumulative shoe and bike wear to help manage lower-limb impact strain and equipment maintenance.
+          </p>
+          <div className="gear-tracker-grid" style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(260px, 1fr))', gap: '0.75rem', marginTop: '0.75rem' }}>
+            {preferences.gearTracker.items.map((gear) => {
+              const isMiles = preferences.preferredUnits.distance === 'miles';
+              const distDisplay = isMiles
+                ? `${(gear.totalDistanceKm * 0.621371).toFixed(1)} mi`
+                : `${gear.totalDistanceKm.toFixed(1)} km`;
+              const maxDistDisplay = gear.maximumDistanceKm != null
+                ? (isMiles ? `${(gear.maximumDistanceKm * 0.621371).toFixed(0)} mi` : `${gear.maximumDistanceKm.toFixed(0)} km`)
+                : null;
+              const pct = gear.maximumDistanceKm && gear.maximumDistanceKm > 0
+                ? Math.min(100, Math.round((gear.totalDistanceKm / gear.maximumDistanceKm) * 100))
+                : null;
+
+              return (
+                <div
+                  key={gear.gearPk}
+                  className="gear-card"
+                  style={{
+                    padding: '0.85rem',
+                    border: '1px solid var(--border-color, #333)',
+                    borderRadius: '8px',
+                    background: 'var(--card-bg, rgba(255,255,255,0.03))'
+                  }}
+                >
+                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '0.4rem' }}>
+                    <strong style={{ fontSize: '0.95rem' }}>{gear.displayName || gear.customMakeModel || 'Gear Item'}</strong>
+                    <span
+                      style={{
+                        fontSize: '0.75rem',
+                        padding: '0.15rem 0.4rem',
+                        borderRadius: '4px',
+                        background: gear.status === 'active' ? 'rgba(46, 204, 113, 0.2)' : 'rgba(149, 165, 166, 0.2)',
+                        color: gear.status === 'active' ? '#2ecc71' : '#95a5a6'
+                      }}
+                    >
+                      {gear.status}
+                    </span>
+                  </div>
+                  {gear.gearType && (
+                    <div style={{ fontSize: '0.8rem', color: 'var(--text-muted, #888)', marginBottom: '0.4rem', textTransform: 'capitalize' }}>
+                      {gear.gearType} {gear.brand ? `• ${gear.brand}` : ''}
+                    </div>
+                  )}
+                  <div style={{ fontSize: '0.9rem', fontWeight: 600, marginBottom: '0.3rem' }}>
+                    {distDisplay} {maxDistDisplay ? `/ ${maxDistDisplay}` : ''}
+                  </div>
+                  {pct !== null && (
+                    <div style={{ width: '100%', background: 'rgba(255,255,255,0.1)', borderRadius: '4px', height: '6px', overflow: 'hidden' }}>
+                      <div
+                        style={{
+                          width: `${pct}%`,
+                          height: '100%',
+                          background: pct > 90 ? '#e74c3c' : pct > 75 ? '#f39c12' : '#3498db',
+                          transition: 'width 0.3s ease'
+                        }}
+                      />
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
     </>
   );
 }

--- a/app/src/engine/models.ts
+++ b/app/src/engine/models.ts
@@ -1261,9 +1261,28 @@ export interface UserPreferences {
         temperature: 'celsius' | 'fahrenheit';
     };
     performanceProfile?: AthletePerformanceProfile;
+    gearTracker?: {
+        items: GearItemSummary[];
+        syncedAt?: string;
+    };
     schemaVersion: number;
     createdAt: string;
     updatedAt: string;
+}
+
+export interface GearItemSummary {
+    gearPk: string;
+    uuid?: string;
+    customMakeModel?: string;
+    displayName?: string;
+    gearType?: string;
+    brand?: string;
+    model?: string;
+    totalDistanceKm: number;
+    maximumDistanceKm?: number;
+    dateBegin?: string;
+    dateEnd?: string;
+    status: string;
 }
 
 // --- Engine Layer Models (Not stored in Firestore) ---

--- a/docs/garmin-gear-tracking.md
+++ b/docs/garmin-gear-tracking.md
@@ -1,0 +1,71 @@
+# Garmin gear mileage tracking
+
+## Purpose
+
+The Garmin sync imports the athlete's registered gear (for example running shoes and bikes), stores a user-scoped canonical snapshot in Firestore, and exposes current mileage plus any configured retirement-distance threshold to the preferences UI.
+
+This is **current profile state**, not historical daily telemetry. It is refreshed after a successful live daily sync and is not replayed during historical rebuilds.
+
+## Garmin data sources
+
+Garmin exposes the data needed for this feature through two related calls:
+
+1. `Garmin.get_user_profile()` resolves the `userProfilePk` required by the gear inventory endpoint.
+2. `Garmin.get_gear(userProfilePk)` returns registered gear metadata such as `gearPk`, `uuid`, make/model, status, start/end dates, and `maximumMeters`.
+3. `Garmin.get_gear_stats(uuid)` returns usage statistics for one gear item, including `totalDistance` in meters.
+
+The inventory response does not reliably include accumulated mileage. `GarminClientWrapper.get_gear()` therefore enriches an inventory item with `get_gear_stats()` **only when `totalDistance` is absent**. If Garmin already includes `totalDistance`, the additional stats request is skipped.
+
+The wrapper accepts these inventory response shapes and normalizes them to a list before the provider layer sees them:
+
+- a list of gear objects;
+- `{ "gearList": [...] }`;
+- one gear object containing `gearPk`.
+
+Unexpected shapes raise instead of being silently interpreted as an empty account.
+
+## Failure semantics
+
+Gear is supplementary data and must not make recovery synchronization fail.
+
+- Low-level `GarminClientWrapper.get_gear()` does **not** convert API failures into `[]`; failures propagate to the provider enrichment boundary.
+- `GarminProviderAdapter.fetch_gear()` uses the existing best-effort enrichment behavior, logs an endpoint failure, and returns no canonical gear for that attempt.
+- `FirestoreRecoveryRepository.upsert_garmin_gear()` currently treats an empty canonical list as a no-op. This intentionally preserves the last successful gear snapshot when Garmin gear enrichment is unavailable.
+
+This means a temporarily failing Garmin endpoint cannot erase previously synchronized mileage. The trade-off is that a genuinely successful account state containing zero gear items is also treated as a no-op; changing that behavior requires an explicit success/failure signal in `ProviderGearResult` rather than inferring success from an empty list.
+
+## Canonical units and fields
+
+`CanonicalGearItem` stores distances in kilometers:
+
+- `total_distance_km`: Garmin `totalDistance` meters / 1000;
+- `maximum_distance_km`: Garmin `maximumMeters` meters / 1000 when configured;
+- `date_begin` / `date_end`: calendar-date portion (`YYYY-MM-DD`);
+- `status`: normalized lowercase Garmin status.
+
+The UI converts kilometers to miles when `preferences.preferredUnits.distance === "miles"`.
+
+## Firestore layout
+
+Each successful non-empty sync writes:
+
+- `users/{userId}/gear/{gearPk}` — one document per gear item;
+- `users/{userId}/preferences/profile.gearTracker` — compact list used by the preferences UI;
+- `gearTracker.syncedAt` — UTC ISO timestamp for the snapshot.
+
+Client security rules permit only the owning user to read `users/{userId}/gear/*`; client writes are denied. Sync writes are performed by the trusted backend.
+
+## Request-volume considerations
+
+A refresh costs one inventory call plus up to one stats call per gear item whose inventory object lacks `totalDistance`. Typical accounts contain a small number of active/retired items, but adding aggressive refresh cadences should account for this fan-out and Garmin rate limits.
+
+## Regression coverage
+
+`tests/test_garmin_gear_sync.py` verifies:
+
+- automatic user-profile resolution;
+- per-gear mileage enrichment from `get_gear_stats()`;
+- `gearList` envelope normalization;
+- skipping redundant stats calls when mileage is already present;
+- propagation of low-level Garmin failures;
+- end-to-end provider canonicalization from meters to kilometers.

--- a/src/garmin_sync/canonical.py
+++ b/src/garmin_sync/canonical.py
@@ -75,6 +75,22 @@ class CanonicalPerformanceTargets:
 
 
 @dataclass
+class CanonicalGearItem:
+    gear_pk: str
+    uuid: str | None = None
+    custom_make_model: str | None = None
+    display_name: str | None = None
+    gear_type: str | None = None
+    brand: str | None = None
+    model: str | None = None
+    total_distance_km: float = 0.0
+    maximum_distance_km: float | None = None
+    date_begin: str | None = None
+    date_end: str | None = None
+    status: str = "active"
+
+
+@dataclass
 class CanonicalDailyMetrics:
     date: str
     resting_heart_rate_bpm: float | None = None

--- a/src/garmin_sync/firestore_repository.py
+++ b/src/garmin_sync/firestore_repository.py
@@ -331,6 +331,79 @@ class FirestoreRecoveryRepository:
             "Updated Garmin performance targets in user-scoped preferences for user=<UID-redacted>."
         )
 
+    def upsert_garmin_gear(self, gear_items: list[Any]) -> None:
+        """Persist gear items to user collection and update preferences profile gearTracker."""
+        if not gear_items:
+            return
+        db = self._get_db()
+        now_iso = datetime.now(timezone.utc).isoformat()
+
+        profile_ref = (
+            db.collection("users")
+            .document(self.user_id)
+            .collection("preferences")
+            .document("profile")
+        )
+
+        gear_dicts = [
+            {
+                key: value
+                for key, value in {
+                    "gearPk": item.gear_pk,
+                    "uuid": item.uuid,
+                    "customMakeModel": item.custom_make_model,
+                    "displayName": item.display_name,
+                    "gearType": item.gear_type,
+                    "brand": item.brand,
+                    "model": item.model,
+                    "totalDistanceKm": item.total_distance_km,
+                    "maximumDistanceKm": item.maximum_distance_km,
+                    "dateBegin": item.date_begin,
+                    "dateEnd": item.date_end,
+                    "status": item.status,
+                }.items()
+                if value is not None
+            }
+            for item in gear_items
+        ]
+
+        batch = db.batch()
+        batch.set(
+            profile_ref,
+            {
+                "userId": self.user_id,
+                "gearTracker": {
+                    "items": gear_dicts,
+                    "syncedAt": now_iso,
+                },
+                "updatedAt": now_iso,
+            },
+            merge=True,
+        )
+
+        for item, g_dict in zip(gear_items, gear_dicts, strict=True):
+            gear_doc_ref = (
+                db.collection("users")
+                .document(self.user_id)
+                .collection("gear")
+                .document(item.gear_pk)
+            )
+            batch.set(
+                gear_doc_ref,
+                {
+                    "userId": self.user_id,
+                    **g_dict,
+                    "updatedAt": now_iso,
+                },
+                merge=True,
+            )
+
+        batch.commit()
+        logger.info(
+            "Updated Garmin gear items (%d) for user=<UID-redacted>.",
+            len(gear_items),
+        )
+
     def count_activities_in_range(self, start_date_iso: str, end_date_iso: str) -> int:
         """Count normalized activity records with date in [start_date_iso, end_date_iso]."""
         db = self._get_db()

--- a/src/garmin_sync/garmin_client.py
+++ b/src/garmin_sync/garmin_client.py
@@ -37,6 +37,7 @@ class GarminDataClient(Protocol):
     def get_activity_splits(self, activity_id: str) -> dict[str, Any]: ...
     def upload_workout(self, workout_json: dict[str, Any]) -> dict[str, Any]: ...
     def schedule_workout(self, workout_id: str, date_iso: str) -> dict[str, Any]: ...
+    def get_gear(self, user_profile_number: str | int | None = None) -> list[dict[str, Any]]: ...
 
 
 class GarminClientWrapper:
@@ -251,19 +252,58 @@ class GarminClientWrapper:
         return self.api.schedule_workout(workout_id, date_iso) or {}
 
     def get_gear(self, user_profile_number: str | int | None = None) -> list[dict[str, Any]]:
+        """Return Garmin gear inventory enriched with per-item accumulated distance.
+
+        ``garminconnect.Garmin.get_gear`` requires a user profile number and its inventory
+        payload does not reliably contain usage mileage. Resolve the profile number when
+        the caller omits it, normalize supported inventory response shapes to a list, and
+        use ``get_gear_stats`` only when ``totalDistance`` is absent from an item.
+
+        Failures deliberately propagate to GarminProviderAdapter's best-effort enrichment
+        boundary. Returning ``[]`` for an API failure would make an unavailable endpoint
+        indistinguishable from a successful account with no configured gear.
+        """
         if not self.api:
             raise RuntimeError("Garmin client is not authenticated. Call login first.")
-        if hasattr(self.api, "get_gear"):
-            try:
-                if user_profile_number is not None:
-                    return self.api.get_gear(user_profile_number) or []
-                if hasattr(self.api, "get_user_profile"):
-                    profile = self.api.get_user_profile() or {}
-                    pk = profile.get("userProfilePk") or profile.get("profileId")
-                    if pk:
-                        return self.api.get_gear(pk) or []
-                return self.api.get_gear() or []
-            except Exception as e:
-                logger.debug("Failed to fetch gear from Garmin: %s", e)
-                return []
-        return []
+
+        profile_number = user_profile_number
+        if profile_number is None:
+            profile = self.api.get_user_profile() or {}
+            profile_number = profile.get("userProfilePk") or profile.get("profileId")
+            if profile_number is None:
+                user_data = profile.get("userData")
+                if isinstance(user_data, dict):
+                    profile_number = user_data.get("userProfilePk") or user_data.get("profileId")
+            if profile_number is None:
+                raise RuntimeError("Garmin user profile did not include a profile identifier.")
+
+        raw_gear = self.api.get_gear(profile_number) or []
+        if isinstance(raw_gear, list):
+            raw_items = raw_gear
+        elif isinstance(raw_gear, dict) and isinstance(raw_gear.get("gearList"), list):
+            raw_items = raw_gear["gearList"]
+        elif isinstance(raw_gear, dict) and raw_gear.get("gearPk") is not None:
+            raw_items = [raw_gear]
+        else:
+            raise TypeError(
+                "Unexpected Garmin gear response shape; expected a list, gearList envelope, "
+                "or single gear object."
+            )
+
+        get_gear_stats = getattr(self.api, "get_gear_stats", None)
+        enriched_items: list[dict[str, Any]] = []
+        for raw_item in raw_items:
+            if not isinstance(raw_item, dict):
+                continue
+            item = dict(raw_item)
+            gear_uuid = item.get("uuid")
+            if item.get("totalDistance") is None and gear_uuid and callable(get_gear_stats):
+                stats = get_gear_stats(str(gear_uuid)) or {}
+                if isinstance(stats, dict):
+                    if stats.get("totalDistance") is not None:
+                        item["totalDistance"] = stats["totalDistance"]
+                    if stats.get("totalActivities") is not None:
+                        item["totalActivities"] = stats["totalActivities"]
+            enriched_items.append(item)
+
+        return enriched_items

--- a/src/garmin_sync/garmin_client.py
+++ b/src/garmin_sync/garmin_client.py
@@ -238,3 +238,21 @@ class GarminClientWrapper:
         if not self.api:
             raise RuntimeError("Garmin client is not authenticated. Call login first.")
         return self.api.schedule_workout(workout_id, date_iso) or {}
+
+    def get_gear(self, user_profile_number: str | int | None = None) -> list[dict[str, Any]]:
+        if not self.api:
+            raise RuntimeError("Garmin client is not authenticated. Call login first.")
+        if hasattr(self.api, "get_gear"):
+            try:
+                if user_profile_number is not None:
+                    return self.api.get_gear(user_profile_number) or []
+                if hasattr(self.api, "get_user_profile"):
+                    profile = self.api.get_user_profile() or {}
+                    pk = profile.get("userProfilePk") or profile.get("profileId")
+                    if pk:
+                        return self.api.get_gear(pk) or []
+                return self.api.get_gear() or []
+            except Exception as e:
+                logger.debug("Failed to fetch gear from Garmin: %s", e)
+                return []
+        return []

--- a/src/garmin_sync/garmin_provider.py
+++ b/src/garmin_sync/garmin_provider.py
@@ -789,6 +789,7 @@ class GarminProviderAdapter:
         activities=True,
         activity_details=True,
         body_composition=True,
+        gear_tracking=True,
     )
 
     def __init__(self, client: GarminClientWrapper):

--- a/src/garmin_sync/garmin_provider.py
+++ b/src/garmin_sync/garmin_provider.py
@@ -13,6 +13,7 @@ from .canonical import (
     CanonicalActivityDetail,
     CanonicalBodyBattery,
     CanonicalDailyMetrics,
+    CanonicalGearItem,
     CanonicalHeartRateZones,
     CanonicalLapSummary,
     CanonicalPerformanceTargets,
@@ -29,6 +30,7 @@ from .provider import (
     ProviderActivityDetailResult,
     ProviderCapabilities,
     ProviderFetchResult,
+    ProviderGearResult,
     ProviderPerformanceTargetsResult,
 )
 
@@ -564,6 +566,69 @@ def canonicalize_performance_targets(
     )
 
 
+def extract_gear_items(raw_gear: Any) -> list[CanonicalGearItem]:
+    """Extract canonical equipment records from Garmin gear API responses."""
+    if not isinstance(raw_gear, list):
+        if isinstance(raw_gear, dict) and isinstance(raw_gear.get("gearList"), list):
+            raw_gear = raw_gear["gearList"]
+        else:
+            return []
+
+    items: list[CanonicalGearItem] = []
+    for entry in raw_gear:
+        if not isinstance(entry, dict):
+            continue
+        gear_pk = entry.get("gearPk") or entry.get("uuid") or entry.get("gearId")
+        if gear_pk is None:
+            continue
+
+        custom_make_model = entry.get("customMakeModel") or entry.get("displayName")
+        display_name = entry.get("displayName") or custom_make_model
+        gear_type_name = entry.get("gearTypeName") or entry.get("gearType")
+        brand = entry.get("gearMakeName") or entry.get("brand")
+        model = entry.get("gearModelName") or entry.get("model")
+
+        total_dist_raw = _non_negative_number(entry.get("totalDistance"))
+        total_dist_km = round(total_dist_raw / 1000.0, 1) if total_dist_raw is not None else 0.0
+
+        max_dist_raw = _non_negative_number(entry.get("maximumMeters") or entry.get("maxDistance"))
+        max_dist_km = round(max_dist_raw / 1000.0, 1) if max_dist_raw is not None else None
+
+        date_begin = entry.get("dateBegin")
+        if isinstance(date_begin, str) and len(date_begin) >= 10:
+            date_begin = date_begin[:10]
+        else:
+            date_begin = None
+
+        date_end = entry.get("dateEnd")
+        if isinstance(date_end, str) and len(date_end) >= 10:
+            date_end = date_end[:10]
+        else:
+            date_end = None
+
+        raw_status = entry.get("gearStatusName") or entry.get("status")
+        status = str(raw_status).lower() if raw_status is not None else "active"
+
+        items.append(
+            CanonicalGearItem(
+                gear_pk=str(gear_pk),
+                uuid=str(entry.get("uuid")) if entry.get("uuid") else None,
+                custom_make_model=str(custom_make_model) if custom_make_model else None,
+                display_name=str(display_name) if display_name else None,
+                gear_type=str(gear_type_name).lower() if gear_type_name else None,
+                brand=str(brand) if brand else None,
+                model=str(model) if model else None,
+                total_distance_km=total_dist_km,
+                maximum_distance_km=max_dist_km,
+                date_begin=date_begin,
+                date_end=date_end,
+                status=status,
+            )
+        )
+
+    return items
+
+
 def canonicalize_from_raw(
     stats_today: dict[str, Any],
     stats_fallback: dict[str, Any] | None,
@@ -922,4 +987,12 @@ class GarminProviderAdapter:
                 splits=splits,
             ),
             raw_payloads=raw_payloads,
+        )
+
+    def fetch_gear(self) -> ProviderGearResult:
+        raw_gear = self._fetch_enrichment("gear", lambda: self.client.get_gear())
+        raw_list = raw_gear if isinstance(raw_gear, list) else []
+        return ProviderGearResult(
+            canonical=extract_gear_items(raw_list),
+            raw_payloads={"gear": raw_list},
         )

--- a/src/garmin_sync/provider.py
+++ b/src/garmin_sync/provider.py
@@ -23,7 +23,7 @@ class ProviderCapabilities:
     activity_details: bool = False
     body_composition: bool = False
     training_readiness: bool = False
-    gear_tracking: bool = True
+    gear_tracking: bool = False
     workout_publishing: bool = False  # no adapter in this codebase exposes mutations
 
 

--- a/src/garmin_sync/provider.py
+++ b/src/garmin_sync/provider.py
@@ -9,6 +9,7 @@ from .canonical import (
     CanonicalActivity,
     CanonicalActivityDetail,
     CanonicalDailyMetrics,
+    CanonicalGearItem,
     CanonicalPerformanceTargets,
 )
 
@@ -22,6 +23,7 @@ class ProviderCapabilities:
     activity_details: bool = False
     body_composition: bool = False
     training_readiness: bool = False
+    gear_tracking: bool = True
     workout_publishing: bool = False  # no adapter in this codebase exposes mutations
 
 
@@ -55,6 +57,14 @@ class ProviderPerformanceTargetsResult:
     """Current, profile-level targets and their untouched provider payloads."""
 
     canonical: CanonicalPerformanceTargets
+    raw_payloads: dict[str, Any]
+
+
+@dataclass
+class ProviderGearResult:
+    """Athlete equipment and gear mileage records."""
+
+    canonical: list[CanonicalGearItem]
     raw_payloads: dict[str, Any]
 
 

--- a/src/garmin_sync/service.py
+++ b/src/garmin_sync/service.py
@@ -412,6 +412,24 @@ class GarminSyncService:
                 f"[{target_iso}] Garmin performance-target import failed, continuing: {e}"
             )
 
+    def _sync_current_gear(self, target_iso: str) -> None:
+        """Best-effort current gear/shoe tracking import."""
+        try:
+            provider = self._init_provider()
+            fetch_gear = getattr(provider, "fetch_gear", None)
+            persist_gear = getattr(self.repository, "upsert_garmin_gear", None)
+            if not callable(fetch_gear) or not callable(persist_gear):
+                return
+            result = fetch_gear()
+            sync_run_id = _new_sync_run_id(f"gear-{target_iso}")
+            for endpoint, payload in result.raw_payloads.items():
+                if payload is not None:
+                    self._archive_raw(endpoint, target_iso, payload, sync_run_id)
+            persist_gear(result.canonical)
+            self.token_store.persist(self.token_file_path)
+        except Exception as e:
+            logger.warning(f"[{target_iso}] Garmin gear import failed, continuing: {e}")
+
     def sync_daily(
         self,
         target_date_str: str | None = None,
@@ -469,6 +487,7 @@ class GarminSyncService:
                     if not backfill_ok:
                         logger.warning("Automated cold-start backfill finished with errors.")
                     self._sync_current_performance_targets(target_iso)
+                    self._sync_current_gear(target_iso)
                     return backfill_ok
 
         # Staleness check gates the whole operation (target date + lookback resync) --
@@ -520,6 +539,7 @@ class GarminSyncService:
             ok = False
         else:
             self._sync_current_performance_targets(target_iso)
+            self._sync_current_gear(target_iso)
 
         return ok
 
@@ -1061,6 +1081,7 @@ class GarminSyncService:
                 if ok:
                     target_iso = get_date_string(local_today(self.settings.app_timezone))
                     self._sync_current_performance_targets(target_iso)
+                    self._sync_current_gear(target_iso)
             except Exception as e:
                 logger.error(f"Manual backfill request failed: {e}")
                 self._finish_manual_sync_request(

--- a/tests/test_garmin_gear_sync.py
+++ b/tests/test_garmin_gear_sync.py
@@ -1,0 +1,104 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from garmin_sync.garmin_client import GarminClientWrapper
+from garmin_sync.garmin_provider import GarminProviderAdapter
+
+
+def _wrapper_with_api() -> tuple[GarminClientWrapper, MagicMock]:
+    wrapper = GarminClientWrapper(allow_credential_login=False)
+    api = MagicMock()
+    wrapper.api = api
+    return wrapper, api
+
+
+def test_get_gear_resolves_profile_and_enriches_missing_mileage_from_stats():
+    wrapper, api = _wrapper_with_api()
+    api.get_user_profile.return_value = {"userProfilePk": 42}
+    api.get_gear.return_value = [
+        {
+            "gearPk": 12345,
+            "uuid": "gear-uuid-1",
+            "displayName": "Daily Shoes",
+            "gearTypeName": "Shoes",
+            "maximumMeters": 600_000,
+            "gearStatusName": "active",
+        }
+    ]
+    api.get_gear_stats.return_value = {
+        "totalDistance": 250_400.0,
+        "totalActivities": 31,
+    }
+
+    gear = wrapper.get_gear()
+
+    api.get_gear.assert_called_once_with(42)
+    api.get_gear_stats.assert_called_once_with("gear-uuid-1")
+    assert gear[0]["totalDistance"] == 250_400.0
+    assert gear[0]["totalActivities"] == 31
+
+
+def test_get_gear_normalizes_gear_list_envelope_and_preserves_existing_mileage():
+    wrapper, api = _wrapper_with_api()
+    api.get_gear.return_value = {
+        "gearList": [
+            {
+                "gearPk": 12345,
+                "uuid": "gear-uuid-1",
+                "totalDistance": 12_345.0,
+            }
+        ]
+    }
+
+    gear = wrapper.get_gear(user_profile_number="42")
+
+    assert gear == [
+        {
+            "gearPk": 12345,
+            "uuid": "gear-uuid-1",
+            "totalDistance": 12_345.0,
+        }
+    ]
+    api.get_user_profile.assert_not_called()
+    api.get_gear.assert_called_once_with("42")
+    api.get_gear_stats.assert_not_called()
+
+
+def test_get_gear_does_not_mask_inventory_failures_as_empty_account():
+    wrapper, api = _wrapper_with_api()
+    api.get_gear.side_effect = RuntimeError("Garmin unavailable")
+
+    with pytest.raises(RuntimeError, match="Garmin unavailable"):
+        wrapper.get_gear(user_profile_number=42)
+
+
+def test_provider_fetch_gear_canonicalizes_enriched_stats_distance_and_threshold():
+    wrapper, api = _wrapper_with_api()
+    api.get_user_profile.return_value = {"userProfilePk": 42}
+    api.get_gear.return_value = [
+        {
+            "gearPk": 12345,
+            "uuid": "gear-uuid-1",
+            "customMakeModel": "Nike Vaporfly 3",
+            "displayName": "Race Shoes",
+            "gearTypeName": "Shoes",
+            "gearMakeName": "Nike",
+            "gearModelName": "Vaporfly 3",
+            "maximumMeters": 600_000,
+            "dateBegin": "2025-01-01T00:00:00.0",
+            "gearStatusName": "ACTIVE",
+        }
+    ]
+    api.get_gear_stats.return_value = {"totalDistance": 250_400.0}
+
+    result = GarminProviderAdapter(wrapper).fetch_gear()
+
+    assert len(result.canonical) == 1
+    item = result.canonical[0]
+    assert item.gear_pk == "12345"
+    assert item.total_distance_km == 250.4
+    assert item.maximum_distance_km == 600.0
+    assert item.date_begin == "2025-01-01"
+    assert item.status == "active"
+    assert result.raw_payloads["gear"][0]["totalDistance"] == 250_400.0

--- a/tests/test_garmin_provider.py
+++ b/tests/test_garmin_provider.py
@@ -840,6 +840,14 @@ def test_canonicalize_performance_targets_with_body_composition():
     assert targets.ftp_measured_at == "2026-08-20"
 
 
+def test_gear_tracking_capability_is_opt_in_per_provider():
+    from garmin_sync.garmin_provider import GarminProviderAdapter
+    from garmin_sync.provider import ProviderCapabilities
+
+    assert ProviderCapabilities().gear_tracking is False
+    assert GarminProviderAdapter.capabilities.gear_tracking is True
+
+
 def test_extract_gear_items():
     from garmin_sync.garmin_provider import extract_gear_items
 

--- a/tests/test_garmin_provider.py
+++ b/tests/test_garmin_provider.py
@@ -838,3 +838,42 @@ def test_canonicalize_performance_targets_with_body_composition():
     assert targets.body_fat_pct == 12.5
     assert targets.weight_measured_at == "2026-08-23"
     assert targets.ftp_measured_at == "2026-08-20"
+
+
+def test_extract_gear_items():
+    from garmin_sync.garmin_provider import extract_gear_items
+
+    raw = [
+        {
+            "gearPk": 12345,
+            "uuid": "gear-uuid-1",
+            "customMakeModel": "Nike Vaporfly 3",
+            "displayName": "Race Shoes",
+            "gearTypeName": "Shoes",
+            "gearMakeName": "Nike",
+            "gearModelName": "Vaporfly 3",
+            "totalDistance": 250400.0,  # 250.4 km
+            "maximumMeters": 600000.0,  # 600.0 km
+            "dateBegin": "2025-01-01",
+            "gearStatusName": "ACTIVE",
+        },
+        {
+            "gearPk": 67890,
+            "customMakeModel": "Specialized Tarmac",
+            "gearTypeName": "Bikes",
+            "totalDistance": 1540200.0,  # 1540.2 km
+            "gearStatusName": "ACTIVE",
+        },
+    ]
+
+    items = extract_gear_items(raw)
+    assert len(items) == 2
+    assert items[0].gear_pk == "12345"
+    assert items[0].custom_make_model == "Nike Vaporfly 3"
+    assert items[0].display_name == "Race Shoes"
+    assert items[0].gear_type == "shoes"
+    assert items[0].brand == "Nike"
+    assert items[0].total_distance_km == 250.4
+    assert items[0].maximum_distance_km == 600.0
+    assert items[0].status == "active"
+    assert items[1].total_distance_km == 1540.2


### PR DESCRIPTION
## Summary

Adds automatic Garmin shoe/equipment mileage synchronization and user-visible wear tracking for registered gear such as running shoes and bikes.

Gear metadata is stored in `users/{userId}/gear/{gearPk}` and a compact current snapshot is stored in `users/{userId}/preferences/profile.gearTracker` for the preferences UI.

## Key changes

### Backend sync
- Adds `CanonicalGearItem` and `ProviderGearResult`.
- Adds Garmin gear capability and `GarminProviderAdapter.fetch_gear()`.
- Resolves the Garmin `userProfilePk` required by the inventory endpoint.
- Normalizes supported Garmin inventory shapes to a list.
- **Fetches real accumulated mileage from `get_gear_stats(uuid)` when the inventory item does not already contain `totalDistance`.** Garmin's inventory payload is metadata-focused and does not reliably carry mileage.
- Converts Garmin meter values to canonical kilometers.
- Persists individual gear documents plus `preferences/profile.gearTracker`.
- Runs gear import as best-effort current-profile enrichment after successful live syncs, so gear endpoint problems cannot fail recovery sync.

### Frontend
- Adds `GearItemSummary` and `UserPreferences.gearTracker`.
- Adds owner-read / backend-write-only Firestore rules for `users/{userId}/gear/*`.
- Adds the **Shoes & Equipment Mileage** preferences section with km/mi display, Garmin status, and retirement-distance progress.

## Review fixes added

The original implementation passed unit tests but had two live-integration gaps:

1. `python-garminconnect` requires a profile number for `get_gear`; response shape handling needed to be normalized at the client boundary.
2. Gear inventory objects do not reliably include `totalDistance`; accumulated distance comes from the separate per-gear `get_gear_stats` endpoint. Without enrichment, real gear could display `0.0 km`.

The wrapper now resolves the profile ID, normalizes list / `gearList` / single-item payloads, enriches missing mileage from stats, skips redundant stats calls when mileage is already present, and no longer masks low-level Garmin failures as a successful empty account.

## Failure semantics

Gear is supplementary. Low-level gear failures propagate out of `GarminClientWrapper`, then the adapter's existing best-effort enrichment boundary converts an unavailable gear endpoint to an empty canonical result. `FirestoreRecoveryRepository.upsert_garmin_gear()` treats that empty result as a no-op, preserving the last successful gear snapshot rather than erasing it during an outage.

That also means a successful account state with zero configured gear is currently a no-op. The design note documents this trade-off explicitly; safely clearing that state requires the provider boundary to preserve success/failure separately from an empty item list.

## Documentation

See `docs/garmin-gear-tracking.md` for:
- Garmin endpoint/data-shape contract;
- mileage enrichment behavior;
- canonical units;
- Firestore layout and security model;
- failure semantics;
- request-volume/rate-limit considerations;
- regression coverage.

## Verification

Added `tests/test_garmin_gear_sync.py` covering:
- profile-ID resolution;
- `gearList` response normalization;
- mileage enrichment via `get_gear_stats`;
- avoiding redundant stats calls;
- propagation of low-level inventory failures;
- end-to-end provider conversion from meters to kilometers.

GitHub Actions CI Pipeline **#1179** passed on the updated PR head (`f10a39c`):
- Python 3.12: pre-commit, Ruff lint/format, mypy, **301 tests passed**, coverage, dependency audit;
- Python 3.14: full Python validation matrix passed;
- Docker image build passed;
- frontend lint, workout validation, engine policy drift check, test suite, coverage, Firestore emulator rules, simulations/semantic diff, production build, and Node dependency audit all passed.