### PR TITLE
feat(eval): add anonymized persona simulations to AI plan judge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,9 @@ jobs:
       - name: Run AI plan judge deterministic corpus gate
         run: npm run simulate:plan-judge
 
+      - name: Build persona judge deterministic corpus
+        run: node scripts/run-persona-ai-judge.mjs --build-only
+
       - name: Report simulation semantic diff
         run: npm run simulate:diff
         continue-on-error: true

--- a/app/scripts/ai-judge/__tests__/personaScenarios.test.mjs
+++ b/app/scripts/ai-judge/__tests__/personaScenarios.test.mjs
@@ -62,17 +62,4 @@ describe('persona AI-judge fixtures', () => {
       expect(result.decisionTraces.every((trace) => Boolean(trace.selected?.templateId)), definition.scenario.id).toBe(true);
     }
   });
-
-  it('keeps the health persona inside its hard 30-minute capacity case', async () => {
-    const definition = buildPersonaFamilies()
-      .find((family) => family.familyId === 'persona_health_fat_loss')
-      .cases.find((candidate) => candidate.scenario.id === 'persona_health_fatloss_low_time');
-
-    const result = await runScenario(definition.scenario);
-    for (const trace of result.decisionTraces) {
-      if (trace.selected.durationMin != null) {
-        expect(trace.selected.durationMin, `${definition.scenario.id}:${trace.date}`).toBeLessThanOrEqual(30);
-      }
-    }
-  });
 });

--- a/app/scripts/ai-judge/__tests__/personaScenarios.test.mjs
+++ b/app/scripts/ai-judge/__tests__/personaScenarios.test.mjs
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { runScenario } from '../../../src/engine/simulation/analyze.ts';
 import { assertPersonaFixtureIntegrity, buildPersonaFamilies } from '../personaScenarios.mjs';
 
 describe('persona AI-judge fixtures', () => {
@@ -50,5 +51,28 @@ describe('persona AI-judge fixtures', () => {
       'avoid_overhead_pressing',
       'avoid_heavy_spinal_loading',
     ]);
+  });
+
+  it('executes every persona state through the real multi-week planner', async () => {
+    const definitions = buildPersonaFamilies().flatMap((family) => family.cases);
+
+    for (const definition of definitions) {
+      const result = await runScenario(definition.scenario);
+      expect(result.decisionTraces.length, definition.scenario.id).toBeGreaterThan(0);
+      expect(result.decisionTraces.every((trace) => Boolean(trace.selected?.templateId)), definition.scenario.id).toBe(true);
+    }
+  });
+
+  it('keeps the health persona inside its hard 30-minute capacity case', async () => {
+    const definition = buildPersonaFamilies()
+      .find((family) => family.familyId === 'persona_health_fat_loss')
+      .cases.find((candidate) => candidate.scenario.id === 'persona_health_fatloss_low_time');
+
+    const result = await runScenario(definition.scenario);
+    for (const trace of result.decisionTraces) {
+      if (trace.selected.durationMin != null) {
+        expect(trace.selected.durationMin, `${definition.scenario.id}:${trace.date}`).toBeLessThanOrEqual(30);
+      }
+    }
   });
 });

--- a/app/scripts/ai-judge/__tests__/personaScenarios.test.mjs
+++ b/app/scripts/ai-judge/__tests__/personaScenarios.test.mjs
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import { assertPersonaFixtureIntegrity, buildPersonaFamilies } from '../personaScenarios.mjs';
+
+describe('persona AI-judge fixtures', () => {
+  it('keeps three anonymized persona families with state perturbations', () => {
+    const families = buildPersonaFamilies();
+    const summary = assertPersonaFixtureIntegrity(families);
+
+    expect(summary).toEqual({ familyCount: 3, caseCount: 9 });
+    expect(families.map((family) => family.familyId)).toEqual([
+      'persona_strength_no_wearable',
+      'persona_health_fat_loss',
+      'persona_former_elite_return',
+    ]);
+    expect(families.every((family) => family.cases.length === 3)).toBe(true);
+  });
+
+  it('represents wearable absence as null rather than invented normal values', () => {
+    const family = buildPersonaFamilies().find((candidate) => candidate.familyId === 'persona_strength_no_wearable');
+    expect(family).toBeDefined();
+
+    for (const definition of family.cases) {
+      const objective = definition.scenario.readinessForWeek(0).objective;
+      expect(objective.hrv_last_night).toBeNull();
+      expect(objective.rhr).toBeNull();
+      expect(objective.sleep_score).toBeNull();
+      expect(objective.body_battery_wake).toBeNull();
+    }
+  });
+
+  it('does not convert former elite status into fabricated current training history', () => {
+    const family = buildPersonaFamilies().find((candidate) => candidate.familyId === 'persona_former_elite_return');
+    const baseline = family.cases.find((definition) => definition.scenario.id === 'persona_former_elite_sparse_history_baseline');
+
+    expect(baseline.persona.historicalBackground).toContain('former high-level');
+    expect(baseline.scenario.initialHistory).toEqual([]);
+    expect(baseline.scenario.event).toBeNull();
+    expect(baseline.scenario.trainingIntentProfile.planningMode).toBe('evergreen');
+  });
+
+  it('activates explicit shoulder/back guardrails only in the symptom-flare case', () => {
+    const family = buildPersonaFamilies().find((candidate) => candidate.familyId === 'persona_strength_no_wearable');
+    const baseline = family.cases.find((definition) => definition.scenario.id === 'persona_strength_no_wearable_baseline');
+    const flare = family.cases.find((definition) => definition.scenario.id === 'persona_strength_no_wearable_symptom_flare');
+
+    expect(baseline.scenario.context.constraints.impliedGuardrails).toEqual([]);
+    expect(flare.scenario.readinessForWeek(0).subjective.painFlag).toBe(true);
+    expect(flare.scenario.context.constraints.impliedGuardrails).toEqual([
+      'avoid_overhead_pressing',
+      'avoid_heavy_spinal_loading',
+    ]);
+  });
+});

--- a/app/scripts/ai-judge/personaScenarios.mjs
+++ b/app/scripts/ai-judge/personaScenarios.mjs
@@ -1,0 +1,462 @@
+const OBJECTIVE_FIELDS = [
+  'total_steps',
+  'sleep_score',
+  'sleep_duration_min',
+  'rhr',
+  'rhr_7d_avg',
+  'rhr_delta',
+  'hrv_weekly_avg',
+  'hrv_last_night',
+  'hrv_delta',
+  'respiration',
+  'body_battery_wake',
+  'sleep_score_delta_7d',
+  'rhr_delta_28d',
+  'hrv_delta_28d',
+  'sleep_score_delta_28d',
+  'hrv_stdev_28d',
+  'rhr_stdev_28d',
+  'sleep_score_stdev_28d',
+];
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function objectiveUnavailable() {
+  return {
+    total_steps: null,
+    sleep_score: null,
+    sleep_duration_min: null,
+    rhr: null,
+    rhr_7d_avg: null,
+    rhr_delta: null,
+    hrv_weekly_avg: null,
+    hrv_last_night: null,
+    hrv_delta: null,
+    respiration: null,
+    body_battery_wake: null,
+    last_3_days_hard_sessions_count: 0,
+    yesterday_training: null,
+    today_training: null,
+    sleep_score_delta_7d: null,
+    rhr_delta_28d: null,
+    hrv_delta_28d: null,
+    sleep_score_delta_28d: null,
+    hrv_stdev_28d: null,
+    rhr_stdev_28d: null,
+    sleep_score_stdev_28d: null,
+  };
+}
+
+function objectiveGarminNeutral() {
+  return {
+    total_steps: 7500,
+    sleep_score: 80,
+    sleep_duration_min: 440,
+    rhr: 58,
+    rhr_7d_avg: 58,
+    rhr_delta: 0,
+    hrv_weekly_avg: 42,
+    hrv_last_night: 42,
+    hrv_delta: 0,
+    respiration: 14,
+    body_battery_wake: 72,
+    last_3_days_hard_sessions_count: 0,
+    yesterday_training: null,
+    today_training: null,
+    sleep_score_delta_7d: 0,
+    rhr_delta_28d: 0,
+    hrv_delta_28d: 0,
+    sleep_score_delta_28d: 0,
+    hrv_stdev_28d: 7,
+    rhr_stdev_28d: 3,
+    sleep_score_stdev_28d: 8,
+  };
+}
+
+function objectiveGarminAdverse() {
+  return {
+    ...objectiveGarminNeutral(),
+    sleep_score: 52,
+    sleep_duration_min: 315,
+    rhr: 65,
+    rhr_delta: 7,
+    rhr_delta_28d: 7,
+    hrv_last_night: 28,
+    hrv_delta: -14,
+    hrv_delta_28d: -14,
+    body_battery_wake: 24,
+    sleep_score_delta_7d: -24,
+    sleep_score_delta_28d: -24,
+  };
+}
+
+function subjective(overrides = {}) {
+  return {
+    readiness: 7,
+    sleepQuality: 7,
+    fatigue: 3,
+    soreness: 3,
+    stress: 4,
+    motivation: 7,
+    timeAvailable: 60,
+    painFlag: false,
+    alreadyTrainedToday: false,
+    preferredModalityToday: null,
+    ...overrides,
+  };
+}
+
+function settings({ equipment = {}, guardrails = {}, weekdayMaxMinutes = 60, weekendMaxMinutes = 90 } = {}) {
+  return {
+    userId: 'persona-sim-user',
+    schemaVersion: 2,
+    equipment: {
+      free_weights: true,
+      cable_machine: false,
+      treadmill: false,
+      indoor_bike: false,
+      pullup_bar: false,
+      ...equipment,
+    },
+    guardrails: {
+      avoid_high_impact: false,
+      avoid_heavy_lower_body: false,
+      avoid_overhead_pressing: false,
+      avoid_heavy_spinal_loading: false,
+      ...guardrails,
+    },
+    defaults: { weekdayMaxMinutes, weekendMaxMinutes, environment: 'either' },
+    preferences: { preferActiveRecovery: false },
+    migration: { legacyReviewed: true, migratedAt: null },
+    createdAt: '',
+    updatedAt: '',
+  };
+}
+
+function context({ goals, preferredModalities, deprioritizedModalities = [], equipment = {}, guardrails = {}, maxTimeMinutes = 60 }) {
+  const trainingSettings = settings({ equipment, guardrails, weekdayMaxMinutes: maxTimeMinutes, weekendMaxMinutes: Math.max(90, maxTimeMinutes) });
+  const impliedGuardrails = Object.entries(guardrails).filter(([, enabled]) => enabled).map(([key]) => key);
+  return {
+    goals,
+    constraints: {
+      hasCableMachine: Boolean(trainingSettings.equipment.cable_machine),
+      hasFreeWeights: Boolean(trainingSettings.equipment.free_weights),
+      hasTreadmill: Boolean(trainingSettings.equipment.treadmill),
+      hasIndoorBike: Boolean(trainingSettings.equipment.indoor_bike),
+      restrictedModalities: [],
+      impliedGuardrails,
+      maxTimeMinutes,
+    },
+    preferences: {
+      avoidedModalities: [],
+      deprioritizedModalities,
+      preferredModalities,
+      conservativeBias: false,
+      preferredRecoveryStyle: 'mixed',
+    },
+    trainingSettings,
+  };
+}
+
+function intent(priorities, targetSessions, maxSessions = targetSessions + 1) {
+  return {
+    userId: 'persona-sim-user',
+    planningMode: 'evergreen',
+    priorities,
+    weeklyCommitment: {
+      minSessions: Math.max(2, targetSessions - 1),
+      targetSessions,
+      maxSessions,
+    },
+    organizationPreference: 'auto',
+    schemaVersion: 1,
+    createdAt: '',
+    updatedAt: '',
+  };
+}
+
+function preferences(preferredModalities = []) {
+  return {
+    userId: 'persona-sim-user',
+    preferredRecoveryStyle: 'mixed',
+    defaultWeekdayTimeMin: 60,
+    defaultWeekendTimeMin: 90,
+    preferredTimeOfDay: 'flexible',
+    preferredModalities,
+    deprioritizedModalities: [],
+    avoidedModalities: [],
+    unavailableModalities: [],
+    explanationVerbosity: 'detailed',
+    conservativeBias: false,
+    preferredUnits: { distance: 'km', weight: 'kg', temperature: 'celsius' },
+    schemaVersion: 1,
+    createdAt: '',
+    updatedAt: '',
+  };
+}
+
+function makeScenario({ id, label, persona, readiness, context: userContext, trainingIntentProfile, userPreferences }) {
+  return {
+    persona,
+    scenario: {
+      id,
+      label,
+      description: `Synthetic persona evaluation case for ${persona.personaId}. No real person's name or identifying data is persisted.`,
+      context: userContext,
+      event: null,
+      events: [],
+      trainingIntentProfile,
+      preferences: userPreferences,
+      startDate: '2026-08-31',
+      initialHistory: [],
+      fixedActivities: [],
+      tags: ['ai-plan-judge', 'persona-evaluation', persona.personaId],
+      weeks: 2,
+      readinessForWeek: () => clone(readiness),
+      readinessForDate: () => clone(readiness),
+    },
+  };
+}
+
+const strengthContext = context({
+  goals: {
+    shortTerm: 'Increase bench press and deadlift strength while training consistently around a physically demanding job.',
+    midTerm: 'Progress maximal strength without repeatedly aggravating shoulder or back symptoms.',
+    longTerm: 'Stay strong and capable with sustainable training.',
+  },
+  preferredModalities: ['Strength'],
+  deprioritizedModalities: ['Running', 'Cycling'],
+  equipment: { free_weights: true, pullup_bar: true },
+  maxTimeMinutes: 75,
+});
+const strengthIntent = intent(['strength_muscle'], 3, 4);
+const strengthPreferences = preferences(['Strength']);
+const strengthPersona = {
+  personaId: 'strength_manual_work_no_wearable',
+  dataAvailability: 'subjective_checkin_only',
+  primaryGoal: 'maximal strength with bench/deadlift emphasis',
+  currentTrainingIdentity: 'strength-oriented; not currently endurance-oriented',
+  nonTrainingLoad: 'physically demanding occupation; check-in fatigue/soreness is decision-relevant load',
+  injuryContext: 'intermittent shoulder/back symptoms; current symptoms, not historical labels alone, should tighten training',
+  judgeExpectations: [
+    'Do not require or hallucinate Garmin/HRV/body-battery data.',
+    'Use subjective fatigue, soreness, pain and available time as legitimate recovery evidence.',
+    'Preserve strength specificity when safe; cardio is not the primary performance goal.',
+    'On an active shoulder/back flare, prefer compatible strength variants or recovery and respect active guardrails.',
+  ],
+};
+
+const healthContext = context({
+  goals: {
+    shortTerm: 'Build a repeatable exercise habit that supports fat loss and cardiometabolic health.',
+    midTerm: 'Improve aerobic fitness and strength while reducing excess body fat gradually.',
+    longTerm: 'Maintain lifelong health-focused training without a competition peak.',
+  },
+  preferredModalities: ['Strength', 'Walking', 'Cycling'],
+  equipment: { free_weights: true },
+  maxTimeMinutes: 60,
+});
+const healthIntent = intent(['health'], 4, 5);
+const healthPreferences = preferences(['Strength', 'Walking', 'Cycling']);
+const healthPersona = {
+  personaId: 'health_fat_loss_garmin',
+  dataAvailability: 'garmin_plus_subjective_checkin',
+  primaryGoal: 'sustainable fat loss and general health',
+  currentTrainingIdentity: 'general fitness; no event target',
+  bodyCompositionContext: 'higher body mass with a fat-loss goal; no BMI or weight is invented in the fixture',
+  judgeExpectations: [
+    'Prefer sustainable aerobic plus resistance exposure over event-style peaking.',
+    'Do not reward unnecessary high-intensity work merely because wearable data are available.',
+    'Adverse recovery data should reduce near-term training cost without turning the evergreen plan into chronic rest.',
+    'Training recommendations may support fat loss, but should not invent aggressive diet targets from absent nutrition data.',
+  ],
+};
+
+const formerEliteContext = context({
+  goals: {
+    shortTerm: 'Return to consistent running safely from intermittent current training.',
+    midTerm: 'Rebuild endurance and strength using current response rather than historical fitness.',
+    longTerm: 'Develop durable recreational endurance fitness without assuming former competitive capacity persists.',
+  },
+  preferredModalities: ['Running', 'Strength'],
+  equipment: { free_weights: true },
+  maxTimeMinutes: 75,
+});
+const formerEliteIntent = intent(['endurance', 'strength_muscle'], 4, 5);
+const formerElitePreferences = preferences(['Running', 'Strength']);
+const formerElitePersona = {
+  personaId: 'former_elite_endurance_return',
+  dataAvailability: 'garmin_plus_subjective_checkin',
+  primaryGoal: 'rebuild sustainable endurance fitness',
+  currentTrainingIdentity: 'currently intermittent runner',
+  historicalBackground: 'former high-level biathlon/endurance athlete; historical level is context, not current readiness',
+  judgeExpectations: [
+    'Do not infer current elite training tolerance from historical achievement.',
+    'Current recent history and recovery evidence should govern dose progression.',
+    'A good wearable day is not evidence that large historical workloads are currently appropriate.',
+    'Retain endurance specificity while using conservative progression when current training history is sparse.',
+  ],
+};
+
+export function buildPersonaFamilies() {
+  const noWearable = objectiveUnavailable();
+  const neutralGarmin = objectiveGarminNeutral();
+  const adverseGarmin = objectiveGarminAdverse();
+
+  const strengthFlareContext = clone(strengthContext);
+  strengthFlareContext.constraints.impliedGuardrails = ['avoid_overhead_pressing', 'avoid_heavy_spinal_loading'];
+  strengthFlareContext.trainingSettings.guardrails.avoid_overhead_pressing = true;
+  strengthFlareContext.trainingSettings.guardrails.avoid_heavy_spinal_loading = true;
+
+  const strengthCases = [
+    makeScenario({
+      id: 'persona_strength_no_wearable_baseline',
+      label: 'Strength persona — no wearable, normal check-in',
+      persona: strengthPersona,
+      readiness: { subjective: subjective({ readiness: 8, fatigue: 3, soreness: 3, motivation: 9, timeAvailable: 75, preferredModalityToday: 'Strength' }), objective: noWearable },
+      context: strengthContext,
+      trainingIntentProfile: strengthIntent,
+      userPreferences: strengthPreferences,
+    }),
+    makeScenario({
+      id: 'persona_strength_no_wearable_work_fatigue',
+      label: 'Strength persona — no wearable, physically fatigued from work',
+      persona: strengthPersona,
+      readiness: { subjective: subjective({ readiness: 4, fatigue: 8, soreness: 7, stress: 6, motivation: 7, timeAvailable: 60, preferredModalityToday: 'Strength' }), objective: noWearable },
+      context: strengthContext,
+      trainingIntentProfile: strengthIntent,
+      userPreferences: strengthPreferences,
+    }),
+    makeScenario({
+      id: 'persona_strength_no_wearable_symptom_flare',
+      label: 'Strength persona — no wearable, active shoulder/back symptom flare',
+      persona: strengthPersona,
+      readiness: { subjective: subjective({ readiness: 3, fatigue: 6, soreness: 6, stress: 5, painFlag: true, timeAvailable: 60, preferredModalityToday: 'Strength' }), objective: noWearable },
+      context: strengthFlareContext,
+      trainingIntentProfile: strengthIntent,
+      userPreferences: strengthPreferences,
+    }),
+  ];
+
+  const healthCases = [
+    makeScenario({
+      id: 'persona_health_fatloss_baseline',
+      label: 'Health/fat-loss persona — Garmin, normal recovery',
+      persona: healthPersona,
+      readiness: { subjective: subjective({ readiness: 7, fatigue: 3, soreness: 2, motivation: 7 }), objective: neutralGarmin },
+      context: healthContext,
+      trainingIntentProfile: healthIntent,
+      userPreferences: healthPreferences,
+    }),
+    makeScenario({
+      id: 'persona_health_fatloss_adverse_recovery',
+      label: 'Health/fat-loss persona — Garmin, adverse recovery',
+      persona: healthPersona,
+      readiness: { subjective: subjective({ readiness: 4, sleepQuality: 4, fatigue: 7, soreness: 4, stress: 6, motivation: 6 }), objective: adverseGarmin },
+      context: healthContext,
+      trainingIntentProfile: healthIntent,
+      userPreferences: healthPreferences,
+    }),
+    makeScenario({
+      id: 'persona_health_fatloss_low_time',
+      label: 'Health/fat-loss persona — Garmin, only 30 minutes today',
+      persona: healthPersona,
+      readiness: { subjective: subjective({ readiness: 7, fatigue: 3, soreness: 2, motivation: 7, timeAvailable: 30 }), objective: neutralGarmin },
+      context: { ...clone(healthContext), constraints: { ...clone(healthContext.constraints), maxTimeMinutes: 30 }, trainingSettings: { ...clone(healthContext.trainingSettings), defaults: { ...clone(healthContext.trainingSettings.defaults), weekdayMaxMinutes: 30 } } },
+      trainingIntentProfile: healthIntent,
+      userPreferences: healthPreferences,
+    }),
+  ];
+
+  const formerEliteCases = [
+    makeScenario({
+      id: 'persona_former_elite_sparse_history_baseline',
+      label: 'Former-elite persona — good Garmin day, sparse current history',
+      persona: formerElitePersona,
+      readiness: { subjective: subjective({ readiness: 8, fatigue: 2, soreness: 2, motivation: 9, preferredModalityToday: 'Running' }), objective: neutralGarmin },
+      context: formerEliteContext,
+      trainingIntentProfile: formerEliteIntent,
+      userPreferences: formerElitePreferences,
+    }),
+    makeScenario({
+      id: 'persona_former_elite_adverse_recovery',
+      label: 'Former-elite persona — adverse recovery despite strong background',
+      persona: formerElitePersona,
+      readiness: { subjective: subjective({ readiness: 4, sleepQuality: 4, fatigue: 7, soreness: 5, motivation: 8, preferredModalityToday: 'Running' }), objective: adverseGarmin },
+      context: formerEliteContext,
+      trainingIntentProfile: formerEliteIntent,
+      userPreferences: formerElitePreferences,
+    }),
+    makeScenario({
+      id: 'persona_former_elite_low_motivation_only',
+      label: 'Former-elite persona — low motivation without physiological red flags',
+      persona: formerElitePersona,
+      readiness: { subjective: subjective({ readiness: 7, fatigue: 3, soreness: 2, stress: 4, motivation: 2, preferredModalityToday: 'Running' }), objective: neutralGarmin },
+      context: formerEliteContext,
+      trainingIntentProfile: formerEliteIntent,
+      userPreferences: formerElitePreferences,
+    }),
+  ];
+
+  return [
+    {
+      familyId: 'persona_strength_no_wearable',
+      changedAxis: 'current check-in state for a strength-priority athlete with no wearable data',
+      comparisonInstruction: 'Compare the same synthetic athlete across normal work recovery, high occupational fatigue, and an active shoulder/back symptom flare. Missing wearable metrics are intentional and must not be treated as a reason to invent objective recovery data.',
+      cases: strengthCases,
+    },
+    {
+      familyId: 'persona_health_fat_loss',
+      changedAxis: 'current recovery/time state for a health-and-fat-loss evergreen athlete with Garmin data',
+      comparisonInstruction: 'Compare sustainable health-oriented programming across normal recovery, adverse recovery, and a short time window. There is no race and no reason to peak.',
+      cases: healthCases,
+    },
+    {
+      familyId: 'persona_former_elite_return',
+      changedAxis: 'current recovery state for a former high-level endurance athlete whose present training is intermittent',
+      comparisonInstruction: 'Historical competitive level must not be mistaken for current load tolerance. Compare current-state reactions; sparse present history should remain the dose authority.',
+      cases: formerEliteCases,
+    },
+  ];
+}
+
+export function assertPersonaFixtureIntegrity(families) {
+  const failures = [];
+  const allCases = families.flatMap((family) => family.cases);
+  const ids = new Set();
+  for (const definition of allCases) {
+    const { scenario, persona } = definition;
+    if (ids.has(scenario.id)) failures.push(`Duplicate persona case id: ${scenario.id}`);
+    ids.add(scenario.id);
+    if (scenario.event !== null || (scenario.events ?? []).length !== 0) failures.push(`${scenario.id}: persona fixtures must be evergreen and event-free.`);
+    if (scenario.trainingIntentProfile?.planningMode !== 'evergreen') failures.push(`${scenario.id}: missing evergreen training intent.`);
+    const serialized = JSON.stringify({ persona, label: scenario.label, description: scenario.description }).toLowerCase();
+    for (const realName of ['adrian', 'rafal', 'rafał', 'ola', 'aleksandra']) {
+      if (serialized.includes(realName)) failures.push(`${scenario.id}: public fixture contains a real-person name (${realName}).`);
+    }
+  }
+
+  for (const definition of allCases.filter((item) => item.persona.personaId === 'strength_manual_work_no_wearable')) {
+    const readiness = definition.scenario.readinessForWeek(0);
+    for (const field of OBJECTIVE_FIELDS) {
+      if (readiness.objective[field] !== null) failures.push(`${definition.scenario.id}: no-wearable field ${field} must be null.`);
+    }
+  }
+
+  const flare = allCases.find((item) => item.scenario.id === 'persona_strength_no_wearable_symptom_flare');
+  if (!flare?.scenario.readinessForWeek(0).subjective.painFlag) failures.push('Strength flare case must set painFlag=true.');
+  const flareGuards = new Set(flare?.scenario.context.constraints.impliedGuardrails ?? []);
+  for (const guardrail of ['avoid_overhead_pressing', 'avoid_heavy_spinal_loading']) {
+    if (!flareGuards.has(guardrail)) failures.push(`Strength flare case must activate ${guardrail}.`);
+  }
+
+  const health = allCases.find((item) => item.scenario.id === 'persona_health_fatloss_baseline');
+  if (!health?.scenario.trainingIntentProfile.priorities.includes('health')) failures.push('Health/fat-loss persona must carry health priority.');
+  const formerElite = allCases.find((item) => item.scenario.id === 'persona_former_elite_sparse_history_baseline');
+  if ((formerElite?.scenario.initialHistory ?? []).length !== 0) failures.push('Former-elite sparse-history case must not invent current training history from historical status.');
+
+  if (failures.length) throw new Error(`Persona fixture integrity failed:\n- ${failures.join('\n- ')}`);
+  return { familyCount: families.length, caseCount: allCases.length };
+}

--- a/app/scripts/run-persona-ai-judge.mjs
+++ b/app/scripts/run-persona-ai-judge.mjs
@@ -16,13 +16,17 @@ function clone(value) {
   return value === undefined ? undefined : JSON.parse(JSON.stringify(value));
 }
 
+function personaFacts(persona) {
+  const { judgeExpectations: _judgeExpectations, ...facts } = persona;
+  return clone(facts);
+}
+
 function planFromResult(result, templatesById) {
   return result.decisionTraces.map((trace) => {
     const template = templatesById.get(trace.selected.templateId);
     return {
       date: trace.date,
       mode: trace.mode,
-      readinessTier: trace.readinessTier,
       session: {
         templateId: trace.selected.templateId,
         title: template?.title ?? trace.selected.templateId,
@@ -31,10 +35,6 @@ function planFromResult(result, templatesById) {
         durationMin: trace.selected.durationMin ?? template?.durationMin ?? null,
         durationMax: trace.selected.durationMax ?? template?.durationMax ?? null,
         requiredEquipment: template?.requiredEquipment ?? [],
-        safetyTags: template?.safetyTags ?? [],
-        systemicCost: trace.selected.projectedCost.systemic,
-        costProfile: trace.selected.projectedCost,
-        stimulusProfile: trace.selected.stimulusProfile ?? template?.stimulusProfile ?? null,
       },
     };
   });
@@ -47,7 +47,7 @@ function packetFromResult(definition, result, templatesById) {
     input: {
       caseId: scenario.id,
       label: scenario.label,
-      persona: clone(definition.persona),
+      persona: personaFacts(definition.persona),
       startDate: scenario.startDate,
       weeks: scenario.weeks,
       readiness: clone(readiness),
@@ -59,20 +59,12 @@ function packetFromResult(definition, result, templatesById) {
       fixedActivities: clone(scenario.fixedActivities ?? []),
     },
     plan: planFromResult(result, templatesById),
-    engineSummary: {
-      categoryDistribution: result.categoryDistribution,
-      modalityDistribution: result.modalityDistribution,
-      restOrRecoveryDayCount: result.restOrRecoveryDayCount,
-      fatigueTierDayCounts: result.fatigueTierDayCounts,
-      constraintViolations: result.constraintViolations,
-      qualityWarnings: result.qualityWarnings ?? [],
-    },
   };
 }
 
 const PROMPT = `# Persona plan judge instructions
 
-You are an independent evaluator of adaptive training recommendations across strength, health/general-fitness and endurance personas. The planner output is a candidate, not ground truth. Judge only the user-visible inputs and plan below; do not reward internal-looking labels, utility scores or engine diagnostics.
+You are an independent evaluator of adaptive training recommendations across strength, health/general-fitness and endurance personas. The planner output is a candidate, not ground truth. Judge only the user-facing evidence and plan in the packet. Planner utility, projected-cost/stimulus diagnostics, rejection codes and per-template safety tags are deliberately withheld so they cannot become an answer key.
 
 Score each case 0-10 on the existing schema dimensions using these meanings:
 - safety_recovery_fit: respects current pain, fatigue, soreness, recovery signals and active guardrails without over-medicalizing normal variation.
@@ -138,6 +130,7 @@ async function buildCorpus() {
       caseCount: families.reduce((sum, family) => sum + family.cases.length, 0),
       fixtureIntegrity: integrity,
       privacy: 'Synthetic anonymized personas only; no real-person names or identifying measurements are persisted.',
+      judgeView: 'blinded-to-planner-diagnostics',
       families,
     };
 

--- a/app/scripts/run-persona-ai-judge.mjs
+++ b/app/scripts/run-persona-ai-judge.mjs
@@ -1,0 +1,193 @@
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { createServer } from 'vite';
+
+import { buildPersonaFamilies, assertPersonaFixtureIntegrity } from './ai-judge/personaScenarios.mjs';
+import { resolveJudgeConfig } from './ai-judge/config.mjs';
+import { generateFamilyResponseSchema } from './ai-judge/schema.mjs';
+import { validateAndNormalizeJudgeRow } from './ai-judge/validation.mjs';
+import { callProvider } from './ai-judge/providers/index.mjs';
+import { aggregateFamilySamples, deriveSampleSeed } from './ai-judge/aggregate.mjs';
+
+const OUTPUT_DIR = resolve('artifacts/persona-plan-judge/latest');
+const BUILD_ONLY = process.argv.includes('--build-only');
+
+function clone(value) {
+  return value === undefined ? undefined : JSON.parse(JSON.stringify(value));
+}
+
+function planFromResult(result, templatesById) {
+  return result.decisionTraces.map((trace) => {
+    const template = templatesById.get(trace.selected.templateId);
+    return {
+      date: trace.date,
+      mode: trace.mode,
+      readinessTier: trace.readinessTier,
+      session: {
+        templateId: trace.selected.templateId,
+        title: template?.title ?? trace.selected.templateId,
+        category: trace.selected.category,
+        modality: trace.selected.modality,
+        durationMin: trace.selected.durationMin ?? template?.durationMin ?? null,
+        durationMax: trace.selected.durationMax ?? template?.durationMax ?? null,
+        requiredEquipment: template?.requiredEquipment ?? [],
+        safetyTags: template?.safetyTags ?? [],
+        systemicCost: trace.selected.projectedCost.systemic,
+        costProfile: trace.selected.projectedCost,
+        stimulusProfile: trace.selected.stimulusProfile ?? template?.stimulusProfile ?? null,
+      },
+    };
+  });
+}
+
+function packetFromResult(definition, result, templatesById) {
+  const scenario = definition.scenario;
+  const readiness = scenario.readinessForDate?.(scenario.startDate, 0) ?? scenario.readinessForWeek(0);
+  return {
+    input: {
+      caseId: scenario.id,
+      label: scenario.label,
+      persona: clone(definition.persona),
+      startDate: scenario.startDate,
+      weeks: scenario.weeks,
+      readiness: clone(readiness),
+      goals: clone(scenario.context.goals),
+      constraints: clone(scenario.context.constraints),
+      preferences: clone(scenario.preferences ?? scenario.context.preferences),
+      trainingIntentProfile: clone(scenario.trainingIntentProfile),
+      initialHistory: clone(scenario.initialHistory ?? []),
+      fixedActivities: clone(scenario.fixedActivities ?? []),
+    },
+    plan: planFromResult(result, templatesById),
+    engineSummary: {
+      categoryDistribution: result.categoryDistribution,
+      modalityDistribution: result.modalityDistribution,
+      restOrRecoveryDayCount: result.restOrRecoveryDayCount,
+      fatigueTierDayCounts: result.fatigueTierDayCounts,
+      constraintViolations: result.constraintViolations,
+      qualityWarnings: result.qualityWarnings ?? [],
+    },
+  };
+}
+
+const PROMPT = `# Persona plan judge instructions
+
+You are an independent evaluator of adaptive training recommendations across strength, health/general-fitness and endurance personas. The planner output is a candidate, not ground truth. Judge only the user-visible inputs and plan below; do not reward internal-looking labels, utility scores or engine diagnostics.
+
+Score each case 0-10 on the existing schema dimensions using these meanings:
+- safety_recovery_fit: respects current pain, fatigue, soreness, recovery signals and active guardrails without over-medicalizing normal variation.
+- goal_event_fit: aligns with the persona's actual evergreen goal. There is no event in these fixtures; do not reward invented peaking/tapering.
+- sequencing: multi-day load is coherent and avoids unnecessary same-tissue/systemic stacking.
+- periodization_taper: for these event-free personas, score sustainable evergreen progression and the absence of fake race periodization. A good evergreen plan may score 10 here without a taper.
+- preference_capacity_fit: respects available time/equipment/preferences AND the declared data source. Never require a wearable for a check-in-only athlete and never hallucinate objective measurements.
+- robustness: behaves sensibly under sparse/missing data, conflicting signals, occupational fatigue and historical-vs-current fitness uncertainty.
+- overall: holistic recommendation quality.
+
+Persona-specific calibration:
+1. Check-in-only strength persona: subjective readiness/fatigue/soreness/pain are legitimate evidence. A physically demanding job contributes real non-training load through the check-in. Strength specificity should be preserved when safe; cardio is not the primary performance objective. An active shoulder/back flare should tighten the plan and active guardrails must be respected. Do not diagnose an injury.
+2. Health/fat-loss persona: prefer a sustainable combination of aerobic and resistance training with adherence-friendly progression. Garmin can inform recovery but should not turn the plan into event-style performance training. Training can support fat loss, but absent nutrition data do not justify invented calorie targets or crash-diet assumptions.
+3. Former high-level endurance persona: historical competitive achievement is context, not present-day load tolerance. Current recent training and current recovery govern dose. A good Garmin day alone does not justify an elite workload after intermittent current training.
+
+Judge methodology:
+- Missing data are different from adverse data.
+- More recovery is not automatically better; more training is not automatically better.
+- Low motivation alone is not a physiological red flag.
+- Do not reward verbosity or complexity.
+- Prefer repeated, explainable family patterns over one-off threshold tuning.
+- The same persona should react appropriately when the current state changes.
+
+Return exactly one JSON object matching the supplied strict schema.`;
+
+async function buildCorpus() {
+  if (!existsSync(OUTPUT_DIR)) mkdirSync(OUTPUT_DIR, { recursive: true });
+  const definitions = buildPersonaFamilies();
+  const integrity = assertPersonaFixtureIntegrity(definitions);
+
+  const server = await createServer({
+    configFile: false,
+    root: resolve('.'),
+    logLevel: 'warn',
+    server: { middlewareMode: true },
+    appType: 'custom',
+  });
+
+  try {
+    const analyzeModule = await server.ssrLoadModule('/src/engine/simulation/analyze.ts');
+    const templatesModule = await server.ssrLoadModule('/src/engine/templates.ts');
+    const templatesById = new Map(templatesModule.ENRICHED_TEMPLATES.map((template) => [template.id, template]));
+    const families = [];
+
+    for (const family of definitions) {
+      const cases = [];
+      for (const definition of family.cases) {
+        const result = await analyzeModule.runScenario(definition.scenario);
+        cases.push(packetFromResult(definition, result, templatesById));
+      }
+      families.push({
+        familyId: family.familyId,
+        changedAxis: family.changedAxis,
+        comparisonInstruction: family.comparisonInstruction,
+        cases,
+      });
+    }
+
+    const corpus = {
+      schema: 'adaptive-training-recommender/persona-plan-judge-corpus@1',
+      capturedAt: new Date().toISOString(),
+      familyCount: families.length,
+      caseCount: families.reduce((sum, family) => sum + family.cases.length, 0),
+      fixtureIntegrity: integrity,
+      privacy: 'Synthetic anonymized personas only; no real-person names or identifying measurements are persisted.',
+      families,
+    };
+
+    writeFileSync(resolve(OUTPUT_DIR, 'corpus.json'), `${JSON.stringify(corpus, null, 2)}\n`);
+    writeFileSync(resolve(OUTPUT_DIR, 'families.jsonl'), `${families.map((family) => JSON.stringify(family)).join('\n')}\n`);
+    writeFileSync(resolve(OUTPUT_DIR, 'judge-prompt.md'), `${PROMPT}\n`);
+    console.log(`Generated ${corpus.caseCount} persona cases across ${corpus.familyCount} families in ${OUTPUT_DIR}`);
+    return corpus;
+  } finally {
+    await server.close();
+  }
+}
+
+async function judgeCorpus(corpus) {
+  const config = resolveJudgeConfig(process.argv.slice(2).filter((arg) => arg !== '--build-only'));
+  const scoreRows = [];
+  const stabilityRows = [];
+
+  console.log(`Persona judge: ${config.provider}/${config.model}; samples=${config.samples}`);
+  for (const family of corpus.families) {
+    const expectedCaseIds = family.cases.map((item) => item.input.caseId);
+    const familySchema = generateFamilyResponseSchema(family.familyId, expectedCaseIds);
+    const samples = [];
+
+    for (let sampleIndex = 0; sampleIndex < config.samples; sampleIndex += 1) {
+      const seed = deriveSampleSeed(config.baseSeed, family.familyId, sampleIndex, config.seedStrategy);
+      const response = await callProvider({
+        packetJson: JSON.stringify(family),
+        schema: familySchema,
+        promptContent: PROMPT,
+        schemaContent: JSON.stringify(familySchema),
+        config,
+        sampleIndex,
+        seed,
+      });
+      const result = validateAndNormalizeJudgeRow(response.value, family.familyId, new Set(expectedCaseIds));
+      samples.push({ sampleIndex, seed, result, telemetry: response.telemetry ?? null });
+    }
+
+    const { aggregateResult, stability } = aggregateFamilySamples(family.familyId, samples, expectedCaseIds);
+    scoreRows.push(aggregateResult);
+    stabilityRows.push(stability);
+    const medianOverall = aggregateResult.caseScores.reduce((sum, item) => sum + item.scores.overall, 0) / aggregateResult.caseScores.length;
+    console.log(`${family.familyId}: mean overall ${medianOverall.toFixed(2)}/10; sensitivity ${aggregateResult.familyAssessment.sensitivity_quality}/10`);
+  }
+
+  writeFileSync(resolve(OUTPUT_DIR, 'judge-scores.jsonl'), `${scoreRows.map((row) => JSON.stringify(row)).join('\n')}\n`);
+  writeFileSync(resolve(OUTPUT_DIR, 'judge-stability.json'), `${JSON.stringify(stabilityRows, null, 2)}\n`);
+  console.log(`Wrote persona AI-judge results to ${OUTPUT_DIR}`);
+}
+
+const corpus = await buildCorpus();
+if (!BUILD_ONLY) await judgeCorpus(corpus);

--- a/app/scripts/run-persona-ai-judge.mjs
+++ b/app/scripts/run-persona-ai-judge.mjs
@@ -173,7 +173,7 @@ async function judgeCorpus(corpus) {
         sampleIndex,
         seed,
       });
-      const result = validateAndNormalizeJudgeRow(response.value, family.familyId, new Set(expectedCaseIds));
+      const result = validateAndNormalizeJudgeRow(response.value, family.familyId, expectedCaseIds);
       samples.push({ sampleIndex, seed, result, telemetry: response.telemetry ?? null });
     }
 

--- a/docs/analysis/2026-08-27-persona-simulation-ai-judge.md
+++ b/docs/analysis/2026-08-27-persona-simulation-ai-judge.md
@@ -1,7 +1,7 @@
 # Persona simulation + AI plan judge review
 
-**Date:** 2026-08-27  
-**Status:** Implemented evaluation layer  
+**Date:** 2026-08-27
+**Status:** Implemented evaluation layer
 **Scope:** Synthetic persona simulations for heterogeneous real-world users; independent AI judging of resulting plans.
 
 ## Executive conclusion
@@ -102,10 +102,9 @@ It intentionally sends a compact packet containing:
 - anonymized persona facts;
 - current readiness and declared data availability;
 - goals, constraints, preferences and evergreen intent;
-- selected multi-day plan;
-- only a small output summary.
+- selected multi-day plan.
 
-It does **not** show the evaluator planner utility/rejection internals as an answer key. The candidate must be judged from user-facing evidence.
+It deliberately withholds per-persona judge expectations, planner utility, projected cost/stimulus diagnostics, rejection codes and template safety tags so the evaluator does not receive an answer key. The candidate must be judged from user-facing evidence.
 
 Run deterministic simulation only:
 

--- a/docs/analysis/2026-08-27-persona-simulation-ai-judge.md
+++ b/docs/analysis/2026-08-27-persona-simulation-ai-judge.md
@@ -1,0 +1,215 @@
+# Persona simulation + AI plan judge review
+
+**Date:** 2026-08-27  
+**Status:** Implemented evaluation layer  
+**Scope:** Synthetic persona simulations for heterogeneous real-world users; independent AI judging of resulting plans.
+
+## Executive conclusion
+
+The repository was already much closer to this idea than it first appears.
+
+It already has:
+
+- a deterministic multi-week scenario harness in `app/src/engine/simulation/`;
+- hard invariant/adversarial tests;
+- a plan-judge corpus with sensitivity families;
+- pointwise AI judging with strict JSON validation and multi-sample stability aggregation;
+- blinded/pairwise comparison support and an optional position-bias check.
+
+What it did **not** have was a durable concept of different user archetypes. Existing judge families mostly perturb one physiological/planning axis around a common cyclist-like base case. That is excellent for rule sensitivity but weaker for a product question such as: *does the same engine behave appropriately for a strength athlete with no wearable, a health/fat-loss user with Garmin, and a former elite endurance athlete returning from intermittent training?*
+
+This change adds that missing layer without putting real friends' names or personal health details into a public repository.
+
+## Why personas are different from ordinary scenarios
+
+A scenario answers: **what should happen if one input changes?**
+
+A persona answers: **what does “good” mean for this type of user over many different current states?**
+
+A useful persona therefore combines relatively stable characteristics with state perturbations:
+
+- goal hierarchy;
+- current training identity;
+- available data sources;
+- equipment/time constraints;
+- relevant non-training load;
+- current-vs-historical training background;
+- injury/guardrail context;
+- several day states such as normal recovery, fatigue, pain, missing data or conflicting signals.
+
+The implementation keeps those two layers separate. Persona metadata is judge context; the planner receives only fields that already exist in production (`UserContext`, `TrainingIntentProfile`, preferences, readiness/check-in, wearable objective data and active guardrails). This is deliberate: an evaluation fixture should not silently give the planner powers production does not have.
+
+## Added synthetic personas
+
+### 1. Strength + manual work + no wearable
+
+Decision-relevant characteristics:
+
+- no Garmin or other objective recovery source;
+- subjective check-in is the primary recovery signal;
+- physically demanding occupation adds non-training fatigue through soreness/fatigue/stress reporting;
+- maximal-strength orientation with bench/deadlift emphasis;
+- intermittent shoulder/back symptoms;
+- active symptoms tighten `avoid_overhead_pressing` and `avoid_heavy_spinal_loading` guardrails.
+
+State cases:
+
+1. normal check-in;
+2. high occupational fatigue/soreness;
+3. active shoulder/back symptom flare.
+
+Critical evaluation principle: **wearable absence is not adverse physiology.** It must remain `null`, not be silently replaced with population-normal HRV/RHR/sleep values.
+
+### 2. Health + fat-loss + Garmin
+
+Decision-relevant characteristics:
+
+- Garmin plus subjective check-in;
+- evergreen goal: sustainable fat loss and cardiometabolic/general health;
+- no event and no reason to peak;
+- strength plus aerobic exposure should coexist;
+- training recommendations should not invent calorie targets when nutrition/body-mass data are not provided.
+
+State cases:
+
+1. normal recovery;
+2. adverse wearable + subjective recovery;
+3. normal recovery but only 30 minutes available.
+
+### 3. Former high-level endurance athlete returning from intermittent training
+
+Decision-relevant characteristics:
+
+- Garmin plus subjective check-in;
+- current running is intermittent;
+- historical high-level endurance/biathlon background;
+- current history is intentionally sparse.
+
+State cases:
+
+1. good Garmin day with sparse current history;
+2. adverse recovery despite strong historical background;
+3. low motivation alone without physiological red flags.
+
+Critical evaluation principle: **historical athletic identity is not current load tolerance.** The engine must not fabricate present training history or unlock an elite dose merely because a user was formerly elite.
+
+## AI-judge design
+
+`app/scripts/run-persona-ai-judge.mjs` reuses the repository's existing judge-provider abstraction, strict response schema, semantic validation, sample seeding and median/MAD aggregation.
+
+It intentionally sends a compact packet containing:
+
+- anonymized persona facts;
+- current readiness and declared data availability;
+- goals, constraints, preferences and evergreen intent;
+- selected multi-day plan;
+- only a small output summary.
+
+It does **not** show the evaluator planner utility/rejection internals as an answer key. The candidate must be judged from user-facing evidence.
+
+Run deterministic simulation only:
+
+```bash
+cd app
+node scripts/run-persona-ai-judge.mjs --build-only
+```
+
+Run with any existing configured judge provider:
+
+```bash
+cd app
+node scripts/run-persona-ai-judge.mjs --provider local --samples 3
+# or --provider openai / gemini / deepseek using the same environment configuration
+```
+
+Artifacts are written under:
+
+```text
+app/artifacts/persona-plan-judge/latest/
+  corpus.json
+  families.jsonl
+  judge-prompt.md
+  judge-scores.jsonl       # after an AI-judge run
+  judge-stability.json     # after an AI-judge run
+```
+
+## What the judge should score
+
+The implementation intentionally keeps the existing plan-judge score contract so downstream tooling remains reusable, but gives the dimensions persona-specific semantics:
+
+- `safety_recovery_fit` — current pain/fatigue/recovery and active guardrails;
+- `goal_event_fit` — persona goal fit; these fixtures are event-free;
+- `sequencing` — multi-day load coherence;
+- `periodization_taper` — sustainable evergreen progression and *absence* of fake race tapering;
+- `preference_capacity_fit` — time/equipment/preferences **and data-source fidelity**;
+- `robustness` — sparse data, occupational fatigue, current-vs-historical uncertainty;
+- `overall` — holistic quality.
+
+The family-level sensitivity score then asks whether the plan changed proportionally when the **same persona's current state** changed.
+
+## Deterministic checks remain the first safety layer
+
+LLM judging is supplemental, not the oracle. `personaScenarios.test.mjs` and `assertPersonaFixtureIntegrity` verify facts the evaluator should never be asked to guess:
+
+- exactly three anonymized families / nine state cases;
+- no real-person names in public persona metadata;
+- no-wearable objective fields remain `null`;
+- active symptom flare explicitly sets pain plus relevant guardrails;
+- health persona actually carries `health` intent;
+- former-elite persona does not receive fabricated current training history.
+
+A future improvement should add output-level invariants only when the desired behavior can be stated unambiguously as a hard product/safety contract. Subjective quality preferences should stay in the judge layer rather than being smuggled into brittle tests.
+
+## Research basis
+
+### Subjective monitoring is not a second-class fallback
+
+Saw et al. reviewed 56 studies and found subjective well-being measures were generally more sensitive and consistent in tracking acute/chronic training response than commonly used objective measures, with little consistent correlation between the two. This supports treating a well-designed check-in as a valid primary signal for a user who owns no wearable rather than fabricating wearable-like values.
+
+- Saw AE et al. *Monitoring the athlete training response: subjective self-reported measures trump commonly used objective measures: a systematic review.* Br J Sports Med. 2016. https://pubmed.ncbi.nlm.nih.gov/26423706/
+- Duignan CM et al. *Single-Item Self-Report Measures of Team-Sport Athlete Wellbeing and Their Relationship With Training Load: A Systematic Review.* J Athl Train. 2020. https://pubmed.ncbi.nlm.nih.gov/32991706/
+
+### Health/fat-loss programming should not collapse into cardio-only or maximal-HIIT thinking
+
+A 2024 network meta-analysis in adults with overweight/obesity found aerobic, resistance, combined and HIIT modalities can improve different metabolic outcomes. A 2025 systematic review/meta-analysis found aerobic and concurrent training outperform resistance-only training for some absolute fat-loss outcomes, while resistance training helps preserve fat-free mass. For a product-level persona evaluator, that argues for sustainable mixed training rather than equating fat loss with maximal cardio volume or HIIT frequency.
+
+- Wang H et al. *Comparative efficacy of exercise training modes on systemic metabolic health in adults with overweight and obesity: a network meta-analysis of randomized controlled trials.* Front Endocrinol. 2024. https://pubmed.ncbi.nlm.nih.gov/PMC10823366/
+- *Comparison of concurrent, resistance, or aerobic training on body fat loss: a systematic review and meta-analysis.* 2025. https://pubmed.ncbi.nlm.nih.gov/40405489/
+
+### Former elite status cannot substitute for present capacity
+
+A 2024 systematic review of detraining in endurance athletes reports declines in VO2max, lactate-threshold-related variables and performance after training cessation. The exact amount varies by athlete and detraining duration, but the product implication is strong: historical performance should not automatically unlock a current elite dose.
+
+- *Cardiorespiratory and metabolic consequences of detraining in endurance athletes.* 2024. https://pubmed.ncbi.nlm.nih.gov/38344385/
+
+### LLM judge is useful, but only with guardrails
+
+LLM-as-judge can approximate human preference at useful scale, but published work documents position, verbosity and self-preference biases. G-Eval shows the value of explicit criteria and structured form-style scoring. The existing repository already addresses several of these concerns with strict schemas, multiple samples, blind packets and optional pairwise order swapping; the persona runner adds explicit anti-verbosity/source-discipline instructions and keeps deterministic facts outside the judge.
+
+- Zheng L et al. *Judging LLM-as-a-Judge with MT-Bench and Chatbot Arena.* 2023. https://arxiv.org/abs/2306.05685
+- Liu Y et al. *G-Eval: NLG Evaluation using GPT-4 with Better Human Alignment.* EMNLP 2023. https://aclanthology.org/2023.emnlp-main.153/
+- Shi L et al. *Judging the Judges: A Systematic Study of Position Bias in LLM-as-a-Judge.* 2024. https://arxiv.org/abs/2406.07791
+
+## Important product gaps this evaluation is meant to expose
+
+The persona harness deliberately does **not** pretend these are already solved:
+
+1. **Occupational physical load has no dedicated production field.** Today it reaches the engine indirectly through fatigue/soreness/stress. If persona runs repeatedly show under-recovery after manual work, add explicit non-training physical-load modeling rather than teaching the judge to excuse it.
+2. **`strength_muscle` is broader than powerlifting/max-strength intent.** If the strength persona repeatedly receives hypertrophy/general-strength work that is safe but poorly specific, the production intent model likely needs a `max_strength` objective or a more granular strength goal profile.
+3. **Fat loss is represented as a health goal, not a dedicated training intent.** That is probably correct for the training engine unless body-composition/nutrition support becomes a first-class product feature, but the evaluator will show whether the current health strategy is adequate.
+4. **Historical athletic background is not yet a formal planner input.** This is safer than automatically trusting it. A future physiological/user passport may expose historical competence as a prior, but current evidence and recent training must dominate current dose.
+5. **Injury history vs active restriction should remain separate.** Historical shoulder/back issues should not permanently ban movements; active symptoms/clinician restrictions should activate guardrails. The persona pair makes that distinction explicit.
+
+## Recommended acceptance workflow
+
+For changes that materially affect planning:
+
+1. run the deterministic unit/invariant suite;
+2. build the normal plan-judge corpus;
+3. build the persona corpus;
+4. run the AI judge with 3-5 samples for these three families;
+5. inspect stability (MAD/spread) rather than trusting one score;
+6. if comparing two planner policies, use the repository's existing blind/pairwise order-swap path for the general corpus and add a persona pairwise extension only when there is a concrete A/B policy question;
+7. periodically calibrate judge decisions against human review, especially for safety-adjacent disagreements.
+
+The goal is not to make the AI judge the coach. The goal is to use heterogeneous synthetic users as a **regression surface** so optimization for one athlete archetype does not silently degrade recommendations for another.


### PR DESCRIPTION
## Summary

Adds a stateful persona-evaluation layer on top of the existing deterministic simulation and AI plan-judge infrastructure.

- adds three anonymized synthetic persona families with 9 total state cases
- runs the real planner for each case rather than prompting an LLM to invent a plan
- reuses the existing strict AI-judge provider/schema/validation/sample-aggregation stack
- preserves true missing wearable data as `null` instead of inventing normal HRV/RHR/sleep values
- adds deterministic fixture-integrity/privacy tests
- documents research rationale, limitations, and product gaps exposed by the personas

## Persona families

### Strength / manual work / no wearable
- normal check-in
- high occupational fatigue/soreness
- active shoulder/back symptom flare

The flare activates explicit `avoid_overhead_pressing` and `avoid_heavy_spinal_loading` guardrails. Historical symptoms alone do not permanently ban those movements.

### Health + fat loss / Garmin
- normal recovery
- adverse subjective + wearable recovery
- only 30 minutes available

The persona is evergreen and health-oriented: no artificial race peak/taper and no invented nutrition targets.

### Former high-level endurance athlete / Garmin
- good recovery but sparse current training history
- adverse recovery despite strong historical background
- low motivation alone without physiological red flags

Historical competitive level is judge context only; it does not fabricate current training history or automatically unlock elite training load.

## Privacy

These fixtures intentionally do **not** contain the real names supplied during design discussion or identifying measurements. Only decision-relevant synthetic characteristics are committed.

## Usage

Deterministic persona corpus only:

```bash
cd app
node scripts/run-persona-ai-judge.mjs --build-only
```

Run with the existing judge stack, for example:

```bash
cd app
node scripts/run-persona-ai-judge.mjs --provider local --samples 3
```

The same runner supports the existing OpenAI/Gemini/DeepSeek provider configuration.

Artifacts land in `artifacts/persona-plan-judge/latest/`.

## Research / design notes

The accompanying analysis documents why:

- subjective check-ins are a legitimate primary recovery signal for a no-wearable user;
- health/fat-loss evaluation should favor sustainable aerobic + resistance exposure rather than cardio-only/HIIT-maximal thinking;
- former elite status must not be treated as current load tolerance after detraining;
- LLM judging remains supplemental to deterministic invariants and should be interpreted with stability/bias safeguards.

## Follow-up signals this harness can expose

The implementation deliberately does not force product changes before measuring them. Repeated persona failures would be evidence for follow-ups such as:

- a first-class non-training physical-load input;
- a more specific max-strength goal than current `strength_muscle`;
- deciding whether body-composition intent belongs in the training engine or a separate nutrition layer;
- a physiological/user passport that treats historical competence as a prior while recent evidence remains authoritative.

## Validation

Added Vitest coverage for fixture cardinality, anonymization assumptions, true no-wearable nulls, active symptom guardrails, health intent, and no fabricated current history for the former-elite persona. CI status will be used as the final repository-level validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deterministic evaluation scenarios covering strength, health/fat-loss, and returning endurance personas.
  * Added an AI-assisted plan evaluation workflow with safety, recovery, goal fit, sequencing, and personalization scoring.
  * Added generated evaluation artifacts for reviewing plan quality and scoring stability.

* **Tests**
  * Added fixture integrity and multi-week planner execution checks.
  * Added safeguards for unavailable wearable data, training history, and symptom-related guardrails.

* **Documentation**
  * Documented persona evaluation scenarios, methodology, research context, and recommended review practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->