### PR TITLE
feat: preview structured sessions before starting

### DIFF
--- a/app/src/components/session/SessionRunner.css
+++ b/app/src/components/session/SessionRunner.css
@@ -107,6 +107,14 @@
     color: #94a3b8;
 }
 
+.fixture-card-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+}
+
 .start-fixture-btn {
     background: #3b82f6;
     color: #ffffff;
@@ -121,6 +129,52 @@
 
 .start-fixture-btn:hover {
     background: #2563eb;
+}
+
+.preview-fixture-btn,
+.preview-back-button {
+    background: transparent;
+    color: #cbd5e1;
+    border: 1px solid #64748b;
+    border-radius: 6px;
+    padding: 0.6rem 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    white-space: nowrap;
+    min-height: 44px;
+}
+
+.preview-fixture-btn:hover,
+.preview-back-button:hover {
+    background: #1e293b;
+    border-color: #94a3b8;
+}
+
+.preview-fixture-btn:disabled {
+    cursor: wait;
+    opacity: 0.65;
+}
+
+.session-definition-preview-screen {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.preview-back-button {
+    align-self: flex-start;
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
 }
 
 /* Running Session Styles */
@@ -879,6 +933,10 @@
         flex-direction: column;
         align-items: flex-start;
     }
+    .fixture-card-actions {
+        width: 100%;
+    }
+    .preview-fixture-btn,
     .start-fixture-btn {
         width: 100%;
     }

--- a/app/src/components/session/SessionRunner.test.tsx
+++ b/app/src/components/session/SessionRunner.test.tsx
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { SessionRunner } from './SessionRunner';
+
+vi.mock('../../hooks/useSessionRunner', () => ({
+    useSessionRunner: () => ({
+        activeStep: null,
+        activeBlock: null,
+        activeBlockIndex: 0,
+        activeStepIndex: 0,
+        definition: null,
+        entries: [],
+        execution: null,
+        isRestoring: false,
+    }),
+}));
+
+vi.mock('../../hooks/useOverloadHistory', () => ({
+    useOverloadHistory: () => ({ history: [], select: vi.fn() }),
+}));
+
+vi.mock('../../services/sessionDefinitionService', () => ({
+    sessionDefinitionService: {
+        getDefinitionRevision: vi.fn(),
+        listDefinitionHeaders: vi.fn(),
+    },
+}));
+
+describe('SessionRunner session picker', () => {
+    it('offers a preview before starting every reviewed session', () => {
+        const html = renderToStaticMarkup(<SessionRunner userId="user-1" />);
+
+        expect(html).toContain('Start a Structured Session');
+        expect(html).toContain('Preview');
+        expect(html).toContain('Start Session →');
+    });
+});

--- a/app/src/components/session/SessionRunner.tsx
+++ b/app/src/components/session/SessionRunner.tsx
@@ -18,6 +18,7 @@ import { stepName } from '../../sessions/stepDisplay';
 import { GroupProgress } from './GroupProgress';
 import { ChoiceCard } from './ChoiceCard';
 import { ExerciseSwapModal } from './ExerciseSwapModal';
+import { SessionDefinitionPreview } from './SessionDefinitionPreview';
 import { isSoundEnabled, setSoundEnabled } from '../../utils/audioFeedback';
 import './SessionRunner.css';
 
@@ -109,6 +110,11 @@ export const SessionRunner: React.FC<SessionRunnerProps> = ({
     const [savedDefinitions, setSavedDefinitions] = useState<SessionDefinitionHeader[]>([]);
     const [savedDefinitionsError, setSavedDefinitionsError] = useState<string | null>(null);
     const [startingSavedDefinitionId, setStartingSavedDefinitionId] = useState<string | null>(null);
+    const [previewDefinition, setPreviewDefinition] = useState<{
+        definition: SessionDefinition;
+        header?: SessionDefinitionHeader;
+    } | null>(null);
+    const [previewingSavedDefinitionId, setPreviewingSavedDefinitionId] = useState<string | null>(null);
     // M4.3: a companion is a separately executable session referenced from the one that just
     // finished (SessionDefinition.companionSessions), never an embedded block -- those already
     // render inline within the same execution. Starting one creates its own execution; it may
@@ -292,6 +298,22 @@ export const SessionRunner: React.FC<SessionRunnerProps> = ({
             setSavedDefinitionsError(error instanceof Error ? error.message : 'Could not start the saved session.');
         } finally {
             setStartingSavedDefinitionId(null);
+        }
+    };
+
+    const previewSavedDefinition = async (header: SessionDefinitionHeader) => {
+        setPreviewingSavedDefinitionId(header.definitionId);
+        setSavedDefinitionsError(null);
+        try {
+            const result = await sessionDefinitionService.getDefinitionRevision(userId, header.definitionId, header.latestRevision);
+            if (result.status !== 'AVAILABLE') {
+                throw new Error(result.status === 'MISSING' ? 'The latest saved revision is missing.' : 'The saved session cannot be read safely.');
+            }
+            setPreviewDefinition({ definition: result.data, header });
+        } catch (error) {
+            setSavedDefinitionsError(error instanceof Error ? error.message : 'Could not preview the saved session.');
+        } finally {
+            setPreviewingSavedDefinitionId(null);
         }
     };
 
@@ -508,6 +530,24 @@ export const SessionRunner: React.FC<SessionRunnerProps> = ({
         }
         return (
             <div className="session-runner-container no-active">
+                {previewDefinition ? (
+                    <section className="session-definition-preview-screen" aria-labelledby="session-definition-preview-title">
+                        <button type="button" className="preview-back-button" onClick={() => setPreviewDefinition(null)}>
+                            ← All structured sessions
+                        </button>
+                        <h2 id="session-definition-preview-title" className="sr-only">Session preview</h2>
+                        <SessionDefinitionPreview
+                            definition={previewDefinition.definition}
+                            onStart={() => {
+                                if (previewDefinition.header) {
+                                    void startSavedDefinition(previewDefinition.header);
+                                } else {
+                                    void runner.startFixtureSession(previewDefinition.definition);
+                                }
+                            }}
+                        />
+                    </section>
+                ) : <>
                 <header className="session-runner-header">
                     <h2>🚀 Start a Structured Session</h2>
                     <p className="session-runner-subtitle">Start a reviewed session, or make one that is stored and validated before execution.</p>
@@ -526,9 +566,19 @@ export const SessionRunner: React.FC<SessionRunnerProps> = ({
                                 <h3 className="fixture-title">{header.title}</h3>
                                 {header.dominantModality && <p className="fixture-summary">{header.dominantModality}</p>}
                             </div>
-                            <button type="button" className="start-fixture-btn" disabled={startingSavedDefinitionId !== null} onClick={() => startSavedDefinition(header)}>
-                                {startingSavedDefinitionId === header.definitionId ? 'Starting…' : 'Start session'}
-                            </button>
+                            <div className="fixture-card-actions">
+                                <button
+                                    type="button"
+                                    className="preview-fixture-btn"
+                                    disabled={previewingSavedDefinitionId !== null}
+                                    onClick={() => { void previewSavedDefinition(header); }}
+                                >
+                                    {previewingSavedDefinitionId === header.definitionId ? 'Loading…' : 'Preview'}
+                                </button>
+                                <button type="button" className="start-fixture-btn" disabled={startingSavedDefinitionId !== null} onClick={() => { void startSavedDefinition(header); }}>
+                                    {startingSavedDefinitionId === header.definitionId ? 'Starting…' : 'Start session'}
+                                </button>
+                            </div>
                         </div>)}
                     </div>
                 </section>}
@@ -540,16 +590,22 @@ export const SessionRunner: React.FC<SessionRunnerProps> = ({
                                 <h3 className="fixture-title">{fixture.title}</h3>
                                 <p className="fixture-summary">{fixture.summary || `${fixture.blocks.length} blocks`}</p>
                             </div>
-                            <button
-                                type="button"
-                                className="start-fixture-btn"
-                                onClick={() => runner.startFixtureSession(fixture)}
-                            >
-                                Start Session →
-                            </button>
+                            <div className="fixture-card-actions">
+                                <button type="button" className="preview-fixture-btn" onClick={() => setPreviewDefinition({ definition: fixture })}>
+                                    Preview
+                                </button>
+                                <button
+                                    type="button"
+                                    className="start-fixture-btn"
+                                    onClick={() => { void runner.startFixtureSession(fixture); }}
+                                >
+                                    Start Session →
+                                </button>
+                            </div>
                         </div>
                     ))}
                 </div>
+                </>}
             </div>
         );
     }


### PR DESCRIPTION
## Summary

Adds a preview-first path to the Structured Sessions picker so athletes can inspect a session before committing to start it. It also makes the Decision Journal recede once it has fulfilled its morning reveal-gate role.

### Structured session previews

- Adds a `Preview` action alongside `Start` for reviewed fixture sessions and persisted saved definitions.
- Loads the saved definition's current validated revision before rendering it, preserving the existing fail-closed `DataState` handling for missing, invalid, or unavailable revisions.
- Reuses `SessionDefinitionPreview`, showing blocks, execution order, doses, effort/rest/tempo prescriptions, notes, stop conditions, authored choices, and companion-session references.
- Keeps preview and execution distinct: opening a preview does not create an occurrence or execution; starting continues through the existing unplanned-launch path.

### Decision Journal follow-up

- Shows the unrecorded journal only on the primary dashboard, where it acts as the intentional recommendation-reveal gate.
- Moves a recorded journal into the collapsed **More insights & history** area, retaining access to its locked morning record and editable actual outcome without competing with today’s plan.
- Makes actual-outcome persistence explicit: a successful save shows the recorded value and a disabled `Saved ✓` button; choosing a different value changes the action to `Update result`.
- Adds a deterministic recorded-journal visual scenario and makes the visual journal service stateful so the reviewed state survives remounting.

## Validation

- `npm run typecheck`
- `npm run lint -- --quiet`
- `npm test` — 2,452 passed, 128 skipped
- `npm run build:bundle`
- Mobile local UI verification: saved morning journal is absent from the primary dashboard and available in More insights; saved actual outcome shows its recorded value and `Saved ✓` confirmation.

## Scope

UI-only changes. No session-definition schema, persistence path, occurrence authority, or recommendation-engine behavior changed. Decision-journal evidence semantics remain unchanged: the morning verdict stays immutable, while only the actual outcome is editable.