### PR TITLE
fix(ui): make decision-inputs-need-repair error actionable

### DIFF
--- a/app/src/components/Home.css
+++ b/app/src/components/Home.css
@@ -750,6 +750,18 @@
   color: var(--text-secondary);
 }
 
+.error-state-hint {
+  margin-top: 0.5rem;
+  font-size: 0.875rem;
+}
+
+.error-state-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.75rem;
+}
+
 .error-state button {
   margin-top: 1rem;
   padding: 0.5rem 1rem;

--- a/app/src/components/Home.tsx
+++ b/app/src/components/Home.tsx
@@ -43,6 +43,7 @@ import { MinimumSafetyCheckin } from './MinimumSafetyCheckin';
 import { WeekAheadStrip } from './WeekAheadStrip';
 import { LaterDayFollowupCard, type LaterDayFollowupTarget } from './session/LaterDayFollowupCard';
 import { GarminSyncNowButton } from './GarminSyncNowButton';
+import type { ErrorRepairAction } from './errorRepairAction';
 import { useAutoGarminSync } from '../hooks/useAutoGarminSync';
 import {
   canGenerateNormalRecommendation,
@@ -182,7 +183,7 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
   const [nextDayPlan, setNextDayPlan] = useState<NextDayPotentialPlan | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [errorRepairTargets, setErrorRepairTargets] = useState<{ screen: Screen; label: string }[]>([]);
+  const [errorRepairTargets, setErrorRepairTargets] = useState<ErrorRepairAction[]>([]);
   const [showWorkoutDetails, setShowWorkoutDetails] = useState(false);
   const [pendingAdherence, setPendingAdherence] = useState<{ date: string; recommendation: DailyRecommendation } | null>(null);
   const [, setTodaysJournalEntry] = useState<DecisionJournalEntry | null>(null);
@@ -355,6 +356,11 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
         setRecommendation(null);
         setNextDayPlan(null);
         clearExternalPlanState();
+        if (recoveryState.status === 'INVALID') {
+          // A malformed stored snapshot is fixed by re-ingesting, not by re-reading it --
+          // offer a forced resync instead of a dead-end Retry.
+          setErrorRepairTargets([{ kind: 'resync' }]);
+        }
         setError(recoveryState.status === 'UNAVAILABLE'
           ? 'Recovery data is temporarily unavailable. Please retry before generating a plan.'
           : 'Recovery data needs repair before generating a plan.');
@@ -371,10 +377,10 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
           // Point the user at whichever screen owns the invalid document(s) so the error
           // is actionable rather than a dead end -- re-saving there re-runs validation
           // and clears the INVALID state.
-          const repairTargets: { screen: Screen; label: string }[] = [];
-          if (input.sourceStates?.activeGoals.status === 'INVALID') repairTargets.push({ screen: 'goals', label: 'Review goals' });
-          if (input.sourceStates?.preferences.status === 'INVALID') repairTargets.push({ screen: 'preferences', label: 'Review preferences' });
-          if (input.sourceStates?.trainingSettings.status === 'INVALID') repairTargets.push({ screen: 'constraints', label: 'Review training settings' });
+          const repairTargets: ErrorRepairAction[] = [];
+          if (input.sourceStates?.activeGoals.status === 'INVALID') repairTargets.push({ kind: 'navigate', screen: 'goals', label: 'Review goals' });
+          if (input.sourceStates?.preferences.status === 'INVALID') repairTargets.push({ kind: 'navigate', screen: 'preferences', label: 'Review preferences' });
+          if (input.sourceStates?.trainingSettings.status === 'INVALID') repairTargets.push({ kind: 'navigate', screen: 'constraints', label: 'Review training settings' });
           setErrorRepairTargets(repairTargets);
         }
         setError(decisionSourceFailure.status === 'UNAVAILABLE'
@@ -852,14 +858,18 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
           <p>{error}</p>
           {errorRepairTargets.length > 0 && (
             <p className="error-state-hint">
-              Re-saving the flagged data below re-validates it and clears this error.
+              {errorRepairTargets.some(target => target.kind === 'resync')
+                ? 'Forcing a fresh Garmin sync below re-writes the flagged data and clears this error.'
+                : 'Re-saving the flagged data below re-validates it and clears this error.'}
             </p>
           )}
           <div className="error-state-actions">
-            {errorRepairTargets.map(target => (
+            {errorRepairTargets.map(target => target.kind === 'navigate' ? (
               <button key={target.screen} type="button" onClick={() => onNavigate(target.screen)}>
                 {target.label} →
               </button>
+            ) : (
+              <GarminSyncNowButton key="resync" userId={userId} onSynced={loadDashboardData} />
             ))}
             <button onClick={loadDashboardData}>Retry</button>
           </div>

--- a/app/src/components/Home.tsx
+++ b/app/src/components/Home.tsx
@@ -182,6 +182,7 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
   const [nextDayPlan, setNextDayPlan] = useState<NextDayPotentialPlan | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [errorRepairTargets, setErrorRepairTargets] = useState<{ screen: Screen; label: string }[]>([]);
   const [showWorkoutDetails, setShowWorkoutDetails] = useState(false);
   const [pendingAdherence, setPendingAdherence] = useState<{ date: string; recommendation: DailyRecommendation } | null>(null);
   const [, setTodaysJournalEntry] = useState<DecisionJournalEntry | null>(null);
@@ -343,6 +344,7 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
     try {
       setLoading(true);
       setError(null);
+      setErrorRepairTargets([]);
       setHistorySnapshot(null);
       const input = await decisionComposer.composeDailyDecisionInput(userId);
       if (!isCurrent()) return;
@@ -365,6 +367,16 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
         setRecommendation(null);
         setNextDayPlan(null);
         clearExternalPlanState();
+        if (decisionSourceFailure.status === 'INVALID') {
+          // Point the user at whichever screen owns the invalid document(s) so the error
+          // is actionable rather than a dead end -- re-saving there re-runs validation
+          // and clears the INVALID state.
+          const repairTargets: { screen: Screen; label: string }[] = [];
+          if (input.sourceStates?.activeGoals.status === 'INVALID') repairTargets.push({ screen: 'goals', label: 'Review goals' });
+          if (input.sourceStates?.preferences.status === 'INVALID') repairTargets.push({ screen: 'preferences', label: 'Review preferences' });
+          if (input.sourceStates?.trainingSettings.status === 'INVALID') repairTargets.push({ screen: 'constraints', label: 'Review training settings' });
+          setErrorRepairTargets(repairTargets);
+        }
         setError(decisionSourceFailure.status === 'UNAVAILABLE'
           ? 'Decision inputs are temporarily unavailable. Please retry before generating a plan.'
           : 'Decision inputs need repair before generating a plan.');
@@ -838,7 +850,19 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
       <div className="home-container">
         <div className="error-state">
           <p>{error}</p>
-          <button onClick={loadDashboardData}>Retry</button>
+          {errorRepairTargets.length > 0 && (
+            <p className="error-state-hint">
+              Re-saving the flagged data below re-validates it and clears this error.
+            </p>
+          )}
+          <div className="error-state-actions">
+            {errorRepairTargets.map(target => (
+              <button key={target.screen} type="button" onClick={() => onNavigate(target.screen)}>
+                {target.label} →
+              </button>
+            ))}
+            <button onClick={loadDashboardData}>Retry</button>
+          </div>
         </div>
       </div>
     );

--- a/app/src/components/PlanView.css
+++ b/app/src/components/PlanView.css
@@ -151,6 +151,13 @@
   line-height: 1.45;
 }
 
+.plan-unavailable-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 10px;
+}
+
 .plan-retry-btn {
   padding: 10px 18px;
   min-height: 40px;

--- a/app/src/components/PlanView.tsx
+++ b/app/src/components/PlanView.tsx
@@ -36,6 +36,8 @@ import type { Screen } from '../types/navigation';
 import { ExternalPlanWeek } from './ExternalPlanWeek';
 import { ExternalPlanImport } from './ExternalPlanImport';
 import { WeekAheadStrip } from './WeekAheadStrip';
+import { GarminSyncNowButton } from './GarminSyncNowButton';
+import type { ErrorRepairAction } from './errorRepairAction';
 import './PlanView.css';
 
 interface PlanViewProps {
@@ -65,7 +67,7 @@ export const PlanView: React.FC<PlanViewProps> = ({ userId, onNavigate, onPlanCh
   const [loading, setLoading] = useState<boolean>(true);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [forecastUnavailable, setForecastUnavailable] = useState<string | null>(null);
-  const [forecastRepairTargets, setForecastRepairTargets] = useState<{ screen: Screen; label: string }[]>([]);
+  const [forecastRepairTargets, setForecastRepairTargets] = useState<ErrorRepairAction[]>([]);
   const [writeError, setWriteError] = useState<string | null>(null);
   const [showImport, setShowImport] = useState<boolean>(false);
 
@@ -113,10 +115,10 @@ export const PlanView: React.FC<PlanViewProps> = ({ userId, onNavigate, onPlanCh
           // Point the user at whichever screen owns the invalid document(s) so the error
           // is actionable rather than a dead end -- re-saving there re-runs validation
           // and clears the INVALID state.
-          const repairTargets: { screen: Screen; label: string }[] = [];
-          if (input.sourceStates?.activeGoals.status === 'INVALID') repairTargets.push({ screen: 'goals', label: 'Review goals' });
-          if (input.sourceStates?.preferences.status === 'INVALID') repairTargets.push({ screen: 'preferences', label: 'Review preferences' });
-          if (input.sourceStates?.trainingSettings.status === 'INVALID') repairTargets.push({ screen: 'constraints', label: 'Review training settings' });
+          const repairTargets: ErrorRepairAction[] = [];
+          if (input.sourceStates?.activeGoals.status === 'INVALID') repairTargets.push({ kind: 'navigate', screen: 'goals', label: 'Review goals' });
+          if (input.sourceStates?.preferences.status === 'INVALID') repairTargets.push({ kind: 'navigate', screen: 'preferences', label: 'Review preferences' });
+          if (input.sourceStates?.trainingSettings.status === 'INVALID') repairTargets.push({ kind: 'navigate', screen: 'constraints', label: 'Review training settings' });
           setForecastRepairTargets(repairTargets);
         }
         setForecastUnavailable(
@@ -129,6 +131,11 @@ export const PlanView: React.FC<PlanViewProps> = ({ userId, onNavigate, onPlanCh
 
       const recoveryState = input.sourceStates?.recoverySnapshot;
       if (recoveryState && recoveryState.status !== 'AVAILABLE' && recoveryState.status !== 'MISSING') {
+        if (recoveryState.status === 'INVALID') {
+          // A malformed stored snapshot is fixed by re-ingesting, not by re-reading it --
+          // offer a forced resync instead of a dead-end Retry.
+          setForecastRepairTargets([{ kind: 'resync' }]);
+        }
         setForecastUnavailable(
           recoveryState.status === 'UNAVAILABLE'
             ? 'Recovery data is temporarily unavailable. Please retry before generating a plan.'
@@ -428,21 +435,27 @@ export const PlanView: React.FC<PlanViewProps> = ({ userId, onNavigate, onPlanCh
         <div className="plan-unavailable-card">
           <h3>7-Day Forecast Temporarily Unavailable</h3>
           <p className="plan-unavailable-message">{forecastUnavailable}</p>
-          {forecastRepairTargets.length > 0 && onNavigate && (
+          {forecastRepairTargets.length > 0 && (
             <p className="plan-unavailable-message">
-              Re-saving the flagged data below re-validates it and clears this error.
+              {forecastRepairTargets.some(target => target.kind === 'resync')
+                ? 'Forcing a fresh Garmin sync below re-writes the flagged data and clears this error.'
+                : 'Re-saving the flagged data below re-validates it and clears this error.'}
             </p>
           )}
           <div className="plan-unavailable-actions">
-            {onNavigate && forecastRepairTargets.map(target => (
-              <button
-                key={target.screen}
-                type="button"
-                className="plan-retry-btn"
-                onClick={() => onNavigate(target.screen)}
-              >
-                {target.label} →
-              </button>
+            {forecastRepairTargets.map(target => target.kind === 'navigate' ? (
+              onNavigate && (
+                <button
+                  key={target.screen}
+                  type="button"
+                  className="plan-retry-btn"
+                  onClick={() => onNavigate(target.screen)}
+                >
+                  {target.label} →
+                </button>
+              )
+            ) : (
+              <GarminSyncNowButton key="resync" userId={userId} onSynced={loadPlanData} />
             ))}
             <button type="button" className="plan-retry-btn" onClick={loadPlanData}>
               🔄 Retry

--- a/app/src/components/PlanView.tsx
+++ b/app/src/components/PlanView.tsx
@@ -65,6 +65,7 @@ export const PlanView: React.FC<PlanViewProps> = ({ userId, onNavigate, onPlanCh
   const [loading, setLoading] = useState<boolean>(true);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [forecastUnavailable, setForecastUnavailable] = useState<string | null>(null);
+  const [forecastRepairTargets, setForecastRepairTargets] = useState<{ screen: Screen; label: string }[]>([]);
   const [writeError, setWriteError] = useState<string | null>(null);
   const [showImport, setShowImport] = useState<boolean>(false);
 
@@ -73,6 +74,7 @@ export const PlanView: React.FC<PlanViewProps> = ({ userId, onNavigate, onPlanCh
     setLoading(true);
     setLoadError(null);
     setForecastUnavailable(null);
+    setForecastRepairTargets([]);
     setWeekAheadPlan(null);
     setNextDayPlan(null);
     setCritique(null);
@@ -107,6 +109,16 @@ export const PlanView: React.FC<PlanViewProps> = ({ userId, onNavigate, onPlanCh
           (state) => state.status === 'INVALID' || state.status === 'UNAVAILABLE',
         );
       if (decisionSourceFailure) {
+        if (decisionSourceFailure.status === 'INVALID') {
+          // Point the user at whichever screen owns the invalid document(s) so the error
+          // is actionable rather than a dead end -- re-saving there re-runs validation
+          // and clears the INVALID state.
+          const repairTargets: { screen: Screen; label: string }[] = [];
+          if (input.sourceStates?.activeGoals.status === 'INVALID') repairTargets.push({ screen: 'goals', label: 'Review goals' });
+          if (input.sourceStates?.preferences.status === 'INVALID') repairTargets.push({ screen: 'preferences', label: 'Review preferences' });
+          if (input.sourceStates?.trainingSettings.status === 'INVALID') repairTargets.push({ screen: 'constraints', label: 'Review training settings' });
+          setForecastRepairTargets(repairTargets);
+        }
         setForecastUnavailable(
           decisionSourceFailure.status === 'UNAVAILABLE'
             ? 'Decision inputs are temporarily unavailable. Please retry before generating a plan.'
@@ -416,9 +428,26 @@ export const PlanView: React.FC<PlanViewProps> = ({ userId, onNavigate, onPlanCh
         <div className="plan-unavailable-card">
           <h3>7-Day Forecast Temporarily Unavailable</h3>
           <p className="plan-unavailable-message">{forecastUnavailable}</p>
-          <button type="button" className="plan-retry-btn" onClick={loadPlanData}>
-            🔄 Retry
-          </button>
+          {forecastRepairTargets.length > 0 && onNavigate && (
+            <p className="plan-unavailable-message">
+              Re-saving the flagged data below re-validates it and clears this error.
+            </p>
+          )}
+          <div className="plan-unavailable-actions">
+            {onNavigate && forecastRepairTargets.map(target => (
+              <button
+                key={target.screen}
+                type="button"
+                className="plan-retry-btn"
+                onClick={() => onNavigate(target.screen)}
+              >
+                {target.label} →
+              </button>
+            ))}
+            <button type="button" className="plan-retry-btn" onClick={loadPlanData}>
+              🔄 Retry
+            </button>
+          </div>
         </div>
       ) : activePlan && viewMode === 'imported' ? (
         <div className="plan-active-content">

--- a/app/src/components/errorRepairAction.ts
+++ b/app/src/components/errorRepairAction.ts
@@ -1,0 +1,9 @@
+import type { Screen } from '../types/navigation';
+
+/** An actionable next step surfaced on a load-error screen: either a specific screen that
+ * owns the flagged document (re-saving there re-runs validation), or a forced Garmin
+ * resync (re-ingesting overwrites a malformed recovery snapshot). Shared between Home and
+ * PlanView, which hit the same decision-input/recovery-snapshot failure modes. */
+export type ErrorRepairAction =
+    | { kind: 'navigate'; screen: Screen; label: string }
+    | { kind: 'resync' };


### PR DESCRIPTION
## Summary

- `Home` and `PlanView` both show "Decision inputs need repair before generating a plan." whenever `composeDailyDecisionInput` reports an `INVALID` `activeGoals`, `preferences`, or `trainingSettings` source (a stored document that fails schema validation) — but the error state was a dead end: just the generic message and a Retry button, with no indication of which document was flagged or how to fix it.
- Both components now check `sourceStates.{activeGoals,preferences,trainingSettings}` on an `INVALID` decision-source failure and render a "Review goals" / "Review preferences" / "Review training settings" button that navigates straight to the screen owning the flagged document. Re-saving there re-runs validation and clears the `INVALID` state.
- User impact: a user who previously hit a dead-end error page now gets a direct path to fix the specific stored document causing the failure.

## Validation

Results:
- `cd app && npm run check` (typecheck, lint, full test suite, workout catalog validation): pass — 204 test files / 2091 tests passed, 0 lint errors (2 pre-existing unrelated warnings), 175 exercises / 37 workouts / 16 parameter binding sets / 25 authored session families validated.
- [x] `cd app && npm run check` (frontend changes)
- [ ] `uv run pytest` (backend changes) — not applicable, no backend changes
- [ ] `uv run ruff check .` and `uv run mypy src/garmin_sync` (backend changes) — not applicable, no backend changes
- [ ] `cd app && npm run test:rules` (Firestore rules changes) — not applicable, no rules changes
- [ ] `cd app && npm run simulate:scenarios` (recommendation-engine changes) — not applicable, no recommendation-engine logic changed
- [ ] `cd app && npm run visual:refresh` (material UI changes) — manual check only (see below); harness has no browser to run the visual-review script against a live deploy

## Risk and reviewer guidance

Low risk: purely additive UI on an existing error path — no changes to `composeDailyDecisionInput`, validation logic, or decision/recommendation computation. The new buttons only render when `errorRepairTargets`/`forecastRepairTargets` is non-empty (i.e. only on an `INVALID` source), so the existing generic-message + Retry behavior for `UNAVAILABLE` sources is unchanged. `PlanView`'s `onNavigate` prop is optional, so the new buttons there are additionally guarded on it being present.

## Domain invariants

Not applicable — this change only adds navigation buttons to an existing error state; it does not touch Firestore paths, date/timezone logic, credentials, or recommendation decision logic (`POLICY_VERSION` unchanged).

## Screenshots or recordings

Not applicable — no running browser/deploy available in this session to capture before/after screenshots. The change adds a "Review goals"/"Review preferences"/"Review training settings" button (styled consistently with the existing Retry button) beneath the existing error message in `Home`'s `.error-state` and `PlanView`'s `.plan-unavailable-card`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9BbvcTuwcrrHb1wGRjL7D)_