### PR TITLE
fix(test): inject a deterministic history provider in plan-judge calibration test

### DIFF
--- a/app/src/engine/rules.planJudgeCalibration.test.ts
+++ b/app/src/engine/rules.planJudgeCalibration.test.ts
@@ -4,6 +4,11 @@ import { evaluateRecoveryConstraints, rankCandidates } from './optimizer';
 import { ENRICHED_TEMPLATES } from './templates';
 import type { DailyReadiness, EngineObjectiveInput, FatigueState, SubjectiveInput, UserContext, UserEvent, UserPreferences } from './models';
 import type { ResolvedAvailability } from './schedule';
+import type { TrainingHistoryProvider } from './trainingHistory';
+
+// Deterministic stand-in for the real Firestore-backed provider: these tests exercise
+// calibration policy in isolation and must not depend on network/Firestore reachability.
+const emptyHistoryProvider: TrainingHistoryProvider = { reconstruct: async () => [] };
 
 const DEFAULT_FATIGUE: FatigueState = {
     lastUpdatedDate: '2026-03-01',
@@ -180,6 +185,8 @@ describe('plan-judge calibration policy guards', () => {
             context(),
             [],
             '2026-08-24',
+            undefined,
+            emptyHistoryProvider,
         );
 
         expect(result.mode).toBe('modify');


### PR DESCRIPTION
## Summary

- Fixes a new CI failure (job [97684125388](https://github.com/Szczepanov/adaptive-training-recommender/actions/runs/32808478947/job/97684125388)) in `rules.planJudgeCalibration.test.ts` → "auto-applies a template easier dose on the intent-aware modify path" — again a hermeticity/flake bug in the test, not a production defect.
- That test called `evaluateTrainingWithIntent(...)` without passing a `historyProvider`, so `resolveTrainingIntent` fell back to the real Firestore-backed `firestoreTrainingHistoryProvider` and made a live network call via `activityService.getActivitiesInRange()`.
- Against the test project that call is unreachable/permission-denied; depending on SDK retry timing it either resolves to an empty `AVAILABLE` snapshot or throws `TrainingHistorySourceError` (`'activities'` `UNAVAILABLE`) — making this the only test in the suite with a real network dependency, and flaky in CI.
- Fix: inject a deterministic `TrainingHistoryProvider` (`{ reconstruct: async () => [] }`), matching the pattern every other calibration/training-intent test in the codebase already uses. No production engine code changed.

## Validation

Results:
- `cd app && npm run check`: pass — typecheck, lint, Vitest (2140 passed | 124 skipped across 216 files), and workout catalog validation all green.
- `npx vitest run src/engine/rules.planJudgeCalibration.test.ts` (5x locally, plus full suite): pass — 13/13 tests.
- Confirmed via `grep` that every other `evaluateTrainingWithIntent`/`resolveTrainingIntent` call in the test suite already injects an explicit history provider; this was the sole outlier reaching real Firestore.

- [ ] `uv run pytest` (backend changes) — not applicable, no backend changes
- [ ] `uv run ruff check .` and `uv run mypy src/garmin_sync` (backend changes) — not applicable, no backend changes
- [x] `cd app && npm run check` (frontend changes)
- [ ] `cd app && npm run test:rules` (Firestore rules changes) — not applicable, no rules changes
- [ ] `cd app && npm run simulate:scenarios` (recommendation-engine changes) — not applicable, no engine logic changed (test-only fix)
- [ ] `cd app && npm run visual:refresh` (material UI changes) — not applicable, no UI changes

## Risk and reviewer guidance

Low risk: confined to one test file, adds a hermetic fixture matching the established pattern used elsewhere in the same suite. No production engine, rules, or UI code is touched.

## Domain invariants

Not applicable — test-only change; no Firestore writes, calendar-date engine logic, or recommendation decision logic were modified.

## Screenshots or recordings

Not applicable — no UI changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_012P7NuhqLJHRyTS38GB1mfP)_