### PR TITLE
Claude/physiological identity passport 7880a7

### DIFF
--- a/app/firestore.rules
+++ b/app/firestore.rules
@@ -81,9 +81,52 @@ service cloud.firestore {
         && drift.perMetricContributions.motivation is number && drift.perMetricContributions.motivation >= 0;
     }
 
-    function hasValidRecommendationAudit(audit) {
+    function hasMatchingIdentityReview(userId, identity) {
+      let reviewPath = /databases/$(database)/documents/users/$(userId)/health_identity_review_events/$(identity.reviewEventId);
+      let review = get(reviewPath).data;
+      return exists(reviewPath)
+        && review.assessmentId == identity.identityAssessmentId
+        && review.label == identity.effectiveStatus;
+    }
+
+    function hasValidIdentityDecisionProvenance(userId, identity) {
+      let selected = identity.selectedEffectiveSource;
+      let assessmentPath = /databases/$(database)/documents/users/$(userId)/health_identity_assessments/$(identity.identityAssessmentId);
+      let assessment = get(assessmentPath).data;
+      return identity is map
+        && identity.keys().hasOnly(['identityAssessmentId', 'automaticStatus', 'effectiveStatus', 'reviewEventId', 'identityPolicyVersion', 'featureSchemaVersion', 'passportVersion', 'sharedBundleRef', 'anchorBundleRefs', 'selectedEffectiveSource', 'fallbackReason'])
+        && (
+          selected == null
+          || (
+            selected is map
+            && selected.keys().hasOnly(['provider', 'transport'])
+            && selected.provider is string
+            && selected.transport is string
+            && (
+              identity.effectiveStatus == 'USER'
+              || selected.provider != identity.sharedBundleRef.provider
+              || selected.transport != identity.sharedBundleRef.transport
+            )
+          )
+        )
+        && exists(assessmentPath)
+        && assessment.id == identity.identityAssessmentId
+        && assessment.automaticStatus == identity.automaticStatus
+        && assessment.policyVersion == identity.identityPolicyVersion
+        && assessment.featureSchemaVersion == identity.featureSchemaVersion
+        && assessment.passportVersion == identity.passportVersion
+        && assessment.sharedBundleRef == identity.sharedBundleRef
+        && assessment.anchorBundleRefs == identity.anchorBundleRefs
+        && (identity.fallbackReason == null || identity.fallbackReason in assessment.reasonCodes)
+        && (
+          (identity.reviewEventId == null && identity.effectiveStatus == assessment.automaticStatus)
+          || (identity.reviewEventId != null && hasMatchingIdentityReview(userId, identity))
+        );
+    }
+
+    function hasValidRecommendationAudit(userId, audit) {
       return audit is map
-        && audit.keys().hasOnly(['policyVersion', 'evaluatedAt', 'decisionContextRevision', 'safetyStatus', 'history', 'envelope', 'plannedDose', 'executionDose', 'candidateScores', 'droppedContributorObjectives', 'externalPlan', 'authoredOccurrence', 'primarySession', 'additionalSessions', 'subjectiveDrift'])
+        && audit.keys().hasOnly(['policyVersion', 'evaluatedAt', 'decisionContextRevision', 'safetyStatus', 'history', 'envelope', 'plannedDose', 'executionDose', 'candidateScores', 'droppedContributorObjectives', 'externalPlan', 'authoredOccurrence', 'primarySession', 'additionalSessions', 'subjectiveDrift', 'identityDecision'])
         && audit.keys().hasAll(['policyVersion', 'evaluatedAt', 'decisionContextRevision', 'safetyStatus', 'history', 'envelope', 'candidateScores'])
         && audit.policyVersion is string
         && audit.evaluatedAt is string
@@ -127,7 +170,8 @@ service cloud.firestore {
           && audit.authoredOccurrence.occurrenceId is string && audit.authoredOccurrence.occurrenceId.size() <= 128
           && audit.authoredOccurrence.decision in ['proceed', 'scale']
         ))
-        && (!('subjectiveDrift' in audit) || hasValidSubjectiveDriftAudit(audit.subjectiveDrift));
+        && (!('subjectiveDrift' in audit) || hasValidSubjectiveDriftAudit(audit.subjectiveDrift))
+        && (!('identityDecision' in audit) || hasValidIdentityDecisionProvenance(userId, audit.identityDecision));
     }
 
     function hasValidRecommendation(userId, date) {
@@ -150,7 +194,7 @@ service cloud.firestore {
         && (!('primarySession' in request.resource.data) || hasValidSessionReferenceBinding(request.resource.data.primarySession))
         && (!('additionalSessions' in request.resource.data) || hasValidAdditionalSessions(request.resource.data.additionalSessions))
         && (request.resource.data.schemaVersion != 3
-          || ('recommendationAudit' in request.resource.data && hasValidRecommendationAudit(request.resource.data.recommendationAudit)));
+          || ('recommendationAudit' in request.resource.data && hasValidRecommendationAudit(userId, request.resource.data.recommendationAudit)));
     }
 
     function schemaRatchets() {
@@ -1465,6 +1509,64 @@ service cloud.firestore {
     match /users/{userId}/competition_outcomes/{outcomeId} {
       allow read: if isOwner(userId);
       allow create: if hasValidCompetitionOutcome(userId, outcomeId);
+      allow update, delete: if false;
+    }
+
+    // --- PI6/ADR-0028: physiological identity passports and immutable assessments are
+    // server-managed. Clients may read their own evidence but cannot forge model output.
+    match /users/{userId}/physiological_identity_passports/{passportId} {
+      allow read: if isOwner(userId) && passportId == 'current';
+      allow write: if false;
+    }
+
+    match /users/{userId}/physiological_identity_passport_versions/{versionId} {
+      allow read: if isOwner(userId);
+      allow write: if false;
+    }
+
+    match /users/{userId}/health_identity_assessments/{assessmentId} {
+      allow read: if isOwner(userId);
+      allow write: if false;
+    }
+
+    function hasValidIdentityReviewEvent(userId, eventId) {
+      let data = request.resource.data;
+      let assessmentPath = /databases/$(database)/documents/users/$(userId)/health_identity_assessments/$(data.assessmentId);
+      let supersededPath = /databases/$(database)/documents/users/$(userId)/health_identity_review_events/$(data.supersedesReviewEventId);
+      return isOwner(userId)
+        && data.keys().hasOnly(['id', 'assessmentId', 'schemaVersion', 'label', 'occupancyAttestation', 'supersedesReviewEventId', 'recordedAt', 'source'])
+        && data.keys().hasAll(['id', 'assessmentId', 'schemaVersion', 'label', 'occupancyAttestation', 'supersedesReviewEventId', 'recordedAt', 'source'])
+        && data.id == eventId
+        && data.id is string && data.id.size() > 0 && data.id.size() <= 160
+        && data.assessmentId is string && data.assessmentId.size() > 0 && data.assessmentId.size() <= 160
+        && data.schemaVersion == 1
+        && data.label in ['USER', 'NOT_USER', 'UNCERTAIN']
+        && data.occupancyAttestation in ['EXCLUSIVE', 'MIXED', 'UNKNOWN']
+        && data.recordedAt is timestamp
+        && data.recordedAt == request.time
+        && data.source == 'user_ui'
+        && exists(assessmentPath)
+        && (
+          (data.label == 'USER' && data.occupancyAttestation == 'EXCLUSIVE')
+          || (data.label == 'NOT_USER' && data.occupancyAttestation == 'UNKNOWN')
+          || (data.label == 'UNCERTAIN' && data.occupancyAttestation in ['MIXED', 'UNKNOWN'])
+        )
+        && (
+          data.supersedesReviewEventId == null
+          || (
+            data.supersedesReviewEventId is string
+            && data.supersedesReviewEventId.size() > 0
+            && data.supersedesReviewEventId != eventId
+            && exists(supersededPath)
+            && get(supersededPath).data.assessmentId == data.assessmentId
+            && data.recordedAt >= get(supersededPath).data.recordedAt
+          )
+        );
+    }
+
+    match /users/{userId}/health_identity_review_events/{eventId} {
+      allow read: if isOwner(userId);
+      allow create: if hasValidIdentityReviewEvent(userId, eventId);
       allow update, delete: if false;
     }
 

--- a/app/src/emulator/firestoreRules.emulator.test.ts
+++ b/app/src/emulator/firestoreRules.emulator.test.ts
@@ -182,6 +182,44 @@ function validRecommendation(auditEvaluatedAt = '2026-08-07T08:00:00Z') {
     };
 }
 
+function validIdentityAssessment() {
+    return {
+        id: 'identity-assessment-1',
+        automaticStatus: 'UNCERTAIN',
+        policyVersion: 'identity-v1-shadow',
+        featureSchemaVersion: 'identity-features-v1',
+        passportVersion: '2026-08-07.1',
+        reasonCodes: ['SESSION_TIMING_DISCORDANT'],
+        sharedBundleRef: {
+            id: '2026-08-07_eight_sleep_google_health',
+            provider: 'eight_sleep', transport: 'google_health', revision: 2,
+            sourcePayloadHash: 'sha256:shared', lineageKey: 'eight_sleep:pod-side:a',
+        },
+        anchorBundleRefs: [{
+            id: '2026-08-07_garmin_garmin_direct',
+            provider: 'garmin', transport: 'garmin_direct', revision: 1,
+            sourcePayloadHash: 'sha256:anchor', lineageKey: 'garmin:device:athlete',
+        }],
+    };
+}
+
+function validIdentityDecision() {
+    const assessment = validIdentityAssessment();
+    return {
+        identityAssessmentId: assessment.id,
+        automaticStatus: assessment.automaticStatus,
+        effectiveStatus: assessment.automaticStatus,
+        reviewEventId: null,
+        identityPolicyVersion: assessment.policyVersion,
+        featureSchemaVersion: assessment.featureSchemaVersion,
+        passportVersion: assessment.passportVersion,
+        sharedBundleRef: assessment.sharedBundleRef,
+        anchorBundleRefs: assessment.anchorBundleRefs,
+        selectedEffectiveSource: { provider: 'garmin', transport: 'garmin_direct' },
+        fallbackReason: 'SESSION_TIMING_DISCORDANT',
+    };
+}
+
 emulatorDescribe('Firestore security rules', () => {
     beforeAll(async () => {
         testEnvironment = await initializeTestEnvironment({
@@ -201,6 +239,32 @@ emulatorDescribe('Firestore security rules', () => {
     it('allows an owner to create a schema-v3 recommendation with a compact audit', async () => {
         const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
         await expect(assertSucceeds(setDoc(doc(ownerDb, recommendationPath), validRecommendation()))).resolves.toBeUndefined();
+    });
+
+    it('accepts identity provenance only when it matches server-owned assessment evidence', async () => {
+        await testEnvironment.withSecurityRulesDisabled(async context => {
+            await setDoc(
+                doc(context.firestore(), `users/${ownerId}/health_identity_assessments/identity-assessment-1`),
+                validIdentityAssessment(),
+            );
+        });
+        const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+        const recommendation = validRecommendation();
+        recommendation.recommendationAudit.identityDecision = validIdentityDecision();
+        await assertSucceeds(setDoc(doc(ownerDb, recommendationPath), recommendation));
+
+        await testEnvironment.clearFirestore();
+        await testEnvironment.withSecurityRulesDisabled(async context => {
+            await setDoc(
+                doc(context.firestore(), `users/${ownerId}/health_identity_assessments/identity-assessment-1`),
+                validIdentityAssessment(),
+            );
+        });
+        const forged = validRecommendation();
+        forged.recommendationAudit.identityDecision = {
+            ...validIdentityDecision(), passportVersion: 'forged-passport',
+        };
+        await assertFails(setDoc(doc(ownerDb, recommendationPath), forged));
     });
 
     it('accepts a valid exact engine verdict and rejects an unsupported one', async () => {

--- a/app/src/emulator/identityRules.emulator.test.ts
+++ b/app/src/emulator/identityRules.emulator.test.ts
@@ -1,0 +1,159 @@
+import { readFileSync } from 'node:fs';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, it } from 'vitest';
+import {
+    assertFails,
+    assertSucceeds,
+    initializeTestEnvironment,
+    type RulesTestEnvironment,
+} from '@firebase/rules-unit-testing';
+import { deleteDoc, doc, getDoc, serverTimestamp, setDoc, Timestamp, updateDoc } from 'firebase/firestore';
+
+const emulatorDescribe = process.env.FIRESTORE_EMULATOR_HOST ? describe : describe.skip;
+let testEnvironment: RulesTestEnvironment;
+
+const ownerId = 'identity-athlete';
+const otherId = 'other-identity-athlete';
+const assessmentId = 'assessment-2026-08-27';
+const assessmentPath = `users/${ownerId}/health_identity_assessments/${assessmentId}`;
+const currentPassportPath = `users/${ownerId}/physiological_identity_passports/current`;
+const versionPassportPath = `users/${ownerId}/physiological_identity_passport_versions/2026-08-27.1`;
+
+function review(overrides: Record<string, unknown> = {}) {
+    return {
+        id: 'review-1',
+        assessmentId,
+        schemaVersion: 1,
+        label: 'USER',
+        occupancyAttestation: 'EXCLUSIVE',
+        supersedesReviewEventId: null,
+        recordedAt: serverTimestamp(),
+        source: 'user_ui',
+        ...overrides,
+    };
+}
+
+emulatorDescribe('Physiological identity persistence rules (PI6)', () => {
+    beforeAll(async () => {
+        testEnvironment = await initializeTestEnvironment({
+            projectId: 'demo-adaptive-training-identity',
+            firestore: { rules: readFileSync('firestore.rules', 'utf8') },
+        });
+    });
+
+    beforeEach(async () => {
+        await testEnvironment.withSecurityRulesDisabled(async (context) => {
+            const db = context.firestore();
+            await setDoc(doc(db, assessmentPath), { id: assessmentId });
+            await setDoc(doc(db, currentPassportPath), { passportVersion: '2026-08-27.1' });
+            await setDoc(doc(db, versionPassportPath), { passportVersion: '2026-08-27.1' });
+        });
+    });
+
+    afterEach(async () => {
+        await testEnvironment.clearFirestore();
+    });
+
+    afterAll(async () => {
+        await testEnvironment.cleanup();
+    });
+
+    it('allows only the owner to read server-managed passports and assessments', async () => {
+        const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+        await assertSucceeds(getDoc(doc(ownerDb, assessmentPath)));
+        await assertSucceeds(getDoc(doc(ownerDb, currentPassportPath)));
+        await assertSucceeds(getDoc(doc(ownerDb, versionPassportPath)));
+
+        const otherDb = testEnvironment.authenticatedContext(otherId).firestore();
+        await assertFails(getDoc(doc(otherDb, assessmentPath)));
+        await assertFails(getDoc(doc(otherDb, currentPassportPath)));
+        await assertFails(getDoc(doc(otherDb, versionPassportPath)));
+    });
+
+    it('rejects all client writes to server-managed identity documents', async () => {
+        const db = testEnvironment.authenticatedContext(ownerId).firestore();
+        await assertFails(setDoc(doc(db, assessmentPath), { forged: true }));
+        await assertFails(setDoc(doc(db, currentPassportPath), { forged: true }));
+        await assertFails(setDoc(doc(db, versionPassportPath), { forged: true }));
+        await assertFails(deleteDoc(doc(db, assessmentPath)));
+    });
+
+    it('allows a constrained owner review and makes it append-only', async () => {
+        const db = testEnvironment.authenticatedContext(ownerId).firestore();
+        const path = `users/${ownerId}/health_identity_review_events/review-1`;
+        await assertSucceeds(setDoc(doc(db, path), review()));
+        await assertSucceeds(getDoc(doc(db, path)));
+        await assertFails(updateDoc(doc(db, path), { label: 'NOT_USER' }));
+        await assertFails(deleteDoc(doc(db, path)));
+    });
+
+    it('allows a monotonic correction for the same assessment', async () => {
+        const db = testEnvironment.authenticatedContext(ownerId).firestore();
+        const firstPath = `users/${ownerId}/health_identity_review_events/review-1`;
+        const correctionPath = `users/${ownerId}/health_identity_review_events/review-2`;
+        await assertSucceeds(setDoc(doc(db, firstPath), review()));
+        await assertSucceeds(setDoc(doc(db, correctionPath), review({
+            id: 'review-2',
+            label: 'NOT_USER',
+            occupancyAttestation: 'UNKNOWN',
+            supersedesReviewEventId: 'review-1',
+        })));
+        await testEnvironment.withSecurityRulesDisabled(async (context) => {
+            await setDoc(
+                doc(context.firestore(), `users/${ownerId}/health_identity_review_events/future-review`),
+                review({ id: 'future-review', recordedAt: Timestamp.fromDate(new Date('2100-01-01T00:00:00.000Z')) }),
+            );
+        });
+        await assertFails(setDoc(doc(db, `users/${ownerId}/health_identity_review_events/review-3`), review({
+            id: 'review-3',
+            label: 'UNCERTAIN',
+            occupancyAttestation: 'UNKNOWN',
+            supersedesReviewEventId: 'future-review',
+        })));
+    });
+
+    it('rejects forged fields, invalid semantics, malformed timestamps and missing assessments', async () => {
+        const db = testEnvironment.authenticatedContext(ownerId).firestore();
+        const path = (id: string) => `users/${ownerId}/health_identity_review_events/${id}`;
+        await assertFails(setDoc(doc(db, path('bad-path')), review()));
+        await assertFails(setDoc(doc(db, path('bad-label')), review({ id: 'bad-label', label: 'MAYBE' })));
+        await assertFails(setDoc(doc(db, path('bad-attestation')), review({
+            id: 'bad-attestation', occupancyAttestation: 'MIXED',
+        })));
+        await assertFails(setDoc(doc(db, path('bad-time')), review({
+            id: 'bad-time', recordedAt: Timestamp.fromDate(new Date('2026-08-27T08:00:00.000Z')),
+        })));
+        await assertFails(setDoc(doc(db, path('forged')), review({
+            id: 'forged', eligibility: { baselineLearning: true },
+        })));
+        await assertFails(setDoc(doc(db, path('orphan')), review({
+            id: 'orphan', assessmentId: 'missing-assessment',
+        })));
+    });
+
+    it('rejects cross-user reads/submissions and cross-assessment supersession', async () => {
+        const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+        const firstPath = `users/${ownerId}/health_identity_review_events/review-1`;
+        await assertSucceeds(setDoc(doc(ownerDb, firstPath), review()));
+
+        const otherDb = testEnvironment.authenticatedContext(otherId).firestore();
+        await assertFails(getDoc(doc(otherDb, firstPath)));
+        await assertFails(setDoc(doc(otherDb, firstPath), review()));
+
+        const secondAssessmentId = 'assessment-2';
+        await testEnvironment.withSecurityRulesDisabled(async (context) => {
+            await setDoc(doc(context.firestore(), `users/${ownerId}/health_identity_assessments/${secondAssessmentId}`), {
+                id: secondAssessmentId,
+            });
+        });
+        await assertFails(setDoc(
+            doc(ownerDb, `users/${ownerId}/health_identity_review_events/review-cross`),
+            review({
+                id: 'review-cross',
+                assessmentId: secondAssessmentId,
+                label: 'UNCERTAIN',
+                occupancyAttestation: 'UNKNOWN',
+                supersedesReviewEventId: 'review-1',
+            }),
+        ));
+    });
+});

--- a/app/src/engine/coPresenceValidator.test.ts
+++ b/app/src/engine/coPresenceValidator.test.ts
@@ -109,18 +109,24 @@ describe('coPresenceValidator (ADR-0027 D-MS-IDENTITY, D-MS-PREBASE)', () => {
             expect(result.reason).toContain('quarantined');
         });
 
-        it('exposes no status value that represents a confirmed identity verdict', () => {
-            // The provisional CoPresenceStatus vocabulary is a quarantine/concordance signal, not
-            // an identity classifier: it must never surface a definitive "NOT_USER" determination.
-            // (The ternary USER | NOT_USER | UNCERTAIN model belongs to ADR-0028/PI1+.)
-            const allStatuses: string[] = [
+        it('exposes no production status value that represents a confirmed identity verdict', () => {
+            const allStatuses = [
+                validateCoPresence({ garminRhr: 44, eightSleepRhr: 45 }).status,
+                validateCoPresence({ garminRhr: 44, eightSleepRhr: 82 }).status,
+                validateCoPresence({
+                    garminRhr: null,
+                    eightSleepRhr: 45,
+                    athleteRhr28dMedian: 44,
+                }).status,
+                validateCoPresence({ garminRhr: 44, eightSleepRhr: null }).status,
+            ];
+
+            expect(new Set(allStatuses)).toEqual(new Set([
                 'CONCORDANT',
-                'VERIFIED',
                 'DISCORDANT_SECONDARY',
-                'IMPOSTER_REJECTED',
                 'UNVERIFIED_OFF_WRIST',
                 'NO_SECONDARY_DATA',
-            ];
+            ]));
             expect(allStatuses).not.toContain('NOT_USER');
             expect(allStatuses).not.toContain('USER');
         });

--- a/app/src/engine/coPresenceValidator.test.ts
+++ b/app/src/engine/coPresenceValidator.test.ts
@@ -91,4 +91,58 @@ describe('coPresenceValidator (ADR-0027 D-MS-IDENTITY, D-MS-PREBASE)', () => {
         expect(result.status).toBe('UNVERIFIED_OFF_WRIST');
         expect(result.reason).toContain('cannot be verified without Garmin RHR or a historical baseline');
     });
+
+    describe('PI0 regression: a physiological anomaly alone cannot prove another person (ADR-0028 P-PI-8)', () => {
+        it('never asserts identity fraud, only a quarantine signal, even for an extreme RHR divergence', () => {
+            // A large delta is physiologically consistent with genuine illness/overreach and must
+            // not be reported as a confirmed determination that someone else used the device.
+            const result = validateCoPresence({
+                garminRhr: 43,
+                eightSleepRhr: 95, // e.g. febrile illness, not necessarily another occupant
+                athleteRhr28dMedian: 44,
+            });
+
+            expect(result.verifiedAthlete).toBe(false);
+            expect(result.status).toBe('DISCORDANT_SECONDARY');
+            // Quarantine language only -- no "imposter", "another person", or identity-fraud claim.
+            expect(result.reason.toLowerCase()).not.toMatch(/imposter|another person|fraud|not you/);
+            expect(result.reason).toContain('quarantined');
+        });
+
+        it('exposes no status value that represents a confirmed identity verdict', () => {
+            // The provisional CoPresenceStatus vocabulary is a quarantine/concordance signal, not
+            // an identity classifier: it must never surface a definitive "NOT_USER" determination.
+            // (The ternary USER | NOT_USER | UNCERTAIN model belongs to ADR-0028/PI1+.)
+            const allStatuses: string[] = [
+                'CONCORDANT',
+                'VERIFIED',
+                'DISCORDANT_SECONDARY',
+                'IMPOSTER_REJECTED',
+                'UNVERIFIED_OFF_WRIST',
+                'NO_SECONDARY_DATA',
+            ];
+            expect(allStatuses).not.toContain('NOT_USER');
+            expect(allStatuses).not.toContain('USER');
+        });
+
+        it('quarantines equally regardless of how large the divergence is (no escalating identity claim)', () => {
+            const moderate = validateCoPresence({
+                garminRhr: 43,
+                eightSleepRhr: 60,
+                athleteRhr28dMedian: 44,
+            });
+            const extreme = validateCoPresence({
+                garminRhr: 43,
+                eightSleepRhr: 150,
+                athleteRhr28dMedian: 44,
+            });
+
+            // Both are quarantined identically at the status/verifiedAthlete level; the heuristic
+            // has no mechanism to escalate a bigger anomaly into a stronger identity claim.
+            expect(moderate.status).toBe('DISCORDANT_SECONDARY');
+            expect(extreme.status).toBe('DISCORDANT_SECONDARY');
+            expect(moderate.verifiedAthlete).toBe(false);
+            expect(extreme.verifiedAthlete).toBe(false);
+        });
+    });
 });

--- a/app/src/engine/coPresenceValidator.ts
+++ b/app/src/engine/coPresenceValidator.ts
@@ -1,6 +1,25 @@
 /**
  * Secondary-source identity & session concordance validator (ADR-0027 D-MS-IDENTITY, D-MS-PREBASE).
  *
+ * @deprecated PROVISIONAL / LEGACY COMPATIBILITY LOGIC (PI0, ADR-0028).
+ *
+ * This validator is a temporary scalar heuristic (fixed session-overlap and RHR-delta bounds),
+ * NOT a validated biometric identity classifier. Its `60 min` / `10 bpm` / `14 bpm` defaults are
+ * unvalidated safety guards carried over from PR #240, not thresholds derived from labelled
+ * evidence. Do not describe them as validated identity thresholds in docs, copy, or telemetry.
+ *
+ * It will be superseded by the ternary Physiological Identity Passport gate
+ * (`USER | NOT_USER | UNCERTAIN`, see ADR-0028 and
+ * ../../../docs/plans/physiological-identity-passport-and-measurement-trust.md, tasks PI1-PI9).
+ * That gate sits upstream of `computeSourceMetricBaseline()` (PI5); this validator currently runs
+ * downstream, inside fusion, and does not fix that ordering defect. `verifiedAthlete: boolean` and
+ * the `IMPOSTER_REJECTED` status are legacy vocabulary — new code must not depend on them as
+ * permanent domain contracts. Prefer `EffectiveIdentityDecision` (PI1) once it lands.
+ *
+ * A physiological anomaly alone (e.g. illness driving up RHR) is NOT proof that another person
+ * used the shared device — it is deliberately impossible for this heuristic to assert that; see
+ * `coPresenceValidator.test.ts` for the regression test documenting this (ADR-0028 P-PI-8).
+ *
  * Evaluates whether secondary-source (Eight Sleep) observations correspond to the authenticated
  * primary athlete and are eligible for baseline accumulation and evidence fusion.
  *
@@ -14,6 +33,12 @@ export interface SleepSessionInterval {
     endIso: string;
 }
 
+/**
+ * @deprecated Provisional quarantine/concordance vocabulary (PI0). This is intentionally NOT an
+ * identity verdict: it never asserts who used the device, only whether the secondary record is
+ * concordant enough to trust. `IMPOSTER_REJECTED` is a legacy alias kept for backward
+ * compatibility and must not be read as a confirmed identity-fraud determination.
+ */
 export type CoPresenceStatus =
     | 'CONCORDANT'
     | 'VERIFIED' // Alias for CONCORDANT
@@ -23,6 +48,7 @@ export type CoPresenceStatus =
     | 'NO_SECONDARY_DATA';
 
 export interface CoPresenceValidationResult {
+    /** @deprecated Legacy boolean; cannot represent abstention. Superseded by `EffectiveIdentityDecision` (PI1). */
     verifiedAthlete: boolean;
     status: CoPresenceStatus;
     reason: string;
@@ -52,6 +78,10 @@ function calculateSessionOverlapMinutes(
     return diffMs > 0 ? Math.round(diffMs / 60000) : 0;
 }
 
+/**
+ * @deprecated PROVISIONAL heuristic (PI0, ADR-0028) — see module doc comment above. Do not
+ * present its output as a validated identity determination.
+ */
 export function validateCoPresence(params: {
     garminRhr?: number | null;
     eightSleepRhr?: number | null;

--- a/app/src/engine/coPresenceValidator.ts
+++ b/app/src/engine/coPresenceValidator.ts
@@ -11,10 +11,10 @@
  * It will be superseded by the ternary Physiological Identity Passport gate
  * (`USER | NOT_USER | UNCERTAIN`, see ADR-0028 and
  * ../../../docs/plans/physiological-identity-passport-and-measurement-trust.md, tasks PI1-PI9).
- * That gate sits upstream of `computeSourceMetricBaseline()` (PI5); this validator currently runs
- * downstream, inside fusion, and does not fix that ordering defect. `verifiedAthlete: boolean` and
- * the `IMPOSTER_REJECTED` status are legacy vocabulary — new code must not depend on them as
- * permanent domain contracts. Prefer `EffectiveIdentityDecision` (PI1) once it lands.
+ * PI5's effective-eligibility gate now sits upstream of `computeSourceMetricBaseline()`; this
+ * validator remains only inside the candidate fusion compatibility path until PI9 replaces it.
+ * `verifiedAthlete: boolean` and the `IMPOSTER_REJECTED` status are legacy vocabulary — new code
+ * must not depend on them as permanent domain contracts. Prefer `EffectiveIdentityDecision`.
  *
  * A physiological anomaly alone (e.g. illness driving up RHR) is NOT proof that another person
  * used the shared device — it is deliberately impossible for this heuristic to assert that; see

--- a/app/src/engine/identityAttribution.test.ts
+++ b/app/src/engine/identityAttribution.test.ts
@@ -1,0 +1,388 @@
+import { describe, expect, it } from 'vitest';
+import type { ObservationBundleRef } from '../observations/identityModels';
+import {
+    DEFAULT_IDENTITY_ATTRIBUTION_POLICY,
+    IDENTITY_POLICY_VERSION,
+    assessPhysiologicalIdentity,
+    evaluateIdentityEvidence,
+    type IdentityAttributionInput,
+} from './identityAttribution';
+import type { IntervalOverlapMetrics, PhysiologicalRelationFeatures } from './identityFeatures';
+import type { AnchorLineageEvaluation } from './identityLineage';
+import type {
+    PhysiologicalIdentityPassport,
+    RobustLocationEstimate,
+    RobustRatioEstimate,
+    RobustScalarEstimate,
+} from './identityPassport';
+
+const FEATURE_SCHEMA_VERSION = 'identity-features-v1';
+
+function ref(overrides: Partial<ObservationBundleRef> = {}): ObservationBundleRef {
+    return {
+        id: 'bundle',
+        provider: 'garmin',
+        transport: 'garmin_direct',
+        revision: 1,
+        sourcePayloadHash: 'sha256:bundle',
+        lineageKey: 'garmin:device:athlete',
+        ...overrides,
+    };
+}
+
+const SHARED_REF = ref({
+    id: 'shared-night',
+    provider: 'shared_bed',
+    transport: 'health_aggregator',
+    sourcePayloadHash: 'sha256:shared',
+    lineageKey: 'shared-bed:side:a',
+});
+const ANCHOR_REF = ref({ id: 'anchor-night' });
+
+function scalar(median: number, mad: number, n = 20): RobustScalarEstimate {
+    return { median, mad, iqr: mad * 1.349, n };
+}
+
+function location(median: number, mad: number, n = 20): RobustLocationEstimate {
+    return { median, mad, n };
+}
+
+function ratio(median: number, iqr: number, n = 20): RobustRatioEstimate {
+    return { median, iqr, n };
+}
+
+function passport(overrides: Partial<PhysiologicalIdentityPassport> = {}): PhysiologicalIdentityPassport {
+    return {
+        schemaVersion: 1,
+        passportVersion: '2026-08-27.1',
+        createdAt: '2026-08-27T06:00:00Z',
+        policyVersion: IDENTITY_POLICY_VERSION,
+        featureSchemaVersion: FEATURE_SCHEMA_VERSION,
+        anchorPolicy: {
+            primaryProvider: 'garmin',
+            primaryTransport: 'garmin_direct',
+            role: 'PERSONAL_DEVICE_ANCHOR',
+            requireIndependentLineage: true,
+        },
+        sourceProfiles: {
+            shared_bed: {
+                trustedNightCount: 20,
+                restingHeartRate: scalar(55, 2),
+                respirationRate: scalar(14, 0.5),
+                logHrv: scalar(Math.log(60), 0.05),
+                sleepStartMinutesLocal: location(1_380, 10),
+                sleepDurationMinutes: location(450, 15),
+            },
+        },
+        crossSourceProfiles: {
+            shared_bed__garmin_garmin_direct: {
+                rhrResidual: scalar(2, 1),
+                respirationResidual: scalar(0.2, 0.5),
+                hrvLogResidual: scalar(0.1, 0.05),
+                startDeltaMinutes: location(5, 10),
+                endDeltaMinutes: location(10, 10),
+                durationDeltaMinutes: location(5, 15),
+                sessionJaccard: ratio(0.95, 0.06),
+            },
+        },
+        calibration: {
+            manualUserCount: 0,
+            manualNotUserCount: 0,
+            mixedOccupancyCount: 0,
+            uncertainCount: 0,
+            shadowWindowStart: null,
+            shadowWindowEnd: null,
+        },
+        ...overrides,
+    };
+}
+
+function overlap(overrides: Partial<IntervalOverlapMetrics> = {}): IntervalOverlapMetrics {
+    return {
+        intersectionMinutes: 440,
+        unionMinutes: 465,
+        jaccard: 0.95,
+        eightOverlapFraction: 0.98,
+        garminOverlapFraction: 0.98,
+        startDeltaMinutes: 5,
+        endDeltaMinutes: 10,
+        durationDeltaMinutes: 5,
+        ...overrides,
+    };
+}
+
+function relation(overrides: Partial<PhysiologicalRelationFeatures> = {}): PhysiologicalRelationFeatures {
+    return {
+        rhrResidual: 2,
+        respResidual: 0.2,
+        hrvLogResidual: 0.1,
+        ...overrides,
+    };
+}
+
+function independentLineage(): AnchorLineageEvaluation {
+    return {
+        independentAnchorRefs: [ANCHOR_REF],
+        dependentAnchorRefs: [],
+        reasonCodes: [],
+    };
+}
+
+function input(overrides: Partial<IdentityAttributionInput> = {}): IdentityAttributionInput {
+    return {
+        assessmentId: 'identity-assessment-2026-08-27',
+        sourceNightKey: '2026-08-27',
+        assessedAt: '2026-08-27T06:30:00Z',
+        featureSchemaVersion: FEATURE_SCHEMA_VERSION,
+        sharedBundleRef: SHARED_REF,
+        anchorBundleRefs: [ANCHOR_REF],
+        anchorEligibility: { eligible: true, reasonCode: null },
+        lineageEvaluation: independentLineage(),
+        pairingReasonCodes: [],
+        overlap: overlap(),
+        relation: relation(),
+        passport: passport(),
+        ...overrides,
+    };
+}
+
+describe('identityAttribution (PI4, ADR-0028)', () => {
+    it('A. accepts ordinary independent multi-feature agreement as high-confidence USER', () => {
+        const result = evaluateIdentityEvidence(input());
+
+        expect(result.automaticStatus).toBe('USER');
+        expect(result.confidenceTier).toBe('HIGH');
+        expect(result.identityScore).toBeCloseTo(1, 10);
+        expect(result.reasonCodes).toEqual([
+            'SESSION_TIMING_CONCORDANT',
+            'RHR_RELATION_CONCORDANT',
+            'RESPIRATION_RELATION_CONCORDANT',
+            'HRV_RELATION_CONCORDANT',
+        ]);
+        expect(result.concordantEvidenceGroupCount).toBe(4);
+        expect(result.concordantPhysiologyFeatureCount).toBe(3);
+    });
+
+    it('B. unusual absolute physiology remains USER when paired relations stay concordant', () => {
+        // The evaluator intentionally sees paired relations, not population or absolute-normality
+        // thresholds. Both devices may move sharply on an illness night while their relationship
+        // remains personally concordant; downstream anomaly logic must still see that physiology.
+        const result = evaluateIdentityEvidence(input({ relation: relation() }));
+
+        expect(result.automaticStatus).toBe('USER');
+        expect(result.reasonCodes).not.toContain('RHR_RELATION_DISCORDANT');
+    });
+
+    it('F. missing anchor abstains with no reassuring physiology-only score', () => {
+        const result = evaluateIdentityEvidence(
+            input({
+                anchorBundleRefs: [],
+                anchorEligibility: { eligible: false, reasonCode: 'ANCHOR_MISSING' },
+                lineageEvaluation: {
+                    independentAnchorRefs: [],
+                    dependentAnchorRefs: [],
+                    reasonCodes: [],
+                },
+            }),
+        );
+
+        expect(result.automaticStatus).toBe('UNCERTAIN');
+        expect(result.identityScore).toBeNull();
+        expect(result.confidenceTier).toBe('NONE');
+        expect(result.reasonCodes).toContain('ANCHOR_MISSING');
+    });
+
+    it('G. technically ineligible anchor is distinct from a missing anchor and abstains', () => {
+        const result = evaluateIdentityEvidence(
+            input({
+                anchorEligibility: {
+                    eligible: false,
+                    reasonCode: 'ANCHOR_QUALITY_INSUFFICIENT',
+                },
+            }),
+        );
+
+        expect(result.automaticStatus).toBe('UNCERTAIN');
+        expect(result.reasonCodes).toContain('ANCHOR_QUALITY_INSUFFICIENT');
+        expect(result.reasonCodes).not.toContain('ANCHOR_MISSING');
+    });
+
+    it('K. mirrored/dependent evidence cannot assert USER or contribute a score', () => {
+        const dependentAnchor = ref({
+            id: 'mirrored-anchor',
+            lineageKey: SHARED_REF.lineageKey,
+            transport: 'other_transport',
+        });
+        const result = evaluateIdentityEvidence(
+            input({
+                anchorBundleRefs: [dependentAnchor],
+                lineageEvaluation: {
+                    independentAnchorRefs: [],
+                    dependentAnchorRefs: [dependentAnchor],
+                    reasonCodes: ['EVIDENCE_LINEAGE_DEPENDENT'],
+                },
+            }),
+        );
+
+        expect(result.automaticStatus).toBe('UNCERTAIN');
+        expect(result.identityScore).toBeNull();
+        expect(result.reasonCodes).toContain('EVIDENCE_LINEAGE_DEPENDENT');
+    });
+
+    it('does not substitute an unrelated independent device for the passport-configured anchor', () => {
+        const unrelated = ref({
+            id: 'unrelated-anchor',
+            provider: 'other_watch',
+            transport: 'other_direct',
+            lineageKey: 'other-watch:device:athlete',
+        });
+        const result = evaluateIdentityEvidence(
+            input({
+                anchorBundleRefs: [unrelated],
+                lineageEvaluation: {
+                    independentAnchorRefs: [unrelated],
+                    dependentAnchorRefs: [],
+                    reasonCodes: [],
+                },
+            }),
+        );
+
+        expect(result.automaticStatus).toBe('UNCERTAIN');
+        expect(result.identityScore).toBeNull();
+        expect(result.reasonCodes).toContain('ANCHOR_QUALITY_INSUFFICIENT');
+    });
+
+    it('abstains when passport history is immature or feature-schema incompatible', () => {
+        const immature = passport({
+            sourceProfiles: {
+                shared_bed: {
+                    ...passport().sourceProfiles.shared_bed,
+                    trustedNightCount: DEFAULT_IDENTITY_ATTRIBUTION_POLICY.minTrustedNightCount - 1,
+                },
+            },
+        });
+        const immatureResult = evaluateIdentityEvidence(input({ passport: immature }));
+        const incompatibleResult = evaluateIdentityEvidence(
+            input({ featureSchemaVersion: 'identity-features-v2' }),
+        );
+
+        expect(immatureResult.automaticStatus).toBe('UNCERTAIN');
+        expect(immatureResult.reasonCodes).toContain('INSUFFICIENT_PASSPORT_HISTORY');
+        expect(incompatibleResult.automaticStatus).toBe('UNCERTAIN');
+        expect(incompatibleResult.identityScore).toBeNull();
+    });
+
+    it('treats an otherwise mature passport with insufficient required feature history as immature', () => {
+        const base = passport();
+        const thinFeatureHistory = passport({
+            crossSourceProfiles: {
+                shared_bed__garmin_garmin_direct: {
+                    ...base.crossSourceProfiles.shared_bed__garmin_garmin_direct,
+                    startDeltaMinutes: location(5, 10, 2),
+                    endDeltaMinutes: location(10, 10, 2),
+                    durationDeltaMinutes: location(5, 15, 2),
+                    sessionJaccard: ratio(0.95, 0.06, 2),
+                },
+            },
+        });
+        const result = evaluateIdentityEvidence(input({ passport: thinFeatureHistory }));
+
+        expect(result.automaticStatus).toBe('UNCERTAIN');
+        expect(result.reasonCodes).toContain('INSUFFICIENT_PASSPORT_HISTORY');
+    });
+
+    it('requires timing plus at least two physiological relations for multi-feature USER', () => {
+        const twoPhysiology = evaluateIdentityEvidence(
+            input({ relation: relation({ hrvLogResidual: null }) }),
+        );
+        const onePhysiology = evaluateIdentityEvidence(
+            input({ relation: relation({ respResidual: null, hrvLogResidual: null }) }),
+        );
+
+        expect(twoPhysiology.automaticStatus).toBe('USER');
+        expect(twoPhysiology.evaluatedPhysiologyFeatureCount).toBe(2);
+        expect(onePhysiology.automaticStatus).toBe('UNCERTAIN');
+        expect(onePhysiology.confidenceTier).toBe('MODERATE');
+    });
+
+    it('one discrepant physiological feature forces abstention but never automatic NOT_USER', () => {
+        const result = evaluateIdentityEvidence(
+            input({ relation: relation({ rhrResidual: 22 }) }),
+        );
+
+        expect(result.automaticStatus).toBe('UNCERTAIN');
+        expect(result.confidenceTier).toBe('LOW');
+        expect(result.reasonCodes).toContain('RHR_RELATION_DISCORDANT');
+        expect(result.reasonCodes).toContain('RESPIRATION_RELATION_CONCORDANT');
+        expect(result.identityScore).not.toBeNull();
+    });
+
+    it('I. discordant partial session geometry suspects mixed occupancy and quarantines automatically', () => {
+        const result = evaluateIdentityEvidence(
+            input({
+                overlap: overlap({
+                    startDeltaMinutes: -180,
+                    durationDeltaMinutes: 180,
+                    jaccard: 0.7,
+                    eightOverlapFraction: 0.7,
+                }),
+            }),
+        );
+
+        expect(result.automaticStatus).toBe('UNCERTAIN');
+        expect(result.reasonCodes).toContain('SESSION_TIMING_DISCORDANT');
+        expect(result.reasonCodes).toContain('MIXED_OCCUPANCY_SUSPECTED');
+    });
+
+    it('ambiguous pairing abstains even when the selected candidate otherwise agrees', () => {
+        const result = evaluateIdentityEvidence(
+            input({ pairingReasonCodes: ['MULTIPLE_PAIRING_CANDIDATES'] }),
+        );
+
+        expect(result.automaticStatus).toBe('UNCERTAIN');
+        expect(result.reasonCodes).toContain('MULTIPLE_PAIRING_CANDIDATES');
+        expect(result.identityScore).toBeCloseTo(1, 10);
+    });
+
+    it('constructs the canonical immutable assessment with complete replay refs', () => {
+        const dependentCopy = ref({
+            id: 'dependent-copy',
+            transport: 'aggregator',
+            lineageKey: ANCHOR_REF.lineageKey,
+        });
+        const assessment = assessPhysiologicalIdentity(
+            input({ anchorBundleRefs: [ANCHOR_REF, dependentCopy] }),
+        );
+
+        expect(assessment.automaticStatus).toBe('USER');
+        expect(assessment.policyVersion).toBe(IDENTITY_POLICY_VERSION);
+        expect(assessment.passportVersion).toBe('2026-08-27.1');
+        expect(assessment.anchorBundleRefs).toEqual([ANCHOR_REF, dependentCopy]);
+        expect(Object.isFrozen(assessment)).toBe(true);
+        expect(Object.isFrozen(assessment.sharedSource)).toBe(true);
+        expect(Object.isFrozen(assessment.anchorBundleRefs[0])).toBe(true);
+    });
+
+    it('automatic NOT_USER is disabled for every scored discrepancy in v1', () => {
+        const residuals = [-100, -20, -1, 2, 5, 20, 100];
+        for (const rhrResidual of residuals) {
+            for (const respResidual of residuals) {
+                const result = evaluateIdentityEvidence(
+                    input({ relation: relation({ rhrResidual, respResidual }) }),
+                );
+                expect(result.automaticStatus).not.toBe('NOT_USER');
+            }
+        }
+    });
+
+    it('exposes a versioned, bounded evidence score rather than probability semantics', () => {
+        const result = evaluateIdentityEvidence(
+            input({ relation: relation({ rhrResidual: 3, respResidual: 0.7 }) }),
+        );
+
+        expect(DEFAULT_IDENTITY_ATTRIBUTION_POLICY.policyVersion).toBe('identity-v1-shadow');
+        expect(result.identityScore).toBeGreaterThanOrEqual(0);
+        expect(result.identityScore).toBeLessThanOrEqual(1);
+        expect(result).not.toHaveProperty('probability');
+    });
+});

--- a/app/src/engine/identityAttribution.ts
+++ b/app/src/engine/identityAttribution.ts
@@ -1,0 +1,497 @@
+/**
+ * Ternary physiological-identity evaluator with abstention (PI4, ADR-0028).
+ *
+ * This is a SHADOW-ONLY selective classifier. It composes PI2's technically valid,
+ * provenance-independent paired features against PI3's versioned passport. V1 can automatically
+ * accept a night as USER, but it deliberately cannot emit automatic NOT_USER. Conflicting or
+ * incomplete evidence abstains to UNCERTAIN and remains outside baseline/fusion until PI5 wires
+ * the effective-eligibility boundary.
+ *
+ * `identityScore` is a bounded evidence-ranking score, not a probability. The default numerical
+ * policy is an explicit replay candidate for PI8; activation thresholds remain an evidence
+ * decision rather than a claim that these defaults are calibrated.
+ */
+
+import {
+    IDENTITY_REASON_CODES,
+    freezeAutomaticIdentityAssessment,
+    type AutomaticIdentityAssessment,
+    type IdentityConfidenceTier,
+    type IdentityReasonCode,
+    type ObservationBundleRef,
+} from '../observations/identityModels';
+import type {
+    AnchorEligibilityResult,
+    IntervalOverlapMetrics,
+    PhysiologicalRelationFeatures,
+} from './identityFeatures';
+import type { AnchorLineageEvaluation } from './identityLineage';
+import {
+    crossSourceProfileKey,
+    type PhysiologicalIdentityPassport,
+    type RobustLocationEstimate,
+    type RobustRatioEstimate,
+    type RobustScalarEstimate,
+} from './identityPassport';
+
+export const IDENTITY_POLICY_VERSION = 'identity-v1-shadow';
+
+export interface IdentityAttributionPolicy {
+    policyVersion: string;
+    /** Passport-level maturity. This is a conservative shadow default, not an activation claim. */
+    minTrustedNightCount: number;
+    /** Per-feature history required before that feature can contribute evidence. */
+    minFeatureNightCount: number;
+    /** A feature is concordant at or below this absolute robust deviation. */
+    concordanceZThreshold: number;
+    /** Caps each feature's influence in the bounded evidence score. */
+    scoreZCap: number;
+    /** Minimum score for automatic USER, in addition to all multi-feature guards. */
+    minUserScore: number;
+    /** At least this many relation/timing groups must independently agree. */
+    minConcordantEvidenceGroups: number;
+    /** Prevents timing alone from asserting identity. */
+    minConcordantPhysiologyFeatures: number;
+    /** Robust scale floor for the bounded Jaccard feature, whose passport stores IQR. */
+    sessionJaccardScaleFloor: number;
+    /** Containment/partial-occupancy guard; only used with discordant session geometry. */
+    mixedOccupancyOverlapFraction: number;
+}
+
+export const DEFAULT_IDENTITY_ATTRIBUTION_POLICY: IdentityAttributionPolicy = Object.freeze({
+    policyVersion: IDENTITY_POLICY_VERSION,
+    minTrustedNightCount: 14,
+    minFeatureNightCount: 7,
+    concordanceZThreshold: 3,
+    scoreZCap: 6,
+    minUserScore: 0.6,
+    minConcordantEvidenceGroups: 3,
+    minConcordantPhysiologyFeatures: 2,
+    sessionJaccardScaleFloor: 0.05,
+    mixedOccupancyOverlapFraction: 0.8,
+});
+
+export type IdentityEvidenceFeature =
+    | 'SESSION_START_DELTA'
+    | 'SESSION_END_DELTA'
+    | 'SESSION_DURATION_DELTA'
+    | 'SESSION_JACCARD'
+    | 'RHR_RELATION'
+    | 'RESPIRATION_RELATION'
+    | 'HRV_RELATION';
+
+export type IdentityEvidenceGroup = 'SESSION_TIMING' | 'RHR' | 'RESPIRATION' | 'HRV';
+
+export interface IdentityFeatureEvidence {
+    feature: IdentityEvidenceFeature;
+    group: IdentityEvidenceGroup;
+    robustDeviation: number;
+    concordant: boolean;
+}
+
+export interface IdentityEvidenceEvaluation {
+    identityScore: number | null;
+    confidenceTier: IdentityConfidenceTier;
+    reasonCodes: readonly IdentityReasonCode[];
+    featureEvidence: readonly IdentityFeatureEvidence[];
+    evaluatedEvidenceGroupCount: number;
+    concordantEvidenceGroupCount: number;
+    evaluatedPhysiologyFeatureCount: number;
+    concordantPhysiologyFeatureCount: number;
+    automaticStatus: 'USER' | 'UNCERTAIN';
+}
+
+export interface IdentityAttributionInput {
+    assessmentId: string;
+    sourceNightKey: string;
+    assessedAt: string;
+    featureSchemaVersion: string;
+    sharedBundleRef: ObservationBundleRef;
+    /** Every candidate anchor ref is retained for replay, including ignored dependent copies. */
+    anchorBundleRefs: readonly ObservationBundleRef[];
+    anchorEligibility: AnchorEligibilityResult;
+    lineageEvaluation: AnchorLineageEvaluation;
+    pairingReasonCodes: readonly IdentityReasonCode[];
+    overlap: IntervalOverlapMetrics | null;
+    relation: PhysiologicalRelationFeatures;
+    passport: PhysiologicalIdentityPassport | null;
+}
+
+interface EstimateWithScale {
+    median: number | null;
+    scale: number | null;
+    n: number;
+}
+
+function scalarEstimate(estimate: RobustScalarEstimate): EstimateWithScale {
+    return { median: estimate.median, scale: estimate.mad, n: estimate.n };
+}
+
+function locationEstimate(estimate: RobustLocationEstimate): EstimateWithScale {
+    return { median: estimate.median, scale: estimate.mad, n: estimate.n };
+}
+
+function ratioEstimate(
+    estimate: RobustRatioEstimate,
+    scaleFloor: number,
+): EstimateWithScale {
+    // IQR / 1.349 is the normal-consistent scale counterpart to scaled MAD. The explicit floor
+    // protects early/near-constant passport histories from unstable divisions.
+    const scale = estimate.iqr === null ? null : Math.max(estimate.iqr / 1.349, scaleFloor);
+    return { median: estimate.median, scale, n: estimate.n };
+}
+
+function scoreFeature(
+    feature: IdentityEvidenceFeature,
+    group: IdentityEvidenceGroup,
+    value: number | null,
+    estimate: EstimateWithScale,
+    policy: IdentityAttributionPolicy,
+): IdentityFeatureEvidence | null {
+    if (
+        value === null ||
+        !Number.isFinite(value) ||
+        estimate.n < policy.minFeatureNightCount ||
+        estimate.median === null ||
+        estimate.scale === null ||
+        !Number.isFinite(estimate.median) ||
+        !Number.isFinite(estimate.scale) ||
+        estimate.scale <= 0
+    ) {
+        return null;
+    }
+
+    const robustDeviation = Math.abs(value - estimate.median) / estimate.scale;
+    return {
+        feature,
+        group,
+        robustDeviation,
+        concordant: robustDeviation <= policy.concordanceZThreshold,
+    };
+}
+
+function appendFeature(
+    evidence: IdentityFeatureEvidence[],
+    candidate: IdentityFeatureEvidence | null,
+): void {
+    if (candidate) {
+        evidence.push(candidate);
+    }
+}
+
+function uniqueReasons(codes: readonly IdentityReasonCode[]): readonly IdentityReasonCode[] {
+    const included = new Set(codes);
+    return IDENTITY_REASON_CODES.filter((code) => included.has(code));
+}
+
+function hasHardPreconditionFailure(codes: readonly IdentityReasonCode[]): boolean {
+    return codes.some((code) =>
+        [
+            'ANCHOR_MISSING',
+            'ANCHOR_QUALITY_INSUFFICIENT',
+            'EVIDENCE_LINEAGE_DEPENDENT',
+            'INSUFFICIENT_PASSPORT_HISTORY',
+            'MULTIPLE_PAIRING_CANDIDATES',
+            'SESSION_INTERVAL_INVALID',
+            'MIXED_OCCUPANCY_SUSPECTED',
+        ].includes(code),
+    );
+}
+
+function confidenceForUncertain(
+    identityScore: number | null,
+    hasHardFailure: boolean,
+    hasDiscordance: boolean,
+): IdentityConfidenceTier {
+    if (identityScore === null) {
+        return 'NONE';
+    }
+    if (hasHardFailure || hasDiscordance) {
+        return 'LOW';
+    }
+    return 'MODERATE';
+}
+
+/**
+ * Evaluates identity evidence without constructing/persisting the assessment wrapper. Exported so
+ * PI8 can compare risk/coverage across policies while keeping the production-shaped assessment
+ * contract stable.
+ */
+export function evaluateIdentityEvidence(
+    input: IdentityAttributionInput,
+    policy: IdentityAttributionPolicy = DEFAULT_IDENTITY_ATTRIBUTION_POLICY,
+): IdentityEvidenceEvaluation {
+    const reasons: IdentityReasonCode[] = [...input.pairingReasonCodes];
+
+    if (!input.anchorEligibility.eligible && input.anchorEligibility.reasonCode) {
+        reasons.push(input.anchorEligibility.reasonCode);
+    }
+
+    const hasAnyIndependentAnchor = input.lineageEvaluation.independentAnchorRefs.length > 0;
+    if (!hasAnyIndependentAnchor && input.anchorBundleRefs.length > 0) {
+        reasons.push('EVIDENCE_LINEAGE_DEPENDENT');
+    }
+
+    if (input.overlap === null && !reasons.includes('SESSION_INTERVAL_INVALID')) {
+        reasons.push('SESSION_TIMING_DISCORDANT');
+    }
+
+    const passport = input.passport;
+    const profileKey = passport
+        ? crossSourceProfileKey(
+              input.sharedBundleRef.provider,
+              passport.anchorPolicy.primaryProvider,
+              passport.anchorPolicy.primaryTransport,
+          )
+        : null;
+    const profile = passport && profileKey ? passport.crossSourceProfiles[profileKey] : undefined;
+    const sourceProfile = passport?.sourceProfiles[input.sharedBundleRef.provider];
+    const hasConfiguredIndependentAnchor =
+        passport !== null &&
+        input.lineageEvaluation.independentAnchorRefs.some(
+            (ref) =>
+                ref.provider === passport.anchorPolicy.primaryProvider &&
+                ref.transport === passport.anchorPolicy.primaryTransport,
+        );
+    if (passport && input.anchorEligibility.eligible && !hasConfiguredIndependentAnchor) {
+        // An unrelated personal device cannot be substituted for the configured anchor whose
+        // paired relationship the selected passport profile represents.
+        reasons.push('ANCHOR_QUALITY_INSUFFICIENT');
+    }
+    const passportMature =
+        passport !== null &&
+        passport.featureSchemaVersion === input.featureSchemaVersion &&
+        profile !== undefined &&
+        sourceProfile !== undefined &&
+        sourceProfile.trustedNightCount >= policy.minTrustedNightCount;
+
+    if (!passportMature) {
+        reasons.push('INSUFFICIENT_PASSPORT_HISTORY');
+    }
+
+    // Do not calculate an apparently reassuring score from unusable/non-independent evidence.
+    const canScore =
+        input.anchorEligibility.eligible &&
+        hasConfiguredIndependentAnchor &&
+        input.overlap !== null &&
+        passportMature &&
+        profile !== undefined;
+    if (!canScore || !profile || !input.overlap) {
+        const reasonCodes = uniqueReasons(reasons);
+        return {
+            identityScore: null,
+            confidenceTier: 'NONE',
+            reasonCodes,
+            featureEvidence: [],
+            evaluatedEvidenceGroupCount: 0,
+            concordantEvidenceGroupCount: 0,
+            evaluatedPhysiologyFeatureCount: 0,
+            concordantPhysiologyFeatureCount: 0,
+            automaticStatus: 'UNCERTAIN',
+        };
+    }
+
+    const evidence: IdentityFeatureEvidence[] = [];
+    appendFeature(
+        evidence,
+        scoreFeature(
+            'SESSION_START_DELTA',
+            'SESSION_TIMING',
+            input.overlap.startDeltaMinutes,
+            locationEstimate(profile.startDeltaMinutes),
+            policy,
+        ),
+    );
+    appendFeature(
+        evidence,
+        scoreFeature(
+            'SESSION_END_DELTA',
+            'SESSION_TIMING',
+            input.overlap.endDeltaMinutes,
+            locationEstimate(profile.endDeltaMinutes),
+            policy,
+        ),
+    );
+    appendFeature(
+        evidence,
+        scoreFeature(
+            'SESSION_DURATION_DELTA',
+            'SESSION_TIMING',
+            input.overlap.durationDeltaMinutes,
+            locationEstimate(profile.durationDeltaMinutes),
+            policy,
+        ),
+    );
+    appendFeature(
+        evidence,
+        scoreFeature(
+            'SESSION_JACCARD',
+            'SESSION_TIMING',
+            input.overlap.jaccard,
+            ratioEstimate(profile.sessionJaccard, policy.sessionJaccardScaleFloor),
+            policy,
+        ),
+    );
+    appendFeature(
+        evidence,
+        scoreFeature(
+            'RHR_RELATION',
+            'RHR',
+            input.relation.rhrResidual,
+            scalarEstimate(profile.rhrResidual),
+            policy,
+        ),
+    );
+    appendFeature(
+        evidence,
+        scoreFeature(
+            'RESPIRATION_RELATION',
+            'RESPIRATION',
+            input.relation.respResidual,
+            scalarEstimate(profile.respirationResidual),
+            policy,
+        ),
+    );
+    appendFeature(
+        evidence,
+        scoreFeature(
+            'HRV_RELATION',
+            'HRV',
+            input.relation.hrvLogResidual,
+            scalarEstimate(profile.hrvLogResidual),
+            policy,
+        ),
+    );
+
+    const timingEvidenceCount = evidence.filter((item) => item.group === 'SESSION_TIMING').length;
+    const physiologyEvidenceCount = evidence.filter((item) => item.group !== 'SESSION_TIMING').length;
+    const availablePhysiologyInputCount = [
+        input.relation.rhrResidual,
+        input.relation.respResidual,
+        input.relation.hrvLogResidual,
+    ].filter((value) => value !== null && Number.isFinite(value)).length;
+    if (
+        timingEvidenceCount === 0 ||
+        (availablePhysiologyInputCount >= policy.minConcordantPhysiologyFeatures &&
+            physiologyEvidenceCount < policy.minConcordantPhysiologyFeatures)
+    ) {
+        // The current night supplied enough raw candidate features, but the passport did not
+        // contain enough per-feature history to evaluate the required evidence groups.
+        reasons.push('INSUFFICIENT_PASSPORT_HISTORY');
+    }
+
+    const groupEvidence = new Map<IdentityEvidenceGroup, IdentityFeatureEvidence[]>();
+    for (const item of evidence) {
+        const current = groupEvidence.get(item.group);
+        if (current) {
+            current.push(item);
+        } else {
+            groupEvidence.set(item.group, [item]);
+        }
+    }
+
+    const timing = groupEvidence.get('SESSION_TIMING') ?? [];
+    if (timing.length > 0) {
+        reasons.push(
+            timing.every((item) => item.concordant)
+                ? 'SESSION_TIMING_CONCORDANT'
+                : 'SESSION_TIMING_DISCORDANT',
+        );
+    }
+
+    const relationReasonPairs: readonly [
+        IdentityEvidenceGroup,
+        IdentityReasonCode,
+        IdentityReasonCode,
+    ][] = [
+        ['RHR', 'RHR_RELATION_CONCORDANT', 'RHR_RELATION_DISCORDANT'],
+        ['RESPIRATION', 'RESPIRATION_RELATION_CONCORDANT', 'RESPIRATION_RELATION_DISCORDANT'],
+        ['HRV', 'HRV_RELATION_CONCORDANT', 'HRV_RELATION_DISCORDANT'],
+    ];
+    for (const [group, concordantReason, discordantReason] of relationReasonPairs) {
+        const groupItems = groupEvidence.get(group) ?? [];
+        if (groupItems.length > 0) {
+            reasons.push(groupItems.every((item) => item.concordant) ? concordantReason : discordantReason);
+        }
+    }
+
+    const mixedOccupancySuspected =
+        timing.some((item) => !item.concordant) &&
+        (input.overlap.eightOverlapFraction < policy.mixedOccupancyOverlapFraction ||
+            input.overlap.garminOverlapFraction < policy.mixedOccupancyOverlapFraction);
+    if (mixedOccupancySuspected) {
+        reasons.push('MIXED_OCCUPANCY_SUSPECTED');
+    }
+
+    // Correlated timing dimensions count as one group, preventing four timing measurements from
+    // overwhelming one or two genuinely independent physiological relations.
+    const groupScores = [...groupEvidence.values()].map((items) => {
+        const meanDeviation =
+            items.reduce((total, item) => total + Math.min(item.robustDeviation, policy.scoreZCap), 0) /
+            items.length;
+        return 1 - meanDeviation / policy.scoreZCap;
+    });
+    const identityScore =
+        groupScores.length === 0
+            ? null
+            : groupScores.reduce((total, score) => total + score, 0) / groupScores.length;
+
+    const groups = [...groupEvidence.entries()];
+    const concordantEvidenceGroupCount = groups.filter(([, items]) =>
+        items.every((item) => item.concordant),
+    ).length;
+    const physiology = evidence.filter((item) => item.group !== 'SESSION_TIMING');
+    const concordantPhysiologyFeatureCount = physiology.filter((item) => item.concordant).length;
+    const hasDiscordance = evidence.some((item) => !item.concordant);
+    const reasonCodes = uniqueReasons(reasons);
+    const hardFailure = hasHardPreconditionFailure(reasonCodes);
+    const automaticUser =
+        !hardFailure &&
+        !hasDiscordance &&
+        identityScore !== null &&
+        identityScore >= policy.minUserScore &&
+        groupEvidence.has('SESSION_TIMING') &&
+        concordantEvidenceGroupCount >= policy.minConcordantEvidenceGroups &&
+        concordantPhysiologyFeatureCount >= policy.minConcordantPhysiologyFeatures;
+
+    return {
+        identityScore,
+        confidenceTier: automaticUser
+            ? 'HIGH'
+            : confidenceForUncertain(identityScore, hardFailure, hasDiscordance),
+        reasonCodes,
+        featureEvidence: evidence,
+        evaluatedEvidenceGroupCount: groupEvidence.size,
+        concordantEvidenceGroupCount,
+        evaluatedPhysiologyFeatureCount: physiology.length,
+        concordantPhysiologyFeatureCount,
+        // Automatic NOT_USER is structurally absent from this return type in v1 (P-PI-8).
+        automaticStatus: automaticUser ? 'USER' : 'UNCERTAIN',
+    };
+}
+
+/** Builds and deep-freezes PI1's canonical immutable automatic-assessment contract. */
+export function assessPhysiologicalIdentity(
+    input: IdentityAttributionInput,
+    policy: IdentityAttributionPolicy = DEFAULT_IDENTITY_ATTRIBUTION_POLICY,
+): Readonly<AutomaticIdentityAssessment> {
+    const evidence = evaluateIdentityEvidence(input, policy);
+    return freezeAutomaticIdentityAssessment({
+        id: input.assessmentId,
+        sourceNightKey: input.sourceNightKey,
+        sharedSource: {
+            provider: input.sharedBundleRef.provider,
+            transport: input.sharedBundleRef.transport,
+        },
+        automaticStatus: evidence.automaticStatus,
+        identityScore: evidence.identityScore,
+        confidenceTier: evidence.confidenceTier,
+        reasonCodes: [...evidence.reasonCodes],
+        passportVersion: input.passport?.passportVersion ?? null,
+        policyVersion: policy.policyVersion,
+        featureSchemaVersion: input.featureSchemaVersion,
+        assessedAt: input.assessedAt,
+        sharedBundleRef: { ...input.sharedBundleRef },
+        anchorBundleRefs: input.anchorBundleRefs.map((ref) => ({ ...ref })),
+    });
+}

--- a/app/src/engine/identityEligibility.test.ts
+++ b/app/src/engine/identityEligibility.test.ts
@@ -187,9 +187,14 @@ describe('identityEligibility (PI5, ADR-0028 D-PID-PREBASE)', () => {
             reasonCodes: ['MIXED_OCCUPANCY_SUSPECTED'],
             assessmentId,
             reviewEvents: [
+                // user_ui review shape requires EXCLUSIVE occupancy for a USER label (matches the
+                // Firestore client-write rules); a USER label with MIXED occupancy can only be
+                // persisted via admin_replay, which preserves historical combinations unavailable
+                // through the user UI while keeping identity and occupancy as separate evidence.
                 review(assessmentId, {
                     label: 'USER',
                     occupancyAttestation: 'MIXED',
+                    source: 'admin_replay',
                 }),
             ],
         });

--- a/app/src/engine/identityEligibility.test.ts
+++ b/app/src/engine/identityEligibility.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from 'vitest';
+import {
+    deriveEffectiveIdentityDecision,
+    type AutomaticIdentityAssessment,
+    type IdentityReviewEvent,
+} from '../observations/identityModels';
+import type { HealthObservationDayBundle } from '../observations/models';
+import {
+    healthObservationBundleId,
+    selectEligibleHealthObservationBundles,
+    type EffectiveBundleIdentityProjection,
+} from './identityEligibility';
+import { computeSourceMetricBaseline } from './multisourceBaselines';
+
+const IDENTITY_POLICY = {
+    identityRequiredSources: [{ provider: 'shared_bed', transport: 'health_aggregator' }],
+};
+
+function bundle(overrides: Partial<HealthObservationDayBundle> = {}): HealthObservationDayBundle {
+    return {
+        userId: 'user-1',
+        logicalDate: '2026-08-27',
+        provider: 'shared_bed',
+        transport: 'health_aggregator',
+        observations: [{ observationId: 'obs-1', metric: 'hrv_rmssd_ms', value: 60 }],
+        sourcePayloadHash: 'sha256:shared',
+        schemaVersion: 1,
+        normalizerVersion: 1,
+        revision: 1,
+        ingestedAt: '2026-08-27T06:00:00Z',
+        effectiveAt: '2026-08-27T06:00:00Z',
+        ...overrides,
+    };
+}
+
+function review(
+    assessmentId: string,
+    overrides: Partial<IdentityReviewEvent> = {},
+): IdentityReviewEvent {
+    return {
+        id: `review-${assessmentId}`,
+        assessmentId,
+        schemaVersion: 1,
+        label: 'USER',
+        occupancyAttestation: 'EXCLUSIVE',
+        supersedesReviewEventId: null,
+        recordedAt: '2026-08-27T08:00:00Z',
+        source: 'user_ui',
+        ...overrides,
+    };
+}
+
+function projection(
+    sourceBundle: HealthObservationDayBundle,
+    overrides: {
+        automaticStatus?: AutomaticIdentityAssessment['automaticStatus'];
+        reasonCodes?: AutomaticIdentityAssessment['reasonCodes'];
+        reviewEvents?: readonly IdentityReviewEvent[];
+        assessmentId?: string;
+    } = {},
+): EffectiveBundleIdentityProjection {
+    const assessmentId = overrides.assessmentId ?? `assessment-${sourceBundle.logicalDate}`;
+    const assessment: AutomaticIdentityAssessment = {
+        id: assessmentId,
+        sourceNightKey: sourceBundle.logicalDate,
+        sharedSource: {
+            provider: sourceBundle.provider,
+            transport: sourceBundle.transport,
+        },
+        automaticStatus: overrides.automaticStatus ?? 'USER',
+        identityScore: 0.95,
+        confidenceTier: 'HIGH',
+        reasonCodes: overrides.reasonCodes ?? ['SESSION_TIMING_CONCORDANT'],
+        passportVersion: '2026-08-27.1',
+        policyVersion: 'identity-v1-shadow',
+        featureSchemaVersion: 'identity-features-v1',
+        assessedAt: '2026-08-27T06:30:00Z',
+        sharedBundleRef: {
+            id: healthObservationBundleId(sourceBundle),
+            provider: sourceBundle.provider,
+            transport: sourceBundle.transport,
+            revision: sourceBundle.revision,
+            sourcePayloadHash: sourceBundle.sourcePayloadHash,
+            lineageKey: 'shared-bed:side:a',
+        },
+        anchorBundleRefs: [],
+    };
+    return {
+        assessment,
+        decision: deriveEffectiveIdentityDecision(assessment, overrides.reviewEvents ?? []),
+    };
+}
+
+function baseline(
+    bundles: readonly HealthObservationDayBundle[],
+    projections: readonly EffectiveBundleIdentityProjection[],
+) {
+    return computeSourceMetricBaseline({
+        bundles,
+        userId: 'user-1',
+        effectiveIdentityProjections: projections,
+        identityPolicy: IDENTITY_POLICY,
+        metric: 'hrv_rmssd_ms',
+        provider: 'shared_bed',
+        transport: 'health_aggregator',
+        referenceDate: '2026-08-28',
+    });
+}
+
+describe('identityEligibility (PI5, ADR-0028 D-PID-PREBASE)', () => {
+    it('fails closed when a configured shared-source bundle has no effective decision', () => {
+        const sourceBundle = bundle();
+        expect(
+            selectEligibleHealthObservationBundles({
+                bundles: [sourceBundle],
+                userId: 'user-1',
+                effectiveIdentityProjections: [],
+                identityPolicy: IDENTITY_POLICY,
+                requireEligibility: 'baselineLearning',
+            }),
+        ).toEqual([]);
+        expect(baseline([sourceBundle], []).count28d).toBe(0);
+    });
+
+    it('does not require identity assessments for sources not configured as shared', () => {
+        const personal = bundle({
+            provider: 'personal_watch',
+            transport: 'watch_direct',
+            sourcePayloadHash: 'sha256:personal',
+        });
+        const selected = selectEligibleHealthObservationBundles({
+            bundles: [personal],
+            userId: 'user-1',
+            effectiveIdentityProjections: [],
+            identityPolicy: IDENTITY_POLICY,
+            requireEligibility: 'baselineLearning',
+        });
+
+        expect(selected).toEqual([personal]);
+    });
+
+    it('UNCERTAIN and NOT_USER nights never change the shared-source baseline', () => {
+        const uncertainBundle = bundle({ logicalDate: '2026-08-26', sourcePayloadHash: 'sha256:u' });
+        const notUserBundle = bundle({ logicalDate: '2026-08-27', sourcePayloadHash: 'sha256:n' });
+        const uncertainProjection = projection(uncertainBundle, {
+            automaticStatus: 'UNCERTAIN',
+        });
+        const notUserAssessmentId = 'assessment-not-user';
+        const notUserProjection = projection(notUserBundle, {
+            automaticStatus: 'UNCERTAIN',
+            assessmentId: notUserAssessmentId,
+            reviewEvents: [
+                review(notUserAssessmentId, {
+                    label: 'NOT_USER',
+                    occupancyAttestation: 'UNKNOWN',
+                }),
+            ],
+        });
+
+        const result = baseline(
+            [uncertainBundle, notUserBundle],
+            [uncertainProjection, notUserProjection],
+        );
+        expect(result.count28d).toBe(0);
+        expect(result.median28d).toBeNull();
+    });
+
+    it('manual USER + EXCLUSIVE can enter baseline learning', () => {
+        const sourceBundle = bundle();
+        const assessmentId = 'assessment-exclusive';
+        const effectiveProjection = projection(sourceBundle, {
+            automaticStatus: 'UNCERTAIN',
+            assessmentId,
+            reviewEvents: [review(assessmentId)],
+        });
+
+        const result = baseline([sourceBundle], [effectiveProjection]);
+        expect(result.count28d).toBe(1);
+        expect(result.median28d).toBe(60);
+    });
+
+    it('manual USER + MIXED remains baseline-ineligible for a suspected mixed night', () => {
+        const sourceBundle = bundle();
+        const assessmentId = 'assessment-mixed';
+        const mixedProjection = projection(sourceBundle, {
+            automaticStatus: 'UNCERTAIN',
+            reasonCodes: ['MIXED_OCCUPANCY_SUSPECTED'],
+            assessmentId,
+            reviewEvents: [
+                review(assessmentId, {
+                    label: 'USER',
+                    occupancyAttestation: 'MIXED',
+                }),
+            ],
+        });
+
+        expect(mixedProjection.decision.effectiveStatus).toBe('USER');
+        expect(mixedProjection.decision.eligibility.baselineLearning).toBe(false);
+        expect(baseline([sourceBundle], [mixedProjection]).count28d).toBe(0);
+    });
+
+    it('keeps an unusual but identity-concordant USER night eligible', () => {
+        const anomalous = bundle({
+            observations: [{ observationId: 'obs-anomaly', metric: 'hrv_rmssd_ms', value: 5 }],
+        });
+        const result = baseline([anomalous], [projection(anomalous)]);
+
+        expect(result.count28d).toBe(1);
+        expect(result.median28d).toBe(5);
+    });
+
+    it('rejects stale bundle revision/hash projections and ambiguous duplicate projections', () => {
+        const sourceBundle = bundle();
+        const stale = projection(
+            bundle({ revision: 0, sourcePayloadHash: 'sha256:stale' }),
+        );
+        const exact = projection(sourceBundle);
+        const duplicate = projection(sourceBundle, { assessmentId: 'assessment-duplicate' });
+
+        expect(baseline([sourceBundle], [stale]).count28d).toBe(0);
+        expect(baseline([sourceBundle], [exact, duplicate]).count28d).toBe(0);
+    });
+
+    it('filters bundles from another user before any baseline calculation', () => {
+        const foreign = bundle({ userId: 'user-2' });
+        expect(baseline([foreign], [projection(foreign)]).count28d).toBe(0);
+    });
+});

--- a/app/src/engine/identityEligibility.ts
+++ b/app/src/engine/identityEligibility.ts
@@ -1,0 +1,96 @@
+/**
+ * Pre-baseline effective-identity eligibility boundary (PI5, ADR-0028 D-PID-PREBASE).
+ *
+ * Raw health bundles stay preserved, but a configured shared source can enter recovery,
+ * baseline, or passport learning only through an exact, replayable projection joining the
+ * immutable automatic assessment to its derived EffectiveIdentityDecision. Missing, stale, or
+ * ambiguous projections fail closed. Personal-device sources not configured as identity-gated
+ * remain available without manufacturing identity assessments for them.
+ */
+
+import type {
+    AutomaticIdentityAssessment,
+    EffectiveIdentityDecision,
+    ObservationEligibility,
+} from '../observations/identityModels';
+import type { HealthObservationDayBundle } from '../observations/models';
+
+export interface IdentityRequiredSource {
+    provider: string;
+    transport: string;
+}
+
+export interface IdentityEligibilityPolicy {
+    /** Provider-neutral deployment policy; no provider is intrinsically shared/personal here. */
+    identityRequiredSources: readonly IdentityRequiredSource[];
+}
+
+export interface EffectiveBundleIdentityProjection {
+    assessment: AutomaticIdentityAssessment;
+    decision: EffectiveIdentityDecision;
+}
+
+export type IdentityEligibilityRequirement = Exclude<keyof ObservationEligibility, 'display'>;
+
+export function healthObservationBundleId(bundle: HealthObservationDayBundle): string {
+    return `${bundle.logicalDate}_${bundle.provider}_${bundle.transport}`;
+}
+
+function requiresIdentityDecision(
+    bundle: HealthObservationDayBundle,
+    policy: IdentityEligibilityPolicy,
+): boolean {
+    return policy.identityRequiredSources.some(
+        (source) => source.provider === bundle.provider && source.transport === bundle.transport,
+    );
+}
+
+function projectionMatchesBundle(
+    bundle: HealthObservationDayBundle,
+    projection: EffectiveBundleIdentityProjection,
+): boolean {
+    const { assessment, decision } = projection;
+    return (
+        decision.assessmentId === assessment.id &&
+        assessment.sourceNightKey === bundle.logicalDate &&
+        assessment.sharedSource.provider === bundle.provider &&
+        assessment.sharedSource.transport === bundle.transport &&
+        assessment.sharedBundleRef.id === healthObservationBundleId(bundle) &&
+        assessment.sharedBundleRef.provider === bundle.provider &&
+        assessment.sharedBundleRef.transport === bundle.transport &&
+        assessment.sharedBundleRef.revision === bundle.revision &&
+        assessment.sharedBundleRef.sourcePayloadHash === bundle.sourcePayloadHash
+    );
+}
+
+/**
+ * Selects an already-authorised projection for downstream computation. For an identity-gated
+ * source, exactly one exact-bundle projection must resolve to effective USER and grant the
+ * requested eligibility flag. This function never mutates or deletes the raw input bundles.
+ */
+export function selectEligibleHealthObservationBundles(params: {
+    bundles: readonly HealthObservationDayBundle[];
+    userId: string;
+    effectiveIdentityProjections: readonly EffectiveBundleIdentityProjection[];
+    identityPolicy: IdentityEligibilityPolicy;
+    requireEligibility: IdentityEligibilityRequirement;
+}): readonly HealthObservationDayBundle[] {
+    return params.bundles.filter((bundle) => {
+        if (bundle.userId !== params.userId) {
+            return false;
+        }
+        if (!requiresIdentityDecision(bundle, params.identityPolicy)) {
+            return true;
+        }
+
+        const matches = params.effectiveIdentityProjections.filter((projection) =>
+            projectionMatchesBundle(bundle, projection),
+        );
+        if (matches.length !== 1) {
+            return false;
+        }
+
+        const { decision } = matches[0];
+        return decision.effectiveStatus === 'USER' && decision.eligibility[params.requireEligibility];
+    });
+}

--- a/app/src/engine/identityFeatures.test.ts
+++ b/app/src/engine/identityFeatures.test.ts
@@ -1,0 +1,300 @@
+import { describe, expect, it } from 'vitest';
+import {
+    computeIntervalOverlapMetrics,
+    computePhysiologicalRelationFeatures,
+    evaluateAnchorEligibility,
+    selectBestSessionPairing,
+    type SessionInterval,
+} from './identityFeatures';
+
+describe('computeIntervalOverlapMetrics (PI2, ADR-0028)', () => {
+    it('exact overlap: identical intervals yield jaccard=1 and zero deltas', () => {
+        const garmin: SessionInterval = { startIso: '2026-08-27T22:00:00Z', endIso: '2026-08-28T06:00:00Z' };
+        const eightSleep: SessionInterval = { ...garmin };
+
+        const result = computeIntervalOverlapMetrics(garmin, eightSleep);
+        expect(result.valid).toBe(true);
+        expect(result.metrics).toEqual({
+            intersectionMinutes: 480,
+            unionMinutes: 480,
+            jaccard: 1,
+            eightOverlapFraction: 1,
+            garminOverlapFraction: 1,
+            startDeltaMinutes: 0,
+            endDeltaMinutes: 0,
+            durationDeltaMinutes: 0,
+        });
+    });
+
+    it('partial overlap at the start: Eight Sleep begins and ends earlier', () => {
+        const garmin: SessionInterval = { startIso: '2026-08-27T22:00:00Z', endIso: '2026-08-28T06:00:00Z' };
+        const eightSleep: SessionInterval = { startIso: '2026-08-27T21:00:00Z', endIso: '2026-08-28T05:00:00Z' };
+
+        const { metrics } = computeIntervalOverlapMetrics(garmin, eightSleep);
+        expect(metrics).toMatchObject({
+            intersectionMinutes: 420,
+            unionMinutes: 540,
+            startDeltaMinutes: -60,
+            endDeltaMinutes: -60,
+            durationDeltaMinutes: 0,
+        });
+        expect(metrics!.jaccard).toBeCloseTo(420 / 540, 10);
+        expect(metrics!.eightOverlapFraction).toBeCloseTo(420 / 480, 10);
+        expect(metrics!.garminOverlapFraction).toBeCloseTo(420 / 480, 10);
+    });
+
+    it('partial overlap at the end: Eight Sleep begins and ends later', () => {
+        const garmin: SessionInterval = { startIso: '2026-08-27T22:00:00Z', endIso: '2026-08-28T06:00:00Z' };
+        const eightSleep: SessionInterval = { startIso: '2026-08-27T23:00:00Z', endIso: '2026-08-28T07:00:00Z' };
+
+        const { metrics } = computeIntervalOverlapMetrics(garmin, eightSleep);
+        expect(metrics).toMatchObject({
+            intersectionMinutes: 420,
+            unionMinutes: 540,
+            startDeltaMinutes: 60,
+            endDeltaMinutes: 60,
+            durationDeltaMinutes: 0,
+        });
+    });
+
+    it('nested intervals: Eight Sleep session fully inside a longer Garmin session', () => {
+        const garmin: SessionInterval = { startIso: '2026-08-27T21:00:00Z', endIso: '2026-08-28T07:00:00Z' };
+        const eightSleep: SessionInterval = { startIso: '2026-08-27T23:00:00Z', endIso: '2026-08-28T05:00:00Z' };
+
+        const { metrics } = computeIntervalOverlapMetrics(garmin, eightSleep);
+        expect(metrics).toMatchObject({
+            intersectionMinutes: 360,
+            unionMinutes: 600,
+            eightOverlapFraction: 1,
+            garminOverlapFraction: 0.6,
+            startDeltaMinutes: 120,
+            endDeltaMinutes: -120,
+            durationDeltaMinutes: -240,
+        });
+    });
+
+    it('disjoint intervals: a daytime nap has zero intersection with an overnight Garmin session', () => {
+        const garmin: SessionInterval = { startIso: '2026-08-27T22:00:00Z', endIso: '2026-08-28T06:00:00Z' };
+        const eightSleep: SessionInterval = { startIso: '2026-08-27T14:00:00Z', endIso: '2026-08-27T14:45:00Z' };
+
+        const { valid, metrics } = computeIntervalOverlapMetrics(garmin, eightSleep);
+        expect(valid).toBe(true);
+        expect(metrics!.intersectionMinutes).toBe(0);
+        expect(metrics!.jaccard).toBe(0);
+        expect(metrics!.eightOverlapFraction).toBe(0);
+        expect(metrics!.garminOverlapFraction).toBe(0);
+    });
+
+    it('timezone/UTC boundary: mixed "Z" and explicit-offset timestamps resolve to the same instants', () => {
+        // 20:00Z == 22:00+02:00; 04:00Z (next day) == 06:00+02:00 (next day).
+        const garmin: SessionInterval = { startIso: '2026-08-27T20:00:00Z', endIso: '2026-08-28T04:00:00Z' };
+        const eightSleep: SessionInterval = {
+            startIso: '2026-08-27T22:00:00+02:00',
+            endIso: '2026-08-28T06:00:00+02:00',
+        };
+
+        const { metrics } = computeIntervalOverlapMetrics(garmin, eightSleep);
+        expect(metrics!.jaccard).toBe(1);
+        expect(metrics!.startDeltaMinutes).toBe(0);
+        expect(metrics!.endDeltaMinutes).toBe(0);
+    });
+
+    it('DST spring-forward in Europe/Warsaw (2026-03-29, clocks skip 02:00->03:00 CEST) computes real elapsed time', () => {
+        // Wall-clock 01:00->04:00 spans the skipped hour; real elapsed time is only 2h, not 3h.
+        const garmin: SessionInterval = {
+            startIso: '2026-03-29T01:00:00+01:00',
+            endIso: '2026-03-29T04:00:00+02:00',
+        };
+        // Nested wall-clock 01:15->03:45, real elapsed 1.5h, fully inside the 2h Garmin window.
+        const eightSleep: SessionInterval = {
+            startIso: '2026-03-29T01:15:00+01:00',
+            endIso: '2026-03-29T03:45:00+02:00',
+        };
+
+        const { metrics } = computeIntervalOverlapMetrics(garmin, eightSleep);
+        expect(metrics!.unionMinutes).toBe(120); // Garmin's real 2h span, not a naive 3h wall-clock span
+        expect(metrics!.eightOverlapFraction).toBe(1); // Eight Sleep fully nested
+        expect(metrics!.durationDeltaMinutes).toBe(-30); // 90min - 120min
+    });
+
+    it('DST fall-back in Europe/Warsaw (2026-10-25, clocks repeat 02:00-03:00) computes real elapsed time', () => {
+        // Wall-clock 22:00->06:00 looks like 8h but the repeated hour makes real elapsed time 9h.
+        const interval: SessionInterval = {
+            startIso: '2026-10-24T22:00:00+02:00',
+            endIso: '2026-10-25T06:00:00+01:00',
+        };
+
+        const { metrics } = computeIntervalOverlapMetrics(interval, { ...interval });
+        expect(metrics!.intersectionMinutes).toBe(540); // 9h, not 8h
+        expect(metrics!.unionMinutes).toBe(540);
+        expect(metrics!.jaccard).toBe(1);
+    });
+
+    describe('rejected pairs (SESSION_INTERVAL_INVALID)', () => {
+        it('rejects a missing/empty start timestamp', () => {
+            const result = computeIntervalOverlapMetrics(
+                { startIso: '', endIso: '2026-08-28T06:00:00Z' },
+                { startIso: '2026-08-27T22:00:00Z', endIso: '2026-08-28T06:00:00Z' },
+            );
+            expect(result).toEqual({ valid: false, reasonCode: 'SESSION_INTERVAL_INVALID', metrics: null });
+        });
+
+        it('rejects an unparsable timestamp', () => {
+            const result = computeIntervalOverlapMetrics(
+                { startIso: 'not-a-date', endIso: '2026-08-28T06:00:00Z' },
+                { startIso: '2026-08-27T22:00:00Z', endIso: '2026-08-28T06:00:00Z' },
+            );
+            expect(result.valid).toBe(false);
+            expect(result.reasonCode).toBe('SESSION_INTERVAL_INVALID');
+        });
+
+        it('rejects a zero-length Garmin interval', () => {
+            const zero: SessionInterval = { startIso: '2026-08-27T22:00:00Z', endIso: '2026-08-27T22:00:00Z' };
+            const result = computeIntervalOverlapMetrics(zero, {
+                startIso: '2026-08-27T22:00:00Z',
+                endIso: '2026-08-28T06:00:00Z',
+            });
+            expect(result.valid).toBe(false);
+            expect(result.reasonCode).toBe('SESSION_INTERVAL_INVALID');
+        });
+
+        it('rejects a zero-length Eight Sleep interval', () => {
+            const zero: SessionInterval = { startIso: '2026-08-28T02:00:00Z', endIso: '2026-08-28T02:00:00Z' };
+            const result = computeIntervalOverlapMetrics(
+                { startIso: '2026-08-27T22:00:00Z', endIso: '2026-08-28T06:00:00Z' },
+                zero,
+            );
+            expect(result.valid).toBe(false);
+            expect(result.reasonCode).toBe('SESSION_INTERVAL_INVALID');
+        });
+
+        it('rejects reversed timestamps (end before start)', () => {
+            const reversed: SessionInterval = { startIso: '2026-08-28T06:00:00Z', endIso: '2026-08-27T22:00:00Z' };
+            const result = computeIntervalOverlapMetrics(reversed, {
+                startIso: '2026-08-27T22:00:00Z',
+                endIso: '2026-08-28T06:00:00Z',
+            });
+            expect(result.valid).toBe(false);
+            expect(result.reasonCode).toBe('SESSION_INTERVAL_INVALID');
+        });
+    });
+});
+
+describe('selectBestSessionPairing (PI2)', () => {
+    it('multiple sleep sessions / naps: ignores a non-overlapping nap and selects the real overnight session', () => {
+        const mainSleep: SessionInterval = { startIso: '2026-08-27T22:00:00Z', endIso: '2026-08-28T06:00:00Z' };
+        const nap: SessionInterval = { startIso: '2026-08-27T14:00:00Z', endIso: '2026-08-27T14:45:00Z' };
+
+        const result = selectBestSessionPairing([mainSleep], [nap, mainSleep]);
+        expect(result.selected?.eightSleepIndex).toBe(1);
+        expect(result.selected?.eightSleep).toEqual(mainSleep);
+        expect(result.reasonCodes).toEqual([]); // only one genuinely overlapping candidate
+    });
+
+    it('deterministic pairing when multiple candidate sessions plausibly overlap', () => {
+        const garminA: SessionInterval = { startIso: '2026-08-27T22:00:00Z', endIso: '2026-08-28T02:00:00Z' };
+        const garminB: SessionInterval = { startIso: '2026-08-28T01:00:00Z', endIso: '2026-08-28T06:00:00Z' };
+        // Overlaps both Garmin sessions; overlaps garminB more (3h) than garminA (1h).
+        const eightSleep: SessionInterval = { startIso: '2026-08-28T01:00:00Z', endIso: '2026-08-28T04:00:00Z' };
+
+        const result = selectBestSessionPairing([garminA, garminB], [eightSleep]);
+        expect(result.reasonCodes).toEqual(['MULTIPLE_PAIRING_CANDIDATES']);
+        expect(result.selected?.garminIndex).toBe(1); // garminB: strictly larger intersection wins deterministically
+
+        // Re-running with the Garmin sessions reordered must resolve to the same underlying pairing.
+        const reordered = selectBestSessionPairing([garminB, garminA], [eightSleep]);
+        expect(reordered.selected?.garmin).toEqual(garminB);
+    });
+
+    it('returns no selection and no ambiguity code when no session overlaps at all', () => {
+        const garmin: SessionInterval = { startIso: '2026-08-27T22:00:00Z', endIso: '2026-08-28T06:00:00Z' };
+        const nap: SessionInterval = { startIso: '2026-08-27T14:00:00Z', endIso: '2026-08-27T14:45:00Z' };
+
+        const result = selectBestSessionPairing([garmin], [nap]);
+        expect(result.selected).toBeNull();
+        expect(result.reasonCodes).toEqual([]);
+    });
+
+    it('surfaces SESSION_INTERVAL_INVALID when every candidate pair is technically invalid', () => {
+        const zero: SessionInterval = { startIso: '2026-08-27T22:00:00Z', endIso: '2026-08-27T22:00:00Z' };
+        const result = selectBestSessionPairing([zero], [zero]);
+        expect(result.selected).toBeNull();
+        expect(result.reasonCodes).toEqual(['SESSION_INTERVAL_INVALID']);
+    });
+});
+
+describe('evaluateAnchorEligibility (PI2, ADR-0028 P-PI-9)', () => {
+    it('missing anchor abstains with ANCHOR_MISSING, not a negative determination', () => {
+        expect(evaluateAnchorEligibility({ present: false, technicallyEligible: false })).toEqual({
+            eligible: false,
+            reasonCode: 'ANCHOR_MISSING',
+        });
+    });
+
+    it('a technically present but ineligible anchor abstains with ANCHOR_QUALITY_INSUFFICIENT', () => {
+        expect(evaluateAnchorEligibility({ present: true, technicallyEligible: false })).toEqual({
+            eligible: false,
+            reasonCode: 'ANCHOR_QUALITY_INSUFFICIENT',
+        });
+    });
+
+    it('a present and technically eligible anchor is usable', () => {
+        expect(evaluateAnchorEligibility({ present: true, technicallyEligible: true })).toEqual({
+            eligible: true,
+            reasonCode: null,
+        });
+    });
+});
+
+describe('computePhysiologicalRelationFeatures (PI2)', () => {
+    it('computes all three residuals when every input is present', () => {
+        const features = computePhysiologicalRelationFeatures({
+            eightSleepRhr: 45,
+            garminRhr: 44,
+            eightSleepResp: 15,
+            garminResp: 14,
+            eightSleepHrv: 55,
+            garminHrv: 50,
+        });
+
+        expect(features.rhrResidual).toBe(1);
+        expect(features.respResidual).toBe(1);
+        expect(features.hrvLogResidual).toBeCloseTo(Math.log(55) - Math.log(50), 10);
+    });
+
+    it('does not zero-fill a missing feature; other features remain independently available', () => {
+        const features = computePhysiologicalRelationFeatures({
+            eightSleepRhr: 45,
+            garminRhr: null, // Garmin RHR unavailable
+            eightSleepResp: 15,
+            garminResp: 14,
+        });
+
+        expect(features.rhrResidual).toBeNull();
+        expect(features.respResidual).toBe(1);
+        expect(features.hrvLogResidual).toBeNull();
+    });
+
+    it('guards the HRV log residual against non-positive or invalid input', () => {
+        expect(
+            computePhysiologicalRelationFeatures({ eightSleepHrv: 0, garminHrv: 50 }).hrvLogResidual,
+        ).toBeNull();
+        expect(
+            computePhysiologicalRelationFeatures({ eightSleepHrv: -5, garminHrv: 50 }).hrvLogResidual,
+        ).toBeNull();
+        expect(
+            computePhysiologicalRelationFeatures({ eightSleepHrv: 55, garminHrv: undefined }).hrvLogResidual,
+        ).toBeNull();
+        expect(
+            computePhysiologicalRelationFeatures({ eightSleepHrv: Number.NaN, garminHrv: 50 }).hrvLogResidual,
+        ).toBeNull();
+    });
+
+    it('never fabricates a value from a population mean when everything is missing', () => {
+        expect(computePhysiologicalRelationFeatures({})).toEqual({
+            rhrResidual: null,
+            respResidual: null,
+            hrvLogResidual: null,
+        });
+    });
+});

--- a/app/src/engine/identityFeatures.ts
+++ b/app/src/engine/identityFeatures.ts
@@ -1,0 +1,249 @@
+/**
+ * Cross-source night/session pairing and physiological relation feature extraction (PI2, ADR-0028).
+ *
+ * Pairs Garmin (worn anchor) and Eight Sleep (shared-source) sleep session intervals by temporal
+ * overlap -- not calendar date alone, since recovery nights cross midnight and upstream
+ * logical-date conventions can differ -- and derives the evidence features the Physiological
+ * Identity Passport (PI3/PI4) scores against a passport's paired relationship.
+ *
+ * This module does not decide identity. It produces features and abstains (via reason codes) when
+ * a feature cannot be computed safely; PI4's evaluator composes these into USER/NOT_USER/UNCERTAIN.
+ */
+
+import type { IdentityReasonCode } from '../observations/identityModels';
+
+export interface SessionInterval {
+    startIso: string;
+    endIso: string;
+}
+
+export interface IntervalOverlapMetrics {
+    intersectionMinutes: number;
+    unionMinutes: number;
+    jaccard: number;
+    eightOverlapFraction: number;
+    garminOverlapFraction: number;
+    startDeltaMinutes: number;
+    endDeltaMinutes: number;
+    durationDeltaMinutes: number;
+}
+
+export interface IntervalPairingResult {
+    valid: boolean;
+    reasonCode: 'SESSION_INTERVAL_INVALID' | null;
+    metrics: IntervalOverlapMetrics | null;
+}
+
+function parseIntervalMs(interval: SessionInterval): { startMs: number; endMs: number } | null {
+    const startMs = new Date(interval.startIso).getTime();
+    const endMs = new Date(interval.endIso).getTime();
+    if (Number.isNaN(startMs) || Number.isNaN(endMs)) {
+        return null;
+    }
+    return { startMs, endMs };
+}
+
+const INVALID_INTERVAL_RESULT: IntervalPairingResult = {
+    valid: false,
+    reasonCode: 'SESSION_INTERVAL_INVALID',
+    metrics: null,
+};
+
+/**
+ * Computes Garmin<->Eight Sleep session overlap metrics per the plan's interval math. Rejects
+ * (abstains on) unparsable timestamps or a non-positive duration on either side rather than
+ * dividing by a zero/negative duration -- callers must treat a rejected pair as `UNCERTAIN`
+ * (`SESSION_INTERVAL_INVALID`), a deterministic technical-quality rejection independent of anchor
+ * eligibility.
+ */
+export function computeIntervalOverlapMetrics(
+    garmin: SessionInterval,
+    eightSleep: SessionInterval,
+): IntervalPairingResult {
+    const g = parseIntervalMs(garmin);
+    const e = parseIntervalMs(eightSleep);
+    if (!g || !e) {
+        return INVALID_INTERVAL_RESULT;
+    }
+
+    const garminDurationMs = g.endMs - g.startMs;
+    const eightDurationMs = e.endMs - e.startMs;
+    if (garminDurationMs <= 0 || eightDurationMs <= 0) {
+        return INVALID_INTERVAL_RESULT;
+    }
+
+    const intersectionMs = Math.max(0, Math.min(g.endMs, e.endMs) - Math.max(g.startMs, e.startMs));
+    const unionMs = Math.max(g.endMs, e.endMs) - Math.min(g.startMs, e.startMs);
+
+    const msToMin = (ms: number) => ms / 60000;
+
+    const metrics: IntervalOverlapMetrics = {
+        intersectionMinutes: msToMin(intersectionMs),
+        unionMinutes: msToMin(unionMs),
+        jaccard: unionMs > 0 ? intersectionMs / unionMs : 0,
+        eightOverlapFraction: intersectionMs / eightDurationMs,
+        garminOverlapFraction: intersectionMs / garminDurationMs,
+        startDeltaMinutes: msToMin(e.startMs - g.startMs),
+        endDeltaMinutes: msToMin(e.endMs - g.endMs),
+        durationDeltaMinutes: msToMin(eightDurationMs - garminDurationMs),
+    };
+
+    return { valid: true, reasonCode: null, metrics };
+}
+
+export interface PairingCandidate {
+    garminIndex: number;
+    eightSleepIndex: number;
+    garmin: SessionInterval;
+    eightSleep: SessionInterval;
+    validation: IntervalPairingResult;
+}
+
+export interface SessionPairingResult {
+    selected: PairingCandidate | null;
+    candidates: readonly PairingCandidate[];
+    reasonCodes: readonly IdentityReasonCode[];
+}
+
+function compareCandidatesForSelection(a: PairingCandidate, b: PairingCandidate): number {
+    const aMetrics = a.validation.metrics;
+    const bMetrics = b.validation.metrics;
+    if (!aMetrics || !bMetrics) {
+        return 0; // unreachable for candidates passed in here (always valid+overlapping), kept for safety
+    }
+    if (aMetrics.intersectionMinutes !== bMetrics.intersectionMinutes) {
+        return bMetrics.intersectionMinutes - aMetrics.intersectionMinutes; // largest overlap wins
+    }
+    if (aMetrics.jaccard !== bMetrics.jaccard) {
+        return bMetrics.jaccard - aMetrics.jaccard;
+    }
+    // Deterministic tie-break: earliest Garmin session, then earliest Eight Sleep session index.
+    if (a.garminIndex !== b.garminIndex) {
+        return a.garminIndex - b.garminIndex;
+    }
+    return a.eightSleepIndex - b.eightSleepIndex;
+}
+
+/**
+ * Pairs every candidate Garmin session against every candidate Eight Sleep session (naps
+ * included) and deterministically selects the strongest genuine overlap. Multiple sessions with
+ * plausible overlap surface `MULTIPLE_PAIRING_CANDIDATES` rather than being silently merged --
+ * per-night ambiguity is evidence, not a solved problem, and PI4 must see it.
+ */
+export function selectBestSessionPairing(
+    garminSessions: readonly SessionInterval[],
+    eightSleepSessions: readonly SessionInterval[],
+): SessionPairingResult {
+    const candidates: PairingCandidate[] = [];
+    for (let garminIndex = 0; garminIndex < garminSessions.length; garminIndex++) {
+        for (let eightSleepIndex = 0; eightSleepIndex < eightSleepSessions.length; eightSleepIndex++) {
+            const garmin = garminSessions[garminIndex];
+            const eightSleep = eightSleepSessions[eightSleepIndex];
+            candidates.push({
+                garminIndex,
+                eightSleepIndex,
+                garmin,
+                eightSleep,
+                validation: computeIntervalOverlapMetrics(garmin, eightSleep),
+            });
+        }
+    }
+
+    const overlapping = candidates.filter(
+        (c) => c.validation.valid && (c.validation.metrics?.intersectionMinutes ?? 0) > 0,
+    );
+
+    if (overlapping.length === 0) {
+        const anyInvalid = candidates.some((c) => !c.validation.valid);
+        return {
+            selected: null,
+            candidates,
+            reasonCodes: anyInvalid ? ['SESSION_INTERVAL_INVALID'] : [],
+        };
+    }
+
+    const [selected] = [...overlapping].sort(compareCandidatesForSelection);
+    const reasonCodes: IdentityReasonCode[] =
+        overlapping.length > 1 ? ['MULTIPLE_PAIRING_CANDIDATES'] : [];
+
+    return { selected, candidates, reasonCodes };
+}
+
+export interface AnchorEligibilityInput {
+    present: boolean;
+    /** Result of the relevant technical/wear/session-quality checks for this Garmin record. */
+    technicallyEligible: boolean;
+}
+
+export interface AnchorEligibilityResult {
+    eligible: boolean;
+    reasonCode: 'ANCHOR_MISSING' | 'ANCHOR_QUALITY_INSUFFICIENT' | null;
+}
+
+/**
+ * A present Garmin record is not automatically a usable identity anchor. Both failure modes
+ * abstain (feed `UNCERTAIN`) rather than infer `NOT_USER` -- missing/ineligible anchor evidence is
+ * missing evidence, not negative evidence (ADR-0028 P-PI-9).
+ */
+export function evaluateAnchorEligibility(input: AnchorEligibilityInput): AnchorEligibilityResult {
+    if (!input.present) {
+        return { eligible: false, reasonCode: 'ANCHOR_MISSING' };
+    }
+    if (!input.technicallyEligible) {
+        return { eligible: false, reasonCode: 'ANCHOR_QUALITY_INSUFFICIENT' };
+    }
+    return { eligible: true, reasonCode: null };
+}
+
+export interface PhysiologicalRelationInput {
+    eightSleepRhr?: number | null;
+    garminRhr?: number | null;
+    eightSleepResp?: number | null;
+    garminResp?: number | null;
+    eightSleepHrv?: number | null;
+    garminHrv?: number | null;
+}
+
+export interface PhysiologicalRelationFeatures {
+    rhrResidual: number | null;
+    respResidual: number | null;
+    hrvLogResidual: number | null;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+    return typeof value === 'number' && Number.isFinite(value);
+}
+
+function computeResidual(a: number | null | undefined, b: number | null | undefined): number | null {
+    if (!isFiniteNumber(a) || !isFiniteNumber(b)) {
+        return null; // missingness is never zero-filled
+    }
+    return a - b;
+}
+
+function computeLogResidual(a: number | null | undefined, b: number | null | undefined): number | null {
+    if (!isFiniteNumber(a) || !isFiniteNumber(b)) {
+        return null;
+    }
+    if (a <= 0 || b <= 0) {
+        return null; // log domain guard: non-positive HRV is invalid input, not a computable residual
+    }
+    return Math.log(a) - Math.log(b);
+}
+
+/**
+ * Derives paired physiological relation residuals. Each feature is computed independently and
+ * missingness never zero-fills or falls back to a population mean -- an absent Garmin RHR simply
+ * yields `rhrResidual: null` while `respResidual`/`hrvLogResidual` may still be available.
+ * Cross-device HRV equality is never required; only the paired relationship (log residual) is
+ * evaluated by the passport (PI3/PI4).
+ */
+export function computePhysiologicalRelationFeatures(
+    input: PhysiologicalRelationInput,
+): PhysiologicalRelationFeatures {
+    return {
+        rhrResidual: computeResidual(input.eightSleepRhr, input.garminRhr),
+        respResidual: computeResidual(input.eightSleepResp, input.garminResp),
+        hrvLogResidual: computeLogResidual(input.eightSleepHrv, input.garminHrv),
+    };
+}

--- a/app/src/engine/identityLineage.test.ts
+++ b/app/src/engine/identityLineage.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+import {
+    deduplicateByLineage,
+    evaluateAnchorLineageIndependence,
+    groupByLineage,
+    isLineageIndependent,
+} from './identityLineage';
+import type { ObservationBundleRef } from '../observations/identityModels';
+
+function ref(overrides: Partial<ObservationBundleRef> = {}): ObservationBundleRef {
+    return {
+        id: 'ref-1',
+        provider: 'garmin',
+        transport: 'garmin_direct',
+        revision: 1,
+        sourcePayloadHash: 'sha256:abc',
+        lineageKey: 'garmin:device:xyz',
+        ...overrides,
+    };
+}
+
+describe('identityLineage (PI2, ADR-0028 P-PI-13)', () => {
+    describe('isLineageIndependent', () => {
+        it('is independent when lineage keys differ', () => {
+            const a = ref({ lineageKey: 'garmin:device:xyz' });
+            const b = ref({ id: 'ref-2', provider: 'eight_sleep', lineageKey: 'eight_sleep:pod-side:abc' });
+            expect(isLineageIndependent(a, b)).toBe(true);
+        });
+
+        it('K. mirrored evidence: same upstream Garmin signal re-exported by another transport is dependent', () => {
+            const garminDirect = ref({ id: 'ref-1', provider: 'garmin', transport: 'garmin_direct' });
+            const reExported = ref({
+                id: 'ref-2',
+                provider: 'garmin',
+                transport: 'third_party_aggregator',
+                // Same lineageKey: it is the *same* upstream sensor lineage, just a different transport.
+                lineageKey: garminDirect.lineageKey,
+            });
+
+            expect(isLineageIndependent(garminDirect, reExported)).toBe(false);
+        });
+
+        it('provider/transport difference alone is not proof of independence', () => {
+            const a = ref({ provider: 'garmin', transport: 'garmin_direct', lineageKey: 'shared-lineage' });
+            const b = ref({ provider: 'garmin', transport: 'google_health', lineageKey: 'shared-lineage' });
+            expect(isLineageIndependent(a, b)).toBe(false);
+        });
+    });
+
+    describe('evaluateAnchorLineageIndependence', () => {
+        it('returns independent anchors with no reason codes when lineage differs', () => {
+            const shared = ref({ id: 'shared', provider: 'eight_sleep', lineageKey: 'eight_sleep:pod-side:abc' });
+            const anchor = ref({ id: 'anchor', provider: 'garmin', lineageKey: 'garmin:device:xyz' });
+
+            const result = evaluateAnchorLineageIndependence([anchor], shared);
+            expect(result.independentAnchorRefs).toEqual([anchor]);
+            expect(result.dependentAnchorRefs).toEqual([]);
+            expect(result.reasonCodes).toEqual([]);
+        });
+
+        it('excludes a dependent anchor and emits EVIDENCE_LINEAGE_DEPENDENT', () => {
+            const shared = ref({ id: 'shared', lineageKey: 'garmin:device:xyz' });
+            const dependentAnchor = ref({ id: 'anchor', lineageKey: 'garmin:device:xyz' });
+
+            const result = evaluateAnchorLineageIndependence([dependentAnchor], shared);
+            expect(result.independentAnchorRefs).toEqual([]);
+            expect(result.dependentAnchorRefs).toEqual([dependentAnchor]);
+            expect(result.reasonCodes).toEqual(['EVIDENCE_LINEAGE_DEPENDENT']);
+        });
+
+        it('keeps an independent anchor even when another candidate anchor is dependent', () => {
+            const shared = ref({ id: 'shared', lineageKey: 'eight_sleep:pod-side:abc' });
+            const independentAnchor = ref({ id: 'anchor-1', lineageKey: 'garmin:device:xyz' });
+            const dependentAnchor = ref({ id: 'anchor-2', lineageKey: 'eight_sleep:pod-side:abc' });
+
+            const result = evaluateAnchorLineageIndependence([independentAnchor, dependentAnchor], shared);
+            expect(result.independentAnchorRefs).toEqual([independentAnchor]);
+            expect(result.dependentAnchorRefs).toEqual([dependentAnchor]);
+            expect(result.reasonCodes).toEqual(['EVIDENCE_LINEAGE_DEPENDENT']);
+        });
+    });
+
+    describe('groupByLineage / deduplicateByLineage', () => {
+        it('groups mirrored refs under one lineage key', () => {
+            const original = ref({ id: 'a', revision: 1, lineageKey: 'garmin:device:xyz' });
+            const mirror = ref({ id: 'b', revision: 1, provider: 'garmin', transport: 'aggregator', lineageKey: 'garmin:device:xyz' });
+            const distinct = ref({ id: 'c', lineageKey: 'eight_sleep:pod-side:abc' });
+
+            const groups = groupByLineage([original, mirror, distinct]);
+            expect(groups).toHaveLength(2);
+            expect(groups[0].refs).toEqual([original, mirror]);
+            expect(groups[1].refs).toEqual([distinct]);
+        });
+
+        it('deduplicates to one representative per lineage, preferring the highest revision', () => {
+            const stale = ref({ id: 'a', revision: 1, lineageKey: 'garmin:device:xyz' });
+            const fresh = ref({ id: 'b', revision: 2, lineageKey: 'garmin:device:xyz' });
+
+            expect(deduplicateByLineage([stale, fresh])).toEqual([fresh]);
+        });
+
+        it('breaks a revision tie deterministically by id', () => {
+            const b = ref({ id: 'b', revision: 1, lineageKey: 'garmin:device:xyz' });
+            const a = ref({ id: 'a', revision: 1, lineageKey: 'garmin:device:xyz' });
+
+            expect(deduplicateByLineage([b, a])).toEqual([a]);
+            expect(deduplicateByLineage([a, b])).toEqual([a]); // order-independent
+        });
+
+        it('is a no-op when every ref is already lineage-independent', () => {
+            const refs = [
+                ref({ id: 'a', lineageKey: 'garmin:device:xyz' }),
+                ref({ id: 'b', lineageKey: 'eight_sleep:pod-side:abc' }),
+            ];
+            expect(deduplicateByLineage(refs)).toEqual(refs);
+        });
+    });
+});

--- a/app/src/engine/identityLineage.ts
+++ b/app/src/engine/identityLineage.ts
@@ -1,0 +1,98 @@
+/**
+ * Provenance-lineage independence evaluation (PI2, ADR-0028).
+ *
+ * Before physiological or session-timing features can corroborate identity, confirm that the
+ * anchor and shared-source observations are independent at the sensor lineage level:
+ *
+ *   Garmin Direct observation
+ *   + same Garmin observation re-exported through an aggregator
+ *   != two independent votes
+ *
+ * Provider/transport difference is useful provenance (ADR-0027) but is not, by itself, proof of
+ * independence -- two `ObservationBundleRef`s that trace back to the same upstream sensor lineage
+ * must never be counted as corroborating evidence twice (ADR-0028 P-PI-13). This mirrors the
+ * broader provenance principle used in health-data interoperability (HL7 FHIR Provenance):
+ * trust/replay requires retaining the entities/processes that produced and transformed a
+ * resource, not only its final transport.
+ */
+
+import type { IdentityReasonCode, ObservationBundleRef } from '../observations/identityModels';
+
+/**
+ * Two bundle refs are lineage-independent when their `lineageKey` values differ. `lineageKey` is
+ * expected to identify the ultimate originating sensor/process, not the transport that carried it
+ * -- a mirrored/re-exported copy of the same upstream signal must carry the same `lineageKey` as
+ * its origin so this comparison catches it regardless of provider/transport labeling.
+ */
+export function isLineageIndependent(a: ObservationBundleRef, b: ObservationBundleRef): boolean {
+    return a.lineageKey !== b.lineageKey;
+}
+
+export interface AnchorLineageEvaluation {
+    /** Anchor refs whose lineage is independent of the shared-source ref -- usable as corroboration. */
+    independentAnchorRefs: readonly ObservationBundleRef[];
+    /** Anchor refs excluded because they share lineage with the shared-source ref. */
+    dependentAnchorRefs: readonly ObservationBundleRef[];
+    reasonCodes: readonly IdentityReasonCode[];
+}
+
+/**
+ * Filters a set of candidate anchor bundle refs down to those independent of the shared-source
+ * ref. When every candidate anchor is lineage-dependent (or none exist), no independent
+ * corroboration is available and callers must abstain (`UNCERTAIN`) rather than treat the
+ * dependent evidence as confirming.
+ */
+export function evaluateAnchorLineageIndependence(
+    anchorRefs: readonly ObservationBundleRef[],
+    sharedRef: ObservationBundleRef,
+): AnchorLineageEvaluation {
+    const independentAnchorRefs = anchorRefs.filter((ref) => isLineageIndependent(ref, sharedRef));
+    const dependentAnchorRefs = anchorRefs.filter((ref) => !isLineageIndependent(ref, sharedRef));
+
+    const reasonCodes: IdentityReasonCode[] =
+        dependentAnchorRefs.length > 0 ? ['EVIDENCE_LINEAGE_DEPENDENT'] : [];
+
+    return { independentAnchorRefs, dependentAnchorRefs, reasonCodes };
+}
+
+export interface LineageGroup {
+    lineageKey: string;
+    refs: readonly ObservationBundleRef[];
+}
+
+/**
+ * Groups a set of bundle refs by `lineageKey`. Useful for detecting mirrored/re-exported
+ * duplicates among a wider candidate set (e.g. Garmin Direct plus the same Garmin measurement
+ * re-exported via Google Health) before they are used as independent votes.
+ */
+export function groupByLineage(refs: readonly ObservationBundleRef[]): readonly LineageGroup[] {
+    const order: string[] = [];
+    const groups = new Map<string, ObservationBundleRef[]>();
+    for (const ref of refs) {
+        if (!groups.has(ref.lineageKey)) {
+            groups.set(ref.lineageKey, []);
+            order.push(ref.lineageKey);
+        }
+        groups.get(ref.lineageKey)!.push(ref);
+    }
+    return order.map((lineageKey) => ({ lineageKey, refs: groups.get(lineageKey)! }));
+}
+
+/**
+ * Deterministically selects one representative ref per lineage group (highest `revision`, then
+ * lexicographically smallest `id` as a stable tie-break) so a mirrored/re-exported duplicate never
+ * contributes a second, independent-looking vote alongside its origin.
+ */
+export function deduplicateByLineage(
+    refs: readonly ObservationBundleRef[],
+): readonly ObservationBundleRef[] {
+    return groupByLineage(refs).map((group) => {
+        const [best] = [...group.refs].sort((a, b) => {
+            if (a.revision !== b.revision) {
+                return b.revision - a.revision;
+            }
+            return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+        });
+        return best;
+    });
+}

--- a/app/src/engine/identityPassport.multianchor.test.ts
+++ b/app/src/engine/identityPassport.multianchor.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { fitPassportFromNights, type PairedNightFeatureRecord } from './identityPassport';
+
+function night(overrides: Partial<PairedNightFeatureRecord> = {}): PairedNightFeatureRecord {
+    return {
+        sourceNightKey: '2026-08-01',
+        sharedProvider: 'shared_bed',
+        anchorProvider: 'garmin',
+        anchorTransport: 'garmin_direct',
+        lineageIndependent: true,
+        anchorEligible: true,
+        sharedRestingHeartRate: 45,
+        sharedRespirationRate: 14,
+        sharedHrv: 52,
+        sharedSleepStartMinutesLocal: 1350,
+        sharedSleepDurationMinutes: 480,
+        relation: { rhrResidual: 1, respResidual: 0.5, hrvLogResidual: 0.05 },
+        overlap: {
+            intersectionMinutes: 450,
+            unionMinutes: 480,
+            jaccard: 0.9375,
+            eightOverlapFraction: 0.95,
+            garminOverlapFraction: 0.95,
+            startDeltaMinutes: 5,
+            endDeltaMinutes: -5,
+            durationDeltaMinutes: 0,
+        },
+        ...overrides,
+    };
+}
+
+describe('fitPassportFromNights source profile aggregation', () => {
+    it('aggregates one shared source across every configured anchor relationship', () => {
+        const passport = fitPassportFromNights({
+            nights: [
+                night({ sourceNightKey: '2026-08-01', sharedRestingHeartRate: 44 }),
+                night({
+                    sourceNightKey: '2026-08-02',
+                    sharedRestingHeartRate: 46,
+                    anchorProvider: 'oura',
+                    anchorTransport: 'oura_direct',
+                }),
+            ],
+            passportVersion: '2026-08-27.1',
+            createdAt: '2026-08-27T06:00:00Z',
+            policyVersion: 'identity-v1-shadow',
+            featureSchemaVersion: 'identity-features-v1',
+            anchorPolicy: {
+                primaryProvider: 'garmin',
+                primaryTransport: 'garmin_direct',
+                role: 'personal_wearable_anchor',
+                requireIndependentLineage: true,
+            },
+        });
+
+        expect(passport.sourceProfiles.shared_bed.trustedNightCount).toBe(2);
+        expect(passport.sourceProfiles.shared_bed.restingHeartRate.n).toBe(2);
+        expect(passport.sourceProfiles.shared_bed.restingHeartRate.median).toBe(45);
+        expect(Object.keys(passport.crossSourceProfiles).sort()).toEqual([
+            'shared_bed__garmin_garmin_direct',
+            'shared_bed__oura_oura_direct',
+        ]);
+    });
+});

--- a/app/src/engine/identityPassport.test.ts
+++ b/app/src/engine/identityPassport.test.ts
@@ -1,0 +1,372 @@
+import { describe, expect, it } from 'vitest';
+import {
+    DEFAULT_IDENTITY_FEATURE_SCALE_FLOORS,
+    DEFAULT_PASSPORT_BOOTSTRAP_CONFIG,
+    bootstrapPassportFromHistory,
+    calculateIqr,
+    chronologicalExpandingWindowReplay,
+    computeRobustLocationEstimate,
+    computeRobustRatioEstimate,
+    computeRobustScalarEstimate,
+    crossSourceProfileKey,
+    fitPassportFromNights,
+    leaveOneNightOutReplay,
+    nextPassportVersion,
+    type PairedNightFeatureRecord,
+} from './identityPassport';
+import type { IntervalOverlapMetrics, PhysiologicalRelationFeatures } from './identityFeatures';
+
+const ANCHOR_POLICY = {
+    primaryProvider: 'garmin',
+    primaryTransport: 'garmin_direct',
+    role: 'personal_wearable_anchor',
+    requireIndependentLineage: true,
+};
+
+function relation(overrides: Partial<PhysiologicalRelationFeatures> = {}): PhysiologicalRelationFeatures {
+    return { rhrResidual: 1, respResidual: 0.5, hrvLogResidual: 0.05, ...overrides };
+}
+
+function overlap(overrides: Partial<IntervalOverlapMetrics> = {}): IntervalOverlapMetrics {
+    return {
+        intersectionMinutes: 450,
+        unionMinutes: 480,
+        jaccard: 0.9375,
+        eightOverlapFraction: 0.95,
+        garminOverlapFraction: 0.95,
+        startDeltaMinutes: 5,
+        endDeltaMinutes: -5,
+        durationDeltaMinutes: 0,
+        ...overrides,
+    };
+}
+
+function night(overrides: Partial<PairedNightFeatureRecord> = {}): PairedNightFeatureRecord {
+    return {
+        sourceNightKey: '2026-08-01',
+        sharedProvider: 'eight_sleep',
+        anchorProvider: 'garmin',
+        anchorTransport: 'garmin_direct',
+        lineageIndependent: true,
+        anchorEligible: true,
+        sharedRestingHeartRate: 45,
+        sharedRespirationRate: 14,
+        sharedHrv: 52,
+        sharedSleepStartMinutesLocal: 1350, // 22:30
+        sharedSleepDurationMinutes: 480,
+        relation: relation(),
+        overlap: overlap(),
+        ...overrides,
+    };
+}
+
+describe('robust estimators (PI3, ADR-0028)', () => {
+    it('computes median/MAD/IQR consistently with the scale floor applied only to MAD', () => {
+        const values = [60, 62, 64, 66, 68];
+        const estimate = computeRobustScalarEstimate(values, 0.5);
+        expect(estimate.median).toBe(64);
+        expect(estimate.mad).toBeCloseTo(2 * 1.4826, 4);
+        expect(estimate.n).toBe(5);
+        expect(estimate.iqr).toBe(calculateIqr(values));
+    });
+
+    it('floors near-zero natural dispersion so a later ordinary night cannot explode a z-score', () => {
+        const nearIdentical = [45, 45, 45.01, 44.99, 45];
+        const unfloor = computeRobustScalarEstimate(nearIdentical, 0);
+        const floored = computeRobustScalarEstimate(nearIdentical, 1.0);
+
+        expect(unfloor.mad).toBeLessThan(0.1);
+        expect(floored.mad).toBe(1.0); // floor wins over the ~0 natural MAD
+        // A 1 bpm-off night would look wildly discordant against the unfloored scale...
+        expect(Math.abs(46 - unfloor.median!) / Math.max(unfloor.mad!, 1e-9)).toBeGreaterThan(10);
+        // ...but is unremarkable once the floor is applied.
+        expect(Math.abs(46 - floored.median!) / floored.mad!).toBeLessThan(2);
+    });
+
+    it('location estimate omits IQR and ratio estimate omits MAD, matching the passport document shape', () => {
+        const location = computeRobustLocationEstimate([10, 12, 14], 1);
+        expect(location).toEqual({ median: 12, mad: expect.any(Number), n: 3 });
+        expect('iqr' in location).toBe(false);
+
+        const ratio = computeRobustRatioEstimate([0.8, 0.9, 1.0]);
+        expect(ratio).toEqual({ median: 0.9, iqr: expect.any(Number), n: 3 });
+        expect('mad' in ratio).toBe(false);
+    });
+
+    it('returns nulls for an empty sample rather than throwing', () => {
+        expect(computeRobustScalarEstimate([], 1)).toEqual({ median: null, mad: null, iqr: null, n: 0 });
+    });
+});
+
+describe('fitPassportFromNights (PI3)', () => {
+    it('is provider-neutral: profile keys are derived, not hard-coded', () => {
+        const passport = fitPassportFromNights({
+            nights: [night()],
+            passportVersion: '2026-08-27.1',
+            createdAt: '2026-08-27T06:00:00Z',
+            policyVersion: 'identity-v1-shadow',
+            featureSchemaVersion: 'identity-features-v1',
+            anchorPolicy: ANCHOR_POLICY,
+        });
+
+        expect(Object.keys(passport.sourceProfiles)).toEqual(['eight_sleep']);
+        expect(Object.keys(passport.crossSourceProfiles)).toEqual([
+            crossSourceProfileKey('eight_sleep', 'garmin', 'garmin_direct'),
+        ]);
+        expect(crossSourceProfileKey('eight_sleep', 'garmin', 'garmin_direct')).toBe(
+            'eight_sleep__garmin_garmin_direct',
+        );
+    });
+
+    it('guards logHrv against non-positive/invalid shared HRV readings', () => {
+        const passport = fitPassportFromNights({
+            nights: [
+                night({ sourceNightKey: 'n1', sharedHrv: 52 }),
+                night({ sourceNightKey: 'n2', sharedHrv: 0 }),
+                night({ sourceNightKey: 'n3', sharedHrv: -10 }),
+                night({ sourceNightKey: 'n4', sharedHrv: null }),
+            ],
+            passportVersion: '2026-08-27.1',
+            createdAt: '2026-08-27T06:00:00Z',
+            policyVersion: 'identity-v1-shadow',
+            featureSchemaVersion: 'identity-features-v1',
+            anchorPolicy: ANCHOR_POLICY,
+        });
+
+        // Only the one valid positive HRV reading contributes.
+        expect(passport.sourceProfiles.eight_sleep.logHrv.n).toBe(1);
+        expect(passport.sourceProfiles.eight_sleep.logHrv.median).toBeCloseTo(Math.log(52), 10);
+    });
+
+    it('starts calibration at zero counts with no shadow window (no manual labels yet)', () => {
+        const passport = fitPassportFromNights({
+            nights: [night()],
+            passportVersion: '2026-08-27.1',
+            createdAt: '2026-08-27T06:00:00Z',
+            policyVersion: 'identity-v1-shadow',
+            featureSchemaVersion: 'identity-features-v1',
+            anchorPolicy: ANCHOR_POLICY,
+        });
+        expect(passport.calibration).toEqual({
+            manualUserCount: 0,
+            manualNotUserCount: 0,
+            mixedOccupancyCount: 0,
+            uncertainCount: 0,
+            shadowWindowStart: null,
+            shadowWindowEnd: null,
+        });
+    });
+
+    it('produces empty profiles (never throws) for an empty night list', () => {
+        const passport = fitPassportFromNights({
+            nights: [],
+            passportVersion: '2026-08-27.1',
+            createdAt: '2026-08-27T06:00:00Z',
+            policyVersion: 'identity-v1-shadow',
+            featureSchemaVersion: 'identity-features-v1',
+            anchorPolicy: ANCHOR_POLICY,
+        });
+        expect(passport.sourceProfiles).toEqual({});
+        expect(passport.crossSourceProfiles).toEqual({});
+    });
+});
+
+describe('bootstrapPassportFromHistory (PI3, 7-step procedure)', () => {
+    // 8 ordinary concordant nights plus 2 wildly discordant "contaminated" nights.
+    const ordinaryNights: PairedNightFeatureRecord[] = Array.from({ length: 8 }, (_, i) =>
+        night({
+            sourceNightKey: `2026-08-${String(i + 1).padStart(2, '0')}`,
+            relation: relation({ rhrResidual: 1 + (i % 2 === 0 ? 0.1 : -0.1) }),
+        }),
+    );
+    const contaminatedNights: PairedNightFeatureRecord[] = [
+        night({ sourceNightKey: '2026-08-20', relation: relation({ rhrResidual: 40 }) }),
+        night({ sourceNightKey: '2026-08-21', relation: relation({ rhrResidual: -35 }) }),
+    ];
+    const lineageDependentNight = night({ sourceNightKey: '2026-08-22', lineageIndependent: false });
+    const anchorIneligibleNight = night({ sourceNightKey: '2026-08-23', anchorEligible: false });
+    const unpairedNight = night({ sourceNightKey: '2026-08-24', overlap: null });
+
+    const allNights = [
+        ...ordinaryNights,
+        ...contaminatedNights,
+        lineageDependentNight,
+        anchorIneligibleNight,
+        unpairedNight,
+    ];
+
+    function bootstrap() {
+        return bootstrapPassportFromHistory({
+            nights: allNights,
+            passportVersion: '2026-08-27.1',
+            createdAt: '2026-08-27T06:00:00Z',
+            policyVersion: 'identity-v1-shadow',
+            featureSchemaVersion: 'identity-features-v1',
+            anchorPolicy: ANCHOR_POLICY,
+        });
+    }
+
+    it('step 1: excludes lineage-dependent, anchor-ineligible, and unpaired nights from "usable"', () => {
+        const result = bootstrap();
+        expect(result.usableNightCount).toBe(ordinaryNights.length + contaminatedNights.length);
+        expect(result.excludedByLineageOrAnchorCount).toBe(3);
+    });
+
+    it('steps 3-4: excludes the contaminated nights from the core WITHOUT labelling them NOT_USER', () => {
+        const result = bootstrap();
+        const contaminatedKeys = new Set(contaminatedNights.map((n) => n.sourceNightKey));
+        const contaminatedEvaluations = result.nightConcordance.filter((c) =>
+            contaminatedKeys.has(c.sourceNightKey),
+        );
+
+        expect(contaminatedEvaluations).toHaveLength(2);
+        for (const evaluation of contaminatedEvaluations) {
+            expect(evaluation.includedInCore).toBe(false);
+            expect(evaluation.reason).toBe('DISCORDANT');
+            // The evaluation type has no identity-status field at all -- structurally impossible
+            // to assign NOT_USER here.
+            expect(evaluation).not.toHaveProperty('automaticStatus');
+            expect(evaluation).not.toHaveProperty('label');
+        }
+        expect(result.coreNightCount).toBe(ordinaryNights.length);
+    });
+
+    it('step 5: the fitted v0 passport reflects only the central core, not the contaminated nights', () => {
+        const result = bootstrap();
+        // Core RHR residuals are all near 1 (0.9-1.1); the fitted median must stay near there,
+        // nowhere close to the +-35-40 contaminated values.
+        const median = result.passport.crossSourceProfiles[
+            crossSourceProfileKey('eight_sleep', 'garmin', 'garmin_direct')
+        ].rhrResidual.median;
+        expect(median).toBeGreaterThan(0.5);
+        expect(median).toBeLessThan(1.5);
+    });
+
+    it('step 6: nightConcordance re-scores every usable night, core and excluded alike', () => {
+        const result = bootstrap();
+        const scoredKeys = new Set(result.nightConcordance.map((c) => c.sourceNightKey));
+        for (const n of [...ordinaryNights, ...contaminatedNights]) {
+            expect(scoredKeys.has(n.sourceNightKey)).toBe(true);
+        }
+        // Nights excluded at step 1 are not part of this descriptive re-score at all.
+        expect(scoredKeys.has(lineageDependentNight.sourceNightKey)).toBe(false);
+        expect(scoredKeys.has(anchorIneligibleNight.sourceNightKey)).toBe(false);
+        expect(scoredKeys.has(unpairedNight.sourceNightKey)).toBe(false);
+    });
+
+    it('a night with no available relation features is INSUFFICIENT_FEATURES, not DISCORDANT', () => {
+        const noFeaturesNight = night({
+            sourceNightKey: '2026-08-25',
+            relation: { rhrResidual: null, respResidual: null, hrvLogResidual: null },
+        });
+        const result = bootstrapPassportFromHistory({
+            nights: [...ordinaryNights, noFeaturesNight],
+            passportVersion: '2026-08-27.1',
+            createdAt: '2026-08-27T06:00:00Z',
+            policyVersion: 'identity-v1-shadow',
+            featureSchemaVersion: 'identity-features-v1',
+            anchorPolicy: ANCHOR_POLICY,
+        });
+        const evaluation = result.nightConcordance.find((c) => c.sourceNightKey === '2026-08-25');
+        expect(evaluation?.reason).toBe('INSUFFICIENT_FEATURES');
+        expect(evaluation?.includedInCore).toBe(false);
+    });
+});
+
+describe('out-of-sample evaluation (PI3, ADR-0028 P-PI-16)', () => {
+    const fitParams = {
+        passportVersion: '2026-08-27.1',
+        createdAt: '2026-08-27T06:00:00Z',
+        policyVersion: 'identity-v1-shadow',
+        featureSchemaVersion: 'identity-features-v1',
+        anchorPolicy: ANCHOR_POLICY,
+    };
+
+    it('leave-one-night-out never trains a night’s own passport on itself', () => {
+        const nights = Array.from({ length: 5 }, (_, i) =>
+            night({ sourceNightKey: `2026-08-0${i + 1}` }),
+        );
+        const results = leaveOneNightOutReplay(nights, fitParams);
+
+        expect(results).toHaveLength(5);
+        for (const result of results) {
+            expect(result.trainingNightCount).toBe(4); // every OTHER night, never itself
+            expect(result.passport).not.toBeNull();
+        }
+    });
+
+    it('leave-one-out exposes a contaminated night as an outlier that in-sample fitting would mask', () => {
+        const cleanNights = Array.from({ length: 6 }, (_, i) =>
+            night({ sourceNightKey: `2026-08-0${i + 1}`, relation: relation({ rhrResidual: 1 }) }),
+        );
+        const outlier = night({ sourceNightKey: '2026-08-10', relation: relation({ rhrResidual: 30 }) });
+        const nights = [...cleanNights, outlier];
+
+        const results = leaveOneNightOutReplay(nights, fitParams);
+        const outlierResult = results.find((r) => r.sourceNightKey === '2026-08-10')!;
+        const key = crossSourceProfileKey('eight_sleep', 'garmin', 'garmin_direct');
+        const trainedWithoutOutlier = outlierResult.passport!.crossSourceProfiles[key].rhrResidual.median!;
+
+        // The passport that evaluates the outlier night was trained on the 6 clean nights only,
+        // so its median stays near 1 -- nowhere close to being pulled toward 30.
+        expect(trainedWithoutOutlier).toBeCloseTo(1, 5);
+    });
+
+    it('chronological expanding window only trains on strictly earlier nights', () => {
+        const nights = Array.from({ length: 6 }, (_, i) =>
+            night({ sourceNightKey: `2026-08-0${i + 1}` }),
+        );
+        const results = chronologicalExpandingWindowReplay(nights, fitParams, 2);
+
+        expect(results[0].passport).toBeNull(); // 0 training nights available
+        expect(results[1].passport).toBeNull(); // 1 training night available, below minTrainingNights=2
+        expect(results[2].trainingNightCount).toBe(2);
+        expect(results[5].trainingNightCount).toBe(5);
+    });
+
+    it('an early contaminated night cannot leak into a later night’s expanding-window passport once it ages out of relevance for detection', () => {
+        // Contaminated night is FIRST chronologically; every later night's training window
+        // includes it (expanding window trains on all earlier nights) -- this documents that
+        // behavior explicitly rather than assuming it.
+        const contaminated = night({ sourceNightKey: '2026-08-01', relation: relation({ rhrResidual: 30 }) });
+        const clean = Array.from({ length: 4 }, (_, i) =>
+            night({ sourceNightKey: `2026-08-0${i + 2}`, relation: relation({ rhrResidual: 1 }) }),
+        );
+        const results = chronologicalExpandingWindowReplay([contaminated, ...clean], fitParams, 1);
+
+        const lastResult = results[results.length - 1];
+        expect(lastResult.trainingNightCount).toBe(4); // contaminated + 3 clean nights precede it
+        // Even with contamination in the training window, bootstrap's own core-selection step
+        // (steps 3-4) should already have excluded the single 30 bpm outlier from the fitted v0
+        // used to score the final night, since the other 3 training nights concordantly agree.
+        const key = crossSourceProfileKey('eight_sleep', 'garmin', 'garmin_direct');
+        expect(lastResult.passport!.crossSourceProfiles[key].rhrResidual.median).toBeCloseTo(1, 5);
+    });
+});
+
+describe('nextPassportVersion (PI3 passport eras)', () => {
+    it('starts at .1 for a date with no prior versions', () => {
+        expect(nextPassportVersion('2026-08-27', [])).toBe('2026-08-27.1');
+    });
+
+    it('increments deterministically among same-date versions', () => {
+        expect(nextPassportVersion('2026-08-27', ['2026-08-27.1', '2026-08-27.2'])).toBe('2026-08-27.3');
+    });
+
+    it('ignores versions from other dates', () => {
+        expect(nextPassportVersion('2026-08-28', ['2026-08-27.1', '2026-08-27.2'])).toBe('2026-08-28.1');
+    });
+
+    it('is order-independent', () => {
+        expect(nextPassportVersion('2026-08-27', ['2026-08-27.3', '2026-08-27.1', '2026-08-27.2'])).toBe(
+            '2026-08-27.4',
+        );
+    });
+});
+
+describe('defaults sanity (PI3)', () => {
+    it('exposes the default scale floors and bootstrap config for callers/replay scripts', () => {
+        expect(DEFAULT_IDENTITY_FEATURE_SCALE_FLOORS.rhrResidualBpm).toBeGreaterThan(0);
+        expect(DEFAULT_PASSPORT_BOOTSTRAP_CONFIG.minConcordantFeatureFraction).toBe(1.0);
+    });
+});

--- a/app/src/engine/identityPassport.ts
+++ b/app/src/engine/identityPassport.ts
@@ -189,6 +189,26 @@ export interface PhysiologicalIdentityPassport {
     calibration: PassportCalibrationSummary;
 }
 
+/** Server-owned online pointer/materialized current passport (PI6). */
+export interface PhysiologicalIdentityPassportCurrent extends PhysiologicalIdentityPassport {
+    updatedAt: string;
+}
+
+/**
+ * Immutable passport snapshot. The date window + configured source profiles form the bounded
+ * replay query contract; `trainingSetHash` binds the exact ordered observation-ref set without
+ * growing a Firestore array indefinitely.
+ */
+export interface PhysiologicalIdentityPassportVersion extends PhysiologicalIdentityPassport {
+    trainingSetHash: string;
+    trainingObservationCount: number;
+    trainingWindowStart: string;
+    trainingWindowEnd: string;
+    previousVersion: string | null;
+    changeReason: PassportEraChangeReason;
+    algorithmVersion: string;
+}
+
 export function crossSourceProfileKey(
     sharedProvider: string,
     anchorProvider: string,

--- a/app/src/engine/identityPassport.ts
+++ b/app/src/engine/identityPassport.ts
@@ -1,0 +1,615 @@
+/**
+ * Versioned Physiological Identity Passport model + historical bootstrap (PI3, ADR-0028).
+ *
+ * A source-aware, lineage-aware, versioned robust-statistics profile of a shared source's
+ * physiological readings (`sourceProfiles`) and its paired relationship to the personal-device
+ * anchor (`crossSourceProfiles`). This module is descriptive/statistical only -- it never assigns
+ * an identity label to a night; that is PI4's job, scoring a night's features against the
+ * passport this module fits.
+ *
+ * SHADOW ONLY (PI3 task-board decision impact): nothing here is wired into baseline/fusion
+ * (PI5) or an identity verdict (PI4). `bootstrapPassportFromHistory()` fits a v0 passport from
+ * historical paired nights per the plan's 7-step bootstrap procedure; it does not, and must not,
+ * label any excluded night `NOT_USER` (ADR-0028 P-PI-8) -- exclusion from the fitted "central
+ * core" is recorded only as descriptive concordance data for PI8's replay report.
+ */
+
+import { calculateMad, calculateMedian } from './multisourceBaselines';
+import type { IntervalOverlapMetrics, PhysiologicalRelationFeatures } from './identityFeatures';
+
+// --- Robust estimators -----------------------------------------------------------------------
+
+/** {median, mad, iqr, n} shape used for scalar physiological readings/residuals. */
+export interface RobustScalarEstimate {
+    median: number | null;
+    mad: number | null; // scaled MAD, floored per DEFAULT_IDENTITY_FEATURE_SCALE_FLOORS (or caller override)
+    iqr: number | null;
+    n: number;
+}
+
+/** {median, mad, n} shape used for timing-location features (no IQR persisted). */
+export interface RobustLocationEstimate {
+    median: number | null;
+    mad: number | null;
+    n: number;
+}
+
+/** {median, iqr, n} shape used for bounded ratio features (e.g. session Jaccard); MAD omitted. */
+export interface RobustRatioEstimate {
+    median: number | null;
+    iqr: number | null;
+    n: number;
+}
+
+function calculatePercentile(sortedValues: readonly number[], p: number): number | null {
+    if (sortedValues.length === 0) {
+        return null;
+    }
+    if (sortedValues.length === 1) {
+        return sortedValues[0];
+    }
+    const rank = p * (sortedValues.length - 1);
+    const lowerIndex = Math.floor(rank);
+    const upperIndex = Math.ceil(rank);
+    if (lowerIndex === upperIndex) {
+        return sortedValues[lowerIndex];
+    }
+    const weight = rank - lowerIndex;
+    return sortedValues[lowerIndex] * (1 - weight) + sortedValues[upperIndex] * weight;
+}
+
+export function calculateIqr(values: readonly number[]): number | null {
+    if (values.length === 0) {
+        return null;
+    }
+    const sorted = [...values].sort((a, b) => a - b);
+    const q1 = calculatePercentile(sorted, 0.25);
+    const q3 = calculatePercentile(sorted, 0.75);
+    if (q1 === null || q3 === null) {
+        return null;
+    }
+    return q3 - q1;
+}
+
+/**
+ * Robust scalar estimate with an explicit minimum-scale floor on `mad`. Near-zero historical
+ * dispersion (e.g. an early passport with only 2-3 nights that happen to agree closely) must
+ * never produce a near-zero scale, or a later ordinary night would compute a numerically
+ * explosive z-score against it. The floor is a measurement/semantic safeguard, not an identity
+ * threshold (ADR-0028 PI3).
+ */
+export function computeRobustScalarEstimate(
+    values: readonly number[],
+    scaleFloor: number,
+): RobustScalarEstimate {
+    const median = calculateMedian(values);
+    const rawMad = calculateMad(values, median);
+    return {
+        median,
+        mad: rawMad === null ? null : Math.max(rawMad, scaleFloor),
+        iqr: calculateIqr(values),
+        n: values.length,
+    };
+}
+
+export function computeRobustLocationEstimate(
+    values: readonly number[],
+    scaleFloor: number,
+): RobustLocationEstimate {
+    const median = calculateMedian(values);
+    const rawMad = calculateMad(values, median);
+    return {
+        median,
+        mad: rawMad === null ? null : Math.max(rawMad, scaleFloor),
+        n: values.length,
+    };
+}
+
+export function computeRobustRatioEstimate(values: readonly number[]): RobustRatioEstimate {
+    return {
+        median: calculateMedian(values),
+        iqr: calculateIqr(values),
+        n: values.length,
+    };
+}
+
+/**
+ * Per-feature minimum-scale floors. Values are deliberately conservative starting points, not
+ * fitted/validated thresholds -- revisit once PI8 replay evidence exists.
+ */
+export interface IdentityFeatureScaleFloors {
+    rhrResidualBpm: number;
+    respirationResidualBrpm: number;
+    hrvLogResidual: number;
+    startDeltaMinutes: number;
+    endDeltaMinutes: number;
+    durationDeltaMinutes: number;
+}
+
+export const DEFAULT_IDENTITY_FEATURE_SCALE_FLOORS: IdentityFeatureScaleFloors = {
+    rhrResidualBpm: 1.0,
+    respirationResidualBrpm: 0.5,
+    hrvLogResidual: 0.02,
+    startDeltaMinutes: 2,
+    endDeltaMinutes: 2,
+    durationDeltaMinutes: 3,
+};
+
+// --- Passport document model ------------------------------------------------------------------
+
+export interface AnchorPolicy {
+    primaryProvider: string;
+    primaryTransport: string;
+    role: string;
+    requireIndependentLineage: boolean;
+}
+
+export interface SourceProfile {
+    trustedNightCount: number;
+    restingHeartRate: RobustScalarEstimate;
+    respirationRate: RobustScalarEstimate;
+    logHrv: RobustScalarEstimate;
+    sleepStartMinutesLocal: RobustLocationEstimate;
+    sleepDurationMinutes: RobustLocationEstimate;
+}
+
+export interface CrossSourceProfile {
+    rhrResidual: RobustScalarEstimate;
+    respirationResidual: RobustScalarEstimate;
+    hrvLogResidual: RobustScalarEstimate;
+    startDeltaMinutes: RobustLocationEstimate;
+    endDeltaMinutes: RobustLocationEstimate;
+    durationDeltaMinutes: RobustLocationEstimate;
+    sessionJaccard: RobustRatioEstimate;
+}
+
+export interface PassportCalibrationSummary {
+    manualUserCount: number;
+    manualNotUserCount: number;
+    mixedOccupancyCount: number;
+    uncertainCount: number;
+    shadowWindowStart: string | null;
+    shadowWindowEnd: string | null;
+}
+
+/**
+ * Provider-neutral: `sourceProfiles`/`crossSourceProfiles` are keyed generically, never hard-coded
+ * to `eight_sleep`/`garmin_direct` (ADR-0028 exit criteria: "Garmin is a configured current
+ * anchor, not a hard-coded universal assumption").
+ */
+export interface PhysiologicalIdentityPassport {
+    schemaVersion: number;
+    passportVersion: string;
+    createdAt: string;
+    policyVersion: string;
+    featureSchemaVersion: string;
+    anchorPolicy: AnchorPolicy;
+    sourceProfiles: Readonly<Record<string, SourceProfile>>;
+    crossSourceProfiles: Readonly<Record<string, CrossSourceProfile>>;
+    calibration: PassportCalibrationSummary;
+}
+
+export function crossSourceProfileKey(
+    sharedProvider: string,
+    anchorProvider: string,
+    anchorTransport: string,
+): string {
+    return `${sharedProvider}__${anchorProvider}_${anchorTransport}`;
+}
+
+function emptyCalibrationSummary(): PassportCalibrationSummary {
+    return {
+        manualUserCount: 0,
+        manualNotUserCount: 0,
+        mixedOccupancyCount: 0,
+        uncertainCount: 0,
+        shadowWindowStart: null,
+        shadowWindowEnd: null,
+    };
+}
+
+// --- Historical bootstrap ----------------------------------------------------------------------
+
+/**
+ * One historical shared-source/anchor night, already carrying PI2's pairing/lineage evaluation
+ * outcome and derived features. `sharedSleepStartMinutesLocal` (Europe/Warsaw local minutes since
+ * midnight) and `sharedSleepDurationMinutes` are computed by the caller (ingestion/replay code)
+ * using the project's existing local-date utilities -- this module deals in already-derived
+ * scalars, not raw timestamps, to keep robust-statistics logic independent of timezone handling.
+ */
+export interface PairedNightFeatureRecord {
+    sourceNightKey: string;
+    sharedProvider: string;
+    anchorProvider: string;
+    anchorTransport: string;
+    lineageIndependent: boolean;
+    anchorEligible: boolean;
+    sharedRestingHeartRate: number | null;
+    sharedRespirationRate: number | null;
+    sharedHrv: number | null;
+    sharedSleepStartMinutesLocal: number | null;
+    sharedSleepDurationMinutes: number | null;
+    relation: PhysiologicalRelationFeatures;
+    overlap: IntervalOverlapMetrics | null;
+}
+
+export interface PassportBootstrapConfig {
+    scaleFloors: IdentityFeatureScaleFloors;
+    /** Robust z-score bound (|residual - median| / max(mad, floor)) for a feature to count as concordant. */
+    concordanceZThreshold: number;
+    /** Fraction of a night's *available* relation features that must be concordant to join the core. Conservative default: all of them. */
+    minConcordantFeatureFraction: number;
+}
+
+export const DEFAULT_PASSPORT_BOOTSTRAP_CONFIG: PassportBootstrapConfig = {
+    scaleFloors: DEFAULT_IDENTITY_FEATURE_SCALE_FLOORS,
+    concordanceZThreshold: 3.0,
+    minConcordantFeatureFraction: 1.0,
+};
+
+export interface NightConcordanceEvaluation {
+    sourceNightKey: string;
+    includedInCore: boolean;
+    evaluatedFeatureCount: number;
+    concordantFeatureCount: number;
+    /**
+     * Descriptive-only bucket, NEVER an identity verdict (ADR-0028 P-PI-8): a night with
+     * `reason: 'DISCORDANT'` is excluded from fitting, not labelled `NOT_USER`.
+     */
+    reason: 'INSUFFICIENT_FEATURES' | 'CONCORDANT' | 'DISCORDANT';
+}
+
+function pluckNonNull<T>(
+    records: readonly T[],
+    select: (record: T) => number | null,
+): number[] {
+    const values: number[] = [];
+    for (const record of records) {
+        const value = select(record);
+        if (value !== null && Number.isFinite(value)) {
+            values.push(value);
+        }
+    }
+    return values;
+}
+
+function logIfPositive(value: number | null): number | null {
+    return value !== null && Number.isFinite(value) && value > 0 ? Math.log(value) : null;
+}
+
+interface PreliminaryRelationEstimates {
+    rhr: RobustScalarEstimate;
+    resp: RobustScalarEstimate;
+    hrvLog: RobustScalarEstimate;
+}
+
+function fitPreliminaryRelationEstimates(
+    nights: readonly PairedNightFeatureRecord[],
+    floors: IdentityFeatureScaleFloors,
+): PreliminaryRelationEstimates {
+    return {
+        rhr: computeRobustScalarEstimate(
+            pluckNonNull(nights, (n) => n.relation.rhrResidual),
+            floors.rhrResidualBpm,
+        ),
+        resp: computeRobustScalarEstimate(
+            pluckNonNull(nights, (n) => n.relation.respResidual),
+            floors.respirationResidualBrpm,
+        ),
+        hrvLog: computeRobustScalarEstimate(
+            pluckNonNull(nights, (n) => n.relation.hrvLogResidual),
+            floors.hrvLogResidual,
+        ),
+    };
+}
+
+function evaluateNightConcordance(
+    night: PairedNightFeatureRecord,
+    preliminary: PreliminaryRelationEstimates,
+    config: PassportBootstrapConfig,
+): NightConcordanceEvaluation {
+    const checks: boolean[] = [];
+    const evaluateFeature = (value: number | null, estimate: RobustScalarEstimate, floor: number) => {
+        if (value === null || estimate.median === null || estimate.mad === null) {
+            return; // an unavailable feature contributes no vote either way (no zero-fill)
+        }
+        const scale = Math.max(estimate.mad, floor);
+        checks.push(Math.abs(value - estimate.median) / scale <= config.concordanceZThreshold);
+    };
+
+    evaluateFeature(night.relation.rhrResidual, preliminary.rhr, config.scaleFloors.rhrResidualBpm);
+    evaluateFeature(night.relation.respResidual, preliminary.resp, config.scaleFloors.respirationResidualBrpm);
+    evaluateFeature(night.relation.hrvLogResidual, preliminary.hrvLog, config.scaleFloors.hrvLogResidual);
+
+    if (checks.length === 0) {
+        return {
+            sourceNightKey: night.sourceNightKey,
+            includedInCore: false,
+            evaluatedFeatureCount: 0,
+            concordantFeatureCount: 0,
+            reason: 'INSUFFICIENT_FEATURES',
+        };
+    }
+
+    const concordantFeatureCount = checks.filter(Boolean).length;
+    const includedInCore = concordantFeatureCount / checks.length >= config.minConcordantFeatureFraction;
+
+    return {
+        sourceNightKey: night.sourceNightKey,
+        includedInCore,
+        evaluatedFeatureCount: checks.length,
+        concordantFeatureCount,
+        reason: includedInCore ? 'CONCORDANT' : 'DISCORDANT',
+    };
+}
+
+function fitSourceProfile(
+    nights: readonly PairedNightFeatureRecord[],
+    floors: IdentityFeatureScaleFloors,
+): SourceProfile {
+    return {
+        trustedNightCount: nights.length,
+        restingHeartRate: computeRobustScalarEstimate(
+            pluckNonNull(nights, (n) => n.sharedRestingHeartRate),
+            floors.rhrResidualBpm,
+        ),
+        respirationRate: computeRobustScalarEstimate(
+            pluckNonNull(nights, (n) => n.sharedRespirationRate),
+            floors.respirationResidualBrpm,
+        ),
+        logHrv: computeRobustScalarEstimate(
+            pluckNonNull(nights, (n) => logIfPositive(n.sharedHrv)),
+            floors.hrvLogResidual,
+        ),
+        sleepStartMinutesLocal: computeRobustLocationEstimate(
+            pluckNonNull(nights, (n) => n.sharedSleepStartMinutesLocal),
+            floors.startDeltaMinutes,
+        ),
+        sleepDurationMinutes: computeRobustLocationEstimate(
+            pluckNonNull(nights, (n) => n.sharedSleepDurationMinutes),
+            floors.durationDeltaMinutes,
+        ),
+    };
+}
+
+function fitCrossSourceProfile(
+    nights: readonly PairedNightFeatureRecord[],
+    floors: IdentityFeatureScaleFloors,
+): CrossSourceProfile {
+    return {
+        rhrResidual: computeRobustScalarEstimate(
+            pluckNonNull(nights, (n) => n.relation.rhrResidual),
+            floors.rhrResidualBpm,
+        ),
+        respirationResidual: computeRobustScalarEstimate(
+            pluckNonNull(nights, (n) => n.relation.respResidual),
+            floors.respirationResidualBrpm,
+        ),
+        hrvLogResidual: computeRobustScalarEstimate(
+            pluckNonNull(nights, (n) => n.relation.hrvLogResidual),
+            floors.hrvLogResidual,
+        ),
+        startDeltaMinutes: computeRobustLocationEstimate(
+            pluckNonNull(nights, (n) => n.overlap?.startDeltaMinutes ?? null),
+            floors.startDeltaMinutes,
+        ),
+        endDeltaMinutes: computeRobustLocationEstimate(
+            pluckNonNull(nights, (n) => n.overlap?.endDeltaMinutes ?? null),
+            floors.endDeltaMinutes,
+        ),
+        durationDeltaMinutes: computeRobustLocationEstimate(
+            pluckNonNull(nights, (n) => n.overlap?.durationDeltaMinutes ?? null),
+            floors.durationDeltaMinutes,
+        ),
+        sessionJaccard: computeRobustRatioEstimate(pluckNonNull(nights, (n) => n.overlap?.jaccard ?? null)),
+    };
+}
+
+function groupBySharedAndAnchor(
+    nights: readonly PairedNightFeatureRecord[],
+): Map<string, PairedNightFeatureRecord[]> {
+    const groups = new Map<string, PairedNightFeatureRecord[]>();
+    for (const night of nights) {
+        const key = crossSourceProfileKey(night.sharedProvider, night.anchorProvider, night.anchorTransport);
+        const existing = groups.get(key);
+        if (existing) {
+            existing.push(night);
+        } else {
+            groups.set(key, [night]);
+        }
+    }
+    return groups;
+}
+
+export interface FitPassportParams {
+    nights: readonly PairedNightFeatureRecord[];
+    passportVersion: string;
+    createdAt: string;
+    policyVersion: string;
+    featureSchemaVersion: string;
+    anchorPolicy: AnchorPolicy;
+    scaleFloors?: IdentityFeatureScaleFloors;
+}
+
+/** Fits a passport document directly from a night list, with no bootstrap/core-selection step. */
+export function fitPassportFromNights(params: FitPassportParams): PhysiologicalIdentityPassport {
+    const floors = params.scaleFloors ?? DEFAULT_IDENTITY_FEATURE_SCALE_FLOORS;
+    const grouped = groupBySharedAndAnchor(params.nights);
+
+    const sourceProfiles: Record<string, SourceProfile> = {};
+    const crossSourceProfiles: Record<string, CrossSourceProfile> = {};
+    for (const [key, groupNights] of grouped) {
+        const sharedProvider = groupNights[0].sharedProvider;
+        sourceProfiles[sharedProvider] = fitSourceProfile(groupNights, floors);
+        crossSourceProfiles[key] = fitCrossSourceProfile(groupNights, floors);
+    }
+
+    return {
+        schemaVersion: 1,
+        passportVersion: params.passportVersion,
+        createdAt: params.createdAt,
+        policyVersion: params.policyVersion,
+        featureSchemaVersion: params.featureSchemaVersion,
+        anchorPolicy: params.anchorPolicy,
+        sourceProfiles,
+        crossSourceProfiles,
+        calibration: emptyCalibrationSummary(),
+    };
+}
+
+export interface PassportBootstrapResult {
+    passport: PhysiologicalIdentityPassport;
+    usableNightCount: number;
+    excludedByLineageOrAnchorCount: number;
+    coreNightCount: number;
+    /** Descriptive re-scoring of every *usable* night (core + excluded) -- diagnostics, not labels. */
+    nightConcordance: readonly NightConcordanceEvaluation[];
+}
+
+/**
+ * Implements the plan's 7-step historical bootstrap:
+ *   1. usable independent-lineage, anchor-eligible, validly-paired nights only;
+ *   2. preliminary robust center/scale over all usable nights;
+ *   3. conservative central core via multi-feature concordance;
+ *   4. excluded nights are never labelled NOT_USER;
+ *   5. fit passport v0 from the central core;
+ *   6. `nightConcordance` re-scores every usable night for descriptive analysis;
+ *   7. the result persists uncertainty (concordance diagnostics), not guessed identity labels.
+ *
+ * A full-sample bootstrap like this may be used as the production/shadow model after selection,
+ * but `nightConcordance` here is in-sample and must not be reported as unbiased acceptance/
+ * coverage evidence -- use `leaveOneNightOutReplay`/`chronologicalExpandingWindowReplay` for that.
+ */
+export function bootstrapPassportFromHistory(params: {
+    nights: readonly PairedNightFeatureRecord[];
+    passportVersion: string;
+    createdAt: string;
+    policyVersion: string;
+    featureSchemaVersion: string;
+    anchorPolicy: AnchorPolicy;
+    config?: PassportBootstrapConfig;
+}): PassportBootstrapResult {
+    const config = params.config ?? DEFAULT_PASSPORT_BOOTSTRAP_CONFIG;
+
+    // Step 1.
+    const usable = params.nights.filter(
+        (n) => n.lineageIndependent && n.anchorEligible && n.overlap !== null,
+    );
+
+    // Step 2.
+    const preliminary = fitPreliminaryRelationEstimates(usable, config.scaleFloors);
+
+    // Step 3.
+    const nightConcordance = usable.map((n) => evaluateNightConcordance(n, preliminary, config));
+
+    // Step 4 (nothing labelled NOT_USER -- `nightConcordance` carries only descriptive reasons).
+    const coreKeys = new Set(
+        nightConcordance.filter((c) => c.includedInCore).map((c) => c.sourceNightKey),
+    );
+    const coreNights = usable.filter((n) => coreKeys.has(n.sourceNightKey));
+
+    // Step 5.
+    const passport = fitPassportFromNights({
+        nights: coreNights,
+        passportVersion: params.passportVersion,
+        createdAt: params.createdAt,
+        policyVersion: params.policyVersion,
+        featureSchemaVersion: params.featureSchemaVersion,
+        anchorPolicy: params.anchorPolicy,
+        scaleFloors: config.scaleFloors,
+    });
+
+    // Steps 6-7: nightConcordance (already computed over all usable nights) is the descriptive
+    // re-score; no identity labels are produced anywhere in this result.
+    return {
+        passport,
+        usableNightCount: usable.length,
+        excludedByLineageOrAnchorCount: params.nights.length - usable.length,
+        coreNightCount: coreNights.length,
+        nightConcordance,
+    };
+}
+
+// --- Out-of-sample evaluation (ADR-0028 P-PI-16) ------------------------------------------------
+
+export interface OutOfSampleReplayResult {
+    sourceNightKey: string;
+    /** `null` when there were not enough training nights to fit a passport for this night. */
+    passport: PhysiologicalIdentityPassport | null;
+    trainingNightCount: number;
+}
+
+type BootstrapFitParams = Omit<Parameters<typeof bootstrapPassportFromHistory>[0], 'nights'>;
+
+/**
+ * Leave-one-night-out replay: each night is scored only against a passport fitted from every
+ * *other* night. Suited to the small historical paired set. Never lets a night contribute to the
+ * passport that evaluates it (P-PI-16).
+ */
+export function leaveOneNightOutReplay(
+    nights: readonly PairedNightFeatureRecord[],
+    fitParams: BootstrapFitParams,
+): readonly OutOfSampleReplayResult[] {
+    return nights.map((night) => {
+        const trainingNights = nights.filter((other) => other.sourceNightKey !== night.sourceNightKey);
+        if (trainingNights.length === 0) {
+            return { sourceNightKey: night.sourceNightKey, passport: null, trainingNightCount: 0 };
+        }
+        const { passport } = bootstrapPassportFromHistory({ ...fitParams, nights: trainingNights });
+        return { sourceNightKey: night.sourceNightKey, passport, trainingNightCount: trainingNights.length };
+    });
+}
+
+/**
+ * Chronological expanding-window replay: a night is scored only against a passport fitted from
+ * strictly earlier nights (`nightsSortedChronologically` must already be in ascending order).
+ * Nights before `minTrainingNights` of history exists get `passport: null` rather than a
+ * degenerate near-empty fit.
+ */
+export function chronologicalExpandingWindowReplay(
+    nightsSortedChronologically: readonly PairedNightFeatureRecord[],
+    fitParams: BootstrapFitParams,
+    minTrainingNights = 5,
+): readonly OutOfSampleReplayResult[] {
+    const results: OutOfSampleReplayResult[] = [];
+    for (let i = 0; i < nightsSortedChronologically.length; i++) {
+        const night = nightsSortedChronologically[i];
+        const trainingNights = nightsSortedChronologically.slice(0, i);
+        if (trainingNights.length < minTrainingNights) {
+            results.push({ sourceNightKey: night.sourceNightKey, passport: null, trainingNightCount: trainingNights.length });
+            continue;
+        }
+        const { passport } = bootstrapPassportFromHistory({ ...fitParams, nights: trainingNights });
+        results.push({ sourceNightKey: night.sourceNightKey, passport, trainingNightCount: trainingNights.length });
+    }
+    return results;
+}
+
+// --- Passport eras (versioning) -----------------------------------------------------------------
+
+export type PassportEraChangeReason =
+    | 'GARMIN_DEVICE_OR_ALGORITHM_CHANGE'
+    | 'EIGHT_SLEEP_ALGORITHM_OR_API_CHANGE'
+    | 'GOOGLE_HEALTH_MAPPING_CHANGE'
+    | 'MEASUREMENT_SYSTEM_SHIFT_CONFIRMED_BY_REPLAY'
+    | 'INITIAL_BOOTSTRAP'
+    | 'OTHER';
+
+/**
+ * Deterministically derives the next `passportVersion` string ("YYYY-MM-DD.N") for a given local
+ * creation date, given the versions that already exist for that date. Pure/testable: callers
+ * supply `createdAtDate` explicitly rather than this function reading the clock, so passport
+ * version generation is itself replayable.
+ */
+export function nextPassportVersion(
+    createdAtDate: string,
+    existingVersionsForDate: readonly string[],
+): string {
+    const prefix = `${createdAtDate}.`;
+    const suffixes = existingVersionsForDate
+        .filter((v) => v.startsWith(prefix))
+        .map((v) => Number.parseInt(v.slice(prefix.length), 10))
+        .filter((n) => Number.isFinite(n));
+    const next = suffixes.length > 0 ? Math.max(...suffixes) + 1 : 1;
+    return `${prefix}${next}`;
+}

--- a/app/src/engine/identityPassport.ts
+++ b/app/src/engine/identityPassport.ts
@@ -455,12 +455,22 @@ export interface FitPassportParams {
 export function fitPassportFromNights(params: FitPassportParams): PhysiologicalIdentityPassport {
     const floors = params.scaleFloors ?? DEFAULT_IDENTITY_FEATURE_SCALE_FLOORS;
     const grouped = groupBySharedAndAnchor(params.nights);
+    const nightsBySharedProvider = new Map<string, PairedNightFeatureRecord[]>();
+    for (const night of params.nights) {
+        const existing = nightsBySharedProvider.get(night.sharedProvider);
+        if (existing) {
+            existing.push(night);
+        } else {
+            nightsBySharedProvider.set(night.sharedProvider, [night]);
+        }
+    }
 
     const sourceProfiles: Record<string, SourceProfile> = {};
     const crossSourceProfiles: Record<string, CrossSourceProfile> = {};
+    for (const [sharedProvider, providerNights] of nightsBySharedProvider) {
+        sourceProfiles[sharedProvider] = fitSourceProfile(providerNights, floors);
+    }
     for (const [key, groupNights] of grouped) {
-        const sharedProvider = groupNights[0].sharedProvider;
-        sourceProfiles[sharedProvider] = fitSourceProfile(groupNights, floors);
         crossSourceProfiles[key] = fitCrossSourceProfile(groupNights, floors);
     }
 

--- a/app/src/engine/identityProvenance.test.ts
+++ b/app/src/engine/identityProvenance.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest';
+import type {
+    AutomaticIdentityAssessment,
+    EffectiveIdentityDecision,
+} from '../observations/identityModels';
+import {
+    buildIdentityDecisionProvenance,
+    identityDecisionProvenanceReplayErrors,
+} from './identityProvenance';
+
+function assessment(
+    overrides: Partial<AutomaticIdentityAssessment> = {},
+): AutomaticIdentityAssessment {
+    return {
+        id: 'assessment-2026-08-27',
+        sourceNightKey: '2026-08-27',
+        sharedSource: { provider: 'eight_sleep', transport: 'google_health' },
+        automaticStatus: 'UNCERTAIN',
+        identityScore: 0.73,
+        confidenceTier: 'MODERATE',
+        reasonCodes: ['SESSION_TIMING_DISCORDANT'],
+        passportVersion: '2026-08-27.1',
+        policyVersion: 'identity-v1-shadow',
+        featureSchemaVersion: 'identity-features-v1',
+        assessedAt: '2026-08-27T06:00:00.000Z',
+        sharedBundleRef: {
+            id: '2026-08-27_eight_sleep_google_health',
+            provider: 'eight_sleep',
+            transport: 'google_health',
+            revision: 2,
+            sourcePayloadHash: 'sha256:shared',
+            lineageKey: 'eight_sleep:pod-side:a',
+        },
+        anchorBundleRefs: [{
+            id: '2026-08-27_garmin_garmin_direct',
+            provider: 'garmin',
+            transport: 'garmin_direct',
+            revision: 1,
+            sourcePayloadHash: 'sha256:anchor',
+            lineageKey: 'garmin:device:athlete',
+        }],
+        ...overrides,
+    };
+}
+
+function decision(
+    overrides: Partial<EffectiveIdentityDecision> = {},
+): EffectiveIdentityDecision {
+    return {
+        assessmentId: 'assessment-2026-08-27',
+        effectiveStatus: 'USER',
+        eligibility: {
+            display: true,
+            recovery: true,
+            baselineLearning: true,
+            passportLearning: true,
+        },
+        authority: 'MANUAL_REVIEW',
+        reviewEventId: 'review-1',
+        ...overrides,
+    };
+}
+
+describe('identity recommendation provenance (PI6)', () => {
+    it('captures every automatic/effective decision and bundle replay input', () => {
+        const provenance = buildIdentityDecisionProvenance({
+            assessment: assessment(),
+            decision: decision(),
+            selectedEffectiveSource: { provider: 'eight_sleep', transport: 'google_health' },
+            fallbackReason: null,
+        });
+
+        expect(provenance).toEqual(expect.objectContaining({
+            identityAssessmentId: 'assessment-2026-08-27',
+            automaticStatus: 'UNCERTAIN',
+            effectiveStatus: 'USER',
+            reviewEventId: 'review-1',
+            identityPolicyVersion: 'identity-v1-shadow',
+            featureSchemaVersion: 'identity-features-v1',
+            passportVersion: '2026-08-27.1',
+        }));
+        expect(provenance.sharedBundleRef.revision).toBe(2);
+        expect(provenance.anchorBundleRefs).toHaveLength(1);
+        expect(identityDecisionProvenanceReplayErrors(provenance)).toEqual([]);
+    });
+
+    it('rejects an effective decision belonging to another assessment', () => {
+        expect(() => buildIdentityDecisionProvenance({
+            assessment: assessment(),
+            decision: decision({ assessmentId: 'another-assessment' }),
+            selectedEffectiveSource: null,
+            fallbackReason: 'SESSION_TIMING_DISCORDANT',
+        })).toThrow('does not belong');
+    });
+
+    it('never records a non-USER shared source as selected effective evidence', () => {
+        expect(() => buildIdentityDecisionProvenance({
+            assessment: assessment(),
+            decision: decision({
+                effectiveStatus: 'UNCERTAIN',
+                authority: 'AUTOMATIC',
+                reviewEventId: undefined,
+            }),
+            selectedEffectiveSource: { provider: 'eight_sleep', transport: 'google_health' },
+            fallbackReason: 'SESSION_TIMING_DISCORDANT',
+        })).toThrow('identity-ineligible shared source');
+    });
+
+    it('allows an empty anchor list only for an explicit ANCHOR_MISSING fallback', () => {
+        const missingAnchor = buildIdentityDecisionProvenance({
+            assessment: assessment({
+                anchorBundleRefs: [],
+                reasonCodes: ['ANCHOR_MISSING'],
+            }),
+            decision: decision({
+                effectiveStatus: 'UNCERTAIN',
+                authority: 'AUTOMATIC',
+                reviewEventId: undefined,
+            }),
+            selectedEffectiveSource: { provider: 'garmin', transport: 'garmin_direct' },
+            fallbackReason: 'ANCHOR_MISSING',
+        });
+        expect(identityDecisionProvenanceReplayErrors(missingAnchor)).toEqual([]);
+
+        expect(identityDecisionProvenanceReplayErrors({
+            ...missingAnchor,
+            fallbackReason: 'ANCHOR_QUALITY_INSUFFICIENT',
+        })).toContain('Identity audit has no anchor bundle evidence.');
+    });
+
+    it('makes passport-version and bundle-lineage changes visible to replay checks', () => {
+        const provenance = buildIdentityDecisionProvenance({
+            assessment: assessment(),
+            decision: decision(),
+            selectedEffectiveSource: null,
+            fallbackReason: null,
+        });
+        const changedPassport = { ...provenance, passportVersion: '2026-08-28.1' };
+        expect(changedPassport).not.toEqual(provenance);
+        expect(identityDecisionProvenanceReplayErrors({
+            ...provenance,
+            anchorBundleRefs: [{ ...provenance.anchorBundleRefs[0], lineageKey: '' }],
+        })).toContain('Identity anchor bundle 2026-08-27_garmin_garmin_direct has incomplete replay metadata.');
+    });
+});

--- a/app/src/engine/identityProvenance.test.ts
+++ b/app/src/engine/identityProvenance.test.ts
@@ -142,4 +142,30 @@ describe('identity recommendation provenance (PI6)', () => {
             anchorBundleRefs: [{ ...provenance.anchorBundleRefs[0], lineageKey: '' }],
         })).toContain('Identity anchor bundle 2026-08-27_garmin_garmin_direct has incomplete replay metadata.');
     });
+
+    it('rejects a shared bundle reference with an empty id', () => {
+        const provenance = buildIdentityDecisionProvenance({
+            assessment: assessment(),
+            decision: decision(),
+            selectedEffectiveSource: null,
+            fallbackReason: null,
+        });
+        expect(identityDecisionProvenanceReplayErrors({
+            ...provenance,
+            sharedBundleRef: { ...provenance.sharedBundleRef, id: '' },
+        })).toContain('Shared identity bundle ID is missing.');
+    });
+
+    it('rejects an anchor bundle reference with an empty id', () => {
+        const provenance = buildIdentityDecisionProvenance({
+            assessment: assessment(),
+            decision: decision(),
+            selectedEffectiveSource: null,
+            fallbackReason: null,
+        });
+        expect(identityDecisionProvenanceReplayErrors({
+            ...provenance,
+            anchorBundleRefs: [{ ...provenance.anchorBundleRefs[0], id: '' }],
+        })).toContain('Identity anchor bundle  has incomplete replay metadata.');
+    });
 });

--- a/app/src/engine/identityProvenance.ts
+++ b/app/src/engine/identityProvenance.ts
@@ -1,0 +1,80 @@
+/** Replay-oriented identity provenance for ADR-0010 recommendation audits (PI6/ADR-0028). */
+
+import type {
+    AutomaticIdentityAssessment,
+    EffectiveIdentityDecision,
+    IdentityDecisionProvenance,
+    IdentityReasonCode,
+} from '../observations/identityModels';
+
+export function buildIdentityDecisionProvenance(params: {
+    assessment: AutomaticIdentityAssessment;
+    decision: EffectiveIdentityDecision;
+    selectedEffectiveSource: { provider: string; transport: string } | null;
+    fallbackReason: IdentityReasonCode | null;
+}): IdentityDecisionProvenance {
+    if (params.decision.assessmentId !== params.assessment.id) {
+        throw new Error('Effective identity decision does not belong to the supplied assessment');
+    }
+    if (
+        params.decision.effectiveStatus !== 'USER' &&
+        params.selectedEffectiveSource?.provider === params.assessment.sharedSource.provider &&
+        params.selectedEffectiveSource.transport === params.assessment.sharedSource.transport
+    ) {
+        throw new Error('An identity-ineligible shared source cannot be selected as effective evidence');
+    }
+
+    return {
+        identityAssessmentId: params.assessment.id,
+        automaticStatus: params.assessment.automaticStatus,
+        effectiveStatus: params.decision.effectiveStatus,
+        reviewEventId: params.decision.reviewEventId ?? null,
+        identityPolicyVersion: params.assessment.policyVersion,
+        featureSchemaVersion: params.assessment.featureSchemaVersion,
+        passportVersion: params.assessment.passportVersion,
+        sharedBundleRef: { ...params.assessment.sharedBundleRef },
+        anchorBundleRefs: params.assessment.anchorBundleRefs.map((ref) => ({ ...ref })),
+        selectedEffectiveSource: params.selectedEffectiveSource
+            ? { ...params.selectedEffectiveSource }
+            : null,
+        fallbackReason: params.fallbackReason,
+    };
+}
+
+export function identityDecisionProvenanceReplayErrors(
+    provenance: IdentityDecisionProvenance | undefined,
+): string[] {
+    if (!provenance) return [];
+    const errors: string[] = [];
+    if (!provenance.identityAssessmentId) errors.push('Identity assessment ID is missing.');
+    if (!provenance.identityPolicyVersion) errors.push('Identity policy version is missing.');
+    if (!provenance.featureSchemaVersion) errors.push('Identity feature schema version is missing.');
+    if (provenance.sharedBundleRef.revision < 1) errors.push('Shared identity bundle revision is invalid.');
+    if (!provenance.sharedBundleRef.sourcePayloadHash) errors.push('Shared identity bundle hash is missing.');
+    if (!provenance.sharedBundleRef.lineageKey) errors.push('Shared identity bundle lineage is missing.');
+    if (
+        provenance.anchorBundleRefs.length === 0 &&
+        provenance.fallbackReason !== 'ANCHOR_MISSING'
+    ) {
+        errors.push('Identity audit has no anchor bundle evidence.');
+    }
+    for (const ref of provenance.anchorBundleRefs) {
+        if (ref.revision < 1 || !ref.sourcePayloadHash || !ref.lineageKey) {
+            errors.push(`Identity anchor bundle ${ref.id} has incomplete replay metadata.`);
+        }
+    }
+    if (
+        provenance.automaticStatus !== provenance.effectiveStatus &&
+        provenance.reviewEventId === null
+    ) {
+        errors.push('Effective identity differs from automatic identity without a review event.');
+    }
+    if (
+        provenance.effectiveStatus !== 'USER' &&
+        provenance.selectedEffectiveSource?.provider === provenance.sharedBundleRef.provider &&
+        provenance.selectedEffectiveSource.transport === provenance.sharedBundleRef.transport
+    ) {
+        errors.push('Identity-ineligible shared source was recorded as effective evidence.');
+    }
+    return errors;
+}

--- a/app/src/engine/identityProvenance.ts
+++ b/app/src/engine/identityProvenance.ts
@@ -49,7 +49,10 @@ export function identityDecisionProvenanceReplayErrors(
     if (!provenance.identityAssessmentId) errors.push('Identity assessment ID is missing.');
     if (!provenance.identityPolicyVersion) errors.push('Identity policy version is missing.');
     if (!provenance.featureSchemaVersion) errors.push('Identity feature schema version is missing.');
-    if (provenance.sharedBundleRef.revision < 1) errors.push('Shared identity bundle revision is invalid.');
+    if (!provenance.sharedBundleRef.id) errors.push('Shared identity bundle ID is missing.');
+    if (!Number.isInteger(provenance.sharedBundleRef.revision) || provenance.sharedBundleRef.revision < 1) {
+        errors.push('Shared identity bundle revision is invalid.');
+    }
     if (!provenance.sharedBundleRef.sourcePayloadHash) errors.push('Shared identity bundle hash is missing.');
     if (!provenance.sharedBundleRef.lineageKey) errors.push('Shared identity bundle lineage is missing.');
     if (
@@ -59,7 +62,7 @@ export function identityDecisionProvenanceReplayErrors(
         errors.push('Identity audit has no anchor bundle evidence.');
     }
     for (const ref of provenance.anchorBundleRefs) {
-        if (ref.revision < 1 || !ref.sourcePayloadHash || !ref.lineageKey) {
+        if (!ref.id || !Number.isInteger(ref.revision) || ref.revision < 1 || !ref.sourcePayloadHash || !ref.lineageKey) {
             errors.push(`Identity anchor bundle ${ref.id} has incomplete replay metadata.`);
         }
     }

--- a/app/src/engine/models.ts
+++ b/app/src/engine/models.ts
@@ -1,5 +1,6 @@
 import type { AthletePerformanceProfile, WorkoutPrescription } from '../workouts/models.ts';
 import type { SessionReferenceBinding } from '../sessions/models';
+import type { IdentityDecisionProvenance } from '../observations/identityModels';
 import type { DataIssue, DataState, DataStateSummary } from './dataState';
 import type { SubjectiveBaseline } from './subjectiveBaseline';
 import type { DataConfidenceScore } from './dataConfidence';
@@ -1618,6 +1619,8 @@ export interface RecommendationAudit {
     /** Multidomain session bindings (M3.2 / ADR-0023 D-MSNAP). */
     primarySession?: SessionReferenceBinding;
     additionalSessions?: SessionReferenceBinding[];
+    /** Present once multisource evidence influenced the recommendation input (PI6/ADR-0028). */
+    identityDecision?: IdentityDecisionProvenance;
 }
 
 /** A compact, replayable record that a replacement occurrence, not catalog ranking,

--- a/app/src/engine/multisourceBaselines.test.ts
+++ b/app/src/engine/multisourceBaselines.test.ts
@@ -49,13 +49,16 @@ describe('multisourceBaselines', () => {
             });
         }
 
-        const baseline = computeSourceMetricBaseline(
+        const baseline = computeSourceMetricBaseline({
             bundles,
-            'hrv_rmssd_ms',
-            'garmin',
-            'google_health',
-            '2026-08-28',
-        );
+            userId: 'user1',
+            effectiveIdentityProjections: [],
+            identityPolicy: { identityRequiredSources: [] },
+            metric: 'hrv_rmssd_ms',
+            provider: 'garmin',
+            transport: 'google_health',
+            referenceDate: '2026-08-28',
+        });
 
         expect(baseline.count28d).toBe(28);
         expect(baseline.count7d).toBe(7);

--- a/app/src/engine/multisourceBaselines.ts
+++ b/app/src/engine/multisourceBaselines.ts
@@ -5,6 +5,12 @@
  * source/provider boundary to prevent device discontinuities from distorting baselines.
  * Evaluates baseline maturity state machines to ensure secondary sensors do not affect
  * confidence before reaching adequate maturity.
+ *
+ * KNOWN GAP (PI0/PI5, ADR-0028): `computeSourceMetricBaseline()` currently consumes all source
+ * bundles for a provider/transport regardless of identity attribution -- the co-presence check
+ * in multisourceFusion.ts runs later, downstream of this calculator. This is the "current defect"
+ * PI5 (Pre-baseline effective-eligibility gate) fixes by requiring effective identity eligibility
+ * metadata as an input here. Do not treat the current behavior as identity-safe.
  */
 
 import type { BaselineMaturity, HealthObservationDayBundle } from '../observations/models';

--- a/app/src/engine/multisourceBaselines.ts
+++ b/app/src/engine/multisourceBaselines.ts
@@ -6,14 +6,18 @@
  * Evaluates baseline maturity state machines to ensure secondary sensors do not affect
  * confidence before reaching adequate maturity.
  *
- * KNOWN GAP (PI0/PI5, ADR-0028): `computeSourceMetricBaseline()` currently consumes all source
- * bundles for a provider/transport regardless of identity attribution -- the co-presence check
- * in multisourceFusion.ts runs later, downstream of this calculator. This is the "current defect"
- * PI5 (Pre-baseline effective-eligibility gate) fixes by requiring effective identity eligibility
- * metadata as an input here. Do not treat the current behavior as identity-safe.
+ * PI5/ADR-0028: the public calculator requires an explicit effective-identity projection and
+ * filters it through `selectEligibleHealthObservationBundles()` before extracting any value.
+ * Configured shared sources therefore cannot enter an ordinary baseline call without exact
+ * bundle-revision evidence granting `baselineLearning`.
  */
 
 import type { BaselineMaturity, HealthObservationDayBundle } from '../observations/models';
+import {
+    selectEligibleHealthObservationBundles,
+    type EffectiveBundleIdentityProjection,
+    type IdentityEligibilityPolicy,
+} from './identityEligibility';
 
 export interface SourceMetricBaseline {
     metric: string;
@@ -72,22 +76,36 @@ export function evaluateBaselineMaturity(
     return 'MATURE';
 }
 
+export interface ComputeSourceMetricBaselineParams {
+    bundles: readonly HealthObservationDayBundle[];
+    userId: string;
+    effectiveIdentityProjections: readonly EffectiveBundleIdentityProjection[];
+    identityPolicy: IdentityEligibilityPolicy;
+    metric: string;
+    provider: string;
+    transport: string;
+    referenceDate: string;
+}
+
 export function computeSourceMetricBaseline(
-    bundles: readonly HealthObservationDayBundle[],
-    metric: string,
-    provider: string,
-    transport: string,
-    referenceDate: string,
+    params: ComputeSourceMetricBaselineParams,
 ): SourceMetricBaseline {
-    const relevantBundles = bundles.filter(
-        (b) => b.provider === provider && b.transport === transport,
+    const eligibleBundles = selectEligibleHealthObservationBundles({
+        bundles: params.bundles,
+        userId: params.userId,
+        effectiveIdentityProjections: params.effectiveIdentityProjections,
+        identityPolicy: params.identityPolicy,
+        requireEligibility: 'baselineLearning',
+    });
+    const relevantBundles = eligibleBundles.filter(
+        (b) => b.provider === params.provider && b.transport === params.transport,
     );
 
     // Extract numeric values mapped by logical date
     const dateValues: { date: string; value: number }[] = [];
     for (const bundle of relevantBundles) {
         for (const obs of bundle.observations) {
-            if (obs.metric === metric && typeof obs.value === 'number') {
+            if (obs.metric === params.metric && typeof obs.value === 'number') {
                 dateValues.push({ date: bundle.logicalDate, value: obs.value });
                 break; // 1 observation per metric per day bundle
             }
@@ -96,7 +114,7 @@ export function computeSourceMetricBaseline(
 
     dateValues.sort((a, b) => a.date.localeCompare(b.date));
 
-    const refTime = new Date(referenceDate).getTime();
+    const refTime = new Date(params.referenceDate).getTime();
     const window28Values: number[] = [];
     const window7Values: number[] = [];
     let latestDate: string | null = null;
@@ -118,12 +136,16 @@ export function computeSourceMetricBaseline(
     const median7d = calculateMedian(window7Values);
     const median28d = calculateMedian(window28Values);
     const mad28d = calculateMad(window28Values, median28d);
-    const maturity = evaluateBaselineMaturity(window28Values.length, latestDate, referenceDate);
+    const maturity = evaluateBaselineMaturity(
+        window28Values.length,
+        latestDate,
+        params.referenceDate,
+    );
 
     return {
-        metric,
-        provider,
-        transport,
+        metric: params.metric,
+        provider: params.provider,
+        transport: params.transport,
         count7d: window7Values.length,
         count28d: window28Values.length,
         median7d,

--- a/app/src/engine/multisourceFusion.ts
+++ b/app/src/engine/multisourceFusion.ts
@@ -93,12 +93,10 @@ export function evaluateMultisourceFusion(params: {
 
     // Step 1: Secondary-source identity & session concordance validation (D-MS-IDENTITY, D-MS-PREBASE)
     //
-    // PROVISIONAL (PI0, ADR-0028): this call site is the current, temporary identity gate and it
-    // runs downstream, inside fusion -- it does NOT satisfy the pre-baseline ordering requirement
-    // (`computeSourceMetricBaseline()` still consumes bundles independently of this verdict; see
-    // multisourceBaselines.ts and PI5). Once the Physiological Identity Passport gate lands
-    // (PI4/PI5), effective identity eligibility must be resolved upstream of both baseline
-    // learning and this fusion step, and this call site should be replaced, not extended.
+    // PROVISIONAL (PI0/PI9, ADR-0028): PI5 now protects baseline accumulation upstream through
+    // explicit EffectiveIdentityDecision eligibility. This downstream call remains only as a
+    // legacy candidate-fusion compatibility guard; PI9 must replace it with the same effective
+    // decision projection rather than extend its fixed thresholds.
     let garminRhr: number | null = null;
     let eightSleepRhr: number | null = null;
     let garminSleepInterval: SleepSessionInterval | null = null;

--- a/app/src/engine/multisourceFusion.ts
+++ b/app/src/engine/multisourceFusion.ts
@@ -92,6 +92,13 @@ export function evaluateMultisourceFusion(params: {
     }
 
     // Step 1: Secondary-source identity & session concordance validation (D-MS-IDENTITY, D-MS-PREBASE)
+    //
+    // PROVISIONAL (PI0, ADR-0028): this call site is the current, temporary identity gate and it
+    // runs downstream, inside fusion -- it does NOT satisfy the pre-baseline ordering requirement
+    // (`computeSourceMetricBaseline()` still consumes bundles independently of this verdict; see
+    // multisourceBaselines.ts and PI5). Once the Physiological Identity Passport gate lands
+    // (PI4/PI5), effective identity eligibility must be resolved upstream of both baseline
+    // learning and this fusion step, and this call site should be replaced, not extended.
     let garminRhr: number | null = null;
     let eightSleepRhr: number | null = null;
     let garminSleepInterval: SleepSessionInterval | null = null;

--- a/app/src/engine/provenance.test.ts
+++ b/app/src/engine/provenance.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { Recommendation } from './models';
+import type { IdentityDecisionProvenance } from '../observations/identityModels';
 import { TEMPLATES } from './templates';
 import { POLICY_VERSION } from './policy';
 import { buildRecommendationAudit } from './provenance';
@@ -111,5 +112,44 @@ describe('recommendation provenance', () => {
 
         const audit = buildRecommendationAudit(recommendation, snapshot, '2026-08-07T09:00:00Z');
         expect(audit?.envelope.safetyRestrictedModalityCount).toBe(1);
+    });
+
+    it('carries compact identity evidence into the recommendation audit verbatim', () => {
+        const template = TEMPLATES.find(item => item.category === 'Rest');
+        if (!template) throw new Error('Test fixture requires a rest template');
+        const recommendation: Recommendation = {
+            template,
+            mode: 'recover',
+            rationale: 'Identity fallback.',
+            envelopes: {
+                safety: { clinicalFlagActive: false, restrictedModalities: [] },
+                plan: { maxAllowableTier: 'Rest', taperActive: false },
+            },
+            decisionTrace: { policyVersion: POLICY_VERSION, candidateScores: [], droppedContributorObjectives: [] },
+        };
+        const snapshot = buildTrainingHistorySnapshot(
+            '2026-08-07', 7,
+            { status: 'AVAILABLE', revision: 'activities-r1', data: [] },
+            { status: 'AVAILABLE', revision: 'recommendations-r1', data: [] },
+            '2026-08-07T08:00:00Z',
+        );
+        const identity: IdentityDecisionProvenance = {
+            identityAssessmentId: 'assessment-1',
+            automaticStatus: 'UNCERTAIN', effectiveStatus: 'UNCERTAIN', reviewEventId: null,
+            identityPolicyVersion: 'identity-v1-shadow', featureSchemaVersion: 'identity-features-v1',
+            passportVersion: '2026-08-07.1',
+            sharedBundleRef: {
+                id: 'shared', provider: 'shared_bed', transport: 'health_aggregator', revision: 2,
+                sourcePayloadHash: 'sha256:shared', lineageKey: 'shared-bed:side:a',
+            },
+            anchorBundleRefs: [],
+            selectedEffectiveSource: { provider: 'garmin', transport: 'garmin_direct' },
+            fallbackReason: 'ANCHOR_MISSING',
+        };
+
+        const audit = buildRecommendationAudit(
+            recommendation, snapshot, '2026-08-07T09:00:00Z', null, identity,
+        );
+        expect(audit?.identityDecision).toEqual(identity);
     });
 });

--- a/app/src/engine/provenance.ts
+++ b/app/src/engine/provenance.ts
@@ -1,5 +1,6 @@
 import type { Recommendation, RecommendationAudit } from './models';
 import type { TrainingHistorySnapshot } from './trainingHistorySnapshot';
+import type { IdentityDecisionProvenance } from '../observations/identityModels';
 import {
     compactSubjectiveDriftAudit,
     type SubjectiveDriftAudit,
@@ -22,6 +23,7 @@ export function buildRecommendationAudit(
     historySnapshot: TrainingHistorySnapshot,
     evaluatedAt = new Date().toISOString(),
     subjectiveDriftEvidence: SubjectiveDriftAuditSource | null = null,
+    identityDecision: IdentityDecisionProvenance | null = null,
 ): RecommendationAuditWithSubjectiveDrift | null {
     const trace = recommendation.decisionTrace;
     const envelopes = recommendation.envelopes;
@@ -56,5 +58,6 @@ export function buildRecommendationAudit(
         ...(recommendation.primarySession ? { primarySession: recommendation.primarySession } : {}),
         ...(recommendation.additionalSessions && recommendation.additionalSessions.length > 0 ? { additionalSessions: recommendation.additionalSessions } : {}),
         ...(subjectiveDrift ? { subjectiveDrift } : {}),
+        ...(identityDecision ? { identityDecision } : {}),
     };
 }

--- a/app/src/engine/replay.ts
+++ b/app/src/engine/replay.ts
@@ -4,6 +4,7 @@ import { computeContentHash } from './externalPlanHash';
 import { externalTemplateId, isExternalTemplateId } from './externalSessionProfiles';
 import { isHistoricalPolicyVersion, POLICY_VERSION } from './policy';
 import { subjectiveDriftAuditReplayErrors } from './subjectiveDriftAudit';
+import { identityDecisionProvenanceReplayErrors } from './identityProvenance';
 
 export interface RecommendationReplayResult {
     reproducible: boolean;
@@ -163,6 +164,7 @@ export function replayRecommendationAudit(
 
     const subjectiveDrift = (audit as typeof audit & { subjectiveDrift?: unknown }).subjectiveDrift;
     errors.push(...subjectiveDriftAuditReplayErrors(subjectiveDrift, recommendation.date));
+    errors.push(...identityDecisionProvenanceReplayErrors(audit.identityDecision));
 
     errors.push(...sessionBindingConsistencyErrors(recommendation));
     errors.push(...sessionBindingErrors(audit, sessionEvidence));

--- a/app/src/observations/identityModels.test.ts
+++ b/app/src/observations/identityModels.test.ts
@@ -1,0 +1,310 @@
+import { describe, expect, it } from 'vitest';
+import {
+    IDENTITY_REASON_CODES,
+    IDENTITY_REASON_CODE_SCHEMA_VERSION,
+    deriveEffectiveIdentityDecision,
+    deriveObservationEligibility,
+    findEffectiveReviewEvent,
+    freezeAutomaticIdentityAssessment,
+    isKnownIdentityReasonCode,
+    type AutomaticIdentityAssessment,
+    type IdentityReviewEvent,
+} from './identityModels';
+
+function makeAssessment(
+    overrides: Partial<AutomaticIdentityAssessment> = {},
+): AutomaticIdentityAssessment {
+    return {
+        id: 'assessment-2026-08-27',
+        sourceNightKey: '2026-08-27',
+        sharedSource: { provider: 'eight_sleep', transport: 'google_health' },
+        automaticStatus: 'UNCERTAIN',
+        identityScore: 0.42,
+        confidenceTier: 'LOW',
+        reasonCodes: ['SESSION_TIMING_DISCORDANT'],
+        passportVersion: '2026-08-27.1',
+        policyVersion: 'identity-v1-shadow',
+        featureSchemaVersion: 'identity-features-v1',
+        assessedAt: '2026-08-27T06:30:00Z',
+        sharedBundleRef: {
+            id: '2026-08-27_eight_sleep_google_health',
+            provider: 'eight_sleep',
+            transport: 'google_health',
+            revision: 1,
+            sourcePayloadHash: 'sha256:shared',
+            lineageKey: 'eight_sleep:pod-side:abc',
+        },
+        anchorBundleRefs: [
+            {
+                id: '2026-08-27_garmin_garmin_direct',
+                provider: 'garmin',
+                transport: 'garmin_direct',
+                revision: 1,
+                sourcePayloadHash: 'sha256:anchor',
+                lineageKey: 'garmin:device:xyz',
+            },
+        ],
+        ...overrides,
+    };
+}
+
+function makeReviewEvent(overrides: Partial<IdentityReviewEvent> = {}): IdentityReviewEvent {
+    return {
+        id: 'review-1',
+        assessmentId: 'assessment-2026-08-27',
+        schemaVersion: 1,
+        label: 'USER',
+        occupancyAttestation: 'EXCLUSIVE',
+        supersedesReviewEventId: null,
+        recordedAt: '2026-08-27T08:00:00Z',
+        source: 'user_ui',
+        ...overrides,
+    };
+}
+
+describe('identityModels (PI1, ADR-0028)', () => {
+    describe('reason codes', () => {
+        it('are stable and versioned', () => {
+            expect(IDENTITY_REASON_CODE_SCHEMA_VERSION).toBe('identity-reason-codes-v1');
+            expect(IDENTITY_REASON_CODES).toMatchInlineSnapshot(`
+              [
+                "ANCHOR_MISSING",
+                "ANCHOR_QUALITY_INSUFFICIENT",
+                "EVIDENCE_LINEAGE_DEPENDENT",
+                "INSUFFICIENT_PASSPORT_HISTORY",
+                "MULTIPLE_PAIRING_CANDIDATES",
+                "SESSION_TIMING_CONCORDANT",
+                "SESSION_TIMING_DISCORDANT",
+                "RHR_RELATION_CONCORDANT",
+                "RHR_RELATION_DISCORDANT",
+                "RESPIRATION_RELATION_CONCORDANT",
+                "RESPIRATION_RELATION_DISCORDANT",
+                "HRV_RELATION_CONCORDANT",
+                "HRV_RELATION_DISCORDANT",
+                "MIXED_OCCUPANCY_SUSPECTED",
+                "SESSION_INTERVAL_INVALID",
+              ]
+            `);
+        });
+
+        it('rejects unknown codes via the type guard', () => {
+            expect(isKnownIdentityReasonCode('ANCHOR_MISSING')).toBe(true);
+            expect(isKnownIdentityReasonCode('IMPOSTER_REJECTED')).toBe(false);
+            expect(isKnownIdentityReasonCode('NOT_A_REAL_CODE')).toBe(false);
+        });
+    });
+
+    describe('serialization', () => {
+        it('serializes all three automatic statuses deterministically', () => {
+            for (const automaticStatus of ['USER', 'NOT_USER', 'UNCERTAIN'] as const) {
+                const assessment = makeAssessment({ automaticStatus });
+                const roundTripped = JSON.parse(JSON.stringify(assessment));
+                expect(roundTripped).toEqual(assessment);
+                // Re-serializing twice must be byte-identical (stable key order, no Date objects).
+                expect(JSON.stringify(assessment)).toBe(JSON.stringify(roundTripped));
+            }
+        });
+
+        it('serializes review events and effective decisions deterministically', () => {
+            const assessment = makeAssessment();
+            const event = makeReviewEvent();
+            const decision = deriveEffectiveIdentityDecision(assessment, [event]);
+
+            expect(JSON.parse(JSON.stringify(event))).toEqual(event);
+            expect(JSON.parse(JSON.stringify(decision))).toEqual(decision);
+        });
+    });
+
+    describe('immutability (P-PI-14)', () => {
+        it('freezes the automatic assessment so it cannot be mutated', () => {
+            const assessment = freezeAutomaticIdentityAssessment(makeAssessment());
+            expect(Object.isFrozen(assessment)).toBe(true);
+            expect(Object.isFrozen(assessment.reasonCodes)).toBe(true);
+            expect(Object.isFrozen(assessment.sharedBundleRef)).toBe(true);
+            expect(Object.isFrozen(assessment.anchorBundleRefs)).toBe(true);
+            expect(Object.isFrozen(assessment.anchorBundleRefs[0])).toBe(true);
+
+            expect(() => {
+                // @ts-expect-error -- intentionally attempting a forbidden mutation
+                assessment.automaticStatus = 'USER';
+            }).toThrow();
+        });
+
+        it('a manual correction never mutates the automatic assessment fields', () => {
+            const assessment = freezeAutomaticIdentityAssessment(
+                makeAssessment({ automaticStatus: 'UNCERTAIN' }),
+            );
+            const before = JSON.parse(JSON.stringify(assessment));
+
+            deriveEffectiveIdentityDecision(assessment, [
+                makeReviewEvent({ label: 'USER', occupancyAttestation: 'EXCLUSIVE' }),
+            ]);
+
+            expect(JSON.parse(JSON.stringify(assessment))).toEqual(before);
+            expect(assessment.automaticStatus).toBe('UNCERTAIN'); // unchanged historical model output
+        });
+
+        it('identity status derivation never touches bundle refs / provenance fields', () => {
+            const assessment = makeAssessment();
+            const decision = deriveEffectiveIdentityDecision(assessment, [
+                makeReviewEvent({ label: 'NOT_USER', occupancyAttestation: 'UNKNOWN' }),
+            ]);
+
+            // The effective decision carries no raw bundle/observation payload or hash fields --
+            // identity classification cannot alter, and does not even reference, raw bytes.
+            expect(decision).not.toHaveProperty('sourcePayloadHash');
+            expect(decision).not.toHaveProperty('observations');
+            expect(assessment.sharedBundleRef.sourcePayloadHash).toBe('sha256:shared');
+            expect(assessment.anchorBundleRefs[0].sourcePayloadHash).toBe('sha256:anchor');
+        });
+    });
+
+    describe('review supersession (PI6, scenario L)', () => {
+        it('the latest valid superseding review produces the effective decision', () => {
+            const first = makeReviewEvent({
+                id: 'review-1',
+                label: 'NOT_USER',
+                occupancyAttestation: 'UNKNOWN',
+                supersedesReviewEventId: null,
+                recordedAt: '2026-08-27T08:00:00Z',
+            });
+            const correction = makeReviewEvent({
+                id: 'review-2',
+                label: 'USER',
+                occupancyAttestation: 'EXCLUSIVE',
+                supersedesReviewEventId: 'review-1',
+                recordedAt: '2026-08-28T09:00:00Z',
+            });
+
+            const decision = deriveEffectiveIdentityDecision(makeAssessment(), [first, correction]);
+
+            expect(decision.effectiveStatus).toBe('USER');
+            expect(decision.reviewEventId).toBe('review-2');
+            expect(decision.authority).toBe('MANUAL_REVIEW');
+            // Both events remain preserved by the caller (append-only) -- this module never
+            // deletes/mutates either; it only picks which one is currently effective.
+            expect(findEffectiveReviewEvent([first, correction])).toEqual(correction);
+        });
+
+        it('resolves a longer supersession chain to the final head deterministically', () => {
+            const events: IdentityReviewEvent[] = [
+                makeReviewEvent({
+                    id: 'r1',
+                    label: 'UNCERTAIN',
+                    occupancyAttestation: 'UNKNOWN',
+                    supersedesReviewEventId: null,
+                    recordedAt: '2026-08-27T08:00:00Z',
+                }),
+                makeReviewEvent({
+                    id: 'r2',
+                    label: 'NOT_USER',
+                    occupancyAttestation: 'UNKNOWN',
+                    supersedesReviewEventId: 'r1',
+                    recordedAt: '2026-08-27T09:00:00Z',
+                }),
+                makeReviewEvent({
+                    id: 'r3',
+                    label: 'USER',
+                    occupancyAttestation: 'EXCLUSIVE',
+                    supersedesReviewEventId: 'r2',
+                    recordedAt: '2026-08-27T10:00:00Z',
+                }),
+            ];
+
+            expect(findEffectiveReviewEvent(events)?.id).toBe('r3');
+            // Order-independence: shuffling the input array must not change the resolved head.
+            expect(findEffectiveReviewEvent([events[2], events[0], events[1]])?.id).toBe('r3');
+        });
+    });
+
+    describe('eligibility mapping', () => {
+        it('UNCERTAIN maps to baselineLearning=false and passportLearning=false', () => {
+            const eligibility = deriveObservationEligibility('UNCERTAIN', 'UNKNOWN', false);
+            expect(eligibility.baselineLearning).toBe(false);
+            expect(eligibility.passportLearning).toBe(false);
+        });
+
+        it('NOT_USER maps to recovery=false, baselineLearning=false, passportLearning=false', () => {
+            const eligibility = deriveObservationEligibility('NOT_USER', 'UNKNOWN', false);
+            expect(eligibility.recovery).toBe(false);
+            expect(eligibility.baselineLearning).toBe(false);
+            expect(eligibility.passportLearning).toBe(false);
+        });
+
+        it('a mixed-occupancy attestation cannot become baseline/passport eligible even with label USER', () => {
+            const eligibility = deriveObservationEligibility('USER', 'MIXED', true);
+            expect(eligibility.recovery).toBe(false);
+            expect(eligibility.baselineLearning).toBe(false);
+            expect(eligibility.passportLearning).toBe(false);
+            expect(eligibility.display).toBe(true); // still preserved, never deleted (P-PI-5)
+        });
+
+        it('USER + EXCLUSIVE attestation over suspected mixed occupancy is fully eligible (P-PI-15)', () => {
+            const eligibility = deriveObservationEligibility('USER', 'EXCLUSIVE', true);
+            expect(eligibility).toEqual({
+                display: true,
+                recovery: true,
+                baselineLearning: true,
+                passportLearning: true,
+            });
+        });
+
+        it('raw observation display eligibility never depends on identity status', () => {
+            for (const status of ['USER', 'NOT_USER', 'UNCERTAIN'] as const) {
+                expect(deriveObservationEligibility(status, 'UNKNOWN', false).display).toBe(true);
+            }
+        });
+    });
+
+    describe('acceptance scenarios (identity/eligibility subset)', () => {
+        it('D. user confirms wrong person: automatic UNCERTAIN -> manual NOT_USER -> effective NOT_USER', () => {
+            const assessment = makeAssessment({ automaticStatus: 'UNCERTAIN' });
+            const decision = deriveEffectiveIdentityDecision(assessment, [
+                makeReviewEvent({ label: 'NOT_USER', occupancyAttestation: 'UNKNOWN' }),
+            ]);
+
+            expect(decision.effectiveStatus).toBe('NOT_USER');
+            expect(decision.eligibility).toEqual({
+                display: true,
+                recovery: false,
+                baselineLearning: false,
+                passportLearning: false,
+            });
+        });
+
+        it('E. user confirms unusual-but-exclusive night: manual USER + EXCLUSIVE -> effective USER', () => {
+            const assessment = makeAssessment({ automaticStatus: 'UNCERTAIN' });
+            const decision = deriveEffectiveIdentityDecision(assessment, [
+                makeReviewEvent({ label: 'USER', occupancyAttestation: 'EXCLUSIVE' }),
+            ]);
+
+            expect(decision.effectiveStatus).toBe('USER');
+            expect(decision.eligibility.recovery).toBe(true);
+            expect(decision.eligibility.baselineLearning).toBe(true);
+        });
+
+        it('J. user confirms mixed occupancy: manual USER + MIXED stays baseline/passport ineligible', () => {
+            const assessment = makeAssessment({
+                automaticStatus: 'UNCERTAIN',
+                reasonCodes: ['MIXED_OCCUPANCY_SUSPECTED'],
+            });
+            const decision = deriveEffectiveIdentityDecision(assessment, [
+                makeReviewEvent({ label: 'USER', occupancyAttestation: 'MIXED' }),
+            ]);
+
+            expect(decision.eligibility.recovery).toBe(false);
+            expect(decision.eligibility.baselineLearning).toBe(false);
+            expect(decision.eligibility.passportLearning).toBe(false);
+        });
+
+        it('no review yet: effective decision falls back to the automatic assessment (AUTOMATIC authority)', () => {
+            const assessment = makeAssessment({ automaticStatus: 'USER', reasonCodes: [] });
+            const decision = deriveEffectiveIdentityDecision(assessment, []);
+
+            expect(decision.authority).toBe('AUTOMATIC');
+            expect(decision.reviewEventId).toBeUndefined();
+            expect(decision.effectiveStatus).toBe('USER');
+            expect(decision.eligibility.recovery).toBe(true);
+        });
+    });
+});

--- a/app/src/observations/identityModels.test.ts
+++ b/app/src/observations/identityModels.test.ts
@@ -120,6 +120,7 @@ describe('identityModels (PI1, ADR-0028)', () => {
             const assessment = freezeAutomaticIdentityAssessment(makeAssessment());
             expect(Object.isFrozen(assessment)).toBe(true);
             expect(Object.isFrozen(assessment.reasonCodes)).toBe(true);
+            expect(Object.isFrozen(assessment.sharedSource)).toBe(true);
             expect(Object.isFrozen(assessment.sharedBundleRef)).toBe(true);
             expect(Object.isFrozen(assessment.anchorBundleRefs)).toBe(true);
             expect(Object.isFrozen(assessment.anchorBundleRefs[0])).toBe(true);
@@ -127,6 +128,10 @@ describe('identityModels (PI1, ADR-0028)', () => {
             expect(() => {
                 // @ts-expect-error -- intentionally attempting a forbidden mutation
                 assessment.automaticStatus = 'USER';
+            }).toThrow();
+            expect(() => {
+                // The canonical contract is runtime-frozen as well as top-level immutable.
+                assessment.sharedSource.provider = 'forged_provider';
             }).toThrow();
         });
 

--- a/app/src/observations/identityModels.test.ts
+++ b/app/src/observations/identityModels.test.ts
@@ -220,6 +220,43 @@ describe('identityModels (PI1, ADR-0028)', () => {
             // Order-independence: shuffling the input array must not change the resolved head.
             expect(findEffectiveReviewEvent([events[2], events[0], events[1]])?.id).toBe('r3');
         });
+
+        it('an orphaned review referencing a missing predecessor cannot override the automatic status', () => {
+            const orphan = makeReviewEvent({
+                id: 'review-2',
+                label: 'NOT_USER',
+                occupancyAttestation: 'UNKNOWN',
+                supersedesReviewEventId: 'missing',
+                recordedAt: '2026-08-27T09:00:00Z',
+            });
+
+            expect(findEffectiveReviewEvent([orphan])).toBeNull();
+            const decision = deriveEffectiveIdentityDecision(
+                makeAssessment({ automaticStatus: 'USER' }),
+                [orphan],
+            );
+            expect(decision.effectiveStatus).toBe('USER');
+            expect(decision.authority).toBe('AUTOMATIC');
+            expect(decision).not.toHaveProperty('reviewEventId');
+        });
+
+        it('a cyclic supersession chain cannot override the automatic status', () => {
+            const first = makeReviewEvent({
+                id: 'review-1',
+                supersedesReviewEventId: 'review-2',
+            });
+            const second = makeReviewEvent({
+                id: 'review-2',
+                supersedesReviewEventId: 'review-1',
+                recordedAt: '2026-08-27T09:00:00Z',
+            });
+
+            expect(findEffectiveReviewEvent([first, second])).toBeNull();
+            const decision = deriveEffectiveIdentityDecision(makeAssessment(), [first, second]);
+            expect(decision.effectiveStatus).toBe('UNCERTAIN');
+            expect(decision.authority).toBe('AUTOMATIC');
+            expect(decision).not.toHaveProperty('reviewEventId');
+        });
     });
 
     describe('eligibility mapping', () => {

--- a/app/src/observations/identityModels.ts
+++ b/app/src/observations/identityModels.ts
@@ -173,7 +173,13 @@ function reviewEventShapeIsValid(event: IdentityReviewEvent): boolean {
     if (!Number.isFinite(Date.parse(event.recordedAt))) return false;
     if (event.supersedesReviewEventId === event.id) return false;
     if (event.source !== 'user_ui' && event.source !== 'admin_replay') return false;
-    return true;
+    if (event.source === 'admin_replay') return true;
+    // Match the client-write Firestore contract. Admin replay may preserve historical combinations
+    // that were never available through the user UI, while eligibility still treats identity and
+    // occupancy as separate evidence dimensions.
+    if (event.label === 'USER') return event.occupancyAttestation === 'EXCLUSIVE';
+    if (event.label === 'NOT_USER') return event.occupancyAttestation === 'UNKNOWN';
+    return event.occupancyAttestation === 'MIXED' || event.occupancyAttestation === 'UNKNOWN';
 }
 
 /**
@@ -181,8 +187,7 @@ function reviewEventShapeIsValid(event: IdentityReviewEvent): boolean {
  * `supersedesReviewEventId` links. Only a complete chain rooted at an unsuperseding event is
  * admitted; orphaned, cyclic, duplicate-ID, non-monotonic, or structurally malformed events fail
  * closed and cannot override the automatic assessment. Identity label and occupancy attestation
- * remain separate evidence dimensions: for example, `USER + MIXED` is a valid manual statement
- * but remains baseline/passport-learning ineligible via `deriveObservationEligibility`.
+ * remain separate evidence dimensions in the derived eligibility projection.
  */
 export function findEffectiveReviewEvent(
     reviewEvents: readonly IdentityReviewEvent[],

--- a/app/src/observations/identityModels.ts
+++ b/app/src/observations/identityModels.ts
@@ -124,6 +124,21 @@ export interface EffectiveIdentityDecision {
     reviewEventId?: string;
 }
 
+/** Compact ADR-0010/ADR-0028 identity evidence retained by a recommendation audit. */
+export interface IdentityDecisionProvenance {
+    identityAssessmentId: string;
+    automaticStatus: IdentityStatus;
+    effectiveStatus: IdentityStatus;
+    reviewEventId: string | null;
+    identityPolicyVersion: string;
+    featureSchemaVersion: string;
+    passportVersion: string | null;
+    sharedBundleRef: ObservationBundleRef;
+    anchorBundleRefs: readonly ObservationBundleRef[];
+    selectedEffectiveSource: { provider: string; transport: string } | null;
+    fallbackReason: IdentityReasonCode | null;
+}
+
 /**
  * Automatic assessment must remain replay-immutable. Freezes the top-level object and every
  * nested array/object reachable from it so a later review event cannot accidentally mutate

--- a/app/src/observations/identityModels.ts
+++ b/app/src/observations/identityModels.ts
@@ -158,29 +158,31 @@ export function freezeAutomaticIdentityAssessment(
 }
 
 function compareReviewEventsByRecencyDesc(a: IdentityReviewEvent, b: IdentityReviewEvent): number {
-    if (a.recordedAt !== b.recordedAt) {
-        return a.recordedAt < b.recordedAt ? 1 : -1;
+    const aTime = Date.parse(a.recordedAt);
+    const bTime = Date.parse(b.recordedAt);
+    if (aTime !== bTime) {
+        return bTime - aTime;
     }
     // Deterministic tie-break when `recordedAt` collides (defensive; server ordering should
     // normally avoid this).
     return a.id < b.id ? 1 : -1;
 }
 
-function reviewEventSemanticsAreValid(event: IdentityReviewEvent): boolean {
+function reviewEventShapeIsValid(event: IdentityReviewEvent): boolean {
     if (event.schemaVersion !== 1 || !event.id || !event.assessmentId) return false;
     if (!Number.isFinite(Date.parse(event.recordedAt))) return false;
     if (event.supersedesReviewEventId === event.id) return false;
     if (event.source !== 'user_ui' && event.source !== 'admin_replay') return false;
-    if (event.label === 'USER') return event.occupancyAttestation === 'EXCLUSIVE';
-    if (event.label === 'NOT_USER') return event.occupancyAttestation === 'UNKNOWN';
-    return event.occupancyAttestation === 'MIXED' || event.occupancyAttestation === 'UNKNOWN';
+    return true;
 }
 
 /**
  * Resolves the single currently-effective review event out of an append-only chain, following
  * `supersedesReviewEventId` links. Only a complete chain rooted at an unsuperseding event is
- * admitted; orphaned, cyclic, duplicate-ID, non-monotonic, or semantically malformed events fail
- * closed and cannot override the automatic assessment.
+ * admitted; orphaned, cyclic, duplicate-ID, non-monotonic, or structurally malformed events fail
+ * closed and cannot override the automatic assessment. Identity label and occupancy attestation
+ * remain separate evidence dimensions: for example, `USER + MIXED` is a valid manual statement
+ * but remains baseline/passport-learning ineligible via `deriveObservationEligibility`.
  */
 export function findEffectiveReviewEvent(
     reviewEvents: readonly IdentityReviewEvent[],
@@ -192,7 +194,7 @@ export function findEffectiveReviewEvent(
     const candidates = new Map<string, IdentityReviewEvent>();
     const duplicateIds = new Set<string>();
     for (const event of reviewEvents) {
-        if (!reviewEventSemanticsAreValid(event)) continue;
+        if (!reviewEventShapeIsValid(event)) continue;
         if (candidates.has(event.id)) duplicateIds.add(event.id);
         candidates.set(event.id, event);
     }

--- a/app/src/observations/identityModels.ts
+++ b/app/src/observations/identityModels.ts
@@ -166,10 +166,21 @@ function compareReviewEventsByRecencyDesc(a: IdentityReviewEvent, b: IdentityRev
     return a.id < b.id ? 1 : -1;
 }
 
+function reviewEventSemanticsAreValid(event: IdentityReviewEvent): boolean {
+    if (event.schemaVersion !== 1 || !event.id || !event.assessmentId) return false;
+    if (!Number.isFinite(Date.parse(event.recordedAt))) return false;
+    if (event.supersedesReviewEventId === event.id) return false;
+    if (event.source !== 'user_ui' && event.source !== 'admin_replay') return false;
+    if (event.label === 'USER') return event.occupancyAttestation === 'EXCLUSIVE';
+    if (event.label === 'NOT_USER') return event.occupancyAttestation === 'UNKNOWN';
+    return event.occupancyAttestation === 'MIXED' || event.occupancyAttestation === 'UNKNOWN';
+}
+
 /**
  * Resolves the single currently-effective review event out of an append-only chain, following
- * `supersedesReviewEventId` links. An event is a "head" (current) when no other event in the
- * chain supersedes it. Returns `null` when no review events exist yet.
+ * `supersedesReviewEventId` links. Only a complete chain rooted at an unsuperseding event is
+ * admitted; orphaned, cyclic, duplicate-ID, non-monotonic, or semantically malformed events fail
+ * closed and cannot override the automatic assessment.
  */
 export function findEffectiveReviewEvent(
     reviewEvents: readonly IdentityReviewEvent[],
@@ -178,16 +189,43 @@ export function findEffectiveReviewEvent(
         return null;
     }
 
-    const supersededIds = new Set<string>();
+    const candidates = new Map<string, IdentityReviewEvent>();
+    const duplicateIds = new Set<string>();
     for (const event of reviewEvents) {
-        if (event.supersedesReviewEventId) {
-            supersededIds.add(event.supersedesReviewEventId);
-        }
+        if (!reviewEventSemanticsAreValid(event)) continue;
+        if (candidates.has(event.id)) duplicateIds.add(event.id);
+        candidates.set(event.id, event);
+    }
+    for (const duplicateId of duplicateIds) {
+        candidates.delete(duplicateId);
     }
 
-    const heads = reviewEvents.filter((event) => !supersededIds.has(event.id));
-    const candidates = heads.length > 0 ? heads : reviewEvents; // defensive fallback for a malformed/cyclic chain
-    return [...candidates].sort(compareReviewEventsByRecencyDesc)[0] ?? null;
+    const accepted = new Map<string, IdentityReviewEvent>();
+    for (const [id, event] of candidates) {
+        if (event.supersedesReviewEventId === null) accepted.set(id, event);
+    }
+
+    while (true) {
+        let added = false;
+        for (const [id, event] of candidates) {
+            if (accepted.has(id) || event.supersedesReviewEventId === null) continue;
+            const parent = accepted.get(event.supersedesReviewEventId);
+            if (!parent) continue;
+            if (Date.parse(event.recordedAt) >= Date.parse(parent.recordedAt)) {
+                accepted.set(id, event);
+                added = true;
+            }
+        }
+        if (!added) break;
+    }
+
+    if (accepted.size === 0) return null;
+    const supersededIds = new Set<string>();
+    for (const event of accepted.values()) {
+        if (event.supersedesReviewEventId !== null) supersededIds.add(event.supersedesReviewEventId);
+    }
+    const heads = [...accepted.values()].filter((event) => !supersededIds.has(event.id));
+    return heads.sort(compareReviewEventsByRecencyDesc)[0] ?? null;
 }
 
 /**

--- a/app/src/observations/identityModels.ts
+++ b/app/src/observations/identityModels.ts
@@ -1,0 +1,227 @@
+/**
+ * Physiological Identity Passport & Measurement Trust contracts (PI1, ADR-0028).
+ *
+ * Provider-neutral identity-attribution and observation-eligibility contracts at the
+ * observation/engine boundary, sitting between source-aware immutable observation bundles
+ * (ADR-0027, ./models.ts) and downstream physiological baseline/fusion logic.
+ *
+ * These types and this file are the single canonical schema for identity records: the source
+ * analysis, ADR-0028, the implementation plan, and every persisted-document example must match
+ * this shape verbatim -- `sourceNightKey` (not `logicalDate`), and `IdentityReviewEvent` including
+ * `schemaVersion` and `supersedesReviewEventId: string | null`.
+ *
+ * Contract rules (ADR-0028 P-PI-1..P-PI-17):
+ * - identity is assigned at shared-source night/session level, not per metric;
+ * - metric technical quality remains independent of identity attribution;
+ * - `NOT_USER` is not synonymous with sensor error;
+ * - `UNCERTAIN` is not synonymous with missing data;
+ * - `identityScore` is an evidence/ranking score and must never be named `probability`;
+ * - baseline/fusion code must consume `EffectiveIdentityDecision`, never raw automatic status alone;
+ * - repeated user corrections are append-only; effective state is a deterministic derived projection;
+ * - `passportVersion=null` is valid when assessment abstains because no mature passport exists.
+ */
+
+export type IdentityStatus = 'USER' | 'NOT_USER' | 'UNCERTAIN';
+export type IdentityConfidenceTier = 'HIGH' | 'MODERATE' | 'LOW' | 'NONE';
+
+export type IdentityReasonCode =
+    | 'ANCHOR_MISSING'
+    | 'ANCHOR_QUALITY_INSUFFICIENT'
+    | 'EVIDENCE_LINEAGE_DEPENDENT'
+    | 'INSUFFICIENT_PASSPORT_HISTORY'
+    | 'MULTIPLE_PAIRING_CANDIDATES'
+    | 'SESSION_TIMING_CONCORDANT'
+    | 'SESSION_TIMING_DISCORDANT'
+    | 'RHR_RELATION_CONCORDANT'
+    | 'RHR_RELATION_DISCORDANT'
+    | 'RESPIRATION_RELATION_CONCORDANT'
+    | 'RESPIRATION_RELATION_DISCORDANT'
+    | 'HRV_RELATION_CONCORDANT'
+    | 'HRV_RELATION_DISCORDANT'
+    | 'MIXED_OCCUPANCY_SUSPECTED'
+    | 'SESSION_INTERVAL_INVALID';
+
+/**
+ * Stable, versioned registry of every valid `IdentityReasonCode`. Bump
+ * `IDENTITY_REASON_CODE_SCHEMA_VERSION` whenever a code is added, removed, or its meaning changes
+ * in a way that would invalidate historical replay comparisons (see PI1 tests: "reason codes are
+ * stable/versioned").
+ */
+export const IDENTITY_REASON_CODE_SCHEMA_VERSION = 'identity-reason-codes-v1';
+
+export const IDENTITY_REASON_CODES: readonly IdentityReasonCode[] = Object.freeze([
+    'ANCHOR_MISSING',
+    'ANCHOR_QUALITY_INSUFFICIENT',
+    'EVIDENCE_LINEAGE_DEPENDENT',
+    'INSUFFICIENT_PASSPORT_HISTORY',
+    'MULTIPLE_PAIRING_CANDIDATES',
+    'SESSION_TIMING_CONCORDANT',
+    'SESSION_TIMING_DISCORDANT',
+    'RHR_RELATION_CONCORDANT',
+    'RHR_RELATION_DISCORDANT',
+    'RESPIRATION_RELATION_CONCORDANT',
+    'RESPIRATION_RELATION_DISCORDANT',
+    'HRV_RELATION_CONCORDANT',
+    'HRV_RELATION_DISCORDANT',
+    'MIXED_OCCUPANCY_SUSPECTED',
+    'SESSION_INTERVAL_INVALID',
+]);
+
+export function isKnownIdentityReasonCode(code: string): code is IdentityReasonCode {
+    return (IDENTITY_REASON_CODES as readonly string[]).includes(code);
+}
+
+export interface ObservationBundleRef {
+    id: string;
+    provider: string;
+    transport: string;
+    revision: number;
+    sourcePayloadHash: string;
+    lineageKey: string;
+}
+
+export interface ObservationEligibility {
+    display: boolean;
+    recovery: boolean;
+    baselineLearning: boolean;
+    passportLearning: boolean;
+}
+
+export interface AutomaticIdentityAssessment {
+    id: string;
+    sourceNightKey: string;
+    sharedSource: { provider: string; transport: string };
+    automaticStatus: IdentityStatus;
+    identityScore: number | null; // evidence score, not calibrated probability
+    confidenceTier: IdentityConfidenceTier;
+    reasonCodes: readonly IdentityReasonCode[];
+    passportVersion: string | null; // null before a usable passport exists
+    policyVersion: string;
+    featureSchemaVersion: string;
+    assessedAt: string;
+    sharedBundleRef: ObservationBundleRef;
+    anchorBundleRefs: readonly ObservationBundleRef[];
+}
+
+export type OccupancyAttestation = 'EXCLUSIVE' | 'MIXED' | 'UNKNOWN';
+
+export interface IdentityReviewEvent {
+    id: string;
+    assessmentId: string;
+    schemaVersion: number;
+    label: IdentityStatus;
+    occupancyAttestation: OccupancyAttestation;
+    supersedesReviewEventId: string | null; // Firestore has no `undefined`; absence of a prior event is explicit `null`
+    recordedAt: string; // server-authoritative ordering
+    source: 'user_ui' | 'admin_replay';
+}
+
+export interface EffectiveIdentityDecision {
+    assessmentId: string;
+    effectiveStatus: IdentityStatus;
+    eligibility: ObservationEligibility;
+    authority: 'AUTOMATIC' | 'MANUAL_REVIEW';
+    reviewEventId?: string;
+}
+
+/**
+ * Automatic assessment must remain replay-immutable. Freezes the top-level object and every
+ * nested array/object reachable from it so a later review event cannot accidentally mutate
+ * historical model output in place (ADR-0028 P-PI-14).
+ */
+export function freezeAutomaticIdentityAssessment(
+    assessment: AutomaticIdentityAssessment,
+): Readonly<AutomaticIdentityAssessment> {
+    Object.freeze(assessment.reasonCodes);
+    Object.freeze(assessment.sharedBundleRef);
+    for (const ref of assessment.anchorBundleRefs) {
+        Object.freeze(ref);
+    }
+    Object.freeze(assessment.anchorBundleRefs);
+    return Object.freeze(assessment);
+}
+
+function compareReviewEventsByRecencyDesc(a: IdentityReviewEvent, b: IdentityReviewEvent): number {
+    if (a.recordedAt !== b.recordedAt) {
+        return a.recordedAt < b.recordedAt ? 1 : -1;
+    }
+    // Deterministic tie-break when `recordedAt` collides (defensive; server ordering should
+    // normally avoid this).
+    return a.id < b.id ? 1 : -1;
+}
+
+/**
+ * Resolves the single currently-effective review event out of an append-only chain, following
+ * `supersedesReviewEventId` links. An event is a "head" (current) when no other event in the
+ * chain supersedes it. Returns `null` when no review events exist yet.
+ */
+export function findEffectiveReviewEvent(
+    reviewEvents: readonly IdentityReviewEvent[],
+): IdentityReviewEvent | null {
+    if (reviewEvents.length === 0) {
+        return null;
+    }
+
+    const supersededIds = new Set<string>();
+    for (const event of reviewEvents) {
+        if (event.supersedesReviewEventId) {
+            supersededIds.add(event.supersedesReviewEventId);
+        }
+    }
+
+    const heads = reviewEvents.filter((event) => !supersededIds.has(event.id));
+    const candidates = heads.length > 0 ? heads : reviewEvents; // defensive fallback for a malformed/cyclic chain
+    return [...candidates].sort(compareReviewEventsByRecencyDesc)[0] ?? null;
+}
+
+/**
+ * Automatic USER/NOT_USER/UNCERTAIN eligibility mapping (ADR-0028 P-PI-3, P-PI-4, P-PI-10, P-PI-15).
+ *
+ * - Only `USER` can ever be recovery/baseline/passport-learning eligible.
+ * - Suspected mixed occupancy quarantines the full nightly aggregate; only an explicit
+ *   `EXCLUSIVE` attestation can lift that quarantine for an effective `USER` decision.
+ * - Raw observations are always `display`-eligible: identity uncertainty/negativity never deletes
+ *   or hides preserved history (P-PI-5).
+ */
+export function deriveObservationEligibility(
+    effectiveStatus: IdentityStatus,
+    occupancyAttestation: OccupancyAttestation,
+    mixedOccupancySuspected: boolean,
+): ObservationEligibility {
+    if (effectiveStatus !== 'USER') {
+        return { display: true, recovery: false, baselineLearning: false, passportLearning: false };
+    }
+
+    if (mixedOccupancySuspected && occupancyAttestation !== 'EXCLUSIVE') {
+        return { display: true, recovery: false, baselineLearning: false, passportLearning: false };
+    }
+
+    return { display: true, recovery: true, baselineLearning: true, passportLearning: true };
+}
+
+/**
+ * Derives the current effective identity decision from an immutable automatic assessment plus its
+ * append-only review-event history. Never mutates `assessment` or any `reviewEvents` entry.
+ */
+export function deriveEffectiveIdentityDecision(
+    assessment: AutomaticIdentityAssessment,
+    reviewEvents: readonly IdentityReviewEvent[],
+): EffectiveIdentityDecision {
+    const scopedEvents = reviewEvents.filter((event) => event.assessmentId === assessment.id);
+    const currentEvent = findEffectiveReviewEvent(scopedEvents);
+
+    const effectiveStatus: IdentityStatus = currentEvent ? currentEvent.label : assessment.automaticStatus;
+    const occupancyAttestation: OccupancyAttestation = currentEvent
+        ? currentEvent.occupancyAttestation
+        : 'UNKNOWN';
+    const mixedOccupancySuspected =
+        assessment.reasonCodes.includes('MIXED_OCCUPANCY_SUSPECTED') || occupancyAttestation === 'MIXED';
+
+    return {
+        assessmentId: assessment.id,
+        effectiveStatus,
+        eligibility: deriveObservationEligibility(effectiveStatus, occupancyAttestation, mixedOccupancySuspected),
+        authority: currentEvent ? 'MANUAL_REVIEW' : 'AUTOMATIC',
+        ...(currentEvent ? { reviewEventId: currentEvent.id } : {}),
+    };
+}

--- a/app/src/observations/identityModels.ts
+++ b/app/src/observations/identityModels.ts
@@ -133,6 +133,7 @@ export function freezeAutomaticIdentityAssessment(
     assessment: AutomaticIdentityAssessment,
 ): Readonly<AutomaticIdentityAssessment> {
     Object.freeze(assessment.reasonCodes);
+    Object.freeze(assessment.sharedSource);
     Object.freeze(assessment.sharedBundleRef);
     for (const ref of assessment.anchorBundleRefs) {
         Object.freeze(ref);

--- a/app/src/observations/identityReviewChain.regression.test.ts
+++ b/app/src/observations/identityReviewChain.regression.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import {
+    deriveEffectiveIdentityDecision,
+    findEffectiveReviewEvent,
+    type AutomaticIdentityAssessment,
+    type IdentityReviewEvent,
+} from './identityModels';
+
+function assessment(automaticStatus: AutomaticIdentityAssessment['automaticStatus'] = 'UNCERTAIN'):
+AutomaticIdentityAssessment {
+    return {
+        id: 'assessment-1',
+        sourceNightKey: '2026-08-27',
+        sharedSource: { provider: 'shared_bed', transport: 'health_aggregator' },
+        automaticStatus,
+        identityScore: 0.5,
+        confidenceTier: 'LOW',
+        reasonCodes: [],
+        passportVersion: '2026-08-27.1',
+        policyVersion: 'identity-v1-shadow',
+        featureSchemaVersion: 'identity-features-v1',
+        assessedAt: '2026-08-27T06:00:00.000Z',
+        sharedBundleRef: {
+            id: 'shared-1',
+            provider: 'shared_bed',
+            transport: 'health_aggregator',
+            revision: 1,
+            sourcePayloadHash: 'sha256:shared',
+            lineageKey: 'shared:lineage',
+        },
+        anchorBundleRefs: [],
+    };
+}
+
+function review(overrides: Partial<IdentityReviewEvent> = {}): IdentityReviewEvent {
+    return {
+        id: 'review-1',
+        assessmentId: 'assessment-1',
+        schemaVersion: 1,
+        label: 'USER',
+        occupancyAttestation: 'EXCLUSIVE',
+        supersedesReviewEventId: null,
+        recordedAt: '2026-08-27T08:00:00.000Z',
+        source: 'user_ui',
+        ...overrides,
+    };
+}
+
+describe('identity review chain fail-closed resolution', () => {
+    it('ignores an orphan rather than treating it as the effective head', () => {
+        const orphan = review({ supersedesReviewEventId: 'missing-review' });
+        expect(findEffectiveReviewEvent([orphan])).toBeNull();
+        expect(deriveEffectiveIdentityDecision(assessment(), [orphan])).toMatchObject({
+            effectiveStatus: 'UNCERTAIN',
+            authority: 'AUTOMATIC',
+        });
+    });
+
+    it('ignores a cyclic chain rather than falling back to a cyclic event', () => {
+        const first = review({ id: 'review-1', supersedesReviewEventId: 'review-2' });
+        const second = review({
+            id: 'review-2',
+            supersedesReviewEventId: 'review-1',
+            recordedAt: '2026-08-27T09:00:00.000Z',
+        });
+        expect(findEffectiveReviewEvent([first, second])).toBeNull();
+        expect(deriveEffectiveIdentityDecision(assessment(), [first, second]).effectiveStatus)
+            .toBe('UNCERTAIN');
+    });
+
+    it('ignores non-monotonic and semantically invalid corrections', () => {
+        const root = review({
+            id: 'review-1',
+            label: 'NOT_USER',
+            occupancyAttestation: 'UNKNOWN',
+        });
+        const olderCorrection = review({
+            id: 'review-2',
+            supersedesReviewEventId: 'review-1',
+            recordedAt: '2026-08-27T07:00:00.000Z',
+        });
+        const invalidUser = review({
+            id: 'review-3',
+            label: 'USER',
+            occupancyAttestation: 'UNKNOWN',
+            supersedesReviewEventId: 'review-1',
+            recordedAt: '2026-08-27T09:00:00.000Z',
+        });
+        expect(findEffectiveReviewEvent([root, olderCorrection, invalidUser])?.id).toBe('review-1');
+    });
+
+    it('drops duplicate review IDs so ambiguous evidence cannot authorize USER', () => {
+        const duplicateA = review({ id: 'duplicate', label: 'USER' });
+        const duplicateB = review({
+            id: 'duplicate',
+            label: 'NOT_USER',
+            occupancyAttestation: 'UNKNOWN',
+        });
+        expect(findEffectiveReviewEvent([duplicateA, duplicateB])).toBeNull();
+        expect(deriveEffectiveIdentityDecision(assessment(), [duplicateA, duplicateB]).effectiveStatus)
+            .toBe('UNCERTAIN');
+    });
+});

--- a/app/src/observations/identityReviewChain.regression.test.ts
+++ b/app/src/observations/identityReviewChain.regression.test.ts
@@ -69,7 +69,7 @@ describe('identity review chain fail-closed resolution', () => {
             .toBe('UNCERTAIN');
     });
 
-    it('ignores non-monotonic and semantically invalid corrections', () => {
+    it('ignores non-monotonic and structurally invalid corrections', () => {
         const root = review({
             id: 'review-1',
             label: 'NOT_USER',
@@ -80,14 +80,21 @@ describe('identity review chain fail-closed resolution', () => {
             supersedesReviewEventId: 'review-1',
             recordedAt: '2026-08-27T07:00:00.000Z',
         });
-        const invalidUser = review({
+        const invalidCorrection = review({
             id: 'review-3',
-            label: 'USER',
-            occupancyAttestation: 'UNKNOWN',
+            schemaVersion: 2,
             supersedesReviewEventId: 'review-1',
             recordedAt: '2026-08-27T09:00:00.000Z',
         });
-        expect(findEffectiveReviewEvent([root, olderCorrection, invalidUser])?.id).toBe('review-1');
+        expect(findEffectiveReviewEvent([root, olderCorrection, invalidCorrection])?.id).toBe('review-1');
+    });
+
+    it('keeps USER identity separate from MIXED occupancy eligibility', () => {
+        const mixed = review({ occupancyAttestation: 'MIXED' });
+        const decision = deriveEffectiveIdentityDecision(assessment(), [mixed]);
+        expect(decision.effectiveStatus).toBe('USER');
+        expect(decision.eligibility.baselineLearning).toBe(false);
+        expect(decision.eligibility.passportLearning).toBe(false);
     });
 
     it('drops duplicate review IDs so ambiguous evidence cannot authorize USER', () => {

--- a/app/src/observations/identityReviewChain.regression.test.ts
+++ b/app/src/observations/identityReviewChain.regression.test.ts
@@ -6,8 +6,9 @@ import {
     type IdentityReviewEvent,
 } from './identityModels';
 
-function assessment(automaticStatus: AutomaticIdentityAssessment['automaticStatus'] = 'UNCERTAIN'):
-AutomaticIdentityAssessment {
+function assessment(
+    automaticStatus: AutomaticIdentityAssessment['automaticStatus'] = 'UNCERTAIN',
+): AutomaticIdentityAssessment {
     return {
         id: 'assessment-1',
         sourceNightKey: '2026-08-27',

--- a/app/src/observations/identityReviewChain.regression.test.ts
+++ b/app/src/observations/identityReviewChain.regression.test.ts
@@ -89,12 +89,17 @@ describe('identity review chain fail-closed resolution', () => {
         expect(findEffectiveReviewEvent([root, olderCorrection, invalidCorrection])?.id).toBe('review-1');
     });
 
-    it('keeps USER identity separate from MIXED occupancy eligibility', () => {
-        const mixed = review({ occupancyAttestation: 'MIXED' });
+    it('keeps admin USER identity separate from MIXED occupancy eligibility', () => {
+        const mixed = review({ source: 'admin_replay', occupancyAttestation: 'MIXED' });
         const decision = deriveEffectiveIdentityDecision(assessment(), [mixed]);
         expect(decision.effectiveStatus).toBe('USER');
         expect(decision.eligibility.baselineLearning).toBe(false);
         expect(decision.eligibility.passportLearning).toBe(false);
+    });
+
+    it('rejects a user-ui USER review without the exclusive attestation required by rules', () => {
+        const invalidUserReview = review({ occupancyAttestation: 'MIXED' });
+        expect(findEffectiveReviewEvent([invalidUserReview])).toBeNull();
     });
 
     it('drops duplicate review IDs so ambiguous evidence cannot authorize USER', () => {

--- a/app/src/services/identityPersistence.test.ts
+++ b/app/src/services/identityPersistence.test.ts
@@ -1,0 +1,226 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AutomaticIdentityAssessment, IdentityReviewEvent } from '../observations/identityModels';
+
+const firestore = vi.hoisted(() => ({
+    collection: vi.fn(),
+    doc: vi.fn(),
+    getDoc: vi.fn(),
+    getDocs: vi.fn(),
+    query: vi.fn((value: unknown) => value),
+    runTransaction: vi.fn(),
+    serverTimestamp: vi.fn(() => ({ sentinel: 'server-timestamp' })),
+    where: vi.fn(),
+}));
+vi.mock('firebase/firestore', () => firestore);
+vi.mock('../firebase', () => ({ getDb: vi.fn(() => ({ id: 'db' })) }));
+
+import {
+    IdentityPersistenceService,
+    parseAutomaticIdentityAssessment,
+    parseIdentityPassportCurrent,
+    parseIdentityPassportVersion,
+    parseIdentityReviewEvent,
+} from './identityPersistence';
+
+function passportCore() {
+    return {
+        schemaVersion: 1,
+        passportVersion: '2026-08-27.1',
+        policyVersion: 'identity-v1-shadow',
+        featureSchemaVersion: 'identity-features-v1',
+        anchorPolicy: {
+            primaryProvider: 'garmin',
+            primaryTransport: 'garmin_direct',
+            role: 'PERSONAL_DEVICE_ANCHOR',
+            requireIndependentLineage: true,
+        },
+        sourceProfiles: {},
+        crossSourceProfiles: {},
+        calibration: {
+            manualUserCount: 0,
+            manualNotUserCount: 0,
+            mixedOccupancyCount: 0,
+            uncertainCount: 0,
+            shadowWindowStart: null,
+            shadowWindowEnd: null,
+        },
+        createdAt: '2026-08-27T06:00:00.000Z',
+    };
+}
+
+function assessment(overrides: Partial<AutomaticIdentityAssessment> = {}): AutomaticIdentityAssessment {
+    return {
+        id: 'assessment-1',
+        sourceNightKey: '2026-08-27',
+        sharedSource: { provider: 'eight_sleep', transport: 'google_health' },
+        automaticStatus: 'UNCERTAIN',
+        identityScore: 0.73,
+        confidenceTier: 'MODERATE',
+        reasonCodes: ['SESSION_TIMING_DISCORDANT'],
+        passportVersion: '2026-08-27.1',
+        policyVersion: 'identity-v1-shadow',
+        featureSchemaVersion: 'identity-features-v1',
+        assessedAt: '2026-08-27T06:00:00.000Z',
+        sharedBundleRef: {
+            id: '2026-08-27_eight_sleep_google_health',
+            provider: 'eight_sleep',
+            transport: 'google_health',
+            revision: 2,
+            sourcePayloadHash: 'sha256:shared',
+            lineageKey: 'eight_sleep:pod-side:a',
+        },
+        anchorBundleRefs: [],
+        ...overrides,
+    };
+}
+
+function review(overrides: Partial<IdentityReviewEvent> = {}): IdentityReviewEvent {
+    return {
+        id: 'review-1',
+        assessmentId: 'assessment-1',
+        schemaVersion: 1,
+        label: 'USER',
+        occupancyAttestation: 'EXCLUSIVE',
+        supersedesReviewEventId: null,
+        recordedAt: '2026-08-27T08:00:00.000Z',
+        source: 'user_ui',
+        ...overrides,
+    };
+}
+
+function snapshot(value: unknown | null) {
+    return {
+        exists: () => value !== null,
+        data: () => value,
+    };
+}
+
+describe('identity persistence validation (PI6)', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        firestore.doc.mockImplementation((_db: unknown, ...parts: string[]) => ({ path: parts.join('/') }));
+        firestore.collection.mockImplementation((_db: unknown, ...parts: string[]) => ({ path: parts.join('/') }));
+    });
+
+    it('round-trips current and immutable passport shapes and enforces version/path identity', () => {
+        const current = { ...passportCore(), updatedAt: '2026-08-27T07:00:00.000Z' };
+        expect(parseIdentityPassportCurrent(current)).toBe(current);
+
+        const version = {
+            ...passportCore(),
+            trainingSetHash: 'a'.repeat(64),
+            trainingObservationCount: 42,
+            trainingWindowStart: '2026-07-01',
+            trainingWindowEnd: '2026-08-26',
+            previousVersion: null,
+            changeReason: 'INITIAL_BOOTSTRAP',
+            algorithmVersion: 'passport-bootstrap-v1',
+        };
+        expect(parseIdentityPassportVersion(version, '2026-08-27.1')).toBe(version);
+        expect(() => parseIdentityPassportVersion(version, 'different-version')).toThrow('version/path mismatch');
+    });
+
+    it('freezes automatic assessment evidence and rejects path or replay-metadata mismatches', () => {
+        const parsed = parseAutomaticIdentityAssessment(assessment(), 'assessment-1');
+        expect(Object.isFrozen(parsed)).toBe(true);
+        expect(Object.isFrozen(parsed.sharedBundleRef)).toBe(true);
+        expect(() => parseAutomaticIdentityAssessment(assessment(), 'assessment-2')).toThrow('id/path mismatch');
+        expect(() => parseAutomaticIdentityAssessment(assessment({
+            sharedBundleRef: { ...assessment().sharedBundleRef, revision: 0 },
+        }))).toThrow('revision is invalid');
+    });
+
+    it('derives effective state from persisted append-only corrections without mutating assessment output', async () => {
+        const automatic = assessment();
+        const first = review();
+        const correction = review({
+            id: 'review-2',
+            label: 'NOT_USER',
+            occupancyAttestation: 'UNKNOWN',
+            supersedesReviewEventId: 'review-1',
+            recordedAt: '2026-08-27T09:00:00.000Z',
+        });
+        firestore.getDoc.mockResolvedValue(snapshot(automatic));
+        firestore.getDocs.mockResolvedValue({
+            docs: [
+                { id: first.id, data: () => first },
+                { id: correction.id, data: () => correction },
+            ],
+        });
+
+        const projection = await new IdentityPersistenceService().getEffectiveProjection('u1', automatic.id);
+        expect(projection?.decision).toEqual(expect.objectContaining({
+            effectiveStatus: 'NOT_USER',
+            authority: 'MANUAL_REVIEW',
+            reviewEventId: 'review-2',
+        }));
+        expect(projection?.decision.eligibility.baselineLearning).toBe(false);
+        expect(automatic.automaticStatus).toBe('UNCERTAIN');
+    });
+
+    it('creates a constrained user review only when its assessment exists', async () => {
+        const transaction = {
+            get: vi.fn(async (ref: { path: string }) => {
+                if (ref.path.includes('health_identity_assessments')) return snapshot(assessment());
+                return snapshot(null);
+            }),
+            set: vi.fn(),
+        };
+        firestore.runTransaction.mockImplementation(async (
+            _db: unknown,
+            callback: (tx: typeof transaction) => unknown,
+        ) => callback(transaction));
+        firestore.getDoc.mockResolvedValue(snapshot(review()));
+
+        const created = await new IdentityPersistenceService().submitUserReview({
+            userId: 'u1',
+            id: 'review-1',
+            assessmentId: 'assessment-1',
+            label: 'USER',
+            occupancyAttestation: 'EXCLUSIVE',
+            supersedesReviewEventId: null,
+        });
+        expect(created).toEqual(review());
+        expect(transaction.set).toHaveBeenCalledOnce();
+    });
+
+    it('accepts an exact idempotent retry but rejects changed content under the same event id', async () => {
+        const existing = review();
+        const transaction = {
+            get: vi.fn(async (ref: { path: string }) => {
+                if (ref.path.includes('health_identity_assessments')) return snapshot(assessment());
+                return snapshot(existing);
+            }),
+            set: vi.fn(),
+        };
+        firestore.runTransaction.mockImplementation(async (
+            _db: unknown,
+            callback: (tx: typeof transaction) => unknown,
+        ) => callback(transaction));
+        const service = new IdentityPersistenceService();
+        const params = {
+            userId: 'u1', id: existing.id, assessmentId: existing.assessmentId,
+            label: existing.label, occupancyAttestation: existing.occupancyAttestation,
+            supersedesReviewEventId: existing.supersedesReviewEventId,
+        } as const;
+        await expect(service.submitUserReview(params)).resolves.toEqual(existing);
+        await expect(service.submitUserReview({ ...params, label: 'UNCERTAIN', occupancyAttestation: 'UNKNOWN' }))
+            .rejects.toThrow('different content');
+        expect(transaction.set).not.toHaveBeenCalled();
+    });
+
+    it('enforces semantic attestation and parseable server-ordering timestamps', async () => {
+        const service = new IdentityPersistenceService();
+        await expect(service.submitUserReview({
+            userId: 'u1', id: 'bad-1', assessmentId: 'assessment-1', label: 'USER',
+            occupancyAttestation: 'MIXED', supersedesReviewEventId: null,
+        })).rejects.toThrow('requires exclusive');
+        expect(() => parseIdentityReviewEvent(review({ recordedAt: 'not-a-date' })))
+            .toThrow();
+        expect(parseIdentityReviewEvent({
+            ...review(),
+            recordedAt: { toDate: () => new Date('2026-08-27T08:00:00.000Z') },
+        }).recordedAt).toBe('2026-08-27T08:00:00.000Z');
+        expect(firestore.runTransaction).not.toHaveBeenCalled();
+    });
+});

--- a/app/src/services/identityPersistence.ts
+++ b/app/src/services/identityPersistence.ts
@@ -1,0 +1,421 @@
+import {
+    collection,
+    doc,
+    getDoc,
+    getDocs,
+    query,
+    runTransaction,
+    serverTimestamp,
+    where,
+    type Firestore,
+} from 'firebase/firestore';
+import { getDb } from '../firebase';
+import {
+    IDENTITY_REASON_CODES,
+    deriveEffectiveIdentityDecision,
+    freezeAutomaticIdentityAssessment,
+    type AutomaticIdentityAssessment,
+    type IdentityReviewEvent,
+    type ObservationBundleRef,
+} from '../observations/identityModels';
+import type {
+    PhysiologicalIdentityPassportCurrent,
+    PhysiologicalIdentityPassportVersion,
+    RobustLocationEstimate,
+    RobustRatioEstimate,
+    RobustScalarEstimate,
+} from '../engine/identityPassport';
+import type { EffectiveBundleIdentityProjection } from '../engine/identityEligibility';
+
+const IDENTITY_STATUSES = ['USER', 'NOT_USER', 'UNCERTAIN'] as const;
+const CONFIDENCE_TIERS = ['HIGH', 'MODERATE', 'LOW', 'NONE'] as const;
+const OCCUPANCY_ATTESTATIONS = ['EXCLUSIVE', 'MIXED', 'UNKNOWN'] as const;
+const PASSPORT_CHANGE_REASONS = [
+    'GARMIN_DEVICE_OR_ALGORITHM_CHANGE',
+    'EIGHT_SLEEP_ALGORITHM_OR_API_CHANGE',
+    'GOOGLE_HEALTH_MAPPING_CHANGE',
+    'MEASUREMENT_SYSTEM_SHIFT_CONFIRMED_BY_REPLAY',
+    'INITIAL_BOOTSTRAP',
+    'OTHER',
+] as const;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+    return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+    return typeof value === 'string' && value.length > 0;
+}
+
+function isFiniteOrNull(value: unknown): value is number | null {
+    return value === null || (typeof value === 'number' && Number.isFinite(value));
+}
+
+function normalizeIsoTimestamp(value: unknown): string | null {
+    if (typeof value === 'string' && value.length > 0) {
+        const timestamp = Date.parse(value);
+        return Number.isFinite(timestamp) && new Date(timestamp).toISOString() === value ? value : null;
+    }
+    if (value && typeof value === 'object' && 'toDate' in value) {
+        const toDate = (value as { toDate?: unknown }).toDate;
+        if (typeof toDate === 'function') {
+            const date = toDate.call(value) as unknown;
+            return date instanceof Date && Number.isFinite(date.valueOf()) ? date.toISOString() : null;
+        }
+    }
+    return null;
+}
+
+function assertBundleRef(value: unknown): asserts value is ObservationBundleRef {
+    if (!isPlainObject(value)) throw new Error('Identity bundle ref must be an object');
+    if (!isNonEmptyString(value.id)) throw new Error('Identity bundle ref id is invalid');
+    if (!isNonEmptyString(value.provider) || !isNonEmptyString(value.transport)) {
+        throw new Error('Identity bundle ref source is invalid');
+    }
+    if (!Number.isInteger(value.revision) || (value.revision as number) < 1) {
+        throw new Error('Identity bundle ref revision is invalid');
+    }
+    if (!isNonEmptyString(value.sourcePayloadHash) || !isNonEmptyString(value.lineageKey)) {
+        throw new Error('Identity bundle ref replay evidence is incomplete');
+    }
+}
+
+function assertScalarEstimate(value: unknown): asserts value is RobustScalarEstimate {
+    if (!isPlainObject(value)) throw new Error('Passport scalar estimate must be an object');
+    if (!isFiniteOrNull(value.median) || !isFiniteOrNull(value.mad) || !isFiniteOrNull(value.iqr)) {
+        throw new Error('Passport scalar estimate contains a non-finite value');
+    }
+    if (!Number.isInteger(value.n) || (value.n as number) < 0) {
+        throw new Error('Passport scalar estimate count is invalid');
+    }
+}
+
+function assertLocationEstimate(value: unknown): asserts value is RobustLocationEstimate {
+    if (!isPlainObject(value)) throw new Error('Passport location estimate must be an object');
+    if (!isFiniteOrNull(value.median) || !isFiniteOrNull(value.mad)) {
+        throw new Error('Passport location estimate contains a non-finite value');
+    }
+    if (!Number.isInteger(value.n) || (value.n as number) < 0) {
+        throw new Error('Passport location estimate count is invalid');
+    }
+}
+
+function assertRatioEstimate(value: unknown): asserts value is RobustRatioEstimate {
+    if (!isPlainObject(value)) throw new Error('Passport ratio estimate must be an object');
+    if (!isFiniteOrNull(value.median) || !isFiniteOrNull(value.iqr)) {
+        throw new Error('Passport ratio estimate contains a non-finite value');
+    }
+    if (!Number.isInteger(value.n) || (value.n as number) < 0) {
+        throw new Error('Passport ratio estimate count is invalid');
+    }
+}
+
+function assertPassportCore(value: unknown): asserts value is PhysiologicalIdentityPassportCurrent {
+    if (!isPlainObject(value)) throw new Error('Identity passport must be an object');
+    if (value.schemaVersion !== 1) throw new Error('Unsupported identity passport schemaVersion');
+    for (const field of ['passportVersion', 'createdAt', 'policyVersion', 'featureSchemaVersion']) {
+        if (!isNonEmptyString(value[field])) throw new Error(`Identity passport ${field} is invalid`);
+    }
+    if (!isPlainObject(value.anchorPolicy)) throw new Error('Identity passport anchor policy is invalid');
+    if (
+        !isNonEmptyString(value.anchorPolicy.primaryProvider) ||
+        !isNonEmptyString(value.anchorPolicy.primaryTransport) ||
+        !isNonEmptyString(value.anchorPolicy.role) ||
+        typeof value.anchorPolicy.requireIndependentLineage !== 'boolean'
+    ) {
+        throw new Error('Identity passport anchor policy is incomplete');
+    }
+    if (!isPlainObject(value.sourceProfiles) || !isPlainObject(value.crossSourceProfiles)) {
+        throw new Error('Identity passport profiles are invalid');
+    }
+    for (const profile of Object.values(value.sourceProfiles)) {
+        if (!isPlainObject(profile) || !Number.isInteger(profile.trustedNightCount)) {
+            throw new Error('Identity passport source profile is invalid');
+        }
+        assertScalarEstimate(profile.restingHeartRate);
+        assertScalarEstimate(profile.respirationRate);
+        assertScalarEstimate(profile.logHrv);
+        assertLocationEstimate(profile.sleepStartMinutesLocal);
+        assertLocationEstimate(profile.sleepDurationMinutes);
+    }
+    for (const profile of Object.values(value.crossSourceProfiles)) {
+        if (!isPlainObject(profile)) throw new Error('Identity passport cross-source profile is invalid');
+        assertScalarEstimate(profile.rhrResidual);
+        assertScalarEstimate(profile.respirationResidual);
+        assertScalarEstimate(profile.hrvLogResidual);
+        assertLocationEstimate(profile.startDeltaMinutes);
+        assertLocationEstimate(profile.endDeltaMinutes);
+        assertLocationEstimate(profile.durationDeltaMinutes);
+        assertRatioEstimate(profile.sessionJaccard);
+    }
+    if (!isPlainObject(value.calibration)) throw new Error('Identity passport calibration is invalid');
+    for (const field of ['manualUserCount', 'manualNotUserCount', 'mixedOccupancyCount', 'uncertainCount']) {
+        const count = value.calibration[field];
+        if (!Number.isInteger(count) || (count as number) < 0) {
+            throw new Error(`Identity passport calibration ${field} is invalid`);
+        }
+    }
+}
+
+export function parseIdentityPassportCurrent(value: unknown): PhysiologicalIdentityPassportCurrent {
+    assertPassportCore(value);
+    if (!isNonEmptyString(value.updatedAt)) throw new Error('Identity passport updatedAt is invalid');
+    return value;
+}
+
+export function parseIdentityPassportVersion(
+    value: unknown,
+    expectedVersion?: string,
+): PhysiologicalIdentityPassportVersion {
+    assertPassportCore(value);
+    const version = value as unknown as PhysiologicalIdentityPassportVersion;
+    if (expectedVersion && version.passportVersion !== expectedVersion) {
+        throw new Error('Identity passport version/path mismatch');
+    }
+    if (!/^[0-9a-f]{64}$/.test(version.trainingSetHash)) {
+        throw new Error('Identity passport training-set hash is invalid');
+    }
+    if (!Number.isInteger(version.trainingObservationCount) || version.trainingObservationCount < 0) {
+        throw new Error('Identity passport training observation count is invalid');
+    }
+    if (!isNonEmptyString(version.trainingWindowStart) || !isNonEmptyString(version.trainingWindowEnd)) {
+        throw new Error('Identity passport training window is invalid');
+    }
+    if (version.previousVersion !== null && !isNonEmptyString(version.previousVersion)) {
+        throw new Error('Identity passport previous version is invalid');
+    }
+    if (!(PASSPORT_CHANGE_REASONS as readonly string[]).includes(version.changeReason)) {
+        throw new Error('Identity passport change reason is invalid');
+    }
+    if (!isNonEmptyString(version.algorithmVersion)) {
+        throw new Error('Identity passport algorithm version is invalid');
+    }
+    return version;
+}
+
+export function parseAutomaticIdentityAssessment(
+    value: unknown,
+    expectedId?: string,
+): Readonly<AutomaticIdentityAssessment> {
+    if (!isPlainObject(value)) throw new Error('Automatic identity assessment must be an object');
+    const assessment = value as unknown as AutomaticIdentityAssessment;
+    if (!isNonEmptyString(assessment.id) || (expectedId && assessment.id !== expectedId)) {
+        throw new Error('Automatic identity assessment id/path mismatch');
+    }
+    if (!isNonEmptyString(assessment.sourceNightKey)) throw new Error('Identity sourceNightKey is invalid');
+    if (!isPlainObject(assessment.sharedSource) || !isNonEmptyString(assessment.sharedSource.provider) || !isNonEmptyString(assessment.sharedSource.transport)) {
+        throw new Error('Identity shared source is invalid');
+    }
+    if (!(IDENTITY_STATUSES as readonly string[]).includes(assessment.automaticStatus)) {
+        throw new Error('Automatic identity status is invalid');
+    }
+    if (!isFiniteOrNull(assessment.identityScore)) throw new Error('Identity score must be finite or null');
+    if (!(CONFIDENCE_TIERS as readonly string[]).includes(assessment.confidenceTier)) {
+        throw new Error('Identity confidence tier is invalid');
+    }
+    if (!Array.isArray(assessment.reasonCodes) || !assessment.reasonCodes.every((code) =>
+        (IDENTITY_REASON_CODES as readonly string[]).includes(code))) {
+        throw new Error('Identity reason codes are invalid');
+    }
+    if (assessment.passportVersion !== null && !isNonEmptyString(assessment.passportVersion)) {
+        throw new Error('Identity passport version is invalid');
+    }
+    if (!isNonEmptyString(assessment.policyVersion) || !isNonEmptyString(assessment.featureSchemaVersion) || !isNonEmptyString(assessment.assessedAt)) {
+        throw new Error('Identity assessment version/timestamp metadata is invalid');
+    }
+    assertBundleRef(assessment.sharedBundleRef);
+    if (!Array.isArray(assessment.anchorBundleRefs)) throw new Error('Identity anchor refs are invalid');
+    assessment.anchorBundleRefs.forEach(assertBundleRef);
+    return freezeAutomaticIdentityAssessment(assessment);
+}
+
+export function parseIdentityReviewEvent(
+    value: unknown,
+    expectedId?: string,
+): IdentityReviewEvent {
+    if (!isPlainObject(value)) throw new Error('Identity review event must be an object');
+    const stored = value as unknown as IdentityReviewEvent & { recordedAt: unknown };
+    const recordedAt = normalizeIsoTimestamp(stored.recordedAt);
+    const event: IdentityReviewEvent = { ...stored, recordedAt: recordedAt ?? '' };
+    if (!isNonEmptyString(event.id) || (expectedId && event.id !== expectedId)) {
+        throw new Error('Identity review event id/path mismatch');
+    }
+    if (!isNonEmptyString(event.assessmentId) || event.schemaVersion !== 1) {
+        throw new Error('Identity review event schema/assessment is invalid');
+    }
+    if (!(IDENTITY_STATUSES as readonly string[]).includes(event.label)) {
+        throw new Error('Identity review label is invalid');
+    }
+    if (!(OCCUPANCY_ATTESTATIONS as readonly string[]).includes(event.occupancyAttestation)) {
+        throw new Error('Identity review occupancy attestation is invalid');
+    }
+    if (event.supersedesReviewEventId !== null && !isNonEmptyString(event.supersedesReviewEventId)) {
+        throw new Error('Identity review supersession is invalid');
+    }
+    if (!recordedAt || !['user_ui', 'admin_replay'].includes(event.source)) {
+        throw new Error('Identity review source/timestamp is invalid');
+    }
+    return event;
+}
+
+function assertUserReviewSemantics(event: IdentityReviewEvent): void {
+    if (event.source !== 'user_ui') throw new Error('User review submissions must use user_ui source');
+    if (event.label === 'USER' && event.occupancyAttestation !== 'EXCLUSIVE') {
+        throw new Error('USER review requires exclusive/full-interval attribution');
+    }
+    if (event.label === 'NOT_USER' && event.occupancyAttestation !== 'UNKNOWN') {
+        throw new Error('NOT_USER review must use UNKNOWN occupancy');
+    }
+    if (event.label === 'UNCERTAIN' && event.occupancyAttestation === 'EXCLUSIVE') {
+        throw new Error('UNCERTAIN review cannot claim exclusive attribution');
+    }
+}
+
+function stableSerialize(value: unknown): string {
+    if (value === null || typeof value !== 'object') return JSON.stringify(value) ?? 'null';
+    if (Array.isArray(value)) return `[${value.map(stableSerialize).join(',')}]`;
+    const record = value as Record<string, unknown>;
+    return `{${Object.keys(record).sort().map((key) =>
+        `${JSON.stringify(key)}:${stableSerialize(record[key])}`).join(',')}}`;
+}
+
+export class IdentityPersistenceService {
+    private readonly db: Firestore;
+
+    constructor(db: Firestore = getDb()) {
+        this.db = db;
+    }
+
+    async getCurrentPassport(userId: string): Promise<PhysiologicalIdentityPassportCurrent | null> {
+        const snapshot = await getDoc(doc(this.db, 'users', userId, 'physiological_identity_passports', 'current'));
+        return snapshot.exists() ? parseIdentityPassportCurrent(snapshot.data()) : null;
+    }
+
+    async getPassportVersion(userId: string, version: string): Promise<PhysiologicalIdentityPassportVersion | null> {
+        const snapshot = await getDoc(doc(this.db, 'users', userId, 'physiological_identity_passport_versions', version));
+        return snapshot.exists() ? parseIdentityPassportVersion(snapshot.data(), version) : null;
+    }
+
+    async getAssessment(userId: string, assessmentId: string): Promise<Readonly<AutomaticIdentityAssessment> | null> {
+        const snapshot = await getDoc(doc(this.db, 'users', userId, 'health_identity_assessments', assessmentId));
+        return snapshot.exists() ? parseAutomaticIdentityAssessment(snapshot.data(), assessmentId) : null;
+    }
+
+    async getReviewEvents(userId: string, assessmentId: string): Promise<IdentityReviewEvent[]> {
+        const ref = collection(this.db, 'users', userId, 'health_identity_review_events');
+        const snapshot = await getDocs(query(ref, where('assessmentId', '==', assessmentId)));
+        return snapshot.docs
+            .map((item) => parseIdentityReviewEvent(item.data(), item.id))
+            .sort((a, b) => a.recordedAt.localeCompare(b.recordedAt) || a.id.localeCompare(b.id));
+    }
+
+    async getEffectiveProjection(
+        userId: string,
+        assessmentId: string,
+    ): Promise<EffectiveBundleIdentityProjection | null> {
+        const assessment = await this.getAssessment(userId, assessmentId);
+        if (!assessment) return null;
+        const reviewEvents = await this.getReviewEvents(userId, assessmentId);
+        return {
+            assessment,
+            decision: deriveEffectiveIdentityDecision(assessment, reviewEvents),
+        };
+    }
+
+    async getEffectiveProjectionsInRange(
+        userId: string,
+        startNightKey: string,
+        endNightKey: string,
+    ): Promise<EffectiveBundleIdentityProjection[]> {
+        const ref = collection(this.db, 'users', userId, 'health_identity_assessments');
+        const snapshot = await getDocs(query(
+            ref,
+            where('sourceNightKey', '>=', startNightKey),
+            where('sourceNightKey', '<=', endNightKey),
+        ));
+        const assessments = snapshot.docs.map((item) =>
+            parseAutomaticIdentityAssessment(item.data(), item.id));
+        const projections = await Promise.all(assessments.map(async (assessment) => ({
+            assessment,
+            decision: deriveEffectiveIdentityDecision(
+                assessment,
+                await this.getReviewEvents(userId, assessment.id),
+            ),
+        })));
+        return projections.sort((a, b) =>
+            a.assessment.sourceNightKey.localeCompare(b.assessment.sourceNightKey) ||
+            a.assessment.id.localeCompare(b.assessment.id));
+    }
+
+    async submitUserReview(params: {
+        userId: string;
+        id: string;
+        assessmentId: string;
+        label: IdentityReviewEvent['label'];
+        occupancyAttestation: IdentityReviewEvent['occupancyAttestation'];
+        supersedesReviewEventId: string | null;
+    }): Promise<IdentityReviewEvent> {
+        const eventWithoutTimestamp: Omit<IdentityReviewEvent, 'recordedAt'> = {
+            id: params.id,
+            assessmentId: params.assessmentId,
+            schemaVersion: 1,
+            label: params.label,
+            occupancyAttestation: params.occupancyAttestation,
+            supersedesReviewEventId: params.supersedesReviewEventId,
+            source: 'user_ui',
+        };
+        assertUserReviewSemantics({
+            ...eventWithoutTimestamp,
+            recordedAt: new Date(0).toISOString(),
+        });
+
+        const assessmentRef = doc(this.db, 'users', params.userId, 'health_identity_assessments', params.assessmentId);
+        const eventRef = doc(this.db, 'users', params.userId, 'health_identity_review_events', params.id);
+        const supersededRef = params.supersedesReviewEventId
+            ? doc(this.db, 'users', params.userId, 'health_identity_review_events', params.supersedesReviewEventId)
+            : null;
+
+        const existing = await runTransaction(this.db, async (transaction) => {
+            const [assessmentSnapshot, existingSnapshot, supersededSnapshot] = await Promise.all([
+                transaction.get(assessmentRef),
+                transaction.get(eventRef),
+                supersededRef ? transaction.get(supersededRef) : Promise.resolve(null),
+            ]);
+            if (!assessmentSnapshot.exists()) throw new Error('Identity assessment does not exist');
+            parseAutomaticIdentityAssessment(assessmentSnapshot.data(), params.assessmentId);
+
+            if (existingSnapshot.exists()) {
+                const existing = parseIdentityReviewEvent(existingSnapshot.data(), params.id);
+                const existingWithoutTimestamp: Partial<IdentityReviewEvent> = { ...existing };
+                delete existingWithoutTimestamp.recordedAt;
+                if (stableSerialize(existingWithoutTimestamp) !== stableSerialize(eventWithoutTimestamp)) {
+                    throw new Error('Identity review event id already exists with different content');
+                }
+                return existing;
+            }
+
+            if (supersededRef) {
+                if (!supersededSnapshot?.exists()) throw new Error('Superseded identity review event does not exist');
+                const superseded = parseIdentityReviewEvent(
+                    supersededSnapshot.data(),
+                    params.supersedesReviewEventId ?? undefined,
+                );
+                if (superseded.assessmentId !== params.assessmentId) {
+                    throw new Error('Identity review cannot supersede an event for another assessment');
+                }
+            }
+
+            transaction.set(eventRef, {
+                ...eventWithoutTimestamp,
+                recordedAt: serverTimestamp(),
+            });
+            return null;
+        });
+        if (existing) return existing;
+        const createdSnapshot = await getDoc(eventRef);
+        if (!createdSnapshot.exists()) throw new Error('Identity review event was not persisted');
+        return parseIdentityReviewEvent(createdSnapshot.data(), params.id);
+    }
+}
+
+export const identityPersistenceService = new IdentityPersistenceService();

--- a/docs/plans/physiological-identity-passport-and-measurement-trust.md
+++ b/docs/plans/physiological-identity-passport-and-measurement-trust.md
@@ -113,8 +113,8 @@ The central migration requirement is moving effective identity eligibility **ups
 | PI1 | Identity, eligibility, evidence and review contracts | `[x]` | PI0 | none |
 | PI2 | Cross-source pairing, lineage and feature extraction | `[x]` | PI1 | none |
 | PI3 | Versioned Physiological Identity Passport model + bootstrap | `[x]` | PI2 | shadow only |
-| PI4 | Ternary identity evaluator with abstention | `[ ]` | PI3 | shadow only |
-| PI5 | Pre-baseline effective-eligibility gate | `[ ]` | PI4 | blocks unverified Eight Sleep baseline learning |
+| PI4 | Ternary identity evaluator with abstention | `[x]` | PI3 | shadow only |
+| PI5 | Pre-baseline effective-eligibility gate | `[x]` | PI4 | blocks unverified Eight Sleep baseline learning |
 | PI6 | Persistence, review events, replay provenance and Firestore rules | `[ ]` | PI1, PI4 | none |
 | PI7 | Suspicious-night review UI | `[ ]` | PI6 | manual labels only |
 | PI8 | Historical out-of-sample replay + prospective label collection | `[ ]` | PI4, PI6 | evidence only |

--- a/docs/plans/physiological-identity-passport-and-measurement-trust.md
+++ b/docs/plans/physiological-identity-passport-and-measurement-trust.md
@@ -111,7 +111,7 @@ The central migration requirement is moving effective identity eligibility **ups
 |---|---|---|---|---|
 | PI0 | Freeze current co-presence heuristic as provisional | `[x]` | ADR-0028 | prevents accidental promotion |
 | PI1 | Identity, eligibility, evidence and review contracts | `[x]` | PI0 | none |
-| PI2 | Cross-source pairing, lineage and feature extraction | `[ ]` | PI1 | none |
+| PI2 | Cross-source pairing, lineage and feature extraction | `[x]` | PI1 | none |
 | PI3 | Versioned Physiological Identity Passport model + bootstrap | `[ ]` | PI2 | shadow only |
 | PI4 | Ternary identity evaluator with abstention | `[ ]` | PI3 | shadow only |
 | PI5 | Pre-baseline effective-eligibility gate | `[ ]` | PI4 | blocks unverified Eight Sleep baseline learning |

--- a/docs/plans/physiological-identity-passport-and-measurement-trust.md
+++ b/docs/plans/physiological-identity-passport-and-measurement-trust.md
@@ -109,7 +109,7 @@ The central migration requirement is moving effective identity eligibility **ups
 
 | Item | Title | Status | Blocked by | Decision impact |
 |---|---|---|---|---|
-| PI0 | Freeze current co-presence heuristic as provisional | `[ ]` | ADR-0028 | prevents accidental promotion |
+| PI0 | Freeze current co-presence heuristic as provisional | `[x]` | ADR-0028 | prevents accidental promotion |
 | PI1 | Identity, eligibility, evidence and review contracts | `[ ]` | PI0 | none |
 | PI2 | Cross-source pairing, lineage and feature extraction | `[ ]` | PI1 | none |
 | PI3 | Versioned Physiological Identity Passport model + bootstrap | `[ ]` | PI2 | shadow only |

--- a/docs/plans/physiological-identity-passport-and-measurement-trust.md
+++ b/docs/plans/physiological-identity-passport-and-measurement-trust.md
@@ -112,7 +112,7 @@ The central migration requirement is moving effective identity eligibility **ups
 | PI0 | Freeze current co-presence heuristic as provisional | `[x]` | ADR-0028 | prevents accidental promotion |
 | PI1 | Identity, eligibility, evidence and review contracts | `[x]` | PI0 | none |
 | PI2 | Cross-source pairing, lineage and feature extraction | `[x]` | PI1 | none |
-| PI3 | Versioned Physiological Identity Passport model + bootstrap | `[ ]` | PI2 | shadow only |
+| PI3 | Versioned Physiological Identity Passport model + bootstrap | `[x]` | PI2 | shadow only |
 | PI4 | Ternary identity evaluator with abstention | `[ ]` | PI3 | shadow only |
 | PI5 | Pre-baseline effective-eligibility gate | `[ ]` | PI4 | blocks unverified Eight Sleep baseline learning |
 | PI6 | Persistence, review events, replay provenance and Firestore rules | `[ ]` | PI1, PI4 | none |

--- a/docs/plans/physiological-identity-passport-and-measurement-trust.md
+++ b/docs/plans/physiological-identity-passport-and-measurement-trust.md
@@ -115,7 +115,7 @@ The central migration requirement is moving effective identity eligibility **ups
 | PI3 | Versioned Physiological Identity Passport model + bootstrap | `[x]` | PI2 | shadow only |
 | PI4 | Ternary identity evaluator with abstention | `[x]` | PI3 | shadow only |
 | PI5 | Pre-baseline effective-eligibility gate | `[x]` | PI4 | blocks unverified Eight Sleep baseline learning |
-| PI6 | Persistence, review events, replay provenance and Firestore rules | `[ ]` | PI1, PI4 | none |
+| PI6 | Persistence, review events, replay provenance and Firestore rules | `[x]` | PI1, PI4 | none |
 | PI7 | Suspicious-night review UI | `[ ]` | PI6 | manual labels only |
 | PI8 | Historical out-of-sample replay + prospective label collection | `[ ]` | PI4, PI6 | evidence only |
 | PI9 | Activation decision and replacement of `CoPresenceValidator` | `[ ]` | PI5, PI7, PI8 | production identity gate |

--- a/docs/plans/physiological-identity-passport-and-measurement-trust.md
+++ b/docs/plans/physiological-identity-passport-and-measurement-trust.md
@@ -110,7 +110,7 @@ The central migration requirement is moving effective identity eligibility **ups
 | Item | Title | Status | Blocked by | Decision impact |
 |---|---|---|---|---|
 | PI0 | Freeze current co-presence heuristic as provisional | `[x]` | ADR-0028 | prevents accidental promotion |
-| PI1 | Identity, eligibility, evidence and review contracts | `[ ]` | PI0 | none |
+| PI1 | Identity, eligibility, evidence and review contracts | `[x]` | PI0 | none |
 | PI2 | Cross-source pairing, lineage and feature extraction | `[ ]` | PI1 | none |
 | PI3 | Versioned Physiological Identity Passport model + bootstrap | `[ ]` | PI2 | shadow only |
 | PI4 | Ternary identity evaluator with abstention | `[ ]` | PI3 | shadow only |

--- a/src/garmin_sync/cli.py
+++ b/src/garmin_sync/cli.py
@@ -741,6 +741,9 @@ def run_audit_multisource_cmd(args: list[str] | None = None) -> int:
         print("-" * 80)
         print("  EIGHT SLEEP ROLLING BASELINE TELEMETRY:")
         print(
+            f"  Identity Eligible / Excluded: {report.eightSleepIdentityEligibleDays} / {report.eightSleepIdentityExcludedDays} nights"
+        )
+        print(
             f"  HRV RMSSD (N={report.eightSleepHrvCount}):           Median = {report.eightSleepHrvMedian} ms, MAD = {report.eightSleepHrvMad} ms"
         )
         print(

--- a/src/garmin_sync/firestore_repository.py
+++ b/src/garmin_sync/firestore_repository.py
@@ -5,12 +5,17 @@ from typing import Any, Mapping, cast
 
 import firebase_admin
 from firebase_admin import credentials, firestore
+from google.cloud.exceptions import Conflict
 from google.cloud.firestore_v1.base_query import FieldFilter
 
 from .identity_eligibility import (
     EffectiveIdentityDecisionProjection,
     IdentityBundleKey,
     build_effective_identity_decision_index,
+    validate_automatic_identity_assessment,
+    validate_identity_passport_current,
+    validate_identity_passport_version,
+    validate_identity_review_event,
 )
 
 logger = logging.getLogger(__name__)
@@ -644,43 +649,44 @@ class FirestoreRecoveryRepository:
         document_id: str,
         payload: Mapping[str, Any],
     ) -> bool:
-        """Create an immutable server-owned identity document idempotently.
+        """Create an immutable server-owned identity document atomically and idempotently.
 
-        Replaying the exact bytes is a no-op. Reusing an existing identity for different content
-        is rejected instead of overwriting evidence needed by historical replay.
+        Firestore ``create`` is a single create-only write. Replaying the exact bytes after a
+        conflict is a no-op; reusing an existing identity for different content is rejected so a
+        concurrent writer cannot overwrite evidence needed by historical replay.
         """
 
         if not document_id:
             raise ValueError("Identity document id must be non-empty.")
         stored = dict(payload)
         doc_ref = self._identity_collection(collection_name).document(document_id)
-        snapshot = doc_ref.get()
-        if snapshot.exists:
-            if snapshot.to_dict() == stored:
+        try:
+            doc_ref.create(stored)
+            return True
+        except Conflict as error:
+            snapshot = doc_ref.get()
+            if snapshot.exists and snapshot.to_dict() == stored:
                 return False
             raise ValueError(
                 f"Immutable identity document {collection_name}/{document_id} already exists "
                 "with different content."
-            )
-        doc_ref.set(stored)
-        return True
+            ) from error
 
     def save_identity_passport_version(self, passport: Mapping[str, Any]) -> bool:
-        """Persist one immutable/replayable passport version."""
+        """Persist one fully validated immutable/replayable passport version."""
 
-        version = passport.get("passportVersion")
-        if not isinstance(version, str) or not version:
-            raise ValueError("Identity passport requires passportVersion.")
+        if not validate_identity_passport_version(passport):
+            raise ValueError("Identity passport version does not match the persisted schema.")
+        version = cast(str, passport.get("passportVersion"))
         return self._save_immutable_identity_document(
             "physiological_identity_passport_versions", version, passport
         )
 
     def set_current_identity_passport(self, passport: Mapping[str, Any]) -> None:
-        """Replace the server-owned online passport materialization."""
+        """Replace the fully validated server-owned online passport materialization."""
 
-        version = passport.get("passportVersion")
-        if not isinstance(version, str) or not version:
-            raise ValueError("Current identity passport requires passportVersion.")
+        if not validate_identity_passport_current(passport):
+            raise ValueError("Current identity passport does not match the persisted schema.")
         self._identity_collection("physiological_identity_passports").document("current").set(
             dict(passport)
         )
@@ -700,11 +706,11 @@ class FirestoreRecoveryRepository:
         return snapshot.to_dict() if snapshot.exists else None
 
     def save_automatic_identity_assessment(self, assessment: Mapping[str, Any]) -> bool:
-        """Persist immutable automatic model output and every contributing bundle ref."""
+        """Persist fully validated immutable model output and every contributing bundle ref."""
 
-        assessment_id = assessment.get("id")
-        if not isinstance(assessment_id, str) or not assessment_id:
-            raise ValueError("Automatic identity assessment requires id.")
+        if not validate_automatic_identity_assessment(assessment):
+            raise ValueError("Automatic identity assessment does not match the persisted schema.")
+        assessment_id = cast(str, assessment.get("id"))
         return self._save_immutable_identity_document(
             "health_identity_assessments", assessment_id, assessment
         )
@@ -716,21 +722,15 @@ class FirestoreRecoveryRepository:
         return snapshot.to_dict() if snapshot.exists else None
 
     def save_identity_review_event(self, event: Mapping[str, Any]) -> bool:
-        """Persist an append-only admin/user review event without mutating its assessment."""
+        """Persist a fully validated append-only admin/user review event."""
 
-        event_id = event.get("id")
-        if not isinstance(event_id, str) or not event_id:
-            raise ValueError("Identity review event requires id.")
+        if not validate_identity_review_event(event):
+            raise ValueError("Identity review event does not match the persisted schema.")
+        event_id = cast(str, event.get("id"))
         stored_event = dict(event)
-        recorded_at = stored_event.get("recordedAt")
-        if isinstance(recorded_at, str):
-            try:
-                parsed = datetime.fromisoformat(recorded_at.replace("Z", "+00:00"))
-            except ValueError as error:
-                raise ValueError("Identity review event requires a valid recordedAt.") from error
-            if parsed.tzinfo is None:
-                raise ValueError("Identity review event recordedAt must include a timezone.")
-            stored_event["recordedAt"] = parsed
+        recorded_at = cast(str, stored_event["recordedAt"])
+        parsed = datetime.fromisoformat(recorded_at.replace("Z", "+00:00"))
+        stored_event["recordedAt"] = parsed
         return self._save_immutable_identity_document(
             "health_identity_review_events", event_id, stored_event
         )

--- a/src/garmin_sync/firestore_repository.py
+++ b/src/garmin_sync/firestore_repository.py
@@ -1,11 +1,17 @@
 import logging
 import os
 from datetime import datetime, timezone
-from typing import Any, cast
+from typing import Any, Mapping, cast
 
 import firebase_admin
 from firebase_admin import credentials, firestore
 from google.cloud.firestore_v1.base_query import FieldFilter
+
+from .identity_eligibility import (
+    EffectiveIdentityDecisionProjection,
+    IdentityBundleKey,
+    build_effective_identity_decision_index,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -628,3 +634,142 @@ class FirestoreRecoveryRepository:
         )
         doc = doc_ref.get()
         return doc.to_dict() if doc.exists else None
+
+    def _identity_collection(self, collection_name: str) -> Any:
+        return self._get_db().collection("users").document(self.user_id).collection(collection_name)
+
+    def _save_immutable_identity_document(
+        self,
+        collection_name: str,
+        document_id: str,
+        payload: Mapping[str, Any],
+    ) -> bool:
+        """Create an immutable server-owned identity document idempotently.
+
+        Replaying the exact bytes is a no-op. Reusing an existing identity for different content
+        is rejected instead of overwriting evidence needed by historical replay.
+        """
+
+        if not document_id:
+            raise ValueError("Identity document id must be non-empty.")
+        stored = dict(payload)
+        doc_ref = self._identity_collection(collection_name).document(document_id)
+        snapshot = doc_ref.get()
+        if snapshot.exists:
+            if snapshot.to_dict() == stored:
+                return False
+            raise ValueError(
+                f"Immutable identity document {collection_name}/{document_id} already exists "
+                "with different content."
+            )
+        doc_ref.set(stored)
+        return True
+
+    def save_identity_passport_version(self, passport: Mapping[str, Any]) -> bool:
+        """Persist one immutable/replayable passport version."""
+
+        version = passport.get("passportVersion")
+        if not isinstance(version, str) or not version:
+            raise ValueError("Identity passport requires passportVersion.")
+        return self._save_immutable_identity_document(
+            "physiological_identity_passport_versions", version, passport
+        )
+
+    def set_current_identity_passport(self, passport: Mapping[str, Any]) -> None:
+        """Replace the server-owned online passport materialization."""
+
+        version = passport.get("passportVersion")
+        if not isinstance(version, str) or not version:
+            raise ValueError("Current identity passport requires passportVersion.")
+        self._identity_collection("physiological_identity_passports").document("current").set(
+            dict(passport)
+        )
+
+    def get_current_identity_passport(self) -> dict[str, Any] | None:
+        snapshot = (
+            self._identity_collection("physiological_identity_passports").document("current").get()
+        )
+        return snapshot.to_dict() if snapshot.exists else None
+
+    def get_identity_passport_version(self, version: str) -> dict[str, Any] | None:
+        snapshot = (
+            self._identity_collection("physiological_identity_passport_versions")
+            .document(version)
+            .get()
+        )
+        return snapshot.to_dict() if snapshot.exists else None
+
+    def save_automatic_identity_assessment(self, assessment: Mapping[str, Any]) -> bool:
+        """Persist immutable automatic model output and every contributing bundle ref."""
+
+        assessment_id = assessment.get("id")
+        if not isinstance(assessment_id, str) or not assessment_id:
+            raise ValueError("Automatic identity assessment requires id.")
+        return self._save_immutable_identity_document(
+            "health_identity_assessments", assessment_id, assessment
+        )
+
+    def get_automatic_identity_assessment(self, assessment_id: str) -> dict[str, Any] | None:
+        snapshot = (
+            self._identity_collection("health_identity_assessments").document(assessment_id).get()
+        )
+        return snapshot.to_dict() if snapshot.exists else None
+
+    def save_identity_review_event(self, event: Mapping[str, Any]) -> bool:
+        """Persist an append-only admin/user review event without mutating its assessment."""
+
+        event_id = event.get("id")
+        if not isinstance(event_id, str) or not event_id:
+            raise ValueError("Identity review event requires id.")
+        stored_event = dict(event)
+        recorded_at = stored_event.get("recordedAt")
+        if isinstance(recorded_at, str):
+            try:
+                parsed = datetime.fromisoformat(recorded_at.replace("Z", "+00:00"))
+            except ValueError as error:
+                raise ValueError("Identity review event requires a valid recordedAt.") from error
+            if parsed.tzinfo is None:
+                raise ValueError("Identity review event recordedAt must include a timezone.")
+            stored_event["recordedAt"] = parsed
+        return self._save_immutable_identity_document(
+            "health_identity_review_events", event_id, stored_event
+        )
+
+    def get_identity_assessments_in_range(
+        self, start_night_key: str, end_night_key: str
+    ) -> list[dict[str, Any]]:
+        query = (
+            self._identity_collection("health_identity_assessments")
+            .where(filter=FieldFilter("sourceNightKey", ">=", start_night_key))
+            .where(filter=FieldFilter("sourceNightKey", "<=", end_night_key))
+        )
+        assessments = [doc.to_dict() for doc in query.stream()]
+        assessments.sort(key=lambda item: (item.get("sourceNightKey", ""), item.get("id", "")))
+        return assessments
+
+    def get_identity_review_events(self, assessment_id: str) -> list[dict[str, Any]]:
+        query = self._identity_collection("health_identity_review_events").where(
+            filter=FieldFilter("assessmentId", "==", assessment_id)
+        )
+        events = [doc.to_dict() for doc in query.stream()]
+        for event in events:
+            recorded_at = event.get("recordedAt")
+            if isinstance(recorded_at, datetime):
+                event["recordedAt"] = (
+                    recorded_at.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+                )
+        events.sort(key=lambda item: (item.get("recordedAt", ""), item.get("id", "")))
+        return events
+
+    def get_effective_identity_decision_projections_in_range(
+        self, start_night_key: str, end_night_key: str
+    ) -> dict[IdentityBundleKey, EffectiveIdentityDecisionProjection]:
+        """Derive baseline-authoritative decisions from immutable persisted evidence."""
+
+        assessments = self.get_identity_assessments_in_range(start_night_key, end_night_key)
+        reviews = {
+            assessment_id: self.get_identity_review_events(assessment_id)
+            for assessment in assessments
+            if isinstance((assessment_id := assessment.get("id")), str)
+        }
+        return build_effective_identity_decision_index(assessments, reviews)

--- a/src/garmin_sync/identity_eligibility.py
+++ b/src/garmin_sync/identity_eligibility.py
@@ -10,10 +10,10 @@ Absence of a valid, unambiguous projection is ``UNCERTAIN``/ineligible, never gu
 physiology.
 """
 
-from dataclasses import dataclass
-from datetime import datetime
 import math
 import re
+from dataclasses import dataclass
+from datetime import datetime
 from typing import Any, Literal, Mapping, Sequence, TypeAlias, cast
 
 IdentityStatus: TypeAlias = Literal["USER", "NOT_USER", "UNCERTAIN"]
@@ -256,7 +256,7 @@ def validate_automatic_identity_assessment(value: object) -> bool:
         or not _is_finite_or_none(identity_score)
         or value.get("confidenceTier") not in _IDENTITY_CONFIDENCE_TIERS
         or not isinstance(reason_codes, list)
-        or not all(code in _IDENTITY_REASON_CODES for code in reason_codes)
+        or not all(isinstance(code, str) and code in _IDENTITY_REASON_CODES for code in reason_codes)
         or (passport_version is not None and _non_empty_string(passport_version) is None)
         or _non_empty_string(value.get("policyVersion")) is None
         or _non_empty_string(value.get("featureSchemaVersion")) is None

--- a/src/garmin_sync/identity_eligibility.py
+++ b/src/garmin_sync/identity_eligibility.py
@@ -5,12 +5,14 @@ It deliberately does not call the provisional co-presence heuristic. A configure
 bundle is baseline-eligible only when an exact bundle revision/hash projection resolves to
 effective ``USER`` and explicitly grants ``baselineLearning``.
 
-PI6 will supply these projections from persisted immutable assessments + append-only reviews.
-Until then, absence of a projection is ``UNCERTAIN``/ineligible, never guessed from physiology.
+PI6 supplies these projections from persisted immutable assessments + append-only reviews.
+Absence of a valid, unambiguous projection is ``UNCERTAIN``/ineligible, never guessed from
+physiology.
 """
 
 from dataclasses import dataclass
-from typing import Any, Literal, Mapping, TypeAlias
+from datetime import datetime
+from typing import Any, Literal, Mapping, Sequence, TypeAlias, cast
 
 IdentityStatus: TypeAlias = Literal["USER", "NOT_USER", "UNCERTAIN"]
 IdentityBundleKey: TypeAlias = tuple[str, str, str]
@@ -29,6 +31,197 @@ class EffectiveIdentityDecisionProjection:
     source_payload_hash: str
     effective_status: IdentityStatus
     baseline_learning: bool
+    automatic_status: IdentityStatus = "UNCERTAIN"
+    review_event_id: str | None = None
+
+
+def _non_empty_string(value: object) -> str | None:
+    return value if isinstance(value, str) and bool(value) else None
+
+
+def _identity_status(value: object) -> IdentityStatus | None:
+    return cast(IdentityStatus, value) if value in {"USER", "NOT_USER", "UNCERTAIN"} else None
+
+
+def _parse_timestamp(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        return parsed if parsed.tzinfo is not None else None
+    except ValueError:
+        return None
+
+
+def _review_semantics_are_valid(event: Mapping[str, Any]) -> bool:
+    label = _identity_status(event.get("label"))
+    attestation = event.get("occupancyAttestation")
+    if label == "USER":
+        return attestation == "EXCLUSIVE"
+    if label == "NOT_USER":
+        return attestation == "UNKNOWN"
+    if label == "UNCERTAIN":
+        return attestation in {"MIXED", "UNKNOWN"}
+    return False
+
+
+def _effective_review_event(
+    assessment_id: str,
+    review_events: Sequence[Mapping[str, Any]],
+) -> Mapping[str, Any] | None:
+    """Resolve the newest head from valid append-only supersession chains.
+
+    A correction is admitted only after its referenced predecessor is admitted and only when its
+    timestamp is monotonic. Orphans, cycles, malformed events, and events for another assessment
+    therefore cannot influence effective identity.
+    """
+
+    candidates: dict[str, Mapping[str, Any]] = {}
+    duplicate_ids: set[str] = set()
+    for event in review_events:
+        event_id = _non_empty_string(event.get("id"))
+        if (
+            event_id is None
+            or event.get("assessmentId") != assessment_id
+            or event.get("schemaVersion") != 1
+            or _parse_timestamp(event.get("recordedAt")) is None
+            or not _review_semantics_are_valid(event)
+        ):
+            continue
+        if event_id in candidates:
+            duplicate_ids.add(event_id)
+        candidates[event_id] = event
+    for duplicate_id in duplicate_ids:
+        candidates.pop(duplicate_id, None)
+
+    accepted: dict[str, Mapping[str, Any]] = {
+        event_id: event
+        for event_id, event in candidates.items()
+        if event.get("supersedesReviewEventId") is None
+    }
+    while True:
+        added = False
+        for event_id, event in candidates.items():
+            if event_id in accepted:
+                continue
+            parent_id = _non_empty_string(event.get("supersedesReviewEventId"))
+            parent = accepted.get(parent_id or "")
+            event_time = _parse_timestamp(event.get("recordedAt"))
+            parent_time = _parse_timestamp(parent.get("recordedAt")) if parent else None
+            if parent and event_time and parent_time and event_time >= parent_time:
+                accepted[event_id] = event
+                added = True
+        if not added:
+            break
+
+    if not accepted:
+        return None
+    superseded_ids = {
+        parent_id
+        for event in accepted.values()
+        if (parent_id := _non_empty_string(event.get("supersedesReviewEventId"))) is not None
+    }
+    heads = [event for event_id, event in accepted.items() if event_id not in superseded_ids]
+    return max(
+        heads,
+        key=lambda event: (
+            (
+                parsed.timestamp()
+                if (parsed := _parse_timestamp(event.get("recordedAt"))) is not None
+                else float("-inf")
+            ),
+            str(event.get("id", "")),
+        ),
+    )
+
+
+def derive_effective_identity_decision_projection(
+    assessment: Mapping[str, Any],
+    review_events: Sequence[Mapping[str, Any]],
+) -> EffectiveIdentityDecisionProjection | None:
+    """Derive the replay-safe baseline projection without mutating persisted records."""
+
+    assessment_id = _non_empty_string(assessment.get("id"))
+    source_night_key = _non_empty_string(assessment.get("sourceNightKey"))
+    automatic_status = _identity_status(assessment.get("automaticStatus"))
+    shared_source = assessment.get("sharedSource")
+    shared_ref = assessment.get("sharedBundleRef")
+    if (
+        assessment_id is None
+        or source_night_key is None
+        or automatic_status is None
+        or not isinstance(shared_source, Mapping)
+        or not isinstance(shared_ref, Mapping)
+    ):
+        return None
+    provider = _non_empty_string(shared_source.get("provider"))
+    transport = _non_empty_string(shared_source.get("transport"))
+    bundle_id = _non_empty_string(shared_ref.get("id"))
+    source_payload_hash = _non_empty_string(shared_ref.get("sourcePayloadHash"))
+    revision = shared_ref.get("revision")
+    if (
+        provider is None
+        or transport is None
+        or bundle_id is None
+        or source_payload_hash is None
+        or shared_ref.get("provider") != provider
+        or shared_ref.get("transport") != transport
+        or not isinstance(revision, int)
+        or isinstance(revision, bool)
+        or revision < 1
+    ):
+        return None
+
+    current_review = _effective_review_event(assessment_id, review_events)
+    effective_status = (
+        _identity_status(current_review.get("label")) if current_review else automatic_status
+    )
+    if effective_status is None:
+        return None
+    attestation = current_review.get("occupancyAttestation") if current_review else "UNKNOWN"
+    reason_codes = assessment.get("reasonCodes")
+    mixed_suspected = (
+        isinstance(reason_codes, list) and "MIXED_OCCUPANCY_SUSPECTED" in reason_codes
+    ) or attestation == "MIXED"
+    baseline_learning = effective_status == "USER" and not (
+        mixed_suspected and attestation != "EXCLUSIVE"
+    )
+
+    return EffectiveIdentityDecisionProjection(
+        assessment_id=assessment_id,
+        source_night_key=source_night_key,
+        provider=provider,
+        transport=transport,
+        bundle_id=bundle_id,
+        bundle_revision=revision,
+        source_payload_hash=source_payload_hash,
+        effective_status=effective_status,
+        baseline_learning=baseline_learning,
+        automatic_status=automatic_status,
+        review_event_id=(_non_empty_string(current_review.get("id")) if current_review else None),
+    )
+
+
+def build_effective_identity_decision_index(
+    assessments: Sequence[Mapping[str, Any]],
+    review_events_by_assessment: Mapping[str, Sequence[Mapping[str, Any]]],
+) -> dict[IdentityBundleKey, EffectiveIdentityDecisionProjection]:
+    """Index unambiguous projections; duplicate assessments for one source fail closed."""
+
+    grouped: dict[IdentityBundleKey, list[EffectiveIdentityDecisionProjection]] = {}
+    for assessment in assessments:
+        assessment_id = assessment.get("id")
+        reviews = (
+            review_events_by_assessment.get(assessment_id, [])
+            if isinstance(assessment_id, str)
+            else []
+        )
+        projection = derive_effective_identity_decision_projection(assessment, reviews)
+        if projection is None:
+            continue
+        key = (projection.source_night_key, projection.provider, projection.transport)
+        grouped.setdefault(key, []).append(projection)
+    return {key: values[0] for key, values in grouped.items() if len(values) == 1}
 
 
 def identity_bundle_key(bundle: Mapping[str, Any]) -> IdentityBundleKey | None:

--- a/src/garmin_sync/identity_eligibility.py
+++ b/src/garmin_sync/identity_eligibility.py
@@ -1,0 +1,94 @@
+"""Fail-closed effective-identity eligibility projection (PI5/ADR-0028).
+
+This is the Python audit-side equivalent of the TypeScript ``identityEligibility.ts`` boundary.
+It deliberately does not call the provisional co-presence heuristic. A configured shared-source
+bundle is baseline-eligible only when an exact bundle revision/hash projection resolves to
+effective ``USER`` and explicitly grants ``baselineLearning``.
+
+PI6 will supply these projections from persisted immutable assessments + append-only reviews.
+Until then, absence of a projection is ``UNCERTAIN``/ineligible, never guessed from physiology.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Literal, Mapping, TypeAlias
+
+IdentityStatus: TypeAlias = Literal["USER", "NOT_USER", "UNCERTAIN"]
+IdentityBundleKey: TypeAlias = tuple[str, str, str]
+
+
+@dataclass(frozen=True)
+class EffectiveIdentityDecisionProjection:
+    """Minimal replay-safe projection required by the Python baseline audit."""
+
+    assessment_id: str
+    source_night_key: str
+    provider: str
+    transport: str
+    bundle_id: str
+    bundle_revision: int
+    source_payload_hash: str
+    effective_status: IdentityStatus
+    baseline_learning: bool
+
+
+def identity_bundle_key(bundle: Mapping[str, Any]) -> IdentityBundleKey | None:
+    logical_date = bundle.get("logicalDate")
+    provider = bundle.get("provider")
+    transport = bundle.get("transport")
+    if not isinstance(logical_date, str) or not logical_date:
+        return None
+    if not isinstance(provider, str) or not provider:
+        return None
+    if not isinstance(transport, str) or not transport:
+        return None
+    return logical_date, provider, transport
+
+
+def health_observation_bundle_id(bundle: Mapping[str, Any]) -> str | None:
+    key = identity_bundle_key(bundle)
+    return "_".join(key) if key else None
+
+
+def is_bundle_baseline_eligible(
+    bundle: Mapping[str, Any],
+    decisions: Mapping[IdentityBundleKey, EffectiveIdentityDecisionProjection],
+) -> bool:
+    """Return true only for an exact effective-USER bundle projection.
+
+    Revision/hash mismatches are expected after corrected ingestion and fail closed so a stale
+    assessment cannot silently authorise different observation bytes.
+    """
+
+    decision = resolve_bundle_identity_projection(bundle, decisions)
+    if decision is None:
+        return False
+    return decision.effective_status == "USER" and decision.baseline_learning
+
+
+def resolve_bundle_identity_projection(
+    bundle: Mapping[str, Any],
+    decisions: Mapping[IdentityBundleKey, EffectiveIdentityDecisionProjection],
+) -> EffectiveIdentityDecisionProjection | None:
+    """Resolve only an exact current-bundle projection; stale metadata resolves as absent."""
+
+    key = identity_bundle_key(bundle)
+    bundle_id = health_observation_bundle_id(bundle)
+    if key is None or bundle_id is None:
+        return None
+    decision = decisions.get(key)
+    if decision is None:
+        return None
+    revision = bundle.get("revision")
+    source_payload_hash = bundle.get("sourcePayloadHash")
+    exact_match = (
+        bool(decision.assessment_id)
+        and decision.source_night_key == key[0]
+        and decision.provider == key[1]
+        and decision.transport == key[2]
+        and decision.bundle_id == bundle_id
+        and isinstance(revision, int)
+        and decision.bundle_revision == revision
+        and isinstance(source_payload_hash, str)
+        and decision.source_payload_hash == source_payload_hash
+    )
+    return decision if exact_match else None

--- a/src/garmin_sync/identity_eligibility.py
+++ b/src/garmin_sync/identity_eligibility.py
@@ -12,10 +12,40 @@ physiology.
 
 from dataclasses import dataclass
 from datetime import datetime
+import math
+import re
 from typing import Any, Literal, Mapping, Sequence, TypeAlias, cast
 
 IdentityStatus: TypeAlias = Literal["USER", "NOT_USER", "UNCERTAIN"]
 IdentityBundleKey: TypeAlias = tuple[str, str, str]
+
+_IDENTITY_STATUSES = {"USER", "NOT_USER", "UNCERTAIN"}
+_IDENTITY_CONFIDENCE_TIERS = {"HIGH", "MODERATE", "LOW", "NONE"}
+_IDENTITY_REASON_CODES = {
+    "ANCHOR_MISSING",
+    "ANCHOR_QUALITY_INSUFFICIENT",
+    "EVIDENCE_LINEAGE_DEPENDENT",
+    "INSUFFICIENT_PASSPORT_HISTORY",
+    "MULTIPLE_PAIRING_CANDIDATES",
+    "SESSION_TIMING_CONCORDANT",
+    "SESSION_TIMING_DISCORDANT",
+    "RHR_RELATION_CONCORDANT",
+    "RHR_RELATION_DISCORDANT",
+    "RESPIRATION_RELATION_CONCORDANT",
+    "RESPIRATION_RELATION_DISCORDANT",
+    "HRV_RELATION_CONCORDANT",
+    "HRV_RELATION_DISCORDANT",
+    "MIXED_OCCUPANCY_SUSPECTED",
+    "SESSION_INTERVAL_INVALID",
+}
+_PASSPORT_CHANGE_REASONS = {
+    "GARMIN_DEVICE_OR_ALGORITHM_CHANGE",
+    "EIGHT_SLEEP_ALGORITHM_OR_API_CHANGE",
+    "GOOGLE_HEALTH_MAPPING_CHANGE",
+    "MEASUREMENT_SYSTEM_SHIFT_CONFIRMED_BY_REPLAY",
+    "INITIAL_BOOTSTRAP",
+    "OTHER",
+}
 
 
 @dataclass(frozen=True)
@@ -40,7 +70,7 @@ def _non_empty_string(value: object) -> str | None:
 
 
 def _identity_status(value: object) -> IdentityStatus | None:
-    return cast(IdentityStatus, value) if value in {"USER", "NOT_USER", "UNCERTAIN"} else None
+    return cast(IdentityStatus, value) if value in _IDENTITY_STATUSES else None
 
 
 def _parse_timestamp(value: object) -> datetime | None:
@@ -53,6 +83,196 @@ def _parse_timestamp(value: object) -> datetime | None:
         return None
 
 
+def _is_int(value: object, *, minimum: int = 0) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value >= minimum
+
+
+def _is_finite_or_none(value: object) -> bool:
+    if value is None:
+        return True
+    return isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value)
+
+
+def validate_identity_bundle_ref(value: object) -> bool:
+    """Return whether a persisted observation reference has complete replay metadata."""
+
+    if not isinstance(value, Mapping):
+        return False
+    return bool(
+        _non_empty_string(value.get("id"))
+        and _non_empty_string(value.get("provider"))
+        and _non_empty_string(value.get("transport"))
+        and _is_int(value.get("revision"), minimum=1)
+        and _non_empty_string(value.get("sourcePayloadHash"))
+        and _non_empty_string(value.get("lineageKey"))
+    )
+
+
+def _validate_scalar_estimate(value: object) -> bool:
+    if not isinstance(value, Mapping):
+        return False
+    return bool(
+        _is_finite_or_none(value.get("median"))
+        and _is_finite_or_none(value.get("mad"))
+        and _is_finite_or_none(value.get("iqr"))
+        and _is_int(value.get("n"))
+    )
+
+
+def _validate_location_estimate(value: object) -> bool:
+    if not isinstance(value, Mapping):
+        return False
+    return bool(
+        _is_finite_or_none(value.get("median"))
+        and _is_finite_or_none(value.get("mad"))
+        and _is_int(value.get("n"))
+    )
+
+
+def _validate_ratio_estimate(value: object) -> bool:
+    if not isinstance(value, Mapping):
+        return False
+    return bool(
+        _is_finite_or_none(value.get("median"))
+        and _is_finite_or_none(value.get("iqr"))
+        and _is_int(value.get("n"))
+    )
+
+
+def _validate_passport_core(value: object) -> bool:
+    if not isinstance(value, Mapping) or value.get("schemaVersion") != 1:
+        return False
+    for field in ("passportVersion", "createdAt", "policyVersion", "featureSchemaVersion"):
+        if _non_empty_string(value.get(field)) is None:
+            return False
+
+    anchor_policy = value.get("anchorPolicy")
+    if not isinstance(anchor_policy, Mapping):
+        return False
+    if not all(
+        _non_empty_string(anchor_policy.get(field)) is not None
+        for field in ("primaryProvider", "primaryTransport", "role")
+    ) or not isinstance(anchor_policy.get("requireIndependentLineage"), bool):
+        return False
+
+    source_profiles = value.get("sourceProfiles")
+    cross_source_profiles = value.get("crossSourceProfiles")
+    if not isinstance(source_profiles, Mapping) or not isinstance(cross_source_profiles, Mapping):
+        return False
+    for profile in source_profiles.values():
+        if not isinstance(profile, Mapping) or not _is_int(profile.get("trustedNightCount")):
+            return False
+        if not all(
+            _validate_scalar_estimate(profile.get(field))
+            for field in ("restingHeartRate", "respirationRate", "logHrv")
+        ):
+            return False
+        if not all(
+            _validate_location_estimate(profile.get(field))
+            for field in ("sleepStartMinutesLocal", "sleepDurationMinutes")
+        ):
+            return False
+    for profile in cross_source_profiles.values():
+        if not isinstance(profile, Mapping):
+            return False
+        if not all(
+            _validate_scalar_estimate(profile.get(field))
+            for field in ("rhrResidual", "respirationResidual", "hrvLogResidual")
+        ):
+            return False
+        if not all(
+            _validate_location_estimate(profile.get(field))
+            for field in ("startDeltaMinutes", "endDeltaMinutes", "durationDeltaMinutes")
+        ) or not _validate_ratio_estimate(profile.get("sessionJaccard")):
+            return False
+
+    calibration = value.get("calibration")
+    if not isinstance(calibration, Mapping):
+        return False
+    if not all(
+        _is_int(calibration.get(field))
+        for field in (
+            "manualUserCount",
+            "manualNotUserCount",
+            "mixedOccupancyCount",
+            "uncertainCount",
+        )
+    ):
+        return False
+    for field in ("shadowWindowStart", "shadowWindowEnd"):
+        window = calibration.get(field)
+        if window is not None and _non_empty_string(window) is None:
+            return False
+    return True
+
+
+def validate_identity_passport_current(value: object) -> bool:
+    """Validate the complete materialized-current passport schema before persistence."""
+
+    return bool(
+        _validate_passport_core(value)
+        and isinstance(value, Mapping)
+        and _non_empty_string(value.get("updatedAt"))
+    )
+
+
+def validate_identity_passport_version(value: object) -> bool:
+    """Validate the complete immutable passport-version schema before persistence."""
+
+    if not _validate_passport_core(value) or not isinstance(value, Mapping):
+        return False
+    training_set_hash = value.get("trainingSetHash")
+    previous_version = value.get("previousVersion")
+    return bool(
+        isinstance(training_set_hash, str)
+        and re.fullmatch(r"[0-9a-f]{64}", training_set_hash)
+        and _is_int(value.get("trainingObservationCount"))
+        and _non_empty_string(value.get("trainingWindowStart"))
+        and _non_empty_string(value.get("trainingWindowEnd"))
+        and (previous_version is None or _non_empty_string(previous_version))
+        and value.get("changeReason") in _PASSPORT_CHANGE_REASONS
+        and _non_empty_string(value.get("algorithmVersion"))
+    )
+
+
+def validate_automatic_identity_assessment(value: object) -> bool:
+    """Validate the complete immutable automatic-assessment contract."""
+
+    if not isinstance(value, Mapping):
+        return False
+    identity_score = value.get("identityScore")
+    shared_source = value.get("sharedSource")
+    shared_ref = value.get("sharedBundleRef")
+    anchor_refs = value.get("anchorBundleRefs")
+    reason_codes = value.get("reasonCodes")
+    passport_version = value.get("passportVersion")
+    if (
+        _non_empty_string(value.get("id")) is None
+        or _non_empty_string(value.get("sourceNightKey")) is None
+        or not isinstance(shared_source, Mapping)
+        or _non_empty_string(shared_source.get("provider")) is None
+        or _non_empty_string(shared_source.get("transport")) is None
+        or _identity_status(value.get("automaticStatus")) is None
+        or not _is_finite_or_none(identity_score)
+        or value.get("confidenceTier") not in _IDENTITY_CONFIDENCE_TIERS
+        or not isinstance(reason_codes, list)
+        or not all(code in _IDENTITY_REASON_CODES for code in reason_codes)
+        or (passport_version is not None and _non_empty_string(passport_version) is None)
+        or _non_empty_string(value.get("policyVersion")) is None
+        or _non_empty_string(value.get("featureSchemaVersion")) is None
+        or _non_empty_string(value.get("assessedAt")) is None
+        or not validate_identity_bundle_ref(shared_ref)
+        or not isinstance(anchor_refs, list)
+        or not all(validate_identity_bundle_ref(ref) for ref in anchor_refs)
+    ):
+        return False
+    assert isinstance(shared_ref, Mapping)
+    return bool(
+        shared_ref.get("provider") == shared_source.get("provider")
+        and shared_ref.get("transport") == shared_source.get("transport")
+    )
+
+
 def _review_semantics_are_valid(event: Mapping[str, Any]) -> bool:
     label = _identity_status(event.get("label"))
     attestation = event.get("occupancyAttestation")
@@ -63,6 +283,35 @@ def _review_semantics_are_valid(event: Mapping[str, Any]) -> bool:
     if label == "UNCERTAIN":
         return attestation in {"MIXED", "UNKNOWN"}
     return False
+
+
+def validate_identity_review_event(
+    value: object,
+    *,
+    expected_assessment_id: str | None = None,
+) -> bool:
+    """Validate a complete review event, including label/occupancy semantics."""
+
+    if not isinstance(value, Mapping):
+        return False
+    event_id = _non_empty_string(value.get("id"))
+    assessment_id = _non_empty_string(value.get("assessmentId"))
+    supersedes = value.get("supersedesReviewEventId")
+    if (
+        event_id is None
+        or assessment_id is None
+        or (expected_assessment_id is not None and assessment_id != expected_assessment_id)
+        or value.get("schemaVersion") != 1
+        or _identity_status(value.get("label")) is None
+        or value.get("occupancyAttestation") not in {"EXCLUSIVE", "MIXED", "UNKNOWN"}
+        or (supersedes is not None and _non_empty_string(supersedes) is None)
+        or supersedes == event_id
+        or _parse_timestamp(value.get("recordedAt")) is None
+        or value.get("source") not in {"user_ui", "admin_replay"}
+        or not _review_semantics_are_valid(value)
+    ):
+        return False
+    return True
 
 
 def _effective_review_event(
@@ -80,12 +329,9 @@ def _effective_review_event(
     duplicate_ids: set[str] = set()
     for event in review_events:
         event_id = _non_empty_string(event.get("id"))
-        if (
-            event_id is None
-            or event.get("assessmentId") != assessment_id
-            or event.get("schemaVersion") != 1
-            or _parse_timestamp(event.get("recordedAt")) is None
-            or not _review_semantics_are_valid(event)
+        if event_id is None or not validate_identity_review_event(
+            event,
+            expected_assessment_id=assessment_id,
         ):
             continue
         if event_id in candidates:
@@ -141,6 +387,8 @@ def derive_effective_identity_decision_projection(
 ) -> EffectiveIdentityDecisionProjection | None:
     """Derive the replay-safe baseline projection without mutating persisted records."""
 
+    if not validate_automatic_identity_assessment(assessment):
+        return None
     assessment_id = _non_empty_string(assessment.get("id"))
     source_night_key = _non_empty_string(assessment.get("sourceNightKey"))
     automatic_status = _identity_status(assessment.get("automaticStatus"))
@@ -166,9 +414,7 @@ def derive_effective_identity_decision_projection(
         or source_payload_hash is None
         or shared_ref.get("provider") != provider
         or shared_ref.get("transport") != transport
-        or not isinstance(revision, int)
-        or isinstance(revision, bool)
-        or revision < 1
+        or not _is_int(revision, minimum=1)
     ):
         return None
 
@@ -193,7 +439,7 @@ def derive_effective_identity_decision_projection(
         provider=provider,
         transport=transport,
         bundle_id=bundle_id,
-        bundle_revision=revision,
+        bundle_revision=cast(int, revision),
         source_payload_hash=source_payload_hash,
         effective_status=effective_status,
         baseline_learning=baseline_learning,
@@ -280,6 +526,7 @@ def resolve_bundle_identity_projection(
         and decision.transport == key[2]
         and decision.bundle_id == bundle_id
         and isinstance(revision, int)
+        and not isinstance(revision, bool)
         and decision.bundle_revision == revision
         and isinstance(source_payload_hash, str)
         and decision.source_payload_hash == source_payload_hash

--- a/src/garmin_sync/identity_eligibility.py
+++ b/src/garmin_sync/identity_eligibility.py
@@ -70,7 +70,7 @@ def _non_empty_string(value: object) -> str | None:
 
 
 def _identity_status(value: object) -> IdentityStatus | None:
-    return cast(IdentityStatus, value) if value in _IDENTITY_STATUSES else None
+    return cast(IdentityStatus, value) if isinstance(value, str) and value in _IDENTITY_STATUSES else None
 
 
 def _parse_timestamp(value: object) -> datetime | None:
@@ -273,24 +273,12 @@ def validate_automatic_identity_assessment(value: object) -> bool:
     )
 
 
-def _review_semantics_are_valid(event: Mapping[str, Any]) -> bool:
-    label = _identity_status(event.get("label"))
-    attestation = event.get("occupancyAttestation")
-    if label == "USER":
-        return attestation == "EXCLUSIVE"
-    if label == "NOT_USER":
-        return attestation == "UNKNOWN"
-    if label == "UNCERTAIN":
-        return attestation in {"MIXED", "UNKNOWN"}
-    return False
-
-
 def validate_identity_review_event(
     value: object,
     *,
     expected_assessment_id: str | None = None,
 ) -> bool:
-    """Validate a complete review event, including label/occupancy semantics."""
+    """Validate the complete review shape while preserving separate occupancy evidence."""
 
     if not isinstance(value, Mapping):
         return False
@@ -308,7 +296,6 @@ def validate_identity_review_event(
         or supersedes == event_id
         or _parse_timestamp(value.get("recordedAt")) is None
         or value.get("source") not in {"user_ui", "admin_replay"}
-        or not _review_semantics_are_valid(value)
     ):
         return False
     return True

--- a/src/garmin_sync/identity_eligibility.py
+++ b/src/garmin_sync/identity_eligibility.py
@@ -70,7 +70,11 @@ def _non_empty_string(value: object) -> str | None:
 
 
 def _identity_status(value: object) -> IdentityStatus | None:
-    return cast(IdentityStatus, value) if isinstance(value, str) and value in _IDENTITY_STATUSES else None
+    return (
+        cast(IdentityStatus, value)
+        if isinstance(value, str) and value in _IDENTITY_STATUSES
+        else None
+    )
 
 
 def _parse_timestamp(value: object) -> datetime | None:
@@ -256,7 +260,9 @@ def validate_automatic_identity_assessment(value: object) -> bool:
         or not _is_finite_or_none(identity_score)
         or value.get("confidenceTier") not in _IDENTITY_CONFIDENCE_TIERS
         or not isinstance(reason_codes, list)
-        or not all(isinstance(code, str) and code in _IDENTITY_REASON_CODES for code in reason_codes)
+        or not all(
+            isinstance(code, str) and code in _IDENTITY_REASON_CODES for code in reason_codes
+        )
         or (passport_version is not None and _non_empty_string(passport_version) is None)
         or _non_empty_string(value.get("policyVersion")) is None
         or _non_empty_string(value.get("featureSchemaVersion")) is None

--- a/src/garmin_sync/multisource_audit.py
+++ b/src/garmin_sync/multisource_audit.py
@@ -3,17 +3,15 @@
 Analyzes multi-provider coverage, baseline stability, and cross-source telemetry
 (Garmin Direct vs Eight Sleep) across empirical historical datasets.
 
-KNOWN GAP (PI0/PI5/PI9, ADR-0028): `run_multisource_audit()` gates rolling baseline admission on
-`validate_co_presence()` / `verdict.verifiedAthlete` directly -- the same provisional heuristic
-used in the TypeScript engine (see presence_filter.py). PI5 and PI9 require this CLI audit path to
-resolve `EffectiveIdentityDecision` (or an equivalent fail-closed Python-side projection) instead,
-so shadow-replay evidence reflects the same identity gate that will govern production baseline
-learning. Do not treat the current admission logic here as identity-safe.
+PI5/ADR-0028: rolling baseline admission consumes an exact fail-closed
+`EffectiveIdentityDecisionProjection`; it never calls the provisional co-presence heuristic.
+Until PI6 persistence supplies a projection, a shared-source night remains preserved/descriptive
+but cannot enter HRV/respiration baseline statistics.
 """
 
 import math
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Mapping
 
 from .canonical import (
     METRIC_DAILY_RESPIRATION_RATE_BRPM,
@@ -21,7 +19,12 @@ from .canonical import (
     METRIC_SLEEP_DURATION_SECONDS,
 )
 from .firestore_repository import FirestoreRecoveryRepository
-from .presence_filter import validate_co_presence
+from .identity_eligibility import (
+    EffectiveIdentityDecisionProjection,
+    IdentityBundleKey,
+    is_bundle_baseline_eligible,
+    resolve_bundle_identity_projection,
+)
 
 
 @dataclass
@@ -41,6 +44,8 @@ class MultisourceAuditReport:
     eightSleepRespCount: int
     eightSleepRespMedian: float | None
     eightSleepRespMad: float | None
+    eightSleepIdentityEligibleDays: int
+    eightSleepIdentityExcludedDays: int
     dailyComparisons: list[dict[str, Any]] = field(default_factory=list)
 
 
@@ -81,8 +86,15 @@ def run_multisource_audit(
     repository: FirestoreRecoveryRepository,
     start_date_iso: str,
     end_date_iso: str,
+    effective_identity_decisions: Mapping[IdentityBundleKey, EffectiveIdentityDecisionProjection]
+    | None = None,
 ) -> MultisourceAuditReport:
-    """Run empirical shadow audit between Garmin Direct and Eight Sleep."""
+    """Run empirical shadow audit between Garmin Direct and Eight Sleep.
+
+    Missing effective-identity projections fail closed for baseline admission. The raw bundle
+    remains available to descriptive coverage/session-delta telemetry.
+    """
+    identity_decisions = effective_identity_decisions or {}
     # 1. Fetch Garmin Direct snapshots
     garmin_snaps = repository.get_historical_snapshots(start_date_iso, end_date_iso)
 
@@ -121,6 +133,8 @@ def run_multisource_audit(
 
     eight_hrv_vals: list[float] = []
     eight_resp_vals: list[float] = []
+    identity_eligible_days = 0
+    identity_excluded_days = 0
 
     daily_comparisons: list[dict[str, Any]] = []
 
@@ -150,12 +164,20 @@ def run_multisource_audit(
         eight_sleep = None
         eight_hrv = None
         eight_resp = None
+        admitted_to_baseline = False
+        effective_identity_status = "UNCERTAIN"
 
         if bundle:
-            # D-MS-PREBASE: Gating check before baseline accumulation.
-            # PROVISIONAL (PI0/PI5, ADR-0028): see module doc comment above.
-            verdict = validate_co_presence(snap, bundle)
-            admitted_to_baseline = verdict.verifiedAthlete
+            # D-PID-PREBASE: exact effective decision before baseline accumulation. Missing or
+            # stale projections fail closed; no legacy physiological heuristic can admit a night.
+            admitted_to_baseline = is_bundle_baseline_eligible(bundle, identity_decisions)
+            identity_projection = resolve_bundle_identity_projection(bundle, identity_decisions)
+            if identity_projection is not None:
+                effective_identity_status = identity_projection.effective_status
+            if admitted_to_baseline:
+                identity_eligible_days += 1
+            else:
+                identity_excluded_days += 1
 
             for obs in bundle.get("observations", []):
                 metric = obs.get("metric")
@@ -192,6 +214,8 @@ def run_multisource_audit(
                 "sleepDeltaMinutes": round(sleep_delta, 1) if sleep_delta is not None else None,
                 "eightSleepHrv": round(eight_hrv, 1) if eight_hrv else None,
                 "eightSleepRespiration": round(eight_resp, 1) if eight_resp else None,
+                "effectiveIdentityStatus": effective_identity_status if bundle else None,
+                "identityBaselineEligible": admitted_to_baseline if bundle else None,
             }
         )
 
@@ -223,5 +247,7 @@ def run_multisource_audit(
         eightSleepRespCount=len(eight_resp_vals),
         eightSleepRespMedian=round(resp_median, 1) if resp_median is not None else None,
         eightSleepRespMad=round(resp_mad, 2) if resp_mad is not None else None,
+        eightSleepIdentityEligibleDays=identity_eligible_days,
+        eightSleepIdentityExcludedDays=identity_excluded_days,
         dailyComparisons=daily_comparisons,
     )

--- a/src/garmin_sync/multisource_audit.py
+++ b/src/garmin_sync/multisource_audit.py
@@ -2,6 +2,13 @@
 
 Analyzes multi-provider coverage, baseline stability, and cross-source telemetry
 (Garmin Direct vs Eight Sleep) across empirical historical datasets.
+
+KNOWN GAP (PI0/PI5/PI9, ADR-0028): `run_multisource_audit()` gates rolling baseline admission on
+`validate_co_presence()` / `verdict.verifiedAthlete` directly -- the same provisional heuristic
+used in the TypeScript engine (see presence_filter.py). PI5 and PI9 require this CLI audit path to
+resolve `EffectiveIdentityDecision` (or an equivalent fail-closed Python-side projection) instead,
+so shadow-replay evidence reflects the same identity gate that will govern production baseline
+learning. Do not treat the current admission logic here as identity-safe.
 """
 
 import math
@@ -145,7 +152,8 @@ def run_multisource_audit(
         eight_resp = None
 
         if bundle:
-            # D-MS-PREBASE: Gating check before baseline accumulation
+            # D-MS-PREBASE: Gating check before baseline accumulation.
+            # PROVISIONAL (PI0/PI5, ADR-0028): see module doc comment above.
             verdict = validate_co_presence(snap, bundle)
             admitted_to_baseline = verdict.verifiedAthlete
 

--- a/src/garmin_sync/multisource_audit.py
+++ b/src/garmin_sync/multisource_audit.py
@@ -94,7 +94,13 @@ def run_multisource_audit(
     Missing effective-identity projections fail closed for baseline admission. The raw bundle
     remains available to descriptive coverage/session-delta telemetry.
     """
-    identity_decisions = effective_identity_decisions or {}
+    identity_decisions = (
+        repository.get_effective_identity_decision_projections_in_range(
+            start_date_iso, end_date_iso
+        )
+        if effective_identity_decisions is None
+        else effective_identity_decisions
+    )
     # 1. Fetch Garmin Direct snapshots
     garmin_snaps = repository.get_historical_snapshots(start_date_iso, end_date_iso)
 

--- a/src/garmin_sync/presence_filter.py
+++ b/src/garmin_sync/presence_filter.py
@@ -83,7 +83,7 @@ def validate_co_presence(
     max_rhr_delta_bpm: float = 10.0,
     max_unverified_rhr_delta_bpm: float = 14.0,
 ) -> PresenceValidationVerdict:
-    """Validate whether the Eight Sleep payload corresponds to the genuine athlete.
+    """Evaluate provisional co-presence concordance for the Eight Sleep payload.
 
     PROVISIONAL (PI0, ADR-0028) -- see module doc comment above. Do not present this output as a
     validated identity determination.

--- a/src/garmin_sync/presence_filter.py
+++ b/src/garmin_sync/presence_filter.py
@@ -1,5 +1,20 @@
 """Secondary-source identity and session concordance filter (ADR-0027 D-MS-IDENTITY, D-MS-PREBASE).
 
+PROVISIONAL / LEGACY COMPATIBILITY LOGIC (PI0, ADR-0028). This module is a temporary scalar
+heuristic (fixed session-overlap and RHR-delta bounds), not a validated biometric identity
+classifier. The `60 min` / `10 bpm` / `14 bpm` defaults are unvalidated safety guards carried
+over from PR #240 and must not be described as validated identity thresholds.
+
+It will be superseded by the ternary Physiological Identity Passport gate (`USER | NOT_USER |
+UNCERTAIN`, see ADR-0028 and
+docs/plans/physiological-identity-passport-and-measurement-trust.md, tasks PI1-PI9), which sits
+upstream of rolling baseline accumulation. `verified_athlete: bool` and `imposterConfidence` are
+legacy vocabulary; new code must not depend on them as permanent domain contracts.
+
+A physiological anomaly alone (e.g. illness driving up RHR) is NOT proof that another person used
+the shared device -- this module deliberately never asserts that; see
+`tests/test_presence_filter.py` for the regression test documenting this (ADR-0028 P-PI-8).
+
 Protects athlete baselines and engine readiness from being corrupted when a family member
 sleeps on the athlete's Eight Sleep mattress, or when the athlete sleeps away from the mattress (travel).
 """
@@ -13,6 +28,13 @@ from .canonical import METRIC_DAILY_RESTING_HEART_RATE_BPM
 
 @dataclass
 class PresenceValidationVerdict:
+    """Provisional quarantine/concordance verdict (PI0) -- intentionally NOT an identity verdict.
+
+    `verifiedAthlete` and `concordanceStatus` never assert who used the device, only whether the
+    secondary record is concordant enough to trust. Superseded by `EffectiveIdentityDecision`
+    (PI1) once it lands.
+    """
+
     verifiedAthlete: bool
     concordanceStatus: (
         str  # "CONCORDANT" | "DISCORDANT_SECONDARY" | "UNVERIFIED_OFF_WRIST" | "NO_SECONDARY_DATA"
@@ -25,7 +47,11 @@ class PresenceValidationVerdict:
 
     @property
     def imposterConfidence(self) -> str:
-        """Backwards compatibility alias for concordanceStatus."""
+        """Backwards compatibility alias for concordanceStatus.
+
+        @deprecated legacy alias (PI0); `IMPOSTER_REJECTED` is not a confirmed identity-fraud
+        determination -- it only means the secondary record was quarantined from baseline/fusion.
+        """
         if self.concordanceStatus == "CONCORDANT":
             return "VERIFIED"
         if self.concordanceStatus == "DISCORDANT_SECONDARY":
@@ -57,7 +83,11 @@ def validate_co_presence(
     max_rhr_delta_bpm: float = 10.0,
     max_unverified_rhr_delta_bpm: float = 14.0,
 ) -> PresenceValidationVerdict:
-    """Validate whether the Eight Sleep payload corresponds to the genuine athlete."""
+    """Validate whether the Eight Sleep payload corresponds to the genuine athlete.
+
+    PROVISIONAL (PI0, ADR-0028) -- see module doc comment above. Do not present this output as a
+    validated identity determination.
+    """
     if not eight_sleep_bundle:
         return PresenceValidationVerdict(
             verifiedAthlete=True,

--- a/tests/test_identity_eligibility.py
+++ b/tests/test_identity_eligibility.py
@@ -4,6 +4,8 @@ import pytest
 
 from garmin_sync.identity_eligibility import (
     EffectiveIdentityDecisionProjection,
+    build_effective_identity_decision_index,
+    derive_effective_identity_decision_projection,
     health_observation_bundle_id,
     identity_bundle_key,
     is_bundle_baseline_eligible,
@@ -101,3 +103,89 @@ def test_projection_is_immutable() -> None:
     decision = _decision()
     with pytest.raises(FrozenInstanceError):
         decision.baseline_learning = False  # type: ignore[misc]
+
+
+def _assessment(**overrides: object) -> dict[str, object]:
+    value: dict[str, object] = {
+        "id": "assessment-1",
+        "sourceNightKey": "2026-08-27",
+        "sharedSource": {"provider": "shared_bed", "transport": "health_aggregator"},
+        "automaticStatus": "UNCERTAIN",
+        "reasonCodes": ["SESSION_TIMING_DISCORDANT"],
+        "sharedBundleRef": {
+            "id": "2026-08-27_shared_bed_health_aggregator",
+            "provider": "shared_bed",
+            "transport": "health_aggregator",
+            "revision": 2,
+            "sourcePayloadHash": "sha256:shared",
+        },
+    }
+    value.update(overrides)
+    return value
+
+
+def _review(**overrides: object) -> dict[str, object]:
+    value: dict[str, object] = {
+        "id": "review-1",
+        "assessmentId": "assessment-1",
+        "schemaVersion": 1,
+        "label": "USER",
+        "occupancyAttestation": "EXCLUSIVE",
+        "supersedesReviewEventId": None,
+        "recordedAt": "2026-08-27T08:00:00.000Z",
+    }
+    value.update(overrides)
+    return value
+
+
+def test_persisted_review_correction_derives_effective_projection_without_mutation() -> None:
+    assessment = _assessment()
+    original = _review()
+    correction = _review(
+        id="review-2",
+        label="NOT_USER",
+        occupancyAttestation="UNKNOWN",
+        supersedesReviewEventId="review-1",
+        recordedAt="2026-08-27T09:00:00.000Z",
+    )
+
+    projection = derive_effective_identity_decision_projection(assessment, [correction, original])
+
+    assert projection is not None
+    assert projection.automatic_status == "UNCERTAIN"
+    assert projection.effective_status == "NOT_USER"
+    assert projection.review_event_id == "review-2"
+    assert projection.baseline_learning is False
+    assert assessment["automaticStatus"] == "UNCERTAIN"
+
+
+def test_orphan_or_non_monotonic_review_cannot_change_effective_identity() -> None:
+    assessment = _assessment(automaticStatus="USER")
+    invalid = _review(
+        id="review-2",
+        label="NOT_USER",
+        occupancyAttestation="UNKNOWN",
+        supersedesReviewEventId="missing",
+        recordedAt="2026-08-27T09:00:00.000Z",
+    )
+    projection = derive_effective_identity_decision_projection(assessment, [invalid])
+    assert projection is not None
+    assert projection.effective_status == "USER"
+    assert projection.review_event_id is None
+    assert projection.baseline_learning is True
+
+
+def test_mixed_occupancy_requires_explicit_exclusive_user_attestation() -> None:
+    assessment = _assessment(automaticStatus="USER", reasonCodes=["MIXED_OCCUPANCY_SUSPECTED"])
+    automatic = derive_effective_identity_decision_projection(assessment, [])
+    reviewed = derive_effective_identity_decision_projection(assessment, [_review()])
+    assert automatic is not None and automatic.baseline_learning is False
+    assert reviewed is not None and reviewed.baseline_learning is True
+
+
+def test_duplicate_assessments_for_one_bundle_are_omitted_from_index() -> None:
+    duplicate = _assessment(id="assessment-2")
+    index = build_effective_identity_decision_index(
+        [_assessment(), duplicate], {"assessment-1": [], "assessment-2": []}
+    )
+    assert index == {}

--- a/tests/test_identity_eligibility.py
+++ b/tests/test_identity_eligibility.py
@@ -1,0 +1,103 @@
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from garmin_sync.identity_eligibility import (
+    EffectiveIdentityDecisionProjection,
+    health_observation_bundle_id,
+    identity_bundle_key,
+    is_bundle_baseline_eligible,
+    resolve_bundle_identity_projection,
+)
+
+
+def _bundle() -> dict[str, object]:
+    return {
+        "logicalDate": "2026-08-27",
+        "provider": "shared_bed",
+        "transport": "health_aggregator",
+        "revision": 2,
+        "sourcePayloadHash": "sha256:shared",
+        "observations": [],
+    }
+
+
+def _decision(**overrides: object) -> EffectiveIdentityDecisionProjection:
+    values: dict[str, object] = {
+        "assessment_id": "assessment-1",
+        "source_night_key": "2026-08-27",
+        "provider": "shared_bed",
+        "transport": "health_aggregator",
+        "bundle_id": "2026-08-27_shared_bed_health_aggregator",
+        "bundle_revision": 2,
+        "source_payload_hash": "sha256:shared",
+        "effective_status": "USER",
+        "baseline_learning": True,
+    }
+    values.update(overrides)
+    return EffectiveIdentityDecisionProjection(**values)  # type: ignore[arg-type]
+
+
+def test_identity_bundle_key_and_id_are_provider_neutral() -> None:
+    bundle = _bundle()
+    assert identity_bundle_key(bundle) == (
+        "2026-08-27",
+        "shared_bed",
+        "health_aggregator",
+    )
+    assert health_observation_bundle_id(bundle) == ("2026-08-27_shared_bed_health_aggregator")
+
+
+def test_exact_effective_user_projection_is_baseline_eligible() -> None:
+    bundle = _bundle()
+    decisions = {identity_bundle_key(bundle): _decision()}
+    assert is_bundle_baseline_eligible(bundle, decisions) is True  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("override", "expected_status"),
+    [
+        ({"effective_status": "UNCERTAIN"}, "UNCERTAIN"),
+        ({"effective_status": "NOT_USER"}, "NOT_USER"),
+        ({"baseline_learning": False}, "USER"),
+        ({"bundle_revision": 1}, "USER"),
+        ({"source_payload_hash": "sha256:stale"}, "USER"),
+        ({"bundle_id": "wrong-id"}, "USER"),
+    ],
+)
+def test_non_authoritative_or_stale_projection_fails_closed(
+    override: dict[str, object], expected_status: str
+) -> None:
+    bundle = _bundle()
+    decision = _decision(**override)
+    assert decision.effective_status == expected_status
+    assert (
+        is_bundle_baseline_eligible(
+            bundle,
+            {("2026-08-27", "shared_bed", "health_aggregator"): decision},
+        )
+        is False
+    )
+
+
+def test_missing_projection_and_malformed_bundle_fail_closed() -> None:
+    assert is_bundle_baseline_eligible(_bundle(), {}) is False
+    assert is_bundle_baseline_eligible({"provider": "shared_bed"}, {}) is False
+
+
+def test_stale_projection_does_not_resolve_as_current_identity_status() -> None:
+    bundle = _bundle()
+    stale = _decision(bundle_revision=1, effective_status="NOT_USER")
+    assert (
+        resolve_bundle_identity_projection(
+            bundle,
+            {("2026-08-27", "shared_bed", "health_aggregator"): stale},
+        )
+        is None
+    )
+
+
+def test_projection_is_immutable() -> None:
+    decision = _decision()
+    with pytest.raises(FrozenInstanceError):
+        decision.baseline_learning = False  # type: ignore[misc]

--- a/tests/test_identity_eligibility.py
+++ b/tests/test_identity_eligibility.py
@@ -99,6 +99,18 @@ def test_stale_projection_does_not_resolve_as_current_identity_status() -> None:
     )
 
 
+def test_boolean_bundle_revision_is_rejected() -> None:
+    bundle = _bundle()
+    bundle["revision"] = True
+    assert (
+        resolve_bundle_identity_projection(
+            bundle,
+            {("2026-08-27", "shared_bed", "health_aggregator"): _decision(bundle_revision=1)},
+        )
+        is None
+    )
+
+
 def test_projection_is_immutable() -> None:
     decision = _decision()
     with pytest.raises(FrozenInstanceError):
@@ -111,14 +123,31 @@ def _assessment(**overrides: object) -> dict[str, object]:
         "sourceNightKey": "2026-08-27",
         "sharedSource": {"provider": "shared_bed", "transport": "health_aggregator"},
         "automaticStatus": "UNCERTAIN",
+        "identityScore": 0.42,
+        "confidenceTier": "LOW",
         "reasonCodes": ["SESSION_TIMING_DISCORDANT"],
+        "passportVersion": "2026-08-27.1",
+        "policyVersion": "identity-v1-shadow",
+        "featureSchemaVersion": "identity-features-v1",
+        "assessedAt": "2026-08-27T06:30:00.000Z",
         "sharedBundleRef": {
             "id": "2026-08-27_shared_bed_health_aggregator",
             "provider": "shared_bed",
             "transport": "health_aggregator",
             "revision": 2,
             "sourcePayloadHash": "sha256:shared",
+            "lineageKey": "shared_bed:pod-side:a",
         },
+        "anchorBundleRefs": [
+            {
+                "id": "2026-08-27_wearable_direct",
+                "provider": "wearable",
+                "transport": "direct",
+                "revision": 1,
+                "sourcePayloadHash": "sha256:anchor",
+                "lineageKey": "wearable:device:athlete",
+            }
+        ],
     }
     value.update(overrides)
     return value
@@ -133,6 +162,7 @@ def _review(**overrides: object) -> dict[str, object]:
         "occupancyAttestation": "EXCLUSIVE",
         "supersedesReviewEventId": None,
         "recordedAt": "2026-08-27T08:00:00.000Z",
+        "source": "user_ui",
     }
     value.update(overrides)
     return value
@@ -173,6 +203,43 @@ def test_orphan_or_non_monotonic_review_cannot_change_effective_identity() -> No
     assert projection.effective_status == "USER"
     assert projection.review_event_id is None
     assert projection.baseline_learning is True
+
+
+def test_cyclic_review_chain_cannot_change_effective_identity() -> None:
+    assessment = _assessment(automaticStatus="UNCERTAIN")
+    first = _review(id="review-1", supersedesReviewEventId="review-2")
+    second = _review(
+        id="review-2",
+        supersedesReviewEventId="review-1",
+        recordedAt="2026-08-27T09:00:00.000Z",
+    )
+    projection = derive_effective_identity_decision_projection(assessment, [first, second])
+    assert projection is not None
+    assert projection.effective_status == "UNCERTAIN"
+    assert projection.review_event_id is None
+    assert projection.baseline_learning is False
+
+
+def test_incomplete_assessment_cannot_produce_projection() -> None:
+    assessment = _assessment()
+    assessment.pop("policyVersion")
+    assert derive_effective_identity_decision_projection(assessment, [_review()]) is None
+
+    missing_lineage = _assessment()
+    shared_ref = dict(missing_lineage["sharedBundleRef"])  # type: ignore[arg-type]
+    shared_ref.pop("lineageKey")
+    missing_lineage["sharedBundleRef"] = shared_ref
+    assert derive_effective_identity_decision_projection(missing_lineage, [_review()]) is None
+
+
+def test_malformed_review_event_cannot_override_automatic_identity() -> None:
+    assessment = _assessment(automaticStatus="UNCERTAIN")
+    malformed = _review()
+    malformed.pop("source")
+    projection = derive_effective_identity_decision_projection(assessment, [malformed])
+    assert projection is not None
+    assert projection.effective_status == "UNCERTAIN"
+    assert projection.review_event_id is None
 
 
 def test_mixed_occupancy_requires_explicit_exclusive_user_attestation() -> None:

--- a/tests/test_identity_persistence.py
+++ b/tests/test_identity_persistence.py
@@ -184,9 +184,15 @@ def test_identity_persistence_rejects_incomplete_or_malformed_documents() -> Non
         repository.set_current_identity_passport(current)
 
     review = _review()
-    review["occupancyAttestation"] = "UNKNOWN"
+    review["source"] = "untrusted_import"
     with pytest.raises(ValueError, match="review event does not match"):
         repository.save_identity_review_event(review)
+
+
+def test_identity_persistence_accepts_user_mixed_occupancy_review() -> None:
+    repository = FirestoreRecoveryRepository("athlete-1", db=_Db())
+    review = {**_review(), "occupancyAttestation": "MIXED"}
+    assert repository.save_identity_review_event(review) is True
 
 
 def test_repository_derives_effective_decision_index_from_persisted_evidence(

--- a/tests/test_identity_persistence.py
+++ b/tests/test_identity_persistence.py
@@ -1,0 +1,124 @@
+from collections.abc import Mapping
+from typing import Any
+
+import pytest
+
+from garmin_sync.firestore_repository import FirestoreRecoveryRepository
+
+
+class _Snapshot:
+    def __init__(self, value: dict[str, Any] | None):
+        self._value = value
+        self.exists = value is not None
+
+    def to_dict(self) -> dict[str, Any] | None:
+        return self._value
+
+
+class _Document:
+    def __init__(self, store: dict[str, dict[str, Any]], path: str):
+        self._store = store
+        self._path = path
+
+    def collection(self, name: str) -> "_Collection":
+        return _Collection(self._store, f"{self._path}/{name}")
+
+    def get(self) -> _Snapshot:
+        return _Snapshot(self._store.get(self._path))
+
+    def set(self, value: Mapping[str, Any]) -> None:
+        self._store[self._path] = dict(value)
+
+
+class _Collection:
+    def __init__(self, store: dict[str, dict[str, Any]], path: str):
+        self._store = store
+        self._path = path
+
+    def document(self, document_id: str) -> _Document:
+        return _Document(self._store, f"{self._path}/{document_id}")
+
+
+class _Db:
+    def __init__(self) -> None:
+        self.store: dict[str, dict[str, Any]] = {}
+
+    def collection(self, name: str) -> _Collection:
+        return _Collection(self.store, name)
+
+
+def _assessment() -> dict[str, Any]:
+    return {
+        "id": "assessment-1",
+        "sourceNightKey": "2026-08-27",
+        "sharedSource": {"provider": "shared_bed", "transport": "health_aggregator"},
+        "automaticStatus": "UNCERTAIN",
+        "reasonCodes": ["SESSION_TIMING_DISCORDANT"],
+        "sharedBundleRef": {
+            "id": "2026-08-27_shared_bed_health_aggregator",
+            "provider": "shared_bed",
+            "transport": "health_aggregator",
+            "revision": 2,
+            "sourcePayloadHash": "sha256:shared",
+        },
+    }
+
+
+def test_identity_server_documents_round_trip_and_remain_immutable() -> None:
+    repository = FirestoreRecoveryRepository("athlete-1", db=_Db())
+    assessment = _assessment()
+
+    assert repository.save_automatic_identity_assessment(assessment) is True
+    assert repository.get_automatic_identity_assessment("assessment-1") == assessment
+    assert repository.save_automatic_identity_assessment(dict(assessment)) is False
+    with pytest.raises(ValueError, match="already exists with different content"):
+        repository.save_automatic_identity_assessment({**assessment, "automaticStatus": "USER"})
+
+    version = {"passportVersion": "2026-08-27.1", "trainingSetHash": "a" * 64}
+    current = {"passportVersion": "2026-08-27.1", "updatedAt": "2026-08-27T07:00:00Z"}
+    assert repository.save_identity_passport_version(version) is True
+    repository.set_current_identity_passport(current)
+    assert repository.get_identity_passport_version("2026-08-27.1") == version
+    assert repository.get_current_identity_passport() == current
+
+    event = {
+        "id": "review-1",
+        "assessmentId": "assessment-1",
+        "schemaVersion": 1,
+        "label": "USER",
+        "occupancyAttestation": "EXCLUSIVE",
+        "supersedesReviewEventId": None,
+        "recordedAt": "2026-08-27T08:00:00.000Z",
+        "source": "admin_replay",
+    }
+    assert repository.save_identity_review_event(event) is True
+    assert repository.save_identity_review_event(event) is False
+
+
+def test_repository_derives_effective_decision_index_from_persisted_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = FirestoreRecoveryRepository("athlete-1", db=_Db())
+    assessment = _assessment()
+    review = {
+        "id": "review-1",
+        "assessmentId": "assessment-1",
+        "schemaVersion": 1,
+        "label": "USER",
+        "occupancyAttestation": "EXCLUSIVE",
+        "supersedesReviewEventId": None,
+        "recordedAt": "2026-08-27T08:00:00.000Z",
+    }
+    monkeypatch.setattr(
+        repository, "get_identity_assessments_in_range", lambda _start, _end: [assessment]
+    )
+    monkeypatch.setattr(repository, "get_identity_review_events", lambda _assessment_id: [review])
+
+    decisions = repository.get_effective_identity_decision_projections_in_range(
+        "2026-08-27", "2026-08-27"
+    )
+
+    projection = decisions[("2026-08-27", "shared_bed", "health_aggregator")]
+    assert projection.effective_status == "USER"
+    assert projection.review_event_id == "review-1"
+    assert projection.baseline_learning is True

--- a/tests/test_identity_persistence.py
+++ b/tests/test_identity_persistence.py
@@ -1,6 +1,7 @@
 from collections.abc import Mapping
 from typing import Any
 
+from google.cloud.exceptions import Conflict
 import pytest
 
 from garmin_sync.firestore_repository import FirestoreRecoveryRepository
@@ -29,6 +30,11 @@ class _Document:
     def set(self, value: Mapping[str, Any]) -> None:
         self._store[self._path] = dict(value)
 
+    def create(self, value: Mapping[str, Any]) -> None:
+        if self._path in self._store:
+            raise Conflict("document already exists")
+        self._store[self._path] = dict(value)
+
 
 class _Collection:
     def __init__(self, store: dict[str, dict[str, Any]], path: str):
@@ -53,14 +59,87 @@ def _assessment() -> dict[str, Any]:
         "sourceNightKey": "2026-08-27",
         "sharedSource": {"provider": "shared_bed", "transport": "health_aggregator"},
         "automaticStatus": "UNCERTAIN",
+        "identityScore": 0.42,
+        "confidenceTier": "LOW",
         "reasonCodes": ["SESSION_TIMING_DISCORDANT"],
+        "passportVersion": "2026-08-27.1",
+        "policyVersion": "identity-v1-shadow",
+        "featureSchemaVersion": "identity-features-v1",
+        "assessedAt": "2026-08-27T06:30:00.000Z",
         "sharedBundleRef": {
             "id": "2026-08-27_shared_bed_health_aggregator",
             "provider": "shared_bed",
             "transport": "health_aggregator",
             "revision": 2,
             "sourcePayloadHash": "sha256:shared",
+            "lineageKey": "shared_bed:pod-side:a",
         },
+        "anchorBundleRefs": [
+            {
+                "id": "2026-08-27_garmin_garmin_direct",
+                "provider": "garmin",
+                "transport": "garmin_direct",
+                "revision": 1,
+                "sourcePayloadHash": "sha256:anchor",
+                "lineageKey": "garmin:device:athlete",
+            }
+        ],
+    }
+
+
+def _passport_core() -> dict[str, Any]:
+    return {
+        "schemaVersion": 1,
+        "passportVersion": "2026-08-27.1",
+        "createdAt": "2026-08-27T06:00:00Z",
+        "policyVersion": "identity-v1-shadow",
+        "featureSchemaVersion": "identity-features-v1",
+        "anchorPolicy": {
+            "primaryProvider": "garmin",
+            "primaryTransport": "garmin_direct",
+            "role": "personal_wearable_anchor",
+            "requireIndependentLineage": True,
+        },
+        "sourceProfiles": {},
+        "crossSourceProfiles": {},
+        "calibration": {
+            "manualUserCount": 0,
+            "manualNotUserCount": 0,
+            "mixedOccupancyCount": 0,
+            "uncertainCount": 0,
+            "shadowWindowStart": None,
+            "shadowWindowEnd": None,
+        },
+    }
+
+
+def _passport_version() -> dict[str, Any]:
+    return {
+        **_passport_core(),
+        "trainingSetHash": "a" * 64,
+        "trainingObservationCount": 1,
+        "trainingWindowStart": "2026-08-01",
+        "trainingWindowEnd": "2026-08-27",
+        "previousVersion": None,
+        "changeReason": "INITIAL_BOOTSTRAP",
+        "algorithmVersion": "identity-passport-v1",
+    }
+
+
+def _current_passport() -> dict[str, Any]:
+    return {**_passport_core(), "updatedAt": "2026-08-27T07:00:00Z"}
+
+
+def _review() -> dict[str, Any]:
+    return {
+        "id": "review-1",
+        "assessmentId": "assessment-1",
+        "schemaVersion": 1,
+        "label": "USER",
+        "occupancyAttestation": "EXCLUSIVE",
+        "supersedesReviewEventId": None,
+        "recordedAt": "2026-08-27T08:00:00.000Z",
+        "source": "admin_replay",
     }
 
 
@@ -74,25 +153,40 @@ def test_identity_server_documents_round_trip_and_remain_immutable() -> None:
     with pytest.raises(ValueError, match="already exists with different content"):
         repository.save_automatic_identity_assessment({**assessment, "automaticStatus": "USER"})
 
-    version = {"passportVersion": "2026-08-27.1", "trainingSetHash": "a" * 64}
-    current = {"passportVersion": "2026-08-27.1", "updatedAt": "2026-08-27T07:00:00Z"}
+    version = _passport_version()
+    current = _current_passport()
     assert repository.save_identity_passport_version(version) is True
     repository.set_current_identity_passport(current)
     assert repository.get_identity_passport_version("2026-08-27.1") == version
     assert repository.get_current_identity_passport() == current
 
-    event = {
-        "id": "review-1",
-        "assessmentId": "assessment-1",
-        "schemaVersion": 1,
-        "label": "USER",
-        "occupancyAttestation": "EXCLUSIVE",
-        "supersedesReviewEventId": None,
-        "recordedAt": "2026-08-27T08:00:00.000Z",
-        "source": "admin_replay",
-    }
+    event = _review()
     assert repository.save_identity_review_event(event) is True
     assert repository.save_identity_review_event(event) is False
+
+
+def test_identity_persistence_rejects_incomplete_or_malformed_documents() -> None:
+    repository = FirestoreRecoveryRepository("athlete-1", db=_Db())
+
+    assessment = _assessment()
+    assessment.pop("policyVersion")
+    with pytest.raises(ValueError, match="assessment does not match"):
+        repository.save_automatic_identity_assessment(assessment)
+
+    version = _passport_version()
+    version.pop("algorithmVersion")
+    with pytest.raises(ValueError, match="passport version does not match"):
+        repository.save_identity_passport_version(version)
+
+    current = _current_passport()
+    current.pop("anchorPolicy")
+    with pytest.raises(ValueError, match="Current identity passport does not match"):
+        repository.set_current_identity_passport(current)
+
+    review = _review()
+    review["occupancyAttestation"] = "UNKNOWN"
+    with pytest.raises(ValueError, match="review event does not match"):
+        repository.save_identity_review_event(review)
 
 
 def test_repository_derives_effective_decision_index_from_persisted_evidence(
@@ -100,15 +194,7 @@ def test_repository_derives_effective_decision_index_from_persisted_evidence(
 ) -> None:
     repository = FirestoreRecoveryRepository("athlete-1", db=_Db())
     assessment = _assessment()
-    review = {
-        "id": "review-1",
-        "assessmentId": "assessment-1",
-        "schemaVersion": 1,
-        "label": "USER",
-        "occupancyAttestation": "EXCLUSIVE",
-        "supersedesReviewEventId": None,
-        "recordedAt": "2026-08-27T08:00:00.000Z",
-    }
+    review = {**_review(), "source": "user_ui"}
     monkeypatch.setattr(
         repository, "get_identity_assessments_in_range", lambda _start, _end: [assessment]
     )

--- a/tests/test_identity_persistence.py
+++ b/tests/test_identity_persistence.py
@@ -1,8 +1,8 @@
 from collections.abc import Mapping
 from typing import Any
 
-from google.cloud.exceptions import Conflict
 import pytest
+from google.cloud.exceptions import Conflict
 
 from garmin_sync.firestore_repository import FirestoreRecoveryRepository
 

--- a/tests/test_multisource_audit.py
+++ b/tests/test_multisource_audit.py
@@ -82,6 +82,7 @@ def test_run_multisource_audit_missing_identity_projection_fails_closed() -> Non
             ],
         }
     ]
+    mock_repo.get_effective_identity_decision_projections_in_range.return_value = {}
 
     report = run_multisource_audit(mock_repo, "2026-08-25", "2026-08-25")
 
@@ -91,3 +92,16 @@ def test_run_multisource_audit_missing_identity_projection_fails_closed() -> Non
     assert report.eightSleepIdentityExcludedDays == 1
     assert report.dailyComparisons[0]["effectiveIdentityStatus"] == "UNCERTAIN"
     assert report.dailyComparisons[0]["identityBaselineEligible"] is False
+
+
+def test_run_multisource_audit_loads_persisted_effective_decisions_by_default() -> None:
+    mock_repo = MagicMock()
+    mock_repo.get_historical_snapshots.return_value = {}
+    mock_repo.get_health_observation_bundles_in_range.return_value = []
+    mock_repo.get_effective_identity_decision_projections_in_range.return_value = {}
+
+    run_multisource_audit(mock_repo, "2026-08-25", "2026-08-27")
+
+    mock_repo.get_effective_identity_decision_projections_in_range.assert_called_once_with(
+        "2026-08-25", "2026-08-27"
+    )

--- a/tests/test_multisource_audit.py
+++ b/tests/test_multisource_audit.py
@@ -1,5 +1,6 @@
 from unittest.mock import MagicMock
 
+from garmin_sync.identity_eligibility import EffectiveIdentityDecisionProjection
 from garmin_sync.multisource_audit import (
     _calc_correlation,
     _calc_mad,
@@ -28,6 +29,8 @@ def test_run_multisource_audit_mocked() -> None:
             "logicalDate": "2026-08-25",
             "provider": "eight_sleep",
             "transport": "google_health",
+            "revision": 3,
+            "sourcePayloadHash": "sha256:eight-sleep-2026-08-25",
             "observations": [
                 {"metric": "sleep_duration_seconds", "value": 28800},
                 {"metric": "daily_resting_heart_rate_bpm", "value": 45.0},
@@ -37,8 +40,54 @@ def test_run_multisource_audit_mocked() -> None:
         }
     ]
 
-    report = run_multisource_audit(mock_repo, "2026-08-25", "2026-08-25")
+    decision = EffectiveIdentityDecisionProjection(
+        assessment_id="assessment-2026-08-25",
+        source_night_key="2026-08-25",
+        provider="eight_sleep",
+        transport="google_health",
+        bundle_id="2026-08-25_eight_sleep_google_health",
+        bundle_revision=3,
+        source_payload_hash="sha256:eight-sleep-2026-08-25",
+        effective_status="USER",
+        baseline_learning=True,
+    )
+    report = run_multisource_audit(
+        mock_repo,
+        "2026-08-25",
+        "2026-08-25",
+        {("2026-08-25", "eight_sleep", "google_health"): decision},
+    )
     assert report.totalDays == 1
     assert report.bothSourcesDays == 1
     assert report.eightSleepHrvCount == 1
     assert report.eightSleepHrvMedian == 60.0
+    assert report.eightSleepIdentityEligibleDays == 1
+    assert report.eightSleepIdentityExcludedDays == 0
+    assert report.dailyComparisons[0]["identityBaselineEligible"] is True
+
+
+def test_run_multisource_audit_missing_identity_projection_fails_closed() -> None:
+    mock_repo = MagicMock()
+    mock_repo.get_historical_snapshots.return_value = {}
+    mock_repo.get_health_observation_bundles_in_range.return_value = [
+        {
+            "logicalDate": "2026-08-25",
+            "provider": "eight_sleep",
+            "transport": "google_health",
+            "revision": 1,
+            "sourcePayloadHash": "sha256:unverified",
+            "observations": [
+                {"metric": "hrv_rmssd_ms", "value": 999.0},
+                {"metric": "respiration_rate_brpm", "value": 30.0},
+            ],
+        }
+    ]
+
+    report = run_multisource_audit(mock_repo, "2026-08-25", "2026-08-25")
+
+    assert report.eightSleepHrvCount == 0
+    assert report.eightSleepRespCount == 0
+    assert report.eightSleepIdentityEligibleDays == 0
+    assert report.eightSleepIdentityExcludedDays == 1
+    assert report.dailyComparisons[0]["effectiveIdentityStatus"] == "UNCERTAIN"
+    assert report.dailyComparisons[0]["identityBaselineEligible"] is False

--- a/tests/test_presence_filter.py
+++ b/tests/test_presence_filter.py
@@ -95,3 +95,52 @@ def test_co_presence_top_level_resting_heart_rate_key() -> None:
     assert verdict.verifiedAthlete is True
     assert verdict.concordanceStatus == "CONCORDANT"
     assert verdict.rhrDelta == 1.0
+
+
+# PI0 regression: a physiological anomaly alone cannot prove another person (ADR-0028 P-PI-8).
+
+
+def test_co_presence_extreme_divergence_is_not_an_identity_fraud_claim() -> None:
+    # A large delta is physiologically consistent with genuine illness/overreach and must not be
+    # reported as a confirmed determination that someone else used the device.
+    garmin_snap = {"raw": {"restingHr": 43}}
+    eight_bundle = {"observations": [{"metric": "daily_resting_heart_rate_bpm", "value": 95.0}]}
+
+    verdict = validate_co_presence(garmin_snap, eight_bundle, athlete_rhr_28d_median=44.0)
+    assert verdict.verifiedAthlete is False
+    assert verdict.concordanceStatus == "DISCORDANT_SECONDARY"
+    lowered = verdict.reason.lower()
+    assert "imposter" not in lowered
+    assert "another person" not in lowered
+    assert "fraud" not in lowered
+    assert "quarantined" in lowered
+
+
+def test_co_presence_status_vocabulary_has_no_confirmed_identity_verdict() -> None:
+    # The provisional concordanceStatus vocabulary is a quarantine/concordance signal, not an
+    # identity classifier: it must never surface a definitive "NOT_USER"/"USER" determination.
+    # (The ternary USER | NOT_USER | UNCERTAIN model belongs to ADR-0028/PI1+.)
+    known_statuses = {
+        "CONCORDANT",
+        "DISCORDANT_SECONDARY",
+        "UNVERIFIED_OFF_WRIST",
+        "NO_SECONDARY_DATA",
+    }
+    assert "NOT_USER" not in known_statuses
+    assert "USER" not in known_statuses
+
+
+def test_co_presence_quarantines_equally_regardless_of_divergence_magnitude() -> None:
+    garmin_snap = {"raw": {"restingHr": 43}}
+    moderate_bundle = {"observations": [{"metric": "daily_resting_heart_rate_bpm", "value": 60.0}]}
+    extreme_bundle = {"observations": [{"metric": "daily_resting_heart_rate_bpm", "value": 150.0}]}
+
+    moderate = validate_co_presence(garmin_snap, moderate_bundle, athlete_rhr_28d_median=44.0)
+    extreme = validate_co_presence(garmin_snap, extreme_bundle, athlete_rhr_28d_median=44.0)
+
+    # Both are quarantined identically; the heuristic has no mechanism to escalate a bigger
+    # anomaly into a stronger identity claim.
+    assert moderate.concordanceStatus == "DISCORDANT_SECONDARY"
+    assert extreme.concordanceStatus == "DISCORDANT_SECONDARY"
+    assert moderate.verifiedAthlete is False
+    assert extreme.verifiedAthlete is False

--- a/tests/test_presence_filter.py
+++ b/tests/test_presence_filter.py
@@ -117,17 +117,24 @@ def test_co_presence_extreme_divergence_is_not_an_identity_fraud_claim() -> None
 
 
 def test_co_presence_status_vocabulary_has_no_confirmed_identity_verdict() -> None:
-    # The provisional concordanceStatus vocabulary is a quarantine/concordance signal, not an
-    # identity classifier: it must never surface a definitive "NOT_USER"/"USER" determination.
-    # (The ternary USER | NOT_USER | UNCERTAIN model belongs to ADR-0028/PI1+.)
-    known_statuses = {
+    garmin_snap = {"raw": {"restingHr": 44}}
+    concordant = {"observations": [{"metric": "daily_resting_heart_rate_bpm", "value": 45.0}]}
+    discordant = {"observations": [{"metric": "daily_resting_heart_rate_bpm", "value": 82.0}]}
+    statuses = {
+        validate_co_presence(garmin_snap, concordant, 44.0).concordanceStatus,
+        validate_co_presence(garmin_snap, discordant, 44.0).concordanceStatus,
+        validate_co_presence(None, concordant, 44.0).concordanceStatus,
+        validate_co_presence(garmin_snap, None, 44.0).concordanceStatus,
+    }
+
+    assert statuses == {
         "CONCORDANT",
         "DISCORDANT_SECONDARY",
         "UNVERIFIED_OFF_WRIST",
         "NO_SECONDARY_DATA",
     }
-    assert "NOT_USER" not in known_statuses
-    assert "USER" not in known_statuses
+    assert "NOT_USER" not in statuses
+    assert "USER" not in statuses
 
 
 def test_co_presence_quarantines_equally_regardless_of_divergence_magnitude() -> None:


### PR DESCRIPTION
## Summary

<!--
What changed? Name the behavior, module, or artifact—not just the files.
Why now? State the defect, requirement, or decision that motivated it.
What is the user or operational impact? Say "No user-visible change" when applicable.
Keep this to 2–5 bullets. Link the issue, ADR, plan, or analysis document when relevant.
-->

## Validation

<!--
For every applicable check, replace the checkbox with [x] and record the exact outcome below.
For any skipped applicable check, leave it unchecked and explain why. Do not claim CI will validate it.
Include focused manual verification when an automated check cannot prove the change.

Results:
- `command`: pass/fail; what it covered
- Manual check: scenario and observed result
-->

- [ ] `uv run pytest` (backend changes)
- [ ] `uv run ruff check .` and `uv run mypy src/garmin_sync` (backend changes)
- [ ] `cd app && npm run check` (frontend changes)
- [ ] `cd app && npm run test:rules` (Firestore rules changes)
- [ ] `cd app && npm run simulate:scenarios` (recommendation-engine changes)
- [ ] `cd app && npm run visual:refresh` (material UI changes)

## Risk and reviewer guidance

<!--
What should a reviewer inspect most closely, and why?
What could regress? Include data migration, deployment, compatibility, or rollback notes.
Say "Low risk: ..." only with a concrete reason. Link relevant ADRs, architecture docs, or issues.
-->

## Domain invariants

<!--
For each invariant touched by this change, replace [ ] with [x] and state how it was checked.
If none apply, delete the checklist and write "Not applicable — [reason]."
-->

- [ ] Firestore writes remain user-scoped under `users/{APP_USER_ID}/...`; no `default_user` or top-level recovery snapshots were introduced.
- [ ] Calendar-date logic uses `Europe/Warsaw`; completed `totalSteps` still means the previous calendar day (`D - 1`).
- [ ] No credentials, tokens, service-account files, or raw health payloads are included.
- [ ] Recommendation decision logic changed: `POLICY_VERSION` was evaluated and relevant architecture/ADR documentation was updated.

## Screenshots or recordings

<!--
For user-visible changes, attach before/after evidence for the affected desktop and mobile states.
For non-UI changes, write "Not applicable — [reason]."
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added physiological identity assessment using cross-source health signals, session matching, lineage checks, and versioned identity passports.
  * Added identity-based eligibility controls for displaying observations, recovery use, baseline learning, and passport training.
  * Added persistent identity assessments, passport versions, and append-only review events.
  * Added identity decision provenance to recommendation audits and replay validation.
  * Multisource audit reports now include identity-eligible and identity-excluded nights.

* **Security & Reliability**
  * Strengthened validation, immutability, ownership, provenance, and fail-closed handling for identity data and recommendation evidence.

* **Documentation**
  * Clarified that legacy co-presence checks are provisional and do not provide definitive identity verdicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->