### PR TITLE
feat(scientific-validation): integrate closed-loop feedback into block outcome and shadow log (SV4/SV5)

### DIFF
--- a/app/src/engine/shadowLog.test.ts
+++ b/app/src/engine/shadowLog.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { buildShadowLog, buildShadowLogRow, deriveEngineVerdictFromMode, renderShadowLogCsv, type ShadowLogDayInput } from './shadowLog';
 import type { DailyRecommendation, DailyRecoverySnapshot, DailySubjectiveCheckin, DecisionJournalEntry, ShadowVerdict } from './models';
+import type { ClosedLoopFeedbackRecord } from '../feedback/feedbackModels';
 
 const DATE = '2026-08-16';
 type RecommendationWithVerdict = DailyRecommendation & { engineVerdict?: ShadowVerdict };
@@ -31,6 +32,34 @@ function checkin(overrides: Partial<DailySubjectiveCheckin> = {}): DailySubjecti
         notes: 'a private note that must never appear in the export',
         submittedAt: DATE, dataQuality: { isComplete: true, missingFields: [] }, schemaVersion: 1,
         createdAt: DATE, updatedAt: DATE,
+        ...overrides,
+    };
+}
+
+function feedbackRecord(overrides: Partial<ClosedLoopFeedbackRecord> = {}): ClosedLoopFeedbackRecord {
+    return {
+        date: DATE,
+        recommendationRef: { recommendationId: 'rec-1', revision: 1 },
+        decision: {
+            date: DATE,
+            recommendationRef: { recommendationId: 'rec-1', revision: 1 },
+            action: 'scaled_down',
+            reasons: ['feeling_fatigued'],
+            note: null,
+            decidedAt: `${DATE}T07:00:00Z`,
+        },
+        doseReconciliation: {
+            date: DATE, plannedDurationMin: 60, actualDurationMin: 45, plannedWorkKj: null, actualWorkKj: null,
+            durationDeltaPct: -25, workDeltaPct: null, completedZoneDistribution: null, holdCompliancePct: null, stepOmissionsCount: 0,
+        },
+        recoveryTrajectory: null,
+        regret: {
+            date: DATE, regretClass: 'optimal_choice', athleteDeclaredRegret: 'none', confidence: 'medium',
+            rationales: ['no adverse signal observed'], counterfactualAlternative: null,
+        },
+        utility: { utilityScore: 4, clarityScore: 5, coachingHelpfulness: 'helpful', feedbackNote: null },
+        createdAt: `${DATE}T07:01:00Z`,
+        updatedAt: `${DATE}T07:02:00Z`,
         ...overrides,
     };
 }
@@ -67,7 +96,7 @@ describe('deriveEngineVerdictFromMode', () => {
 });
 
 describe('buildShadowLogRow', () => {
-    it('returns null for a day with none of the three evidence sources', () => {
+    it('returns null for a day with none of the four evidence sources', () => {
         const row = buildShadowLogRow({ date: DATE, recommendation: null, journalEntry: null, checkin: null, recoverySnapshot: null });
         expect(row).toBeNull();
     });
@@ -162,6 +191,28 @@ describe('buildShadowLogRow', () => {
         expect(JSON.stringify(row)).not.toContain('totalSteps');
     });
 
+    it('builds a row from a closed-loop feedback record alone (no recommendation/journal/checkin that day)', () => {
+        const row = buildShadowLogRow({
+            date: DATE, recommendation: null, journalEntry: null, checkin: null, recoverySnapshot: null,
+            feedbackRecord: feedbackRecord(),
+        });
+        expect(row).not.toBeNull();
+        expect(row!.athleteDecisionAction).toBe('scaled_down');
+        expect(row!.athleteDecisionReasons).toEqual(['feeling_fatigued']);
+        expect(row!.regretClass).toBe('optimal_choice');
+        expect(row!.regretConfidence).toBe('medium');
+        expect(row!.athleteDeclaredRegret).toBe('none');
+        expect(row!.utilityScore).toBe(4);
+        expect(row!.coachingHelpfulness).toBe('helpful');
+    });
+
+    it('leaves the feedback fields null when no feedback record exists for the day', () => {
+        const row = buildShadowLogRow({ date: DATE, recommendation: recommendation(), journalEntry: null, checkin: null, recoverySnapshot: null });
+        expect(row!.athleteDecisionAction).toBeNull();
+        expect(row!.regretClass).toBeNull();
+        expect(row!.utilityScore).toBeNull();
+    });
+
     it('carries the journal note through, but never the check-in free-text notes field', () => {
         const row = buildShadowLogRow({
             date: DATE, recommendation: null,
@@ -196,7 +247,8 @@ describe('renderShadowLogCsv', () => {
             'date,engineVerdict,engineMode,externalVerdict,externalNote,sawEngineVerdictFirst,actualVerdict,adherenceFollowed,'
             + 'actualDurationMin,agreement,readiness,sleepQuality,fatigue,soreness,mentalStress,motivation,'
             + 'sleepScoreVs7d,sleepScoreVs28d,restingHrVs7d,restingHrVs28d,hrvVs7d,hrvVs28d,respirationVs7d,respirationVs28d,'
-            + 'policyVersion,externalPlanContentHash',
+            + 'policyVersion,externalPlanContentHash,athleteDecisionAction,athleteDecisionReasons,regretClass,'
+            + 'regretConfidence,athleteDeclaredRegret,utilityScore,coachingHelpfulness',
         );
         expect(lines[1]).toContain(DATE);
         expect(lines[1]).toContain('"took it easy, race, ""quotes"""');

--- a/app/src/engine/shadowLog.ts
+++ b/app/src/engine/shadowLog.ts
@@ -5,6 +5,14 @@ import type {
     DecisionJournalEntry,
     ShadowVerdict,
 } from './models';
+import type {
+    AthleteDecisionAction,
+    AthleteDeclaredRegret,
+    ClosedLoopFeedbackRecord,
+    CoachingHelpfulness,
+    CounterfactualRegretClass,
+    ModificationReason,
+} from '../feedback/feedbackModels';
 import { classifyAgreement, resolveEngineShadowVerdict, type AgreementClass } from './shadowAgreement';
 
 type PersistedRecommendationWithVerdict = DailyRecommendation & { engineVerdict?: ShadowVerdict };
@@ -54,6 +62,16 @@ export interface ShadowLogRow {
     } | null;
     policyVersion: string | null;
     externalPlanContentHash: string | null;
+    /** SV4: closed-loop athlete-decision/regret/utility telemetry, when a validated feedback
+     * record exists for the day. Null fields mean the athlete has not yet reported that
+     * evidence -- not that it was favorable. */
+    athleteDecisionAction: AthleteDecisionAction | null;
+    athleteDecisionReasons: readonly ModificationReason[] | null;
+    regretClass: CounterfactualRegretClass | null;
+    regretConfidence: 'low' | 'medium' | 'high' | null;
+    athleteDeclaredRegret: AthleteDeclaredRegret | null;
+    utilityScore: number | null;
+    coachingHelpfulness: CoachingHelpfulness | null;
 }
 
 export interface ShadowLogDayInput {
@@ -62,6 +80,8 @@ export interface ShadowLogDayInput {
     journalEntry: DecisionJournalEntry | null;
     checkin: DailySubjectiveCheckin | null;
     recoverySnapshot: DailyRecoverySnapshot | null;
+    /** Optional: omitted for callers that have not wired a closed-loop feedback reader yet. */
+    feedbackRecord?: ClosedLoopFeedbackRecord | null;
 }
 
 /** Legacy fallback for recommendations written before the exact Phase 9.0 verdict field
@@ -83,7 +103,8 @@ function persistedEngineVerdict(recommendation: DailyRecommendation): ShadowVerd
  * finding (the day the athlete skipped the check-in), not something to silently drop. */
 export function buildShadowLogRow(input: ShadowLogDayInput): ShadowLogRow | null {
     const { date, recommendation, journalEntry, checkin, recoverySnapshot } = input;
-    if (!recommendation && !journalEntry && !checkin) return null;
+    const feedbackRecord = input.feedbackRecord ?? null;
+    if (!recommendation && !journalEntry && !checkin && !feedbackRecord) return null;
 
     const engineVerdict = recommendation ? persistedEngineVerdict(recommendation) : null;
     const externalVerdict = journalEntry?.externalVerdict ?? null;
@@ -122,6 +143,13 @@ export function buildShadowLogRow(input: ShadowLogDayInput): ShadowLogRow | null
         } : null,
         policyVersion: recommendation?.recommendationAudit?.policyVersion ?? null,
         externalPlanContentHash: recommendation?.recommendationAudit?.externalPlan?.contentHash ?? null,
+        athleteDecisionAction: feedbackRecord?.decision.action ?? null,
+        athleteDecisionReasons: feedbackRecord?.decision.reasons ?? null,
+        regretClass: feedbackRecord?.regret?.regretClass ?? null,
+        regretConfidence: feedbackRecord?.regret?.confidence ?? null,
+        athleteDeclaredRegret: feedbackRecord?.regret?.athleteDeclaredRegret ?? null,
+        utilityScore: feedbackRecord?.utility?.utilityScore ?? null,
+        coachingHelpfulness: feedbackRecord?.utility?.coachingHelpfulness ?? null,
     };
 }
 
@@ -163,6 +191,13 @@ const CSV_COLUMNS: Array<{ header: string; read: (row: ShadowLogRow) => string |
     { header: 'respirationVs28d', read: r => r.objective?.respirationVs28d ?? null },
     { header: 'policyVersion', read: r => r.policyVersion },
     { header: 'externalPlanContentHash', read: r => r.externalPlanContentHash },
+    { header: 'athleteDecisionAction', read: r => r.athleteDecisionAction },
+    { header: 'athleteDecisionReasons', read: r => r.athleteDecisionReasons?.join(';') ?? null },
+    { header: 'regretClass', read: r => r.regretClass },
+    { header: 'regretConfidence', read: r => r.regretConfidence },
+    { header: 'athleteDeclaredRegret', read: r => r.athleteDeclaredRegret },
+    { header: 'utilityScore', read: r => r.utilityScore },
+    { header: 'coachingHelpfulness', read: r => r.coachingHelpfulness },
 ];
 
 function csvCell(value: string | number | boolean | null): string {

--- a/app/src/outcomes/blockOutcome.test.ts
+++ b/app/src/outcomes/blockOutcome.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { CompetitionOutcome } from '../observations/models';
 import type { ProgressResult, ProgressStatus } from '../observations/progress';
+import type { ClosedLoopFeedbackRecord } from '../feedback/feedbackModels';
 import type { BlockProcessEvidence } from './blockProcessEvidence';
 import { BLOCK_VERDICT_POLICY_VERSION, deriveBlockOutcome } from './blockOutcome';
 import type { OutcomeEvaluationSnapshot } from './evaluationSpec';
@@ -107,6 +108,34 @@ function derive(
     });
 }
 
+function feedbackRecord(overrides: Partial<ClosedLoopFeedbackRecord> = {}): ClosedLoopFeedbackRecord {
+    return {
+        date: '2026-08-05',
+        recommendationRef: { recommendationId: 'rec-1', revision: 1 },
+        decision: {
+            date: '2026-08-05',
+            recommendationRef: { recommendationId: 'rec-1', revision: 1 },
+            action: 'scaled_down',
+            reasons: ['feeling_fatigued'],
+            note: null,
+            decidedAt: '2026-08-05T07:00:00Z',
+        },
+        doseReconciliation: {
+            date: '2026-08-05', plannedDurationMin: 60, actualDurationMin: 45, plannedWorkKj: null, actualWorkKj: null,
+            durationDeltaPct: -25, workDeltaPct: null, completedZoneDistribution: null, holdCompliancePct: null, stepOmissionsCount: 0,
+        },
+        recoveryTrajectory: null,
+        regret: {
+            date: '2026-08-05', regretClass: 'overreaching_crash', athleteDeclaredRegret: 'should_have_rested',
+            confidence: 'high', rationales: ['corroborated suppression'], counterfactualAlternative: 'lower dose',
+        },
+        utility: { utilityScore: 3, clarityScore: 4, coachingHelpfulness: 'neutral', feedbackNote: null },
+        createdAt: '2026-08-05T07:01:00Z',
+        updatedAt: '2026-08-05T07:02:00Z',
+        ...overrides,
+    };
+}
+
 describe('deriveBlockOutcome', () => {
     it('is on-track only with meaningful primary progress and adequate process/response evidence', () => {
         const report = derive([
@@ -117,6 +146,41 @@ describe('deriveBlockOutcome', () => {
         expect(report.blockVerdictPolicyVersion).toBe(BLOCK_VERDICT_POLICY_VERSION);
         expect(report.reasons).toContain('meaningful_primary_improvement');
         expect(report).not.toHaveProperty('score');
+    });
+
+    it('defaults to an explicit empty feedback-loop evidence summary when no records are supplied', () => {
+        const report = derive([progress('cycling_tt_20m_mean_power_w', 'meaningful_improvement')]);
+        expect(report.feedbackLoopEvidence.recordCount).toBe(0);
+        expect(report.feedbackLoopEvidence.regretRatePct).toBeNull();
+        expect(report.sourceIds.feedbackRecordIds).toEqual([]);
+    });
+
+    it('summarizes supplied feedback records as additive evidence without changing the verdict', () => {
+        const withoutFeedback = deriveBlockOutcome({
+            evaluation: evaluation(),
+            metricProgress: [progress('cycling_tt_20m_mean_power_w', 'meaningful_improvement')],
+            process: process(),
+            ecologicalOutcomes: [],
+            policySegments: [{
+                startDate: '2026-08-01', endDate: '2026-08-21', policyVersion: 'policy-v1', planningMode: 'unknown',
+            }],
+        });
+        const withFeedback = deriveBlockOutcome({
+            evaluation: evaluation(),
+            metricProgress: [progress('cycling_tt_20m_mean_power_w', 'meaningful_improvement')],
+            process: process(),
+            ecologicalOutcomes: [],
+            policySegments: [{
+                startDate: '2026-08-01', endDate: '2026-08-21', policyVersion: 'policy-v1', planningMode: 'unknown',
+            }],
+            feedbackRecords: [feedbackRecord()],
+        });
+
+        // Even a severe regret label must not silently move the versioned block verdict.
+        expect(withFeedback.verdict).toBe(withoutFeedback.verdict);
+        expect(withFeedback.feedbackLoopEvidence.recordCount).toBe(1);
+        expect(withFeedback.feedbackLoopEvidence.regretClassCounts.overreaching_crash).toBe(1);
+        expect(withFeedback.sourceIds.feedbackRecordIds).toEqual(['2026-08-05@r1']);
     });
 
     it('withholds the verdict when process adequacy is below the versioned threshold', () => {

--- a/app/src/outcomes/blockOutcome.test.ts
+++ b/app/src/outcomes/blockOutcome.test.ts
@@ -180,7 +180,7 @@ describe('deriveBlockOutcome', () => {
         expect(withFeedback.verdict).toBe(withoutFeedback.verdict);
         expect(withFeedback.feedbackLoopEvidence.recordCount).toBe(1);
         expect(withFeedback.feedbackLoopEvidence.regretClassCounts.overreaching_crash).toBe(1);
-        expect(withFeedback.sourceIds.feedbackRecordIds).toEqual(['2026-08-05@r1']);
+        expect(withFeedback.sourceIds.feedbackRecordIds).toEqual(['2026-08-05@r1:rec-1']);
     });
 
     it('withholds the verdict when process adequacy is below the versioned threshold', () => {

--- a/app/src/outcomes/blockOutcome.ts
+++ b/app/src/outcomes/blockOutcome.ts
@@ -1,7 +1,9 @@
 import type { CompetitionOutcome } from '../observations/models';
 import type { ProgressResult } from '../observations/progress';
+import type { ClosedLoopFeedbackRecord } from '../feedback/feedbackModels';
 import type { OutcomeEvaluationSnapshot, OutcomeMetricBinding } from './evaluationSpec';
 import type { BlockProcessEvidence } from './blockProcessEvidence';
+import { deriveFeedbackLoopEvidence, type FeedbackLoopEvidence } from './feedbackLoopEvidence';
 import type { PolicySegment } from './policySegments';
 
 export const BLOCK_VERDICT_POLICY_VERSION = 'block-adequacy-v1' as const;
@@ -23,6 +25,11 @@ export interface BlockOutcomeReport {
     metricProgress: readonly ProgressResult[];
     ecologicalOutcomes: readonly CompetitionOutcome[];
     process: BlockProcessEvidence;
+    /**
+     * SV4 evidence sidecar: closed-loop athlete-decision/regret/utility telemetry summarized
+     * over the same window. Purely additive -- it never participates in `verdict`.
+     */
+    feedbackLoopEvidence: FeedbackLoopEvidence;
     verdict: BlockVerdict;
     reasons: readonly string[];
     policySegments: readonly PolicySegment[];
@@ -32,6 +39,7 @@ export interface BlockOutcomeReport {
         sessionIds: readonly string[];
         recommendationIds: readonly string[];
         ecologicalOutcomeIds: readonly string[];
+        feedbackRecordIds: readonly string[];
     };
 }
 
@@ -46,6 +54,9 @@ export interface BlockOutcomeInput {
     ecologicalOutcomes: readonly CompetitionOutcome[];
     process: BlockProcessEvidence;
     policySegments: readonly PolicySegment[];
+    /** Optional: omitted or empty when no closed-loop feedback records exist yet for this
+     * window (no reader has been wired to a persistence store as of SV4). */
+    feedbackRecords?: readonly ClosedLoopFeedbackRecord[];
 }
 
 function pct(numerator: number, denominator: number): number {
@@ -167,6 +178,7 @@ export function deriveBlockOutcome(input: BlockOutcomeInput): BlockOutcomeReport
     }
 
     const ecologicalOutcomes = sortedEcologicalOutcomes(input.ecologicalOutcomes);
+    const feedbackLoopEvidence = deriveFeedbackLoopEvidence(input.feedbackRecords ?? []);
     return {
         evaluationRef: {
             id: evaluation.revision.id,
@@ -177,6 +189,7 @@ export function deriveBlockOutcome(input: BlockOutcomeInput): BlockOutcomeReport
         metricProgress,
         ecologicalOutcomes,
         process,
+        feedbackLoopEvidence,
         verdict,
         reasons,
         policySegments: [...input.policySegments].sort((a, b) => compareCodeUnits(a.startDate, b.startDate)),
@@ -186,6 +199,7 @@ export function deriveBlockOutcome(input: BlockOutcomeInput): BlockOutcomeReport
             sessionIds: uniqueSorted(process.sourceIds.sessionIds),
             recommendationIds: uniqueSorted(process.sourceIds.recommendationIds),
             ecologicalOutcomeIds: uniqueSorted(ecologicalOutcomes.map(item => item.id)),
+            feedbackRecordIds: feedbackLoopEvidence.sourceIds.feedbackRecordIds,
         },
     };
 }

--- a/app/src/outcomes/blockOutcomeReport.test.ts
+++ b/app/src/outcomes/blockOutcomeReport.test.ts
@@ -65,6 +65,25 @@ function report(context: Record<string, string | number | boolean | null>): Bloc
                 sessionIds: ['execution-b', 'execution-a'],
             },
         },
+        feedbackLoopEvidence: {
+            recordCount: 0,
+            decisionActionCounts: {
+                accepted: 0, scaled_down: 0, scaled_up: 0, substituted: 0, rejected_rest: 0, rejected_train_harder: 0,
+            },
+            modificationRatePct: null,
+            regretClassCounts: {
+                optimal_choice: 0, overreaching_crash: 0, unnecessary_forfeiture: 0, injury_exacerbation: 0, inconclusive: 0,
+            },
+            regretRatePct: null,
+            averageUtilityScore: null,
+            averageClarityScore: null,
+            coachingHelpfulnessCounts: {
+                very_helpful: 0, helpful: 0, neutral: 0, unhelpful: 0, counterproductive: 0,
+            },
+            averageHoldCompliancePct: null,
+            averageDurationDeltaPct: null,
+            sourceIds: { feedbackRecordIds: [] },
+        },
         verdict: 'on_track',
         reasons: ['meaningful_primary_improvement', 'process_adequate'],
         policySegments: [{
@@ -77,6 +96,7 @@ function report(context: Record<string, string | number | boolean | null>): Bloc
             sessionIds: ['execution-a', 'execution-b'],
             recommendationIds: ['2026-08-01@r2', '2026-08-02@r1'],
             ecologicalOutcomeIds: ['race-1'],
+            feedbackRecordIds: [],
         },
     };
 }

--- a/app/src/outcomes/feedbackLoopEvidence.test.ts
+++ b/app/src/outcomes/feedbackLoopEvidence.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import type { ClosedLoopFeedbackRecord } from '../feedback/feedbackModels';
+import { deriveFeedbackLoopEvidence } from './feedbackLoopEvidence';
+
+function record(overrides: Partial<ClosedLoopFeedbackRecord> = {}): ClosedLoopFeedbackRecord {
+    return {
+        date: '2026-08-26',
+        recommendationRef: { recommendationId: 'rec-123', revision: 1 },
+        decision: {
+            date: '2026-08-26',
+            recommendationRef: { recommendationId: 'rec-123', revision: 1 },
+            action: 'accepted',
+            reasons: [],
+            note: null,
+            decidedAt: '2026-08-26T07:30:00Z',
+        },
+        doseReconciliation: {
+            date: '2026-08-26',
+            plannedDurationMin: 60,
+            actualDurationMin: 60,
+            plannedWorkKj: null,
+            actualWorkKj: null,
+            durationDeltaPct: 0,
+            workDeltaPct: null,
+            completedZoneDistribution: null,
+            holdCompliancePct: null,
+            stepOmissionsCount: 0,
+        },
+        recoveryTrajectory: null,
+        regret: null,
+        utility: null,
+        createdAt: '2026-08-26T07:31:00Z',
+        updatedAt: '2026-08-26T07:32:00Z',
+        ...overrides,
+    };
+}
+
+describe('deriveFeedbackLoopEvidence', () => {
+    it('returns an explicit zero/null-state summary for no evidence rather than implying zero modification', () => {
+        const evidence = deriveFeedbackLoopEvidence([]);
+        expect(evidence.recordCount).toBe(0);
+        expect(evidence.modificationRatePct).toBeNull();
+        expect(evidence.regretRatePct).toBeNull();
+        expect(evidence.averageUtilityScore).toBeNull();
+        expect(evidence.sourceIds.feedbackRecordIds).toEqual([]);
+    });
+
+    it('counts decision actions and computes the modification rate over accepted vs. not', () => {
+        const evidence = deriveFeedbackLoopEvidence([
+            record({ date: '2026-08-01', decision: { ...record().decision, date: '2026-08-01', action: 'accepted' } }),
+            record({ date: '2026-08-02', decision: { ...record().decision, date: '2026-08-02', action: 'scaled_down' } }),
+            record({ date: '2026-08-03', decision: { ...record().decision, date: '2026-08-03', action: 'rejected_rest' } }),
+        ]);
+        expect(evidence.recordCount).toBe(3);
+        expect(evidence.decisionActionCounts).toMatchObject({ accepted: 1, scaled_down: 1, rejected_rest: 1 });
+        expect(evidence.modificationRatePct).toBeCloseTo(66.67, 1);
+    });
+
+    it('excludes inconclusive regret labels from both the numerator and denominator of the regret rate', () => {
+        const evidence = deriveFeedbackLoopEvidence([
+            record({ regret: { date: '2026-08-26', regretClass: 'optimal_choice', athleteDeclaredRegret: 'none', confidence: 'medium', rationales: [], counterfactualAlternative: null } }),
+            record({ regret: { date: '2026-08-26', regretClass: 'overreaching_crash', athleteDeclaredRegret: 'should_have_rested', confidence: 'high', rationales: [], counterfactualAlternative: 'lower dose' } }),
+            record({ regret: { date: '2026-08-26', regretClass: 'inconclusive', athleteDeclaredRegret: null, confidence: 'low', rationales: [], counterfactualAlternative: null } }),
+        ]);
+        expect(evidence.regretClassCounts).toMatchObject({ optimal_choice: 1, overreaching_crash: 1, inconclusive: 1 });
+        // 1 regretful out of 2 classified (the inconclusive record is excluded from the denominator).
+        expect(evidence.regretRatePct).toBe(50);
+    });
+
+    it('averages utility, clarity, hold compliance and duration delta only over records that report them', () => {
+        const evidence = deriveFeedbackLoopEvidence([
+            record({
+                utility: { utilityScore: 4, clarityScore: 5, coachingHelpfulness: 'helpful', feedbackNote: null },
+                doseReconciliation: { ...record().doseReconciliation, holdCompliancePct: 90, durationDeltaPct: 10 },
+            }),
+            record({
+                utility: { utilityScore: 2, clarityScore: 3, coachingHelpfulness: 'unhelpful', feedbackNote: null },
+                doseReconciliation: { ...record().doseReconciliation, holdCompliancePct: null, durationDeltaPct: null },
+            }),
+            record({ doseReconciliation: { ...record().doseReconciliation, holdCompliancePct: null, durationDeltaPct: null } }), // no utility, no dose deltas reported
+        ]);
+        expect(evidence.averageUtilityScore).toBe(3);
+        expect(evidence.averageClarityScore).toBe(4);
+        expect(evidence.coachingHelpfulnessCounts).toMatchObject({ helpful: 1, unhelpful: 1 });
+        expect(evidence.averageHoldCompliancePct).toBe(90);
+        expect(evidence.averageDurationDeltaPct).toBe(10);
+    });
+
+    it('derives sorted, deduplicated feedback record ids from date and recommendation revision', () => {
+        const evidence = deriveFeedbackLoopEvidence([
+            record({ date: '2026-08-02', recommendationRef: { recommendationId: 'rec-2', revision: 1 } }),
+            record({ date: '2026-08-01', recommendationRef: { recommendationId: 'rec-1', revision: 3 } }),
+            record({ date: '2026-08-01', recommendationRef: { recommendationId: 'rec-1', revision: 3 } }),
+        ]);
+        expect(evidence.sourceIds.feedbackRecordIds).toEqual(['2026-08-01@r3', '2026-08-02@r1']);
+    });
+});

--- a/app/src/outcomes/feedbackLoopEvidence.test.ts
+++ b/app/src/outcomes/feedbackLoopEvidence.test.ts
@@ -92,6 +92,14 @@ describe('deriveFeedbackLoopEvidence', () => {
             record({ date: '2026-08-01', recommendationRef: { recommendationId: 'rec-1', revision: 3 } }),
             record({ date: '2026-08-01', recommendationRef: { recommendationId: 'rec-1', revision: 3 } }),
         ]);
-        expect(evidence.sourceIds.feedbackRecordIds).toEqual(['2026-08-01@r3', '2026-08-02@r1']);
+        expect(evidence.sourceIds.feedbackRecordIds).toEqual(['2026-08-01@r3:rec-1', '2026-08-02@r1:rec-2']);
+    });
+
+    it('keeps distinct recommendations with the same date and revision from colliding in feedbackRecordIds', () => {
+        const evidence = deriveFeedbackLoopEvidence([
+            record({ date: '2026-08-01', recommendationRef: { recommendationId: 'rec-a', revision: 1 } }),
+            record({ date: '2026-08-01', recommendationRef: { recommendationId: 'rec-b', revision: 1 } }),
+        ]);
+        expect(evidence.sourceIds.feedbackRecordIds).toEqual(['2026-08-01@r1:rec-a', '2026-08-01@r1:rec-b']);
     });
 });

--- a/app/src/outcomes/feedbackLoopEvidence.ts
+++ b/app/src/outcomes/feedbackLoopEvidence.ts
@@ -1,0 +1,149 @@
+import type { AthleteDecisionAction, ClosedLoopFeedbackRecord, CoachingHelpfulness, CounterfactualRegretClass } from '../feedback/feedbackModels';
+
+export type DecisionActionCounts = Record<AthleteDecisionAction, number>;
+export type RegretClassCounts = Record<CounterfactualRegretClass, number>;
+
+const REGRETFUL_CLASSES: readonly CounterfactualRegretClass[] = [
+    'overreaching_crash',
+    'unnecessary_forfeiture',
+    'injury_exacerbation',
+];
+
+export interface FeedbackLoopEvidence {
+    /** Count of closed-loop records folded into this window; 0 means no evidence exists yet,
+     * not that zero modifications/regret occurred. */
+    recordCount: number;
+    decisionActionCounts: DecisionActionCounts;
+    /** Percent of decisions that were not a plain `accepted`. Null when recordCount is 0. */
+    modificationRatePct: number | null;
+    regretClassCounts: RegretClassCounts;
+    /**
+     * SV goal #6: the operational regret-label rate. Denominator is records with a non-null,
+     * non-`inconclusive` regret classification -- ambiguous observations are excluded from
+     * both numerator and denominator rather than forced toward either bound. Null when no
+     * record has a resolvable classification.
+     */
+    regretRatePct: number | null;
+    averageUtilityScore: number | null;
+    averageClarityScore: number | null;
+    coachingHelpfulnessCounts: Record<CoachingHelpfulness, number>;
+    averageHoldCompliancePct: number | null;
+    averageDurationDeltaPct: number | null;
+    sourceIds: {
+        /** `date@r<revision>` of the recommendation each record reconciles against, mirroring
+         * `blockProcessEvidence.ts`'s recommendation reference format. */
+        feedbackRecordIds: readonly string[];
+    };
+}
+
+function emptyDecisionActionCounts(): DecisionActionCounts {
+    return {
+        accepted: 0,
+        scaled_down: 0,
+        scaled_up: 0,
+        substituted: 0,
+        rejected_rest: 0,
+        rejected_train_harder: 0,
+    };
+}
+
+function emptyRegretClassCounts(): RegretClassCounts {
+    return {
+        optimal_choice: 0,
+        overreaching_crash: 0,
+        unnecessary_forfeiture: 0,
+        injury_exacerbation: 0,
+        inconclusive: 0,
+    };
+}
+
+function emptyCoachingHelpfulnessCounts(): Record<CoachingHelpfulness, number> {
+    return {
+        very_helpful: 0,
+        helpful: 0,
+        neutral: 0,
+        unhelpful: 0,
+        counterproductive: 0,
+    };
+}
+
+function average(values: readonly number[]): number | null {
+    if (values.length === 0) return null;
+    const sum = values.reduce((total, value) => total + value, 0);
+    return Math.round((sum / values.length) * 100) / 100;
+}
+
+function percentage(numerator: number, denominator: number): number | null {
+    if (denominator === 0) return null;
+    return Math.round((10000 * numerator) / denominator) / 100;
+}
+
+function compareCodeUnits(left: string, right: string): number {
+    return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function feedbackRecordRef(record: ClosedLoopFeedbackRecord): string {
+    return `${record.date}@r${record.recommendationRef.revision}`;
+}
+
+/**
+ * SV4 evidence-only read model. Pure aggregation over already-validated closed-loop feedback
+ * records (see `feedback/feedbackValidation.ts`); it never derives, mutates, or infers a
+ * record and it never feeds back into `verdict` -- see the plan's "not an immediate
+ * recommendation-policy mutation" framing.
+ */
+export function deriveFeedbackLoopEvidence(records: readonly ClosedLoopFeedbackRecord[]): FeedbackLoopEvidence {
+    const decisionActionCounts = emptyDecisionActionCounts();
+    const regretClassCounts = emptyRegretClassCounts();
+    const coachingHelpfulnessCounts = emptyCoachingHelpfulnessCounts();
+
+    let nonAccepted = 0;
+    let classifiedRegret = 0;
+    let regretfulRegret = 0;
+    const utilityScores: number[] = [];
+    const clarityScores: number[] = [];
+    const holdCompliancePcts: number[] = [];
+    const durationDeltaPcts: number[] = [];
+
+    for (const record of records) {
+        decisionActionCounts[record.decision.action] += 1;
+        if (record.decision.action !== 'accepted') nonAccepted += 1;
+
+        if (record.regret) {
+            regretClassCounts[record.regret.regretClass] += 1;
+            if (record.regret.regretClass !== 'inconclusive') {
+                classifiedRegret += 1;
+                if (REGRETFUL_CLASSES.includes(record.regret.regretClass)) regretfulRegret += 1;
+            }
+        }
+
+        if (record.utility) {
+            utilityScores.push(record.utility.utilityScore);
+            clarityScores.push(record.utility.clarityScore);
+            coachingHelpfulnessCounts[record.utility.coachingHelpfulness] += 1;
+        }
+
+        if (record.doseReconciliation.holdCompliancePct !== null) {
+            holdCompliancePcts.push(record.doseReconciliation.holdCompliancePct);
+        }
+        if (record.doseReconciliation.durationDeltaPct !== null) {
+            durationDeltaPcts.push(record.doseReconciliation.durationDeltaPct);
+        }
+    }
+
+    return {
+        recordCount: records.length,
+        decisionActionCounts,
+        modificationRatePct: percentage(nonAccepted, records.length),
+        regretClassCounts,
+        regretRatePct: percentage(regretfulRegret, classifiedRegret),
+        averageUtilityScore: average(utilityScores),
+        averageClarityScore: average(clarityScores),
+        coachingHelpfulnessCounts,
+        averageHoldCompliancePct: average(holdCompliancePcts),
+        averageDurationDeltaPct: average(durationDeltaPcts),
+        sourceIds: {
+            feedbackRecordIds: [...new Set(records.map(feedbackRecordRef))].sort(compareCodeUnits),
+        },
+    };
+}

--- a/app/src/outcomes/feedbackLoopEvidence.ts
+++ b/app/src/outcomes/feedbackLoopEvidence.ts
@@ -83,7 +83,7 @@ function compareCodeUnits(left: string, right: string): number {
 }
 
 function feedbackRecordRef(record: ClosedLoopFeedbackRecord): string {
-    return `${record.date}@r${record.recommendationRef.revision}`;
+    return `${record.date}@r${record.recommendationRef.revision}:${record.recommendationRef.recommendationId}`;
 }
 
 /**

--- a/docs/plans/scientific-validation-and-feedback-loop.md
+++ b/docs/plans/scientific-validation-and-feedback-loop.md
@@ -113,14 +113,14 @@ SV6: Multi-Block Prospective Calibration Synthesis
 - [x] Implement unit tests in `regretEvaluator.test.ts` and utility-schema coverage in `feedbackValidation.test.ts`.
 
 ### `SV4`: Outcome & Shadow Integration
-- [ ] Update `app/src/outcomes/blockOutcome.ts` to include feedback loop metrics in `BlockOutcomeReport`.
-- [ ] Update `app/src/engine/shadowLog.ts` to include athlete decision and regret telemetry in shadow log rows.
-- [ ] Verify test suite compatibility across `blockOutcome.test.ts` and `shadowLog.test.ts`.
+- [x] Update `app/src/outcomes/blockOutcome.ts` to include feedback loop metrics in `BlockOutcomeReport`, via a new pure `app/src/outcomes/feedbackLoopEvidence.ts` read model (`deriveFeedbackLoopEvidence`) that aggregates `ClosedLoopFeedbackRecord[]` into decision-action counts, an operational regret-label rate (excluding `inconclusive`), and utility/dose-compliance averages. Additive only — evidence never participates in `verdict`.
+- [x] Update `app/src/engine/shadowLog.ts` to include athlete decision and regret telemetry (`athleteDecisionAction`, `regretClass`, `regretConfidence`, `athleteDeclaredRegret`, `utilityScore`, `coachingHelpfulness`) in shadow log rows, sourced from an optional `feedbackRecord` on `ShadowLogDayInput`.
+- [x] Verify test suite compatibility across `blockOutcome.test.ts` and `shadowLog.test.ts`; added `feedbackLoopEvidence.test.ts`.
 
 ### `SV5`: Verification & Invariant Assurance
-- [ ] Run full unit test suite (`npm test`) on the final review head.
-- [ ] Run scenario simulation suite (`npm run simulate:scenarios`) on the final review head.
-- [ ] Run baseline diff (`npm run simulate:diff`) ensuring zero unintended drift in live decision policy.
+- [x] Run full unit test suite (`npm test`) on the final review head — 2312 passed, 124 skipped.
+- [x] Run scenario simulation suite (`npm run simulate:scenarios`) on the final review head — 32 scenarios simulated.
+- [x] Run baseline diff (`npm run simulate:diff`) ensuring zero unintended drift in live decision policy — no semantic differences found.
 
 ### `SV6`: Multi-Block Prospective Calibration Synthesis
 - [ ] Accumulate sufficient real-athlete history across multiple blocks before estimating signal marginal value or policy changes.


### PR DESCRIPTION
## Summary

Continues [docs/plans/scientific-validation-and-feedback-loop.md](docs/plans/scientific-validation-and-feedback-loop.md). `SV0`–`SV3` (domain models, validation, signal fidelity analytics, regret evaluator) were already merged; this PR delivers `SV4` (Outcome & Shadow Integration) and `SV5` (Verification & Invariant Assurance).

- **New `app/src/outcomes/feedbackLoopEvidence.ts`**: a pure read model (`deriveFeedbackLoopEvidence`) aggregating `ClosedLoopFeedbackRecord[]` into decision-action counts, an operational regret-label rate (excludes `inconclusive` from both numerator and denominator, per the causality guardrails in the review-hardening doc), utility/clarity averages, coaching-helpfulness counts, and dose-compliance averages. Empty input returns an explicit zero/null-state summary rather than implying "no issues."
- **`app/src/outcomes/blockOutcome.ts`**: adds `feedbackLoopEvidence` to `BlockOutcomeReport` via an optional `feedbackRecords` input (defaults to empty). Purely additive — a test confirms even a severe `overreaching_crash` regret label does not move the versioned block `verdict`, preserving the plan's "not an immediate recommendation-policy mutation" guarantee.
- **`app/src/engine/shadowLog.ts`**: surfaces `athleteDecisionAction`, `athleteDecisionReasons`, `regretClass`, `regretConfidence`, `athleteDeclaredRegret`, `utilityScore`, and `coachingHelpfulness` on each shadow log row (and its CSV export), sourced from an optional `feedbackRecord` input. A feedback record alone is now sufficient to produce a row.
- Existing services (`blockOutcomeReportService.ts`, `shadowLogService.ts`) need no changes — the new inputs are optional since no closed-loop-feedback persistence reader has been wired yet (future work, outside SV4's scope).

## Verification (SV5)

- `npm run check` (typecheck + lint + 2312 tests + workout catalog): **pass**
- `npm run simulate:scenarios`: 32 scenarios simulated
- `npm run simulate:diff`: **no semantic differences vs. committed baseline** — confirms zero drift in live decision policy

## Notes for reviewers

- `feedbackLoopEvidence` and the new shadow-log fields are evidence sidecars only; they do not feed into `verdict`, selection, or any production weight/gate. `SV6` (multi-block prospective calibration, requiring real multi-block athlete history) remains correctly blocked/untouched.
- `docs/plans/scientific-validation-and-feedback-loop.md` task board updated to mark `SV4`/`SV5` complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added closed-loop feedback evidence to block outcome reports, including decision, regret, utility, and coaching metrics.
  * Shadow logs now capture available athlete feedback, even when it is the only evidence source.
  * CSV exports include new feedback fields and source references.
  * Added aggregate feedback metrics such as action counts, regret rates, modification rates, and average scores.

* **Bug Fixes**
  * Empty or unavailable feedback metrics are now represented clearly as null or zero values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->