### PR TITLE
feat(data-quality): add diagnostic confidence indicator

### DIFF
--- a/app/src/components/DataConfidenceIndicator.css
+++ b/app/src/components/DataConfidenceIndicator.css
@@ -1,0 +1,322 @@
+.data-confidence-wrapper {
+    position: relative;
+    display: inline-block;
+    margin: 0.25rem 0;
+}
+
+.data-confidence-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.35rem 0.75rem;
+    border-radius: 9999px;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    cursor: pointer;
+    border: 1px solid transparent;
+    transition: all 0.2s ease;
+    background: #f1f5f9;
+    color: #334155;
+}
+
+.data-confidence-badge:hover {
+    filter: brightness(0.95);
+}
+
+.data-confidence-badge:focus-visible,
+.confidence-close-btn:focus-visible,
+.confidence-refresh-btn:focus-visible {
+    outline: 3px solid rgba(14, 165, 233, 0.35);
+    outline-offset: 2px;
+}
+
+.confidence-high {
+    background-color: #ecfdf5;
+    color: #065f46;
+    border-color: #a7f3d0;
+}
+
+.confidence-moderate {
+    background-color: #fefce8;
+    color: #854d0e;
+    border-color: #fde047;
+}
+
+.confidence-low {
+    background-color: #fff7ed;
+    color: #9a3412;
+    border-color: #fdba74;
+}
+
+.confidence-insufficient {
+    background-color: #fef2f2;
+    color: #991b1b;
+    border-color: #fca5a5;
+}
+
+.confidence-expand-arrow {
+    font-size: 0.65rem;
+    opacity: 0.7;
+}
+
+.data-confidence-panel {
+    position: absolute;
+    top: calc(100% + 0.5rem);
+    right: 0;
+    z-index: 50;
+    width: 340px;
+    max-width: 90vw;
+    background: #ffffff;
+    border: 1px solid #e2e8f0;
+    border-radius: 0.75rem;
+    box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
+    padding: 1rem;
+    color: #1e293b;
+    font-size: 0.8125rem;
+    max-height: min(720px, 75vh);
+    overflow-y: auto;
+}
+
+.confidence-panel-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.5rem;
+}
+
+.confidence-panel-header h4 {
+    margin: 0;
+    font-size: 0.875rem;
+    font-weight: 600;
+}
+
+.confidence-panel-header-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+}
+
+.confidence-close-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.75rem;
+    height: 1.75rem;
+    padding: 0;
+    border: 1px solid #cbd5e1;
+    border-radius: 9999px;
+    background: #ffffff;
+    color: #475569;
+    cursor: pointer;
+    font-size: 1.15rem;
+    line-height: 1;
+}
+
+.confidence-close-btn:hover {
+    background: #f1f5f9;
+}
+
+.sensor-tier-tag {
+    font-size: 0.7rem;
+    padding: 0.15rem 0.45rem;
+    border-radius: 0.375rem;
+    font-weight: 600;
+    background: #e2e8f0;
+    color: #475569;
+}
+
+.sensor-tier-tag.tier-full_wearable {
+    background: #dbeafe;
+    color: #1e40af;
+}
+
+.confidence-summary {
+    margin: 0.25rem 0 0.75rem 0;
+    color: #475569;
+    font-size: 0.75rem;
+    line-height: 1.3;
+}
+
+.confidence-breakdown-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.5rem;
+    margin-bottom: 0.75rem;
+    background: #f8fafc;
+    padding: 0.5rem;
+    border-radius: 0.5rem;
+}
+
+.breakdown-meter {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+}
+
+.meter-label {
+    font-size: 0.6875rem;
+    color: #64748b;
+}
+
+.meter-bar-track {
+    height: 4px;
+    background: #e2e8f0;
+    border-radius: 2px;
+    overflow: hidden;
+}
+
+.meter-bar-fill {
+    height: 100%;
+    background: #0ea5e9;
+    border-radius: 2px;
+}
+
+.meter-value {
+    font-size: 0.6875rem;
+    font-weight: 600;
+    color: #334155;
+}
+
+.confidence-safeguards-box {
+    background: #fffbeb;
+    border: 1px solid #fef3c7;
+    border-radius: 0.375rem;
+    padding: 0.5rem;
+    margin-bottom: 0.75rem;
+    font-size: 0.75rem;
+}
+
+.safeguards-title {
+    font-weight: 600;
+    color: #92400e;
+    margin-bottom: 0.25rem;
+}
+
+.confidence-safeguards-box ul {
+    margin: 0;
+    padding-left: 1.2rem;
+    color: #b45309;
+}
+
+.confidence-signals-table {
+    margin-bottom: 0.75rem;
+}
+
+.signals-header {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: #475569;
+    margin-bottom: 0.25rem;
+}
+
+.signals-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.signal-item {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.2rem;
+    font-size: 0.75rem;
+    padding: 0.35rem 0;
+    border-bottom: 1px solid #f1f5f9;
+}
+
+.signal-heading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+}
+
+.signal-name {
+    color: #334155;
+}
+
+.signal-status-tag {
+    font-size: 0.65rem;
+    padding: 0.1rem 0.35rem;
+    border-radius: 0.25rem;
+    font-weight: 600;
+}
+
+.signal-status-tag.status-present {
+    background: #dcfce7;
+    color: #15803d;
+}
+
+.signal-status-tag.status-missing {
+    background: #f1f5f9;
+    color: #64748b;
+}
+
+.signal-status-tag.status-invalid {
+    background: #fee2e2;
+    color: #b91c1c;
+}
+
+.signal-status-tag.status-stale {
+    background: #fef3c7;
+    color: #b45309;
+}
+
+.signal-status-tag.status-degraded {
+    background: #ffedd5;
+    color: #c2410c;
+}
+
+.signal-value {
+    color: #334155;
+    font-variant-numeric: tabular-nums;
+}
+
+.signal-meta {
+    color: #64748b;
+    font-size: 0.6875rem;
+}
+
+.signal-issue-note {
+    font-size: 0.6875rem;
+    color: #b91c1c;
+    line-height: 1.35;
+}
+
+.confidence-actions {
+    margin-top: 0.5rem;
+    text-align: center;
+}
+
+.confidence-refresh-btn {
+    font-size: 0.75rem;
+    padding: 0.35rem 0.75rem;
+    background: #f8fafc;
+    border: 1px solid #cbd5e1;
+    border-radius: 0.375rem;
+    color: #334155;
+    cursor: pointer;
+    font-weight: 500;
+}
+
+.confidence-refresh-btn:hover {
+    background: #f1f5f9;
+}
+
+@media (max-width: 480px) {
+    .confidence-label {
+        display: none;
+    }
+
+    .data-confidence-panel {
+        position: fixed;
+        top: 5.5rem;
+        right: 1rem;
+        bottom: 5.5rem;
+        left: 1rem;
+        width: auto;
+        max-width: none;
+        max-height: none;
+    }
+}

--- a/app/src/components/DataConfidenceIndicator.test.tsx
+++ b/app/src/components/DataConfidenceIndicator.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { DataConfidenceIndicator } from './DataConfidenceIndicator';
+import type { DataConfidenceScore } from '../engine/dataConfidence';
+
+describe('DataConfidenceIndicator', () => {
+    const mockHighConfidence: DataConfidenceScore = {
+        rating: 'HIGH',
+        score: 92,
+        sensorTier: 'FULL_WEARABLE',
+        breakdown: {
+            completenessScore: 100,
+            freshnessScore: 90,
+            baselineMaturityScore: 100,
+            plausibilityScore: 100,
+        },
+        signals: {
+            hrv: { signal: 'hrv', displayName: 'Overnight HRV', status: 'PRESENT', value: 65, isPlausible: true },
+            rhr: { signal: 'rhr', displayName: 'Resting Heart Rate', status: 'PRESENT', value: 48, isPlausible: true },
+        },
+        activeSafeguards: [],
+        summaryMessage: 'Complete, current, plausible core signals with mature wearable baselines.',
+    };
+
+    it('renders null when confidence is undefined or null', () => {
+        const html = renderToStaticMarkup(<DataConfidenceIndicator confidence={null} />);
+        expect(html).toBe('');
+    });
+
+    it('renders the high confidence badge correctly with class and text', () => {
+        const html = renderToStaticMarkup(<DataConfidenceIndicator confidence={mockHighConfidence} />);
+        expect(html).toContain('confidence-high');
+        expect(html).toContain('Confidence:');
+        expect(html).toContain('HIGH (92%)');
+    });
+
+    it('renders low confidence with appropriate styling', () => {
+        const lowConfidence: DataConfidenceScore = {
+            ...mockHighConfidence,
+            rating: 'LOW',
+            score: 45,
+            sensorTier: 'SUBJECTIVE_ONLY',
+            activeSafeguards: ['Subjective-only coverage: wearable telemetry is absent or unusable.'],
+        };
+
+        const html = renderToStaticMarkup(<DataConfidenceIndicator confidence={lowConfidence} />);
+        expect(html).toContain('confidence-low');
+        expect(html).toContain('LOW (45%)');
+    });
+});

--- a/app/src/components/DataConfidenceIndicator.tsx
+++ b/app/src/components/DataConfidenceIndicator.tsx
@@ -1,0 +1,161 @@
+import React, { useId, useState } from 'react';
+import type { ConfidenceRating, DataConfidenceScore, SensorTier } from '../engine/dataConfidence';
+import './DataConfidenceIndicator.css';
+
+export interface DataConfidenceIndicatorProps {
+    confidence?: DataConfidenceScore | null;
+    onRefresh?: () => void;
+}
+
+export const DataConfidenceIndicator: React.FC<DataConfidenceIndicatorProps> = ({
+    confidence,
+    onRefresh,
+}) => {
+    const [isExpanded, setIsExpanded] = useState(false);
+    const panelId = useId();
+
+    if (!confidence) return null;
+
+    const { rating, score, sensorTier, breakdown, signals, activeSafeguards, summaryMessage } = confidence;
+
+    const ratingClasses: Record<ConfidenceRating, string> = {
+        HIGH: 'confidence-high',
+        MODERATE: 'confidence-moderate',
+        LOW: 'confidence-low',
+        INSUFFICIENT: 'confidence-insufficient',
+    };
+
+    const ratingIcons: Record<ConfidenceRating, string> = {
+        HIGH: '🛡️',
+        MODERATE: '⚠️',
+        LOW: '⚡',
+        INSUFFICIENT: '🛑',
+    };
+
+    const tierLabels: Record<SensorTier, string> = {
+        FULL_WEARABLE: 'Full Wearable',
+        BASIC_WEARABLE: 'Basic Wearable',
+        SUBJECTIVE_ONLY: 'Subjective Only',
+    };
+
+    return (
+        <div className='data-confidence-wrapper'>
+            <button
+                type='button'
+                className={'data-confidence-badge ' + (ratingClasses[rating] || 'confidence-low')}
+                onClick={() => setIsExpanded(!isExpanded)}
+                aria-expanded={isExpanded}
+                aria-controls={panelId}
+                aria-label={'Data confidence: ' + rating + ' (' + score + '%). Click to toggle diagnostic breakdown.'}
+            >
+                <span className='confidence-icon' aria-hidden='true'>{ratingIcons[rating] || 'ℹ️'}</span>
+                <span className='confidence-label'>
+                    Confidence: <strong>{rating} ({score}%)</strong>
+                </span>
+                <span className='confidence-expand-arrow' aria-hidden='true'>{isExpanded ? '▲' : '▼'}</span>
+            </button>
+
+            {isExpanded && (
+                <div id={panelId} className='data-confidence-panel' role='region' aria-label='Data confidence diagnostic breakdown'>
+                    <div className='confidence-panel-header'>
+                        <h4>Data Quality & Telemetry Confidence</h4>
+                        <div className='confidence-panel-header-actions'>
+                            <span className={'sensor-tier-tag tier-' + sensorTier.toLowerCase()}>
+                                {tierLabels[sensorTier]}
+                            </span>
+                            <button
+                                type='button'
+                                className='confidence-close-btn'
+                                aria-label='Close data confidence details'
+                                onClick={() => setIsExpanded(false)}
+                            >
+                                ×
+                            </button>
+                        </div>
+                    </div>
+
+                    <p className='confidence-summary'>{summaryMessage}</p>
+
+                    <div className='confidence-breakdown-grid'>
+                        <div className='breakdown-meter'>
+                            <div className='meter-label'>Completeness</div>
+                            <div className='meter-bar-track'>
+                                <div className='meter-bar-fill' style={{ width: breakdown.completenessScore + '%' }} />
+                            </div>
+                            <div className='meter-value'>{breakdown.completenessScore}%</div>
+                        </div>
+
+                        <div className='breakdown-meter'>
+                            <div className='meter-label'>Freshness</div>
+                            <div className='meter-bar-track'>
+                                <div className='meter-bar-fill' style={{ width: breakdown.freshnessScore + '%' }} />
+                            </div>
+                            <div className='meter-value'>{breakdown.freshnessScore}%</div>
+                        </div>
+
+                        <div className='breakdown-meter'>
+                            <div className='meter-label'>Baseline Maturity</div>
+                            <div className='meter-bar-track'>
+                                <div className='meter-bar-fill' style={{ width: breakdown.baselineMaturityScore + '%' }} />
+                            </div>
+                            <div className='meter-value'>{breakdown.baselineMaturityScore}%</div>
+                        </div>
+
+                        <div className='breakdown-meter'>
+                            <div className='meter-label'>Plausibility</div>
+                            <div className='meter-bar-track'>
+                                <div className='meter-bar-fill' style={{ width: breakdown.plausibilityScore + '%' }} />
+                            </div>
+                            <div className='meter-value'>{breakdown.plausibilityScore}%</div>
+                        </div>
+                    </div>
+
+                    {activeSafeguards && activeSafeguards.length > 0 && (
+                        <div className='confidence-safeguards-box'>
+                            <div className='safeguards-title'>Data quality cautions</div>
+                            <ul>
+                                {activeSafeguards.map((safeguard, idx) => (
+                                    <li key={idx}>{safeguard}</li>
+                                ))}
+                            </ul>
+                        </div>
+                    )}
+
+                    <div className='confidence-signals-table'>
+                        <div className='signals-header'>Signal Diagnostics:</div>
+                        <div className='signals-list'>
+                            {Object.values(signals).map(sig => (
+                                <div key={sig.signal} className={'signal-item status-' + sig.status.toLowerCase()}>
+                                    <div className='signal-heading'>
+                                        <span className='signal-name'>{sig.displayName}</span>
+                                        <span className={'signal-status-tag status-' + sig.status.toLowerCase()}>
+                                            {sig.status}
+                                        </span>
+                                    </div>
+                                    {sig.value !== null && (
+                                        <span className='signal-value'>{String(sig.value)}{typeof sig.value === 'number' && sig.unit ? ` ${sig.unit}` : ''}</span>
+                                    )}
+                                    {sig.freshnessHours !== undefined && sig.freshnessHours !== null && (
+                                        <span className='signal-meta'>Updated {sig.freshnessHours < 1 ? '<1' : Math.round(sig.freshnessHours)}h ago</span>
+                                    )}
+                                    {sig.historyDays !== undefined && sig.historyDays !== null && (
+                                        <span className='signal-meta'>{sig.historyDays}-day baseline window</span>
+                                    )}
+                                    {sig.issues?.map(issue => <span key={issue} className='signal-issue-note'>{issue}</span>)}
+                                </div>
+                            ))}
+                        </div>
+                    </div>
+
+                    {onRefresh && (
+                        <div className='confidence-actions'>
+                            <button type='button' className='confidence-refresh-btn' onClick={onRefresh}>
+                                Refresh displayed data
+                            </button>
+                        </div>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+};

--- a/app/src/components/Home.css
+++ b/app/src/components/Home.css
@@ -415,6 +415,11 @@
   margin-bottom: var(--mobile-section-gap, 16px);
   background: rgba(255, 255, 255, 0.03);
   border: 1px solid rgba(255, 255, 255, 0.07);
+  cursor: default;
+}
+
+.today-status-summary-card:hover {
+  transform: none;
 }
 
 .today-status-row {

--- a/app/src/components/Home.tsx
+++ b/app/src/components/Home.tsx
@@ -43,6 +43,7 @@ import { MinimumSafetyCheckin } from './MinimumSafetyCheckin';
 import { WeekAheadStrip } from './WeekAheadStrip';
 import { LaterDayFollowupCard, type LaterDayFollowupTarget } from './session/LaterDayFollowupCard';
 import { GarminSyncNowButton } from './GarminSyncNowButton';
+import { DataConfidenceIndicator } from './DataConfidenceIndicator';
 import type { ErrorRepairAction } from './errorRepairAction';
 import { useAutoGarminSync } from '../hooks/useAutoGarminSync';
 import {
@@ -950,6 +951,7 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
                 </h3>
               </div>
               <div className="today-status-header-actions">
+                <DataConfidenceIndicator confidence={decisionInput?.dataConfidence} onRefresh={loadDashboardData} />
                 {activeRec && (
                   <span className={`status-badge mode-${activeRec.mode}`}>
                     {MODE_LABELS[activeRec.mode]}

--- a/app/src/engine/composer.ts
+++ b/app/src/engine/composer.ts
@@ -3,6 +3,7 @@ import type { DataIssue, DataState, DataStateSummary } from './dataState';
 import { summarizeDataState } from './dataState';
 import { isSupportedTrainingSettingsSchemaVersion } from './trainingSettingsSchema';
 import { computeSubjectiveBaseline, REFERENCE_SUBJECTIVE_BASELINE_POLICY, type SubjectiveBaseline } from './subjectiveBaseline';
+import { evaluateDataConfidence } from './dataConfidence';
 import { checkinService } from '../services/checkinService';
 import { goalService } from '../services/goalService';
 import { trainingSettingsService } from '../services/trainingSettingsService';
@@ -122,7 +123,7 @@ export class DecisionComposer {
                 profileReady: preferences !== null
             };
 
-            return {
+            const baseInput: DailyDecisionInput = {
                 userId,
                 date: targetDate,
                 recoverySnapshot,
@@ -133,6 +134,16 @@ export class DecisionComposer {
                 trainingIntentProfile,
                 sourceStates,
                 dataQuality,
+            };
+
+            // Keep wall-clock evaluation at the composition boundary. The pure evaluator
+            // accepts this timestamp explicitly so tests and historical inspection remain
+            // deterministic.
+            const dataConfidence = evaluateDataConfidence(baseInput, new Date().toISOString());
+
+            return {
+                ...baseInput,
+                dataConfidence,
                 subjectiveBaseline,
                 subjectiveHistoryState,
                 subjectiveHistoryIssues,

--- a/app/src/engine/dataConfidence.test.ts
+++ b/app/src/engine/dataConfidence.test.ts
@@ -1,0 +1,275 @@
+import { describe, it, expect } from 'vitest';
+import { evaluateDataConfidence } from './dataConfidence';
+import type { DailyDecisionInput, DailyRecoverySnapshot, DailySubjectiveCheckin } from './models';
+
+const EVALUATED_AT = '2026-08-26T09:00:00Z';
+
+function createMockCheckin(overrides?: Partial<DailySubjectiveCheckin>): DailySubjectiveCheckin {
+    return {
+        userId: 'u1',
+        date: '2026-08-26',
+        readiness: 8,
+        fatigue: 3,
+        soreness: 2,
+        mentalStress: 3,
+        sleepQuality: 8,
+        motivation: 8,
+        painOrInjury: false,
+        illnessSymptoms: false,
+        unusuallyLimitedTime: false,
+        alreadyTrainedToday: false,
+        availability: { timeAvailableMin: 60, preferredModalityToday: null, indoorOnly: false },
+        notes: null,
+        submittedAt: '2026-08-26T07:00:00Z',
+        dataQuality: { isComplete: true, missingFields: [] },
+        schemaVersion: 1,
+        createdAt: '2026-08-26T07:00:00Z',
+        updatedAt: '2026-08-26T07:00:00Z',
+        ...overrides,
+    };
+}
+
+function createMockSnapshot(overrides?: Partial<DailyRecoverySnapshot['raw']>, derivedOverrides?: Partial<DailyRecoverySnapshot['derived']>): DailyRecoverySnapshot {
+    return {
+        userId: 'u1',
+        date: '2026-08-26',
+        schemaVersion: 3,
+        source: {
+            garminSyncedAt: '2026-08-26T08:00:00Z',
+            sourceSchemaVersion: 3,
+            timezone: 'Europe/Warsaw',
+            metricDates: {
+                sleep: '2026-08-26',
+                hrv: '2026-08-26',
+                restingHr: '2026-08-26',
+                bodyBatteryWake: '2026-08-26',
+                steps: '2026-08-25',
+            },
+        },
+        raw: {
+            hrvOvernightAvg: 65,
+            restingHr: 48,
+            sleepScore: 85,
+            sleepDurationSec: 28800, // 8h
+            totalSteps: 8500,
+            respirationAvg: 14.5,
+            bodyBatteryWake: 90,
+            last3DaysHardSessionsCount: 0,
+            yesterdayTraining: null,
+            todayTraining: null,
+            ...overrides,
+        },
+        derived: {
+            baselineComputationVersion: 3,
+            hrv7dAvg: 63,
+            hrv28dAvg: 64,
+            hrv28dStdev: 6.2,
+            restingHr7dAvg: 49,
+            restingHr28dAvg: 48.5,
+            restingHr28dStdev: 2.1,
+            sleepScore7dAvg: 82,
+            sleepScore28dAvg: 80,
+            sleepScore28dStdev: 7.5,
+            respiration7dAvg: 14.2,
+            respiration28dAvg: 14.1,
+            respiration28dMad: 0.8,
+            steps7dAvg: 9000,
+            steps28dAvg: 8800,
+            deltas: {
+                hrvVs7d: 2,
+                hrvVs28d: 1,
+                restingHrVs7d: -1,
+                restingHrVs28d: -0.5,
+                sleepScoreVs7d: 3,
+                sleepScoreVs28d: 5,
+                respirationVs7d: 0.3,
+                respirationVs28d: 0.4,
+                stepsVs7d: -500,
+                stepsVs28d: -300,
+            },
+            ...derivedOverrides,
+        },
+        dataQuality: {
+            sleepScoreAvailable: true,
+            restingHrAvailable: true,
+            hrvAvailable: true,
+            baseline7dReady: true,
+            baseline28dReady: true,
+        },
+    } as unknown as DailyRecoverySnapshot;
+}
+
+function createDecisionInput(snapshot: DailyRecoverySnapshot | null, checkin: DailySubjectiveCheckin | null): DailyDecisionInput {
+    return {
+        userId: 'u1',
+        date: '2026-08-26',
+        recoverySnapshot: snapshot,
+        subjectiveCheckin: checkin,
+        activeGoals: [],
+        trainingSettings: {
+            userId: 'u1',
+            schemaVersion: 2,
+            equipment: { free_weights: true, cable_machine: false, treadmill: false, indoor_bike: false, pullup_bar: true },
+            guardrails: { avoid_high_impact: false, avoid_heavy_lower_body: false, avoid_overhead_pressing: false, avoid_heavy_spinal_loading: false },
+            defaults: { weekdayMaxMinutes: 60, weekendMaxMinutes: 120, environment: 'either' },
+            preferences: { preferActiveRecovery: false },
+            migration: { legacyReviewed: true, migratedAt: '2026-08-01' },
+            createdAt: '2026-08-01',
+            updatedAt: '2026-08-01',
+        },
+        preferences: null,
+        trainingIntentProfile: null,
+        dataQuality: {
+            hasRecoverySnapshot: snapshot !== null,
+            hasSubjectiveCheckin: checkin !== null,
+            subjectiveCheckinComplete: checkin !== null,
+            profileReady: true,
+        },
+    };
+}
+
+describe('evaluateDataConfidence', () => {
+    it('evaluates HIGH confidence with full valid biometrics and check-in', () => {
+        const snapshot = createMockSnapshot();
+        const checkin = createMockCheckin();
+        const input = createDecisionInput(snapshot, checkin);
+
+        const confidence = evaluateDataConfidence(input, EVALUATED_AT);
+
+        expect(confidence.rating).toBe('HIGH');
+        expect(confidence.sensorTier).toBe('FULL_WEARABLE');
+        expect(confidence.score).toBeGreaterThanOrEqual(80);
+        expect(confidence.breakdown.completenessScore).toBe(100);
+        expect(confidence.breakdown.plausibilityScore).toBe(100);
+        expect(confidence.signals.hrv.status).toBe('PRESENT');
+        expect(confidence.signals.rhr.status).toBe('PRESENT');
+    });
+
+    it('evaluates MODERATE confidence when HRV is missing but Sleep and RHR are present', () => {
+        const snapshot = createMockSnapshot({ hrvOvernightAvg: null });
+        const checkin = createMockCheckin();
+        const input = createDecisionInput(snapshot, checkin);
+
+        const confidence = evaluateDataConfidence(input, EVALUATED_AT);
+
+        expect(confidence.rating).toBe('MODERATE');
+        expect(confidence.sensorTier).toBe('BASIC_WEARABLE');
+        expect(confidence.signals.hrv.status).toBe('MISSING');
+        expect(confidence.signals.rhr.status).toBe('PRESENT');
+    });
+
+    it('evaluates LOW confidence for subjective checkin only (no Garmin snapshot)', () => {
+        const checkin = createMockCheckin();
+        const input = createDecisionInput(null, checkin);
+
+        const confidence = evaluateDataConfidence(input, EVALUATED_AT);
+
+        expect(confidence.rating).toBe('LOW');
+        expect(confidence.sensorTier).toBe('SUBJECTIVE_ONLY');
+        expect(confidence.signals.hrv.status).toBe('MISSING');
+        expect(confidence.activeSafeguards).toContain('Subjective-only coverage: wearable telemetry is absent or unusable.');
+    });
+
+    it('evaluates INSUFFICIENT confidence when subjective checkin is missing', () => {
+        const snapshot = createMockSnapshot();
+        const input = createDecisionInput(snapshot, null);
+
+        const confidence = evaluateDataConfidence(input, EVALUATED_AT);
+
+        expect(confidence.rating).toBe('INSUFFICIENT');
+        expect(confidence.signals.subjectiveCheckin.status).toBe('MISSING');
+        expect(confidence.activeSafeguards.some(s => s.includes('Missing check-in'))).toBe(true);
+    });
+
+    it('evaluates INSUFFICIENT confidence when current check-in values are invalid', () => {
+        const checkin = createMockCheckin({ fatigue: 14 });
+
+        const confidence = evaluateDataConfidence(createDecisionInput(createMockSnapshot(), checkin), EVALUATED_AT);
+
+        expect(confidence.rating).toBe('INSUFFICIENT');
+        expect(confidence.signals.subjectiveCheckin.status).toBe('INVALID');
+    });
+
+    it('detects and flags physiologically implausible biometric values', () => {
+        const snapshot = createMockSnapshot({
+            restingHr: 220, // Cadence lock or sensor fault
+            respirationAvg: 52, // Sensor fault
+            hrvOvernightAvg: 450, // Impossible rMSSD
+        });
+        const checkin = createMockCheckin();
+        const input = createDecisionInput(snapshot, checkin);
+
+        const confidence = evaluateDataConfidence(input, EVALUATED_AT);
+
+        expect(confidence.signals.rhr.status).toBe('INVALID');
+        expect(confidence.signals.respiration.status).toBe('INVALID');
+        expect(confidence.signals.hrv.status).toBe('INVALID');
+        expect(confidence.breakdown.plausibilityScore).toBeLessThan(100);
+        expect(confidence.activeSafeguards.some(s => s.includes('physiologically implausible'))).toBe(true);
+    });
+
+    it('applies conservative safeguard when RHR is elevated but HRV is missing', () => {
+        const snapshot = createMockSnapshot(
+            { hrvOvernightAvg: null, restingHr: 54 },
+            { deltas: { restingHrVs7d: 5, hrvVs7d: null, restingHrVs28d: null, hrvVs28d: null, sleepScoreVs7d: null, sleepScoreVs28d: null, respirationVs7d: null, respirationVs28d: null } } as unknown as DailyRecoverySnapshot['derived']
+        );
+        const checkin = createMockCheckin();
+        const input = createDecisionInput(snapshot, checkin);
+
+        const confidence = evaluateDataConfidence(input, EVALUATED_AT);
+
+        expect(confidence.activeSafeguards.some(s => s.includes('HRV is unavailable while RHR is elevated'))).toBe(true);
+    });
+
+    it('does not mistake undefined legacy baseline fields for mature 28-day history', () => {
+        const snapshot = createMockSnapshot({}, {
+            hrv28dAvg: undefined,
+            hrv28dStdev: undefined,
+            restingHr28dAvg: undefined,
+            restingHr28dStdev: undefined,
+            sleepScore28dAvg: undefined,
+            sleepScore28dStdev: undefined,
+        });
+
+        const confidence = evaluateDataConfidence(createDecisionInput(snapshot, createMockCheckin()), EVALUATED_AT);
+
+        expect(confidence.breakdown.baselineMaturityScore).toBe(60);
+        expect(confidence.rating).toBe('MODERATE');
+        expect(confidence.signals.hrv.historyDays).toBe(7);
+    });
+
+    it('marks a prior-date HRV observation stale even when the snapshot was synced recently', () => {
+        const snapshot = createMockSnapshot();
+        snapshot.source.metricDates = { ...snapshot.source.metricDates, hrv: '2026-08-25' };
+
+        const confidence = evaluateDataConfidence(createDecisionInput(snapshot, createMockCheckin()), EVALUATED_AT);
+
+        expect(confidence.signals.hrv.status).toBe('STALE');
+        expect(confidence.rating).toBe('MODERATE');
+    });
+
+    it('rejects an out-of-range sleep score even when duration is plausible', () => {
+        const snapshot = createMockSnapshot({ sleepScore: 140 });
+
+        const confidence = evaluateDataConfidence(createDecisionInput(snapshot, createMockCheckin()), EVALUATED_AT);
+
+        expect(confidence.signals.sleep.status).toBe('INVALID');
+        expect(confidence.signals.sleep.issues).toContain('Sleep score 140 is outside 0-100.');
+    });
+
+    it('uses the Warsaw D-1 metric date for ambient steps', () => {
+        const snapshot = createMockSnapshot();
+        snapshot.source.metricDates = { ...snapshot.source.metricDates, steps: '2026-08-26' };
+
+        const confidence = evaluateDataConfidence(createDecisionInput(snapshot, createMockCheckin()), EVALUATED_AT);
+
+        expect(confidence.signals.steps.expectedDate).toBe('2026-08-25');
+        expect(confidence.signals.steps.status).toBe('STALE');
+    });
+
+    it('rejects an invalid evaluation timestamp instead of falling back to wall-clock time', () => {
+        const input = createDecisionInput(createMockSnapshot(), createMockCheckin());
+
+        expect(() => evaluateDataConfidence(input, 'not-a-date')).toThrow('valid ISO date-time');
+    });
+});

--- a/app/src/engine/dataConfidence.ts
+++ b/app/src/engine/dataConfidence.ts
@@ -316,6 +316,8 @@ export function evaluateDataConfidence(
         signals.rhr = { signal: 'rhr', displayName: 'Resting Heart Rate', status: 'MISSING', value: null, unit: 'bpm', isPlausible: false };
         signals.sleep = { signal: 'sleep', displayName: 'Sleep Duration & Score', status: 'MISSING', value: null, unit: 'min', isPlausible: false };
         signals.steps = { signal: 'steps', displayName: 'Ambient Steps (D-1)', status: 'MISSING', value: null, unit: 'steps', expectedDate: getPreviousLocalDateString(input.date), isPlausible: false };
+        signals.respiration = { signal: 'respiration', displayName: 'Sleeping Respiration', status: 'MISSING', value: null, unit: 'brpm', isPlausible: false };
+        signals.bodyBattery = { signal: 'bodyBattery', displayName: 'Body Battery (Wake)', status: 'MISSING', value: null, unit: 'pts', isPlausible: false };
     }
 
     const sensorTier: SensorTier = hasPlausibleHrv && hasPlausibleRhr && hasPlausibleSleep

--- a/app/src/engine/dataConfidence.ts
+++ b/app/src/engine/dataConfidence.ts
@@ -1,0 +1,383 @@
+import { getPreviousLocalDateString } from '../utils/localDate';
+import type { DailyDecisionInput, DailyRecoverySnapshot } from './models';
+
+/**
+ * Dashboard-facing observability only. This evaluator describes the evidence available
+ * at composition time; it does not change readiness mode, eligibility, dose, or ranking.
+ * Existing safety rules remain the sole decision authority.
+ */
+export type ConfidenceRating = 'HIGH' | 'MODERATE' | 'LOW' | 'INSUFFICIENT';
+export type SensorTier = 'FULL_WEARABLE' | 'BASIC_WEARABLE' | 'SUBJECTIVE_ONLY';
+export type SignalStatus = 'PRESENT' | 'DEGRADED' | 'STALE' | 'MISSING' | 'INVALID';
+
+export interface SignalQualityDetail {
+    signal: string;
+    displayName: string;
+    status: SignalStatus;
+    value: number | string | boolean | null;
+    unit?: string;
+    freshnessHours?: number | null;
+    historyDays?: number | null;
+    observedDate?: string | null;
+    expectedDate?: string;
+    validRange?: [number, number];
+    isPlausible: boolean;
+    issues?: string[];
+}
+
+export interface ConfidenceBreakdown {
+    completenessScore: number;
+    freshnessScore: number;
+    baselineMaturityScore: number;
+    plausibilityScore: number;
+}
+
+export interface DataConfidenceScore {
+    rating: ConfidenceRating;
+    score: number;
+    sensorTier: SensorTier;
+    breakdown: ConfidenceBreakdown;
+    signals: Record<string, SignalQualityDetail>;
+    activeSafeguards: string[];
+    summaryMessage: string;
+}
+
+export const PHYSIOLOGICAL_BOUNDS = {
+    hrv: { min: 8, max: 300, warnMin: 15, warnMax: 200, unit: 'ms' },
+    rhr: { min: 28, max: 140, warnMin: 35, warnMax: 100, unit: 'bpm' },
+    sleepScore: { min: 0, max: 100, unit: 'pts' },
+    sleepDurationMin: { min: 60, max: 900, warnMin: 180, warnMax: 720, unit: 'min' },
+    respiration: { min: 6, max: 35, warnMin: 8, warnMax: 25, unit: 'brpm' },
+    bodyBattery: { min: 0, max: 100, unit: 'pts' },
+    steps: { min: 0, max: 100000, warnMax: 50000, unit: 'steps' },
+    subjectiveScale: { min: 1, max: 10, unit: '1-10' },
+} as const;
+
+export const FRESHNESS_LIMITS_HOURS = {
+    sleep: 18,
+    biometrics: 18,
+    bodyBatteryWake: 14,
+    stepsD1: 36,
+    subjectiveCheckin: 24,
+} as const;
+
+function isFiniteNumber(value: unknown): value is number {
+    return typeof value === 'number' && Number.isFinite(value);
+}
+
+function isWithinRange(value: unknown, min: number, max: number): value is number {
+    return isFiniteNumber(value) && value >= min && value <= max;
+}
+
+function ageHours(timestamp: string | null | undefined, now: Date): number | null {
+    if (!timestamp) return null;
+    const parsed = new Date(timestamp);
+    if (!Number.isFinite(parsed.getTime())) return null;
+    const age = (now.getTime() - parsed.getTime()) / 3_600_000;
+    if (age < -(5 / 60)) return null;
+    return Math.max(0, age);
+}
+
+function statusForCurrentSignal(options: {
+    plausible: boolean;
+    freshnessHours: number | null;
+    freshnessLimitHours: number;
+    observedDate: string | null;
+    expectedDate: string;
+    degraded?: boolean;
+}): SignalStatus {
+    if (!options.plausible) return 'INVALID';
+    if (options.observedDate !== null && options.observedDate !== options.expectedDate) return 'STALE';
+    if (options.freshnessHours !== null && options.freshnessHours > options.freshnessLimitHours) return 'STALE';
+    if (options.freshnessHours === null || options.degraded) return 'DEGRADED';
+    return 'PRESENT';
+}
+
+function historyDays(
+    snapshot: DailyRecoverySnapshot,
+    sevenDayValue: unknown,
+    twentyEightDayValue: unknown,
+    twentyEightDaySpread: unknown,
+): number {
+    if (
+        snapshot.dataQuality?.baseline28dReady === true
+        && isFiniteNumber(twentyEightDayValue)
+        && isFiniteNumber(twentyEightDaySpread)
+    ) return 28;
+    if (snapshot.dataQuality?.baseline7dReady === true && isFiniteNumber(sevenDayValue)) return 7;
+    return 0;
+}
+
+function baselineScore(days: number): number {
+    if (days >= 28) return 100;
+    if (days >= 7) return 60;
+    return 20;
+}
+
+function average(values: number[]): number {
+    if (values.length === 0) return 0;
+    return Math.round(values.reduce((sum, value) => sum + value, 0) / values.length);
+}
+
+function statusCompleteness(status: SignalStatus): number {
+    if (status === 'PRESENT') return 1;
+    if (status === 'DEGRADED') return 0.75;
+    if (status === 'STALE') return 0.25;
+    return 0;
+}
+
+function statusFreshness(status: SignalStatus): number {
+    if (status === 'PRESENT') return 100;
+    if (status === 'DEGRADED') return 70;
+    return 0;
+}
+
+export function evaluateDataConfidence(
+    input: DailyDecisionInput,
+    evaluationTimestampIso: string = new Date().toISOString(),
+): DataConfidenceScore {
+    const signals: Record<string, SignalQualityDetail> = {};
+    const activeSafeguards: string[] = [];
+    const snapshot = input.recoverySnapshot;
+    const checkin = input.subjectiveCheckin;
+    const evaluationTime = new Date(evaluationTimestampIso);
+    if (!Number.isFinite(evaluationTime.getTime())) {
+        throw new Error('Data-confidence evaluation timestamp must be a valid ISO date-time.');
+    }
+
+    const subjectiveValues = checkin
+        ? [checkin.readiness, checkin.fatigue, checkin.soreness, checkin.mentalStress, checkin.sleepQuality, checkin.motivation]
+        : [];
+    const subjectiveScalesValid = subjectiveValues.length > 0
+        && subjectiveValues.every(value => isWithinRange(value, PHYSIOLOGICAL_BOUNDS.subjectiveScale.min, PHYSIOLOGICAL_BOUNDS.subjectiveScale.max));
+    const subjectiveTimeValid = checkin !== null && isWithinRange(checkin.availability?.timeAvailableMin, 0, 360);
+    const subjectiveShapeValid = checkin !== null
+        && typeof checkin.painOrInjury === 'boolean'
+        && typeof checkin.illnessSymptoms === 'boolean';
+    const subjectivePlausible = subjectiveScalesValid && subjectiveTimeValid && subjectiveShapeValid;
+    const subjectiveAge = ageHours(checkin?.submittedAt, evaluationTime);
+    const subjectiveIssues: string[] = [];
+    if (checkin && !subjectiveScalesValid) subjectiveIssues.push('Check-in scale values must be between 1 and 10.');
+    if (checkin && !subjectiveTimeValid) subjectiveIssues.push('Available time must be between 0 and 360 minutes.');
+    if (checkin && !subjectiveShapeValid) subjectiveIssues.push('Required safety answers are missing.');
+    if (checkin && checkin.date !== input.date) subjectiveIssues.push(`Check-in is for ${checkin.date}, not ${input.date}.`);
+    if (checkin?.dataQuality.isComplete === false) subjectiveIssues.push('Check-in is incomplete; minimum safety fields remain available.');
+    if (checkin && subjectiveAge === null) subjectiveIssues.push('Check-in submission time is unavailable or invalid.');
+
+    let subjectiveStatus: SignalStatus = 'MISSING';
+    if (checkin) {
+        if (!subjectivePlausible) subjectiveStatus = 'INVALID';
+        else if (checkin.date !== input.date || (subjectiveAge !== null && subjectiveAge > FRESHNESS_LIMITS_HOURS.subjectiveCheckin)) subjectiveStatus = 'STALE';
+        else if (subjectiveAge === null || !checkin.dataQuality.isComplete) subjectiveStatus = 'DEGRADED';
+        else subjectiveStatus = 'PRESENT';
+    }
+    signals.subjectiveCheckin = {
+        signal: 'subjectiveCheckin', displayName: 'Daily Check-in', status: subjectiveStatus,
+        value: checkin ? (checkin.dataQuality.isComplete ? 'Complete' : 'Minimum safety only') : null,
+        freshnessHours: subjectiveAge,
+        observedDate: checkin?.date ?? null, expectedDate: input.date, validRange: [1, 10],
+        isPlausible: subjectivePlausible,
+        issues: checkin ? subjectiveIssues : ['Subjective check-in has not been submitted today.'],
+    };
+    if (!checkin) activeSafeguards.push('Missing check-in: normal plan generation remains blocked by the existing safety gate.');
+    else if (subjectiveStatus === 'INVALID' || subjectiveStatus === 'STALE') activeSafeguards.push('Unusable check-in: current subjective safety evidence is insufficient.');
+
+    let hasPlausibleHrv = false;
+    let hasPlausibleRhr = false;
+    let hasPlausibleSleep = false;
+    let hasPlausibleSteps = false;
+    const baselineScores: number[] = [];
+
+    if (snapshot?.raw && snapshot.derived) {
+        const { raw, derived } = snapshot;
+        const metricDates = snapshot.source?.metricDates;
+        const syncAge = ageHours(snapshot.source?.garminSyncedAt, evaluationTime);
+
+        const hrvValue = raw.hrvOvernightAvg;
+        const hrvHistoryDays = historyDays(snapshot, derived.hrv7dAvg, derived.hrv28dAvg, derived.hrv28dStdev);
+        if (hrvValue === null || hrvValue === undefined) {
+            signals.hrv = { signal: 'hrv', displayName: 'Overnight HRV', status: 'MISSING', value: null, unit: 'ms', historyDays: hrvHistoryDays, isPlausible: false, issues: ['Overnight HRV was not recorded.'] };
+        } else {
+            const plausible = isWithinRange(hrvValue, PHYSIOLOGICAL_BOUNDS.hrv.min, PHYSIOLOGICAL_BOUNDS.hrv.max);
+            const warning = plausible && (hrvValue < PHYSIOLOGICAL_BOUNDS.hrv.warnMin || hrvValue > PHYSIOLOGICAL_BOUNDS.hrv.warnMax);
+            const observedDate = metricDates?.hrv ?? snapshot.date;
+            const status = statusForCurrentSignal({ plausible, freshnessHours: syncAge, freshnessLimitHours: FRESHNESS_LIMITS_HOURS.biometrics, observedDate, expectedDate: input.date, degraded: warning });
+            hasPlausibleHrv = plausible;
+            baselineScores.push(baselineScore(hrvHistoryDays));
+            signals.hrv = {
+                signal: 'hrv', displayName: 'Overnight HRV', status, value: hrvValue, unit: 'ms', freshnessHours: syncAge,
+                historyDays: hrvHistoryDays, observedDate, expectedDate: input.date,
+                validRange: [PHYSIOLOGICAL_BOUNDS.hrv.min, PHYSIOLOGICAL_BOUNDS.hrv.max], isPlausible: plausible,
+                issues: !plausible ? [`HRV ${hrvValue} ms is outside the physiological range.`] : warning ? ['HRV is within hard bounds but unusually extreme.'] : [],
+            };
+        }
+
+        const rhrValue = raw.restingHr;
+        const rhrHistoryDays = historyDays(snapshot, derived.restingHr7dAvg, derived.restingHr28dAvg, derived.restingHr28dStdev);
+        if (rhrValue === null || rhrValue === undefined) {
+            signals.rhr = { signal: 'rhr', displayName: 'Resting Heart Rate', status: 'MISSING', value: null, unit: 'bpm', historyDays: rhrHistoryDays, isPlausible: false, issues: ['Resting heart rate was not recorded.'] };
+        } else {
+            const plausible = isWithinRange(rhrValue, PHYSIOLOGICAL_BOUNDS.rhr.min, PHYSIOLOGICAL_BOUNDS.rhr.max);
+            const warning = plausible && (rhrValue < PHYSIOLOGICAL_BOUNDS.rhr.warnMin || rhrValue > PHYSIOLOGICAL_BOUNDS.rhr.warnMax);
+            const observedDate = metricDates?.restingHr ?? snapshot.date;
+            const status = statusForCurrentSignal({ plausible, freshnessHours: syncAge, freshnessLimitHours: FRESHNESS_LIMITS_HOURS.biometrics, observedDate, expectedDate: input.date, degraded: warning });
+            hasPlausibleRhr = plausible;
+            baselineScores.push(baselineScore(rhrHistoryDays));
+            signals.rhr = {
+                signal: 'rhr', displayName: 'Resting Heart Rate', status, value: rhrValue, unit: 'bpm', freshnessHours: syncAge,
+                historyDays: rhrHistoryDays, observedDate, expectedDate: input.date,
+                validRange: [PHYSIOLOGICAL_BOUNDS.rhr.min, PHYSIOLOGICAL_BOUNDS.rhr.max], isPlausible: plausible,
+                issues: !plausible ? [`Resting heart rate ${rhrValue} bpm is outside the physiological range.`] : warning ? ['Resting heart rate is within hard bounds but unusually extreme.'] : [],
+            };
+        }
+
+        const sleepSeconds = raw.sleepDurationSec;
+        const sleepMinutes = isFiniteNumber(sleepSeconds) ? Math.round(sleepSeconds / 60) : null;
+        const sleepScore = raw.sleepScore;
+        const durationPlausible = isWithinRange(sleepMinutes, PHYSIOLOGICAL_BOUNDS.sleepDurationMin.min, PHYSIOLOGICAL_BOUNDS.sleepDurationMin.max);
+        const scorePlausible = sleepScore === null || sleepScore === undefined
+            || isWithinRange(sleepScore, PHYSIOLOGICAL_BOUNDS.sleepScore.min, PHYSIOLOGICAL_BOUNDS.sleepScore.max);
+        const sleepHistoryDays = historyDays(snapshot, derived.sleepScore7dAvg, derived.sleepScore28dAvg, derived.sleepScore28dStdev);
+        if (sleepMinutes === null) {
+            signals.sleep = { signal: 'sleep', displayName: 'Sleep Duration & Score', status: 'MISSING', value: null, unit: 'min', historyDays: sleepHistoryDays, isPlausible: false, issues: ['No sleep duration was recorded for last night.'] };
+        } else {
+            const plausible = durationPlausible && scorePlausible;
+            const durationWarning = durationPlausible && (sleepMinutes < PHYSIOLOGICAL_BOUNDS.sleepDurationMin.warnMin || sleepMinutes > PHYSIOLOGICAL_BOUNDS.sleepDurationMin.warnMax);
+            const observedDate = metricDates?.sleep ?? snapshot.date;
+            const status = statusForCurrentSignal({
+                plausible, freshnessHours: syncAge, freshnessLimitHours: FRESHNESS_LIMITS_HOURS.sleep,
+                observedDate, expectedDate: input.date,
+                degraded: durationWarning || sleepScore === null || sleepScore === undefined,
+            });
+            hasPlausibleSleep = plausible;
+            baselineScores.push(baselineScore(sleepHistoryDays));
+            const issues: string[] = [];
+            if (!durationPlausible) issues.push(`Sleep duration ${sleepMinutes} minutes is outside the physiological range.`);
+            if (!scorePlausible) issues.push(`Sleep score ${sleepScore} is outside 0-100.`);
+            if (plausible && durationWarning) issues.push('Sleep duration is within hard bounds but unusually extreme.');
+            if (plausible && (sleepScore === null || sleepScore === undefined)) issues.push('Sleep score is missing; duration-only evidence is available.');
+            signals.sleep = {
+                signal: 'sleep', displayName: 'Sleep Duration & Score', status,
+                value: sleepScore === null || sleepScore === undefined ? `${sleepMinutes}m` : `${sleepMinutes}m (Score: ${sleepScore})`,
+                unit: 'min', freshnessHours: syncAge, historyDays: sleepHistoryDays, observedDate, expectedDate: input.date,
+                validRange: [PHYSIOLOGICAL_BOUNDS.sleepDurationMin.min, PHYSIOLOGICAL_BOUNDS.sleepDurationMin.max], isPlausible: plausible, issues,
+            };
+        }
+
+        const expectedStepsDate = getPreviousLocalDateString(input.date);
+        const stepsValue = raw.totalSteps;
+        if (stepsValue === null || stepsValue === undefined) {
+            signals.steps = { signal: 'steps', displayName: 'Ambient Steps (D-1)', status: 'MISSING', value: null, unit: 'steps', expectedDate: expectedStepsDate, isPlausible: false, issues: ['No step summary was recorded for D-1.'] };
+        } else {
+            const plausible = isWithinRange(stepsValue, PHYSIOLOGICAL_BOUNDS.steps.min, PHYSIOLOGICAL_BOUNDS.steps.max);
+            const suspicious = plausible && stepsValue > PHYSIOLOGICAL_BOUNDS.steps.warnMax;
+            const observedDate = metricDates?.steps ?? expectedStepsDate;
+            const status = statusForCurrentSignal({ plausible, freshnessHours: syncAge, freshnessLimitHours: FRESHNESS_LIMITS_HOURS.stepsD1, observedDate, expectedDate: expectedStepsDate, degraded: suspicious });
+            hasPlausibleSteps = plausible;
+            signals.steps = {
+                signal: 'steps', displayName: 'Ambient Steps (D-1)', status, value: stepsValue, unit: 'steps', freshnessHours: syncAge,
+                observedDate, expectedDate: expectedStepsDate, validRange: [PHYSIOLOGICAL_BOUNDS.steps.min, PHYSIOLOGICAL_BOUNDS.steps.max], isPlausible: plausible,
+                issues: !plausible ? [`Total steps ${stepsValue} exceeds the physiological bound.`] : suspicious ? ['Step count exceeds the suspicious-surge threshold and needs corroboration.'] : [],
+            };
+        }
+
+        const respirationValue = raw.respirationAvg;
+        if (respirationValue !== null && respirationValue !== undefined) {
+            const plausible = isWithinRange(respirationValue, PHYSIOLOGICAL_BOUNDS.respiration.min, PHYSIOLOGICAL_BOUNDS.respiration.max);
+            const warning = plausible && (respirationValue < PHYSIOLOGICAL_BOUNDS.respiration.warnMin || respirationValue > PHYSIOLOGICAL_BOUNDS.respiration.warnMax);
+            const observedDate = metricDates?.sleep ?? snapshot.date;
+            signals.respiration = {
+                signal: 'respiration', displayName: 'Sleeping Respiration',
+                status: statusForCurrentSignal({ plausible, freshnessHours: syncAge, freshnessLimitHours: FRESHNESS_LIMITS_HOURS.biometrics, observedDate, expectedDate: input.date, degraded: warning }),
+                value: respirationValue, unit: 'brpm', freshnessHours: syncAge, observedDate, expectedDate: input.date,
+                validRange: [PHYSIOLOGICAL_BOUNDS.respiration.min, PHYSIOLOGICAL_BOUNDS.respiration.max], isPlausible: plausible,
+                issues: !plausible ? [`Respiration ${respirationValue} brpm is outside the physiological range.`] : warning ? ['Respiration is within hard bounds but unusually extreme.'] : [],
+            };
+        } else {
+            signals.respiration = { signal: 'respiration', displayName: 'Sleeping Respiration', status: 'MISSING', value: null, unit: 'brpm', isPlausible: false };
+        }
+
+        const bodyBatteryValue = raw.bodyBatteryWake;
+        if (bodyBatteryValue !== null && bodyBatteryValue !== undefined) {
+            const plausible = isWithinRange(bodyBatteryValue, PHYSIOLOGICAL_BOUNDS.bodyBattery.min, PHYSIOLOGICAL_BOUNDS.bodyBattery.max);
+            const observedDate = metricDates?.bodyBatteryWake ?? snapshot.date;
+            signals.bodyBattery = {
+                signal: 'bodyBattery', displayName: 'Body Battery (Wake)',
+                status: statusForCurrentSignal({ plausible, freshnessHours: syncAge, freshnessLimitHours: FRESHNESS_LIMITS_HOURS.bodyBatteryWake, observedDate, expectedDate: input.date }),
+                value: bodyBatteryValue, unit: 'pts', freshnessHours: syncAge, observedDate, expectedDate: input.date,
+                validRange: [PHYSIOLOGICAL_BOUNDS.bodyBattery.min, PHYSIOLOGICAL_BOUNDS.bodyBattery.max], isPlausible: plausible,
+                issues: plausible ? [] : [`Body Battery ${bodyBatteryValue} is outside 0-100.`],
+            };
+        } else {
+            signals.bodyBattery = { signal: 'bodyBattery', displayName: 'Body Battery (Wake)', status: 'MISSING', value: null, unit: 'pts', isPlausible: false };
+        }
+    } else {
+        signals.hrv = { signal: 'hrv', displayName: 'Overnight HRV', status: 'MISSING', value: null, unit: 'ms', isPlausible: false };
+        signals.rhr = { signal: 'rhr', displayName: 'Resting Heart Rate', status: 'MISSING', value: null, unit: 'bpm', isPlausible: false };
+        signals.sleep = { signal: 'sleep', displayName: 'Sleep Duration & Score', status: 'MISSING', value: null, unit: 'min', isPlausible: false };
+        signals.steps = { signal: 'steps', displayName: 'Ambient Steps (D-1)', status: 'MISSING', value: null, unit: 'steps', expectedDate: getPreviousLocalDateString(input.date), isPlausible: false };
+    }
+
+    const sensorTier: SensorTier = hasPlausibleHrv && hasPlausibleRhr && hasPlausibleSleep
+        ? 'FULL_WEARABLE'
+        : hasPlausibleSleep || hasPlausibleRhr || hasPlausibleSteps
+            ? 'BASIC_WEARABLE'
+            : 'SUBJECTIVE_ONLY';
+    const coreSignals = [signals.subjectiveCheckin, signals.sleep, signals.rhr, signals.hrv, signals.steps];
+    const completenessScore = average(coreSignals.map(signal => statusCompleteness(signal.status) * 100));
+    const timestampedSignals = coreSignals.filter(signal => signal.status !== 'MISSING');
+    const freshnessScore = average(timestampedSignals.map(signal => statusFreshness(signal.status)));
+    const baselineMaturityScore = average(baselineScores);
+    const assessedSignals = Object.values(signals).filter(signal => signal.value !== null);
+    const plausibilityScore = assessedSignals.length === 0
+        ? 0
+        : Math.round(assessedSignals.filter(signal => signal.isPlausible).length / assessedSignals.length * 100);
+
+    const invalidCount = Object.values(signals).filter(signal => signal.status === 'INVALID').length;
+    const staleCount = Object.values(signals).filter(signal => signal.status === 'STALE').length;
+    if (!hasPlausibleHrv && hasPlausibleRhr && (snapshot?.derived?.deltas?.restingHrVs7d ?? 0) >= 3) {
+        activeSafeguards.push('HRV is unavailable while RHR is elevated; the existing RHR safety signal remains active.');
+    }
+    if (!hasPlausibleSleep && subjectivePlausible) activeSafeguards.push('Sleep telemetry is unavailable; the dashboard can only show subjective sleep evidence.');
+    if (invalidCount > 0) activeSafeguards.push(`${invalidCount} signal(s) are excluded from confidence because they are physiologically implausible.`);
+    if (staleCount > 0) activeSafeguards.push(`${staleCount} signal(s) are stale for the target calendar date or freshness window.`);
+    if (sensorTier === 'FULL_WEARABLE' && baselineMaturityScore < 80) activeSafeguards.push('Wearable baselines are still maturing; positive biometrics are not presented as high-confidence evidence.');
+    if (sensorTier === 'BASIC_WEARABLE') activeSafeguards.push('Partial wearable coverage: confidence relies on the objective channels available today.');
+    else if (sensorTier === 'SUBJECTIVE_ONLY') activeSafeguards.push('Subjective-only coverage: wearable telemetry is absent or unusable.');
+
+    const score = Math.round(
+        completenessScore * 0.35
+        + freshnessScore * 0.25
+        + baselineMaturityScore * 0.20
+        + plausibilityScore * 0.20,
+    );
+    const subjectiveUsable = subjectiveStatus === 'PRESENT' || subjectiveStatus === 'DEGRADED';
+    const fullFreshCoverage = subjectiveStatus === 'PRESENT'
+        && signals.hrv.status === 'PRESENT'
+        && signals.rhr.status === 'PRESENT'
+        && signals.sleep.status === 'PRESENT'
+        && signals.steps.status === 'PRESENT';
+    const rating: ConfidenceRating = !subjectiveUsable
+        ? 'INSUFFICIENT'
+        : score >= 80 && sensorTier === 'FULL_WEARABLE' && fullFreshCoverage && baselineMaturityScore >= 80 && plausibilityScore === 100
+            ? 'HIGH'
+            : score >= 55 && (signals.sleep.status === 'PRESENT' || signals.sleep.status === 'DEGRADED' || signals.rhr.status === 'PRESENT' || signals.rhr.status === 'DEGRADED')
+                ? 'MODERATE'
+                : 'LOW';
+    const summaryMessage: Record<ConfidenceRating, string> = {
+        HIGH: 'Complete, current, plausible core signals with mature wearable baselines.',
+        MODERATE: 'Key evidence is usable, with gaps, reduced freshness, or maturing baselines.',
+        LOW: 'Several signals are missing, stale, or degraded; interpret the recommendation cautiously.',
+        INSUFFICIENT: 'A current, usable safety check-in is missing; normal plan generation remains blocked.',
+    };
+
+    return {
+        rating,
+        score,
+        sensorTier,
+        breakdown: { completenessScore, freshnessScore, baselineMaturityScore, plausibilityScore },
+        signals,
+        activeSafeguards,
+        summaryMessage: summaryMessage[rating],
+    };
+}

--- a/app/src/engine/models.ts
+++ b/app/src/engine/models.ts
@@ -2,6 +2,7 @@ import type { AthletePerformanceProfile, WorkoutPrescription } from '../workouts
 import type { SessionReferenceBinding } from '../sessions/models';
 import type { DataIssue, DataState, DataStateSummary } from './dataState';
 import type { SubjectiveBaseline } from './subjectiveBaseline';
+import type { DataConfidenceScore } from './dataConfidence';
 
 // --- Engine Input Models ---
 export interface SubjectiveInput {
@@ -1335,6 +1336,8 @@ export interface DailyDecisionInput {
         subjectiveCheckinComplete: boolean;
         profileReady: boolean; // True if preferences exist
     };
+    /** Composition-time dashboard diagnostic. It is not an engine decision input. */
+    dataConfidence?: DataConfidenceScore;
 }
 
 /**

--- a/app/src/engine/tests/failures/activityAdapterResilience.test.ts
+++ b/app/src/engine/tests/failures/activityAdapterResilience.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { mapSnapshotToEngineInput } from '../../adapters';
+import type { DailyRecoverySnapshot } from '../../models';
+
+describe('Legacy activity-summary adapter resilience', () => {
+    it('preserves a finite zero Training Effect from a manual activity', () => {
+        const snapshot: DailyRecoverySnapshot = {
+            date: '2026-08-26',
+            schemaVersion: 3,
+            raw: {
+                totalSteps: 5000,
+                restingHr: 50,
+                yesterdayTraining: {
+                    activityCount: 1,
+                    totalDurationMin: 45,
+                    hardActivityCount: 0,
+                    primaryActivity: {
+                        activityId: 'manual_123',
+                        type: 'running',
+                        durationMin: 45,
+                        trainingEffect: 0, // Manual activity has 0 TE
+                        intensityTag: 'moderate/easy',
+                    },
+                },
+                todayTraining: null,
+                last3DaysHardSessionsCount: 0,
+            },
+            derived: {
+                baselineComputationVersion: 3,
+                deltas: {},
+            },
+        } as unknown as DailyRecoverySnapshot;
+
+        const engineInput = mapSnapshotToEngineInput(snapshot);
+        expect(engineInput.yesterday_training).not.toBeNull();
+        expect(engineInput.yesterday_training?.training_effect).toBe(0);
+        expect(Number.isFinite(engineInput.yesterday_training?.training_effect)).toBe(true);
+    });
+
+    it('safely normalizes activities with null duration or missing primary activity', () => {
+        const snapshot: DailyRecoverySnapshot = {
+            date: '2026-08-26',
+            schemaVersion: 3,
+            raw: {
+                totalSteps: 5000,
+                yesterdayTraining: {
+                    activityCount: 2,
+                    totalDurationMin: 10,
+                    hardActivityCount: 0,
+                    primaryActivity: null,
+                },
+                todayTraining: null,
+                last3DaysHardSessionsCount: 0,
+            },
+            derived: {
+                baselineComputationVersion: 3,
+                deltas: {},
+            },
+        } as unknown as DailyRecoverySnapshot;
+
+        const engineInput = mapSnapshotToEngineInput(snapshot);
+        expect(engineInput.yesterday_training).toBeNull();
+    });
+});

--- a/app/src/engine/tests/failures/baselineMaturity.test.ts
+++ b/app/src/engine/tests/failures/baselineMaturity.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { evaluateDataConfidence } from '../../dataConfidence';
+import type { DailyDecisionInput, DailyRecoverySnapshot, DailySubjectiveCheckin } from '../../models';
+
+describe('Data confidence: immature baseline coverage', () => {
+    const mockCheckin = {
+        userId: 'u1',
+        date: '2026-08-26',
+        readiness: 8,
+        fatigue: 3,
+        soreness: 2,
+        mentalStress: 2,
+        sleepQuality: 8,
+        motivation: 8,
+        painOrInjury: false,
+        illnessSymptoms: false,
+        unusuallyLimitedTime: false,
+        alreadyTrainedToday: false,
+        availability: { timeAvailableMin: 60, preferredModalityToday: null, indoorOnly: false },
+        notes: null,
+        submittedAt: '2026-08-26T07:00:00Z',
+        dataQuality: { isComplete: true, missingFields: [] },
+        schemaVersion: 1,
+        createdAt: '2026-08-26T07:00:00Z',
+        updatedAt: '2026-08-26T07:00:00Z',
+    } as DailySubjectiveCheckin;
+
+    const mockSettings = {
+        userId: 'u1',
+        schemaVersion: 2 as const,
+        equipment: { free_weights: true, cable_machine: false, treadmill: false, indoor_bike: false, pullup_bar: true },
+        guardrails: { avoid_high_impact: false, avoid_heavy_lower_body: false, avoid_overhead_pressing: false, avoid_heavy_spinal_loading: false },
+        defaults: { weekdayMaxMinutes: 60, weekendMaxMinutes: 120, environment: 'either' as const },
+        preferences: { preferActiveRecovery: false },
+        migration: { legacyReviewed: true, migratedAt: '2026-08-01' },
+        createdAt: '2026-08-01',
+        updatedAt: '2026-08-01',
+    };
+
+    it('keeps confidence below HIGH when a shifted signal has only a 7-day baseline', () => {
+        const immatureSnapshot = {
+            userId: 'u1',
+            date: '2026-08-26',
+            schemaVersion: 3,
+            source: { garminSyncedAt: '2026-08-26T08:00:00Z', sourceSchemaVersion: 3, timezone: 'Europe/Warsaw' },
+            raw: {
+                hrvOvernightAvg: 75, // +15ms jump on new device
+                restingHr: 46,
+                sleepScore: 88,
+                sleepDurationSec: 28800,
+                totalSteps: 8000,
+            },
+            derived: {
+                baselineComputationVersion: 3,
+                hrv7dAvg: 72,
+                hrv28dAvg: null, // New device has not accumulated 28d history yet
+                hrv28dStdev: null,
+                restingHr7dAvg: 47,
+                restingHr28dAvg: null,
+                restingHr28dStdev: null,
+                deltas: { hrvVs7d: 3, restingHrVs7d: -1 },
+            },
+            dataQuality: { sleepScoreAvailable: true, restingHrAvailable: true, hrvAvailable: true, baseline7dReady: true, baseline28dReady: false },
+        } as unknown as DailyRecoverySnapshot;
+
+        const input: DailyDecisionInput = {
+            userId: 'u1',
+            date: '2026-08-26',
+            recoverySnapshot: immatureSnapshot,
+            subjectiveCheckin: mockCheckin,
+            activeGoals: [],
+            trainingSettings: mockSettings,
+            preferences: null,
+            trainingIntentProfile: null,
+            dataQuality: { hasRecoverySnapshot: true, hasSubjectiveCheckin: true, subjectiveCheckinComplete: true, profileReady: true },
+        };
+
+        const confidence = evaluateDataConfidence(input, '2026-08-26T09:00:00Z');
+        expect(confidence.breakdown.baselineMaturityScore).toBeLessThan(100);
+        expect(confidence.rating).toBe('MODERATE');
+        expect(confidence.activeSafeguards.some(item => item.includes('baselines are still maturing'))).toBe(true);
+    });
+});

--- a/app/src/engine/tests/failures/implausibleSensors.test.ts
+++ b/app/src/engine/tests/failures/implausibleSensors.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { evaluateDataConfidence } from '../../dataConfidence';
+import type { DailyDecisionInput, DailyRecoverySnapshot, DailySubjectiveCheckin } from '../../models';
+
+describe('Data confidence physiological plausibility bounds', () => {
+    it('rejects invalid biometrics and degrades a suspicious-but-bounded step surge', () => {
+        const corruptSnapshot = {
+            userId: 'u1',
+            date: '2026-08-26',
+            schemaVersion: 3,
+            source: { garminSyncedAt: '2026-08-26T08:00:00Z', sourceSchemaVersion: 3, timezone: 'Europe/Warsaw' },
+            raw: {
+                hrvOvernightAvg: 350, // Implausible
+                restingHr: 165, // Implausible resting HR
+                sleepScore: 100,
+                sleepDurationSec: 65000, // 18 hours (implausible)
+                totalSteps: 98000, // Suspicious
+                respirationAvg: 48, // Implausible
+                bodyBatteryWake: 150, // Out of 0-100 bounds
+            },
+            derived: {
+                baselineComputationVersion: 3,
+                deltas: {},
+            },
+            dataQuality: { sleepScoreAvailable: true, restingHrAvailable: true, hrvAvailable: true, baseline7dReady: true, baseline28dReady: true },
+        } as unknown as DailyRecoverySnapshot;
+
+        const checkin = {
+            userId: 'u1',
+            date: '2026-08-26',
+            readiness: 7,
+            fatigue: 4,
+            soreness: 3,
+            mentalStress: 3,
+            sleepQuality: 7,
+            motivation: 7,
+            painOrInjury: false,
+            illnessSymptoms: false,
+            unusuallyLimitedTime: false,
+            alreadyTrainedToday: false,
+            availability: { timeAvailableMin: 60, preferredModalityToday: null, indoorOnly: false },
+            notes: null,
+            submittedAt: '2026-08-26T07:00:00Z',
+            dataQuality: { isComplete: true, missingFields: [] },
+            schemaVersion: 1,
+            createdAt: '2026-08-26T07:00:00Z',
+            updatedAt: '2026-08-26T07:00:00Z',
+        } as DailySubjectiveCheckin;
+
+        const input: DailyDecisionInput = {
+            userId: 'u1',
+            date: '2026-08-26',
+            recoverySnapshot: corruptSnapshot,
+            subjectiveCheckin: checkin,
+            activeGoals: [],
+            trainingSettings: {
+                userId: 'u1',
+                schemaVersion: 2,
+                equipment: { free_weights: true, cable_machine: false, treadmill: false, indoor_bike: false, pullup_bar: true },
+                guardrails: { avoid_high_impact: false, avoid_heavy_lower_body: false, avoid_overhead_pressing: false, avoid_heavy_spinal_loading: false },
+                defaults: { weekdayMaxMinutes: 60, weekendMaxMinutes: 120, environment: 'either' },
+                preferences: { preferActiveRecovery: false },
+                migration: { legacyReviewed: true, migratedAt: '2026-08-01' },
+                createdAt: '2026-08-01',
+                updatedAt: '2026-08-01',
+            },
+            preferences: null,
+            trainingIntentProfile: null,
+            dataQuality: { hasRecoverySnapshot: true, hasSubjectiveCheckin: true, subjectiveCheckinComplete: true, profileReady: true },
+        };
+
+        const confidence = evaluateDataConfidence(input, '2026-08-26T09:00:00Z');
+
+        expect(confidence.signals.hrv.status).toBe('INVALID');
+        expect(confidence.signals.rhr.status).toBe('INVALID');
+        expect(confidence.signals.sleep.status).toBe('INVALID');
+        expect(confidence.signals.respiration.status).toBe('INVALID');
+        expect(confidence.signals.bodyBattery.status).toBe('INVALID');
+        expect(confidence.signals.steps.status).toBe('DEGRADED');
+        expect(confidence.breakdown.plausibilityScore).toBeLessThan(50);
+        expect(confidence.activeSafeguards.some(s => s.includes('physiologically implausible'))).toBe(true);
+    });
+});

--- a/app/src/engine/tests/failures/legacySnapshotCompatibility.test.ts
+++ b/app/src/engine/tests/failures/legacySnapshotCompatibility.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { mapSnapshotToEngineInput } from '../../adapters';
+import type { DailyRecoverySnapshot } from '../../models';
+
+describe('Legacy recovery-snapshot schema compatibility', () => {
+    it('gracefully handles legacy schema version documents missing modern fields', () => {
+        // v1 document missing 28d stdev and respiration MAD
+        const legacySnapshot: DailyRecoverySnapshot = {
+            date: '2026-08-26',
+            schemaVersion: 1,
+            raw: {
+                totalSteps: 6000,
+                restingHr: 52,
+                hrvOvernightAvg: 58,
+                sleepScore: 80,
+                sleepDurationSec: 27000,
+            },
+            derived: {
+                baselineComputationVersion: 1,
+                hrv7dAvg: 60,
+                restingHr7dAvg: 50,
+                deltas: { hrvVs7d: -2, restingHrVs7d: 2 },
+            },
+        } as unknown as DailyRecoverySnapshot;
+
+        const engineInput = mapSnapshotToEngineInput(legacySnapshot);
+        expect(engineInput.total_steps).toBe(6000);
+        expect(engineInput.hrv_delta).toBe(-2);
+        expect(engineInput.hrv_stdev_28d).toBeNull();
+        expect(engineInput.respiration_mad_28d).toBeNull();
+    });
+});

--- a/app/src/engine/tests/failures/missingHrv.test.ts
+++ b/app/src/engine/tests/failures/missingHrv.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest';
+import { evaluateDataConfidence } from '../../dataConfidence';
+import { evaluateReadinessAndSafetyEnvelope } from '../../rules';
+import type { DailyDecisionInput, DailyReadiness, DailyRecoverySnapshot, DailySubjectiveCheckin, UserContext } from '../../models';
+
+describe('Failure Mode 4: Missing HRV While Other Signals Remain Present', () => {
+    const mockSubjective = {
+        userId: 'u1',
+        date: '2026-08-26',
+        readiness: 7,
+        fatigue: 4,
+        soreness: 3,
+        mentalStress: 4,
+        sleepQuality: 7,
+        motivation: 7,
+        painOrInjury: false,
+        illnessSymptoms: false,
+        unusuallyLimitedTime: false,
+        alreadyTrainedToday: false,
+        availability: { timeAvailableMin: 60, preferredModalityToday: null, indoorOnly: false },
+        notes: null,
+        submittedAt: '2026-08-26T07:00:00Z',
+        dataQuality: { isComplete: true, missingFields: [] },
+        schemaVersion: 1,
+        createdAt: '2026-08-26T07:00:00Z',
+        updatedAt: '2026-08-26T07:00:00Z',
+    } as DailySubjectiveCheckin;
+
+    const mockSettings = {
+        userId: 'u1',
+        schemaVersion: 2 as const,
+        equipment: { free_weights: true, cable_machine: false, treadmill: false, indoor_bike: false, pullup_bar: true },
+        guardrails: { avoid_high_impact: false, avoid_heavy_lower_body: false, avoid_overhead_pressing: false, avoid_heavy_spinal_loading: false },
+        defaults: { weekdayMaxMinutes: 60, weekendMaxMinutes: 120, environment: 'either' as const },
+        preferences: { preferActiveRecovery: false },
+        migration: { legacyReviewed: true, migratedAt: '2026-08-01' },
+        createdAt: '2026-08-01',
+        updatedAt: '2026-08-01',
+    };
+
+    const mockContext: UserContext = {
+        goals: { shortTerm: '', midTerm: '', longTerm: '' },
+        constraints: {
+            maxTimeMinutes: 60,
+            hasCableMachine: false,
+            hasFreeWeights: true,
+            hasTreadmill: false,
+            hasIndoorBike: false,
+            restrictedModalities: [],
+        },
+        preferences: {
+            preferredModalities: ['Running'],
+            avoidedModalities: [],
+            deprioritizedModalities: [],
+            conservativeBias: false,
+        },
+    };
+
+    it('applies conservative safeguard without throwing when HRV is null but RHR and Sleep are valid', () => {
+        const snapshot = {
+            userId: 'u1',
+            date: '2026-08-26',
+            schemaVersion: 3,
+            source: { garminSyncedAt: new Date().toISOString(), sourceSchemaVersion: 3, timezone: 'Europe/Warsaw' },
+            raw: {
+                hrvOvernightAvg: null, // Watch dropped HRV
+                restingHr: 56,
+                sleepScore: 78,
+                sleepDurationSec: 27000,
+                totalSteps: 7000,
+            },
+            derived: {
+                baselineComputationVersion: 3,
+                restingHr7dAvg: 49,
+                restingHr28dAvg: 49,
+                restingHr28dStdev: 1.5,
+                deltas: { restingHrVs7d: 7, restingHrVs28d: 7, hrvVs7d: null, hrvVs28d: null },
+            },
+            dataQuality: { sleepScoreAvailable: true, restingHrAvailable: true, hrvAvailable: false, baseline7dReady: true, baseline28dReady: true },
+        } as unknown as DailyRecoverySnapshot;
+
+        const input: DailyDecisionInput = {
+            userId: 'u1',
+            date: '2026-08-26',
+            recoverySnapshot: snapshot,
+            subjectiveCheckin: mockSubjective,
+            activeGoals: [],
+            trainingSettings: mockSettings,
+            preferences: null,
+            trainingIntentProfile: null,
+            dataQuality: { hasRecoverySnapshot: true, hasSubjectiveCheckin: true, subjectiveCheckinComplete: true, profileReady: true },
+        };
+
+        const confidence = evaluateDataConfidence(input);
+        expect(confidence.signals.hrv.status).toBe('MISSING');
+        expect(confidence.signals.rhr.status).toBe('PRESENT');
+        expect(confidence.activeSafeguards.some(s => s.includes('HRV is unavailable while RHR is elevated'))).toBe(true);
+
+        const readiness: DailyReadiness = {
+            subjective: {
+                readiness: 7,
+                fatigue: 4,
+                soreness: 3,
+                stress: 4,
+                sleepQuality: 7,
+                motivation: 7,
+                timeAvailable: 60,
+                painFlag: false,
+                alreadyTrainedToday: false,
+                preferredModalityToday: null,
+            },
+            objective: {
+                total_steps: 7000,
+                sleep_score: 78,
+                sleep_duration_min: 450,
+                rhr: 56,
+                rhr_7d_avg: 49,
+                rhr_delta: 7,
+                hrv_weekly_avg: null,
+                hrv_last_night: null,
+                hrv_delta: null,
+                hrv_delta_28d: null,
+                hrv_stdev_28d: null,
+                rhr_delta_28d: 7,
+                rhr_stdev_28d: 1.5,
+                sleep_score_delta_7d: null,
+                sleep_score_delta_28d: null,
+                sleep_score_stdev_28d: null,
+                respiration: 14,
+                body_battery_wake: 70,
+                last_3_days_hard_sessions_count: 0,
+                yesterday_training: null,
+                today_training: null,
+            },
+        };
+
+        const result = evaluateReadinessAndSafetyEnvelope(readiness, mockContext, '2026-08-26');
+        expect(result.mode).toBeDefined();
+        // RHR +7 bpm acute elevation triggers acuteBiometricStrainFloor -> 'modify' mode
+        expect(result.mode).toBe('modify');
+    });
+});

--- a/app/src/engine/tests/failures/recommendationAuditRevision.test.ts
+++ b/app/src/engine/tests/failures/recommendationAuditRevision.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { buildRecommendationAudit } from '../../provenance';
+import type { Recommendation } from '../../models';
+import type { TrainingHistorySnapshot } from '../../trainingHistorySnapshot';
+
+describe('Recommendation audit revision anchoring', () => {
+    it('records the immutable training-history revision used by the decision', () => {
+        const recommendation: Recommendation = {
+            template: {
+                id: 'run-tempo-30',
+                category: 'Hard Endurance',
+                modality: 'Running',
+                durationMin: 30,
+                durationMax: 45,
+                title: 'Tempo Run',
+                description: 'Tempo run',
+                requiredEquipment: [],
+                environment: 'either',
+                safetyTags: [],
+                systemicCost: 4,
+                objectiveTransferable: true,
+            },
+            mode: 'train',
+            rationale: 'Baseline is stable, load approved.',
+            envelopes: {
+                safety: { clinicalFlagActive: false, restrictedModalities: [] },
+                plan: { maxAllowableTier: 'Hard', taperActive: false },
+            },
+            telemetry: {
+                metricStrain: { acuteDeviation: 0, multiDayDrift: 0, totalMetricStrain: 0 },
+                contextPenalties: { recentHardSessions: 0, bodyBatteryDeficit: 0, sleepFloorPenalty: 0, conservativeBias: 0 },
+                subjectiveDrift: 0,
+                totalDecisionScore: 0,
+            },
+            decisionTrace: { policyVersion: 'test-v1', candidateScores: [], droppedContributorObjectives: [] },
+        };
+
+        const historySnapshot: TrainingHistorySnapshot = {
+            throughDateExclusive: '2026-08-26',
+            windowDays: 7,
+            completedEvents: [],
+            exposures: [],
+            sourceStates: {
+                activities: { status: 'AVAILABLE', revision: 'r1' },
+                recommendations: { status: 'AVAILABLE', revision: 'r1' },
+                manualTraining: { status: 'AVAILABLE', revision: 'r1' },
+            },
+            generatedAt: new Date().toISOString(),
+            revision: 'rev_12345',
+        };
+
+        const audit = buildRecommendationAudit(recommendation, historySnapshot);
+        expect(audit).not.toBeNull();
+        expect(audit?.decisionContextRevision).toBe('rev_12345');
+        expect(audit?.policyVersion).toBe('test-v1');
+    });
+});

--- a/app/src/engine/tests/failures/sameDayTrainingOverride.test.ts
+++ b/app/src/engine/tests/failures/sameDayTrainingOverride.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { evaluateReadinessAndSafetyEnvelope } from '../../rules';
+import type { DailyReadiness, UserContext } from '../../models';
+
+describe('Same-day completed-training safety override', () => {
+    it('recovers when both wearable training and already-trained check-in evidence are present', () => {
+        const readiness: DailyReadiness = {
+            subjective: {
+                readiness: 8,
+                fatigue: 3,
+                soreness: 2,
+                stress: 3,
+                sleepQuality: 8,
+                motivation: 8,
+                timeAvailable: 60,
+                painFlag: false,
+                alreadyTrainedToday: true, // Athlete completed session
+                preferredModalityToday: null,
+            },
+            objective: {
+                total_steps: 8000,
+                sleep_score: 85,
+                sleep_duration_min: 480,
+                rhr: 48,
+                rhr_7d_avg: 48,
+                rhr_delta: 0,
+                hrv_weekly_avg: 65,
+                hrv_last_night: 65,
+                hrv_delta: 0,
+                hrv_delta_28d: 0,
+                hrv_stdev_28d: 5.0,
+                rhr_delta_28d: 0,
+                rhr_stdev_28d: 2.0,
+                sleep_score_delta_7d: 0,
+                sleep_score_delta_28d: 0,
+                sleep_score_stdev_28d: 5.0,
+                respiration: 14,
+                body_battery_wake: 85,
+                last_3_days_hard_sessions_count: 0,
+                yesterday_training: null,
+                today_training: {
+                    type: 'strength_training',
+                    duration_min: 60,
+                    training_effect: 2.5,
+                    intensity_tag: 'moderate',
+                },
+            },
+        };
+
+        const context: UserContext = {
+            goals: { shortTerm: '', midTerm: '', longTerm: '' },
+            constraints: {
+                maxTimeMinutes: 60,
+                hasCableMachine: false,
+                hasFreeWeights: true,
+                hasTreadmill: false,
+                hasIndoorBike: false,
+                restrictedModalities: [],
+            },
+            preferences: {
+                preferredModalities: ['Running'],
+                avoidedModalities: [],
+                deprioritizedModalities: [],
+                conservativeBias: false,
+            },
+        };
+
+        const result = evaluateReadinessAndSafetyEnvelope(readiness, context, '2026-08-26');
+        expect(result.alreadyTrainedOverride).toBe(true);
+        expect(result.mode).toBe('recover');
+    });
+});

--- a/app/src/engine/tests/failures/sensorTiers.test.ts
+++ b/app/src/engine/tests/failures/sensorTiers.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { evaluateDataConfidence } from '../../dataConfidence';
+import type { DailyDecisionInput, DailyRecoverySnapshot, DailySubjectiveCheckin } from '../../models';
+
+describe('Failure Mode 10: Different Users Having Different Sensor Availability', () => {
+    const mockCheckin = {
+        userId: 'u1',
+        date: '2026-08-26',
+        readiness: 8,
+        fatigue: 3,
+        soreness: 2,
+        mentalStress: 2,
+        sleepQuality: 8,
+        motivation: 8,
+        painOrInjury: false,
+        illnessSymptoms: false,
+        unusuallyLimitedTime: false,
+        alreadyTrainedToday: false,
+        availability: { timeAvailableMin: 60, preferredModalityToday: null, indoorOnly: false },
+        notes: null,
+        submittedAt: '2026-08-26T07:00:00Z',
+        dataQuality: { isComplete: true, missingFields: [] },
+        schemaVersion: 1,
+        createdAt: '2026-08-26T07:00:00Z',
+        updatedAt: '2026-08-26T07:00:00Z',
+    } as DailySubjectiveCheckin;
+
+    const mockSettings = {
+        userId: 'u1',
+        schemaVersion: 2 as const,
+        equipment: { free_weights: true, cable_machine: false, treadmill: false, indoor_bike: false, pullup_bar: true },
+        guardrails: { avoid_high_impact: false, avoid_heavy_lower_body: false, avoid_overhead_pressing: false, avoid_heavy_spinal_loading: false },
+        defaults: { weekdayMaxMinutes: 60, weekendMaxMinutes: 120, environment: 'either' as const },
+        preferences: { preferActiveRecovery: false },
+        migration: { legacyReviewed: true, migratedAt: '2026-08-01' },
+        createdAt: '2026-08-01',
+        updatedAt: '2026-08-01',
+    };
+
+    it('correctly classifies Tier 1 (Full Wearable), Tier 2 (Basic Wearable), and Tier 3 (Subjective Only)', () => {
+        // Tier 3: Subjective only
+        const tier3Input: DailyDecisionInput = {
+            userId: 'u1',
+            date: '2026-08-26',
+            recoverySnapshot: null,
+            subjectiveCheckin: mockCheckin,
+            activeGoals: [],
+            trainingSettings: mockSettings,
+            preferences: null,
+            trainingIntentProfile: null,
+            dataQuality: { hasRecoverySnapshot: false, hasSubjectiveCheckin: true, subjectiveCheckinComplete: true, profileReady: true },
+        };
+        const tier3Confidence = evaluateDataConfidence(tier3Input, '2026-08-26T09:00:00Z');
+        expect(tier3Confidence.sensorTier).toBe('SUBJECTIVE_ONLY');
+
+        // Tier 2: Basic Wearable (RHR + Steps only, no HRV)
+        const tier2Input: DailyDecisionInput = {
+            ...tier3Input,
+            recoverySnapshot: {
+                userId: 'u1',
+                date: '2026-08-26',
+                schemaVersion: 3,
+                source: { garminSyncedAt: '2026-08-26T08:00:00Z', sourceSchemaVersion: 3 },
+                raw: { totalSteps: 7500, restingHr: 50, hrvOvernightAvg: null, sleepScore: null, sleepDurationSec: 28000 },
+                derived: { baselineComputationVersion: 3, restingHr7dAvg: 49, deltas: { restingHrVs7d: 1 } },
+                dataQuality: { sleepScoreAvailable: false, restingHrAvailable: true, hrvAvailable: false, baseline7dReady: true, baseline28dReady: false },
+            } as unknown as DailyRecoverySnapshot,
+        };
+        const tier2Confidence = evaluateDataConfidence(tier2Input, '2026-08-26T09:00:00Z');
+        expect(tier2Confidence.sensorTier).toBe('BASIC_WEARABLE');
+
+        // Tier 1: Full Wearable (HRV + RHR + Sleep)
+        const tier1Input: DailyDecisionInput = {
+            ...tier3Input,
+            recoverySnapshot: {
+                userId: 'u1',
+                date: '2026-08-26',
+                schemaVersion: 3,
+                source: { garminSyncedAt: '2026-08-26T08:00:00Z', sourceSchemaVersion: 3 },
+                raw: { totalSteps: 7500, restingHr: 50, hrvOvernightAvg: 65, sleepScore: 85, sleepDurationSec: 28000 },
+                derived: { baselineComputationVersion: 3, hrv7dAvg: 63, hrv28dStdev: 5.0, restingHr7dAvg: 49, restingHr28dStdev: 2.0, deltas: { hrvVs7d: 2, restingHrVs7d: 1 } },
+                dataQuality: { sleepScoreAvailable: true, restingHrAvailable: true, hrvAvailable: true, baseline7dReady: true, baseline28dReady: true },
+            } as unknown as DailyRecoverySnapshot,
+        };
+        const tier1Confidence = evaluateDataConfidence(tier1Input, '2026-08-26T09:00:00Z');
+        expect(tier1Confidence.sensorTier).toBe('FULL_WEARABLE');
+    });
+});

--- a/app/src/engine/tests/failures/sleepRevisions.test.ts
+++ b/app/src/engine/tests/failures/sleepRevisions.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import { evaluateDataConfidence } from '../../dataConfidence';
+import type { DailyDecisionInput, DailyRecoverySnapshot, DailySubjectiveCheckin } from '../../models';
+
+describe('Failure Mode 1: Sleep Arriving Late or Being Revised', () => {
+    const mockCheckin = {
+        userId: 'u1',
+        date: '2026-08-26',
+        readiness: 7,
+        fatigue: 4,
+        soreness: 3,
+        mentalStress: 3,
+        sleepQuality: 6,
+        motivation: 7,
+        painOrInjury: false,
+        illnessSymptoms: false,
+        unusuallyLimitedTime: false,
+        alreadyTrainedToday: false,
+        availability: { timeAvailableMin: 60, preferredModalityToday: null, indoorOnly: false },
+        notes: null,
+        submittedAt: '2026-08-26T06:00:00Z',
+        dataQuality: { isComplete: true, missingFields: [] },
+        schemaVersion: 1,
+        createdAt: '2026-08-26T06:00:00Z',
+        updatedAt: '2026-08-26T06:00:00Z',
+    } as DailySubjectiveCheckin;
+
+    const mockSettings = {
+        userId: 'u1',
+        schemaVersion: 2 as const,
+        equipment: { free_weights: true, cable_machine: false, treadmill: false, indoor_bike: false, pullup_bar: true },
+        guardrails: { avoid_high_impact: false, avoid_heavy_lower_body: false, avoid_overhead_pressing: false, avoid_heavy_spinal_loading: false },
+        defaults: { weekdayMaxMinutes: 60, weekendMaxMinutes: 120, environment: 'either' as const },
+        preferences: { preferActiveRecovery: false },
+        migration: { legacyReviewed: true, migratedAt: '2026-08-01' },
+        createdAt: '2026-08-01',
+        updatedAt: '2026-08-01',
+    };
+
+    it('evaluates lower confidence when sleep is missing or provisional at early morning sync', () => {
+        const earlySnapshot = {
+            userId: 'u1',
+            date: '2026-08-26',
+            schemaVersion: 3,
+            source: { garminSyncedAt: '2026-08-26T05:30:00Z', sourceSchemaVersion: 3, timezone: 'Europe/Warsaw' },
+            raw: {
+                hrvOvernightAvg: null,
+                restingHr: 52,
+                sleepScore: null,
+                sleepDurationSec: 10800, // Partial/provisional 3h recorded so far
+                totalSteps: 200,
+                respirationAvg: 14.0,
+                bodyBatteryWake: 45,
+                last3DaysHardSessionsCount: 0,
+                yesterdayTraining: null,
+                todayTraining: null,
+            },
+            derived: {
+                baselineComputationVersion: 3,
+                hrv7dAvg: 60,
+                hrv28dAvg: 61,
+                hrv28dStdev: 5.0,
+                restingHr7dAvg: 50,
+                restingHr28dAvg: 49.5,
+                restingHr28dStdev: 2.0,
+                deltas: { restingHrVs7d: 2, hrvVs7d: null },
+            },
+            dataQuality: { sleepScoreAvailable: false, restingHrAvailable: true, hrvAvailable: false, baseline7dReady: true, baseline28dReady: true },
+        } as unknown as DailyRecoverySnapshot;
+
+        const input: DailyDecisionInput = {
+            userId: 'u1',
+            date: '2026-08-26',
+            recoverySnapshot: earlySnapshot,
+            subjectiveCheckin: mockCheckin,
+            activeGoals: [],
+            trainingSettings: mockSettings,
+            preferences: null,
+            trainingIntentProfile: null,
+            dataQuality: { hasRecoverySnapshot: true, hasSubjectiveCheckin: true, subjectiveCheckinComplete: true, profileReady: true },
+        };
+
+        const earlyConfidence = evaluateDataConfidence(input, '2026-08-26T09:00:00Z');
+        expect(earlyConfidence.rating).toBe('MODERATE');
+        expect(earlyConfidence.signals.hrv.status).toBe('MISSING');
+        expect(earlyConfidence.signals.sleep.value).toContain('180m');
+    });
+
+    it('upgrades confidence to HIGH when finalized sleep revision is synced later', () => {
+        const finalizedSnapshot = {
+            userId: 'u1',
+            date: '2026-08-26',
+            schemaVersion: 3,
+            source: { garminSyncedAt: '2026-08-26T08:15:00Z', sourceSchemaVersion: 3, timezone: 'Europe/Warsaw' },
+            raw: {
+                hrvOvernightAvg: 62,
+                restingHr: 49,
+                sleepScore: 84,
+                sleepDurationSec: 28200, // Final 7.8h
+                totalSteps: 1200,
+                respirationAvg: 13.8,
+                bodyBatteryWake: 88,
+                last3DaysHardSessionsCount: 0,
+                yesterdayTraining: null,
+                todayTraining: null,
+            },
+            derived: {
+                baselineComputationVersion: 3,
+                hrv7dAvg: 60,
+                hrv28dAvg: 61,
+                hrv28dStdev: 5.0,
+                restingHr7dAvg: 50,
+                restingHr28dAvg: 49.5,
+                restingHr28dStdev: 2.0,
+                sleepScore7dAvg: 80,
+                sleepScore28dAvg: 79,
+                sleepScore28dStdev: 6.0,
+                deltas: { restingHrVs7d: -1, hrvVs7d: 2, restingHrVs28d: -0.5, hrvVs28d: 1 },
+            },
+            dataQuality: { sleepScoreAvailable: true, restingHrAvailable: true, hrvAvailable: true, baseline7dReady: true, baseline28dReady: true },
+        } as unknown as DailyRecoverySnapshot;
+
+        const input: DailyDecisionInput = {
+            userId: 'u1',
+            date: '2026-08-26',
+            recoverySnapshot: finalizedSnapshot,
+            subjectiveCheckin: mockCheckin,
+            activeGoals: [],
+            trainingSettings: mockSettings,
+            preferences: null,
+            trainingIntentProfile: null,
+            dataQuality: { hasRecoverySnapshot: true, hasSubjectiveCheckin: true, subjectiveCheckinComplete: true, profileReady: true },
+        };
+
+        const finalConfidence = evaluateDataConfidence(input, '2026-08-26T09:00:00Z');
+        expect(finalConfidence.rating).toBe('HIGH');
+        expect(finalConfidence.sensorTier).toBe('FULL_WEARABLE');
+        expect(finalConfidence.signals.hrv.status).toBe('PRESENT');
+        expect(finalConfidence.signals.sleep.value).toContain('470m (Score: 84)');
+    });
+});

--- a/app/src/engine/tests/failures/sleepRevisions.test.ts
+++ b/app/src/engine/tests/failures/sleepRevisions.test.ts
@@ -91,7 +91,12 @@ describe('Failure Mode 1: Sleep Arriving Late or Being Revised', () => {
             userId: 'u1',
             date: '2026-08-26',
             schemaVersion: 3,
-            source: { garminSyncedAt: '2026-08-26T08:15:00Z', sourceSchemaVersion: 3, timezone: 'Europe/Warsaw' },
+            source: {
+                garminSyncedAt: '2026-08-26T08:15:00Z',
+                sourceSchemaVersion: 3,
+                timezone: 'Europe/Warsaw',
+                metricDates: { steps: '2026-08-25' },
+            },
             raw: {
                 hrvOvernightAvg: 62,
                 restingHr: 49,

--- a/app/src/engine/tests/failures/timezoneDst.test.ts
+++ b/app/src/engine/tests/failures/timezoneDst.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { getPreviousLocalDateString, addDaysToLocalDateString } from '../../../utils/localDate';
+
+describe('Europe/Warsaw calendar arithmetic across DST', () => {
+    it('reliably maintains Europe/Warsaw local calendar date arithmetic across DST transitions', () => {
+        const dstFallDate = '2026-10-25'; // Fall DST transition date
+        const nextDay = addDaysToLocalDateString(dstFallDate, 1);
+        const prevDay = getPreviousLocalDateString(dstFallDate);
+
+        expect(nextDay).toBe('2026-10-26');
+        expect(prevDay).toBe('2026-10-24');
+    });
+
+    it('ensures discrete day string mapping does not suffer from UTC offset drift', () => {
+        const d1 = addDaysToLocalDateString('2026-08-26', -1);
+        expect(d1).toBe('2026-08-25');
+    });
+});

--- a/app/src/visual/fixtures.ts
+++ b/app/src/visual/fixtures.ts
@@ -10,6 +10,7 @@ import {
   type UserGoal,
   type UserPreferences,
 } from '../engine/models';
+import { evaluateDataConfidence } from '../engine/dataConfidence';
 
 import type { StrengthSession } from '../engine/models';
 
@@ -181,6 +182,24 @@ function buildFixture(
   const fixtureGoals = overrides.goals ?? [eventGoal];
   const fixtureActivities = overrides.activities ?? [];
 
+  const input: DailyDecisionInput = {
+    userId: VISUAL_USER_ID,
+    date: VISUAL_DATE,
+    recoverySnapshot: fixtureRecovery,
+    subjectiveCheckin: fixtureCheckin,
+    activeGoals: fixtureGoals,
+    trainingSettings: fixtureSettings,
+    preferences: fixturePreferences,
+    trainingIntentProfile,
+    dataQuality: {
+      hasRecoverySnapshot: fixtureRecovery !== null,
+      hasSubjectiveCheckin: fixtureCheckin !== null,
+      subjectiveCheckinComplete: fixtureCheckin?.dataQuality.isComplete ?? false,
+      profileReady: fixturePreferences !== null,
+    },
+  };
+  input.dataConfidence = evaluateDataConfidence(input, TIMESTAMP);
+
   return {
     settings: fixtureSettings,
     preferences: fixturePreferences,
@@ -190,22 +209,7 @@ function buildFixture(
     activities: fixtureActivities,
     ...(overrides.externalPlan ? { externalPlan: overrides.externalPlan } : {}),
     ...(overrides.strengthSession ? { strengthSession: overrides.strengthSession } : {}),
-    input: {
-      userId: VISUAL_USER_ID,
-      date: VISUAL_DATE,
-      recoverySnapshot: fixtureRecovery,
-      subjectiveCheckin: fixtureCheckin,
-      activeGoals: fixtureGoals,
-      trainingSettings: fixtureSettings,
-      preferences: fixturePreferences,
-      trainingIntentProfile,
-      dataQuality: {
-        hasRecoverySnapshot: fixtureRecovery !== null,
-        hasSubjectiveCheckin: fixtureCheckin !== null,
-        subjectiveCheckinComplete: fixtureCheckin?.dataQuality.isComplete ?? false,
-        profileReady: fixturePreferences !== null,
-      },
-    },
+    input,
   };
 }
 

--- a/app/tests/visual/capture.pw.ts
+++ b/app/tests/visual/capture.pw.ts
@@ -71,6 +71,27 @@ for (const scenario of VISUAL_SCENARIOS) {
 
     await capture(page, scenario);
 
+    if (scenario.id === 'home-normal-load') {
+      const confidenceButton = page.getByRole('button', { name: /Data confidence: / });
+      await confidenceButton.click();
+      await expect(confidenceButton).toHaveAttribute('aria-expanded', 'true');
+      const confidencePanel = page.getByRole('region', { name: 'Data confidence diagnostic breakdown' });
+      await expect(confidencePanel).toBeVisible();
+      const panelBounds = await confidencePanel.boundingBox();
+      const viewport = page.viewportSize();
+      expect(panelBounds).not.toBeNull();
+      expect(viewport).not.toBeNull();
+      expect(panelBounds!.x).toBeGreaterThanOrEqual(0);
+      expect(panelBounds!.x + panelBounds!.width).toBeLessThanOrEqual(viewport!.width);
+      expect(panelBounds!.y).toBeGreaterThanOrEqual(0);
+      expect(panelBounds!.y + panelBounds!.height).toBeLessThanOrEqual(viewport!.height);
+      await capture(page, scenario, 'confidence-expanded', [
+        'The data-confidence badge exposes signal freshness, maturity, plausibility, and cautions without competing with today’s training decision.',
+      ]);
+      await page.getByRole('button', { name: 'Close data confidence details' }).click();
+      await expect(confidenceButton).toHaveAttribute('aria-expanded', 'false');
+    }
+
     if (scenario.id.startsWith('home-') && scenario.id !== 'home-missing-data') {
       // Home can also contain imported-plan session buttons with the same label. This
       // interaction captures the recommendation card's own disclosure specifically.

--- a/docs/architecture/recommendation-engine.md
+++ b/docs/architecture/recommendation-engine.md
@@ -597,6 +597,31 @@ comparison data and reasoning. Greedy (`generateWeekAheadPlan`) remains the live
 
 ---
 
+## Data-confidence observability (`dataConfidence.ts`)
+
+`DecisionComposer.composeDailyDecisionInput` computes a dashboard-only
+`DataConfidenceScore` after the normal source-state composition step. The evaluator reports
+four bounded diagnostics (completeness, freshness, baseline maturity, and physiological
+plausibility), an operational coverage tier, per-signal status, and plain-language
+cautions. Freshness uses the snapshot sync timestamp together with metric dates: sleep,
+HRV, RHR, and wake Body Battery must belong to the target date, while `totalSteps` must
+belong to the completed Warsaw calendar day D-1.
+
+This score is **not a third readiness authority**. It is not passed into
+`evaluateReadinessAndSafetyEnvelope`, eligibility, dose, or ranking, and therefore cannot
+strengthen or weaken a recommendation. Existing fail-closed composition and adverse-only
+readiness rules remain authoritative. The dashboard indicator exposes why evidence is
+missing, stale, immature, or implausible; the neighboring Garmin sync control remains the
+actual ingestion action.
+
+The confidence profile is recomputed when dashboard data is composed and is not persisted
+in `RecommendationAudit`. Consequently it describes current composition-time evidence and
+must not be presented as frozen replay provenance. Adding it to decision policy or replay
+would require an explicit ADR/schema change, Firestore validation updates, and a
+`POLICY_VERSION` review.
+
+---
+
 ## Verification & audit tooling
 
 ### Coverage visibility (`test:coverage` / `pytest --cov`)

--- a/tests/test_failure_modes.py
+++ b/tests/test_failure_modes.py
@@ -1,0 +1,65 @@
+from garmin_sync.canonical import CanonicalDailyMetrics
+from garmin_sync.garmin_provider import canonicalize_activities, canonicalize_from_raw
+from garmin_sync.metrics import (
+    calculate_average,
+    calculate_delta,
+    calculate_mad,
+    calculate_median,
+    classify_activity_intensity,
+)
+
+
+def test_failure_mode_missing_keys_in_raw_payload():
+    corrupt_payload = {"unexpectedKey": 123}
+    canonical = canonicalize_from_raw(
+        stats_today=corrupt_payload,
+        stats_fallback=None,
+        sleep_today=corrupt_payload,
+        sleep_fallback=None,
+        hrv_today=corrupt_payload,
+        target_date_iso="2026-08-26",
+        yesterday_iso="2026-08-25",
+    )
+    assert isinstance(canonical, CanonicalDailyMetrics)
+    assert canonical.resting_heart_rate_bpm is None
+    assert canonical.sleep_duration_seconds is None
+    assert canonical.hrv_overnight_avg_ms is None
+
+
+def test_failure_mode_empty_or_sparse_activities_list():
+    empty_res = canonicalize_activities([])
+    assert empty_res == []
+
+    malformed_activity = [{"activityId": 999, "activityType": {}}]
+    res = canonicalize_activities(malformed_activity)
+    assert len(res) == 1
+    assert res[0].activity_id == "999"
+
+
+def test_failure_mode_zero_and_negative_training_effect():
+    is_hard, tag = classify_activity_intensity(training_effect=0.0, average_hr=None)
+    assert is_hard is False
+    assert tag == "easy"
+
+    is_hard_neg, tag_neg = classify_activity_intensity(training_effect=-1.0, average_hr=120)
+    assert is_hard_neg is False
+
+
+def test_failure_mode_baseline_insufficient_samples():
+    values = [45, 48]
+    assert calculate_average(values, min_required=7) is None
+    assert calculate_median(values, min_required=7) is None
+    assert calculate_mad(values, min_required=14) is None
+
+
+def test_failure_mode_activity_intensity_hr_fallback_boundary():
+    is_hard, tag = classify_activity_intensity(training_effect=2.5, average_hr=165)
+    assert is_hard is True
+    assert tag == "hard"
+
+
+def test_failure_mode_delta_with_none_inputs():
+    assert calculate_delta(None, 50.0) is None
+    assert calculate_delta(50.0, None) is None
+    assert calculate_delta(None, None) is None
+    assert calculate_delta(55.0, 50.0) == 5.0

--- a/tests/test_failure_modes.py
+++ b/tests/test_failure_modes.py
@@ -9,7 +9,7 @@ from garmin_sync.metrics import (
 )
 
 
-def test_failure_mode_missing_keys_in_raw_payload():
+def test_failure_mode_missing_keys_in_raw_payload() -> None:
     corrupt_payload = {"unexpectedKey": 123}
     canonical = canonicalize_from_raw(
         stats_today=corrupt_payload,
@@ -26,7 +26,7 @@ def test_failure_mode_missing_keys_in_raw_payload():
     assert canonical.hrv_overnight_avg_ms is None
 
 
-def test_failure_mode_empty_or_sparse_activities_list():
+def test_failure_mode_empty_or_sparse_activities_list() -> None:
     empty_res = canonicalize_activities([])
     assert empty_res == []
 
@@ -36,7 +36,7 @@ def test_failure_mode_empty_or_sparse_activities_list():
     assert res[0].activity_id == "999"
 
 
-def test_failure_mode_zero_and_negative_training_effect():
+def test_failure_mode_zero_and_negative_training_effect() -> None:
     is_hard, tag = classify_activity_intensity(training_effect=0.0, average_hr=None)
     assert is_hard is False
     assert tag == "easy"
@@ -44,21 +44,53 @@ def test_failure_mode_zero_and_negative_training_effect():
     is_hard_neg, tag_neg = classify_activity_intensity(training_effect=-1.0, average_hr=120)
     assert is_hard_neg is False
 
+    # Boundary cases: training_effect just below 2.0 (easy)
+    is_hard_below_2, tag_below_2 = classify_activity_intensity(training_effect=1.9, average_hr=None)
+    assert is_hard_below_2 is False
+    assert tag_below_2 == "easy"
 
-def test_failure_mode_baseline_insufficient_samples():
+    # Boundary cases: training_effect exactly 2.0 (moderate, not easy)
+    is_hard_2, tag_2 = classify_activity_intensity(training_effect=2.0, average_hr=None)
+    assert is_hard_2 is False
+    assert tag_2 == "moderate"
+
+    # Boundary cases: training_effect just below 3.0 (moderate)
+    is_hard_below_3, tag_below_3 = classify_activity_intensity(training_effect=2.9, average_hr=None)
+    assert is_hard_below_3 is False
+    assert tag_below_3 == "moderate"
+
+    # Boundary cases: training_effect exactly 3.0 (hard, inclusive)
+    is_hard_3, tag_3 = classify_activity_intensity(training_effect=3.0, average_hr=None)
+    assert is_hard_3 is True
+    assert tag_3 == "hard"
+
+    # Boundary cases: average_hr just below 145 (not hard based on HR)
+    is_hard_hr_below, tag_hr_below = classify_activity_intensity(
+        training_effect=2.5, average_hr=144
+    )
+    assert is_hard_hr_below is False
+    assert tag_hr_below == "moderate"
+
+    # Boundary cases: average_hr exactly 145 (hard, inclusive)
+    is_hard_hr_145, tag_hr_145 = classify_activity_intensity(training_effect=2.5, average_hr=145)
+    assert is_hard_hr_145 is True
+    assert tag_hr_145 == "hard"
+
+
+def test_failure_mode_baseline_insufficient_samples() -> None:
     values = [45, 48]
     assert calculate_average(values, min_required=7) is None
     assert calculate_median(values, min_required=7) is None
     assert calculate_mad(values, min_required=14) is None
 
 
-def test_failure_mode_activity_intensity_hr_fallback_boundary():
+def test_failure_mode_activity_intensity_hr_fallback_boundary() -> None:
     is_hard, tag = classify_activity_intensity(training_effect=2.5, average_hr=165)
     assert is_hard is True
     assert tag == "hard"
 
 
-def test_failure_mode_delta_with_none_inputs():
+def test_failure_mode_delta_with_none_inputs() -> None:
     assert calculate_delta(None, 50.0) is None
     assert calculate_delta(50.0, None) is None
     assert calculate_delta(None, None) is None


### PR DESCRIPTION
## Summary

- add a pure, composition-time data-confidence evaluator covering completeness, freshness, baseline maturity, and physiological plausibility
- expose confidence as an accessible dashboard badge with a scrollable signal/caution panel on desktop and mobile
- add deterministic engine, adapter, backend, component, and visual regression coverage for missing, stale, immature, legacy, and implausible data states
- document the authority boundary: confidence is observability only and does not change readiness, eligibility, dose, ranking, persistence, or replay

## Plan review and scope correction

The handoff plan mixed three materially different initiatives: dashboard observability, recommendation-policy changes, and new ingestion/reconciliation mechanisms. The partial implementation only supported the first, while several test names claimed deduplication, device-transition detection, or exact-input replay that their assertions did not prove.

This PR narrows the delivery to a truthful, independently shippable observability slice. Regression files and descriptions now name the contracts they actually verify. Activity deduplication/reconciliation, device migration detection, ingestion quarantine, and persisting confidence into recommendation audits remain explicit follow-up work requiring their own ADR/schema/calibration review.

## Implementation details

- `dataConfidence.ts`
  - classifies current operational coverage as full wearable, basic wearable, or subjective-only
  - validates HRV, RHR, sleep duration/score, respiration, Body Battery, steps, and subjective inputs against hard physiological bounds
  - distinguishes `PRESENT`, `DEGRADED`, `STALE`, `MISSING`, and `INVALID`
  - combines source sync age with per-metric calendar dates
  - enforces the repository invariant that `totalSteps` represents Warsaw calendar day D-1
  - treats missing legacy 28-day fields as immature instead of incorrectly interpreting `undefined !== null` as mature history
  - requires an explicit valid evaluation timestamp for deterministic tests and historical inspection
- `DecisionComposer`
  - computes confidence only after ordinary source composition
  - carries it as optional dashboard telemetry on `DailyDecisionInput`
- `DataConfidenceIndicator`
  - shows rating, aggregate score, operational tier, score breakdown, per-signal values/freshness/history, and data-quality cautions
  - keeps the real Garmin sync button as the ingestion action; the panel action only refreshes displayed data
  - includes focus states, ARIA relationships, an explicit close control, responsive scroll behavior, and viewport-bound visual assertions
- architecture documentation now states that this score is not a third readiness authority and is not frozen replay provenance

## Decision-policy impact

None. No decision-affecting engine files were changed, no `POLICY_VERSION` bump is required, and the semantic simulation diff is empty.

## Verification

- `npm run check` — 238 test files passed, 6 skipped; 2,262 tests passed, 124 skipped
- `npm run build:bundle` — production bundle built successfully
- `uv run pytest` — 334 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy src/garmin_sync`
- `npm run simulate:scenarios` — 32 scenarios
- `npm run simulate:diff` — no semantic differences from the committed baseline
- `node app/scripts/check-policy-drift.mjs origin/main` — passed; no decision-affecting files modified
- `npm run visual:refresh` — 50 desktop/mobile Playwright visual tests passed, including expanded confidence-panel bounds and close behavior
- repository commit and pre-push hooks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a data-confidence indicator to the dashboard.
  * View confidence ratings, scores, sensor coverage, signal quality, safeguards, and metric breakdowns.
  * Expand the diagnostic panel for detailed insights and refresh data when available.
  * Confidence status now identifies missing, stale, invalid, or incomplete health data.

* **Bug Fixes**
  * Improved resilience when activity and recovery data is missing, malformed, outdated, or implausible.
  * Preserved compatibility with older recovery data formats.

* **Documentation**
  * Documented how confidence diagnostics are calculated and displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->