### PR TITLE
test: harden the whole-app AST-scan architecture guards against CI flakiness

### DIFF
--- a/app/src/engine/externalArchitecture.test.ts
+++ b/app/src/engine/externalArchitecture.test.ts
@@ -24,7 +24,11 @@ function parse(absolutePath: string): ts.SourceFile {
         fileName,
         readFileSync(absolutePath, 'utf8'),
         ts.ScriptTarget.Latest,
-        true,
+        // setParentNodes=false: this file's traversal never reads node.parent, so skip the
+        // extra pass the parser would otherwise spend wiring parent pointers up -- this
+        // parses the whole app source tree synchronously, twice (once per describe block
+        // below), on every run.
+        false,
         fileName.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
     );
 }

--- a/app/src/engine/planningModeArchitecture.test.ts
+++ b/app/src/engine/planningModeArchitecture.test.ts
@@ -64,7 +64,10 @@ function planningModeLiterals(): Set<string> {
         'models.ts',
         readFileSync(modelsPath, 'utf8'),
         ts.ScriptTarget.Latest,
-        true,
+        // setParentNodes=false: the traversal below is purely top-down (forEachChild) and
+        // never reads node.parent, so skip the extra pass the parser would otherwise spend
+        // wiring parent pointers up.
+        false,
         ts.ScriptKind.TS,
     );
     const modes = new Set<string>();
@@ -113,6 +116,13 @@ function lineOf(source: ts.SourceFile, node: ts.Node): number {
 }
 
 describe('planning-mode architecture authority', () => {
+    // This test synchronously parses the whole app source tree (270+ files) with the
+    // TypeScript compiler on every run -- the single heaviest CPU-bound unit test in the
+    // suite. The default 5s timeout is measured to be comfortable in isolation, but this
+    // is exactly the kind of synchronous parsing work that suffers most from a busy CI
+    // runner (many workers contending for a couple of vCPUs, made worse by coverage
+    // instrumentation on every concurrently-running test). A generous fixed budget keeps
+    // this from flaking under load while still catching a genuine hang or infinite loop.
     it('keeps effective planning-mode derivation inside planningMode.ts, across the whole app', () => {
         const violations: string[] = [];
         const modeLiterals = planningModeLiterals();
@@ -124,8 +134,12 @@ describe('planning-mode architecture authority', () => {
             // disables JSX parsing, so every expression inside a JSX attribute becomes
             // invisible to the traversal below -- which would make the whole reason this
             // scan was widened to components inert.
+            //
+            // setParentNodes=false (see planningModeLiterals above): this traversal never
+            // reads node.parent either, and skipping it measurably matters here -- this
+            // parses the entire app source tree synchronously, once per file, on every run.
             const source = ts.createSourceFile(
-                fileName, sourceText, ts.ScriptTarget.Latest, true,
+                fileName, sourceText, ts.ScriptTarget.Latest, false,
                 fileName.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
             );
 
@@ -174,5 +188,5 @@ describe('planning-mode architecture authority', () => {
             violations,
             'ADR-0017 requires planningMode.ts to be the sole authority that derives effective planning mode. Consume PlanningContext.mode downstream instead of re-deriving it.',
         ).toEqual([]);
-    });
+    }, 30_000);
 });

--- a/app/src/observations/architecture.test.ts
+++ b/app/src/observations/architecture.test.ts
@@ -53,7 +53,10 @@ function runtimeImportGraph(): Map<string, string[]> {
             fileName,
             readFileSync(absolutePath, 'utf8'),
             ts.ScriptTarget.Latest,
-            true,
+            // setParentNodes=false: this file's traversal never reads node.parent, so skip
+            // the extra pass the parser would otherwise spend wiring parent pointers up --
+            // this parses the whole app source tree synchronously on every run.
+            false,
             fileName.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
         );
         const edges: string[] = [];

--- a/app/src/outcomes/blockOutcomeArchitecture.test.ts
+++ b/app/src/outcomes/blockOutcomeArchitecture.test.ts
@@ -51,7 +51,10 @@ function runtimeImportGraph(): Map<string, string[]> {
             fileName,
             readFileSync(absolutePath, 'utf8'),
             ts.ScriptTarget.Latest,
-            true,
+            // setParentNodes=false: this file's traversal never reads node.parent, so skip
+            // the extra pass the parser would otherwise spend wiring parent pointers up --
+            // this parses the whole app source tree synchronously on every run.
+            false,
             fileName.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
         );
         const edges: string[] = [];

--- a/app/src/sessions/architecture.test.ts
+++ b/app/src/sessions/architecture.test.ts
@@ -24,7 +24,10 @@ function parse(absolutePath: string): ts.SourceFile {
         fileName,
         readFileSync(absolutePath, 'utf8'),
         ts.ScriptTarget.Latest,
-        true,
+        // setParentNodes=false: this file's traversal never reads node.parent, so skip the
+        // extra pass the parser would otherwise spend wiring parent pointers up -- this
+        // parses the whole app source tree synchronously on every run.
+        false,
         fileName.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
     );
 }


### PR DESCRIPTION
## Summary

- The production deploy pipeline (`Deploy Production E2E` run [32657455325](https://github.com/Szczepanov/adaptive-training-recommender/actions/runs/32657455325)) flaked on `planningModeArchitecture.test.ts`: `Test timed out in 5000ms`. That test lists every production `.ts`/`.tsx` file under `src/` and parses each with the TypeScript compiler — all inside one timed `it()` block. It clears the default 5s budget comfortably in isolation, but under V8 coverage instrumentation plus a busy CI runner sharing a couple of vCPUs across many concurrent workers, that margin isn't reliable. A re-run of the identical commit's failed job passed cleanly, confirming it as a flake rather than a real regression.
- Two fixes, applied together: (1) give the test a generous fixed timeout (30s) that comfortably survives CI contention while still catching a genuine hang, and (2) stop asking the TS parser to build parent pointers (`setParentNodes=true`) that this file's purely top-down traversal never reads — real, measurable parse cost across ~55k lines / 270+ files, for free.
- The same unnecessary `setParentNodes=true` was present in every sibling whole-source-tree architecture guard (`sessions/`, `outcomes/`, `observations/`, `engine/externalArchitecture.test.ts`), so it's fixed there too. Those four already build their import graph once at `describe`-body scope (collection time, not inside a timed `it()`), so they weren't at risk of this specific timeout — but the same unused-work waste applied equally.
- User impact: none directly — this is a CI-reliability fix. No test semantics changed.

## Validation

Results:
- `cd app && npm run check` (typecheck, lint, full test suite, workout catalog validation): pass — 204 test files / 2091 tests passed, 0 lint errors (2 pre-existing unrelated warnings), 175 exercises / 37 workouts / 16 parameter binding sets / 25 authored session families validated.
- `cd app && npx vitest run --coverage` (matches the exact CI step that flaked): pass — 204 test files / 2091 tests passed, coverage report generated successfully.
- [x] `cd app && npm run check` (frontend changes)
- [ ] `uv run pytest` (backend changes) — not applicable, no backend changes
- [ ] `uv run ruff check .` and `uv run mypy src/garmin_sync` (backend changes) — not applicable, no backend changes
- [ ] `cd app && npm run test:rules` (Firestore rules changes) — not applicable, no rules changes
- [ ] `cd app && npm run simulate:scenarios` (recommendation-engine changes) — not applicable, test-only changes to architecture guards
- [ ] `cd app && npm run visual:refresh` (material UI changes) — not applicable, no UI changes

## Risk and reviewer guidance

Very low risk: every change is inside `*.test.ts` files, either a `setParentNodes` parser flag (verified unused via `.parent` grep in each file, and the full suite still passes) or a per-test timeout bump. No production source, validation, or recommendation logic touched.

## Domain invariants

Not applicable — test-infrastructure-only change; no Firestore paths, date/timezone logic, credentials, or recommendation decision logic (`POLICY_VERSION` unchanged) are touched.

## Screenshots or recordings

Not applicable — no UI change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9BbvcTuwcrrHb1wGRjL7D)_