### PR TITLE
✍️ Scribe: [documentation improvement] Fix missing 2026-08-26 analysis docs in docs/README.md index

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -1,3 +1,7 @@
 ## 2026-08-16 - README.md Missing Technical Features
 **Learning:** `README.md` was missing two major features: Decision Provenance & Audit Replay (ADR-0010) and Rolling 7-Day Week-Ahead Planning (ADR-0008). This was documented as finding F13 in `docs/analysis/2026-08-08-architecture-review.md`.
 **Action:** When auditing documentation drift, always compare feature lists in READMEs against the accepted Architectural Decision Records (ADRs) to ensure the high-level documentation reflects recent architectural additions.
+
+## 2026-08-26 - README.md Index Missing Recent Analysis Documents
+**Learning:** The documentation hub (docs/README.md) acts as the routing table but can easily fall out of sync with newly added review/analysis files in docs/analysis/.
+**Action:** Always verify that newly added files in docs/analysis/ are indexed in the root docs/README.md.

--- a/docs/README.md
+++ b/docs/README.md
@@ -105,6 +105,9 @@ Point-in-time assessments of the system as built, including gaps between documen
 * [**2026-08-21 Performance outcome validation**](./analysis/2026-08-21-performance-outcome-validation.md) — Closes the recommendation → adaptation loop: the repeated-testing usage trigger formerly recorded under M7 has fired, and OV is the dedicated evidence-only outcome/progress/block-report implementation plan rather than a parallel M task family.
 * [**2026-08-21 Physiological anomaly and illness-risk research**](./analysis/2026-08-21-physiological-anomaly-and-illness-risk-research.md) — Evidence-backed research into respiratory rate, RHR, HRV, and confounder modelling for health anomaly alerting.
 * [**2026-08-21 Post-HA-D plan reconciliation**](./analysis/2026-08-21-post-ha-d-plan-reconciliation.md) — Status audit of executable tasks across HA, OV, S, and Multidomain following PR #171.
+* [**2026-08-26 Architecture and maintainability review**](./analysis/2026-08-26-architecture-and-maintainability-review.md) — Architectural integrity, policy boundaries, and schema evolution audit across the backend, frontend, and rules layer.
+* [**2026-08-26 Scientific and recommendation-quality validation**](./analysis/2026-08-26-scientific-and-recommendation-quality-validation.md) — Point-in-time analysis of physiological/mathematical validity of signals, baseline sensitivity, and closed-loop feedback design.
+* [**2026-08-26 Scientific validation PR review hardening**](./analysis/2026-08-26-scientific-validation-review-hardening.md) — Review corrections for the SV1–SV3 evidence-sidecar implementation.
 * [**Phase 9.4 Subjective history integration**](./analysis/phase-9-4-subjective-history-integration.md) — Integration analysis for composition-boundary range reads and data-quality handling.
 
 ---


### PR DESCRIPTION
📄 **What:** Added the three recently merged `2026-08-26` analysis documents to the `docs/README.md` `🔍 Reviews & Analysis` index. Also recorded a new Scribe learning in `.jules/scribe.md` about keeping the routing table in sync.

⚠️ **Problem:** The documentation hub (`docs/README.md`) acts as a central routing table for all ADRs, architecture docs, and point-in-time analyses. However, three recent and highly significant review documents from August 26, 2026, were placed in `docs/analysis/` but never added to the central index, making them hard to discover and violating the documentation maintenance guidelines (orphan documents).

📚 **Source of truth:** Directory listing of `docs/analysis/` vs the contents of `docs/README.md`.

✅ **Verification:** Ran `make check` to ensure no Markdown formatting or related codebase linting/testing was broken. Tests passed. 

🎯 **Impact:** Future developers and agents reading `docs/README.md` will immediately see the latest architectural and scientific validation reviews, reducing friction and preventing duplicate work or misunderstanding of the current validated state.

🔒 **Governance:** No product scope, architecture, or policy was expanded. Only the documentation index was updated to reflect existing files.

---
*PR created automatically by Jules for task [3964210739201055706](https://jules.google.com/task/3964210739201055706) started by @Szczepanov*