### PR TITLE
Architecture/maintainability review: cross-boundary contracts, fixed and continued

### DIFF
--- a/app/src/contracts/enginePersistenceContract.test.ts
+++ b/app/src/contracts/enginePersistenceContract.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import { validateRecommendationAuditContract, validatePersistedRecommendationContract } from './enginePersistenceContract';
+import { evaluateTrainingWithIntent } from '../engine/rules';
+import { buildRecommendationAudit } from '../engine/provenance';
+import { parseDailyRecommendation } from '../persistence/parsers/trainingHistory';
+import type { DailyReadiness, EngineObjectiveInput, SubjectiveInput, UserContext } from '../engine/models';
+import type { TrainingHistorySnapshot } from '../engine/trainingHistorySnapshot';
+
+describe('EnginePersistenceContract', () => {
+    const baseSubjective: SubjectiveInput = {
+        readiness: 8,
+        sleepQuality: 8,
+        fatigue: 2,
+        soreness: 2,
+        stress: 2,
+        motivation: 8,
+        timeAvailable: 60,
+        painFlag: false,
+        alreadyTrainedToday: false,
+        preferredModalityToday: null,
+    };
+
+    const baseObjective: EngineObjectiveInput = {
+        sleep_score: 85,
+        sleep_duration_min: 480,
+        rhr: 48,
+        rhr_7d_avg: 49,
+        rhr_delta: -1,
+        hrv_weekly_avg: 65,
+        hrv_last_night: 68,
+        hrv_delta: 3,
+        hrv_stdev_28d: null,
+        rhr_stdev_28d: null,
+        sleep_score_stdev_28d: null,
+        respiration: 14.2,
+        respiration_delta: 0,
+        respiration_delta_28d: 0,
+        respiration_mad_28d: null,
+        body_battery_wake: 85,
+        last_3_days_hard_sessions_count: 0,
+        yesterday_training: null,
+        today_training: null,
+        sleep_score_delta_7d: 2,
+        rhr_delta_28d: -2,
+        hrv_delta_28d: 4,
+        sleep_score_delta_28d: 3,
+        total_steps: 8000,
+        steps_7d_avg: 8500,
+        steps_28d_avg: 8400,
+        steps_delta_7d: -500,
+        steps_delta_28d: -400,
+    };
+
+    const baseReadiness: DailyReadiness = {
+        subjective: baseSubjective,
+        objective: baseObjective,
+    };
+
+    const baseContext: UserContext = {
+        preferences: {
+            preferredModalities: ['Running', 'Cycling'],
+            deprioritizedModalities: [],
+            avoidedModalities: [],
+            conservativeBias: false,
+        },
+        constraints: {
+            hasCableMachine: false,
+            hasFreeWeights: false,
+            hasTreadmill: false,
+            hasIndoorBike: false,
+            maxTimeMinutes: 60,
+            restrictedModalities: [],
+            restrictedCategories: [],
+            impliedGuardrails: [],
+        },
+        goals: { shortTerm: '', midTerm: '', longTerm: '' },
+    };
+
+    const mockHistoryProvider = {
+        reconstruct: async () => [],
+    };
+
+    const mockHistorySnapshot: TrainingHistorySnapshot = {
+        revision: 'rev-2026-08-26',
+        generatedAt: '2026-08-26T06:00:00Z',
+        throughDateExclusive: '2026-08-26',
+        windowDays: 7,
+        sourceStates: {
+            activities: { status: 'AVAILABLE', revision: 'r1' },
+            recommendations: { status: 'AVAILABLE', revision: 'r1' },
+            manualTraining: { status: 'AVAILABLE', revision: 'r1' },
+        },
+        exposures: [],
+        completedEvents: [],
+    };
+
+    it('generates recommendations that strictly satisfy persistence contracts', async () => {
+        const rec = await evaluateTrainingWithIntent(
+            'user-1',
+            baseReadiness,
+            baseContext,
+            [],
+            '2026-08-26',
+            undefined,
+            mockHistoryProvider,
+        );
+
+        expect(rec.template).toBeDefined();
+        expect(rec.decisionTrace).toBeDefined();
+
+        const audit = buildRecommendationAudit(rec, mockHistorySnapshot);
+        expect(audit).not.toBeNull();
+        const auditContractResult = validateRecommendationAuditContract(audit);
+        expect(auditContractResult.valid).toBe(true);
+        expect(auditContractResult.errors).toEqual([]);
+
+        const persistedDoc = {
+            userId: 'user-1',
+            date: '2026-08-26',
+            templateId: rec.template.id,
+            templateTitle: rec.template.title,
+            category: rec.template.category,
+            modality: rec.template.modality,
+            mode: rec.mode,
+            rationale: rec.rationale,
+            revision: 1,
+            recommendationAudit: audit!,
+        };
+
+        const recContractResult = validatePersistedRecommendationContract(persistedDoc);
+        expect(recContractResult.valid).toBe(true);
+
+        const parseResult = parseDailyRecommendation(persistedDoc, 'users/user-1/daily_recommendations/2026-08-26');
+        expect(parseResult.status).toBe('AVAILABLE');
+        if (parseResult.status === 'AVAILABLE') {
+            expect(parseResult.data.templateId).toBe(rec.template.id);
+        }
+    });
+});

--- a/app/src/contracts/enginePersistenceContract.test.ts
+++ b/app/src/contracts/enginePersistenceContract.test.ts
@@ -136,4 +136,26 @@ describe('EnginePersistenceContract', () => {
             expect(parseResult.data.templateId).toBe(rec.template.id);
         }
     });
+
+    it('rejects a schemaVersion the real parser would also reject as unsupported-schema-version', () => {
+        const persistedDoc = {
+            userId: 'user-1',
+            date: '2026-08-26',
+            templateId: 't-1',
+            templateTitle: 'Template',
+            category: 'run',
+            modality: 'Running',
+            mode: 'train',
+            rationale: 'rationale',
+            revision: 1,
+            schemaVersion: 4,
+        };
+
+        const contractResult = validatePersistedRecommendationContract(persistedDoc);
+        expect(contractResult.valid).toBe(false);
+        expect(contractResult.errors).toContain('schemaVersion must be 1, 2, or 3 when present, got 4');
+
+        const parseResult = parseDailyRecommendation(persistedDoc, 'users/user-1/daily_recommendations/2026-08-26');
+        expect(parseResult.status).toBe('INVALID');
+    });
 });

--- a/app/src/contracts/enginePersistenceContract.ts
+++ b/app/src/contracts/enginePersistenceContract.ts
@@ -1,0 +1,96 @@
+/* eslint-disable @typescript-eslint/no-explicit-any -- validating untrusted raw persisted data, matching engine/validationCore.ts's own convention */
+
+export interface EnginePersistenceContractResult {
+    valid: boolean;
+    errors: string[];
+}
+
+export function validateRecommendationAuditContract(audit: unknown): EnginePersistenceContractResult {
+    const errors: string[] = [];
+    if (!audit || typeof audit !== 'object' || Array.isArray(audit)) {
+        return { valid: false, errors: ['RecommendationAudit must be a non-null object'] };
+    }
+
+    const a = audit as Record<string, any>;
+    if (typeof a.policyVersion !== 'string' || !a.policyVersion.trim()) {
+        errors.push('policyVersion must be a non-empty string');
+    }
+    if (typeof a.evaluatedAt !== 'string' || !a.evaluatedAt.trim()) {
+        errors.push('evaluatedAt must be a non-empty ISO-8601 string');
+    }
+    if (typeof a.decisionContextRevision !== 'string') {
+        errors.push('decisionContextRevision must be a string');
+    }
+    if (a.safetyStatus !== 'complete') {
+        errors.push('safetyStatus must be \'complete\', got ' + a.safetyStatus);
+    }
+
+    // History block
+    if (!a.history || typeof a.history !== 'object') {
+        errors.push('history block is required');
+    } else {
+        if (typeof a.history.completedEventCount !== 'number' || a.history.completedEventCount < 0) {
+            errors.push('history.completedEventCount must be a non-negative integer');
+        }
+        if (typeof a.history.unmatchedEventCount !== 'number' || a.history.unmatchedEventCount < 0) {
+            errors.push('history.unmatchedEventCount must be a non-negative integer');
+        }
+        if (!a.history.sourceStatuses || typeof a.history.sourceStatuses !== 'object') {
+            errors.push('history.sourceStatuses is required');
+        } else {
+            const validStatuses = ['AVAILABLE', 'MISSING', 'INVALID', 'UNAVAILABLE'];
+            for (const key of ['activities', 'recommendations', 'manualTraining']) {
+                if (!validStatuses.includes(a.history.sourceStatuses[key])) {
+                    errors.push('history.sourceStatuses.' + key + ' must be one of ' + validStatuses.join(', '));
+                }
+            }
+        }
+    }
+
+    // Envelope block
+    if (!a.envelope || typeof a.envelope !== 'object') {
+        errors.push('envelope block is required');
+    } else {
+        if (typeof a.envelope.safetyRestrictedModalityCount !== 'number' || a.envelope.safetyRestrictedModalityCount < 0) {
+            errors.push('envelope.safetyRestrictedModalityCount must be a non-negative integer');
+        }
+        const validTiers = ['Rest', 'Mobility', 'Easy', 'Moderate', 'Hard'];
+        if (!validTiers.includes(a.envelope.planMaxAllowableTier)) {
+            errors.push('envelope.planMaxAllowableTier must be one of ' + validTiers.join(', '));
+        }
+    }
+
+    // Candidate scores
+    if (!Array.isArray(a.candidateScores) || a.candidateScores.length > 64) {
+        errors.push('candidateScores must be an array with length <= 64');
+    }
+
+    return { valid: errors.length === 0, errors };
+}
+
+export function validatePersistedRecommendationContract(rec: unknown): EnginePersistenceContractResult {
+    const errors: string[] = [];
+    if (!rec || typeof rec !== 'object' || Array.isArray(rec)) {
+        return { valid: false, errors: ['DailyRecommendation must be a non-null object'] };
+    }
+
+    const r = rec as Record<string, any>;
+    if (typeof r.userId !== 'string' || !r.userId.trim()) errors.push('userId is required');
+    if (typeof r.date !== 'string' || !/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/.test(r.date)) errors.push('date is required (YYYY-MM-DD)');
+    if (typeof r.templateId !== 'string' || !r.templateId.trim()) errors.push('templateId is required');
+    if (typeof r.templateTitle !== 'string' || !r.templateTitle.trim()) errors.push('templateTitle is required');
+    if (typeof r.category !== 'string' || !r.category.trim()) errors.push('category is required');
+    if (typeof r.modality !== 'string' || !r.modality.trim()) errors.push('modality is required');
+    if (!['train', 'modify', 'recover'].includes(r.mode)) errors.push('mode must be train, modify, or recover, got ' + r.mode);
+    if (typeof r.rationale !== 'string') errors.push('rationale is required');
+    if (typeof r.revision !== 'number' || r.revision < 1) errors.push('revision must be an integer >= 1');
+
+    if (r.recommendationAudit) {
+        const auditValidation = validateRecommendationAuditContract(r.recommendationAudit);
+        if (!auditValidation.valid) {
+            errors.push(...auditValidation.errors);
+        }
+    }
+
+    return { valid: errors.length === 0, errors };
+}

--- a/app/src/contracts/enginePersistenceContract.ts
+++ b/app/src/contracts/enginePersistenceContract.ts
@@ -75,6 +75,12 @@ export function validatePersistedRecommendationContract(rec: unknown): EnginePer
     }
 
     const r = rec as Record<string, any>;
+    // parseDailyRecommendation (persistence/parsers/trainingHistory.ts) rejects a
+    // defined schemaVersion that isn't 1, 2, or 3 as 'unsupported-schema-version' --
+    // keep this contract in lockstep so a bad version fails here, not only at parse time.
+    if (r.schemaVersion !== undefined && ![1, 2, 3].includes(r.schemaVersion)) {
+        errors.push('schemaVersion must be 1, 2, or 3 when present, got ' + r.schemaVersion);
+    }
     if (typeof r.userId !== 'string' || !r.userId.trim()) errors.push('userId is required');
     if (typeof r.date !== 'string' || !/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/.test(r.date)) errors.push('date is required (YYYY-MM-DD)');
     if (typeof r.templateId !== 'string' || !r.templateId.trim()) errors.push('templateId is required');

--- a/app/src/contracts/index.ts
+++ b/app/src/contracts/index.ts
@@ -1,0 +1,4 @@
+export * from './ingestionSnapshotContract';
+export * from './observationEngineContract';
+export * from './enginePersistenceContract';
+export * from './workoutExportContract';

--- a/app/src/contracts/ingestionSnapshotContract.test.ts
+++ b/app/src/contracts/ingestionSnapshotContract.test.ts
@@ -1,0 +1,55 @@
+/* eslint-disable @typescript-eslint/no-explicit-any -- fixture is loosely-typed JSON manipulated ad hoc per test case, matching engine/validationCore.ts's own convention */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { validateIngestionSnapshotContract, validateNormalizedActivityContract } from './ingestionSnapshotContract';
+import { parseRecoverySnapshot } from '../persistence/parsers/decisionInputs';
+
+// Read (not `import ... .json`) so these shared cross-language fixtures -- which live
+// outside app/'s tsconfig `include` -- don't need `resolveJsonModule` or a rootDir
+// carve-out just to be loaded by a test. The same files are loaded by
+// tests/test_contracts_ingestion.py on the Python side, so editing one field here
+// without updating the Python dataclass fixture fails both suites, not neither.
+function readFixture(relativePath: string): any {
+    const fixturePath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), relativePath);
+    return JSON.parse(readFileSync(fixturePath, 'utf-8'));
+}
+
+const validSnapshot = readFixture('../../../tests/fixtures/contracts/ingestion_snapshot.json');
+const activityFixture = readFixture('../../../tests/fixtures/contracts/normalized_activity.json');
+
+describe('IngestionSnapshotContract', () => {
+    it('passes valid snapshot contract validation and parser', () => {
+        const contractResult = validateIngestionSnapshotContract(validSnapshot);
+        expect(contractResult.valid).toBe(true);
+        expect(contractResult.errors).toEqual([]);
+
+        const parseResult = parseRecoverySnapshot(validSnapshot, 'users/athlete-1/daily_recovery_snapshots/2026-08-26', 'athlete-1', '2026-08-26');
+        expect(parseResult.status).toBe('AVAILABLE');
+    });
+
+    it('rejects invalid schema version', () => {
+        const invalid = { ...validSnapshot, source: { ...validSnapshot.source, sourceSchemaVersion: 1 } };
+        const result = validateIngestionSnapshotContract(invalid);
+        expect(result.valid).toBe(false);
+        expect(result.errors).toContain('sourceSchemaVersion must be 2 or 3, got 1');
+    });
+
+    it('rejects out-of-range sleep score or negative steps', () => {
+        const invalid = {
+            ...validSnapshot,
+            raw: { ...validSnapshot.raw, sleepScore: 120, totalSteps: -50 },
+        };
+        const result = validateIngestionSnapshotContract(invalid);
+        expect(result.valid).toBe(false);
+        expect(result.errors).toContain('raw.sleepScore must be null or [0, 100]');
+        expect(result.errors).toContain('raw.totalSteps must be null or non-negative number');
+    });
+
+    it('validates the normalized activity record produced by the Python mapper', () => {
+        const result = validateNormalizedActivityContract(activityFixture.normalized);
+        expect(result.valid).toBe(true);
+        expect(result.errors).toEqual([]);
+    });
+});

--- a/app/src/contracts/ingestionSnapshotContract.ts
+++ b/app/src/contracts/ingestionSnapshotContract.ts
@@ -1,0 +1,118 @@
+/* eslint-disable @typescript-eslint/no-explicit-any -- validating untrusted raw ingestion payloads, matching engine/validationCore.ts's own convention */
+
+export interface IngestionSnapshotContractResult {
+    valid: boolean;
+    errors: string[];
+}
+
+export function validateIngestionSnapshotContract(snapshot: unknown): IngestionSnapshotContractResult {
+    const errors: string[] = [];
+    if (!snapshot || typeof snapshot !== 'object' || Array.isArray(snapshot)) {
+        return { valid: false, errors: ['Snapshot must be a non-null object'] };
+    }
+
+    const s = snapshot as Record<string, any>;
+    if (typeof s.userId !== 'string' || !s.userId.trim()) {
+        errors.push('userId must be a non-empty string');
+    }
+    if (typeof s.date !== 'string' || !/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/.test(s.date)) {
+        errors.push('date must match YYYY-MM-DD format');
+    }
+
+    // Source block
+    if (!s.source || typeof s.source !== 'object') {
+        errors.push('source metadata block is required');
+    } else {
+        if (![2, 3].includes(s.source.sourceSchemaVersion)) {
+            errors.push('sourceSchemaVersion must be 2 or 3, got ' + s.source.sourceSchemaVersion);
+        }
+        if (typeof s.source.garminSyncedAt !== 'string' || !s.source.garminSyncedAt) {
+            errors.push('source.garminSyncedAt must be a valid ISO-8601 string');
+        }
+    }
+
+    // Raw metrics block
+    if (!s.raw || typeof s.raw !== 'object') {
+        errors.push('raw metrics block is required');
+    } else {
+        const r = s.raw;
+        if (r.sleepScore !== null && r.sleepScore !== undefined && (typeof r.sleepScore !== 'number' || r.sleepScore < 0 || r.sleepScore > 100)) {
+            errors.push('raw.sleepScore must be null or [0, 100]');
+        }
+        if (r.restingHr !== null && r.restingHr !== undefined && (typeof r.restingHr !== 'number' || r.restingHr < 20 || r.restingHr > 240)) {
+            errors.push('raw.restingHr must be null or [20, 240]');
+        }
+        if (r.hrvOvernightAvg !== null && r.hrvOvernightAvg !== undefined && (typeof r.hrvOvernightAvg !== 'number' || r.hrvOvernightAvg < 0 || r.hrvOvernightAvg > 350)) {
+            errors.push('raw.hrvOvernightAvg must be null or [0, 350]');
+        }
+        if (r.respirationAvg !== null && r.respirationAvg !== undefined && (typeof r.respirationAvg !== 'number' || r.respirationAvg < 4 || r.respirationAvg > 50)) {
+            errors.push('raw.respirationAvg must be null or [4, 50]');
+        }
+        if (r.totalSteps !== null && r.totalSteps !== undefined && (typeof r.totalSteps !== 'number' || r.totalSteps < 0)) {
+            errors.push('raw.totalSteps must be null or non-negative number');
+        }
+        if (r.bodyBatteryWake !== null && r.bodyBatteryWake !== undefined && (typeof r.bodyBatteryWake !== 'number' || r.bodyBatteryWake < 0 || r.bodyBatteryWake > 100)) {
+            errors.push('raw.bodyBatteryWake must be null or [0, 100]');
+        }
+        if (typeof r.last3DaysHardSessionsCount !== 'number' || r.last3DaysHardSessionsCount < 0) {
+            errors.push('raw.last3DaysHardSessionsCount must be a non-negative integer');
+        }
+    }
+
+    // Derived metrics block
+    if (!s.derived || typeof s.derived !== 'object') {
+        errors.push('derived metrics block is required');
+    } else {
+        const d = s.derived;
+        if (!d.deltas || typeof d.deltas !== 'object') {
+            errors.push('derived.deltas block is required');
+        }
+    }
+
+    // Data quality block
+    if (!s.dataQuality || typeof s.dataQuality !== 'object') {
+        errors.push('dataQuality block is required');
+    } else {
+        const dq = s.dataQuality;
+        const requiredFlags = ['sleepScoreAvailable', 'restingHrAvailable', 'hrvAvailable', 'baseline7dReady', 'baseline28dReady'];
+        for (const flag of requiredFlags) {
+            if (typeof dq[flag] !== 'boolean') {
+                errors.push('dataQuality.' + flag + ' must be a boolean');
+            }
+        }
+    }
+
+    return { valid: errors.length === 0, errors };
+}
+
+export function validateNormalizedActivityContract(activity: unknown): IngestionSnapshotContractResult {
+    const errors: string[] = [];
+    if (!activity || typeof activity !== 'object' || Array.isArray(activity)) {
+        return { valid: false, errors: ['Activity must be a non-null object'] };
+    }
+
+    const a = activity as Record<string, any>;
+    if (typeof a.activityId !== 'string' || !a.activityId.trim()) {
+        errors.push('activityId must be a non-empty string');
+    }
+    if (a.date !== null && a.date !== undefined && (typeof a.date !== 'string' || !/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/.test(a.date))) {
+        errors.push('date must match YYYY-MM-DD format if provided');
+    }
+    if (typeof a.type !== 'string' || !a.type.trim()) {
+        errors.push('type must be a non-empty string');
+    }
+    if (typeof a.durationMin !== 'number' || a.durationMin < 0) {
+        errors.push('durationMin must be a non-negative number');
+    }
+    if (typeof a.intensityTag !== 'string' || !a.intensityTag.trim()) {
+        errors.push('intensityTag must be a non-empty string');
+    }
+    if (typeof a.syncRunId !== 'string' || !a.syncRunId.trim()) {
+        errors.push('syncRunId must be a non-empty string');
+    }
+    if (typeof a.syncedAt !== 'string' || !a.syncedAt.trim()) {
+        errors.push('syncedAt must be a non-empty string');
+    }
+
+    return { valid: errors.length === 0, errors };
+}

--- a/app/src/contracts/observationEngineContract.test.ts
+++ b/app/src/contracts/observationEngineContract.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import { validateSubjectiveInputContract, validateObservationEnvelopesContract } from './observationEngineContract';
+import { evaluateEnvelopes } from '../engine/rules';
+import type { DailyReadiness, EngineObjectiveInput, SubjectiveInput, UserContext } from '../engine/models';
+
+describe('ObservationEngineContract', () => {
+    const baseSubjective: SubjectiveInput = {
+        readiness: 8,
+        sleepQuality: 8,
+        fatigue: 3,
+        soreness: 2,
+        stress: 2,
+        motivation: 8,
+        timeAvailable: 60,
+        painFlag: false,
+        alreadyTrainedToday: false,
+        preferredModalityToday: null,
+    };
+
+    const baseObjective: EngineObjectiveInput = {
+        sleep_score: 85,
+        sleep_duration_min: 480,
+        rhr: 48,
+        rhr_7d_avg: 49,
+        rhr_delta: -1,
+        hrv_weekly_avg: 65,
+        hrv_last_night: 68,
+        hrv_delta: 3,
+        hrv_stdev_28d: null,
+        rhr_stdev_28d: null,
+        sleep_score_stdev_28d: null,
+        respiration: 14.2,
+        respiration_delta: 0,
+        respiration_delta_28d: 0,
+        respiration_mad_28d: null,
+        body_battery_wake: 85,
+        last_3_days_hard_sessions_count: 0,
+        yesterday_training: null,
+        today_training: null,
+        sleep_score_delta_7d: 2,
+        rhr_delta_28d: -2,
+        hrv_delta_28d: 4,
+        sleep_score_delta_28d: 3,
+        total_steps: 8000,
+        steps_7d_avg: 8500,
+        steps_28d_avg: 8400,
+        steps_delta_7d: -500,
+        steps_delta_28d: -400,
+    };
+
+    const baseContext: UserContext = {
+        preferences: {
+            preferredModalities: ['Running', 'Cycling'],
+            deprioritizedModalities: [],
+            avoidedModalities: [],
+            conservativeBias: false,
+        },
+        constraints: {
+            hasCableMachine: false,
+            hasFreeWeights: false,
+            hasTreadmill: false,
+            hasIndoorBike: false,
+            maxTimeMinutes: 60,
+            restrictedModalities: [],
+            restrictedCategories: [],
+            impliedGuardrails: [],
+        },
+        goals: { shortTerm: '', midTerm: '', longTerm: '' },
+    };
+
+    it('enforces subjective checkin score bounds [1, 10]', () => {
+        expect(validateSubjectiveInputContract(baseSubjective).valid).toBe(true);
+
+        const invalid = { ...baseSubjective, fatigue: 15 };
+        const res = validateSubjectiveInputContract(invalid);
+        expect(res.valid).toBe(false);
+        expect(res.errors[0]).toContain('fatigue must be an integer between 1 and 10');
+    });
+
+    it('enforces safety envelope contracts for active painFlag', () => {
+        const painReadiness: DailyReadiness = {
+            subjective: { ...baseSubjective, painFlag: true },
+            objective: baseObjective,
+        };
+        const envelopes = evaluateEnvelopes(painReadiness, baseContext);
+        const contractCheck = validateObservationEnvelopesContract(painReadiness, envelopes.safety, envelopes.plan);
+        expect(contractCheck.valid).toBe(true);
+        expect(envelopes.safety.clinicalFlagActive).toBe(true);
+        expect(envelopes.safety.restrictedModalities).toContain('Running');
+        expect(envelopes.plan.maxAllowableTier).toBe('Mobility');
+    });
+
+    it('enforces safety envelope contracts for alreadyTrainedToday', () => {
+        const trainedReadiness: DailyReadiness = {
+            subjective: { ...baseSubjective, alreadyTrainedToday: true },
+            objective: baseObjective,
+        };
+        const envelopes = evaluateEnvelopes(trainedReadiness, baseContext);
+        const contractCheck = validateObservationEnvelopesContract(trainedReadiness, envelopes.safety, envelopes.plan);
+        expect(contractCheck.valid).toBe(true);
+        expect(envelopes.plan.maxAllowableTier).toBe('Rest');
+    });
+
+    it('enforces plan tier cap for severe recovery depression (sleep score < 55)', () => {
+        const depressedReadiness: DailyReadiness = {
+            subjective: baseSubjective,
+            objective: { ...baseObjective, sleep_score: 45, body_battery_wake: 25 },
+        };
+        const envelopes = evaluateEnvelopes(depressedReadiness, baseContext);
+        const contractCheck = validateObservationEnvelopesContract(depressedReadiness, envelopes.safety, envelopes.plan);
+        expect(contractCheck.valid).toBe(true);
+        expect(envelopes.plan.maxAllowableTier).toBe('Easy');
+    });
+});

--- a/app/src/contracts/observationEngineContract.ts
+++ b/app/src/contracts/observationEngineContract.ts
@@ -1,0 +1,73 @@
+/* eslint-disable @typescript-eslint/no-explicit-any -- validating untrusted raw subjective input, matching engine/validationCore.ts's own convention */
+import type { DailyReadiness, SafetyEnvelope, PlanEnvelope } from '../engine/models';
+
+export interface ObservationEngineContractResult {
+    valid: boolean;
+    errors: string[];
+}
+
+export function validateSubjectiveInputContract(subjective: unknown): ObservationEngineContractResult {
+    const errors: string[] = [];
+    if (!subjective || typeof subjective !== 'object' || Array.isArray(subjective)) {
+        return { valid: false, errors: ['Subjective input must be a non-null object'] };
+    }
+
+    const s = subjective as Record<string, any>;
+    const scoreFields = ['readiness', 'sleepQuality', 'fatigue', 'soreness', 'stress', 'motivation'];
+    for (const field of scoreFields) {
+        if (typeof s[field] !== 'number' || s[field] < 1 || s[field] > 10 || !Number.isInteger(s[field])) {
+            errors.push('subjective.' + field + ' must be an integer between 1 and 10, got ' + s[field]);
+        }
+    }
+
+    if (typeof s.timeAvailable !== 'number' || s.timeAvailable < 0 || s.timeAvailable > 480) {
+        errors.push('subjective.timeAvailable must be a non-negative number <= 480 min, got ' + s.timeAvailable);
+    }
+    if (typeof s.painFlag !== 'boolean') {
+        errors.push('subjective.painFlag must be a boolean');
+    }
+    if (typeof s.alreadyTrainedToday !== 'boolean') {
+        errors.push('subjective.alreadyTrainedToday must be a boolean');
+    }
+
+    return { valid: errors.length === 0, errors };
+}
+
+export function validateObservationEnvelopesContract(
+    readiness: DailyReadiness,
+    safety: SafetyEnvelope,
+    plan: PlanEnvelope
+): ObservationEngineContractResult {
+    const errors: string[] = [];
+
+    // Clinical safety invariants
+    if (readiness.subjective.painFlag) {
+        if (!safety.clinicalFlagActive) {
+            errors.push('Contract violation: painFlag=true MUST set safety.clinicalFlagActive=true');
+        }
+        if (!safety.restrictedModalities.includes('Running')) {
+            errors.push('Contract violation: painFlag=true MUST restrict Running modality');
+        }
+        if (plan.maxAllowableTier === 'Hard' || plan.maxAllowableTier === 'Moderate' || plan.maxAllowableTier === 'Easy') {
+            errors.push('Contract violation: painFlag=true MUST NOT permit tier ' + plan.maxAllowableTier);
+        }
+    }
+
+    // Already trained today invariant
+    if (readiness.subjective.alreadyTrainedToday) {
+        if (plan.maxAllowableTier !== 'Rest') {
+            errors.push('Contract violation: alreadyTrainedToday=true MUST restrict plan tier to Rest, got ' + plan.maxAllowableTier);
+        }
+    }
+
+    // Severe recovery depression invariants
+    const wakeDepressed = readiness.objective.body_battery_wake !== null && readiness.objective.body_battery_wake < 30;
+    const sleepDepressed = readiness.objective.sleep_score !== null && readiness.objective.sleep_score < 55;
+    if ((wakeDepressed || sleepDepressed) && !readiness.subjective.alreadyTrainedToday && !readiness.subjective.painFlag) {
+        if (plan.maxAllowableTier === 'Hard' || plan.maxAllowableTier === 'Moderate') {
+            errors.push('Contract violation: severe recovery depression MUST cap tier at Easy or lower, got ' + plan.maxAllowableTier);
+        }
+    }
+
+    return { valid: errors.length === 0, errors };
+}

--- a/app/src/contracts/workoutExportContract.test.ts
+++ b/app/src/contracts/workoutExportContract.test.ts
@@ -56,6 +56,72 @@ describe('WorkoutExportContract', () => {
         expect(result.errors.some((e) => e.includes('durationSeconds or repetitions'))).toBe(true);
     });
 
+    it('rejects a non-strength step that has repetitions but no durationSeconds (would silently hit the 300s fallback)', () => {
+        const broken = {
+            ...workoutPayload,
+            modality: 'cycling',
+            blocks: [
+                {
+                    id: 'main',
+                    name: 'Main',
+                    role: 'main',
+                    steps: [{ id: 's1', name: 'Reps only, no duration', repetitions: 10 }],
+                },
+            ],
+        };
+        const result = validateCanonicalWorkoutExportContract(broken);
+        expect(result.valid).toBe(false);
+        expect(result.errors.some((e) => e.includes('durationSeconds or repetitions'))).toBe(true);
+    });
+
+    it('accepts a strength step with repetitions and no durationSeconds', () => {
+        const strengthWorkout = {
+            ...workoutPayload,
+            modality: 'strength',
+            blocks: [
+                {
+                    id: 'main',
+                    name: 'Main',
+                    role: 'main',
+                    steps: [{ id: 's1', name: 'Back Squat', repetitions: 5, sets: 3 }],
+                },
+            ],
+        };
+        const result = validateCanonicalWorkoutExportContract(strengthWorkout);
+        expect(result.valid).toBe(true);
+        expect(result.errors).toEqual([]);
+    });
+
+    it('rejects targets containing non-string elements (e.g. a leftover target object)', () => {
+        const broken = {
+            ...workoutPayload,
+            blocks: [
+                {
+                    id: 'main',
+                    name: 'Main',
+                    role: 'main',
+                    steps: [{ id: 's1', name: 'Step', durationSeconds: 300, targets: [{ watts: 300 }] }],
+                },
+            ],
+        };
+        const result = validateCanonicalWorkoutExportContract(broken);
+        expect(result.valid).toBe(false);
+        expect(result.errors.some((e) => e.includes('targets must be a string array'))).toBe(true);
+    });
+
+    it('reports an error instead of throwing when a catalog block contains a malformed (null) step', () => {
+        const malformedCatalogWorkout = {
+            id: 'w-1',
+            name: 'Broken Workout',
+            modality: 'Running',
+            blocks: [{ steps: [null] }],
+        };
+        expect(() => validateCatalogWorkoutStructure(malformedCatalogWorkout)).not.toThrow();
+        const result = validateCatalogWorkoutStructure(malformedCatalogWorkout);
+        expect(result.valid).toBe(false);
+        expect(result.errors.some((e) => e.includes('must be a non-null object'))).toBe(true);
+    });
+
     it('rejects the legacy durationSec/target-object shape (the field names workout_export.py does NOT read)', () => {
         const legacyShape = {
             schemaVersion: 'canonical_workout_v1',

--- a/app/src/contracts/workoutExportContract.test.ts
+++ b/app/src/contracts/workoutExportContract.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import {
+    validateQueuedWorkoutContract,
+    validateCatalogWorkoutStructure,
+    validateCanonicalWorkoutExportContract,
+} from './workoutExportContract';
+import { WORKOUTS } from '../workouts/catalog';
+
+// Read (not `import ... .json`) so this shared cross-language fixture -- which lives
+// outside app/'s tsconfig `include` -- doesn't need `resolveJsonModule` or a rootDir
+// carve-out just to be loaded by a test.
+const fixturePath = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '../../../tests/fixtures/contracts/workout_export.json',
+);
+const sharedFixture = JSON.parse(readFileSync(fixturePath, 'utf-8')) as {
+    queueEntry: Record<string, unknown> & { payload: Record<string, unknown> };
+};
+const workoutPayload = sharedFixture.queueEntry.payload;
+
+describe('WorkoutExportContract', () => {
+    it('validates the real GarminQueuedWorkout document shape end-to-end, including the nested payload (status: pending|synced|failed, no workoutId field)', () => {
+        const result = validateQueuedWorkoutContract(sharedFixture.queueEntry);
+        expect(result.errors).toEqual([]);
+        expect(result.valid).toBe(true);
+
+        // Guard the enum this contract encodes: the wire type only ever holds
+        // these three statuses (garminWorkoutQueueService.ts), not 'in_flight'/'completed'.
+        const wrongEnum = { ...sharedFixture.queueEntry, status: 'in_flight' };
+        expect(validateQueuedWorkoutContract(wrongEnum).valid).toBe(false);
+    });
+
+    it('validates the real CanonicalWorkoutExport wire shape crossing into workout_export.py', () => {
+        const result = validateCanonicalWorkoutExportContract(workoutPayload);
+        expect(result.errors).toEqual([]);
+        expect(result.valid).toBe(true);
+    });
+
+    it('rejects a step with no durationSeconds/repetitions instead of letting it silently sync as a fabricated 300s block', () => {
+        const broken = {
+            ...workoutPayload,
+            blocks: [
+                {
+                    id: 'main',
+                    name: 'Main',
+                    role: 'main',
+                    steps: [{ id: 's1', name: 'Undated step', targets: ['300 W'] }],
+                },
+            ],
+        };
+        const result = validateCanonicalWorkoutExportContract(broken);
+        expect(result.valid).toBe(false);
+        expect(result.errors.some((e) => e.includes('durationSeconds or repetitions'))).toBe(true);
+    });
+
+    it('rejects the legacy durationSec/target-object shape (the field names workout_export.py does NOT read)', () => {
+        const legacyShape = {
+            schemaVersion: 'canonical_workout_v1',
+            title: 'Legacy Shape',
+            workoutId: 'legacy',
+            modality: 'cycling',
+            blocks: [
+                {
+                    id: 'b1',
+                    role: 'main',
+                    steps: [{ id: 's1', name: 'Step', durationSec: 600, target: { type: 'power', watts: 200 } }],
+                },
+            ],
+        };
+        const result = validateCanonicalWorkoutExportContract(legacyShape);
+        expect(result.valid).toBe(false);
+    });
+
+    it('verifies every workout in the static catalog satisfies catalog authoring structure', () => {
+        expect(WORKOUTS.length).toBeGreaterThan(0);
+        for (const workout of WORKOUTS) {
+            const result = validateCatalogWorkoutStructure(workout);
+            expect(result.valid, 'Workout ' + workout.id + ' failed catalog structure contract: ' + result.errors.join(', ')).toBe(true);
+        }
+    });
+});

--- a/app/src/contracts/workoutExportContract.ts
+++ b/app/src/contracts/workoutExportContract.ts
@@ -54,12 +54,16 @@ export function validateCanonicalWorkoutExportContract(payload: unknown): Workou
             // step needs a real durationSeconds to avoid silently syncing as a
             // fixed 5-minute block, and every strength step needs either
             // repetitions or durationSeconds.
+            const isStrength = typeof w.modality === 'string' && w.modality.toLowerCase() === 'strength';
             const hasDuration = typeof step?.durationSeconds === 'number' && step.durationSeconds > 0;
             const hasRepetitions = typeof step?.repetitions === 'number' && step.repetitions > 0;
-            if (!hasDuration && !hasRepetitions) {
+            if ((!isStrength && !hasDuration) || (isStrength && !hasDuration && !hasRepetitions)) {
                 errors.push(where + ' must specify durationSeconds or repetitions (workout_export.py otherwise fabricates a 300s default)');
             }
-            if (step?.targets !== undefined && !Array.isArray(step.targets)) {
+            if (
+                step?.targets !== undefined
+                && (!Array.isArray(step.targets) || !step.targets.every((target: unknown) => typeof target === 'string'))
+            ) {
                 errors.push(where + '.targets must be a string array, not ' + typeof step.targets);
             }
         }
@@ -126,6 +130,10 @@ export function validateCatalogWorkoutStructure(workout: unknown): WorkoutExport
             } else {
                 for (let sIdx = 0; sIdx < block.steps.length; sIdx++) {
                     const step = block.steps[sIdx];
+                    if (!step || typeof step !== 'object' || Array.isArray(step)) {
+                        errors.push('block[' + bIdx + '].step[' + sIdx + '] must be a non-null object');
+                        continue;
+                    }
                     if (!step.id || typeof step.id !== 'string') {
                         errors.push('block[' + bIdx + '].step[' + sIdx + '] must have a valid string id');
                     }

--- a/app/src/contracts/workoutExportContract.ts
+++ b/app/src/contracts/workoutExportContract.ts
@@ -1,0 +1,148 @@
+/* eslint-disable @typescript-eslint/no-explicit-any -- validating untrusted raw export payloads, matching engine/validationCore.ts's own convention */
+
+export interface WorkoutExportContractResult {
+    valid: boolean;
+    errors: string[];
+}
+
+/**
+ * Validates the real cross-language wire shape that crosses into Python:
+ * `CanonicalWorkoutExport` (app/src/utils/workoutJsonExport.ts), which is what
+ * `GarminQueuedWorkout.payload` holds and what `src/garmin_sync/workout_export.py`
+ * actually reads (`title`, `workoutId`, `blocks[].role`, `steps[].durationSeconds`,
+ * `steps[].targets` as a string array). This is distinct from the catalog's own
+ * `WorkoutDefinition` shape (see `validateCatalogWorkoutStructure` below), which is
+ * authoring-time only and never crosses the export boundary as-is.
+ */
+export function validateCanonicalWorkoutExportContract(payload: unknown): WorkoutExportContractResult {
+    const errors: string[] = [];
+    if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+        return { valid: false, errors: ['CanonicalWorkoutExport must be a non-null object'] };
+    }
+
+    const w = payload as Record<string, any>;
+    if (w.schemaVersion !== 'canonical_workout_v1') {
+        errors.push('schemaVersion must be \'canonical_workout_v1\', got ' + w.schemaVersion);
+    }
+    if (typeof w.title !== 'string' || !w.title.trim()) errors.push('title is required');
+    if (typeof w.workoutId !== 'string' || !w.workoutId.trim()) errors.push('workoutId is required');
+    if (typeof w.modality !== 'string' || !w.modality.trim()) errors.push('modality is required');
+
+    if (!Array.isArray(w.blocks) || w.blocks.length === 0) {
+        errors.push('blocks must be a non-empty array');
+        return { valid: errors.length === 0, errors };
+    }
+
+    for (let bIdx = 0; bIdx < w.blocks.length; bIdx++) {
+        const block = w.blocks[bIdx];
+        if (!block || typeof block.role !== 'string' || !block.role.trim()) {
+            errors.push('block[' + bIdx + '] must have a non-empty role');
+        }
+        if (!block || !Array.isArray(block.steps) || block.steps.length === 0) {
+            errors.push('block[' + bIdx + '] must contain at least one step');
+            continue;
+        }
+        for (let sIdx = 0; sIdx < block.steps.length; sIdx++) {
+            const step = block.steps[sIdx];
+            const where = 'block[' + bIdx + '].step[' + sIdx + ']';
+            if (!step || typeof step.name !== 'string' || !step.name.trim()) {
+                errors.push(where + ' must have a non-empty name');
+            }
+            // workout_export.py's _build_step_dto falls back to a 300s default
+            // whenever durationSeconds is absent, and _resolve_end_condition only
+            // honors repetitions for strength modality -- so every non-strength
+            // step needs a real durationSeconds to avoid silently syncing as a
+            // fixed 5-minute block, and every strength step needs either
+            // repetitions or durationSeconds.
+            const hasDuration = typeof step?.durationSeconds === 'number' && step.durationSeconds > 0;
+            const hasRepetitions = typeof step?.repetitions === 'number' && step.repetitions > 0;
+            if (!hasDuration && !hasRepetitions) {
+                errors.push(where + ' must specify durationSeconds or repetitions (workout_export.py otherwise fabricates a 300s default)');
+            }
+            if (step?.targets !== undefined && !Array.isArray(step.targets)) {
+                errors.push(where + '.targets must be a string array, not ' + typeof step.targets);
+            }
+        }
+    }
+
+    return { valid: errors.length === 0, errors };
+}
+
+/**
+ * Validates the persisted `GarminQueuedWorkout` document at
+ * `users/{userId}/garmin_workout_queue/{date}` (app/src/services/garminWorkoutQueueService.ts).
+ */
+export function validateQueuedWorkoutContract(entry: unknown): WorkoutExportContractResult {
+    const errors: string[] = [];
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+        return { valid: false, errors: ['GarminQueuedWorkout must be a non-null object'] };
+    }
+
+    const e = entry as Record<string, any>;
+    if (typeof e.userId !== 'string' || !e.userId.trim()) errors.push('userId is required');
+    if (typeof e.date !== 'string' || !/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/.test(e.date)) errors.push('date is required (YYYY-MM-DD)');
+    if (typeof e.workoutTitle !== 'string' || !e.workoutTitle.trim()) errors.push('workoutTitle is required');
+    if (typeof e.modality !== 'string' || !e.modality.trim()) errors.push('modality is required');
+    if (!['pending', 'synced', 'failed'].includes(e.status)) {
+        errors.push('status must be pending, synced, or failed, got ' + e.status);
+    }
+    if (typeof e.queuedAt !== 'string' || !e.queuedAt.trim()) errors.push('queuedAt ISO timestamp is required');
+
+    if (e.payload !== undefined) {
+        const payloadResult = validateCanonicalWorkoutExportContract(e.payload);
+        if (!payloadResult.valid) {
+            errors.push(...payloadResult.errors.map((err) => 'payload.' + err));
+        }
+    }
+
+    return { valid: errors.length === 0, errors };
+}
+
+/**
+ * Validates the app's own authoring-time `WorkoutDefinition` catalog shape
+ * (app/src/workouts/catalog). This is upstream of export -- catalog entries get
+ * adapted into a `CanonicalWorkoutExport` (via `exportWorkoutPrescriptionToJson`
+ * or similar) before they ever reach `workout_export.py` -- so this check catches
+ * malformed catalog authoring, not export-boundary drift. Use
+ * `validateCanonicalWorkoutExportContract` for the actual cross-language contract.
+ */
+export function validateCatalogWorkoutStructure(workout: unknown): WorkoutExportContractResult {
+    const errors: string[] = [];
+    if (!workout || typeof workout !== 'object' || Array.isArray(workout)) {
+        return { valid: false, errors: ['WorkoutDefinition must be a non-null object'] };
+    }
+
+    const w = workout as Record<string, any>;
+    if (typeof w.id !== 'string' || !w.id.trim()) errors.push('workout.id is required');
+    if (typeof w.name !== 'string' || !w.name.trim()) errors.push('workout.name is required');
+    if (typeof w.modality !== 'string' || !w.modality.trim()) errors.push('workout.modality is required');
+    if (!Array.isArray(w.blocks) || w.blocks.length === 0) {
+        errors.push('workout.blocks must be a non-empty array');
+    } else {
+        for (let bIdx = 0; bIdx < w.blocks.length; bIdx++) {
+            const block = w.blocks[bIdx];
+            if (!block || !Array.isArray(block.steps) || block.steps.length === 0) {
+                errors.push('block[' + bIdx + '] must contain at least one step');
+            } else {
+                for (let sIdx = 0; sIdx < block.steps.length; sIdx++) {
+                    const step = block.steps[sIdx];
+                    if (!step.id || typeof step.id !== 'string') {
+                        errors.push('block[' + bIdx + '].step[' + sIdx + '] must have a valid string id');
+                    }
+                    if (!step.name || typeof step.name !== 'string') {
+                        errors.push('block[' + bIdx + '].step[' + sIdx + '] must have a valid string name');
+                    }
+                    const stepDurationType = step.duration?.type;
+                    if (!stepDurationType || !['time', 'distance', 'repetitions', 'open'].includes(stepDurationType)) {
+                        errors.push('block[' + bIdx + '].step[' + sIdx + '] has invalid duration type ' + stepDurationType);
+                    }
+                }
+            }
+        }
+    }
+
+    return { valid: errors.length === 0, errors };
+}
+
+/** @deprecated Use {@link validateCatalogWorkoutStructure} — kept as an alias during migration. */
+export const validateWorkoutDefinitionForExport = validateCatalogWorkoutStructure;

--- a/docs/analysis/2026-08-26-architecture-and-maintainability-review.md
+++ b/docs/analysis/2026-08-26-architecture-and-maintainability-review.md
@@ -1,0 +1,285 @@
+# Architecture and Maintainability Review (2026-08-26)
+
+## Executive Summary
+
+This audit evaluates the architectural integrity, policy boundaries, schema evolution, and maintainability of the `adaptive-training-recommender` system across its Python backend (`src/garmin_sync/`), TypeScript recommendation engine and frontend (`app/src/`), and Firestore security layer (`app/firestore.rules`).
+
+While the core algorithmic foundations (ADR-0010 provenance, ADR-0012 plan intent authority, ADR-0014 honest load credit, ADR-0017 evergreen planning) are sound and mathematically disciplined, the system exhibits notable architectural complexity:
+
+1. **Dual Selection Paths**: Path A (`evaluateTraining`, synchronous) and Path B (`evaluateTrainingWithIntent`, asynchronous) both exist in `rules.ts`. Production (`Home.tsx`, `PlanView.tsx`) uses Path B, but Path A is still actively used in tests and by `evaluateNextDayPlan`, leaving room for behavioral drift between test harnesses and production execution.
+2. **Schema & Policy Duplication**: Critical schema definitions and validation logic are triplicated across Python dataclasses (`src/garmin_sync/models.py`), TypeScript interfaces/parsers (`app/src/engine/models.ts`, `app/src/persistence/parsers/`), and Firestore security rules (`app/firestore.rules`, 1,471 lines).
+3. **Layer Inversions in Engine**: `app/src/engine/composer.ts` and `app/src/engine/firestoreTrainingHistory.ts` import directly from `app/src/services/`, breaking the pure functional engine boundary.
+4. **Lack of Explicit Cross-Boundary Integration Contracts**: Unit test coverage is extensive, but the integration boundaries between Python ingestion, the TS recommendation engine, Firestore persistence, and privileged workout exports relied on implicit structural typing rather than formal contract validation — this review adds that layer (Section 11).
+
+---
+
+## 1. Authoritative Selection Path Analysis
+
+### 1.1 Current Architecture
+
+The engine currently houses two distinct selection paths within `app/src/engine/rules.ts`:
+
+* **Path A — Synchronous / Readiness-Only (`evaluateTraining`)**:
+  - Filters raw `TEMPLATES` (lacking newer enriched stimulus profiles).
+  - Evaluates mode (`train` | `modify` | `recover`) and safety envelopes via `evaluateReadinessAndSafetyEnvelope`.
+  - Filters by category allow-lists and modality preferences (`rankByModalityPreference`).
+  - Selects a template via date-hash tie-breaking (`pickTemplate(rankedOptions, date)`).
+  - Completely excludes phase-gated templates (`phaseEligibility`) and ignores multi-day fatigue states (`fatigue.ts`), objective credit (`stimulus.ts`), candidate optimization (`optimizer.ts`), evergreen strategies (`evergreenPlanning.ts`), and authored overlays.
+
+* **Path B — Asynchronous / Intent-Aware (`evaluateTrainingWithIntent`)**:
+  - The true production selection engine.
+  - Consumes `ENRICHED_TEMPLATES` with full multi-dimensional stimulus and cost profiles.
+  - Evaluates `evaluateReadinessAndSafetyEnvelope` to share envelope math with Path A.
+  - Resolves planning mode (`planningMode.ts`), evergreen plans (`evergreenPlanning.ts`), and fixed activity credits (`fixedActivityIdentity.ts`).
+  - Runs candidate optimization (`optimizer.ts:rankCandidates`) via lexicographic utility scoring (stimulus benefit vs. fatigue cost penalty, subject to injury constraints and dose caps).
+  - Emits a full `DecisionTrace`, `plannedDose`, and `executionDose`.
+
+* **Adjudication (`externalSession.ts`, ADR-0019)**:
+  - Not a third selection path; an adjudication entry point where external sessions are gated through `evaluateTemplateEligibility` and `resolveExecutionDose`.
+
+* **Authored Occurrences (`authoredSessionGates.ts`, ADR-0023)**:
+  - Adjudicated occurrences resolved at the `Home.tsx` composition boundary for date-scoped execution.
+
+### 1.2 Identified Risks & Drift
+
+* `evaluateNextDayPlan` (sync) in `rules.ts` calls Path A (`evaluateTraining`), whereas `evaluateNextDayPlanWithIntent` (async) calls Path B (`evaluateTrainingWithIntent`).
+* Multiple unit tests (e.g. `rules.test.ts`, `safetyInvariants.test.ts`, `sequenceSearch.test.ts`) still call `evaluateTraining` directly. If an invariant is verified only under Path A, it does not guarantee that Path B — which runs `rankCandidates` and utility optimization — obeys the same invariant under complex multi-day fatigue.
+* **Remediation**: Deprecate direct external calls to `evaluateTraining` and unify all recommendation evaluation under `evaluateTrainingWithIntent` (with an in-memory mock history provider for synchronous/isolated testing where appropriate). This review does not perform that migration — it is a larger, riskier change than fits this pass — but flags it as the top follow-up item, and Section 11's Contract 2 (Observations ↔ Engine) is written against the shared envelope function (`evaluateEnvelopes`) so it holds regardless of which path consumes it.
+
+---
+
+## 2. Cross-Language & Cross-Layer Policy Duplication
+
+| Policy Area | Python Backend (`src/garmin_sync/`) | TypeScript Engine (`app/src/`) | Firestore Security Rules (`app/firestore.rules`) |
+|---|---|---|---|
+| **Activity Intensity Classification** | `metrics.py:classify_activity_intensity` (`te >= 3.0` or `avg_hr >= 145` → hard) | `strengthExposure.ts` (1RM percentage / RIR thresholds), `completedTraining.ts` | Implicitly permitted through string fields |
+| **Biometric Baselines & Deltas** | `metrics.py:compute_derived_metrics` (7d/28d mean, median, stdev, scaled MAD) | `subjectiveBaseline.ts` (exponential & rolling drift), `healthAnomalyFeatures.ts` | Validated for nullable number types |
+| **Recommendation Audits** | None (pure client write) | `provenance.ts:buildRecommendationAudit`, `replay.ts` | `hasValidRecommendationAudit` (strict key checks, array length <= 64, enum constraints) |
+| **Subjective Drift Audits** | None | `subjectiveDriftAudit.ts` | `hasValidSubjectiveDriftAudit` (strict keys, range checks) |
+| **External Plan Schemas** | None | `sessions/externalPlanV2.ts`, `validationCore.ts` | `hasValidExternalPlanHeader`, `hasValidExternalPlanRevision` |
+| **Session Definitions & Prescriptions** | `workout_export.py` (DTO subset) | `sessions/models.ts`, `sessions/validation.ts` | `hasValidSessionDefinitionHeader`, `hasValidExecutionPrescription` |
+
+### 2.1 Drift Hazards
+
+1. **Firestore Rules Desynchronization**: Whenever a field is added to `RecommendationAudit` or `SubjectiveDriftAudit` in TypeScript, omitting the field in `app/firestore.rules` causes silent permission-denied write failures in production, not a compile-time error.
+2. **Intensity Heuristics**: Python classifies Garmin activities into `hard`, `moderate`, and `easy` using training effect and HR, while strength workouts use set-level RPE/RIR in TypeScript. Downstream engine consumers in `fatigue.ts` must reconcile both signal families without conflating cardiovascular and neuromuscular strain.
+
+---
+
+## 3. Firestore Security Rules Size and Testability
+
+### 3.1 Metrics
+
+* **File**: `app/firestore.rules` — **Size**: 1,471 lines, ~93 KB.
+* **Scope**: 34+ collection/subcollection match blocks, 60+ custom validation functions.
+* **Test Suite**: `app/src/emulator/firestoreRules.emulator.test.ts` (1,580 lines, ~89 test cases) plus several other emulator test suites.
+
+### 3.2 Testability Assessment
+
+* **Strengths**: The rules are extraordinarily thorough, validating not just ownership (`isOwner(userId)`), but deep document structure, map keys (`hasOnly`, `hasAll`), number ranges, and string formats (e.g. SHA-256 hashes, ISO-8601 dates).
+* **Weaknesses**: The emulator test suites require a live Firebase emulator (Java runtime). As a result, plain `npm test` skips the security rule tests by default. A developer working without Java can introduce a rule drift that passes `npm test` but breaks writes in staging/production.
+* **Tooling**: `app/scripts/check-firestore-rules-drift.mjs` provides static git-drift verification, mitigating (but not eliminating) that risk in CI.
+
+---
+
+## 4. Client-Computed versus Server-Authoritative Fields
+
+```text
+[ Garmin Connect API ]
+         │ (Garmin client with backoff)
+         ▼
+[ Python Ingestion Service ]
+   ├── Writes Immutable Raw Archive: users/{userId}/raw_archive/{date}
+   ├── Computes Derived Baselines (7d/28d avg, median, stdev, MAD)
+   ├── Normalizes Activities: users/{userId}/activities/{activityId}
+   └── Writes Snapshot: users/{userId}/daily_recovery_snapshots/{date}
+         │
+         ▼ (Firestore Read)
+[ TypeScript React Client ]
+   ├── Reads Recovery Snapshot + Activities
+   ├── Captures Athlete Subjective Check-in: users/{userId}/daily_subjective_checkins/{date}
+   ├── Computes Health Anomaly Telemetry (ADR-0025)
+   ├── Computes Multi-day Fatigue State & Training Intent
+   ├── Executes Recommendation Engine (evaluateTrainingWithIntent)
+   ├── Writes Persisted Recommendation & Audit: users/{userId}/daily_recommendations/{date}
+   ├── Executes Session Runner & Computes 1RM Updates: users/{userId}/session_executions/{id}
+   └── Queues Workout Exports: users/{userId}/garmin_workout_queue/{date}
+         │
+         ▼ (Firestore Read / CLI Worker)
+[ Python Workout Export Worker ]
+   └── Transforms Canonical Workouts -> Garmin Workout DTOs -> Garmin API
+```
+
+### 4.1 Boundary Evaluation
+
+* **Server-Authoritative**: Wearable biometrics, raw archive payloads, device sync metadata. The client never modifies raw recovery snapshots or historical synced activities.
+* **Client-Authoritative**: Subjective check-ins, user preferences, training intent profiles, authored workouts, daily recommendations, session execution logs, and health anomaly assessments.
+* **Integrity Guard**: Because recommendations and anomaly evaluations are computed client-side, Firestore security rules are the only server-side boundary — they must enforce that clients only write valid, revisioned documents, since there is no server-side recomputation to catch a malformed or forged write.
+
+---
+
+## 5. Schema-Version Migration Strategy
+
+### 5.1 Python Ingestion Snapshots
+
+* `SCHEMA_VERSION = 3` and `BASELINE_COMPUTATION_VERSION = 5` (`src/garmin_sync/models.py`).
+* **Rebuild Pipeline** (ADR-0005): `src/garmin_sync/service.py:rebuild_snapshots` can regenerate all historical daily recovery snapshots offline from the immutable `raw_archive` when baseline estimators or schemas change.
+* **User Data Migration**: `src/garmin_sync/migrate_user_data.py` supports migrating documents across user IDs during account consolidation.
+
+### 5.2 TypeScript Domain Models & Persisted State
+
+* `POLICY_VERSION`: a monotonically versioned date string (e.g. `2026.08.26.1`), tracked in every recommendation audit.
+* **Content Hashing**: Authored sessions and execution prescriptions use canonical SHA-256 content addressing (`sessionDefinitionHash.ts`), making revisions immutable and tamper-evident.
+* **Tolerant Parsers**: Parsers in `app/src/persistence/parsers/` safely parse legacy documents (e.g. handling a missing 28d MAD, or a legacy `strength_sessions` structure) by supplying clean defaults or flagging an explicit `DataState.INVALID`.
+
+---
+
+## 6. Backward Compatibility of Stored Recommendation Audits & Replay
+
+### 6.1 Audit Contract (ADR-0010, ADR-0014)
+
+`RecommendationAudit` captures:
+  - `policyVersion`, `evaluatedAt`, `decisionContextRevision`, `safetyStatus`
+  - `history` (with `sourceStatuses`)
+  - `envelope`, `plannedDose` / `executionDose`
+  - `candidateScores` (all evaluated candidates, utility scores, penalties, and exclusion reasons)
+  - `droppedContributorObjectives`, `externalPlan` / `authoredOccurrence` provenance
+  - `subjectiveDrift`
+
+### 6.2 Replay Integrity (`replay.ts`)
+
+* `replayRecommendation(audit, currentEngine)` takes a persisted audit, re-runs the recommendation pipeline against the snapshot state, and verifies that the output matches the original decision.
+* `isHistoricalPolicyVersion` detects when an audit was generated under an earlier policy version, letting replay tools distinguish intended algorithmic evolution from a regression defect.
+* **Validation**: fixture test `tests/fixtures/pre_zone_credit_recommendation_audit.json` verifies backward compatibility against a historical audit revision predating zone-derived credit (ADR-0022).
+
+---
+
+## 7. Engine Module Dependency Direction & Layer Inversions
+
+### 7.1 Coupling & Inversion Findings
+
+1. **Layer Inversion in Engine**:
+   - `app/src/engine/composer.ts` imports directly from `../services/` (`checkinService`, `goalService`, `preferencesService`, `recoverySnapshotService`, `trainingIntentProfileService`, `trainingSettingsService`).
+   - `app/src/engine/firestoreTrainingHistory.ts` imports directly from `../services/` (`activityService`, `recommendationService`, `strengthHistoryReadService`).
+   - *Architectural principle*: `app/src/engine/` should be a pure, functional domain layer. Services should orchestrate I/O and pass plain data into engine functions, rather than engine modules reaching back into stateful services.
+2. **Workouts / Catalog Coupling**:
+   - `engine/coverage.ts`, `engine/planningCandidate.ts`, `engine/weeklyDosePacking.ts`, and `engine/fixedActivityIdentity.ts` import directly from `app/src/workouts/catalog` and `app/src/workouts/event-plan`.
+   - The engine is tightly coupled to the static workout catalog definitions rather than operating against an abstract `WorkoutCatalogProvider` interface, which would make the engine testable against synthetic catalogs and would decouple catalog content changes from engine logic changes.
+
+---
+
+## 8. Dead and Experimental Code Reachability Audit
+
+1. **`sequenceSearch.ts`** (beam-search prototype referenced by ADR-0015, 410 lines):
+   - **Reachability**: verified safe. It is imported only by `goldenWeek.test.ts`, `sequenceSearch.test.ts`, and the architectural boundary tests `src/observations/architecture.test.ts` and `src/sessions/architecture.test.ts`.
+   - **Production isolation**: not imported by `rules.ts`, `planner.ts`, `composer.ts`, or any UI component. ADR-0015's "beam search deferred, greedy reservation used" status is accurate.
+2. **`shadowAgreement.ts` & `shadowLog.ts`**:
+   - **Reachability**: active in production. Used by `Home.tsx` and `recommendationService.ts` to compute `engineVerdict` (`proceed` | `scale` | `defer`) and to render CSV shadow-agreement telemetry — not dead code, but worth naming explicitly since "shadow" naming reads as experimental at a glance.
+3. **AI-judge tooling** (`app/scripts/ai-judge/`):
+   - **Reachability**: isolated to offline simulation scripts (`.mjs`, not `.ts`). Not imported by any `src/` module and not bundled into the Vite production application.
+
+---
+
+## 9. ADR Alignment Matrix (ADR-0001–ADR-0026)
+
+| ADR | Title | Status in Reality | Alignment Assessment |
+|---|---|---|---|
+| 0001 | Record Architecture Decisions | Active | Fully followed; ADRs are recorded and referenced. |
+| 0002 | User-Scoped Firestore Isolation | Active | Fully enforced in Python (`firestore_repository.py`) and in Firestore rules. |
+| 0003 | Timezone Semantics & D-1 Steps | Active | `Europe/Warsaw` strictly enforced (`dates.py`, `localDate.ts`). |
+| 0004 | Decoupled Workout Library | Active | `WorkoutDefinition` vs. `Prescription` separation active. |
+| 0005 | Raw Ingestion Archive & Rebuild | Active | GCS/Firestore raw archive and rebuild orchestrator operational. |
+| 0006 | Reconciled Strain Telemetry | Active (heuristic) | Telemetry active; "chronic overtraining" wording is a product heuristic label, not a clinical claim. |
+| 0007 | Adaptive Multi-Sport Engine | Active | Utility optimization pipeline active in `optimizer.ts`. |
+| 0008 | Rolling 7-Day Planning | Active | Rolling projection with confidence tiers active in `planner.ts`. |
+| 0009 | Training Intent History-Seeded | Active | Dynamic intent evaluation active in `trainingIntent.ts`. |
+| 0010 | Provenance, Audits & Replay | Active | Persisted audits and deterministic replay fully active. |
+| 0011 | Weekly Anchors & Ranking Modifiers | Partially displaced | Anchor utility tie-breaking remains in `optimizer.ts`; primary safety enforcement moved to lexicographic rules (ADR-0012/0018). The ADR text should be updated to note this displacement. |
+| 0012 | Plan Intent Authority | Active | Strict priority ordering and envelope constraints enforced. |
+| 0013 | Structured Injury Constraints | Active | Canonical `InjuryConstraint[]` mapping enforced in `injuryPolicy.ts`. |
+| 0014 | Objective Credit V2 & Honest Load | Active | Single credit ledger and delivered-dose scaling active. |
+| 0015 | Sequence Planning (Beam Search Deferred) | Active | Beam search kept in prototype (Section 8); greedy reservation used in production. |
+| 0016 | Adaptation Credit vs. Weekly Coverage | Active | Coverage registry and adaptation credit cleanly separated. |
+| 0017 | Training Intent Profiles & Modes | Active | `planningMode.ts` is the single authority for planning mode. |
+| 0018 | Weekly Allocation & Role Reservations | Active | Bounded deterministic reservation search active in `weeklyAllocation.ts`. |
+| 0019 | External Plans & Adjudication | Active | `externalSession.ts` adjudicates imported plans through the standard eligibility/dose gates. |
+| 0020 | Subjective Baselines in Readiness | Active | Recent-vs-long subjective baseline drift active in `subjectiveBaseline.ts`. |
+| 0021 | Strength Session Logging | Active | Exercise set tracking, RPE/RIR, and intensity gauges active. |
+| 0022 | Zone-Derived Training Credit | Active | Heart-rate/power zone time-allocation credit active. |
+| 0023 | Multidomain Session Authoring | Active | Pinned SHA-256 definitions, occurrences, and executions active. |
+| 0024 | Biometric Baseline Estimator Policy | Active | Metric-specific estimators (median/MAD for respiration, mean/stdev for HRV/RHR). |
+| 0025 | Physiological Anomaly Signals | Active | Illness-risk detection and anomaly classification active in `healthAnomaly.ts`. |
+| 0026 | Wearable Telemetry Boundaries | Active | High-resolution telemetry ingestion boundaries active. |
+
+**Action item**: ADR-0011 is the one entry that no longer describes reality precisely — it should get a short "Superseded in part by ADR-0012/0018" amendment rather than being silently reinterpreted by readers.
+
+---
+
+## 10. Complexity Hotspots and Change Coupling
+
+### 10.1 Top Complexity Modules (by line count)
+
+1. **`app/src/engine/validationCore.ts`** (1,690 lines) and **`app/src/engine/models.ts`** (1,653 lines): domain interfaces, JSON schemas, and validators for the entire engine. High churn and tight coupling to every subsystem — almost any new field touches both files.
+2. **`app/src/engine/planner.ts`** (1,497 lines): combines week-ahead generation, greedy slot filling, multi-day load projection, and fallback strategies in a single module.
+3. **`app/firestore.rules`** (1,471 lines): high cognitive complexity, and a manual, hand-maintained duplicate of the TypeScript model schemas (Section 2).
+4. **`app/src/engine/rules.ts`** (1,104 lines): envelope resolution, Path A selection, Path B selection, next-day scenario generation, and adjustment logic all in one file (Section 1).
+5. **`app/src/engine/optimizer.ts`** (921 lines): utility scoring, recovery-style resolution, history feature summaries, and candidate ranking.
+
+These five files are the natural starting point for any future decomposition effort — they concentrate both size and blast radius.
+
+---
+
+## 11. Explicit Contracts Between Subsystems
+
+To prevent cross-boundary integration regressions, this review introduces four formal contracts, each backed by a contract test suite that exercises the *real* production functions on both sides of the boundary rather than re-deriving expectations from documentation alone:
+
+```text
+┌─────────────────────────────────────────────────────────────┐
+│ 1. Ingestion <───> Canonical Observations / Snapshots        │
+│    (src/garmin_sync/models.py <──> DailyRecoverySnapshot)    │
+└──────────────────────────────┬───────────────────────────────┘
+                                │
+                                ▼
+┌─────────────────────────────────────────────────────────────┐
+│ 2. Observations <───> Recommendation Engine                  │
+│    (DailyReadiness, EngineObjectiveInput <──> rules.ts)       │
+└──────────────────────────────┬───────────────────────────────┘
+                                │
+                                ▼
+┌─────────────────────────────────────────────────────────────┐
+│ 3. Recommendation Engine <───> Persistence & Firestore Rules  │
+│    (Recommendation, RecommendationAudit <──> firestore.rules) │
+└──────────────────────────────┬───────────────────────────────┘
+                                │
+                                ▼
+┌─────────────────────────────────────────────────────────────┐
+│ 4. Persistence <───> Privileged Workout-Export Jobs           │
+│    (garmin_workout_queue <──> workout_export.py)              │
+└─────────────────────────────────────────────────────────────┘
+```
+
+1. **Contract 1 — Ingestion & Canonical Observations** (`app/src/contracts/ingestionSnapshotContract.ts`, `tests/test_contracts_ingestion.py`):
+   Formalizes payload shape, required vs. nullable biometric fields, version flags (`sourceSchemaVersion`, `baselineComputationVersion`), and Europe/Warsaw date invariants. The Python test round-trips a real `DailyRecoverySnapshot.to_dict()` and `normalize_activity()` payload; the TypeScript test feeds an equivalent literal payload through the real `parseRecoverySnapshot` parser.
+2. **Contract 2 — Observations & Recommendation Engine** (`app/src/contracts/observationEngineContract.ts`):
+   Formalizes subjective input bounds and the safety-envelope invariants (pain → `Mobility`/`Rest` only and `Running` restricted; already-trained-today → `Rest`; depressed sleep/body-battery → capped at `Easy`). The test calls the real `evaluateEnvelopes` from `rules.ts`, so it is exercised regardless of whether a future change routes through Path A or Path B.
+3. **Contract 3 — Engine & Persistence** (`app/src/contracts/enginePersistenceContract.ts`):
+   Formalizes the persisted `DailyRecommendation` document shape and the `RecommendationAudit` schema (history/envelope/candidateScores blocks, `safetyStatus`, `candidateScores.length <= 64`, matching the Firestore rule's own cap). The test runs a real `evaluateTrainingWithIntent` → `buildRecommendationAudit` → `parseDailyRecommendation` round trip.
+4. **Contract 4 — Persistence & Workout Export** (`app/src/contracts/workoutExportContract.ts`, `tests/test_contracts_workout_export.py`):
+   Formalizes the queued `GarminQueuedWorkout` document and its nested `CanonicalWorkoutExport` payload — the shape that actually crosses into `workout_export.py` (non-empty blocks/steps, a real `durationSeconds`/`repetitions` dose signal, `targets` as a string array). The Python test exercises the real `canonical_workout_to_garmin_payload`/`summarize_garmin_payload` and asserts the transformed duration/target/rest *values* survive, not just that a payload came back. A separate `validateCatalogWorkoutStructure` check still validates every entry of the app's authoring-time `WORKOUTS` catalog, but that catalog shape is explicitly *not* claimed to be the export wire contract (see 11.1).
+
+### 11.1 A Contract Test Catching a Real Boundary Bug
+
+While implementing Contract 4, comparing the TypeScript validator against the actual Python reader (`workout_export.py`'s `step.get("durationSeconds")`, `step.get("targets")`) surfaced two real defects in the first draft of this contract, both now fixed and covered by regression tests:
+
+1. **Wrong artifact validated.** The TypeScript side validated the app's authoring-time `WorkoutDefinition` catalog shape (`blocks[].steps[].duration.type`) as if it were the export wire contract. The shape that actually crosses to Python is `CanonicalWorkoutExport` (`app/src/utils/workoutJsonExport.ts`): `title`/`workoutId`, `blocks[].role`, `steps[].durationSeconds`, `steps[].targets: string[]`. These are different types with different field names — validating the catalog shape would never have caught a regression in the real export path. Fixed by adding `validateCanonicalWorkoutExportContract`, which checks the real `CanonicalWorkoutExport`/`GarminQueuedWorkout` shapes, and keeping the catalog check under its own, clearly-labeled name.
+2. **Silent fallback masked a wrong fixture.** The first draft's Python test built a step with `durationSec` (singular) and a `target: {...}` object — neither of which `workout_export.py` reads. Because `_build_step_dto` defaults to `step.get("durationSeconds") or 300` and `_compile_target_sources` falls back to `no.target` when it finds nothing, the test still passed: every step silently became a generic 300-second no-target block, and the assertions were loose enough not to notice. Fixed by renaming the fixture fields to match production and adding assertions on the actual transformed duration/target/rest values (`tests/test_contracts_workout_export.py`), so a future regression to the wrong field names fails loudly instead of silently degrading.
+
+This is the concrete case for contract tests the original prompt anticipated: a validator or fixture written by inference from documentation, rather than checked against the real reader on the other side of the boundary, can pass indefinitely while testing nothing real.
+
+### 11.2 Shared Cross-Language Fixtures
+
+Contract 1 and Contract 4 each span the Python/TypeScript boundary. Both now load one shared JSON fixture from `tests/fixtures/contracts/` (`ingestion_snapshot.json`, `normalized_activity.json`, `workout_export.json`) from both the `pytest` and the `vitest` suite, rather than each language hand-authoring its own literal. The Python tests assert their real serialization/transform functions reproduce the fixture's declared fields exactly (not just "some output came back"); the TypeScript tests run the same literal through the real parser/validator. A field renamed or removed on either side without updating the shared fixture now fails both suites, not neither.
+
+### 11.3 Scope Not Covered
+
+These contracts validate structure and range invariants; they do not (and cannot, from TypeScript alone) validate that `app/firestore.rules` accepts every document the contracts consider valid, or rejects every one they consider invalid — that still requires the emulator-backed rules tests (Section 3). Closing that last gap would mean generating rules-test fixtures from the same contract validators, which is a reasonable next step but out of scope for this pass.

--- a/tests/fixtures/contracts/ingestion_snapshot.json
+++ b/tests/fixtures/contracts/ingestion_snapshot.json
@@ -1,0 +1,55 @@
+{
+    "_comment": "Shared Contract 1 fixture (Ingestion <-> Canonical Observations). Loaded by both tests/test_contracts_ingestion.py and app/src/contracts/ingestionSnapshotContract.test.ts. Only fields the contract validates are listed here -- see src/garmin_sync/models.py for the full (larger) DailyRecoverySnapshot schema. Edit this file, not a copy, when the shared shape changes.",
+    "userId": "athlete-1",
+    "date": "2026-08-26",
+    "source": {
+        "sourceSchemaVersion": 3,
+        "garminSyncedAt": "2026-08-26T06:00:00Z"
+    },
+    "raw": {
+        "sleepScore": 85,
+        "sleepDurationSec": 28800,
+        "restingHr": 48,
+        "hrvOvernightAvg": 65.0,
+        "respirationAvg": 14.5,
+        "bodyBatteryWake": 85,
+        "bodyBatteryChange": 50,
+        "totalSteps": 9000,
+        "last3DaysHardSessionsCount": 1,
+        "yesterdayTraining": null,
+        "todayTraining": null
+    },
+    "derived": {
+        "baselineComputationVersion": 5,
+        "sleepScore7dAvg": 82.0,
+        "sleepScore28dAvg": 80.0,
+        "restingHr7dAvg": 49.0,
+        "restingHr28dAvg": 50.0,
+        "hrv7dAvg": 64.0,
+        "hrv28dAvg": 63.0,
+        "respiration7dAvg": 14.2,
+        "respiration28dAvg": 14.1,
+        "steps7dAvg": 9200.0,
+        "steps28dAvg": 8900.0,
+        "steps28dStdev": 1100.0,
+        "deltas": {
+            "sleepScoreVs7d": 3.0,
+            "sleepScoreVs28d": 5.0,
+            "restingHrVs7d": -1.0,
+            "restingHrVs28d": -2.0,
+            "hrvVs7d": 1.0,
+            "hrvVs28d": 2.0,
+            "respirationVs7d": 0.3,
+            "respirationVs28d": 0.4,
+            "stepsVs7d": -200.0,
+            "stepsVs28d": 100.0
+        }
+    },
+    "dataQuality": {
+        "sleepScoreAvailable": true,
+        "restingHrAvailable": true,
+        "hrvAvailable": true,
+        "baseline7dReady": true,
+        "baseline28dReady": true
+    }
+}

--- a/tests/fixtures/contracts/normalized_activity.json
+++ b/tests/fixtures/contracts/normalized_activity.json
@@ -1,0 +1,24 @@
+{
+    "_comment": "Shared Contract 1 fixture (normalized activity). Loaded by both tests/test_contracts_ingestion.py (as CanonicalActivity constructor args, snake_case) and app/src/contracts/ingestionSnapshotContract.test.ts (as the already-normalized camelCase output shape). Keep the two field sets in sync by hand -- they describe the same activity across the snake_case/camelCase boundary.",
+    "canonical": {
+        "activity_id": "act-101",
+        "date": "2026-08-26",
+        "type": "running",
+        "duration_min": 50,
+        "duration_seconds": 3000,
+        "training_effect_aerobic": 3.5,
+        "training_effect_anaerobic": 1.2,
+        "average_hr": 152.0,
+        "training_load": 120.0,
+        "intensity_tag": "hard"
+    },
+    "normalized": {
+        "activityId": "act-101",
+        "date": "2026-08-26",
+        "type": "running",
+        "durationMin": 50,
+        "intensityTag": "hard",
+        "syncRunId": "run-contract",
+        "syncedAt": "2026-08-26T12:00:00Z"
+    }
+}

--- a/tests/fixtures/contracts/workout_export.json
+++ b/tests/fixtures/contracts/workout_export.json
@@ -1,0 +1,64 @@
+{
+    "_comment": "Shared Contract 4 fixture (Persistence <-> Privileged Workout-Export Jobs). Loaded by both tests/test_contracts_workout_export.py and app/src/contracts/workoutExportContract.test.ts. `queueEntry` mirrors the real GarminQueuedWorkout document at users/{userId}/garmin_workout_queue/{date} (app/src/services/garminWorkoutQueueService.ts) -- note the status enum is pending|synced|failed, not in_flight|completed. `queueEntry.payload` is the real cross-language wire shape (CanonicalWorkoutExport, app/src/utils/workoutJsonExport.ts) that src/garmin_sync/service.py reads via `data.get('payload')` and hands to workout_export.py -- durationSeconds (not durationSec) and targets as a string array (not a target object).",
+    "queueEntry": {
+        "userId": "user-1",
+        "date": "2026-08-26",
+        "workoutTitle": "VO2 Max Intervals",
+        "modality": "cycling",
+        "status": "pending",
+        "queuedAt": "2026-08-26T06:30:00Z",
+        "syncedAt": null,
+        "error": null,
+        "payload": {
+            "schemaVersion": "canonical_workout_v1",
+            "title": "VO2 Max Intervals",
+            "workoutId": "cycling_vo2_intervals",
+            "modality": "cycling",
+            "targetDurationMin": 30,
+            "exportedAt": "2026-08-26T06:00:00Z",
+            "blocks": [
+                {
+                    "id": "warmup",
+                    "name": "Warm-up",
+                    "role": "warmup",
+                    "steps": [
+                        {
+                            "id": "wu_step",
+                            "name": "Easy spin",
+                            "durationSeconds": 600,
+                            "targets": ["140-160 W"]
+                        }
+                    ]
+                },
+                {
+                    "id": "intervals",
+                    "name": "VO2 Intervals",
+                    "role": "main",
+                    "steps": [
+                        {
+                            "id": "work_step",
+                            "name": "VO2 Repeat",
+                            "durationSeconds": 180,
+                            "sets": 4,
+                            "restAfterSec": 180,
+                            "targets": ["300-320 W"]
+                        }
+                    ]
+                },
+                {
+                    "id": "cooldown",
+                    "name": "Cool-down",
+                    "role": "cooldown",
+                    "steps": [
+                        {
+                            "id": "cd_step",
+                            "name": "Easy spin",
+                            "durationSeconds": 240,
+                            "targets": ["110-130 W"]
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/tests/test_contracts_ingestion.py
+++ b/tests/test_contracts_ingestion.py
@@ -1,0 +1,113 @@
+"""Contract 1: Ingestion <-> Canonical Observations / Snapshots.
+
+Loads the same JSON fixtures as app/src/contracts/ingestionSnapshotContract.test.ts
+(tests/fixtures/contracts/), so a field added to DailyRecoverySnapshot or
+CanonicalActivity without updating the TypeScript-side contract fails this suite
+too, instead of the two suites silently drifting apart.
+
+The fixtures only cover the subset of fields the contract validates -- see
+src/garmin_sync/models.py for the full DailyRecoverySnapshot schema, which carries
+many more optional/observation-only fields (metric enrichment, medians, MADs) than
+are worth coupling to a cross-language contract.
+"""
+
+import json
+import re
+from pathlib import Path
+
+from garmin_sync.canonical import CanonicalActivity
+from garmin_sync.mapper import normalize_activity
+from garmin_sync.models import (
+    DailyRecoverySnapshot,
+    DataQuality,
+    DerivedDeltas,
+    DerivedMetrics,
+    RawMetrics,
+    SourceMetadata,
+)
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures" / "contracts"
+
+
+def _load(name: str) -> dict:
+    return json.loads((FIXTURES_DIR / name).read_text(encoding="utf-8"))
+
+
+def _assert_subset(expected: dict, actual: dict, path: str = "") -> None:
+    """Assert every key in `expected` is present in `actual` with an equal value,
+    recursing into nested dicts. `actual` may have additional keys the fixture
+    doesn't care about (e.g. DailyRecoverySnapshot's many observation-only fields)."""
+    for key, expected_value in expected.items():
+        if key == "_comment":
+            continue
+        full_path = f"{path}.{key}" if path else key
+        assert key in actual, f"missing key {full_path!r} in real output"
+        actual_value = actual[key]
+        if isinstance(expected_value, dict):
+            assert isinstance(actual_value, dict), f"{full_path!r} expected an object"
+            _assert_subset(expected_value, actual_value, full_path)
+        else:
+            assert actual_value == expected_value, (
+                f"{full_path!r} mismatch: fixture says {expected_value!r}, "
+                f"real serialization produced {actual_value!r}"
+            )
+
+
+def test_ingestion_snapshot_contract_serialization() -> None:
+    fixture = _load("ingestion_snapshot.json")
+
+    snapshot = DailyRecoverySnapshot(
+        userId=fixture["userId"],
+        date=fixture["date"],
+        source=SourceMetadata(
+            sourceSchemaVersion=fixture["source"]["sourceSchemaVersion"],
+            garminSyncedAt=fixture["source"]["garminSyncedAt"],
+        ),
+        raw=RawMetrics(**{k: v for k, v in fixture["raw"].items() if k != "_comment"}),
+        derived=DerivedMetrics(
+            **{k: v for k, v in fixture["derived"].items() if k not in ("_comment", "deltas")},
+            deltas=DerivedDeltas(**fixture["derived"]["deltas"]),
+        ),
+        dataQuality=DataQuality(
+            **{k: v for k, v in fixture["dataQuality"].items() if k != "_comment"}
+        ),
+    )
+
+    payload = snapshot.to_dict()
+
+    # The real serialization must reproduce every fixture-declared field exactly --
+    # this is the cross-language contract, not just "some snapshot came out".
+    _assert_subset(fixture, payload)
+
+    # Range/shape invariants the TypeScript-side validator also enforces.
+    assert re.match(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}$", payload["date"])
+    assert payload["source"]["sourceSchemaVersion"] in [2, 3]
+    assert 0 <= payload["raw"]["sleepScore"] <= 100
+    assert 20 <= payload["raw"]["restingHr"] <= 240
+    assert payload["raw"]["totalSteps"] >= 0
+
+
+def test_normalized_activity_contract() -> None:
+    fixture = _load("normalized_activity.json")
+
+    activity = CanonicalActivity(
+        activity_id=fixture["canonical"]["activity_id"],
+        date=fixture["canonical"]["date"],
+        type=fixture["canonical"]["type"],
+        duration_min=fixture["canonical"]["duration_min"],
+        duration_seconds=fixture["canonical"]["duration_seconds"],
+        training_effect_aerobic=fixture["canonical"]["training_effect_aerobic"],
+        training_effect_anaerobic=fixture["canonical"]["training_effect_anaerobic"],
+        average_hr=fixture["canonical"]["average_hr"],
+        training_load=fixture["canonical"]["training_load"],
+        intensity_tag=fixture["canonical"]["intensity_tag"],
+    )
+
+    payload = normalize_activity(activity, sync_run_id=fixture["normalized"]["syncRunId"])
+
+    # syncedAt is stamped with a real timestamp by normalize_activity, so the
+    # fixture's value is a placeholder for the TS-side literal-shape test only --
+    # everything else must match exactly.
+    expected = {k: v for k, v in fixture["normalized"].items() if k != "syncedAt"}
+    _assert_subset(expected, payload)
+    assert isinstance(payload["syncedAt"], str) and payload["syncedAt"]

--- a/tests/test_contracts_workout_export.py
+++ b/tests/test_contracts_workout_export.py
@@ -1,0 +1,111 @@
+"""Contract 4: Persistence <-> Privileged Workout-Export Jobs.
+
+Loads the same JSON fixture as app/src/contracts/workoutExportContract.test.ts
+(tests/fixtures/contracts/workout_export.json) so a field-name or enum change on
+either side of the Python/TypeScript boundary has to update one shared fixture,
+not two independently-drifting literals.
+
+`workout_export.py` reads `durationSeconds` (not `durationSec`) and `targets` as a
+list of strings (not a `target` object) -- see canonical_workout_to_garmin_payload's
+`step.get("durationSeconds") or 300` fallback and `_compile_target_sources`. The
+assertions below check the *actual* transformed values (not just "some payload came
+back") specifically so a regression back to the wrong field names is caught: with
+the wrong names every step would silently fall back to a 300s duration and a
+`no.target` target type instead of failing loudly.
+"""
+
+import json
+from pathlib import Path
+
+from garmin_sync.workout_export import canonical_workout_to_garmin_payload, summarize_garmin_payload
+
+FIXTURE_PATH = Path(__file__).parent / "fixtures" / "contracts" / "workout_export.json"
+
+
+def _load_workout_payload() -> dict:
+    fixture = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+    return fixture["queueEntry"]["payload"]
+
+
+def _flatten_steps(steps: list[dict]) -> list[dict]:
+    """A step with sets > 1 gets wrapped in a RepeatGroupDTO (see
+    canonical_workout_to_garmin_payload's Case B), so its child ExecutableStepDTOs
+    live under `workoutSteps`, not at the top level -- recurse the same way
+    `summarize_garmin_payload`'s own `_count_recovery_steps` does."""
+    flat: list[dict] = []
+    for step in steps:
+        if step.get("type") == "RepeatGroupDTO":
+            flat.extend(_flatten_steps(step.get("workoutSteps", [])))
+        else:
+            flat.append(step)
+    return flat
+
+
+def test_workout_export_contract_transformation() -> None:
+    workout = _load_workout_payload()
+
+    payload = canonical_workout_to_garmin_payload(workout)
+
+    assert payload["workoutName"] == "VO2 Max Intervals"
+    assert payload["sportType"]["sportTypeKey"] == "cycling"
+    assert len(payload["workoutSegments"]) > 0
+
+    summary = summarize_garmin_payload(workout, payload)
+    assert summary["modality"] == "Cycling" or summary["modality"] == "cycling"
+    assert summary["garminTopLevelStepCount"] >= 3
+
+
+def test_workout_export_honors_durationSeconds_not_a_fallback_default() -> None:
+    """Regression guard: `_build_step_dto` defaults to a 300s block whenever
+    `durationSeconds` is missing/misnamed. The fixture's warm-up step is 600s and
+    its main interval step is 180s -- neither equals the 300s fallback, so this
+    fails loudly if the field name silently stops matching (e.g. a future rename
+    to `durationSec` on either side without updating the other)."""
+    workout = _load_workout_payload()
+    payload = canonical_workout_to_garmin_payload(workout)
+
+    all_steps = _flatten_steps(payload["workoutSegments"][0]["workoutSteps"])
+    durations = [s["endConditionValue"] for s in all_steps if s.get("type") == "ExecutableStepDTO"]
+
+    assert 600 in durations, (
+        f"expected the warm-up's durationSeconds=600 to survive, got {durations}"
+    )
+    assert 180 in durations, (
+        f"expected the main interval's durationSeconds=180 to survive, got {durations}"
+    )
+    assert 300 not in durations, (
+        "a step landed on workout_export.py's 300s fallback default -- this means "
+        "durationSeconds wasn't recognized on at least one step"
+    )
+
+
+def test_workout_export_honors_targets_list_not_a_target_object() -> None:
+    """Regression guard: `_compile_target_sources` reads `targets` (a list of
+    strings) and falls back to `no.target` if it can't find a power/zone match
+    anywhere. The fixture's main interval targets '300-320 W', which must resolve
+    to an actual power.zone target, not silently degrade to no.target."""
+    workout = _load_workout_payload()
+    payload = canonical_workout_to_garmin_payload(workout)
+
+    all_steps = _flatten_steps(payload["workoutSegments"][0]["workoutSteps"])
+    main_step = next(
+        s
+        for s in all_steps
+        if s.get("endConditionValue") == 180 and s.get("type") == "ExecutableStepDTO"
+    )
+
+    assert main_step["targetType"]["workoutTargetTypeKey"] == "power.zone"
+    assert main_step["targetValueOne"] == 300.0
+    assert main_step["targetValueTwo"] == 320.0
+
+
+def test_workout_export_rest_step_uses_restAfterSec() -> None:
+    workout = _load_workout_payload()
+    payload = canonical_workout_to_garmin_payload(workout)
+
+    all_steps = _flatten_steps(payload["workoutSegments"][0]["workoutSteps"])
+    rest_steps = [s for s in all_steps if s.get("stepType", {}).get("stepTypeKey") == "recovery"]
+
+    assert any(s["endConditionValue"] == 180 for s in rest_steps), (
+        "expected a 180s recovery step from the main interval's restAfterSec=180"
+    )


### PR DESCRIPTION
## Summary

Continues and hardens a prior agent's architecture-and-maintainability review of the system's Python ingestion / TypeScript engine / Firestore rules boundaries, per the original review prompt (authoritative selection path, policy duplication, Firestore rules testability, client vs. server authority, schema migration, audit backward-compatibility, engine dependency direction, dead code reachability, ADR alignment, complexity hotspots, and explicit cross-boundary contracts).

## What changed

**Rewrote the review document** ([docs/analysis/2026-08-26-architecture-and-maintainability-review.md](docs/analysis/2026-08-26-architecture-and-maintainability-review.md)): the version left on this branch was badly corrupted — every inline-code backtick had been silently eaten by what looks like a PowerShell write step (e.g. `` `rules.ts` `` rendered as `ules.ts`, `` `replay.ts` `` as `eplay.ts`). I verified the underlying technical claims against the real codebase (file line counts, the Path A/Path B selection split, engine→services layer inversions, dead-code reachability) — they mostly held up — corrected the few drifts found, and rewrote the doc cleanly.

**Fixed a real bug in Contract 4 (Persistence ↔ Privileged Workout-Export Jobs)**, the boundary the review's own prompt called out as a priority:
1. The TypeScript validator checked the app's authoring-time `WorkoutDefinition` catalog shape instead of `CanonicalWorkoutExport`, the shape that actually crosses into `workout_export.py`. Added `validateCanonicalWorkoutExportContract`/`validateQueuedWorkoutContract` against the real wire shapes; kept the catalog check under its own clearly-labeled name.
2. The Python contract test's literal fixture used `durationSec`/`target: {...}`, fields `workout_export.py` never reads — its silent fallback defaults (300s duration, `no.target`) masked the mismatch, so the test passed while validating nothing real. Rewrote the fixture to the real field names and added assertions on the actual transformed duration/target/rest values so this can't hide again.

**Added shared cross-language fixtures** ([tests/fixtures/contracts/](tests/fixtures/contracts/)): Contract 1 (ingestion) and Contract 4 (workout export) now load one JSON fixture from both the `pytest` and `vitest` suites, so a field rename/removal on either side of the Python/TypeScript boundary fails both suites instead of neither — closing the exact drift risk the review itself identifies (Section 2).

**Fixed pre-existing lint errors** in the contract modules (`@typescript-eslint/no-explicit-any`) that would have failed `npm run check`, using the same `eslint-disable` convention already established in `engine/validationCore.ts`.

## Verification

- `tsc --noEmit`: clean
- `eslint app/src/contracts`: clean
- `vitest run app/src/contracts`: 14/14 passing
- `pytest tests/test_contracts_ingestion.py tests/test_contracts_workout_export.py`: 6/6 passing
- `ruff check` / `ruff format --check`: clean
- `mypy`: clean
- Full pre-commit and pre-push hooks (including the frontend typecheck/lint/test/workout-validation suite) passed on commit and push

## Notes for reviewers

- No production code paths changed — this PR is documentation plus new contract-test infrastructure (`app/src/contracts/`, `tests/test_contracts_*.py`, `tests/fixtures/contracts/`).
- The review document flags several follow-ups it does *not* attempt in this pass (deprecating Path A `evaluateTraining`, an `WorkoutCatalogProvider` abstraction, an ADR-0011 amendment, generating Firestore-rules fixtures from the contract validators) — see Section 11.3 and the remediation notes in Sections 1 and 9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added validation for recovery data, readiness inputs, recommendations, workout exports, and activity records.
  - Added safeguards for pain, recovery, rest, workout status, required fields, and invalid ranges.
  - Added cross-platform contract checks to keep serialized data consistent.

- **Documentation**
  - Added an architecture and maintainability review covering integration boundaries and compatibility considerations.

- **Tests**
  - Added comprehensive shared-fixture tests for ingestion, recommendation persistence, observation safety, and workout exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->