### PR TITLE
✍️ Scribe: [documentation improvement]

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,17 +260,15 @@ docker build -t gcr.io/YOUR_GCP_PROJECT/garmin-sync:latest .
 docker push gcr.io/YOUR_GCP_PROJECT/garmin-sync:latest
 ```
 
-### 2. Cloud Run Job Configuration
+### 2. Cloud Run Configuration
 
-Create a Cloud Run Job executing `python -m garmin_sync sync`:
+Create a Cloud Run Job executing `python -m garmin_sync sync-all` (and refer to `docs/ops/cloud-run-deployment.md` for deploying the multi-user linking API and the other scheduled jobs):
 * Tasks: 1
 * Service Account: Minimum Firestore Write + GCS Token/Archive Object Read/Write permissions
 * Environment variables:
-  * `APP_USER_ID`: `<YOUR_FIREBASE_UID>`
   * `APP_TIMEZONE`: `Europe/Warsaw`
   * `GARMIN_TOKEN_STORE`: `gcs`
   * `GARMIN_TOKEN_BUCKET`: `<YOUR_PRIVATE_TOKEN_BUCKET>`
-  * `GARMIN_TOKEN_OBJECT`: `garmin/garmin_tokens.json`
   * `GARMIN_ALLOW_CREDENTIAL_LOGIN`: `false` (token-only; Cloud Run can't complete interactive MFA)
   * Optional: `GARMIN_ARCHIVE_ENABLED`: `true`, `GARMIN_ARCHIVE_STORE`: `gcs` (reuses `GARMIN_TOKEN_BUCKET` unless `GARMIN_ARCHIVE_BUCKET` is set)
 * Secret Manager injections for `GARMIN_EMAIL` and `GARMIN_PASSWORD` (used only for the local/interactive bootstrap flow, not required by the Cloud Run job itself when token-only).

--- a/docs/README.md
+++ b/docs/README.md
@@ -153,7 +153,7 @@ In-depth technical design documents covering system subsystems:
 ### 🛠️ Operations & Guides
 Operational manuals and operational procedures:
 
-* [**GCP Cloud Run & Cloud Scheduler Deployment**](./ops/cloud-run-deployment.md) — Packaging Docker images, GCS token store management, Cloud Run jobs, and Cloud Scheduler setups.
+* [**GCP Cloud Run & Cloud Scheduler Deployment**](./ops/cloud-run-deployment.md) — Packaging Docker images, GCS token store management, Cloud Run services and jobs, and Cloud Scheduler setups.
 * [**Data Backfill, Audit & Offline Rebuild**](./ops/data-backfill-and-rebuild.md) — Executing historical backfills, data completeness audits, and offline raw payload rebuilds.
 * [**Firestore Rules Deployment**](./ops/firestore-rules-deployment.md) — Local repository-owned deployment, deployed-source drift checks, and ruleset rollback.
 * [**Frontend, Firestore Rules & Indexes Deployment**](./ops/frontend-deployment.md) — Manual and automated procedures for Firebase Hosting, Security Rules, and Firestore Index deployment.

--- a/docs/ops/cloud-run-deployment.md
+++ b/docs/ops/cloud-run-deployment.md
@@ -1,22 +1,21 @@
 # GCP Cloud Run & Cloud Scheduler Deployment Guide
 
-This guide containerizes the Python Garmin ingestion/sync package and schedules three
-recurring jobs on Google Cloud Platform (GCP):
+This guide containerizes the Python Garmin ingestion/sync package and deploys a self-service HTTP API and three scheduled jobs on Google Cloud Platform (GCP):
 
-* **`garmin-sync`** -- recovery-metrics ingestion (`python -m garmin_sync sync`),
+* **`garmin-account-link`** -- self-service HTTP service used by the web app to establish per-user Garmin tokens (`python -m garmin_sync.account_link_api`)
+* **`garmin-sync`** -- multi-user recovery-metrics ingestion (`python -m garmin_sync sync-all`),
   polled every 15 min through a morning wake window rather than run once at a
   fixed time (see step 6) -- most ticks are a free Firestore freshness check,
   not a Garmin call
 * **`garmin-push-pending-workouts`** -- polls the Firestore workout queue every few
   minutes and pushes anything queued by "Sync to Garmin" in the web app
-  (`python -m garmin_sync push-pending-workouts`)
+  (`python -m garmin_sync push-pending-workouts-all`)
 * **`garmin-manual-sync`** -- polls for a "Sync Now" request queued by the web app's
   Garmin Sync Now button (e.g. because the athlete is up before the morning poll
   window) and runs an immediate forced sync if one is pending
-  (`python -m garmin_sync poll-manual-sync`)
+  (`python -m garmin_sync poll-manual-sync-all`)
 
-All three share one container image and one runtime service account; only their
-`--args` differ. Run the sections below in order.
+All four share one container image and one runtime service account. Run the sections below in order.
 
 **No local machine?** See [Deploying from GitHub Actions](#deploying-from-github-actions-no-local-machine)
 below instead -- it runs this same sequence as two `workflow_dispatch` workflows you trigger
@@ -133,18 +132,32 @@ It prompts for an MFA code interactively if your Garmin account has 2FA enabled.
 
 ---
 
-## 5. Create the three Cloud Run Jobs
+## 5. Create the Cloud Run services and jobs
 
 Copy `docs/ops/cloud-run-job.env.yaml.example` to `cloud-run-job.env.yaml`
-(gitignored) and fill in `APP_USER_ID` (your Firebase Auth UID),
-`GARMIN_TOKEN_BUCKET` (`${GCP_PROJECT}-garmin-tokens`), and `GCP_PROJECT_ID`.
+(gitignored) and fill in `GARMIN_TOKEN_BUCKET` (`${GCP_PROJECT}-garmin-tokens`) and `GCP_PROJECT_ID`.
+
+```bash
+# Garmin's interactive MFA continuation requires the same in-memory client/session.
+# max-instances=1 intentionally preserves that invariant without persisting a password
+# or SSO session. If the instance restarts, the short-lived challenge simply expires
+# and the user restarts login.
+gcloud run deploy garmin-account-link \
+  --image=${IMAGE_TAG} --region=${REGION} \
+  --service-account=${JOB_SA_EMAIL} \
+  --env-vars-file=cloud-run-job.env.yaml \
+  --command=python --args=-m,garmin_sync.account_link_api \
+  --port=8080 --timeout=300 --concurrency=10 \
+  --min-instances=0 --max-instances=1 \
+  --allow-unauthenticated
+```
 
 ```bash
 gcloud run jobs create garmin-sync \
   --image=${IMAGE_TAG} --region=${REGION} \
   --service-account=${JOB_SA_EMAIL} \
   --env-vars-file=cloud-run-job.env.yaml \
-  --args=sync \
+  --args=sync-all \
   --max-retries=0
 ```
 
@@ -153,7 +166,7 @@ gcloud run jobs create garmin-push-pending-workouts \
   --image=${IMAGE_TAG} --region=${REGION} \
   --service-account=${JOB_SA_EMAIL} \
   --env-vars-file=cloud-run-job.env.yaml \
-  --args=push-pending-workouts \
+  --args=push-pending-workouts-all \
   --max-retries=0
 ```
 
@@ -162,7 +175,7 @@ gcloud run jobs create garmin-manual-sync \
   --image=${IMAGE_TAG} --region=${REGION} \
   --service-account=${JOB_SA_EMAIL} \
   --env-vars-file=cloud-run-job.env.yaml \
-  --args=poll-manual-sync \
+  --args=poll-manual-sync-all \
   --max-retries=0
 ```
 


### PR DESCRIPTION
* **📄 What:** Updated `docs/ops/cloud-run-deployment.md` and `README.md` to reflect the multi-user architecture and the newly added `garmin-account-link` Cloud Run service.
* **⚠️ Problem:** The deployment documentation (and `README.md` configuration section) instructed users to configure `APP_USER_ID`, omitted the `garmin-account-link` service, and documented the single-user python execution commands (e.g., `sync`). These instructions were stale, contradicted the `.github/workflows/deploy-garmin-sync.yml` automation, and omitted the changes introduced in `docs/ops/multi-user-family-setup.md`.
* **📚 Source of truth:** `.github/workflows/deploy-garmin-sync.yml`, `docs/ops/multi-user-family-setup.md`, `src/garmin_sync/cli.py`
* **✅ Verification:** `make check` ran successfully. Inspected the output of the workflow files and CLI commands.
* **🎯 Impact:** Ensures that users or future maintainers are provided with correct instructions to deploy the application for multi-user capabilities, aligning documentation with current configuration defaults and multi-tenant constraints.
* **🔒 Governance:** Governance preserved. The changes accurately reflect current deployment mechanisms without introducing changes to policy, scope, privacy, or limit constraints.

---
*PR created automatically by Jules for task [3520206960873912602](https://jules.google.com/task/3520206960873912602) started by @Szczepanov*