### PR TITLE
⚡ Bolt: Optimize exercise lookups with O(1) Map

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,15 +1,3 @@
-## 2025-02-12 - [Redundant array filtering in React renders]
-**Learning:** React components containing inline `.filter()` calls on arrays inside render methods (like `activeSettings.filter(s => s.kind === 'guardrail')`) can be optimized by extracting the filtered result into a `useMemo` hook, avoiding O(N) redundant operations on every render, especially when the filtered result is used multiple times.
-**Action:** Always memoize derived array computations (like filtering and mapping) that rely on props or state, especially if they are used more than once in the JSX.
-
-## 2024-05-18 - Use Map for O(1) template lookup by ID
-**Learning:** Creating a Map for template lookups by ID avoids repeated O(N) array scans for the 655 templates in `ENRICHED_TEMPLATES`. Using `.find(t => t.id === ...)` on a 655-element array is an anti-pattern when it's done repeatedly inside loops or frequently called engine functions like `enrichedCostProfile`. A simple dictionary/Map speeds up lookups by 40x.
-**Action:** When performing repeated lookups by ID in static data like templates or workouts, always build a Map on initialization and use `.get()` rather than iterating arrays.
-
-## 2024-05-18 - [N+1 Firestore Writes in _archive_activities]
-**Learning:** Looping over records to write documents sequentially to Firestore using individual network requests causes severe N+1 latency problems.
-**Action:** Use Firestore batched writes (`db.batch()`) combined with chunking (max 500 documents per batch) when writing multiple documents to greatly reduce network latency. Always update mock tests properly, as batched methods take `call_args` as single large data structures.
-
-## 2024-05-18 - Concurrent Fetching for Garmin API during Backfill
-**Learning:** Sequential API calls within loops (like `fetch_detail(activity.activity_id)` over many activities) create substantial bottlenecks, especially in historical data backfills. Using `concurrent.futures.ThreadPoolExecutor` along with `as_completed` allows concurrent processing while avoiding shared state issues by collecting results in the main thread loop.
-**Action:** When implementing any data backfill logic hitting external APIs in the Python backend, default to `concurrent.futures.ThreadPoolExecutor` if the rate limits allow it. Always make sure to properly cancel futures when a `GarminConnectTooManyRequestsError` or equivalent is encountered to avoid further requests when limits are already hit.
+## $(date +%Y-%m-%d) - Optimize Exercise Catalog Lookups
+**Learning:** React components and engine functions were scanning the `EXERCISES` catalog (a large array) using `.find()` inside `map` and loops (`O(N)` per lookup), creating `O(M*N)` performance bottlenecks on heavily rendered or iterated paths.
+**Action:** Replace all `.find()` calls on static datasets like `EXERCISES` with `EXERCISES_BY_ID.get()` (an `O(1)` Map lookup) across all components and engine files.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,19 @@
-## $(date +%Y-%m-%d) - Optimize Exercise Catalog Lookups
-**Learning:** React components and engine functions were scanning the `EXERCISES` catalog (a large array) using `.find()` inside `map` and loops (`O(N)` per lookup), creating `O(M*N)` performance bottlenecks on heavily rendered or iterated paths.
-**Action:** Replace all `.find()` calls on static datasets like `EXERCISES` with `EXERCISES_BY_ID.get()` (an `O(1)` Map lookup) across all components and engine files.
+## 2025-02-12 - [Redundant array filtering in React renders]
+**Learning:** React components containing inline `.filter()` calls on arrays inside render methods (like `activeSettings.filter(s => s.kind === 'guardrail')`) can be optimized by extracting the filtered result into a `useMemo` hook, avoiding O(N) redundant operations on every render, especially when the filtered result is used multiple times.
+**Action:** Always memoize derived array computations (like filtering and mapping) that rely on props or state, especially if they are used more than once in the JSX.
+
+## 2024-05-18 - Use Map for O(1) template lookup by ID
+**Learning:** Creating a Map for template lookups by ID avoids repeated O(N) array scans for the 655 templates in `ENRICHED_TEMPLATES`. Using `.find(t => t.id === ...)` on a 655-element array is an anti-pattern when it's done repeatedly inside loops or frequently called engine functions like `enrichedCostProfile`. A simple dictionary/Map speeds up lookups by 40x.
+**Action:** When performing repeated lookups by ID in static data like templates or workouts, always build a Map on initialization and use `.get()` rather than iterating arrays.
+
+## 2024-05-18 - [N+1 Firestore Writes in _archive_activities]
+**Learning:** Looping over records to write documents sequentially to Firestore using individual network requests causes severe N+1 latency problems.
+**Action:** Use Firestore batched writes (`db.batch()`) combined with chunking (max 500 documents per batch) when writing multiple documents to greatly reduce network latency. Always update mock tests properly, as batched methods take `call_args` as single large data structures.
+
+## 2024-05-18 - Concurrent Fetching for Garmin API during Backfill
+**Learning:** Sequential API calls within loops (like `fetch_detail(activity.activity_id)` over many activities) create substantial bottlenecks, especially in historical data backfills. Using `concurrent.futures.ThreadPoolExecutor` along with `as_completed` allows concurrent processing while avoiding shared state issues by collecting results in the main thread loop.
+**Action:** When implementing any data backfill logic hitting external APIs in the Python backend, default to `concurrent.futures.ThreadPoolExecutor` if the rate limits allow it. Always make sure to properly cancel futures when a `GarminConnectTooManyRequestsError` or equivalent is encountered to avoid further requests when limits are already hit.
+
+## 2026-08-24 - Optimize Exercise Catalog Lookups
+**Learning:** React components and engine functions were scanning the canonical `EXERCISES` catalog with `.find()` in repeated lookup paths even though `exercises.ts` already exports `EXERCISES_BY_ID` for constant-time identity resolution.
+**Action:** Reuse the canonical `EXERCISES_BY_ID` map for repeated exercise-ID lookups; do not introduce a second exercise map or duplicate catalog index.

--- a/app/src/components/DailyCheckin.tsx
+++ b/app/src/components/DailyCheckin.tsx
@@ -4,7 +4,7 @@ import { recoverySnapshotService } from '../services/recoverySnapshotService';
 import { sessionExecutionService } from '../services/sessionExecutionService';
 import { sessionResponseService } from '../services/sessionResponseService';
 import { relevantFollowupRegions } from '../responses/followupSchedule';
-import { EXERCISES } from '../workouts/exercises';
+import { EXERCISES_BY_ID } from '../workouts/exercises';
 import type { BodyRegion, DailySubjectiveCheckin, RegionTissueResponse, TissueResponseLevel } from '../engine/models';
 import type { HealthContextCheckin } from '../engine/healthAnomalyModels';
 import { BODY_REGIONS, TISSUE_LEVELS } from '../engine/models';
@@ -170,7 +170,7 @@ export function DailyCheckin({ userId, onNavigate, onBack, onCheckinSaved }: Dai
               if (entry.exerciseRef?.kind === 'catalog') exerciseIds.push(entry.exerciseRef.exerciseId);
             }
             const facets = exerciseIds
-              .map(id => EXERCISES.find(item => item.id === id)?.facets)
+              .map(id => EXERCISES_BY_ID.get(id)?.facets)
               .filter((facet): facet is NonNullable<typeof facet> => !!facet);
             const sessionRef: RegionTissueResponse['sourceSessionRef'] = { kind: 'execution', id: execution.executionId, date: execution.date };
             const sessionKey = `execution:${execution.executionId}`;

--- a/app/src/components/Home.tsx
+++ b/app/src/components/Home.tsx
@@ -34,7 +34,7 @@ import { checkinService } from '../services/checkinService';
 import { sessionExecutionService } from '../services/sessionExecutionService';
 import { sessionResponseService } from '../services/sessionResponseService';
 import { relevantFollowupRegions } from '../responses/followupSchedule';
-import { EXERCISES } from '../workouts/exercises';
+import { EXERCISES_BY_ID } from '../workouts/exercises';
 import { ExternalVerdictBanner } from './ExternalVerdictBanner';
 import { WorkoutExportMenu } from './WorkoutExportMenu';
 import { AdherencePrompt, type AdherenceAnswer } from './AdherencePrompt';
@@ -269,7 +269,7 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
             if (entry.exerciseRef?.kind === 'catalog') exerciseIds.push(entry.exerciseRef.exerciseId);
           }
           const facets = exerciseIds
-            .map(id => EXERCISES.find(item => item.id === id)?.facets)
+            .map(id => EXERCISES_BY_ID.get(id)?.facets)
             .filter((facet): facet is NonNullable<typeof facet> => !!facet);
           if (relevantFollowupRegions(facets).length === 0) continue;
 

--- a/app/src/components/session/ManualSessionBuilder.tsx
+++ b/app/src/components/session/ManualSessionBuilder.tsx
@@ -372,7 +372,7 @@ export const ManualSessionBuilder: React.FC<ManualSessionBuilderProps> = ({ user
                                                     return <div key={alt.id} className="builder-alternative-row">
                                                         <input value={alt.title} onChange={event => updateAlternative(blockIndex, stepIndex, alt.id, altExercise === '__custom__' ? undefined : altExercise, event.target.value)} aria-label="Alternative title" />
                                                         <select value={altExercise} onChange={event => {
-                                                            const exercise = EXERCISES.find(item => item.id === event.target.value);
+                                                            const exercise = EXERCISES_BY_ID.get(event.target.value);
                                                             updateAlternative(blockIndex, stepIndex, alt.id, exercise?.id, exercise?.name ?? alt.title);
                                                         }} aria-label="Alternative movement"><option value="__custom__">Custom / free text</option>{EXERCISES.map(exercise => <option key={exercise.id} value={exercise.id}>{exercise.name}</option>)}</select>
                                                         <button type="button" onClick={() => removeAlternative(blockIndex, stepIndex, alt.id)} aria-label="Remove alternative">Remove</button>

--- a/app/src/components/session/SessionDefinitionPreview.tsx
+++ b/app/src/components/session/SessionDefinitionPreview.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { RangeOrNumber, SessionChoiceAction, SessionDefinition, SessionStep } from '../../sessions/models';
-import { EXERCISES } from '../../workouts/exercises';
+import { EXERCISES_BY_ID } from '../../workouts/exercises';
 import './SessionDefinitionPreview.css';
 
 interface SessionDefinitionPreviewProps {
@@ -17,7 +17,7 @@ function stepName(step: SessionStep): string {
     if (step.title) return step.title;
     if (step.exerciseRef?.kind === 'catalog') {
         const id = step.exerciseRef.exerciseId;
-        const found = EXERCISES.find(e => e.id === id);
+        const found = EXERCISES_BY_ID.get(id);
         return found ? found.name : id;
     }
     if (step.exerciseRef?.kind === 'unresolved_free_text') return step.exerciseRef.name;
@@ -82,7 +82,7 @@ export const SessionDefinitionPreview: React.FC<SessionDefinitionPreviewProps> =
                                 const isUnresolved = step.exerciseRef?.kind === 'unresolved_free_text';
                                 const ref = step.exerciseRef;
                                 const catalogItem = ref?.kind === 'catalog'
-                                    ? EXERCISES.find(e => e.id === ref.exerciseId)
+                                    ? EXERCISES_BY_ID.get(ref.exerciseId)
                                     : undefined;
                                 return <li key={step.id ?? sIdx} className="preview-step-item">
                                     <div className="step-main">

--- a/app/src/engine/sessionChoiceEligibility.ts
+++ b/app/src/engine/sessionChoiceEligibility.ts
@@ -18,7 +18,7 @@
 import type { SessionDefinition, SessionStep } from '../sessions/models';
 import type { SessionTemplate } from './models';
 import type { WorkoutModality } from '../workouts/models';
-import { EXERCISES } from '../workouts/exercises';
+import { EXERCISES_BY_ID } from '../workouts/exercises';
 
 /**
  * `resolveInjuryRestrictions` (engine/injuryPolicy.ts) works in the engine-level,
@@ -67,7 +67,7 @@ export function ineligibleAlternativeOptionIds(
                     const alternative = step?.alternatives?.find(candidate => candidate.id === action.alternativeId);
                     const exerciseRef = alternative?.exerciseRef;
                     if (!exerciseRef || exerciseRef.kind !== 'catalog') return false;
-                    const exercise = EXERCISES.find(candidate => candidate.id === exerciseRef.exerciseId);
+                    const exercise = EXERCISES_BY_ID.get(exerciseRef.exerciseId);
                     if (!exercise) return false;
                     const templateModality = WORKOUT_TO_TEMPLATE_MODALITY[exercise.modality];
                     return templateModality !== null && restricted.has(templateModality);

--- a/app/src/workouts/exercisesMap.ts
+++ b/app/src/workouts/exercisesMap.ts
@@ -1,0 +1,5 @@
+import { EXERCISES, type ExerciseIdentity } from './exercises';
+
+export const EXERCISES_MAP: Map<string, ExerciseIdentity> = new Map(
+  EXERCISES.map(exercise => [exercise.id, exercise])
+);

--- a/app/src/workouts/exercisesMap.ts
+++ b/app/src/workouts/exercisesMap.ts
@@ -1,5 +1,0 @@
-import { EXERCISES, type ExerciseIdentity } from './exercises';
-
-export const EXERCISES_MAP: Map<string, ExerciseIdentity> = new Map(
-  EXERCISES.map(exercise => [exercise.id, exercise])
-);


### PR DESCRIPTION
**💡 What**: Replaces repeated `EXERCISES.find(...)` identity lookups in UI and engine paths with the repository's existing canonical `EXERCISES_BY_ID.get()` map.

**🎯 Why**: `EXERCISES.find(...)` scans the catalog for every lookup. In loops/render paths this can become O(M×N); the existing map makes identity resolution O(1) per lookup without changing exercise semantics.

**📍 Scope**:
- `Home.tsx`
- `DailyCheckin.tsx`
- `ManualSessionBuilder.tsx`
- `SessionDefinitionPreview.tsx`
- `sessionChoiceEligibility.ts`

**🔧 Review fix**: Removed a redundant `exercisesMap.ts` introduced by the generated change (it duplicated the canonical map and failed TypeScript because it referenced a nonexistent `ExerciseIdentity` export). Restored the existing `.jules/bolt.md` history and appended the new learning instead of overwriting it.

**✅ Validation**: The original CI failure was isolated to the redundant `exercisesMap.ts` TypeScript error. No behavioral contracts are changed by the remaining diff; the lookup source changes from array scan to the existing map.

---
*PR created automatically by Jules for task [17318677711225152337](https://jules.google.com/task/17318677711225152337) started by @Szczepanov*