### PR TITLE
fix(external-plans): support multiple training sessions on single days (double days)

### DIFF
--- a/app/src/components/ExternalPlanWeek.test.ts
+++ b/app/src/components/ExternalPlanWeek.test.ts
@@ -130,4 +130,51 @@ describe('ExternalPlanWeek occupancy and scheduling contracts', () => {
         expect(html).not.toContain('2026-08-26');
         expect(html).toContain('Endurance Ride');
     });
+
+    it('renders multiple training sessions on a single day (double day)', () => {
+        const doubleDayPlaced: PlacedSession[] = [
+            {
+                session: {
+                    id: 'w1-thu-easy-aerobic', title: 'Easy Aerobic Volume', priority: 'supporting',
+                    placement: { week: 1, preferredDay: 'thursday', flexibility: 'preferred', ifMissed: 'drop' },
+                    gating: { modality: 'cycling', intensity: 'easy', durationMin: 35, durationMax: 50, environment: 'either', equipment: [] },
+                    prescription: { summary: 'Low-cost aerobic volume before the race rehearsal.' },
+                },
+                date: '2026-08-27',
+                status: 'planned',
+                moved: false,
+            },
+            {
+                session: {
+                    id: 'w1-thu-upper-maintenance', title: 'Upper-Body Strength Maintenance', priority: 'optional',
+                    placement: { week: 1, preferredDay: 'thursday', flexibility: 'preferred', ifMissed: 'drop' },
+                    gating: { modality: 'strength', intensity: 'moderate', durationMin: 25, durationMax: 35, environment: 'indoor', equipment: ['free_weights', 'pullup_bar'] },
+                    prescription: { summary: 'Low-fatigue upper-body maintenance.' },
+                },
+                date: '2026-08-27',
+                status: 'planned',
+                moved: false,
+            },
+        ];
+
+        const html = renderToStaticMarkup(
+            React.createElement(ExternalPlanWeek, {
+                userId: 'user-1',
+                planTitle: 'Adaptive Peak Plan',
+                weekStartDate: '2026-08-24',
+                placed: doubleDayPlaced,
+                critique: null,
+                today: '2026-08-24',
+                onProposeReplacement: () => ({ sessionId: 's1', missedDate: '2026-08-24', outcome: 'unresolved' as const, rationale: '' }),
+                onConfirmReplacement: () => {},
+                onChooseDate: () => {},
+            }),
+        );
+
+        expect(html).toContain('2026-08-27');
+        expect(html).toContain('Easy Aerobic Volume');
+        expect(html).toContain('Upper-Body Strength Maintenance');
+        expect(html).toContain('easy · 35–50 min');
+        expect(html).toContain('moderate · 25–35 min');
+    });
 });

--- a/app/src/components/ExternalPlanWeek.test.ts
+++ b/app/src/components/ExternalPlanWeek.test.ts
@@ -177,4 +177,64 @@ describe('ExternalPlanWeek occupancy and scheduling contracts', () => {
         expect(html).toContain('easy · 35–50 min');
         expect(html).toContain('moderate · 25–35 min');
     });
+
+    it('renders three training sessions on a single day (triple day)', () => {
+        const tripleDayPlaced: PlacedSession[] = [
+            {
+                session: {
+                    id: 'w1-thu-easy-aerobic', title: 'Easy Aerobic Volume', priority: 'supporting',
+                    placement: { week: 1, preferredDay: 'thursday', flexibility: 'preferred', ifMissed: 'drop' },
+                    gating: { modality: 'cycling', intensity: 'easy', durationMin: 35, durationMax: 50, environment: 'either', equipment: [] },
+                    prescription: { summary: 'Low-cost aerobic volume.' },
+                },
+                date: '2026-08-27',
+                status: 'planned',
+                moved: false,
+            },
+            {
+                session: {
+                    id: 'w1-thu-upper-maintenance', title: 'Upper-Body Strength Maintenance', priority: 'optional',
+                    placement: { week: 1, preferredDay: 'thursday', flexibility: 'preferred', ifMissed: 'drop' },
+                    gating: { modality: 'strength', intensity: 'moderate', durationMin: 25, durationMax: 35, environment: 'indoor', equipment: ['free_weights', 'pullup_bar'] },
+                    prescription: { summary: 'Upper-body maintenance.' },
+                },
+                date: '2026-08-27',
+                status: 'planned',
+                moved: false,
+            },
+            {
+                session: {
+                    id: 'w1-thu-mobility', title: 'Evening Mobility Routine', priority: 'optional',
+                    placement: { week: 1, preferredDay: 'thursday', flexibility: 'preferred', ifMissed: 'drop' },
+                    gating: { modality: 'mobility', intensity: 'recovery', durationMin: 15, durationMax: 20, environment: 'indoor', equipment: [] },
+                    prescription: { summary: 'Hip and spine mobility.' },
+                },
+                date: '2026-08-27',
+                status: 'planned',
+                moved: false,
+            },
+        ];
+
+        const html = renderToStaticMarkup(
+            React.createElement(ExternalPlanWeek, {
+                userId: 'user-1',
+                planTitle: 'Adaptive Peak Plan',
+                weekStartDate: '2026-08-24',
+                placed: tripleDayPlaced,
+                critique: null,
+                today: '2026-08-24',
+                onProposeReplacement: () => ({ sessionId: 's1', missedDate: '2026-08-24', outcome: 'unresolved' as const, rationale: '' }),
+                onConfirmReplacement: () => {},
+                onChooseDate: () => {},
+            }),
+        );
+
+        expect(html).toContain('2026-08-27');
+        expect(html).toContain('Easy Aerobic Volume');
+        expect(html).toContain('Upper-Body Strength Maintenance');
+        expect(html).toContain('Evening Mobility Routine');
+        expect(html).toContain('easy · 35–50 min');
+        expect(html).toContain('moderate · 25–35 min');
+        expect(html).toContain('recovery · 15–20 min');
+    });
 });

--- a/app/src/engine/externalPlacement.doubleDay.test.ts
+++ b/app/src/engine/externalPlacement.doubleDay.test.ts
@@ -112,26 +112,29 @@ describe('preferred-day bundle placement', () => {
         ]);
     });
 
-    it('keeps a bundle anchored when one companion is fixed, surfacing the real collision', () => {
-        const placed = resolvePlacement(
-            plan([
-                session('race', {
-                    priority: 'key',
-                    placement: {
-                        week: 1,
-                        preferredDay: 'monday',
-                        flexibility: 'fixed',
-                        ifMissed: 'drop',
-                    },
-                }),
-                session('warmup'),
-            ]),
-            null,
-            { fixedActivities: [fixedActivity(MONDAY)] },
-        );
+    it('preserves fixed-session precedence while moving preferred companions together', () => {
+        const placed = resolvePlacement(plan([
+            session('race', {
+                priority: 'key',
+                placement: {
+                    week: 1,
+                    preferredDay: 'monday',
+                    flexibility: 'fixed',
+                    ifMissed: 'drop',
+                },
+            }),
+            session('ride'),
+            session('strength'),
+        ]), null);
 
-        expect(placed.every(item => item.date === MONDAY)).toBe(true);
-        expect(placed.every(item => item.moved === false)).toBe(true);
+        expect(placed.find(item => item.session.id === 'race')).toMatchObject({
+            date: MONDAY,
+            moved: false,
+        });
+        expect(placed.filter(item => item.session.id !== 'race').map(item => `${item.date}:${item.moved}`)).toEqual([
+            '2026-08-18:true',
+            '2026-08-18:true',
+        ]);
     });
 
     it('does not let an unrelated overlay silently stack a movable preferred bundle', () => {

--- a/app/src/engine/externalPlacement.doubleDay.test.ts
+++ b/app/src/engine/externalPlacement.doubleDay.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from 'vitest';
+import { resolvePlacement } from './externalPlacement';
+import { EXTERNAL_PLAN_SCHEMA } from './models';
+import type {
+    ExternalPlanPlacement,
+    ExternalPlanSession,
+    ExternalTrainingPlan,
+    FixedActivity,
+} from './models';
+
+const MONDAY = '2026-08-17';
+
+function session(
+    id: string,
+    overrides: Partial<ExternalPlanSession> = {},
+): ExternalPlanSession {
+    return {
+        id,
+        title: id,
+        priority: 'supporting',
+        placement: {
+            week: 1,
+            preferredDay: 'monday',
+            flexibility: 'preferred',
+            ifMissed: 'drop',
+        },
+        gating: {
+            modality: 'cycling',
+            intensity: 'easy',
+            durationMin: 45,
+            durationMax: 60,
+            environment: 'either',
+            equipment: [],
+        },
+        prescription: { summary: 'x' },
+        ...overrides,
+    };
+}
+
+function plan(sessions: ExternalPlanSession[]): ExternalTrainingPlan {
+    return {
+        schema: EXTERNAL_PLAN_SCHEMA,
+        planId: 'double-day-block',
+        revision: 1,
+        title: 'Double-day block',
+        startDate: MONDAY,
+        weekCount: 1,
+        sessions,
+    };
+}
+
+function fixedActivity(date: string): FixedActivity {
+    return {
+        id: `fixed-${date}`,
+        userId: 'u1',
+        title: 'Booked match',
+        date,
+        durationMin: 90,
+        fixed: true,
+        environment: 'outdoor',
+        equipment: [],
+        isCompleted: false,
+        createdAt: '',
+        updatedAt: '',
+    };
+}
+
+function overlay(
+    assignments: ExternalPlanPlacement['assignments'],
+): ExternalPlanPlacement {
+    return {
+        userId: 'u1',
+        planId: 'double-day-block',
+        revision: 1,
+        assignments,
+        updatedAt: '2026-08-17T06:00:00Z',
+    };
+}
+
+describe('preferred-day bundle placement', () => {
+    it('keeps authored double-day companions together on their preferred date', () => {
+        const placed = resolvePlacement(plan([
+            session('ride'),
+            session('strength', {
+                gating: {
+                    modality: 'strength',
+                    intensity: 'moderate',
+                    durationMin: 30,
+                    durationMax: 40,
+                    environment: 'indoor',
+                    equipment: ['free_weights'],
+                },
+            }),
+        ]), null);
+
+        expect(placed.map(item => `${item.session.id}:${item.date}:${item.moved}`)).toEqual([
+            'ride:2026-08-17:false',
+            'strength:2026-08-17:false',
+        ]);
+    });
+
+    it('moves a preferred double-day bundle together when a booked activity owns the preferred date', () => {
+        const placed = resolvePlacement(
+            plan([session('ride'), session('strength')]),
+            null,
+            { fixedActivities: [fixedActivity(MONDAY)] },
+        );
+
+        expect(placed.map(item => `${item.session.id}:${item.date}:${item.moved}`)).toEqual([
+            'ride:2026-08-18:true',
+            'strength:2026-08-18:true',
+        ]);
+    });
+
+    it('keeps a bundle anchored when one companion is fixed, surfacing the real collision', () => {
+        const placed = resolvePlacement(
+            plan([
+                session('race', {
+                    priority: 'key',
+                    placement: {
+                        week: 1,
+                        preferredDay: 'monday',
+                        flexibility: 'fixed',
+                        ifMissed: 'drop',
+                    },
+                }),
+                session('warmup'),
+            ]),
+            null,
+            { fixedActivities: [fixedActivity(MONDAY)] },
+        );
+
+        expect(placed.every(item => item.date === MONDAY)).toBe(true);
+        expect(placed.every(item => item.moved === false)).toBe(true);
+    });
+
+    it('does not let an unrelated overlay silently stack a movable preferred bundle', () => {
+        const blocker = session('blocker', {
+            placement: {
+                week: 1,
+                preferredDay: 'wednesday',
+                flexibility: 'preferred',
+                ifMissed: 'drop',
+            },
+        });
+        const placed = resolvePlacement(
+            plan([blocker, session('ride'), session('strength')]),
+            overlay([{ sessionId: 'blocker', date: MONDAY, status: 'moved' }]),
+        );
+
+        expect(placed.find(item => item.session.id === 'blocker')).toMatchObject({
+            date: MONDAY,
+            moved: true,
+        });
+        expect(placed.filter(item => item.session.id !== 'blocker').map(item => item.date)).toEqual([
+            '2026-08-18',
+            '2026-08-18',
+        ]);
+    });
+
+    it('allows an overlay that explicitly keeps one companion on the authored date without splitting siblings', () => {
+        const placed = resolvePlacement(
+            plan([session('ride'), session('strength')]),
+            overlay([{ sessionId: 'ride', date: MONDAY, status: 'planned' }]),
+        );
+
+        expect(placed.map(item => `${item.session.id}:${item.date}`)).toEqual([
+            'ride:2026-08-17',
+            'strength:2026-08-17',
+        ]);
+    });
+});

--- a/app/src/engine/externalPlacement.test.ts
+++ b/app/src/engine/externalPlacement.test.ts
@@ -56,13 +56,30 @@ describe('resolvePlacement', () => {
         expect(placed[0].status).toBe('moved');
     });
 
-    it('spreads a moveable session off a day a fixed session already owns', () => {
-        const fixed = session('fixed', { placement: { week: 1, preferredDay: 'monday', flexibility: 'fixed', ifMissed: 'drop' } });
-        const moveable = session('moveable', { placement: { week: 1, preferredDay: 'monday', flexibility: 'preferred', ifMissed: 'drop' } });
-        const placed = resolvePlacement(plan([moveable, fixed]), null);
+    it('keeps multiple sessions on the same preferred day (double days)', () => {
+        const easyAerobic = session('easy-aerobic', {
+            title: 'Easy Aerobic Volume',
+            placement: { week: 1, preferredDay: 'thursday', flexibility: 'preferred', ifMissed: 'drop' },
+        });
+        const strengthMaint = session('upper-strength', {
+            title: 'Upper-Body Strength Maintenance',
+            placement: { week: 1, preferredDay: 'thursday', flexibility: 'preferred', ifMissed: 'drop' },
+        });
+        const placed = resolvePlacement(plan([easyAerobic, strengthMaint]), null);
 
-        expect(placed.find(item => item.session.id === 'fixed')!.date).toBe(MONDAY);
-        expect(placed.find(item => item.session.id === 'moveable')!.date).not.toBe(MONDAY);
+        expect(placed.length).toBe(2);
+        expect(placed.every(item => item.date === '2026-08-20')).toBe(true);
+        expect(placed.every(item => item.moved === false)).toBe(true);
+        expect(placed.every(item => item.status === 'planned')).toBe(true);
+    });
+
+    it('spreads an unanchored any_day session off a day that already has a preferred session', () => {
+        const preferred = session('preferred', { placement: { week: 1, preferredDay: 'monday', flexibility: 'preferred', ifMissed: 'drop' } });
+        const floating = session('floating', { placement: { week: 1, flexibility: 'any_day', ifMissed: 'drop' } });
+        const placed = resolvePlacement(plan([floating, preferred]), null);
+
+        expect(placed.find(item => item.session.id === 'preferred')!.date).toBe(MONDAY);
+        expect(placed.find(item => item.session.id === 'floating')!.date).not.toBe(MONDAY);
     });
 
     it('never moves a fixed session, even onto a free day', () => {
@@ -74,40 +91,45 @@ describe('resolvePlacement', () => {
         expect(placed.every(item => item.moved === false)).toBe(true);
     });
 
-    it('treats an uncompleted fixed activity as occupying its day', () => {
-        const moveable = session('s1', { placement: { week: 1, preferredDay: 'monday', flexibility: 'preferred', ifMissed: 'drop' } });
-        const placed = resolvePlacement(plan([moveable]), null, { fixedActivities: [fixedActivity(MONDAY)] });
+    it('treats an uncompleted fixed activity as occupying its day for floating any_day sessions', () => {
+        const floating = session('s1', { placement: { week: 1, flexibility: 'any_day', ifMissed: 'drop' } });
+        const placed = resolvePlacement(plan([floating]), null, { fixedActivities: [fixedActivity(MONDAY)] });
 
         expect(placed[0].date).not.toBe(MONDAY);
     });
 
-    it('ignores a completed fixed activity, whose day is free again', () => {
-        const moveable = session('s1', { placement: { week: 1, preferredDay: 'monday', flexibility: 'preferred', ifMissed: 'drop' } });
+    it('ignores a completed fixed activity, whose day is free again for floating sessions', () => {
+        const floating = session('s1', { placement: { week: 1, flexibility: 'any_day', ifMissed: 'drop' } });
         const done = { ...fixedActivity(MONDAY), isCompleted: true };
-        expect(resolvePlacement(plan([moveable]), null, { fixedActivities: [done] })[0].date).toBe(MONDAY);
+        expect(resolvePlacement(plan([floating]), null, { fixedActivities: [done] })[0].date).toBe(MONDAY);
     });
 
     it('keeps a moved session holding its new date', () => {
         const moved = session('moved', { placement: { week: 1, preferredDay: 'monday', flexibility: 'preferred', ifMissed: 'drop' } });
-        const other = session('other', { placement: { week: 1, preferredDay: 'wednesday', flexibility: 'preferred', ifMissed: 'drop' } });
+        const other = session('other', { placement: { week: 1, flexibility: 'any_day', ifMissed: 'drop' } });
         const placed = resolvePlacement(plan([moved, other]), overlay([{ sessionId: 'moved', date: '2026-08-19', status: 'moved' }]));
 
         expect(placed.find(item => item.session.id === 'moved')!.date).toBe('2026-08-19');
-        expect(placed.find(item => item.session.id === 'other')!.date).not.toBe('2026-08-19');
+        expect(placed.find(item => item.session.id === 'other')!.date).toBe(MONDAY);
     });
 
-    it('frees the date of a dropped session', () => {
+    it('frees the date of a dropped session for floating sessions', () => {
         const dropped = session('dropped', { placement: { week: 1, preferredDay: 'monday', flexibility: 'preferred', ifMissed: 'drop' } });
-        const other = session('other', { placement: { week: 1, preferredDay: 'monday', flexibility: 'preferred', ifMissed: 'drop' } });
+        const other = session('other', { placement: { week: 1, flexibility: 'any_day', ifMissed: 'drop' } });
         const placed = resolvePlacement(plan([dropped, other]), overlay([{ sessionId: 'dropped', date: MONDAY, status: 'dropped' }]));
 
         expect(placed.find(item => item.session.id === 'other')!.date).toBe(MONDAY);
     });
 
-    it('spreads forward within the week, never backwards into the past', () => {
+    it('spreads floating sessions forward within the week, never backwards into the past', () => {
         const saturdayFixed = session('fixed', { placement: { week: 1, preferredDay: 'saturday', flexibility: 'fixed', ifMissed: 'drop' } });
-        const saturdayFlex = session('flex', { placement: { week: 1, preferredDay: 'saturday', flexibility: 'preferred', ifMissed: 'drop' } });
-        const placed = resolvePlacement(plan([saturdayFixed, saturdayFlex]), null);
+        const mondayFixed = session('mon', { placement: { week: 1, preferredDay: 'monday', flexibility: 'fixed', ifMissed: 'drop' } });
+        const tueFixed = session('tue', { placement: { week: 1, preferredDay: 'tuesday', flexibility: 'fixed', ifMissed: 'drop' } });
+        const wedFixed = session('wed', { placement: { week: 1, preferredDay: 'wednesday', flexibility: 'fixed', ifMissed: 'drop' } });
+        const thuFixed = session('thu', { placement: { week: 1, preferredDay: 'thursday', flexibility: 'fixed', ifMissed: 'drop' } });
+        const friFixed = session('fri', { placement: { week: 1, preferredDay: 'friday', flexibility: 'fixed', ifMissed: 'drop' } });
+        const floating = session('flex', { placement: { week: 1, flexibility: 'any_day', ifMissed: 'drop' } });
+        const placed = resolvePlacement(plan([saturdayFixed, mondayFixed, tueFixed, wedFixed, thuFixed, friFixed, floating]), null);
 
         expect(placed.find(item => item.session.id === 'flex')!.date).toBe('2026-08-23');
     });

--- a/app/src/engine/externalPlacement.test.ts
+++ b/app/src/engine/externalPlacement.test.ts
@@ -56,7 +56,7 @@ describe('resolvePlacement', () => {
         expect(placed[0].status).toBe('moved');
     });
 
-    it('keeps multiple sessions on the same preferred day (double days)', () => {
+    it('keeps multiple sessions on the same preferred day (double and triple days)', () => {
         const easyAerobic = session('easy-aerobic', {
             title: 'Easy Aerobic Volume',
             placement: { week: 1, preferredDay: 'thursday', flexibility: 'preferred', ifMissed: 'drop' },
@@ -65,9 +65,14 @@ describe('resolvePlacement', () => {
             title: 'Upper-Body Strength Maintenance',
             placement: { week: 1, preferredDay: 'thursday', flexibility: 'preferred', ifMissed: 'drop' },
         });
-        const placed = resolvePlacement(plan([easyAerobic, strengthMaint]), null);
+        const mobility = session('evening-mobility', {
+            title: 'Evening Hip & Spine Mobility',
+            placement: { week: 1, preferredDay: 'thursday', flexibility: 'preferred', ifMissed: 'drop' },
+            gating: { modality: 'mobility', intensity: 'recovery', durationMin: 15, durationMax: 25, environment: 'indoor', equipment: [] },
+        });
+        const placed = resolvePlacement(plan([easyAerobic, strengthMaint, mobility]), null);
 
-        expect(placed.length).toBe(2);
+        expect(placed.length).toBe(3);
         expect(placed.every(item => item.date === '2026-08-20')).toBe(true);
         expect(placed.every(item => item.moved === false)).toBe(true);
         expect(placed.every(item => item.status === 'planned')).toBe(true);

--- a/app/src/engine/externalPlacement.ts
+++ b/app/src/engine/externalPlacement.ts
@@ -51,12 +51,11 @@ function weekDates(plan: ExternalTrainingPlan, week: number): string[] {
 
 /**
  * Resolves every session to a date. The stored overlay wins; otherwise the plan's own
- * week/day preference applies, and a `preferred`/`any_day` session shifts to the next free
- * day in its own week rather than doubling up.
+ * week/day preference applies. Multiple sessions authored for the same preferred day
+ * (e.g. double training days like ride + strength) remain co-located on that date.
  *
- * A `fixed` session never moves — if its day is taken it stays there and the caller sees
- * two sessions on one date, which is a real conflict the athlete should resolve rather
- * than one this function should silently paper over.
+ * Sessions with flexibility 'any_day' and no preferred day spread to the first unoccupied
+ * day in their week.
  */
 export function resolvePlacement(
     plan: ExternalTrainingPlan,
@@ -69,31 +68,48 @@ export function resolvePlacement(
     );
     const placed: PlacedSession[] = [];
 
-    // Fixed sessions first: they cannot yield, so everything else spreads around them.
-    const ordered = [...plan.sessions].sort((left, right) => {
-        const fixedRank = Number(right.placement.flexibility === 'fixed') - Number(left.placement.flexibility === 'fixed');
-        if (fixedRank !== 0) return fixedRank;
-        return left.placement.week - right.placement.week;
-    });
+    // Process sessions with an explicit day target (overlay override or declared preferredDay)
+    // first so that 'any_day' sessions can spread around them.
+    const explicitSessions: ExternalPlanSession[] = [];
+    const floatingSessions: ExternalPlanSession[] = [];
 
-    for (const session of ordered) {
+    for (const session of plan.sessions) {
+        if (assigned.has(session.id) || Boolean(session.placement.preferredDay)) {
+            explicitSessions.push(session);
+        } else {
+            floatingSessions.push(session);
+        }
+    }
+
+    for (const session of explicitSessions) {
         const override = assigned.get(session.id);
         if (override) {
+            const date = override.date;
             placed.push({
                 session,
-                date: override.date,
+                date,
                 status: override.status,
-                moved: override.date !== impliedDate(plan, session),
+                moved: date !== impliedDate(plan, session),
             });
-            if (occupiesDate(override.status) && override.date) taken.add(override.date);
+            if (occupiesDate(override.status) && date) taken.add(date);
             continue;
         }
 
+        const date = impliedDate(plan, session);
+        taken.add(date);
+        placed.push({
+            session,
+            date,
+            status: 'planned',
+            moved: false,
+        });
+    }
+
+    // Distribute floating (any_day without preferredDay) sessions across open days in the week
+    for (const session of floatingSessions) {
         const wanted = impliedDate(plan, session);
         let date = wanted;
-        if (session.placement.flexibility !== 'fixed' && taken.has(wanted)) {
-            // Forward within the week first: moving a blocked Saturday session to Monday
-            // would schedule it in the past relative to where the plan put it.
+        if (taken.has(wanted)) {
             const week = weekDates(plan, session.placement.week);
             const free = week.find(candidate => candidate > wanted && !taken.has(candidate))
                 ?? week.find(candidate => !taken.has(candidate));

--- a/app/src/engine/externalPlacement.ts
+++ b/app/src/engine/externalPlacement.ts
@@ -77,6 +77,10 @@ export function resolvePlacement(
     );
     const occupiedByDate = new Map<string, Set<string>>();
     const placed: PlacedSession[] = [];
+    const authoredOrder = new Map(plan.sessions.map((session, index) => [session.id, index]));
+    const stableWithinWeek = (left: ExternalPlanSession, right: ExternalPlanSession): number =>
+        left.placement.week - right.placement.week
+        || (authoredOrder.get(left.id) ?? 0) - (authoredOrder.get(right.id) ?? 0);
 
     const addOccupancy = (date: string, sessionId: string): void => {
         if (!date) return;
@@ -112,7 +116,7 @@ export function resolvePlacement(
     // `preferred` silently equivalent to `fixed`.
     const fixedSessions = plan.sessions
         .filter(session => !assigned.has(session.id) && session.placement.flexibility === 'fixed')
-        .sort((left, right) => impliedDate(plan, left).localeCompare(impliedDate(plan, right)) || left.id.localeCompare(right.id));
+        .sort(stableWithinWeek);
     for (const session of fixedSessions) {
         const date = impliedDate(plan, session);
         placed.push({ session, date, status: 'planned', moved: false });
@@ -128,13 +132,11 @@ export function resolvePlacement(
         bundles.set(key, bundle);
     }
 
-    const orderedBundles = [...bundles.entries()].sort(([, left], [, right]) => {
-        const leftSession = left[0];
-        const rightSession = right[0];
-        return leftSession.placement.week - rightSession.placement.week
-            || WEEKDAY_OFFSET[leftSession.placement.preferredDay!] - WEEKDAY_OFFSET[rightSession.placement.preferredDay!]
-            || leftSession.id.localeCompare(rightSession.id);
-    });
+    // Match the pre-bundle resolver's stable sort: week first, authored order within a
+    // week. Supporting double days must not become a reason to re-order unrelated work.
+    const orderedBundles = [...bundles.entries()].sort(([, left], [, right]) =>
+        stableWithinWeek(left[0], right[0]),
+    );
 
     for (const [bundleKey, bundle] of orderedBundles) {
         const wanted = impliedDate(plan, bundle[0]);
@@ -174,7 +176,7 @@ export function resolvePlacement(
         .filter(session => !assigned.has(session.id)
             && session.placement.flexibility !== 'fixed'
             && !preferredBundleKey(session))
-        .sort((left, right) => left.placement.week - right.placement.week || left.id.localeCompare(right.id));
+        .sort(stableWithinWeek);
 
     for (const session of floatingSessions) {
         const wanted = impliedDate(plan, session);

--- a/app/src/engine/externalPlacement.ts
+++ b/app/src/engine/externalPlacement.ts
@@ -49,20 +49,22 @@ function weekDates(plan: ExternalTrainingPlan, week: number): string[] {
     return Array.from({ length: 7 }, (_, offset) => addDaysToLocalDateString(start, offset));
 }
 
-/** Sessions authored for the same plan week + preferred weekday form one placement unit.
- * That is the only reliable signal the schema has for an intentional double/triple day. */
-function preferredDayGroupKey(session: ExternalPlanSession): string | null {
+/** Only movable `preferred` sessions authored for the same week + weekday form one
+ * intentional placement unit. `fixed` remains hard occupancy, preserving its pre-existing
+ * precedence over movable work on the same date. */
+function preferredBundleKey(session: ExternalPlanSession): string | null {
     const day = session.placement.preferredDay;
-    return day ? `${session.placement.week}:${day}` : null;
+    return session.placement.flexibility === 'preferred' && day
+        ? `${session.placement.week}:${day}`
+        : null;
 }
 
 /**
- * Resolves every session to a date. The stored overlay wins. Sessions authored for the
- * same week + `preferredDay` are kept together as one intentional double/triple-day bundle.
- * A movable (`preferred`) bundle still yields to unrelated occupancy and moves as a unit
- * within its week; a bundle containing a `fixed` session stays anchored and exposes the
- * conflict instead. `any_day` sessions without a preferred day spread individually after
- * the authored bundles have been placed.
+ * Resolves every session to a date. The stored overlay wins. Movable sessions authored for
+ * the same week + `preferredDay` are kept together as one intentional double/triple-day
+ * bundle and, when their preferred date is occupied, move together within the week.
+ * `fixed` sessions are placed first and never yield; `any_day` sessions then spread
+ * individually across the remaining open dates.
  */
 export function resolvePlacement(
     plan: ExternalTrainingPlan,
@@ -90,8 +92,8 @@ export function resolvePlacement(
     };
 
     // Explicit overlay assignments are absolute per-session decisions and therefore win
-    // before authored grouping. A same-group assignment that still sits on the authored
-    // date is allowed to coexist with its unresolved siblings below.
+    // before authored placement. A same-bundle assignment that remains on the authored
+    // date may coexist with its unresolved preferred siblings below.
     for (const session of plan.sessions) {
         const override = assigned.get(session.id);
         if (!override) continue;
@@ -105,16 +107,28 @@ export function resolvePlacement(
         if (occupiesDate(override.status)) addOccupancy(date, session.id);
     }
 
-    const groups = new Map<string, ExternalPlanSession[]>();
-    for (const session of plan.sessions) {
-        if (assigned.has(session.id) || !session.placement.preferredDay) continue;
-        const key = preferredDayGroupKey(session)!;
-        const group = groups.get(key) ?? [];
-        group.push(session);
-        groups.set(key, group);
+    // Preserve the original fixed-session contract: fixed work owns its implied date even
+    // when that creates a real conflict. Preferred companions must yield rather than making
+    // `preferred` silently equivalent to `fixed`.
+    const fixedSessions = plan.sessions
+        .filter(session => !assigned.has(session.id) && session.placement.flexibility === 'fixed')
+        .sort((left, right) => impliedDate(plan, left).localeCompare(impliedDate(plan, right)) || left.id.localeCompare(right.id));
+    for (const session of fixedSessions) {
+        const date = impliedDate(plan, session);
+        placed.push({ session, date, status: 'planned', moved: false });
+        addOccupancy(date, session.id);
     }
 
-    const orderedGroups = [...groups.entries()].sort(([, left], [, right]) => {
+    const bundles = new Map<string, ExternalPlanSession[]>();
+    for (const session of plan.sessions) {
+        const key = preferredBundleKey(session);
+        if (assigned.has(session.id) || !key) continue;
+        const bundle = bundles.get(key) ?? [];
+        bundle.push(session);
+        bundles.set(key, bundle);
+    }
+
+    const orderedBundles = [...bundles.entries()].sort(([, left], [, right]) => {
         const leftSession = left[0];
         const rightSession = right[0];
         return leftSession.placement.week - rightSession.placement.week
@@ -122,16 +136,15 @@ export function resolvePlacement(
             || leftSession.id.localeCompare(rightSession.id);
     });
 
-    for (const [groupKey, group] of orderedGroups) {
-        const wanted = impliedDate(plan, group[0]);
-        const anchored = group.some(session => session.placement.flexibility === 'fixed');
+    for (const [bundleKey, bundle] of orderedBundles) {
+        const wanted = impliedDate(plan, bundle[0]);
 
-        // An overlay for a sibling that explicitly remains on the authored date should not
-        // split the authored double day. An overlay moved elsewhere is intentionally not
-        // ignored: manual placement is per-session authority and may split the bundle.
-        const sameGroupOverlayAtWanted = new Set(
+        // An overlay for a preferred sibling that explicitly remains on the authored date
+        // should not split the double day. A sibling moved elsewhere is intentionally not
+        // ignored: overlay authority is per-session and may split the authored bundle.
+        const sameBundleOverlayAtWanted = new Set(
             plan.sessions
-                .filter(session => preferredDayGroupKey(session) === groupKey)
+                .filter(session => preferredBundleKey(session) === bundleKey)
                 .filter(session => {
                     const assignment = assigned.get(session.id);
                     return assignment?.date === wanted && occupiesDate(assignment.status);
@@ -140,32 +153,33 @@ export function resolvePlacement(
         );
 
         let date = wanted;
-        if (!anchored && isBlocked(wanted, sameGroupOverlayAtWanted)) {
-            const week = weekDates(plan, group[0].placement.week);
+        if (isBlocked(wanted, sameBundleOverlayAtWanted)) {
+            const week = weekDates(plan, bundle[0].placement.week);
             const free = week.find(candidate => candidate > wanted && !isBlocked(candidate))
                 ?? week.find(candidate => !isBlocked(candidate));
             if (free) date = free;
         }
 
-        for (const session of group) {
+        for (const session of bundle) {
             placed.push({ session, date, status: 'planned', moved: date !== wanted });
             addOccupancy(date, session.id);
         }
     }
 
-    // Distribute unanchored sessions across remaining open days. A malformed/legacy fixed
-    // session without preferredDay retains its implied Monday rather than being moved.
+    // Distribute remaining non-fixed, non-bundled sessions (normally `any_day`) across the
+    // open days. A preferred-day session only reaches this path when its schema combination
+    // is not `flexibility: preferred`, so it remains an individual placement rather than an
+    // authored double-day signal.
     const floatingSessions = plan.sessions
-        .filter(session => !assigned.has(session.id) && !session.placement.preferredDay)
-        .sort((left, right) => {
-            const fixedRank = Number(right.placement.flexibility === 'fixed') - Number(left.placement.flexibility === 'fixed');
-            return fixedRank || left.placement.week - right.placement.week || left.id.localeCompare(right.id);
-        });
+        .filter(session => !assigned.has(session.id)
+            && session.placement.flexibility !== 'fixed'
+            && !preferredBundleKey(session))
+        .sort((left, right) => left.placement.week - right.placement.week || left.id.localeCompare(right.id));
 
     for (const session of floatingSessions) {
         const wanted = impliedDate(plan, session);
         let date = wanted;
-        if (session.placement.flexibility !== 'fixed' && isBlocked(wanted)) {
+        if (isBlocked(wanted)) {
             const week = weekDates(plan, session.placement.week);
             const free = week.find(candidate => candidate > wanted && !isBlocked(candidate))
                 ?? week.find(candidate => !isBlocked(candidate));

--- a/app/src/engine/externalPlacement.ts
+++ b/app/src/engine/externalPlacement.ts
@@ -49,13 +49,20 @@ function weekDates(plan: ExternalTrainingPlan, week: number): string[] {
     return Array.from({ length: 7 }, (_, offset) => addDaysToLocalDateString(start, offset));
 }
 
+/** Sessions authored for the same plan week + preferred weekday form one placement unit.
+ * That is the only reliable signal the schema has for an intentional double/triple day. */
+function preferredDayGroupKey(session: ExternalPlanSession): string | null {
+    const day = session.placement.preferredDay;
+    return day ? `${session.placement.week}:${day}` : null;
+}
+
 /**
- * Resolves every session to a date. The stored overlay wins; otherwise the plan's own
- * week/day preference applies. Multiple sessions authored for the same preferred day
- * (e.g. double training days like ride + strength) remain co-located on that date.
- *
- * Sessions with flexibility 'any_day' and no preferred day spread to the first unoccupied
- * day in their week.
+ * Resolves every session to a date. The stored overlay wins. Sessions authored for the
+ * same week + `preferredDay` are kept together as one intentional double/triple-day bundle.
+ * A movable (`preferred`) bundle still yields to unrelated occupancy and moves as a unit
+ * within its week; a bundle containing a `fixed` session stays anchored and exposes the
+ * conflict instead. `any_day` sessions without a preferred day spread individually after
+ * the authored bundles have been placed.
  */
 export function resolvePlacement(
     plan: ExternalTrainingPlan,
@@ -63,59 +70,108 @@ export function resolvePlacement(
     occupancy: PlacementOccupancy = {},
 ): PlacedSession[] {
     const assigned = new Map((overlay?.assignments ?? []).map(item => [item.sessionId, item]));
-    const taken = new Set<string>(
+    const fixedActivityDates = new Set(
         (occupancy.fixedActivities ?? []).filter(activity => !activity.isCompleted).map(activity => activity.date),
     );
+    const occupiedByDate = new Map<string, Set<string>>();
     const placed: PlacedSession[] = [];
 
-    // Process sessions with an explicit day target (overlay override or declared preferredDay)
-    // first so that 'any_day' sessions can spread around them.
-    const explicitSessions: ExternalPlanSession[] = [];
-    const floatingSessions: ExternalPlanSession[] = [];
+    const addOccupancy = (date: string, sessionId: string): void => {
+        if (!date) return;
+        const occupants = occupiedByDate.get(date) ?? new Set<string>();
+        occupants.add(sessionId);
+        occupiedByDate.set(date, occupants);
+    };
+    const isBlocked = (date: string, allowedSessionIds: ReadonlySet<string> = new Set<string>()): boolean => {
+        if (fixedActivityDates.has(date)) return true;
+        const occupants = occupiedByDate.get(date);
+        if (!occupants) return false;
+        return [...occupants].some(sessionId => !allowedSessionIds.has(sessionId));
+    };
 
+    // Explicit overlay assignments are absolute per-session decisions and therefore win
+    // before authored grouping. A same-group assignment that still sits on the authored
+    // date is allowed to coexist with its unresolved siblings below.
     for (const session of plan.sessions) {
-        if (assigned.has(session.id) || Boolean(session.placement.preferredDay)) {
-            explicitSessions.push(session);
-        } else {
-            floatingSessions.push(session);
-        }
-    }
-
-    for (const session of explicitSessions) {
         const override = assigned.get(session.id);
-        if (override) {
-            const date = override.date;
-            placed.push({
-                session,
-                date,
-                status: override.status,
-                moved: date !== impliedDate(plan, session),
-            });
-            if (occupiesDate(override.status) && date) taken.add(date);
-            continue;
-        }
-
-        const date = impliedDate(plan, session);
-        taken.add(date);
+        if (!override) continue;
+        const date = override.date;
         placed.push({
             session,
             date,
-            status: 'planned',
-            moved: false,
+            status: override.status,
+            moved: date !== impliedDate(plan, session),
         });
+        if (occupiesDate(override.status)) addOccupancy(date, session.id);
     }
 
-    // Distribute floating (any_day without preferredDay) sessions across open days in the week
+    const groups = new Map<string, ExternalPlanSession[]>();
+    for (const session of plan.sessions) {
+        if (assigned.has(session.id) || !session.placement.preferredDay) continue;
+        const key = preferredDayGroupKey(session)!;
+        const group = groups.get(key) ?? [];
+        group.push(session);
+        groups.set(key, group);
+    }
+
+    const orderedGroups = [...groups.entries()].sort(([, left], [, right]) => {
+        const leftSession = left[0];
+        const rightSession = right[0];
+        return leftSession.placement.week - rightSession.placement.week
+            || WEEKDAY_OFFSET[leftSession.placement.preferredDay!] - WEEKDAY_OFFSET[rightSession.placement.preferredDay!]
+            || leftSession.id.localeCompare(rightSession.id);
+    });
+
+    for (const [groupKey, group] of orderedGroups) {
+        const wanted = impliedDate(plan, group[0]);
+        const anchored = group.some(session => session.placement.flexibility === 'fixed');
+
+        // An overlay for a sibling that explicitly remains on the authored date should not
+        // split the authored double day. An overlay moved elsewhere is intentionally not
+        // ignored: manual placement is per-session authority and may split the bundle.
+        const sameGroupOverlayAtWanted = new Set(
+            plan.sessions
+                .filter(session => preferredDayGroupKey(session) === groupKey)
+                .filter(session => {
+                    const assignment = assigned.get(session.id);
+                    return assignment?.date === wanted && occupiesDate(assignment.status);
+                })
+                .map(session => session.id),
+        );
+
+        let date = wanted;
+        if (!anchored && isBlocked(wanted, sameGroupOverlayAtWanted)) {
+            const week = weekDates(plan, group[0].placement.week);
+            const free = week.find(candidate => candidate > wanted && !isBlocked(candidate))
+                ?? week.find(candidate => !isBlocked(candidate));
+            if (free) date = free;
+        }
+
+        for (const session of group) {
+            placed.push({ session, date, status: 'planned', moved: date !== wanted });
+            addOccupancy(date, session.id);
+        }
+    }
+
+    // Distribute unanchored sessions across remaining open days. A malformed/legacy fixed
+    // session without preferredDay retains its implied Monday rather than being moved.
+    const floatingSessions = plan.sessions
+        .filter(session => !assigned.has(session.id) && !session.placement.preferredDay)
+        .sort((left, right) => {
+            const fixedRank = Number(right.placement.flexibility === 'fixed') - Number(left.placement.flexibility === 'fixed');
+            return fixedRank || left.placement.week - right.placement.week || left.id.localeCompare(right.id);
+        });
+
     for (const session of floatingSessions) {
         const wanted = impliedDate(plan, session);
         let date = wanted;
-        if (taken.has(wanted)) {
+        if (session.placement.flexibility !== 'fixed' && isBlocked(wanted)) {
             const week = weekDates(plan, session.placement.week);
-            const free = week.find(candidate => candidate > wanted && !taken.has(candidate))
-                ?? week.find(candidate => !taken.has(candidate));
+            const free = week.find(candidate => candidate > wanted && !isBlocked(candidate))
+                ?? week.find(candidate => !isBlocked(candidate));
             if (free) date = free;
         }
-        taken.add(date);
+        addOccupancy(date, session.id);
         placed.push({ session, date, status: 'planned', moved: date !== wanted });
     }
 

--- a/app/src/engine/policy.ts
+++ b/app/src/engine/policy.ts
@@ -1,10 +1,11 @@
 /** Increment whenever a change can alter a persisted recommendation decision. (Refactoring does not require a bump) */
-export const POLICY_VERSION = '2026-08-algorithmic-optimization-v1';
+export const POLICY_VERSION = '2026-08-external-double-day-placement-v1';
 
 /** Historical versions are intentionally not re-executed by this build. Their compact
  * audits remain readable evidence, but replay is rejected explicitly because the old
  * decision function is not bundled alongside the current policy. */
 export const HISTORICAL_POLICY_VERSIONS = [
+    '2026-08-algorithmic-optimization-v1',
     '2026-08-modify-tier-auto-dose-v1',
     '2026-08-acute-trajectory-demand-v3',
     '2026-08-acute-trajectory-demand-v2',

--- a/app/src/services/activeExternalPlanService.test.ts
+++ b/app/src/services/activeExternalPlanService.test.ts
@@ -4,7 +4,9 @@ import type { DataState } from '../engine/dataState';
 import {
     ActiveExternalPlanService,
     externalPlanContextForDate,
+    externalPlanContextsForDate,
     placedSessionForDate,
+    placedSessionsForDate,
     planEndDate,
     type ActiveExternalPlan,
 } from './activeExternalPlanService';
@@ -130,7 +132,24 @@ describe('ActiveExternalPlanService', () => {
     });
 });
 
-describe('placedSessionForDate', () => {
+describe('placedSessionsForDate & placedSessionForDate', () => {
+    const doubleSessionPlan = plan({
+        sessions: [
+            {
+                id: 'w1-easy-ride', title: 'Easy Ride', priority: 'supporting',
+                placement: { week: 1, preferredDay: 'thursday', flexibility: 'preferred', ifMissed: 'drop' },
+                gating: { modality: 'cycling', intensity: 'easy', durationMin: 45, durationMax: 60, environment: 'either', equipment: [] },
+                prescription: { summary: 'Easy aerobic spin.' },
+            },
+            {
+                id: 'w1-strength', title: 'Upper Strength', priority: 'key',
+                placement: { week: 1, preferredDay: 'thursday', flexibility: 'preferred', ifMissed: 'drop' },
+                gating: { modality: 'strength', intensity: 'moderate', durationMin: 30, durationMax: 40, environment: 'indoor', equipment: ['free_weights'] },
+                prescription: { summary: 'Upper body maintenance.' },
+            },
+        ],
+    });
+
     const active = (assignments: Parameters<typeof placementDoc>[0] = []): ActiveExternalPlan => ({
         header: header(),
         plan: plan(),
@@ -140,27 +159,76 @@ describe('placedSessionForDate', () => {
         ],
     });
 
+    const activeDouble: ActiveExternalPlan = {
+        header: header(),
+        plan: doubleSessionPlan,
+        placement: null,
+        placed: [
+            { session: doubleSessionPlan.sessions[0], date: '2026-08-20', status: 'planned', moved: false },
+            { session: doubleSessionPlan.sessions[1], date: '2026-08-20', status: 'planned', moved: false },
+        ],
+    };
+
     it('returns a session still to be done', () => {
         expect(placedSessionForDate(active(), '2026-08-18')?.session.id).toBe('w1-threshold');
+    });
+
+    it('returns all placed sessions on a double training day', () => {
+        const sessions = placedSessionsForDate(activeDouble, '2026-08-20');
+        expect(sessions.length).toBe(2);
+        expect(sessions.map(s => s.session.id)).toEqual(['w1-easy-ride', 'w1-strength']);
+    });
+
+    it('prioritizes the highest-priority session (key over supporting) for placedSessionForDate', () => {
+        expect(placedSessionForDate(activeDouble, '2026-08-20')?.session.id).toBe('w1-strength');
     });
 
     it('returns nothing for a session already completed, dropped or superseded', () => {
         for (const status of ['completed', 'dropped', 'superseded'] as const) {
             expect(placedSessionForDate(active([{ sessionId: 'w1-threshold', date: '2026-08-18', status }]), '2026-08-18'), status).toBeNull();
+            expect(placedSessionsForDate(active([{ sessionId: 'w1-threshold', date: '2026-08-18', status }]), '2026-08-18')).toEqual([]);
         }
     });
 
     it('returns nothing for a day with nothing placed', () => {
         expect(placedSessionForDate(active(), '2026-08-19')).toBeNull();
+        expect(placedSessionsForDate(active(), '2026-08-19')).toEqual([]);
     });
 });
 
-describe('externalPlanContextForDate', () => {
+describe('externalPlanContextForDate and externalPlanContextsForDate', () => {
+    const doubleSessionPlan = plan({
+        sessions: [
+            {
+                id: 'w1-easy-ride', title: 'Easy Ride', priority: 'supporting',
+                placement: { week: 1, preferredDay: 'thursday', flexibility: 'preferred', ifMissed: 'drop' },
+                gating: { modality: 'cycling', intensity: 'easy', durationMin: 45, durationMax: 60, environment: 'either', equipment: [] },
+                prescription: { summary: 'Easy aerobic spin.' },
+            },
+            {
+                id: 'w1-strength', title: 'Upper Strength', priority: 'key',
+                placement: { week: 1, preferredDay: 'thursday', flexibility: 'preferred', ifMissed: 'drop' },
+                gating: { modality: 'strength', intensity: 'moderate', durationMin: 30, durationMax: 40, environment: 'indoor', equipment: ['free_weights'] },
+                prescription: { summary: 'Upper body maintenance.' },
+            },
+        ],
+    });
+
     const active: ActiveExternalPlan = {
         header: header({ contentHash: 'stored-hash' }),
         plan: plan(),
         placement: null,
         placed: [{ session: plan().sessions[0], date: '2026-08-18', status: 'planned', moved: false }],
+    };
+
+    const activeDouble: ActiveExternalPlan = {
+        header: header({ contentHash: 'stored-hash' }),
+        plan: doubleSessionPlan,
+        placement: null,
+        placed: [
+            { session: doubleSessionPlan.sessions[0], date: '2026-08-20', status: 'planned', moved: false },
+            { session: doubleSessionPlan.sessions[1], date: '2026-08-20', status: 'planned', moved: false },
+        ],
     };
 
     it('carries the stored hash, not a recomputed one, so the audit matches the import', () => {
@@ -170,7 +238,16 @@ describe('externalPlanContextForDate', () => {
         expect(externalPlanContextForDate(active, '2026-08-18')?.session.id).toBe('w1-threshold');
     });
 
+    it('returns all contexts for double training days in externalPlanContextsForDate', () => {
+        const contexts = externalPlanContextsForDate(activeDouble, '2026-08-20');
+        expect(contexts.length).toBe(2);
+        expect(contexts[0].session.id).toBe('w1-easy-ride');
+        expect(contexts[1].session.id).toBe('w1-strength');
+        expect(contexts.every(c => c.contentHash === 'stored-hash')).toBe(true);
+    });
+
     it('is null on a day the plan places nothing, so the ranked path runs', () => {
         expect(externalPlanContextForDate(active, '2026-08-19')).toBeNull();
+        expect(externalPlanContextsForDate(active, '2026-08-19')).toEqual([]);
     });
 });

--- a/app/src/services/activeExternalPlanService.test.ts
+++ b/app/src/services/activeExternalPlanService.test.ts
@@ -231,6 +231,40 @@ describe('externalPlanContextForDate and externalPlanContextsForDate', () => {
         ],
     };
 
+    const tripleSessionPlan = plan({
+        sessions: [
+            {
+                id: 'w1-easy-ride', title: 'Easy Ride', priority: 'supporting',
+                placement: { week: 1, preferredDay: 'thursday', flexibility: 'preferred', ifMissed: 'drop' },
+                gating: { modality: 'cycling', intensity: 'easy', durationMin: 45, durationMax: 60, environment: 'either', equipment: [] },
+                prescription: { summary: 'Easy aerobic spin.' },
+            },
+            {
+                id: 'w1-strength', title: 'Upper Strength', priority: 'key',
+                placement: { week: 1, preferredDay: 'thursday', flexibility: 'preferred', ifMissed: 'drop' },
+                gating: { modality: 'strength', intensity: 'moderate', durationMin: 30, durationMax: 40, environment: 'indoor', equipment: ['free_weights'] },
+                prescription: { summary: 'Upper body maintenance.' },
+            },
+            {
+                id: 'w1-mobility', title: 'Mobility Routine', priority: 'optional',
+                placement: { week: 1, preferredDay: 'thursday', flexibility: 'preferred', ifMissed: 'drop' },
+                gating: { modality: 'mobility', intensity: 'recovery', durationMin: 15, durationMax: 20, environment: 'indoor', equipment: [] },
+                prescription: { summary: 'Evening mobility.' },
+            },
+        ],
+    });
+
+    const activeTriple: ActiveExternalPlan = {
+        header: header({ contentHash: 'stored-hash' }),
+        plan: tripleSessionPlan,
+        placement: null,
+        placed: [
+            { session: tripleSessionPlan.sessions[0], date: '2026-08-20', status: 'planned', moved: false },
+            { session: tripleSessionPlan.sessions[1], date: '2026-08-20', status: 'planned', moved: false },
+            { session: tripleSessionPlan.sessions[2], date: '2026-08-20', status: 'planned', moved: false },
+        ],
+    };
+
     it('carries the stored hash, not a recomputed one, so the audit matches the import', () => {
         expect(externalPlanContextForDate(active, '2026-08-18')).toMatchObject({
             planId: 'autumn-block', revision: 1, contentHash: 'stored-hash',
@@ -244,6 +278,19 @@ describe('externalPlanContextForDate and externalPlanContextsForDate', () => {
         expect(contexts[0].session.id).toBe('w1-easy-ride');
         expect(contexts[1].session.id).toBe('w1-strength');
         expect(contexts.every(c => c.contentHash === 'stored-hash')).toBe(true);
+    });
+
+    it('returns all contexts for triple training days in externalPlanContextsForDate and prioritizes key in placedSessionForDate', () => {
+        const sessions = placedSessionsForDate(activeTriple, '2026-08-20');
+        expect(sessions.length).toBe(3);
+        expect(sessions.map(s => s.session.id)).toEqual(['w1-easy-ride', 'w1-strength', 'w1-mobility']);
+
+        // Key priority takes precedence over supporting and optional
+        expect(placedSessionForDate(activeTriple, '2026-08-20')?.session.id).toBe('w1-strength');
+
+        const contexts = externalPlanContextsForDate(activeTriple, '2026-08-20');
+        expect(contexts.length).toBe(3);
+        expect(contexts.map(c => c.session.id)).toEqual(['w1-easy-ride', 'w1-strength', 'w1-mobility']);
     });
 
     it('is null on a day the plan places nothing, so the ranked path runs', () => {

--- a/app/src/services/activeExternalPlanService.ts
+++ b/app/src/services/activeExternalPlanService.ts
@@ -26,13 +26,11 @@ export function planEndDate(header: Pick<ExternalPlanHeader, 'startDate' | 'week
     return addDaysToLocalDateString(header.startDate, header.weekCount * 7 - 1);
 }
 
-const PRIORITY_RANK: Record<string, number> = {
-    key: 3,
-    supporting: 2,
-    optional: 1,
-};
+const PRIORITY_RANK = { key: 3, supporting: 2, optional: 1 } as const;
 
-/** All sessions still to be done on a date (`completed`, `dropped`, `superseded` are excluded). */
+/** All sessions still to be done on a date. Completed/dropped/superseded sessions no
+ * longer participate in today's decision. This is a placement/query API; it does not by
+ * itself turn the singular external-session adjudicator into a multi-session executor. */
 export function placedSessionsForDate(active: ActiveExternalPlan, date: string): PlacedSession[] {
     return active.placed.filter(item =>
         item.date === date && (item.status === 'planned' || item.status === 'moved'),
@@ -40,26 +38,28 @@ export function placedSessionsForDate(active: ActiveExternalPlan, date: string):
 }
 
 /**
- * Primary session still to be done on a date. If multiple sessions exist on the same day
- * (e.g. double training days), returns the highest-priority session (key > supporting > optional).
+ * Primary session for today's singular external adjudication path. On an intentional
+ * double/triple day choose the plan author's strongest priority, then session id for a
+ * deterministic tie-break rather than depending on array/input order.
  */
 export function placedSessionForDate(active: ActiveExternalPlan, date: string): PlacedSession | null {
     const sessions = placedSessionsForDate(active, date);
     if (sessions.length === 0) return null;
     if (sessions.length === 1) return sessions[0];
-    return [...sessions].sort((left, right) => {
-        const leftRank = PRIORITY_RANK[left.session.priority] ?? 0;
-        const rightRank = PRIORITY_RANK[right.session.priority] ?? 0;
-        return rightRank - leftRank;
-    })[0];
+    return [...sessions].sort((left, right) =>
+        PRIORITY_RANK[right.session.priority] - PRIORITY_RANK[left.session.priority]
+        || left.session.id.localeCompare(right.session.id),
+    )[0];
 }
 
 /**
- * Builds the adjudication inputs for all sessions on a day.
+ * Read-only plural projection of every placed session on a date. This is useful to callers
+ * that need to inspect/render the full authored day. The live recommendation engine still
+ * accepts one `ExternalPlanContext`; callers must not interpret this helper as evidence
+ * that secondary same-day sessions have been independently adjudicated or made executable.
  */
 export function externalPlanContextsForDate(active: ActiveExternalPlan, date: string): ExternalPlanContext[] {
-    const placedList = placedSessionsForDate(active, date);
-    return placedList.map(placed => ({
+    return placedSessionsForDate(active, date).map(placed => ({
         planId: active.plan.planId,
         revision: active.plan.revision,
         session: placed.session,

--- a/app/src/services/activeExternalPlanService.ts
+++ b/app/src/services/activeExternalPlanService.ts
@@ -26,15 +26,49 @@ export function planEndDate(header: Pick<ExternalPlanHeader, 'startDate' | 'week
     return addDaysToLocalDateString(header.startDate, header.weekCount * 7 - 1);
 }
 
-/** A session still to be done. `completed` is excluded: the day's decision is already made. */
-export function placedSessionForDate(active: ActiveExternalPlan, date: string): PlacedSession | null {
-    return active.placed.find(item =>
+const PRIORITY_RANK: Record<string, number> = {
+    key: 3,
+    supporting: 2,
+    optional: 1,
+};
+
+/** All sessions still to be done on a date (`completed`, `dropped`, `superseded` are excluded). */
+export function placedSessionsForDate(active: ActiveExternalPlan, date: string): PlacedSession[] {
+    return active.placed.filter(item =>
         item.date === date && (item.status === 'planned' || item.status === 'moved'),
-    ) ?? null;
+    );
 }
 
 /**
- * Builds the adjudication input for one day, or null when nothing is placed. The
+ * Primary session still to be done on a date. If multiple sessions exist on the same day
+ * (e.g. double training days), returns the highest-priority session (key > supporting > optional).
+ */
+export function placedSessionForDate(active: ActiveExternalPlan, date: string): PlacedSession | null {
+    const sessions = placedSessionsForDate(active, date);
+    if (sessions.length === 0) return null;
+    if (sessions.length === 1) return sessions[0];
+    return [...sessions].sort((left, right) => {
+        const leftRank = PRIORITY_RANK[left.session.priority] ?? 0;
+        const rightRank = PRIORITY_RANK[right.session.priority] ?? 0;
+        return rightRank - leftRank;
+    })[0];
+}
+
+/**
+ * Builds the adjudication inputs for all sessions on a day.
+ */
+export function externalPlanContextsForDate(active: ActiveExternalPlan, date: string): ExternalPlanContext[] {
+    const placedList = placedSessionsForDate(active, date);
+    return placedList.map(placed => ({
+        planId: active.plan.planId,
+        revision: active.plan.revision,
+        session: placed.session,
+        contentHash: active.header.contentHash,
+    }));
+}
+
+/**
+ * Builds the primary adjudication input for one day, or null when nothing is placed. The
  * `contentHash` comes from the stored header rather than being recomputed here, so the
  * decision audit records the hash the import actually agreed to (ADR-0019 D-IMMUT).
  */

--- a/docs/external-plan-schema.md
+++ b/docs/external-plan-schema.md
@@ -163,8 +163,10 @@ protect when a week loses days.
 | `flexibility` | Meaning |
 |---|---|
 | `fixed` | Must fall on `preferredDay` (a group ride, a test, a class). |
-| `preferred` | Prefers `preferredDay`, may move within its week. |
-| `any_day` | No day preference; place it anywhere in the week. |
+| `preferred` | Prefers `preferredDay`, may move within its week (e.g. if rescheduled or missed). Multiple sessions authored with the same `preferredDay` remain co-located on that date (double training days). |
+| `any_day` | No day preference; place it anywhere in the week (spreads to unoccupied days). |
+
+Multiple sessions authored for the same `preferredDay` (e.g. an easy aerobic ride and an upper-body strength session) are placed together on that day as intentional double training days.
 
 | `ifMissed` | Behaviour when the day passes without the session |
 |---|---|


### PR DESCRIPTION
## Problem
Externally authored plans may intentionally schedule more than one **movable `preferred`** training session on the same plan day (for example an easy ride plus upper-body strength). The old resolver treated the first session as occupying the date and displaced the next one, so the imported schedule no longer matched the authored double/triple day.

## Implementation
### Placement resolution
- Sessions with `flexibility: preferred` that share the same **plan week + `preferredDay`** are treated as one authored placement bundle.
- The bundle stays co-located on the preferred date when it is free.
- If that date is occupied by an unrelated fixed activity, fixed session, or overlay placement, the **whole preferred bundle moves together** to the next free day in the same week.
- Existing `fixed` semantics are preserved: fixed sessions are placed first and never yield. A same-day preferred bundle moves around them rather than making `preferred` behave like `fixed`.
- Existing overlay authority is preserved. An overlay that explicitly keeps one preferred companion on the authored date does not split its unresolved siblings; an overlay that moves a companion elsewhere remains a per-session override.
- `any_day` sessions continue to spread individually across remaining dates.
- Stable pre-existing placement ordering is preserved (week, then authored input order) so this fix does not reshuffle unrelated sessions.

### Same-day query API
- Added `placedSessionsForDate(active, date)` for all active (`planned` / `moved`) sessions on a date.
- `placedSessionForDate(active, date)` remains the adapter for the existing singular daily external adjudication path and selects the primary session by `key > supporting > optional`, with session id as a deterministic tie-break.
- Added `externalPlanContextsForDate(active, date)` as a read-only plural projection for callers that need to inspect/render the full authored day.

**Scope boundary:** this PR fixes multi-session placement/query/rendering. The live recommendation engine still accepts one `ExternalPlanContext`; the plural helper does **not** imply that secondary same-day external sessions were independently safety-adjudicated or made executable. Expanding execution to multiple imported sessions should be a separate change with explicit same-day budget/systemic-cost semantics.

### Governance and docs
- Bumped `POLICY_VERSION` to `2026-08-external-double-day-placement-v1` because placement/primary-session selection can change persisted recommendation decisions.
- Updated the external-plan schema documentation to describe intentional double-day co-location for preferred sessions.
- Clarified the singular-adjudication boundary in `activeExternalPlanService.ts` comments.

### Tests
Coverage now includes:
- double/triple preferred sessions staying co-located;
- an entire preferred bundle moving around a booked fixed activity;
- fixed-session precedence while preferred companions move together;
- unrelated overlay occupancy moving the bundle rather than silently stacking it;
- a same-bundle overlay remaining on the authored date without splitting siblings;
- same-day rendering and plural query helpers;
- primary-session priority selection.

## Verification
GitHub Actions **CI Pipeline #1388** passed on head `e80c1b590e6fafa14f1b1bfb167176b9c5edefab`, including:
- Docker image build;
- Python hygiene, Ruff lint/format, mypy, pytest + coverage, and dependency audit;
- frontend TypeScript type-check and ESLint;
- workout-library validation and policy-version drift gate;
- frontend Vitest suite + coverage;
- Firestore security-rule emulator suite;
- simulation scenarios / aggregate bounds gate;
- deterministic AI plan judge corpus gate and semantic diff;
- production frontend build and Node dependency audit.