### PR TITLE
Enforce 72h spacing before peak cycling race simulations

### DIFF
--- a/app/src/engine/policy.ts
+++ b/app/src/engine/policy.ts
@@ -1,10 +1,11 @@
 /** Increment whenever a change can alter a persisted recommendation decision. (Refactoring does not require a bump) */
-export const POLICY_VERSION = '2026-08-respiration-strain-v1';
+export const POLICY_VERSION = '2026-08-race-recovery-spacing-v1';
 
 /** Historical versions are intentionally not re-executed by this build. Their compact
  * audits remain readable evidence, but replay is rejected explicitly because the old
  * decision function is not bundled alongside the current policy. */
 export const HISTORICAL_POLICY_VERSIONS = [
+    '2026-08-respiration-strain-v1',
     '2026-08-external-plan-v2-v2',
     '2026-08-external-plan-v2-v1',
     '2026-08-authored-session-authority-v3',

--- a/app/src/engine/raceRecoverySpacing.test.ts
+++ b/app/src/engine/raceRecoverySpacing.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import type { FatigueState, UserPreferences } from './models';
+import { rankCandidates, type RecentHistoryEntry } from './optimizer';
+import { resolveMinimumDaysAfterHardLowerBody } from './planningCandidate';
+import type { ResolvedAvailability } from './schedule';
+import { ENRICHED_TEMPLATES } from './templates';
+
+const ZERO_FATIGUE: FatigueState = {
+    lastUpdatedDate: '2026-08-23',
+    externalLoadFatigue: { systemic: 0, cardiovascular: 0, lowerBody: 0, upperBody: 0, impactTissue: 0, neuromuscular: 0 },
+    internalResponseStrain: { systemic: 0, cardiovascular: 0, lowerBody: 0, upperBody: 0, impactTissue: 0, neuromuscular: 0 },
+    combinedFatigue: { systemic: 0, cardiovascular: 0, lowerBody: 0, upperBody: 0, impactTissue: 0, neuromuscular: 0 },
+};
+
+const AVAILABILITY: ResolvedAvailability = {
+    date: '2026-08-25',
+    maxTimeMinutes: 120,
+    availableEquipment: ['free_weights', 'indoor_bike', 'treadmill', 'cable_machine'],
+    fixedActivities: [],
+    reservedCapacityCost: 0,
+    reservedCapacityCostProfile: { systemic: 0, cardiovascular: 0, lowerBody: 0, upperBody: 0, impactTissue: 0, neuromuscular: 0 },
+    environmentOverride: null,
+};
+
+const PREFERENCES: UserPreferences = {
+    userId: 'recovery-spacing-test',
+    avoidedModalities: [],
+    deprioritizedModalities: [],
+    preferredModalities: [],
+    conservativeBias: false,
+    preferredRecoveryStyle: 'mixed',
+    defaultWeekdayTimeMin: 60,
+    defaultWeekendTimeMin: 90,
+    preferredTimeOfDay: 'flexible',
+    explanationVerbosity: 'detailed',
+    preferredUnits: { distance: 'km', weight: 'kg', temperature: 'celsius' },
+    schemaVersion: 1,
+    createdAt: '',
+    updatedAt: '',
+};
+
+const HARD_CYCLING_HISTORY: RecentHistoryEntry[] = [
+    {
+        date: '2026-08-23',
+        templateId: 'end_hard_02',
+        modality: 'Cycling',
+        category: 'Hard Endurance',
+        role: 'anchor',
+        systemicCost: 1,
+        lowerBodyCost: 0.8,
+        durationMin: 75,
+    },
+];
+
+describe('race simulation recovery spacing', () => {
+    const raceSimulation = ENRICHED_TEMPLATES.find(template => template.id === 'end_race_sim_01');
+    if (!raceSimulation) throw new Error('Missing end_race_sim_01 fixture');
+
+    it('publishes a three-day minimum after hard lower-body work', () => {
+        expect(resolveMinimumDaysAfterHardLowerBody(raceSimulation.id)).toBe(3);
+    });
+
+    it('rejects the race simulation two calendar days after a hard cycling anchor', () => {
+        const result = rankCandidates(
+            [raceSimulation],
+            [],
+            ZERO_FATIGUE,
+            AVAILABILITY,
+            [],
+            PREFERENCES,
+            {
+                date: '2026-08-25',
+                recentHistory: HARD_CYCLING_HISTORY,
+                resolveMinimumDaysAfterHardLowerBody,
+            },
+        );
+
+        expect(result.rejected).toHaveLength(1);
+        expect(result.rejected[0].excludedReasons).toContain('HARD_LOWER_BODY_SPACING_VIOLATION');
+    });
+
+    it('allows the race simulation three calendar days after a hard cycling anchor', () => {
+        const result = rankCandidates(
+            [raceSimulation],
+            [],
+            ZERO_FATIGUE,
+            { ...AVAILABILITY, date: '2026-08-26' },
+            [],
+            PREFERENCES,
+            {
+                date: '2026-08-26',
+                recentHistory: HARD_CYCLING_HISTORY,
+                resolveMinimumDaysAfterHardLowerBody,
+            },
+        );
+
+        expect(result.accepted).toHaveLength(1);
+        expect(result.accepted[0].excludedReasons).not.toContain('HARD_LOWER_BODY_SPACING_VIOLATION');
+    });
+});

--- a/app/src/workouts/catalog/cycling-race.ts
+++ b/app/src/workouts/catalog/cycling-race.ts
@@ -36,4 +36,3 @@ export const CYCLING_RACE_WORKOUTS: WorkoutDefinition[] = [
     sourceNotes: ['Macrocycle simulation target is 45–60 minutes with variable power, repeated surges, limited coasting, harder one-to-three-minute work and a hard final kilometre. Keep at least three calendar days after hard lower-body work before this peak-specific simulation.']
   }
 ];
-

--- a/app/src/workouts/catalog/cycling-race.ts
+++ b/app/src/workouts/catalog/cycling-race.ts
@@ -36,3 +36,4 @@ export const CYCLING_RACE_WORKOUTS: WorkoutDefinition[] = [
     sourceNotes: ['Macrocycle simulation target is 45–60 minutes with variable power, repeated surges, limited coasting, harder one-to-three-minute work and a hard final kilometre. Keep at least three calendar days after hard lower-body work before this peak-specific simulation.']
   }
 ];
+

--- a/app/src/workouts/catalog/cycling-race.ts
+++ b/app/src/workouts/catalog/cycling-race.ts
@@ -3,13 +3,13 @@ import { timeStep } from './helpers.ts';
 
 export const CYCLING_RACE_WORKOUTS: WorkoutDefinition[] = [
   {
-    id: 'cycling_race_simulation_50_01', version: 1, status: 'active',
+    id: 'cycling_race_simulation_50_01', version: 2, status: 'active',
     name: 'Adjustable Variable Race Simulation',
     description: 'Peak-specific simulation with variable power, surges, limited coasting and a hard late finish.',
     modality: 'cycling', category: 'race_simulation', objectives: ['surge_tolerance', 'high_aerobic_power', 'fatigue_resistant_finish'],
     duration: { defaultMin: 75, minimumMin: 50, maximumMin: 95 },
     loadProfile: { cardiovascular: 5, muscular: 4, mechanical: 1, eccentric: 1, coordination: 4, recoveryHours: 72 },
-    eligibility: { minimumReadiness: 8, maximumSoreness: 4, minimumDaysAfterHardLowerBody: 2, forbiddenPainFlags: ['knee_swelling', 'acute_knee_pain', 'worsening_achilles_pain'] },
+    eligibility: { minimumReadiness: 8, maximumSoreness: 4, minimumDaysAfterHardLowerBody: 3, forbiddenPainFlags: ['knee_swelling', 'acute_knee_pain', 'worsening_achilles_pain'] },
     equipment: ['bike'], contraindicationTags: ['acute_knee_pain'], engineTemplateIds: ['end_race_sim_01'],
     blocks: [
       { id: 'warmup', name: 'Race warm-up', role: 'warmup', steps: [ timeStep('race_warmup', 'bike_progressive_warmup', 'Progressive warm-up', 900, { target: { type: 'rpe', min: 1, max: 4 } }) ]},
@@ -33,6 +33,6 @@ export const CYCLING_RACE_WORKOUTS: WorkoutDefinition[] = [
     regressions: ['cycling_event_specific_endurance_01', 'cycling_over_under_3x12_01', 'cycling_short_surges_10x20_01'], progressions: ['cycling_taper_sharpening_01'], substitutions: [],
     garmin: { exportable: true, supportedSport: 'cycling' },
     tags: ['peak_specific', 'outdoor_preferred', 'hard_finish', 'adjustable'],
-    sourceNotes: ['Macrocycle simulation target is 45–60 minutes with variable power, repeated surges, limited coasting, harder one-to-three-minute work and a hard final kilometre.']
+    sourceNotes: ['Macrocycle simulation target is 45–60 minutes with variable power, repeated surges, limited coasting, harder one-to-three-minute work and a hard final kilometre. Keep at least three calendar days after hard lower-body work before this peak-specific simulation.']
   }
 ];


### PR DESCRIPTION
## Why

The week-ahead planner can currently place the peak-specific cycling race simulation only two calendar days after hard lower-body work because `cycling_race_simulation_50_01` declares `minimumDaysAfterHardLowerBody: 2`, despite the same workout declaring a 72-hour recovery requirement.

That is too permissive for the highest-cost race-specific workout (`end_race_sim_01`, systemic 0.95 / lower-body 0.60), and it enables the planner to repack peak-specific work too aggressively after a hard cycling anchor.

## Change

- bump `cycling_race_simulation_50_01` to version 2
- change `minimumDaysAfterHardLowerBody` from 2 to 3, matching its 72-hour recovery classification
- add regression coverage proving:
  - day +2 after a hard cycling anchor is rejected with `HARD_LOWER_BODY_SPACING_VIOLATION`
  - day +3 is admissible
- bump `POLICY_VERSION` because this can change persisted recommendation decisions

## Training rationale

This is deliberately a hard sequencing constraint rather than another ranking multiplier. It is consistent with the repository's ADR direction and with the practical distinction between ordinary hard cycling (where ~48 h can be adequate) and the catalog's peak-specific race simulation, which already carries a 72 h recovery classification.

For an A-priority cycling event, this prevents cramming the biggest race-specific stimulus too close to prior hard work while still allowing intensity to be retained as overall volume falls into the taper.

## Scope / follow-up

This PR intentionally does **not** infer recovery from Garmin metrics or fuzzy-match completed Garmin activities to imported external-plan occurrences. Those need separate calibration/provenance work. The broader architectural follow-up is to propagate `PlanningCandidate.recoveryHours` into projected-history sequencing so every catalog workout's declared recovery consequence can constrain the next hard session, not only workouts with an explicit `minimumDaysAfterHardLowerBody` precondition.