### PR TITLE
perf: memoize UI hot paths and batch sync reads

### DIFF
--- a/app/src/components/DailyCheckin.tsx
+++ b/app/src/components/DailyCheckin.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useId } from 'react';
+import { useState, useEffect, useCallback, useId, useMemo } from 'react';
 import { checkinService } from '../services/checkinService';
 import { recoverySnapshotService } from '../services/recoverySnapshotService';
 import { sessionExecutionService } from '../services/sessionExecutionService';
@@ -423,6 +423,30 @@ export function DailyCheckin({ userId, onNavigate, onBack, onCheckinSaved }: Dai
     }
   };
 
+  // ⚡ Bolt: Memoize tissue and physiology derivations before early returns to satisfy Hook rules
+  const tissueResponses = useMemo(
+    () => Object.values(checkin?.tissueResponses ?? {}).filter(
+      (response): response is RegionTissueResponse => response !== undefined,
+    ),
+    [checkin?.tissueResponses],
+  );
+  const manualPhysiologyMissing = useMemo(
+    () => ({
+      rhr: recoverySnapshot?.raw.restingHr == null,
+      hrv: recoverySnapshot?.raw.hrvOvernightAvg == null,
+      respiration: recoverySnapshot?.raw.respirationAvg == null,
+    }),
+    [
+      recoverySnapshot?.raw.restingHr,
+      recoverySnapshot?.raw.hrvOvernightAvg,
+      recoverySnapshot?.raw.respirationAvg,
+    ],
+  );
+  const availableBodyRegions = useMemo(
+    () => BODY_REGIONS.filter(region => !checkin?.tissueResponses?.[region]),
+    [checkin?.tissueResponses],
+  );
+
   if (loading) {
     return (
       <div className="checkin-container">
@@ -464,9 +488,6 @@ export function DailyCheckin({ userId, onNavigate, onBack, onCheckinSaved }: Dai
 
   const answeredSubjectiveCount = SCALES.filter(scale => typeof checkin[scale.key] === 'number').length;
   const wearableRevealAllowed = Boolean(checkin.initialSubmittedAt && checkin.dataQuality?.isComplete);
-  const tissueResponses = Object.values(checkin.tissueResponses ?? {}).filter(
-    (response): response is RegionTissueResponse => response !== undefined,
-  );
   const isAlreadySubmitted = isCompletedSubjectiveCheckin(checkin);
 
   return (
@@ -627,11 +648,7 @@ export function DailyCheckin({ userId, onNavigate, onBack, onCheckinSaved }: Dai
           <HealthContextSection
             value={checkin.healthContext}
             symptomsPresent={Boolean(checkin.illnessSymptoms)}
-            manualPhysiologyMissing={{
-              rhr: recoverySnapshot?.raw.restingHr == null,
-              hrv: recoverySnapshot?.raw.hrvOvernightAvg == null,
-              respiration: recoverySnapshot?.raw.respirationAvg == null,
-            }}
+            manualPhysiologyMissing={manualPhysiologyMissing}
             onChange={handleHealthContextChange}
           />
 
@@ -652,7 +669,7 @@ export function DailyCheckin({ userId, onNavigate, onBack, onCheckinSaved }: Dai
                 onChange={(e) => setPendingTissueRegion(e.target.value as BodyRegion | '')}
               >
                 <option value="">Select a region…</option>
-                {BODY_REGIONS.filter(region => !checkin.tissueResponses?.[region]).map(region => (
+                {availableBodyRegions.map(region => (
                   <option key={region} value={region}>{REGION_LABELS[region]}</option>
                 ))}
               </select>

--- a/app/src/components/TrainingSettings.tsx
+++ b/app/src/components/TrainingSettings.tsx
@@ -1,4 +1,4 @@
-import { type FormEvent, useCallback, useEffect, useState } from 'react';
+import { type FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
 import type { BodyRegion, GuardrailKey, InjuryConstraint, SessionTemplate, TrainingSettings as TrainingSettingsModel } from '../engine/models';
 import { resolveInjuryRestrictions } from '../engine/injuryPolicy';
 import { trainingSettingsService, type TrainingSettingsUpdate } from '../services/trainingSettingsService';
@@ -93,6 +93,16 @@ export function TrainingSettings({ userId }: TrainingSettingsProps) {
       note: injury.note ?? '',
     });
   };
+
+  const today = getLocalDateString();
+  // ⚡ Bolt: Memoize derived injury restrictions to prevent recalculation on every draft keystroke
+  const derivedRestrictions = useMemo(
+    () => resolveInjuryRestrictions(settings?.injuries, today),
+    [settings?.injuries, today],
+  );
+  const hasDerived = derivedRestrictions.restrictedModalities.length > 0
+    || derivedRestrictions.impliedGuardrails.length > 0
+    || derivedRestrictions.restrictedCategories.length > 0;
 
   if (!settings) return <main className="training-settings"><p>{error ?? 'Loading training settings…'}</p></main>;
 
@@ -214,19 +224,14 @@ export function TrainingSettings({ userId }: TrainingSettingsProps) {
           <p><small>No active injuries recorded.</small></p>
         )}
 
-        {(() => {
-          const derived = resolveInjuryRestrictions(settings.injuries, getLocalDateString());
-          const hasDerived = derived.restrictedModalities.length > 0 || derived.impliedGuardrails.length > 0 || derived.restrictedCategories.length > 0;
-          if (!hasDerived) return null;
-          return (
-            <div className="derived-restrictions" style={{ marginTop: '12px', padding: '8px 12px', background: '#f5f5f5', borderRadius: '4px' }}>
-              <h4>Derived Restrictions (Read-only)</h4>
-              {derived.restrictedModalities.length > 0 && <p><small><strong>Restricted Modalities:</strong> {derived.restrictedModalities.join(', ')}</small></p>}
-              {derived.impliedGuardrails.length > 0 && <p><small><strong>Implied Guardrails:</strong> {derived.impliedGuardrails.join(', ')}</small></p>}
-              {derived.restrictedCategories.length > 0 && <p><small><strong>Restricted Categories:</strong> {derived.restrictedCategories.join(', ')}</small></p>}
-            </div>
-          );
-        })()}
+        {hasDerived && (
+          <div className="derived-restrictions" style={{ marginTop: '12px', padding: '8px 12px', background: '#f5f5f5', borderRadius: '4px' }}>
+            <h4>Derived Restrictions (Read-only)</h4>
+            {derivedRestrictions.restrictedModalities.length > 0 && <p><small><strong>Restricted Modalities:</strong> {derivedRestrictions.restrictedModalities.join(', ')}</small></p>}
+            {derivedRestrictions.impliedGuardrails.length > 0 && <p><small><strong>Implied Guardrails:</strong> {derivedRestrictions.impliedGuardrails.join(', ')}</small></p>}
+            {derivedRestrictions.restrictedCategories.length > 0 && <p><small><strong>Restricted Categories:</strong> {derivedRestrictions.restrictedCategories.join(', ')}</small></p>}
+          </div>
+        )}
       </section>
     </main>
   );

--- a/app/src/components/session/ManualSessionBuilder.tsx
+++ b/app/src/components/session/ManualSessionBuilder.tsx
@@ -106,6 +106,12 @@ export const ManualSessionBuilder: React.FC<ManualSessionBuilderProps> = ({ user
         blocks,
     }), [blocks, definitionId, durationMin, modality, summary, title]);
 
+    // ⚡ Bolt: Precompute static exercise options to prevent full 176-item catalog array mapping on every keystroke
+    const exerciseOptions = useMemo(
+        () => EXERCISES.map(exercise => <option key={exercise.id} value={exercise.id}>{exercise.name}</option>),
+        [],
+    );
+
     const updateBlock = (blockIndex: number, patch: Partial<SessionBlock>) => setBlocks(current =>
         current.map((block, index) => index === blockIndex ? { ...block, ...patch } : block));
 
@@ -342,7 +348,7 @@ export const ManualSessionBuilder: React.FC<ManualSessionBuilderProps> = ({ user
                                                 updateStep(blockIndex, stepIndex, exercise
                                                     ? { title: exercise.name, exerciseRef: { kind: 'catalog', exerciseId: exercise.id }, resolutionNote: undefined }
                                                     : { exerciseRef: { kind: 'unresolved_free_text', name: step.title ?? 'Custom movement' }, resolutionNote: 'Custom movement: executable and loggable, but it has no catalog-derived safety, cost, stimulus, PR or 1RM semantics.' });
-                                            }}><option value="__custom__">Custom / free text</option>{EXERCISES.map(exercise => <option key={exercise.id} value={exercise.id}>{exercise.name}</option>)}</select></label>
+                                            }}><option value="__custom__">Custom / free text</option>{exerciseOptions}</select></label>
                                             <label>Dose<select value={dose?.kind ?? 'repetition'} onChange={event => changeDose(blockIndex, stepIndex, event.target.value as SessionDose['kind'])}><option value="repetition">Repetitions</option><option value="duration">Timed hold</option><option value="distance">Distance</option><option value="checkoff">Check-off</option></select></label>
                                             {dose?.kind === 'repetition' && <><label>Sets<input type="number" min={1} value={dose.sets} onChange={event => updateStep(blockIndex, stepIndex, { dose: { ...dose, sets: Math.max(1, Number(event.target.value) || 1) } })} /></label><label>Reps<input type="number" min={1} value={typeof dose.reps === 'number' ? dose.reps : dose.reps.min} onChange={event => updateStep(blockIndex, stepIndex, { dose: { ...dose, reps: Math.max(1, Number(event.target.value) || 1) } })} /></label></>}
                                             {dose?.kind === 'duration' && <><label>Sets<input type="number" min={1} value={dose.sets ?? 1} onChange={event => updateStep(blockIndex, stepIndex, { dose: { ...dose, sets: Math.max(1, Number(event.target.value) || 1) } })} /></label><label>Seconds<input type="number" min={1} value={typeof dose.seconds === 'number' ? dose.seconds : dose.seconds.min} onChange={event => updateStep(blockIndex, stepIndex, { dose: { ...dose, seconds: Math.max(1, Number(event.target.value) || 1) } })} /></label></>}
@@ -374,7 +380,7 @@ export const ManualSessionBuilder: React.FC<ManualSessionBuilderProps> = ({ user
                                                         <select value={altExercise} onChange={event => {
                                                             const exercise = EXERCISES_BY_ID.get(event.target.value);
                                                             updateAlternative(blockIndex, stepIndex, alt.id, exercise?.id, exercise?.name ?? alt.title);
-                                                        }} aria-label="Alternative movement"><option value="__custom__">Custom / free text</option>{EXERCISES.map(exercise => <option key={exercise.id} value={exercise.id}>{exercise.name}</option>)}</select>
+                                                        }} aria-label="Alternative movement"><option value="__custom__">Custom / free text</option>{exerciseOptions}</select>
                                                         <button type="button" onClick={() => removeAlternative(blockIndex, stepIndex, alt.id)} aria-label="Remove alternative">Remove</button>
                                                     </div>;
                                                 })}

--- a/app/src/components/session/SessionRunner.tsx
+++ b/app/src/components/session/SessionRunner.tsx
@@ -372,12 +372,85 @@ export const SessionRunner: React.FC<SessionRunnerProps> = ({
         if (runner.sessionEnded) setShowCompletionSheet(true);
     }, [runner.sessionEnded]);
 
+    const definition = runner.definition;
+    const activeBlock = runner.activeBlock;
+
+    // ⚡ Bolt: Memoize AST comparison, choice lookups, step summaries, and group progress before early returns
+    const comparison = useMemo(
+        () => (definition ? comparePlannedVsPerformed(definition, entries) : null),
+        [definition, entries],
+    );
+
+    const answeredChoiceIds = useMemo(
+        () => new Set(
+            entries
+                .filter(e => e.payload.kind === 'choice')
+                .map(e => (e.payload as { choiceId: string }).choiceId),
+        ),
+        [entries],
+    );
+
+    // The choice due at the active step is authored and not yet answered. Other step
+    // controls stay blocked until it is resolved, so a prescribed step never changes
+    // without a recorded athlete action (D-MCHOICE).
+    const dueChoice = useMemo(
+        () => activeStep && activeBlock
+            ? (activeBlock.optionSets ?? []).find(choice => choice.appliesAtStepId === activeStep.id && !answeredChoiceIds.has(choice.id)) ?? null
+            : null,
+        [activeStep, activeBlock, answeredChoiceIds],
+    );
+
+    const stepSummaries: SessionStepSummary[] = useMemo(
+        () => (comparison
+            ? comparison.stepComparisons.map((sc, idx) => ({
+                exerciseIndex: idx,
+                exerciseId: null,
+                displayName: sc.stepTitle,
+                isPlanned: true,
+                optional: sc.isOptional,
+                targetSets: sc.targetSets,
+                targetReps: null,
+                targetGauge: null,
+                loggedSetsCount: sc.completedSets,
+                isComplete: sc.isComplete,
+            }))
+            : []),
+        [comparison],
+    );
+
+    const stepCompletedCounts = useMemo(() => {
+        const counts = new Map<string, number>();
+        for (const e of entries) {
+            if (e.stepId && e.payload.kind !== 'choice') {
+                counts.set(e.stepId, (counts.get(e.stepId) ?? 0) + 1);
+            }
+        }
+        return counts;
+    }, [entries]);
+
+    // The rest banner previews the next step, including rotation within circuits and
+    // supersets, instead of naming the set that was just logged.
+    const restNextStep = useMemo(() => {
+        if (!definition || !activeBlock) return null;
+        const groupProgress = getGroupProgress(activeBlock, entries, runner.activeStepIndex);
+        if (groupProgress) {
+            return groupProgress.nextStepIndex !== null ? activeBlock.steps[groupProgress.nextStepIndex] : null;
+        }
+        if (runner.activeStepIndex + 1 < activeBlock.steps.length) {
+            return activeBlock.steps[runner.activeStepIndex + 1];
+        }
+        const nextBlock = definition.blocks.find(
+            (candidate, index) => index > runner.activeBlockIndex && candidate.steps.length > 0,
+        );
+        return nextBlock ? nextBlock.steps[0] : null;
+    }, [definition, activeBlock, entries, runner.activeStepIndex, runner.activeBlockIndex]);
+
     // If no active session, show fixture picker to start an unplanned session
     if (runner.isRestoring) {
         return <div className="session-runner-container no-active"><p>Restoring an active session…</p></div>;
     }
 
-    if (!runner.definition || !runner.execution || runner.execution.state !== 'in_progress') {
+    if (!definition || !comparison || !runner.execution || runner.execution.state !== 'in_progress') {
         // M4.3: offered once, right after the primary session finishes (completed or
         // abandoned) -- never concurrently with it. Starting a companion creates its own
         // execution and takes over this same "active session" view normally; skipping just
@@ -481,22 +554,7 @@ export const SessionRunner: React.FC<SessionRunnerProps> = ({
         );
     }
 
-    const definition = runner.definition!;
-    const comparison = comparePlannedVsPerformed(definition, entries);
-
-    const answeredChoiceIds = new Set(
-        entries
-            .filter(e => e.payload.kind === 'choice')
-            .map(e => (e.payload as { choiceId: string }).choiceId),
-    );
-    // The choice due at the active step -- authored, not yet answered (D-MCHOICE). Other
-    // step controls stay blocked until it is resolved: no code path changes a prescribed
-    // step without a recorded athlete action.
-    const dueChoice = activeStep && runner.activeBlock
-        ? (runner.activeBlock.optionSets ?? []).find(choice => choice.appliesAtStepId === activeStep.id && !answeredChoiceIds.has(choice.id)) ?? null
-        : null;
-
-    function describeChoiceEntry(entry: SessionEntry): string {
+    const describeChoiceEntry = (entry: SessionEntry): string => {
         if (entry.payload.kind !== 'choice') return '';
         const { choiceId, optionId } = entry.payload;
         for (const block of definition.blocks) {
@@ -505,20 +563,7 @@ export const SessionRunner: React.FC<SessionRunnerProps> = ({
             if (option) return option.label;
         }
         return optionId;
-    }
-
-    const stepSummaries: SessionStepSummary[] = comparison.stepComparisons.map((sc, idx) => ({
-        exerciseIndex: idx,
-        exerciseId: null,
-        displayName: sc.stepTitle,
-        isPlanned: true,
-        optional: sc.isOptional,
-        targetSets: sc.targetSets,
-        targetReps: null,
-        targetGauge: null,
-        loggedSetsCount: sc.completedSets,
-        isComplete: sc.isComplete,
-    }));
+    };
 
     const formatTime = (totalSec: number) => {
         const m = Math.floor(totalSec / 60);
@@ -591,27 +636,6 @@ export const SessionRunner: React.FC<SessionRunnerProps> = ({
 
     const inputProfile = activeStep ? resolveStepInputProfile(activeStep) : 'repetition_mass';
     const activeEffort = activeStep ? formatEffort(activeStep) : null;
-    const activeBlock = runner.activeBlock;
-
-    // The step the rest banner should preview as "Next" -- not simply activeStep, which for an
-    // ordinary sequential block doesn't advance until the athlete moves on, so it would still
-    // name the exercise a set was just logged for. Rotating groups (circuit/superset/alternating)
-    // use the same rotation logic GroupProgress renders; other blocks fall through to the plain
-    // next step/next non-empty block, mirroring useSessionRunner's own nextStep().
-    const restNextStep = (() => {
-        if (!definition || !activeBlock) return null;
-        const groupProgress = getGroupProgress(activeBlock, entries, runner.activeStepIndex);
-        if (groupProgress) {
-            return groupProgress.nextStepIndex !== null ? activeBlock.steps[groupProgress.nextStepIndex] : null;
-        }
-        if (runner.activeStepIndex + 1 < activeBlock.steps.length) {
-            return activeBlock.steps[runner.activeStepIndex + 1];
-        }
-        const nextBlock = definition.blocks.find(
-            (candidate, index) => index > runner.activeBlockIndex && candidate.steps.length > 0,
-        );
-        return nextBlock ? nextBlock.steps[0] : null;
-    })();
 
     return (
         <div className="session-runner-container">
@@ -690,7 +714,7 @@ export const SessionRunner: React.FC<SessionRunnerProps> = ({
                         <span className="block-role-label">{block.title || block.role}</span>
                         <div className="step-pills">
                             {block.steps.map((step, sIdx) => {
-                                const stepCompletedSets = entries.filter(e => e.stepId === step.id && e.payload.kind !== 'choice').length;
+                                const stepCompletedSets = stepCompletedCounts.get(step.id) ?? 0;
                                 // Shares the same target-set contract GroupProgress uses below, so a
                                 // rotating group's block.rounds (not just the step's own dose.sets)
                                 // is honored consistently between the two displays.

--- a/app/src/engine/optimizer.ts
+++ b/app/src/engine/optimizer.ts
@@ -263,8 +263,13 @@ export function buildHistoryFeatureSummary(
     let lastEntry: SessionHistoryEntry | null = null;
     let lastEntryDiff = Number.POSITIVE_INFINITY;
 
+    const historyByDate = new Map<string, SessionHistoryEntry>();
+
     for (let i = 0; i < history.length; i++) {
         const h = history[i];
+        if (!historyByDate.has(h.date)) {
+            historyByDate.set(h.date, h);
+        }
         const diff = getDayDiff(targetDate, h.date);
 
         if (diff > 0 && diff < 2 && (h.role === 'anchor' || (h.category && ANCHOR_HISTORY_CATEGORIES.includes(h.category)))) {
@@ -327,7 +332,7 @@ export function buildHistoryFeatureSummary(
     let consecutiveHardStreak = 0;
     for (let checkOffset = 1; checkOffset <= 14; checkOffset++) {
         const checkDate = addDaysToLocalDateString(targetDate, -checkOffset);
-        const entry = history.find(h => h.date === checkDate);
+        const entry = historyByDate.get(checkDate);
         if (!entry || entry.category === 'Rest' || entry.category === 'Mobility/Recovery') {
             break;
         }

--- a/app/src/engine/optimizer.ts
+++ b/app/src/engine/optimizer.ts
@@ -263,13 +263,8 @@ export function buildHistoryFeatureSummary(
     let lastEntry: SessionHistoryEntry | null = null;
     let lastEntryDiff = Number.POSITIVE_INFINITY;
 
-    const historyByDate = new Map<string, SessionHistoryEntry>();
-
     for (let i = 0; i < history.length; i++) {
         const h = history[i];
-        if (!historyByDate.has(h.date)) {
-            historyByDate.set(h.date, h);
-        }
         const diff = getDayDiff(targetDate, h.date);
 
         if (diff > 0 && diff < 2 && (h.role === 'anchor' || (h.category && ANCHOR_HISTORY_CATEGORIES.includes(h.category)))) {
@@ -332,7 +327,7 @@ export function buildHistoryFeatureSummary(
     let consecutiveHardStreak = 0;
     for (let checkOffset = 1; checkOffset <= 14; checkOffset++) {
         const checkDate = addDaysToLocalDateString(targetDate, -checkOffset);
-        const entry = historyByDate.get(checkDate);
+        const entry = history.find(h => h.date === checkDate);
         if (!entry || entry.category === 'Rest' || entry.category === 'Mobility/Recovery') {
             break;
         }

--- a/app/src/hooks/useStrengthSessionRunner.ts
+++ b/app/src/hooks/useStrengthSessionRunner.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { LoggedExercise, LoggedSet, StrengthSession } from '../engine/models';
 import { strengthSessionService } from '../services/strengthSessionService';
 import { recommendationService } from '../services/recommendationService';
@@ -336,7 +336,11 @@ export function useStrengthSessionRunner(userId: string | null | undefined): Use
         return acknowledgedSetKeys.has(setSyncKey(exercise, set)) ? 'synced' as const : 'pending' as const;
     }, [acknowledgedSetKeys, syncUnavailable]);
 
-    const navigationSteps = resolveStepNavigation(session?.exercises ?? [], plannedExercises);
+    // ⚡ Bolt: Memoize navigation steps to prevent recalculation on every draft keystroke
+    const navigationSteps = useMemo(
+        () => resolveStepNavigation(session?.exercises ?? [], plannedExercises),
+        [session?.exercises, plannedExercises],
+    );
 
     return {
         loading, saving, error, session, plannedExercises, navigationSteps,

--- a/src/garmin_sync/garmin_provider.py
+++ b/src/garmin_sync/garmin_provider.py
@@ -1472,11 +1472,13 @@ class GarminProviderAdapter:
         # Not actually date-scoped (a profile setting, not per-day telemetry) but fetched
         # on the same daily cadence as the other enrichment endpoints for simplicity --
         # see GarminClientWrapper.get_heart_rate_zones.
-        heart_rate_zones = self._fetch_enrichment(
-            "heart_rate_zones", lambda: self.client.get_heart_rate_zones()
-        )
-        if isinstance(heart_rate_zones, list):
-            self._heart_rate_zones_cache = heart_rate_zones
+        heart_rate_zones = self._heart_rate_zones_cache
+        if heart_rate_zones is None:
+            heart_rate_zones = self._fetch_enrichment(
+                "heart_rate_zones", lambda: self.client.get_heart_rate_zones()
+            )
+            if isinstance(heart_rate_zones, list):
+                self._heart_rate_zones_cache = heart_rate_zones
 
         body_comp_today = self._fetch_enrichment(
             "body_composition", lambda: self.client.get_daily_weigh_ins(target_date_iso)

--- a/src/garmin_sync/service.py
+++ b/src/garmin_sync/service.py
@@ -664,11 +664,30 @@ class GarminSyncService:
 
         self._seed_prehistory(raw_memory_store, start_d)
 
+        existing_snapshots: dict[str, dict[str, Any]] = {}
+        bulk_snapshot_lookup_succeeded = False
+        if not force:
+            get_historical = getattr(self.repository, "get_historical_snapshots", None)
+            if callable(get_historical):
+                try:
+                    start_target_iso = get_date_string(target_dates[0])
+                    end_target_iso = get_date_string(target_dates[-1])
+                    fetched_snapshots = get_historical(start_target_iso, end_target_iso)
+                    if isinstance(fetched_snapshots, dict):
+                        existing_snapshots = fetched_snapshots
+                        bulk_snapshot_lookup_succeeded = True
+                except Exception as exc:
+                    logger.debug("Failed to bulk fetch historical snapshots for backfill: %s", exc)
+
         for target_date in target_dates:
             target_iso = get_date_string(target_date)
 
             if not force:
-                existing = self.repository.get_snapshot(target_iso)
+                existing = (
+                    existing_snapshots.get(target_iso)
+                    if bulk_snapshot_lookup_succeeded
+                    else self.repository.get_snapshot(target_iso)
+                )
                 if existing and existing.get("raw"):
                     raw_memory_store[target_iso] = existing["raw"]
                     logger.info(

--- a/tests/test_garmin_provider.py
+++ b/tests/test_garmin_provider.py
@@ -521,6 +521,7 @@ def test_provider_adapter_reuses_cached_stats_and_sleep_across_overlapping_dates
     # that call and this test would never exercise sleep-cache reuse.
     mock_client.get_sleep_data.return_value = {}
     mock_client.get_hrv_data.return_value = {"hrvSummary": {"lastNightAvg": 60}}
+    mock_client.get_heart_rate_zones.return_value = []
 
     adapter = GarminProviderAdapter(mock_client)
 
@@ -537,6 +538,9 @@ def test_provider_adapter_reuses_cached_stats_and_sleep_across_overlapping_dates
         "2026-08-06",
         "2026-08-07",
     }
+    # Heart-rate zones are profile-level settings, so the same adapter should fetch
+    # them only once even while daily telemetry advances through a backfill window.
+    mock_client.get_heart_rate_zones.assert_called_once_with()
 
     # Same reasoning applies to sleep: get_sleep_data(target) always fires, and (since
     # sleep_today is empty here) get_sleep_data(yesterday_iso) fires for the fallback too

--- a/tests/test_sync_service.py
+++ b/tests/test_sync_service.py
@@ -284,6 +284,23 @@ def test_backfill_with_include_details_fetches_and_persists_details():
     assert payload["powerInZones"][0]["zoneNumber"] == 2
 
 
+def test_backfill_uses_bulk_snapshot_lookup_without_per_date_reads():
+    provider = DetailFakeProvider()
+    service, repo = _detail_service(provider)
+
+    assert service.backfill(
+        start_date_str="2026-08-06",
+        end_date_str="2026-08-08",
+        force=False,
+    )
+
+    # One range query seeds prehistory and one covers the requested dates. An empty
+    # successful range result is authoritative; it must not trigger an N+1 fallback.
+    assert repo.get_historical_snapshots.call_count == 2
+    repo.get_snapshot.assert_not_called()
+    assert len(provider.fetch_daily_metrics_calls) == 3
+
+
 def test_push_workout_fails_when_garmin_does_not_return_a_workout_id():
     settings = Settings(app_user_id="test_uid_789")
     client = MagicMock()


### PR DESCRIPTION
## Summary

This PR completes the full-stack performance and memoization pass while preserving existing behavior and recommendation policy semantics.

### Frontend hot paths

- Memoizes stable tissue, physiology, injury-restriction, navigation, and session-comparison derivations.
- Reuses the 176-item exercise option list in the manual session builder.
- Pre-indexes session-entry completion counts for O(1) step-ribbon lookups.
- Avoids rebuilding choice lookup state, completion summaries, and rest-step previews on one-second runner timer renders.

### Sync backend

- Reuses Garmin heart-rate zones across a provider adapter's backfill window instead of re-fetching profile-level data per day.
- Replaces per-date existing-snapshot reads during backfill with one authoritative range query.
- Falls back to individual snapshot reads only when range lookup is unavailable, fails, or returns an unsupported shape.

### Review improvements over the interrupted implementation

- Repaired an incomplete `SessionRunner` edit that had removed the choice-label resolver and broken parsing.
- Moved memoization hooks above early returns and corrected their dependency sets.
- Removed a counter memoization that would necessarily invalidate on every slider update and therefore added overhead without avoiding work.
- Fixed the empty-range-result path so it does not silently reintroduce N+1 Firestore reads.
- Added regressions for one-time heart-rate-zone fetching and batched backfill snapshot lookup.
- Kept `optimizer.ts` unchanged because repository governance classifies it as policy-affecting; the small lookup optimization did not justify a misleading `POLICY_VERSION` bump in a semantics-preserving PR.

## Verification

- `npm run check` — TypeScript, ESLint, 2,234 tests passed (124 skipped), workout catalog validation passed.
- `npx vitest run src/components/session/ src/engine/optimizer.test.ts src/engine/fatigue.test.ts` — 35 targeted tests passed.
- `npm run build:bundle` — production bundle built successfully.
- `npm run simulate:diff` — no semantic differences from the committed simulation baseline.
- `uv run pytest` — 328 backend tests passed.
- `uv run ruff check .` — passed.
- `uv run ruff format --check .` — passed.
- `uv run mypy src/garmin_sync` — passed.
- `node scripts/check-policy-drift.mjs <main-sha>` — passed with no decision-affecting engine files modified.
- Staged pre-commit hooks and full pre-push hooks — passed.

## Risk and policy impact

This is a performance-only change. It does not alter recommendation thresholds, candidate ordering, policy version, user-scoped Firestore paths, or Europe/Warsaw date semantics.