### PR TITLE
⚡ Bolt: Memoize step array filters in SessionCompletionSheet

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -18,6 +18,6 @@
 **Learning:** React components and engine functions were scanning the canonical `EXERCISES` catalog with `.find()` in repeated lookup paths even though `exercises.ts` already exports `EXERCISES_BY_ID` for constant-time identity resolution.
 **Action:** Reuse the canonical `EXERCISES_BY_ID` map for repeated exercise-ID lookups; do not introduce a second exercise map or duplicate catalog index.
 
-## $(date +%Y-%m-%d) - Prevent Redundant Array Filtering on Render
+## 2026-08-26 - Prevent Redundant Array Filtering on Render
 **Learning:** In components with frequent state changes (like form inputs updating `notes`), inline array operations like `.filter()` that rely on static props (like `steps`) will re-execute on every keystroke, causing unnecessary O(N) operations.
 **Action:** Always wrap derived data calculations that iterate over arrays using `useMemo` when the input array is stable and the component is subject to frequent re-renders from other state changes.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,3 +17,7 @@
 ## 2026-08-24 - Optimize Exercise Catalog Lookups
 **Learning:** React components and engine functions were scanning the canonical `EXERCISES` catalog with `.find()` in repeated lookup paths even though `exercises.ts` already exports `EXERCISES_BY_ID` for constant-time identity resolution.
 **Action:** Reuse the canonical `EXERCISES_BY_ID` map for repeated exercise-ID lookups; do not introduce a second exercise map or duplicate catalog index.
+
+## $(date +%Y-%m-%d) - Prevent Redundant Array Filtering on Render
+**Learning:** In components with frequent state changes (like form inputs updating `notes`), inline array operations like `.filter()` that rely on static props (like `steps`) will re-execute on every keystroke, causing unnecessary O(N) operations.
+**Action:** Always wrap derived data calculations that iterate over arrays using `useMemo` when the input array is stable and the component is subject to frequent re-renders from other state changes.

--- a/app/src/components/session/SessionCompletionSheet.test.tsx
+++ b/app/src/components/session/SessionCompletionSheet.test.tsx
@@ -1,8 +1,154 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { SessionCompletionSheet } from './SessionCompletionSheet';
 import { COMPLETION_TISSUE_LEVEL_OPTIONS } from './sessionCompletionOptions';
+import type { SessionStepSummary } from '../../workouts/strengthSessionEntry';
 
 describe('SessionCompletionSheet', () => {
     it('uses the canonical tissue-response vocabulary for completion feedback', () => {
         expect(COMPLETION_TISSUE_LEVEL_OPTIONS.map(option => option.value)).toEqual(['mild', 'moderate', 'severe']);
+    });
+
+    it('renders summary metrics correctly including duration, total sets, and completed exercises count', () => {
+        const steps: SessionStepSummary[] = [
+            {
+                exerciseIndex: 0,
+                exerciseId: 'back_squat',
+                displayName: 'Back Squat',
+                isPlanned: true,
+                optional: false,
+                targetSets: 3,
+                targetReps: 5,
+                targetGauge: null,
+                loggedSetsCount: 3,
+                isComplete: true,
+            },
+            {
+                exerciseIndex: 1,
+                exerciseId: 'bench_press',
+                displayName: 'Bench Press',
+                isPlanned: true,
+                optional: false,
+                targetSets: 3,
+                targetReps: 5,
+                targetGauge: null,
+                loggedSetsCount: 0,
+                isComplete: false,
+            },
+        ];
+
+        const startedAt = new Date(Date.now() - 30 * 60 * 1000).toISOString();
+        const html = renderToStaticMarkup(
+            <SessionCompletionSheet
+                startedAt={startedAt}
+                totalSets={3}
+                steps={steps}
+                onComplete={vi.fn()}
+                onAbandon={vi.fn()}
+                onCancel={vi.fn()}
+                saving={false}
+            />,
+        );
+
+        expect(html).toContain('30 min');
+        expect(html).toContain('Total Sets');
+        expect(html).toContain('3');
+        expect(html).toContain('Exercises');
+        expect(html).toContain('1'); // Only 1 exercise has loggedSetsCount > 0
+    });
+
+    it('renders warning box when there are incomplete required steps', () => {
+        const steps: SessionStepSummary[] = [
+            {
+                exerciseIndex: 0,
+                exerciseId: 'back_squat',
+                displayName: 'Back Squat',
+                isPlanned: true,
+                optional: false,
+                targetSets: 3,
+                targetReps: 5,
+                targetGauge: null,
+                loggedSetsCount: 1,
+                isComplete: false,
+            },
+            {
+                exerciseIndex: 1,
+                exerciseId: 'plank',
+                displayName: 'Plank',
+                isPlanned: true,
+                optional: true, // optional step, should not show in warning
+                targetSets: 2,
+                targetReps: null,
+                targetGauge: null,
+                loggedSetsCount: 0,
+                isComplete: false,
+            },
+        ];
+
+        const html = renderToStaticMarkup(
+            <SessionCompletionSheet
+                startedAt={new Date().toISOString()}
+                totalSets={1}
+                steps={steps}
+                onComplete={vi.fn()}
+                onAbandon={vi.fn()}
+                onCancel={vi.fn()}
+                saving={false}
+            />,
+        );
+
+        expect(html).toContain('Incomplete Required Steps (1)');
+        expect(html).toContain('Back Squat (1/3 sets)');
+        expect(html).not.toContain('Plank (0/2 sets)');
+    });
+
+    it('does not render warning box when all required steps are completed', () => {
+        const steps: SessionStepSummary[] = [
+            {
+                exerciseIndex: 0,
+                exerciseId: 'back_squat',
+                displayName: 'Back Squat',
+                isPlanned: true,
+                optional: false,
+                targetSets: 3,
+                targetReps: 5,
+                targetGauge: null,
+                loggedSetsCount: 3,
+                isComplete: true,
+            },
+        ];
+
+        const html = renderToStaticMarkup(
+            <SessionCompletionSheet
+                startedAt={new Date().toISOString()}
+                totalSets={3}
+                steps={steps}
+                onComplete={vi.fn()}
+                onAbandon={vi.fn()}
+                onCancel={vi.fn()}
+                saving={false}
+            />,
+        );
+
+        expect(html).not.toContain('Incomplete Required Steps');
+    });
+
+    it('renders abandon confirmation when openAbandonConfirmation is true', () => {
+        const html = renderToStaticMarkup(
+            <SessionCompletionSheet
+                startedAt={new Date().toISOString()}
+                totalSets={2}
+                steps={[]}
+                onComplete={vi.fn()}
+                onAbandon={vi.fn()}
+                onCancel={vi.fn()}
+                saving={false}
+                openAbandonConfirmation={true}
+            />,
+        );
+
+        expect(html).toContain('Abandon Session?');
+        expect(html).toContain('Yes, Abandon Session');
+        expect(html).toContain('Partial sets you have logged (2 sets) are permanently retained');
     });
 });

--- a/app/src/components/session/SessionCompletionSheet.tsx
+++ b/app/src/components/session/SessionCompletionSheet.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import type { BodyRegion, TissueResponseLevel } from '../../engine/models';
 import type { SessionStepSummary } from '../../workouts/strengthSessionEntry';
 import { COMPLETION_TISSUE_LEVEL_OPTIONS } from './sessionCompletionOptions';
@@ -58,7 +58,9 @@ export const SessionCompletionSheet: React.FC<SessionCompletionSheetProps> = ({
     const [showAbandonConfirm, setShowAbandonConfirm] = useState(openAbandonConfirmation);
     const [elapsedMinutes] = useState(() => Math.max(1, Math.round((Date.now() - Date.parse(startedAt)) / 60000)));
 
-    const missingRequiredSteps = steps.filter(s => s.isPlanned && !s.optional && !s.isComplete);
+    // ⚡ Bolt: Memoize step array filters to prevent redundant O(N) operations on every form state change (e.g. typing in notes)
+    const missingRequiredSteps = useMemo(() => steps.filter(s => s.isPlanned && !s.optional && !s.isComplete), [steps]);
+    const completedExercisesCount = useMemo(() => steps.filter(s => s.loggedSetsCount > 0).length, [steps]);
 
     const handleConfirmComplete = async () => {
         const payload: SessionCompletionPayload = {
@@ -118,7 +120,7 @@ export const SessionCompletionSheet: React.FC<SessionCompletionSheetProps> = ({
                             </div>
                             <div className="metric-pill">
                                 <span className="metric-label">Exercises</span>
-                                <span className="metric-value">{steps.filter(s => s.loggedSetsCount > 0).length}</span>
+                                <span className="metric-value">{completedExercisesCount}</span>
                             </div>
                         </div>
 


### PR DESCRIPTION
💡 **What**: Extracted inline `.filter()` operations on the `steps` prop in `SessionCompletionSheet.tsx` into memoized variables using `useMemo`.

🎯 **Why**: The `SessionCompletionSheet` component contains local state that updates frequently (e.g., typing in the `notes` textarea, changing the `sessionRpe` slider). Without memoization, these state changes trigger a re-render of the entire component, causing the inline `.filter()` operations (which scan all steps in the session) to execute repeatedly and redundantly on every keystroke or slider movement, creating an O(N) performance overhead.

📊 **Impact**: Reduces redundant array filtering operations from running on every render/keystroke to only running when the actual `steps` prop changes, eliminating unnecessary CPU work and potentially preventing input lag on slower devices during session completion logging.

🔬 **Measurement**: Verified that `cd app && npm run check` passes completely (linting, typechecking, tests, and validation scripts), ensuring that the memoized variables retain identical logical behavior to the previous inline implementations.

---
*PR created automatically by Jules for task [6734958114357931974](https://jules.google.com/task/6734958114357931974) started by @Szczepanov*