### PR TITLE
fix(phase-9-0): restore reveal gate, fix undefined theme vars, unhide journal

### DIFF
--- a/app/src/components/Home.css
+++ b/app/src/components/Home.css
@@ -18,6 +18,38 @@
   margin: 0;
 }
 
+/* Phase 9.0.3 reveal gate: recovered after being dropped, along with the JSX that renders
+   it, by the mobile-responsiveness redesign (b97c248) that hardcoded
+   recommendationEffectivelyRevealed to true. */
+.recommendation-hidden {
+  text-align: center;
+  padding: 1rem 0.5rem;
+}
+
+.reveal-recommendation-btn {
+  margin: 0.75rem 0;
+  padding: 0.6rem 1.25rem;
+  border-radius: 10px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  border: 1px solid rgba(56, 189, 248, 0.4);
+  background: var(--card-background);
+  color: var(--text-color);
+  transition: all 0.2s;
+}
+
+.reveal-recommendation-btn:hover {
+  background: var(--hover-background);
+}
+
+.reveal-hint {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  max-width: 32rem;
+  margin: 0 auto;
+}
+
 .logout-btn {
   background: rgba(239, 68, 68, 0.2);
   color: #f87171;

--- a/app/src/components/Home.tsx
+++ b/app/src/components/Home.tsx
@@ -96,7 +96,8 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
   const [error, setError] = useState<string | null>(null);
   const [errorRepairTargets, setErrorRepairTargets] = useState<ErrorRepairAction[]>([]);
   const [pendingAdherence, setPendingAdherence] = useState<{ date: string; recommendation: DailyRecommendation } | null>(null);
-  const [, setTodaysJournalEntry] = useState<DecisionJournalEntry | null>(null);
+  const [recommendationRevealed, setRecommendationRevealed] = useState(false);
+  const [todaysJournalEntry, setTodaysJournalEntry] = useState<DecisionJournalEntry | null>(null);
   const [historySnapshot, setHistorySnapshot] = useState<TrainingHistorySnapshot | null>(null);
   const [yesterdaySnapshot, setYesterdaySnapshot] = useState<DailyRecoverySnapshot | null>(null);
   const [yesterdayRecommendation, setYesterdayRecommendation] = useState<DailyRecommendation | null>(null);
@@ -125,6 +126,7 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
     }
   }, [userId]);
   const handleJournalEntryChange = useCallback((entry: DecisionJournalEntry | null) => setTodaysJournalEntry(entry), []);
+  const handleRevealRecommendation = useCallback(() => setRecommendationRevealed(true), []);
   const dashboardRequest = useRef(0);
 
   useEffect(() => {
@@ -597,7 +599,13 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
     onSynced: loadDashboardData,
   });
 
+  // Phase 9.0.3: a new calendar day starts hidden again. todaysJournalEntry must be reset
+  // here too, not left to DecisionJournalCard's own async read -- otherwise a non-null
+  // entry from yesterday would make recommendationEffectivelyRevealed true for today until
+  // the new fetch resolves, revealing today's recommendation before the athlete has had a
+  // chance to record (or decline to record) today's blind verdict.
   useEffect(() => {
+    setRecommendationRevealed(false);
     setTodaysJournalEntry(null);
   }, [decisionInput?.date]);
 
@@ -794,7 +802,7 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
   const todaysEngineVerdict = activeRec && canGenerateNormalPlan
     ? resolveEngineShadowVerdict(activeRec.mode, activeRec.externalVerdict?.decision)
     : null;
-  const recommendationEffectivelyRevealed = true;
+  const recommendationEffectivelyRevealed = recommendationRevealed || !!todaysJournalEntry;
 
   const eventPeriodization = useMemo(() => {
     if (!decisionInput) return null;
@@ -998,27 +1006,53 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
             <DataConfidenceIndicator confidence={decisionInput?.dataConfidence} onRefresh={loadDashboardData} />
           </div>
 
+          {/* Phase 9.0.3: the journal renders first and un-collapsed, above the reveal gate
+              it controls -- it was previously buried in the sidebar's collapsed "More
+              insights" disclosure, where an athlete had no reason to open it before ever
+              seeing today's recommendation. */}
+          {decisionInput && (
+            <DecisionJournalCard
+              userId={userId}
+              date={decisionInput.date}
+              engineVerdict={todaysEngineVerdict}
+              engineRevealed={recommendationEffectivelyRevealed}
+              onEntryChange={handleJournalEntryChange}
+            />
+          )}
+
           {/* Hero Morning Decision Card with Progressive Disclosure */}
           {activeRec ? (
-            <MorningDecisionCard
-              userId={userId}
-              date={decisionInput?.date ?? ''}
-              recommendation={activeRec}
-              evidence={morningEvidence}
-              prescription={activeRec?.prescription}
-              adjustmentDirection={adjustmentDirection}
-              activeAlternativeId={activeAlternativeId}
-              isGateLocked={recommendation?.envelopes?.safety.clinicalFlagActive ?? false}
-              gateLockedReason={recommendation?.envelopes?.safety.clinicalFlagActive ? 'Harder option is disabled because an active pain or injury flag restricts physical loading.' : undefined}
-              onAdjustLoad={handleAdjustSession}
-              onSelectTimeCrunch={handleSelectTimeCrunch}
-              onSelectHomeAlternative={handleSelectHomeAlternative}
-              onSelectMobilityAlternative={handleSelectMobilityAlternative}
-              onSelectActiveRecoveryWalk={handleSelectActiveRecoveryWalk}
-              onResetAlternative={handleResetAlternative}
-              onStartSession={onStartSession}
-              onOpenReclassify={recentActivities.length > 0 ? () => setReclassifyModalOpen(true) : undefined}
-            />
+            canGenerateNormalPlan && !recommendationEffectivelyRevealed ? (
+              <div className="dashboard-card recommendation-hidden">
+                <p className="card-empty">Today's recommendation is ready.</p>
+                <button type="button" className="reveal-recommendation-btn" onClick={handleRevealRecommendation}>
+                  👁️ Reveal today's recommendation
+                </button>
+                <p className="reveal-hint">
+                  Recording your own plan's verdict first is what the Decision Journal card above measures.
+                </p>
+              </div>
+            ) : (
+              <MorningDecisionCard
+                userId={userId}
+                date={decisionInput?.date ?? ''}
+                recommendation={activeRec}
+                evidence={morningEvidence}
+                prescription={activeRec?.prescription}
+                adjustmentDirection={adjustmentDirection}
+                activeAlternativeId={activeAlternativeId}
+                isGateLocked={recommendation?.envelopes?.safety.clinicalFlagActive ?? false}
+                gateLockedReason={recommendation?.envelopes?.safety.clinicalFlagActive ? 'Harder option is disabled because an active pain or injury flag restricts physical loading.' : undefined}
+                onAdjustLoad={handleAdjustSession}
+                onSelectTimeCrunch={handleSelectTimeCrunch}
+                onSelectHomeAlternative={handleSelectHomeAlternative}
+                onSelectMobilityAlternative={handleSelectMobilityAlternative}
+                onSelectActiveRecoveryWalk={handleSelectActiveRecoveryWalk}
+                onResetAlternative={handleResetAlternative}
+                onStartSession={onStartSession}
+                onOpenReclassify={recentActivities.length > 0 ? () => setReclassifyModalOpen(true) : undefined}
+              />
+            )
           ) : (
             <div className="dashboard-card empty-recommendation-card">
               <p className="card-empty">
@@ -1097,16 +1131,6 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
               date={pendingAdherence.date}
               recommendation={pendingAdherence.recommendation}
               onResolved={handlePendingAdherenceResolved}
-            />
-          )}
-
-          {decisionInput && (
-            <DecisionJournalCard
-              userId={userId}
-              date={decisionInput.date}
-              engineVerdict={todaysEngineVerdict}
-              engineRevealed={recommendationEffectivelyRevealed}
-              onEntryChange={handleJournalEntryChange}
             />
           )}
 

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -23,6 +23,25 @@
   --touch-target-min: 44px;
   --radius-card: 14px;
   --radius-control: 10px;
+
+  /* Aliases: several components (DecisionJournalCard, AdherencePrompt, ActivityTelemetry,
+     DataView, Home's reveal gate, TestingWorkflow) reference --text-color/--card-background/
+     --border-color/--hover-background, which were never actually defined anywhere in this
+     theme. An undefined var() falls back to the property's initial/inherited value rather
+     than the intended dark surface, which is what produced form controls (e.g. the Decision
+     Journal's verdict <select>) rendering as unstyled black-on-white or white-on-white
+     depending on browser/OS defaults. Aliased to the real tokens above instead of hunting
+     down and rewriting every call site. */
+  --text-color: var(--text-primary);
+  --card-background: var(--surface-card);
+  --border-color: rgba(148, 163, 184, 0.24);
+  --hover-background: rgba(255, 255, 255, 0.06);
+
+  /* This app has one dark theme only. Without this, native form-control chrome (a <select>'s
+     own dropdown popup, checkboxes, scrollbars) renders using the browser/OS default color
+     scheme -- typically light -- regardless of the author styles above, which is the other
+     half of how "white text on white background" happens inside an open <select> popup. */
+  color-scheme: dark;
 }
 
 body {


### PR DESCRIPTION
## What prompted this

Reported: the Decision Journal is "quite hidden" and its inputs render as white text on white background.

## Three real defects found, not just cosmetics

**1. The reveal gate was silently dropped.** `Home.tsx`'s `recommendationEffectivelyRevealed` was hardcoded to `true`, regressed by the earlier mobile-responsiveness redesign (b97c248), which removed the click-driven reveal state, the reveal button, and the conditional hiding of the recommendation card. Effect: today's recommendation was always shown immediately, which makes `sawEngineVerdictFirst` always `true` — **structurally blocking [9.0.7](docs/plans/phase-9-0-shadow-mode-and-decision-journal.md)'s ≥7-blind-day gate forever**, no matter how diligently the journal is used. Restored the state, button, placeholder, and day-rollover reset.

**2. The contrast bug is a real, pre-existing, repo-wide bug — not isolated to this card.** `--text-color`, `--card-background`, `--border-color`, and `--hover-background` are referenced across six components (`DecisionJournalCard`, `AdherencePrompt`, `ActivityTelemetry`, `DataView`, `Home`, `TestingWorkflow`) but were **never defined anywhere** in this theme (`index.css` only defines `--text-primary`, `--surface-card`, etc.). An undefined `var()` falls back to the property's initial/inherited value instead of the intended dark surface — that's what produced the verdict `<select>` rendering illegibly. Aliased the missing tokens to the real ones in `index.css`'s `:root`, plus `color-scheme: dark` so native form-control chrome (a `<select>`'s own dropdown popup) doesn't default to a light system scheme underneath dark author styles.

**3. The journal was buried.** It rendered inside the sidebar's collapsed `<details>`/"More insights & history" disclosure, below Profile Completeness and the adherence prompt — despite being the one thing that has to happen *before* the athlete looks at today's recommendation. Moved it to the top of the main column, above the (now-restored) reveal gate it controls.

## Verification

`npm run typecheck` / `lint` / `test` all pass — 2427 tests, 0 regressions. No test file exists for `Home.tsx` to extend for the reveal-gate fix specifically; flagging as a coverage gap rather than silently leaving it untested.

## Changes

- [app/src/components/Home.tsx](app/src/components/Home.tsx)
- [app/src/components/Home.css](app/src/components/Home.css)
- [app/src/index.css](app/src/index.css)

🤖 Generated with [Claude Code](https://claude.com/claude-code)