### PR TITLE
fix(ci): match the smoke test to the current Garmin-link error envelope

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -246,7 +246,11 @@ jobs:
 
       # GET /api/garmin/login is intentionally unsupported by the account-link service. A
       # backend-shaped 404 therefore proves the Hosting rewrite reached Cloud Run without
-      # submitting credentials or consuming a login-rate-limit attempt.
+      # submitting credentials or consuming a login-rate-limit attempt. The body must carry
+      # the structured error envelope account_link_api.py actually emits (errorCode/
+      # retryable/requestId, see _error_response) -- matching only the literal legacy
+      # {"error":"not_found"} shape broke this check the moment the handler was rewritten
+      # to the richer envelope, even though the deploy itself was fine.
       - name: Smoke test Hosting to Garmin API rewrite
         if: ${{ inputs.deploy_hosting }}
         run: |
@@ -254,7 +258,7 @@ jobs:
           STATUS="$(curl --silent --show-error --retry 5 --retry-delay 3 --retry-all-errors \
             --output "${BODY_FILE}" --write-out '%{http_code}' \
             "https://${GCP_PROJECT}.web.app/api/garmin/login")"
-          if [ "${STATUS}" != "404" ] || ! grep -q '"error":"not_found"' "${BODY_FILE}"; then
+          if [ "${STATUS}" != "404" ] || ! grep -q '"errorCode":"garmin_link.not_found"' "${BODY_FILE}"; then
             echo "Expected Cloud Run JSON 404 through Firebase Hosting rewrite; got HTTP ${STATUS}." >&2
             cat "${BODY_FILE}" >&2
             exit 1


### PR DESCRIPTION
## Summary

- The production deploy pipeline's final gate — `Smoke test Hosting to Garmin API rewrite` — failed on the last two deploy attempts (run [32694221769](https://github.com/Szczepanov/adaptive-training-recommender/actions/runs/32694221769), both attempts). I initially suspected Firebase Hosting/Cloud-Run rewrite propagation or IAM, but live investigation (direct `curl` to the Cloud Run URL bypassing Hosting entirely, plus `gcloud logging read` against the exact request) proved the request **did** reach a correctly-deployed, correctly-configured, correctly-routed container, and the container itself produced the response.
- Root cause: commit `9c9d8cf` ("Return structured account-link errors with request references") replaced `account_link_api.py`'s plain `{"error": "not_found"}` 404 body with a structured envelope (`errorCode`/`retryable`/`requestId`, via the new `_error_response` helper) — an intentional, already-shipped improvement. This smoke test's assertion was never updated to match, so the literal `'"error":"not_found"'` grep has been failing the deploy pipeline's final gate on every real deploy since, even though the service itself is completely healthy.
- Fix: match the current envelope by asserting on `"errorCode":"garmin_link.not_found"` instead of the retired literal body.
- User impact: none — the Garmin account-link service was never broken; only the CI smoke test's assertion was stale. This restores the deploy pipeline's ability to reach a green state.

## Validation

Results:
- Live production verification (not reproducible in CI, done via Cloud Shell against the actual deployed service): `curl -i https://garmin-account-link-<hash>.europe-central2.run.app/api/garmin/login` → `404` with body `{"error":"Not found.","errorCode":"garmin_link.not_found","retryable":false,"requestId":"..."}` — exactly what the updated assertion now matches.
- `gcloud logging read` against the `garmin-account-link` Cloud Run service confirmed the request reached the currently-deployed revision (`garmin-account-link-00008-mqs`, built from the exact commit that was deployed) and the container's own `garmin_account_link` logger recorded the `404`.
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-frontend.yml'))"` — YAML parses cleanly.
- [ ] `uv run pytest` (backend changes) — not applicable, no Python source changed, only the CI workflow's assertion
- [ ] `uv run ruff check .` and `uv run mypy src/garmin_sync` (backend changes) — not applicable
- [ ] `cd app && npm run check` (frontend changes) — not applicable, no frontend changes
- [ ] `cd app && npm run test:rules` (Firestore rules changes) — not applicable
- [ ] `cd app && npm run simulate:scenarios` (recommendation-engine changes) — not applicable
- [ ] `cd app && npm run visual:refresh` (material UI changes) — not applicable

## Risk and reviewer guidance

Very low risk: a one-line assertion change inside a CI smoke-test step, matched against the exact response the live service already returns (verified directly, not guessed). No application code, Firestore rules, or deploy configuration changed.

## Domain invariants

Not applicable — CI-workflow-only change; no Firestore paths, date/timezone logic, credentials, or recommendation decision logic touched.

## Screenshots or recordings

Not applicable — no UI change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9BbvcTuwcrrHb1wGRjL7D)_