### PR TITLE
fix(preferences): stop rejecting real performanceProfile.targetSources documents

### DIFF
--- a/app/src/engine/validation.test.ts
+++ b/app/src/engine/validation.test.ts
@@ -15,6 +15,55 @@ describe('validatePreferences unavailable modalities', () => {
     });
 });
 
+describe('validatePreferences performanceProfile.targetSources', () => {
+    const valid = {
+        userId: 'u1', preferredRecoveryStyle: 'mixed', defaultWeekdayTimeMin: 45, defaultWeekendTimeMin: 60,
+        preferredTimeOfDay: 'flexible', preferredModalities: [], avoidedModalities: [],
+        explanationVerbosity: 'detailed', conservativeBias: false,
+        preferredUnits: { distance: 'km', weight: 'kg', temperature: 'celsius' },
+    };
+
+    it('accepts every key AthletePerformanceProfile.targetSources declares, not only the three FTP/pace/LTHR fields', () => {
+        // firestore_repository.py's upsert_garmin_performance_targets writes weightKg and
+        // bodyFatPct target sources on every Garmin body-composition sync -- a preferences
+        // document with those keys must not become permanently INVALID.
+        const result = validatePreferences({
+            ...valid,
+            performanceProfile: {
+                targetSources: { ftpWatts: 'garmin', weightKg: 'garmin', bodyFatPct: 'manual', cyclingLthr: 'garmin', runningLthr: 'manual' },
+            },
+        });
+        expect(result.isValid).toBe(true);
+    });
+
+    it("accepts a 'coach' source, which firestore_repository.py treats as protected alongside 'manual'", () => {
+        const result = validatePreferences({
+            ...valid,
+            performanceProfile: { targetSources: { ftpWatts: 'coach' } },
+        });
+        expect(result.isValid).toBe(true);
+    });
+
+    it('accepts a derived source, matching the shared TargetSource union', () => {
+        const result = validatePreferences({
+            ...valid,
+            performanceProfile: { targetSources: { lthrBpm: 'derived' } },
+        });
+        expect(result.isValid).toBe(true);
+    });
+
+    it('still rejects an unrecognized key or value', () => {
+        expect(validatePreferences({
+            ...valid,
+            performanceProfile: { targetSources: { notARealTarget: 'garmin' } },
+        }).isValid).toBe(false);
+        expect(validatePreferences({
+            ...valid,
+            performanceProfile: { targetSources: { ftpWatts: 'estimated' } },
+        }).isValid).toBe(false);
+    });
+});
+
 describe('isValidDate', () => {
     it('rejects impossible calendar dates rather than normalizing them', () => {
         expect(isValidDate('2026-02-30')).toBe(false);

--- a/app/src/engine/validationCore.ts
+++ b/app/src/engine/validationCore.ts
@@ -862,8 +862,15 @@ export function validatePreferences(raw: any): ValidationResult<UserPreferences>
             if (raw.performanceProfile.targetSources !== undefined &&
                 (typeof raw.performanceProfile.targetSources !== 'object' || raw.performanceProfile.targetSources === null ||
                  !Object.entries(raw.performanceProfile.targetSources).every(([key, value]) =>
-                    ['ftpWatts', 'thresholdPaceSecPerKm', 'lthrBpm'].includes(key) && (value === 'garmin' || value === 'manual')))) {
-                errors.push({ field: 'performanceProfile.targetSources', message: 'Target sources must be manual or garmin for a supported target' });
+                    // Keys and values must match AthletePerformanceProfile.targetSources / TargetSource
+                    // (workouts/models.ts) exactly -- this previously allowed only
+                    // ftpWatts/thresholdPaceSecPerKm/lthrBpm with garmin/manual, which rejected
+                    // every real document as soon as the Garmin weight/body-composition sync
+                    // (firestore_repository.py upsert_garmin_performance_targets) started writing
+                    // weightKg/bodyFatPct keys, or a coach-assigned target's 'coach' source.
+                    ['ftpWatts', 'thresholdPaceSecPerKm', 'lthrBpm', 'cyclingLthr', 'runningLthr', 'weightKg', 'bodyFatPct'].includes(key)
+                    && ['garmin', 'manual', 'coach', 'derived'].includes(value as string)))) {
+                errors.push({ field: 'performanceProfile.targetSources', message: 'Target sources must be garmin, manual, coach or derived for a supported target' });
             }
             if (raw.performanceProfile.garmin !== undefined) {
                 const garmin = raw.performanceProfile.garmin;


### PR DESCRIPTION
## Summary

- Root cause of the `Validation failed: performanceProfile.targetSources: Target sources must be manual or garmin for a supported target` error: `validatePreferences`'s inline check for `performanceProfile.targetSources` only accepted the keys `ftpWatts`/`thresholdPaceSecPerKm`/`lthrBpm` with values `garmin`/`manual` — narrower than `AthletePerformanceProfile.targetSources` itself (`workouts/models.ts`), which types the keys as also including `cyclingLthr`/`runningLthr`/`weightKg`/`bodyFatPct` and the values as the full `TargetSource` union (`garmin`/`manual`/`coach`/`derived`).
- `firestore_repository.py`'s `upsert_garmin_performance_targets` writes a `weightKg` and `bodyFatPct` target source on every Garmin body-composition sync, and treats `'coach'` as a protected source alongside `'manual'`. Any document with either — i.e. anyone syncing Garmin weight/body-fat data, or anyone with a coach-assigned target — became permanently `INVALID`.
- Because `upsertPreferences` merges the existing (unvalidated-read) `performanceProfile` back into whatever gets saved, re-saving through the Preferences screen hit the exact same validation failure — so the "Review preferences" repair button added in #204 couldn't actually fix this specific case; the fix has to be in the validator itself.
- Widened the check to accept every key/value the type declares, and added regression coverage for the `weightKg`/`bodyFatPct` keys, the `'coach'` and `'derived'` values, plus confirmation that an actually-unrecognized key/value is still rejected.
- User impact: a user whose preferences document has a Garmin-synced weight/body-fat target or a coach-assigned target no longer gets stuck behind a validation error they cannot self-repair.

## Validation

Results:
- `cd app && npm run check` (typecheck, lint, full test suite, workout catalog validation): pass — 204 test files / 2095 tests passed (4 new regression tests), 0 lint errors (2 pre-existing unrelated warnings).
- [x] `cd app && npm run check` (frontend changes)
- [ ] `uv run pytest` (backend changes) — not applicable, no backend changes (the Python writer's existing behavior is what the frontend validator is being brought in line with; not modified here)
- [ ] `uv run ruff check .` and `uv run mypy src/garmin_sync` (backend changes) — not applicable, no backend changes
- [ ] `cd app && npm run test:rules` (Firestore rules changes) — not applicable, no rules changes
- [ ] `cd app && npm run simulate:scenarios` (recommendation-engine changes) — not applicable, preferences validation only
- [ ] `cd app && npm run visual:refresh` (material UI changes) — not applicable, no UI changes

## Risk and reviewer guidance

Low risk, but worth a close read: this widens what `validatePreferences` accepts, which is a validation *loosening*. The new key/value set is not arbitrary — it's copied exactly from the authoritative `AthletePerformanceProfile.targetSources` field type and the `TargetSource` union in `workouts/models.ts`, so this brings the validator in line with the type it's meant to enforce rather than introducing new tolerance. An unrecognized key or value is still rejected (covered by the added test).

## Domain invariants

- [x] No Firestore write-path or user-scoping change — validation-only.
- Not applicable — no calendar-date logic touched.
- [x] No credentials, tokens, service-account files, or raw health payloads included.
- Not applicable — no recommendation decision logic touched (`POLICY_VERSION` unchanged); this is a preferences-document schema validator.

## Screenshots or recordings

Not applicable — no UI change; the effect is that preferences saves that previously failed validation now succeed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9BbvcTuwcrrHb1wGRjL7D)_