### PR TITLE
fix(test): pin 'today' date in Race-Specific Endurance utility test

### DIFF
--- a/app/src/engine/architecture.test.ts
+++ b/app/src/engine/architecture.test.ts
@@ -572,7 +572,7 @@ describe('Architecture & Phased Engine Integration', () => {
             const periodization = evaluatePeriodizationPhase([cyclingEvent('2026-08-27')], '2026-08-07');
             const candidates = ENRICHED_TEMPLATES.filter(t => isTemplatePhaseEligible(t, periodization));
             expect(candidates.some(t => t.category === 'Race-Specific Endurance')).toBe(true);
-            const ranked = rankCandidatesByUtility(candidates, [], fatigue, availability, [], prefs, { focusEvent: periodization.focusEvent });
+            const ranked = rankCandidatesByUtility(candidates, [], fatigue, availability, [], prefs, { date: '2026-08-07', focusEvent: periodization.focusEvent });
             const raceSpecificPick = ranked.find(r => r.template.category === 'Race-Specific Endurance');
             expect(raceSpecificPick).toBeDefined();
             expect(raceSpecificPick!.utilityScore).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary

- Fixes a failing CI job (`architecture.test.ts` → "Path B ranks a phase-eligible Race-Specific Endurance template with real (non-zero) utility") caused by a date-dependent test bug, not a production defect.
- The test builds its scenario around a fixed "today" of `2026-08-07` (event on `2026-08-27`, 20 days out) but omitted `date` from the `options` passed to `rankCandidatesByUtility`. That call fell back to `getLocalDateString()` (the real wall-clock date).
- As the actual date advanced to `2026-08-25`, the fallback made the engine compute `daysToRace = 2` against the `2026-08-27` fixture event, correctly triggering `PRE_EVENT_TAPER_RESTRICTION` and excluding every Race-Specific Endurance candidate — failing the assertion.
- Fix: pass `date: '2026-08-07'` explicitly in the test's options so the scenario is deterministic regardless of when the suite runs. No production engine code changed.

## Validation

Results:
- `cd app && npm run check`: pass — typecheck, lint, Vitest (2140 passed | 124 skipped across 216 files), and workout catalog validation all green.
- `npx vitest run src/engine/architecture.test.ts`: pass — 37/37 tests, including the previously-failing test.

- [ ] `uv run pytest` (backend changes) — not applicable, no backend changes
- [ ] `uv run ruff check .` and `uv run mypy src/garmin_sync` (backend changes) — not applicable, no backend changes
- [x] `cd app && npm run check` (frontend changes)
- [ ] `cd app && npm run test:rules` (Firestore rules changes) — not applicable, no rules changes
- [ ] `cd app && npm run simulate:scenarios` (recommendation-engine changes) — not applicable, no engine logic changed (test-only fix)
- [ ] `cd app && npm run visual:refresh` (material UI changes) — not applicable, no UI changes

## Risk and reviewer guidance

Low risk: the change is confined to one test file and pins an existing options field (`date`) that the test scenario already implicitly assumed. No production engine, rules, or UI code is touched.

## Domain invariants

Not applicable — test-only change; no Firestore writes, calendar-date engine logic, or recommendation decision logic were modified. (`POLICY_VERSION` unaffected — the fix only stabilizes a test fixture's assumed "today", not any engine behavior.)

## Screenshots or recordings

Not applicable — no UI changes.

---

Fixes CI failure from https://github.com/Szczepanov/adaptive-training-recommender/actions/runs/32807252782/job/97679682892


---
_Generated by [Claude Code](https://claude.ai/code/session_012P7NuhqLJHRyTS38GB1mfP)_