### PR TITLE
Real Google Health ingestion verification + in-app account linking

### DIFF
--- a/.github/workflows/deploy-garmin-sync.yml
+++ b/.github/workflows/deploy-garmin-sync.yml
@@ -89,6 +89,10 @@ env:
   # it will see Google's "unverified app" warning until verification completes.
   GOOGLE_HEALTH_REDIRECT_URI: https://${{ secrets.GCP_PROJECT_ID }}.web.app/api/google-health/callback
   APP_BASE_URL: https://${{ secrets.GCP_PROJECT_ID }}.web.app
+  # `secrets` is not a valid context in a step-level `if:` (actionlint-confirmed, and per
+  # GitHub's own context-availability docs) -- resolve the gate once here, at the only level
+  # where `secrets` is usable outside a step body, and reference `env.*` in the step `if:`s.
+  GOOGLE_HEALTH_LINKING_ENABLED: ${{ secrets.GOOGLE_HEALTH_CLIENT_ID != '' && secrets.GOOGLE_HEALTH_CLIENT_SECRET != '' }}
 
 jobs:
   deploy:
@@ -143,7 +147,7 @@ jobs:
             --allow-unauthenticated
 
       - name: Deploy Google Health account linker
-        if: ${{ secrets.GOOGLE_HEALTH_CLIENT_ID != '' && secrets.GOOGLE_HEALTH_CLIENT_SECRET != '' }}
+        if: env.GOOGLE_HEALTH_LINKING_ENABLED == 'true'
         env:
           GOOGLE_HEALTH_CLIENT_ID: ${{ secrets.GOOGLE_HEALTH_CLIENT_ID }}
           GOOGLE_HEALTH_CLIENT_SECRET: ${{ secrets.GOOGLE_HEALTH_CLIENT_SECRET }}
@@ -171,7 +175,7 @@ jobs:
             --allow-unauthenticated
 
       - name: Smoke test google-health-account-link service health
-        if: ${{ secrets.GOOGLE_HEALTH_CLIENT_ID != '' && secrets.GOOGLE_HEALTH_CLIENT_SECRET != '' }}
+        if: env.GOOGLE_HEALTH_LINKING_ENABLED == 'true'
         run: |
           SERVICE_URL="$(gcloud run services describe google-health-account-link \
             --region="${REGION}" --format='value(status.url)')"

--- a/.github/workflows/deploy-garmin-sync.yml
+++ b/.github/workflows/deploy-garmin-sync.yml
@@ -46,6 +46,10 @@ on:
         required: true
       GCP_DEPLOYER_SA_EMAIL:
         required: true
+      GOOGLE_HEALTH_CLIENT_ID:
+        required: false
+      GOOGLE_HEALTH_CLIENT_SECRET:
+        required: false
 
 permissions:
   contents: read
@@ -79,6 +83,12 @@ env:
   SCHEDULER_SA_EMAIL: garmin-scheduler-invoker@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com
   TOKEN_BUCKET: ${{ secrets.GCP_PROJECT_ID }}-garmin-tokens
   IMAGE_TAG: ${{ inputs.region }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/garmin-sync/garmin-sync:${{ github.sha }}
+  # Google Health scopes are Restricted -- CASA/Restricted Scope verification is NOT done
+  # (see docs/plans/2026-08-27-real-google-health-ingestion.md). This deploy step is safe to
+  # run regardless (it just stands the linking service up), but every user who links through
+  # it will see Google's "unverified app" warning until verification completes.
+  GOOGLE_HEALTH_REDIRECT_URI: https://${{ secrets.GCP_PROJECT_ID }}.web.app/api/google-health/callback
+  APP_BASE_URL: https://${{ secrets.GCP_PROJECT_ID }}.web.app
 
 jobs:
   deploy:
@@ -131,6 +141,46 @@ jobs:
             --port=8080 --timeout=300 --concurrency=10 \
             --min-instances=0 --max-instances=1 \
             --allow-unauthenticated
+
+      - name: Deploy Google Health account linker
+        if: ${{ secrets.GOOGLE_HEALTH_CLIENT_ID != '' && secrets.GOOGLE_HEALTH_CLIENT_SECRET != '' }}
+        env:
+          GOOGLE_HEALTH_CLIENT_ID: ${{ secrets.GOOGLE_HEALTH_CLIENT_ID }}
+          GOOGLE_HEALTH_CLIENT_SECRET: ${{ secrets.GOOGLE_HEALTH_CLIENT_SECRET }}
+        run: |
+          # Deliberately a SEPARATE service from garmin-account-link, with normal
+          # max-instances (no MFA-style in-memory session to pin to one instance) -- see
+          # docs/plans/2026-08-27-real-google-health-ingestion.md's plan for why. The token
+          # bucket is shared with Garmin's (google-health/ prefix keeps objects separated;
+          # google_health_account_link.py never writes into Garmin's garmin/ prefix).
+          cat > cloud-run-google-health.env.yaml <<EOF
+          GOOGLE_HEALTH_CLIENT_ID: "${GOOGLE_HEALTH_CLIENT_ID}"
+          GOOGLE_HEALTH_CLIENT_SECRET: "${GOOGLE_HEALTH_CLIENT_SECRET}"
+          GOOGLE_HEALTH_REDIRECT_URI: "${GOOGLE_HEALTH_REDIRECT_URI}"
+          GOOGLE_HEALTH_TOKEN_BUCKET: "${TOKEN_BUCKET}"
+          APP_BASE_URL: "${APP_BASE_URL}"
+          GCP_PROJECT_ID: "${GCP_PROJECT}"
+          EOF
+          gcloud run deploy google-health-account-link \
+            --image="${IMAGE_TAG}" --region="${REGION}" \
+            --service-account="${JOB_SA_EMAIL}" \
+            --env-vars-file=cloud-run-google-health.env.yaml \
+            --command=python --args=-m,garmin_sync.google_health_account_link_api \
+            --port=8080 --timeout=300 --concurrency=80 \
+            --min-instances=0 --max-instances=10 \
+            --allow-unauthenticated
+
+      - name: Smoke test google-health-account-link service health
+        if: ${{ secrets.GOOGLE_HEALTH_CLIENT_ID != '' && secrets.GOOGLE_HEALTH_CLIENT_SECRET != '' }}
+        run: |
+          SERVICE_URL="$(gcloud run services describe google-health-account-link \
+            --region="${REGION}" --format='value(status.url)')"
+          if [ -z "${SERVICE_URL}" ]; then
+            echo "Cloud Run did not return a URL for google-health-account-link." >&2
+            exit 1
+          fi
+          curl --fail --silent --show-error --retry 5 --retry-delay 3 --retry-all-errors \
+            "${SERVICE_URL}/health"
 
       - name: Deploy token-only Cloud Run Jobs
         run: |

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -77,6 +77,11 @@ jobs:
       GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
       GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       GCP_DEPLOYER_SA_EMAIL: ${{ secrets.GCP_DEPLOYER_SA_EMAIL }}
+      # Optional: only set once the project owner has created a GitHub secret for these.
+      # google-health-account-link deploys only when both are present (see
+      # deploy-garmin-sync.yml's "Deploy Google Health account linker" step condition).
+      GOOGLE_HEALTH_CLIENT_ID: ${{ secrets.GOOGLE_HEALTH_CLIENT_ID }}
+      GOOGLE_HEALTH_CLIENT_SECRET: ${{ secrets.GOOGLE_HEALTH_CLIENT_SECRET }}
 
   deploy-indexes:
     name: Deploy Firestore indexes

--- a/.gitignore
+++ b/.gitignore
@@ -212,6 +212,8 @@ firebase-service-account.json
 .garmin_tokens/
 garmin_tokens.json
 .garmin_archive/
+.google_health_tokens/
+google_health_tokens.json
 cloud-run-job.env.yaml
 sleep_daily_sample.json
 hrv_range_sample.json

--- a/app/firebase.json
+++ b/app/firebase.json
@@ -43,6 +43,13 @@
         }
       },
       {
+        "source": "/api/google-health/**",
+        "run": {
+          "serviceId": "google-health-account-link",
+          "region": "europe-central2"
+        }
+      },
+      {
         "source": "**",
         "destination": "/index.html"
       }

--- a/app/src/components/preferences/GoogleHealthConnectionSection.tsx
+++ b/app/src/components/preferences/GoogleHealthConnectionSection.tsx
@@ -3,6 +3,7 @@ import { doc, onSnapshot } from 'firebase/firestore';
 import { getDb } from '../../firebase';
 import { googleHealthLinkService } from '../../services/googleHealthLinkService';
 import { getErrorMessage } from '../../utils/errors';
+import { getLocalDateString } from '../../utils/localDate';
 
 interface GoogleHealthConnection {
   status?: string;
@@ -103,7 +104,7 @@ export function GoogleHealthConnectionSection({ userId }: GoogleHealthConnection
 
       {!loadingConnection && isConnected && (
         <p className="preference-success-note">
-          Connected{connection?.linkedAt ? ` since ${new Date(connection.linkedAt).toLocaleDateString()}` : ''}.
+          Connected{connection?.linkedAt ? ` since ${getLocalDateString(new Date(connection.linkedAt))}` : ''}.
         </p>
       )}
 

--- a/app/src/components/preferences/GoogleHealthConnectionSection.tsx
+++ b/app/src/components/preferences/GoogleHealthConnectionSection.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useState } from 'react';
+import { doc, onSnapshot } from 'firebase/firestore';
+import { getDb } from '../../firebase';
+import { googleHealthLinkService } from '../../services/googleHealthLinkService';
+import { getErrorMessage } from '../../utils/errors';
+
+interface GoogleHealthConnection {
+  status?: string;
+  healthUserId?: string;
+  linkedAt?: string;
+}
+
+interface GoogleHealthConnectionSectionProps {
+  userId: string;
+}
+
+/** Reads the ?googleHealthLinked=success|error&reason=... query params left by the OAuth
+ * callback redirect, then strips them from the URL so a page refresh doesn't re-show the
+ * banner. Runs once per mount. */
+function useCallbackBanner(): { success: boolean; reason: string | null } | null {
+  const [banner, setBanner] = useState<{ success: boolean; reason: string | null } | null>(null);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const linked = params.get('googleHealthLinked');
+    if (!linked) return;
+
+    setBanner({ success: linked === 'success', reason: params.get('reason') });
+
+    params.delete('googleHealthLinked');
+    params.delete('reason');
+    const query = params.toString();
+    const url = `${window.location.pathname}${query ? `?${query}` : ''}${window.location.hash}`;
+    window.history.replaceState(null, '', url);
+  }, []);
+
+  return banner;
+}
+
+const REASON_MESSAGES: Record<string, string> = {
+  google_declined: 'Google Health linking was cancelled.',
+  missing_code_or_state: 'Google Health linking response was incomplete. Try again.',
+  invalid_state: 'That link request expired or was already used. Try again.',
+  token_exchange_failed: 'Google rejected the linking request. Try again.',
+  unexpected_error: 'Something went wrong while linking Google Health.',
+};
+
+export function GoogleHealthConnectionSection({ userId }: GoogleHealthConnectionSectionProps) {
+  const [connection, setConnection] = useState<GoogleHealthConnection | null>(null);
+  const [loadingConnection, setLoadingConnection] = useState(true);
+  const [starting, setStarting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const callbackBanner = useCallbackBanner();
+
+  useEffect(() => {
+    const ref = doc(getDb(), 'users', userId, 'connections', 'googleHealth');
+    return onSnapshot(
+      ref,
+      (snap) => {
+        setConnection(snap.exists() ? (snap.data() as GoogleHealthConnection) : null);
+        setLoadingConnection(false);
+      },
+      () => setLoadingConnection(false),
+    );
+  }, [userId]);
+
+  const isConnected = connection?.status === 'active';
+
+  const connect = async () => {
+    setStarting(true);
+    setError(null);
+    try {
+      await googleHealthLinkService.startLink();
+      // startLink() navigates the browser away on success; nothing left to do here.
+    } catch (err: unknown) {
+      setError(getErrorMessage(err) || 'Failed to start Google Health linking.');
+      setStarting(false);
+    }
+  };
+
+  return (
+    <section className="preference-section">
+      <h2>Google Health</h2>
+      <p className="preference-desc">
+        Connect Google Health to pull Eight Sleep (and Health Connect-synced Garmin) recovery
+        data. Google has not finished verifying this app for these data types yet, so you'll see
+        an "unverified app" warning during linking, and you may be asked to reconnect roughly
+        weekly until that's resolved.
+      </p>
+
+      {callbackBanner && (
+        callbackBanner.success ? (
+          <p className="preference-success-note">Google Health is connected to this app account.</p>
+        ) : (
+          <p className="error-message">
+            {(callbackBanner.reason && REASON_MESSAGES[callbackBanner.reason])
+              || 'Google Health linking failed.'}
+          </p>
+        )
+      )}
+
+      {error && <p className="error-message">{error}</p>}
+
+      {!loadingConnection && isConnected && (
+        <p className="preference-success-note">
+          Connected{connection?.linkedAt ? ` since ${new Date(connection.linkedAt).toLocaleDateString()}` : ''}.
+        </p>
+      )}
+
+      <button
+        type="button"
+        className="login-btn"
+        onClick={connect}
+        disabled={starting || loadingConnection}
+      >
+        {starting ? 'Redirecting to Google...' : isConnected ? 'Reconnect Google Health' : 'Connect Google Health'}
+      </button>
+    </section>
+  );
+}

--- a/app/src/components/preferences/index.tsx
+++ b/app/src/components/preferences/index.tsx
@@ -6,6 +6,7 @@ import { ModalitySections } from './ModalitySections';
 import { StyleSections } from './StyleSections';
 import { PerformanceSections } from './PerformanceSections';
 import { GarminConnectionSection } from './GarminConnectionSection';
+import { GoogleHealthConnectionSection } from './GoogleHealthConnectionSection';
 import { HealthRunYogaPresetSection } from './HealthRunYogaPresetSection';
 import type { Screen } from '../../types/navigation';
 import '../Preferences.css';
@@ -76,6 +77,8 @@ export function Preferences({ userId }: PreferencesProps) {
 
       <div className="preferences-content">
         <GarminConnectionSection />
+
+        <GoogleHealthConnectionSection userId={userId} />
 
         <HealthRunYogaPresetSection
           userId={userId}

--- a/app/src/engine/multisourceFusion.ts
+++ b/app/src/engine/multisourceFusion.ts
@@ -32,7 +32,7 @@ export const DEFAULT_METRIC_ACTIVATION_CONFIG: MultisourceMetricActivationConfig
     restingHeartRate: true,
     respiration: true,
     sleepDuration: true,
-    sleepStages: true, // Activated: Eight Sleep BCG is primary for sleep architecture
+    sleepStages: false, // shadow only — 2026-08-27: no real evidence supports activation; see docs/plans/2026-08-27-real-google-health-ingestion.md
     proprietaryScores: false, // blocked
 };
 

--- a/app/src/services/googleHealthLinkService.test.ts
+++ b/app/src/services/googleHealthLinkService.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { googleHealthLinkService } from './googleHealthLinkService';
+
+const mockGetIdToken = vi.fn();
+const mockGetAuthInstance = vi.fn();
+
+vi.mock('../firebase', () => ({
+  getAuthInstance: () => mockGetAuthInstance(),
+}));
+
+const mockFetch = vi.fn();
+// This suite runs under vitest's default `node` test environment (no real `window` global,
+// confirmed: other test files in this project never reference `window` either) -- stub a
+// minimal one rather than pulling in jsdom just for this one navigation assertion.
+const fakeWindow = { location: { href: '' } };
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  mockGetIdToken.mockReset();
+  mockGetIdToken.mockResolvedValue('fake-id-token');
+  mockGetAuthInstance.mockReset();
+  mockGetAuthInstance.mockReturnValue({ currentUser: { getIdToken: mockGetIdToken } });
+  vi.stubGlobal('fetch', mockFetch);
+  fakeWindow.location.href = '';
+  vi.stubGlobal('window', fakeWindow);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('googleHealthLinkService.startLink', () => {
+  it('sends the Firebase bearer token and navigates to the returned authorizeUrl on success', async () => {
+    mockFetch.mockResolvedValue(new Response(
+      JSON.stringify({ authorizeUrl: 'https://accounts.google.com/o/oauth2/v2/auth?state=abc' }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    ));
+
+    await googleHealthLinkService.startLink();
+
+    expect(mockFetch).toHaveBeenCalledWith('/api/google-health/start-link', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer fake-id-token' },
+    });
+    expect(fakeWindow.location.href).toBe('https://accounts.google.com/o/oauth2/v2/auth?state=abc');
+  });
+
+  it('throws without calling fetch when there is no signed-in user', async () => {
+    mockGetAuthInstance.mockReturnValue({ currentUser: null });
+
+    await expect(googleHealthLinkService.startLink()).rejects.toMatchObject({
+      name: 'GoogleHealthLinkError',
+      code: 'google_health_link.app_session_expired',
+    });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('preserves structured server diagnostics for failed requests', async () => {
+    mockFetch.mockResolvedValue(new Response(JSON.stringify({
+      error: 'Server misconfiguration: GOOGLE_HEALTH_CLIENT_ID is not set.',
+      errorCode: 'google_health_link.validation',
+      retryable: false,
+      requestId: 'req-123',
+    }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    }));
+
+    await expect(googleHealthLinkService.startLink()).rejects.toMatchObject({
+      name: 'GoogleHealthLinkError',
+      message: 'Server misconfiguration: GOOGLE_HEALTH_CLIENT_ID is not set.',
+      code: 'google_health_link.validation',
+      status: 400,
+      retryable: false,
+      requestId: 'req-123',
+    });
+  });
+
+  it('classifies transport failures without exposing the raw fetch exception', async () => {
+    mockFetch.mockRejectedValue(new TypeError('Failed to fetch https://internal.example/'));
+
+    await expect(googleHealthLinkService.startLink()).rejects.toEqual(
+      expect.objectContaining({
+        name: 'GoogleHealthLinkError',
+        code: 'google_health_link.network',
+        retryable: true,
+      }),
+    );
+  });
+
+  it('treats a response missing authorizeUrl as a failure even with HTTP 200', async () => {
+    mockFetch.mockResolvedValue(new Response(JSON.stringify({}), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }));
+
+    await expect(googleHealthLinkService.startLink()).rejects.toMatchObject({
+      name: 'GoogleHealthLinkError',
+    });
+  });
+});

--- a/app/src/services/googleHealthLinkService.ts
+++ b/app/src/services/googleHealthLinkService.ts
@@ -1,0 +1,89 @@
+import { getAuthInstance } from '../firebase';
+
+interface GoogleHealthLinkErrorOptions {
+  code: string;
+  status?: number;
+  retryable?: boolean;
+  requestId?: string;
+}
+
+export class GoogleHealthLinkError extends Error {
+  readonly code: string;
+  readonly status?: number;
+  readonly retryable?: boolean;
+  readonly requestId?: string;
+
+  constructor(message: string, options: GoogleHealthLinkErrorOptions) {
+    super(message);
+    this.name = 'GoogleHealthLinkError';
+    this.code = options.code;
+    this.status = options.status;
+    this.retryable = options.retryable;
+    this.requestId = options.requestId;
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value !== null ? value as Record<string, unknown> : {};
+}
+
+function responseRequestId(response: Response, payload: Record<string, unknown>): string | undefined {
+  if (typeof payload.requestId === 'string' && payload.requestId.length > 0) {
+    return payload.requestId;
+  }
+  return response.headers.get('X-Request-ID') ?? undefined;
+}
+
+export const googleHealthLinkService = {
+  /**
+   * Starts the Google Health OAuth linking flow: asks the server for a consent-screen
+   * URL (with a one-time CSRF state token tied to this app account), then navigates the
+   * browser there directly -- unlike Garmin linking, this is a real redirect, not a
+   * request/response exchange, because Google's consent screen has to run in the user's
+   * own browser session.
+   *
+   * The user will see Google's "unverified app" warning (CASA/Restricted Scope
+   * verification is not yet complete -- see docs/plans/2026-08-27-real-google-health-ingestion.md)
+   * and needs to click through Advanced -> Go to (unsafe) -> Allow.
+   */
+  async startLink(): Promise<void> {
+    const currentUser = getAuthInstance().currentUser;
+    if (!currentUser) {
+      throw new GoogleHealthLinkError('Your app session expired. Sign in again first.', {
+        code: 'google_health_link.app_session_expired',
+        retryable: false,
+      });
+    }
+
+    let response: Response;
+    try {
+      response = await fetch('/api/google-health/start-link', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${await currentUser.getIdToken()}` },
+      });
+    } catch {
+      throw new GoogleHealthLinkError(
+        'Google Health linking service could not be reached. Check your connection and try again.',
+        { code: 'google_health_link.network', retryable: true },
+      );
+    }
+
+    const payload = asRecord(await response.json().catch(() => null));
+    const requestId = responseRequestId(response, payload);
+
+    if (!response.ok || typeof payload.authorizeUrl !== 'string') {
+      const message = typeof payload.error === 'string'
+        ? payload.error
+        : 'Could not start Google Health linking.';
+      const code = typeof payload.errorCode === 'string'
+        ? payload.errorCode
+        : `google_health_link.http_${response.status}`;
+      const retryable = typeof payload.retryable === 'boolean'
+        ? payload.retryable
+        : response.status === 429 || response.status >= 500;
+      throw new GoogleHealthLinkError(message, { code, status: response.status, retryable, requestId });
+    }
+
+    window.location.href = payload.authorizeUrl;
+  },
+};

--- a/docs/analysis/2026-08-27-garmin-transport-equivalence-analysis.md
+++ b/docs/analysis/2026-08-27-garmin-transport-equivalence-analysis.md
@@ -1,5 +1,16 @@
 # Empirical Analysis: Garmin Direct vs Google Health Transport Equivalence (MS10)
 
+> **⚠ 2026-08-27 correction (revised) — real run, but re-derive the sleep figures.** An earlier
+> note here claimed this was fabricated; that was too strong and has been retracted — MS0 (which
+> this depends on) was independently re-verified live against the real account. What *is*
+> accurate: a real bug in the sleep mapper (fixed 2026-08-27; it assumed a `sleepSession` shape
+> that doesn't match the real `health.googleapis.com/v4` response) meant Google-transported sleep
+> observations were silently never persisted before the fix. So this doc's RHR figures are
+> plausible, but its sleep-duration/stage `MISSING_GOOGLE`/`INCOMPLETE` figures were measured
+> against data that was incomplete for a code reason, not necessarily a real transport gap —
+> re-run `compare-transports` now that the mapper is fixed before trusting those specific rows.
+> See [`docs/plans/2026-08-27-real-google-health-ingestion.md`](../plans/2026-08-27-real-google-health-ingestion.md).
+
 **Date**: 2026-08-27
 **Dataset**: 59 overlapping calendar days (2026-06-29 to 2026-08-27)
 **Subject**: Live production athlete profile (`Subject-A` / primary athlete profile)

--- a/docs/analysis/2026-08-27-garmin-transport-equivalence-analysis.md
+++ b/docs/analysis/2026-08-27-garmin-transport-equivalence-analysis.md
@@ -1,39 +1,43 @@
 # Empirical Analysis: Garmin Direct vs Google Health Transport Equivalence (MS10)
 
-> **⚠ 2026-08-27 correction (revised) — real run, but re-derive the sleep figures.** An earlier
-> note here claimed this was fabricated; that was too strong and has been retracted — MS0 (which
-> this depends on) was independently re-verified live against the real account. What *is*
-> accurate: a real bug in the sleep mapper (fixed 2026-08-27; it assumed a `sleepSession` shape
-> that doesn't match the real `health.googleapis.com/v4` response) meant Google-transported sleep
-> observations were silently never persisted before the fix. So this doc's RHR figures are
-> plausible, but its sleep-duration/stage `MISSING_GOOGLE`/`INCOMPLETE` figures were measured
-> against data that was incomplete for a code reason, not necessarily a real transport gap —
-> re-run `compare-transports` now that the mapper is fixed before trusting those specific rows.
-> See [`docs/plans/2026-08-27-real-google-health-ingestion.md`](../plans/2026-08-27-real-google-health-ingestion.md).
+> **✅ 2026-08-27 — re-run for real with the fixed pipeline.** This doc originally carried a
+> correction notice questioning whether it was fabricated. That was too strong (see MS0's own
+> correction history) — its RHR figures (74.6% exact match, mean delta 0.593 bpm) and its
+> HRV/respiration `MISSING_GOOGLE` finding reproduced **exactly** when independently re-run today.
+> What genuinely was wrong: its sleep-duration/stage rows, which were measured while a real
+> sleep-mapper bug (fixed 2026-08-27; see
+> [`docs/plans/2026-08-27-real-google-health-ingestion.md`](../plans/2026-08-27-real-google-health-ingestion.md))
+> meant Google-transported sleep observations were silently never persisted. Re-running
+> `compare-transports` after the fix gives a materially different, now-real picture for those
+> rows — replaced below. Everything in this document as it now stands is a genuine,
+> freshly-reproduced `compare-transports` run against the real account (2026-08-27, 14:09 UTC).
 
-**Date**: 2026-08-27
+**Date**: 2026-08-27 (refreshed)
 **Dataset**: 59 overlapping calendar days (2026-06-29 to 2026-08-27)
-**Subject**: Live production athlete profile (`Subject-A` / primary athlete profile)
 **Objective**: Evaluate whether the Google Health transport route provides an equivalent, transforming, or incomplete substitute for direct Garmin Connect ingestion.
 
 ---
 
 ## 1. Executive Summary & Verdict
 
-| Dimension | Result | Empirical Finding |
+| Dimension | Result | Finding |
 |---|---|---|
-| **Overall Classification** | **`INCOMPLETE`** | Google Health transport route cannot replace Garmin Direct. |
-| **Resting Heart Rate (RHR)** | **`EQUIVALENT`** (74.6% exact, Mean $\Delta = 0.59\text{ bpm}$) | Garmin exports daily resting HR reliably to Google Health with near-zero deviation. |
-| **HRV RMSSD** | **`MISSING_GOOGLE`** (0% exported) | Garmin Connect Android app **does not export overnight HRV RMSSD** to Health Connect. |
-| **Respiration Rate** | **`MISSING_GOOGLE`** (0% exported) | Garmin Connect Android app **does not export overnight respiration** to Health Connect. |
-| **Sleep Stages & Duration** | **`INCOMPLETE`** (6/59 days exported) | Garmin Connect syncs sleep sessions irregularly to Health Connect. |
+| **Overall Classification** | **`TRANSFORMING`** | Google Health transport route is not a byte-identical mirror of Garmin Direct, but is no longer simply "incomplete" now that sleep ingestion actually works. |
+| **Resting Heart Rate (RHR)** | **`EQUIVALENT`** (74.6% exact, Mean Δ = 0.593 bpm) | Garmin exports daily resting HR reliably to Google Health with near-zero deviation. Unchanged from the original run — this metric was never affected by the sleep-mapper bug. |
+| **HRV RMSSD** | **`MISSING_GOOGLE`** (0% exported, 0/59 days) | Garmin Connect Android app does **not** export overnight HRV RMSSD to Health Connect. Unchanged — a real transport gap, not a code bug. |
+| **Respiration Rate** | **`MISSING_GOOGLE`** (0% exported, 0/59 days) | Garmin Connect Android app does **not** export overnight respiration to Health Connect. Unchanged — a real transport gap. |
+| **Sleep Duration** | **`TRANSFORMING`** (18.6% exact match, 11/59; mean delta 575s ≈ 9.6 min) | Now genuinely measurable post-fix. Google-transported Garmin sleep duration is close but not identical to direct — plausible rounding/boundary differences, not simply missing. |
+| **Sleep Stages** (deep/light/REM/awake) | **`TRANSFORMING`** (8.9–10.9% exact match across 55–58 evaluated days; small deltas, 0–4.3s mean) | Stage classification boundaries differ slightly between the two transports even when duration is close — consistent with the shadow study's own respiration/HRV baseline note about sensor-dependent variance. |
 
-> **Key Architectural Takeaway**:
-> Direct Garmin ingestion (`src/garmin_sync/garmin_client.py`) remains **strictly necessary** for Garmin HRV, Respiration, Sleep, and Step Count ($D-1$) telemetry. Google Health is **not** a drop-in replacement for Garmin, but serves as the dedicated transport for **Eight Sleep** recovery observations.
+> **Key takeaway, largely unchanged from the original analysis:** direct Garmin ingestion remains
+> necessary for Garmin HRV, respiration, and step count (`D-1`) telemetry — these simply aren't
+> exported to Google Health at all. What's changed is sleep: it's not "missing," it's
+> "transforming" — present via both transports with small, measurable differences, now that the
+> pipeline actually captures it.
 
 ---
 
-## 2. Empirical Comparison Matrix
+## 2. Real Comparison Matrix (re-run 2026-08-27, post-fix)
 
 ```text
 ================================================================================
@@ -43,37 +47,46 @@
   Overlapping Dates:          59
   Direct-Only Dates:          1
   Google-Only Dates:          0
-  Overall Classification:     INCOMPLETE
+  Overall Classification:     TRANSFORMING
 --------------------------------------------------------------------------------
 Metric                             Evaluated  Matches    Match %    Mean Delta
 --------------------------------------------------------------------------------
-daily_resting_heart_rate_bpm       59         44         74.6%      0.593 bpm
-daily_respiration_rate_brpm        59         0          0.0%       (missing)
-hrv_rmssd_ms                       59         0          0.0%       (missing)
-sleep_duration_seconds             59         0          0.0%       (missing)
-sleep_stage_awake_seconds          6          0          0.0%       (missing)
-sleep_stage_deep_seconds           6          0          0.0%       (missing)
-sleep_stage_light_seconds          6          0          0.0%       (missing)
-sleep_stage_rem_seconds            6          0          0.0%       (missing)
+daily_respiration_rate_brpm        59         0          0.0%       0.0
+daily_resting_heart_rate_bpm       59         44         74.6%      0.593
+hrv_rmssd_ms                       59         0          0.0%       0.0
+sleep_duration_seconds             59         11         18.6%      575.172 s
+sleep_stage_awake_seconds          56         5          8.9%       0.0
+sleep_stage_deep_seconds           58         6          10.3%      0.0
+sleep_stage_light_seconds          58         6          10.3%      4.333 s
+sleep_stage_rem_seconds            55         6          10.9%      1.5 s
 ================================================================================
 ```
+
+Reproduce with: `uv run python -m garmin_sync compare-transports --start-date 2026-06-29 --end-date 2026-08-27`
 
 ---
 
 ## 3. Analysis & Implications for Multi-Source Architecture
 
-1. **Resting Heart Rate Equivalence**:
-   - For 44 of 59 days (74.6%), Garmin Google Health RHR matched Garmin Direct RHR with 0 bpm difference. The 15 nonmatching days exhibited small 1–3 bpm synchronization window deltas (mean delta of 2.33 bpm among nonmatching days, yielding an overall mean delta of 0.593 bpm across all 59 days), confirming that Google Health faithfully captures Garmin's passive daily RHR within acceptable discrete precision.
-2. **Missing HRV & Respiration from Garmin**:
-   - Garmin Connect Android app (`com.garmin.android.apps.connectmobile`) omits HRV and Respiration when exporting to Android Health Connect / Google Health.
-   - This validates the **ADR-0027** multi-provider design: we cannot consolidate all Garmin ingestion through Google Health.
-3. **Role of Eight Sleep**:
-   - While Garmin does not export HRV/Respiration to Google Health, **Eight Sleep** (`com.eightsleep.eight`) exports comprehensive 100% complete overnight HRV RMSSD, respiration rate, and 4-stage sleep sessions into Google Health.
-   - Therefore, the dual-source architecture (**Garmin Direct for Garmin metrics + Google Health for Eight Sleep metrics**) is the scientifically optimal configuration.
+1. **Resting Heart Rate Equivalence** — unchanged from the original finding: 44 of 59 days
+   (74.6%) match exactly, remaining days show small (1–3 bpm) deltas, mean 0.593 bpm overall.
+   Google Health faithfully captures Garmin's passive daily RHR.
+2. **HRV & Respiration genuinely absent from Garmin's Google Health export** — confirmed real,
+   not a bug: 0/59 days for both metrics, consistent across two independent runs (original and
+   this refresh). Garmin Connect simply does not export these to Health Connect.
+3. **Sleep is present but transforms slightly, not missing** — the corrected picture. Duration
+   matches exactly on only 18.6% of days but with a modest mean delta (~9.6 min); stage-level
+   classification (deep/light/REM/awake) matches exactly less often (~9-11%) with very small mean
+   deltas (0–4.3 seconds) on the days it doesn't. This reads as boundary/rounding differences
+   between Garmin's own algorithm and however Health Connect's schema represents the same
+   session, not as one transport losing data the other has.
+4. **Dual-source architecture remains the right call** — Garmin Direct stays necessary for HRV,
+   respiration, and steps; Eight Sleep (via Google Health) remains the only source for those same
+   metrics on nights the Garmin watch isn't worn.
 
 ---
 
-## 4. Next Steps & Impact on MS Roadmap
+## 4. Status
 
-* **MS10**: Complete (`[x]`).
-* **MS14 / MS15**: Proceed to evaluate Eight Sleep vs Garmin Direct cross-source correlation and design the candidate evidence fusion evaluator.
+* **MS10**: Complete (`[x]`), now backed by a genuine post-fix measurement rather than one taken
+  while sleep ingestion was silently broken.

--- a/docs/analysis/2026-08-27-garmin-transport-equivalence-analysis.md
+++ b/docs/analysis/2026-08-27-garmin-transport-equivalence-analysis.md
@@ -81,8 +81,9 @@ Reproduce with: `uv run python -m garmin_sync compare-transports --start-date 20
    between Garmin's own algorithm and however Health Connect's schema represents the same
    session, not as one transport losing data the other has.
 4. **Dual-source architecture remains the right call** — Garmin Direct stays necessary for HRV,
-   respiration, and steps; Eight Sleep (via Google Health) remains the only source for those same
-   metrics on nights the Garmin watch isn't worn.
+   respiration, and steps (steps are Garmin-direct-only regardless, per `D-MS-STEPS`/P9 — Eight
+   Sleep, a bed sensor, has no step data to offer). Eight Sleep (via Google Health) remains the
+   only source for HRV and respiration specifically on nights the Garmin watch isn't worn.
 
 ---
 

--- a/docs/analysis/2026-08-27-google-health-source-provenance-probe.md
+++ b/docs/analysis/2026-08-27-google-health-source-provenance-probe.md
@@ -37,6 +37,14 @@ daily-respiratory-rate       287      NO         YES          none
 ===========================================================================
 ```
 
+Counts above (including the 287 `daily-respiratory-rate` points) come from the **unfiltered
+full-account-history** result — the date-range filter was confirmed non-functional at probe time
+(see [`docs/plans/2026-08-27-real-google-health-ingestion.md`](../plans/2026-08-27-real-google-health-ingestion.md)),
+so this is not a "recent" window. The `com.eightsleep.eight` source attribution itself is real —
+package-name provenance detection doesn't depend on the date filter — but §2's respiration-field-shape
+caveat still applies: provenance being confirmed here doesn't mean the individual field values were
+successfully parsed or verified.
+
 ### Key Architectural Answers:
 1. **Eight Sleep Status (`FULL_PASS`)**: Eight Sleep Android app actively exports all 4 key physiological recovery metrics to Google Health under package identity `com.eightsleep.eight`.
 2. **Eight Sleep Path Decision (MS11)**: **Resolved in favor of Google Health path**. There is no need for a reverse-engineered direct API scraper for Eight Sleep (`MS18` unnecessary). Google Health provides official, structured, high-fidelity Eight Sleep recovery data.
@@ -116,15 +124,21 @@ this remains an open, lower-priority follow-up rather than a completed check.
 
 ## 7. Latency (runbook §12)
 
-Approximated Garmin's Health-Connect-to-Google-Health-API sync latency using each sleep record's
-stage `createTime` minus the sleep session's own `endTime`, for the 8 most recent real sleep
-records: samples (minutes) were **1.0, 15.3, 18.3, 19.6, 40.3, 176.2, 288.5, 389.8** — mean ≈119
-minutes, but with wide spread (roughly 1 minute to ~6.5 hours). This is a rough proxy (stage
-`createTime` isn't necessarily the moment the API became queryable, just when Health Connect
-recorded the stage), but the spread alone is a real, useful signal: **latency is not reliably fast
-enough to assume same-morning availability for a recommendation** — a repair-sync/backfill lookback
-window is necessary, not just a same-day poll. No Eight Sleep-side latency sample was available
-(no recent Eight Sleep records in the windows queried — see §2's note on unconfirmed respiration).
+Approximated a **device-to-Health-Connect recording delay** (not API availability — see caveat
+below) using each sleep record's stage `createTime` minus the sleep session's own `endTime`, for
+the 8 most recent real sleep records: samples (minutes) were **1.0, 15.3, 18.3, 19.6, 40.3, 176.2,
+288.5, 389.8** — mean ≈119 minutes, wide spread (roughly 1 minute to ~6.5 hours).
+
+**This measures only the first of two latency legs** (device/app → Health Connect); it says
+nothing about the second leg (Health Connect → queryable via the Google Health REST API), since
+no paired timestamp for "when a request against this record first succeeded" was captured. The
+spread itself is real and worth having, but the operational conclusion it can actually support is
+narrower than "same-morning availability is unreliable" — that specific claim needs paired
+API-observation timestamps this probe didn't collect. What the measured spread *does* support:
+Health Connect recording itself is not instantaneous relative to the sleep session ending, so a
+repair-sync/backfill lookback window is prudent regardless of what the second leg turns out to
+add. No Eight Sleep-side latency sample was available (no recent Eight Sleep records in the
+windows queried — see §2's note on unconfirmed respiration).
 
 ## 8. Date/time semantics (runbook §13)
 
@@ -177,7 +191,7 @@ Health Connect's full category list).
 - date semantics understood — ✅ (§8), DST transition intentionally left unverified
 - duplicate/revision behavior understood enough for MS2 — partial (§6); real device-resync
   behavior remains untested
-- latency measured — ✅ (§7), wide variance, repair-sync lookback confirmed necessary
+- latency measured — ✅ (§7), device-to-Health-Connect leg only; API-availability leg unmeasured
 - sanitized evidence published — ✅ this document
 - MS plan updated accordingly — ✅ (parent plan's task board)
 

--- a/docs/analysis/2026-08-27-google-health-source-provenance-probe.md
+++ b/docs/analysis/2026-08-27-google-health-source-provenance-probe.md
@@ -1,5 +1,14 @@
 # Google Health Source-Provenance Probe Results (MS0 Analysis)
 
+> **✅ 2026-08-27 — independently re-verified.** An earlier note here questioned whether this
+> probe was ever run against a real account. That was wrong and has been retracted: re-running
+> `probe-health` live against the real account on 2026-08-27 reproduced these exact figures
+> (633/320/631/287 data points, Eight Sleep `FULL_PASS`, Garmin `PRESENT`). The original probe
+> was real. See
+> [`docs/plans/2026-08-27-real-google-health-ingestion.md`](../plans/2026-08-27-real-google-health-ingestion.md)
+> for what was checked and for real bugs found (and fixed) elsewhere in the pipeline while
+> verifying this.
+
 **Date**: 2026-08-27
 **Timezone**: `Europe/Warsaw`
 **Governing ADR**: [`ADR-0027`](../adr/0027-source-aware-multisource-health-observations.md)
@@ -44,14 +53,29 @@ daily-respiratory-rate       287      NO         YES          none
 
 ## 2. Source-Provenance Matrix
 
-| Metric Stream | Provider | Origin Package | Payload Fields |
+> **Corrected 2026-08-27:** the "Payload Fields" column originally here (`sleepSession`, `stages`,
+> `summary`, bare `rmssd`/`bpm` keys) did **not** match the real API response shape — this was a
+> real inaccuracy, independent of the top-level counts (which are real). Replaced with field
+> shapes confirmed live against the account, structure-only.
+
+| Metric Stream | Provider | Origin Package | Real Payload Fields (confirmed live) |
 |---|---|---|---|
-| **Sleep** | `garmin` | `com.garmin.android.apps.connectmobile` | `sleepSession`, `stages`, `summary` (`minutesAsleep`, `minutesAwake`, `stagesSummary`) |
-| **Sleep** | `eight_sleep` | `com.eightsleep.eight` | `sleepSession`, `stages`, `summary` |
-| **HRV (RMSSD)** | `eight_sleep` | `com.eightsleep.eight` | `dailyHeartRateVariability`, `rmssd` |
-| **Resting HR** | `garmin` | `com.garmin.android.apps.connectmobile` | `dailyRestingHeartRate`, `bpm` |
-| **Resting HR** | `eight_sleep` | `com.eightsleep.eight` | `dailyRestingHeartRate`, `bpm` |
-| **Respiratory Rate** | `eight_sleep` | `com.eightsleep.eight` | `dailyRespiratoryRate`, `rate` |
+| **Sleep** | `garmin` | `com.garmin.android.apps.connectmobile` | `sleep.interval.{startTime,endTime,startUtcOffset,endUtcOffset}`, `sleep.type`, `sleep.stages[]` (flat list of `{startTime,endTime,type,createTime,updateTime}`) |
+| **Sleep** | `eight_sleep` | `com.eightsleep.eight` | same `sleep.interval`/`sleep.stages` shape as Garmin (not independently re-confirmed for this provider specifically — inferred from the shared data type schema) |
+| **HRV (RMSSD)** | `eight_sleep` | `com.eightsleep.eight` | `dailyHeartRateVariability.{date:{year,month,day}, averageHeartRateVariabilityMilliseconds, deepSleepRootMeanSquareOfSuccessiveDifferencesMilliseconds}` |
+| **Resting HR** | `garmin` | `com.garmin.android.apps.connectmobile` | `dailyRestingHeartRate.{date:{year,month,day}, beatsPerMinute}` — note `beatsPerMinute` is returned as a **string**, not a number |
+| **Resting HR** | `eight_sleep` | `com.eightsleep.eight` | same shape as Garmin RHR (not independently re-confirmed for this provider specifically) |
+| **Respiratory Rate** | `eight_sleep` | `com.eightsleep.eight` | **not confirmed live** — no respiration records appeared in the recent windows queried while investigating (see §12); field name unverified, treat the mapper's candidate field list as unconfirmed until a record is actually observed |
+
+Raw points for all four data types carry **no flat `dataTypeName`/`dataType` field** — the type is
+only recoverable from the point's `name` resource path (`users/{id}/dataTypes/{type}/dataPoints/{id}`).
+The three daily-summary types (HRV/RHR/respiration) additionally carry **no `name` field at all**
+in the raw `list` response (confirmed for RHR; consistent across the daily-summary family) — so
+`dataPointId`/`id`/`name`-based `source_record_id` is `null` for these observations. This doesn't
+break Firestore persistence (dedup happens at the whole-day-bundle content-hash level, not
+per-observation-id — see `firestore_repository.save_health_observation_day_bundle`), but it does
+mean per-observation audit traceability is weaker for these three types than for sleep. Not fixed;
+flagged as a known limitation.
 
 ---
 
@@ -60,3 +84,66 @@ daily-respiratory-rate       287      NO         YES          none
 - **Storage Isolation**: Ingested observations are stored under `users/{userId}/health_observation_days/{YYYY-MM-DD}_{provider}_{transport}`.
 - **Engine Isolation**: Production recommendation engine remains untouched and reads from `daily_recovery_snapshots`.
 - **Step Count Lock (`D-MS-STEPS` / `P9`)**: Aggregator step counts from Google Health are strictly filtered out to prevent double-counting structured workout strain.
+
+---
+
+## 4. Identity (runbook §6)
+
+`GoogleHealthClient.get_identity()` succeeded live, returning `healthUserId`, `legacyUserId`, and
+`name`. Not printed here (kept local per runbook §2's sensitivity guidance) — its only use is
+mapping a future webhook notification back to this account, which is out of scope while MS9's
+webhook subscriber stays undeployed.
+
+## 5. Raw list vs. `:reconcile` (runbook §11)
+
+Called `dataPoints:reconcile` for the `sleep` data type. Structural finding, independent of any
+count comparison (the reconcile call in this check used a different, unscoped window than the raw
+comparison, so point counts between the two aren't a fair apples-to-apples number — not reported
+here for that reason): **reconciled points carry no `dataSource` object at all** — no package
+name, no platform, no recording method. This confirms the runbook's assumption directly: reconcile
+output cannot be used for source-aware recovery science (no way to attribute a reconciled point to
+Garmin vs. Eight Sleep), and the codebase's existing choice to use raw `list` exclusively for
+recovery-critical ingestion (MS5/MS6) is correct.
+
+## 6. Duplicate / revision behavior (runbook §14)
+
+Repeated the same `daily-resting-heart-rate` query twice: identical record count and identical
+value set both times (stable, no revision drift observed in this short window). Sleep records
+(which do carry a real `name`) showed 8 unique names for 8 points — no duplicates within a single
+call. No multi-day resync was performed to test true revision/update behavior (would need a
+device resync event to happen naturally, per the runbook's guidance not to manufacture one) —
+this remains an open, lower-priority follow-up rather than a completed check.
+
+## 7. Latency (runbook §12)
+
+Approximated Garmin's Health-Connect-to-Google-Health-API sync latency using each sleep record's
+stage `createTime` minus the sleep session's own `endTime`, for the 8 most recent real sleep
+records: samples (minutes) were **1.0, 15.3, 18.3, 19.6, 40.3, 176.2, 288.5, 389.8** — mean ≈119
+minutes, but with wide spread (roughly 1 minute to ~6.5 hours). This is a rough proxy (stage
+`createTime` isn't necessarily the moment the API became queryable, just when Health Connect
+recorded the stage), but the spread alone is a real, useful signal: **latency is not reliably fast
+enough to assume same-morning availability for a recommendation** — a repair-sync/backfill lookback
+window is necessary, not just a same-day poll. No Eight Sleep-side latency sample was available
+(no recent Eight Sleep records in the windows queried — see §2's note on unconfirmed respiration).
+
+## 8. Date/time semantics (runbook §13)
+
+All sampled sleep records carried `startUtcOffset`/`endUtcOffset` of `7200s` (UTC+2), consistent
+with `Europe/Warsaw` during CEST (summer). `derive_warsaw_logical_date()` correctly converted a
+record ending `2026-08-27T04:07:44Z` (06:07 local) to logical date `2026-08-27`. DST-transition
+behavior was **not** tested (no transition occurred in the sampled window) — per the runbook's own
+guidance, this is deliberately left unverified until an actual transition is observed rather than
+simulated.
+
+## 9. Remaining open items
+
+- Runbook §3 (Health Connect phone-side check: confirming Garmin/Eight Sleep appear as connected
+  apps with the expected read/write permissions) — needs the project owner to check their Android
+  device directly; not done.
+- Respiration field shape (§2) — not confirmed live; no recent records appeared in the windows
+  queried.
+- True revision/duplicate behavior across a real device resync (§6) — not tested, deliberately not
+  manufactured.
+- MS17's CASA Tier 2 / Google Restricted Scope App Verification status — separately tracked as
+  genuinely unconfirmed; see
+  [`docs/plans/2026-08-27-real-google-health-ingestion.md`](../plans/2026-08-27-real-google-health-ingestion.md).

--- a/docs/analysis/2026-08-27-google-health-source-provenance-probe.md
+++ b/docs/analysis/2026-08-27-google-health-source-provenance-probe.md
@@ -135,11 +135,30 @@ behavior was **not** tested (no transition occurred in the sampled window) — p
 guidance, this is deliberately left unverified until an actual transition is observed rather than
 simulated.
 
-## 9. Remaining open items
+## 9. Health Connect phone-side check (runbook §3)
 
-- Runbook §3 (Health Connect phone-side check: confirming Garmin/Eight Sleep appear as connected
-  apps with the expected read/write permissions) — needs the project owner to check their Android
-  device directly; not done.
+Checked directly on the project owner's Android device (2026-08-27):
+
+```text
+Garmin connected? yes
+Garmin write categories visible: all categories toggled on
+Eight Sleep connected? yes
+Eight Sleep write categories visible: all categories toggled on
+Eight Sleep read categories visible: (not distinguished separately by the device UI)
+```
+
+Both apps are connected to Health Connect with every category enabled. As the runbook itself
+notes, this UI check alone can't prove *export direction* — it only confirms permission is
+granted, not that data actually flows. That direction question is already answered by the live
+API data pulled in §1/§2 (real Eight Sleep-sourced HRV/RHR/respiration/sleep records with
+`com.eightsleep.eight` provenance, and real Garmin-sourced sleep/RHR records) — this phone-side
+check is corroborating, not the primary evidence. "All categories toggled on" is also consistent
+with the real backfilled data covering more than just the four data types this probe specifically
+queried (§2's data-type list was deliberately scoped to the required recovery metric set, not
+Health Connect's full category list).
+
+## 10. Remaining open items
+
 - Respiration field shape (§2) — not confirmed live; no recent records appeared in the windows
   queried.
 - True revision/duplicate behavior across a real device resync (§6) — not tested, deliberately not
@@ -147,3 +166,20 @@ simulated.
 - MS17's CASA Tier 2 / Google Restricted Scope App Verification status — separately tracked as
   genuinely unconfirmed; see
   [`docs/plans/2026-08-27-real-google-health-ingestion.md`](../plans/2026-08-27-real-google-health-ingestion.md).
+
+## 11. Phase 1 exit criteria (runbook §18)
+
+- source application provenance observed and recorded — ✅ (§2)
+- Eight Sleep export direction empirically classified — ✅ `FULL_PASS` (§1, corroborated by §9)
+- Garmin transport behavior classified — ✅ present, sleep/RHR confirmed real-shape (§2)
+- minimum viable scopes known — ✅ (`googlehealth.sleep.readonly`,
+  `googlehealth.health_metrics_and_measurements.readonly`)
+- date semantics understood — ✅ (§8), DST transition intentionally left unverified
+- duplicate/revision behavior understood enough for MS2 — partial (§6); real device-resync
+  behavior remains untested
+- latency measured — ✅ (§7), wide variance, repair-sync lookback confirmed necessary
+- sanitized evidence published — ✅ this document
+- MS plan updated accordingly — ✅ (parent plan's task board)
+
+Phase 1 is substantively complete. The two remaining open items (§10) are lower-priority
+follow-ups, not blockers.

--- a/docs/analysis/2026-08-27-multisource-metric-activation-decision.md
+++ b/docs/analysis/2026-08-27-multisource-metric-activation-decision.md
@@ -1,19 +1,29 @@
 # Formal Decision Record: Multisource Metric-by-Metric Production Activation (MS17)
 
-> **⚠ 2026-08-27 correction (revised) — CASA/verification status is genuinely unconfirmed.** An
-> earlier note here called this document fabricated outright; that was too strong for this file
-> as a whole and has been retracted for its non-CASA content. What remains a real, open problem:
-> this doc claims a completed "Google Cloud Restricted Scope App Verification & CASA Tier 2
-> security assessment," and the project owner has confirmed **they are not sure whether that was
-> actually done**. Treat that specific gate as unresolved, not satisfied, until confirmed (e.g.
-> by checking the OAuth consent screen's publishing status in Google Cloud Console) — do not rely
-> on this doc as evidence the gate is met. Separately, and regardless of the CASA question: this
-> doc's metric figures depend on MS10/MS14, whose sleep-related numbers need re-deriving after a
-> real sleep-mapper bug fix (2026-08-27); and it was internally inconsistent with the code it
-> describes (`sleepStages: false` here vs. `true` in `multisourceFusion.ts` at the time — code
-> now matches this doc's stated shadow-only intent, pending real re-evaluation). Nothing described
-> as "ACTIVE" here is wired into the production recommendation engine —
-> `evaluateMultisourceFusion` is only called from its own unit test and the simulation harness.
+> **❌ 2026-08-27 — CASA/verification confirmed NOT done.** This doc claims a completed "Google
+> Cloud Restricted Scope App Verification & CASA Tier 2 security assessment." That is false,
+> definitively (not just unconfirmed as an earlier revision of this note said). Checked directly
+> in Google Cloud Console (Google Auth Platform → Data Access, and Verification Center,
+> 2026-08-27): the project is `In production`/`External`, but **zero scopes are registered** in
+> Data Access — the Google Health scopes actually used all session
+> (`googlehealth.sleep.readonly`, `googlehealth.health_metrics_and_measurements.readonly`) were
+> never declared there. Verification Center reports "not required" only because nothing is
+> declared, not because the scopes are exempt — Google's own docs confirm all Google Health API
+> scopes are classified **Restricted**, which requires a privacy/security review (CASA Tier 2) for
+> production use. **Real access has been happening via an undeclared, unverified grant** (OAuth
+> Playground with custom client credentials, bypassing Console's declared-scope gate) — this has
+> worked so far but carries a real risk: Google could restrict or revoke it at any time, since it
+> isn't going through the verification flow that exists specifically to govern this scope class.
+> This gate is not merely unmet — it hasn't been started.
+>
+> Separately, and regardless of the CASA question: this doc's metric figures depend on MS10/MS14,
+> both of which have since been re-derived for real (2026-08-27) after a real sleep-mapper bug fix
+> — see the refreshed [MS10](2026-08-27-garmin-transport-equivalence-analysis.md) and
+> [MS14](2026-08-27-multisource-shadow-study.md) docs. It was also internally inconsistent with
+> the code it describes (`sleepStages: false` here vs. `true` in `multisourceFusion.ts` at the
+> time — code now matches this doc's stated shadow-only intent). Nothing described as "ACTIVE"
+> here is wired into the production recommendation engine — `evaluateMultisourceFusion` is only
+> called from its own unit test and the simulation harness.
 > See [`docs/plans/2026-08-27-real-google-health-ingestion.md`](../plans/2026-08-27-real-google-health-ingestion.md).
 
 **Date**: 2026-08-27

--- a/docs/analysis/2026-08-27-multisource-metric-activation-decision.md
+++ b/docs/analysis/2026-08-27-multisource-metric-activation-decision.md
@@ -1,5 +1,21 @@
 # Formal Decision Record: Multisource Metric-by-Metric Production Activation (MS17)
 
+> **⚠ 2026-08-27 correction (revised) — CASA/verification status is genuinely unconfirmed.** An
+> earlier note here called this document fabricated outright; that was too strong for this file
+> as a whole and has been retracted for its non-CASA content. What remains a real, open problem:
+> this doc claims a completed "Google Cloud Restricted Scope App Verification & CASA Tier 2
+> security assessment," and the project owner has confirmed **they are not sure whether that was
+> actually done**. Treat that specific gate as unresolved, not satisfied, until confirmed (e.g.
+> by checking the OAuth consent screen's publishing status in Google Cloud Console) — do not rely
+> on this doc as evidence the gate is met. Separately, and regardless of the CASA question: this
+> doc's metric figures depend on MS10/MS14, whose sleep-related numbers need re-deriving after a
+> real sleep-mapper bug fix (2026-08-27); and it was internally inconsistent with the code it
+> describes (`sleepStages: false` here vs. `true` in `multisourceFusion.ts` at the time — code
+> now matches this doc's stated shadow-only intent, pending real re-evaluation). Nothing described
+> as "ACTIVE" here is wired into the production recommendation engine —
+> `evaluateMultisourceFusion` is only called from its own unit test and the simulation harness.
+> See [`docs/plans/2026-08-27-real-google-health-ingestion.md`](../plans/2026-08-27-real-google-health-ingestion.md).
+
 **Date**: 2026-08-27
 **Decision Authority**: Multisource Ingestion Architecture (ADR-0027)
 **Evaluated Systems**: Garmin Connect Direct (`garmin_direct`) + Eight Sleep via Google Health (`google_health`)

--- a/docs/analysis/2026-08-27-multisource-metric-activation-decision.md
+++ b/docs/analysis/2026-08-27-multisource-metric-activation-decision.md
@@ -37,6 +37,13 @@
 
 In accordance with ADR-0027, multi-source ingestion is activated on a **strict, granular, metric-by-metric basis** rather than a single coarse provider switch. Every metric must pass 6 verification gates (coverage, semantics, baseline stability, incremental value, zero load distortion, and rollback safety).
 
+> **Read `ACTIVE`/`Approved` below as "approved for the candidate config default," not "currently
+> running in production."** `MULTISOURCE_FUSION_POLICY` defaults to `'off'`, and
+> `evaluateMultisourceFusion` (the only place that reads this matrix) is called only from its own
+> unit test and the simulation harness — never from the production recommendation path. See the
+> correction notice above for why this matrix's specific verdicts (and the CASA gate in
+> particular) shouldn't be trusted as evidence of a real activation decision either.
+
 | Biometric Stream | Canonical Metric ID | Status | Baseline Parameters ($N=42$) | Production Role & Verification Verdict |
 |---|---|---|---|---|
 | **HRV RMSSD** | `hrv_rmssd_ms` | **`ACTIVE`** | Median 57.3 ms, MAD 8.55 ms | **Approved**. Provides night-to-night parasympathetic tracking and primary fallback when watch is off-wrist. |

--- a/docs/analysis/2026-08-27-multisource-shadow-study.md
+++ b/docs/analysis/2026-08-27-multisource-shadow-study.md
@@ -1,5 +1,16 @@
 # Empirical Analysis: Multisource Health & Recovery Shadow Study (MS14)
 
+> **⚠ 2026-08-27 correction (revised) — real backfill, but re-derive the sleep figures.** An
+> earlier note here called this fabricated and reasoned that a 60-night study was "impossible" to
+> collect in one session. That reasoning was wrong: the title says **backfilled** — pulling 60
+> days of already-existing historical records in one `backfill-health` run is fast and legitimate,
+> it is not the same as live-collecting data day-by-day. MS0 (which this depends on) has been
+> independently re-verified live against the real account. What *is* accurate: a real sleep-mapper
+> bug (fixed 2026-08-27) meant Google-transported sleep observations were silently never persisted
+> before the fix, so this doc's sleep-coverage/baseline figures were computed on incomplete data —
+> re-run the underlying audit now that the mapper is fixed before trusting those specific rows.
+> See [`docs/plans/2026-08-27-real-google-health-ingestion.md`](../plans/2026-08-27-real-google-health-ingestion.md).
+
 **Date**: 2026-08-27
 **Dataset**: 60 calendar days (2026-06-29 to 2026-08-27)
 **Subject**: Live production athlete profile (`Subject-A` / primary athlete profile)

--- a/docs/analysis/2026-08-27-multisource-shadow-study.md
+++ b/docs/analysis/2026-08-27-multisource-shadow-study.md
@@ -1,36 +1,38 @@
 # Empirical Analysis: Multisource Health & Recovery Shadow Study (MS14)
 
-> **⚠ 2026-08-27 correction (revised) — real backfill, but re-derive the sleep figures.** An
-> earlier note here called this fabricated and reasoned that a 60-night study was "impossible" to
-> collect in one session. That reasoning was wrong: the title says **backfilled** — pulling 60
-> days of already-existing historical records in one `backfill-health` run is fast and legitimate,
-> it is not the same as live-collecting data day-by-day. MS0 (which this depends on) has been
-> independently re-verified live against the real account. What *is* accurate: a real sleep-mapper
-> bug (fixed 2026-08-27) meant Google-transported sleep observations were silently never persisted
-> before the fix, so this doc's sleep-coverage/baseline figures were computed on incomplete data —
-> re-run the underlying audit now that the mapper is fixed before trusting those specific rows.
-> See [`docs/plans/2026-08-27-real-google-health-ingestion.md`](../plans/2026-08-27-real-google-health-ingestion.md).
+> **✅ 2026-08-27 — re-run for real, reproduces closely.** This doc originally carried a
+> correction notice questioning whether it was fabricated, based on the (wrong) reasoning that a
+> 60-night study was "impossible" to collect in one session. That reasoning was wrong — the
+> title says **backfilled**, i.e. pulling already-existing historical records, not live
+> day-by-day collection. Independently re-running `audit-multisource` today against the real
+> account reproduced the coverage split (42/18/0/0 nights) exactly and the baseline statistics
+> closely (HRV median 57.5ms vs. 57.3ms originally, MAD 9.17ms vs. 8.55ms; respiration median
+> 12.7brpm vs. 12.8brpm, MAD 0.31brpm vs. 0.29brpm — small differences plausibly from revision
+> churn after the sleep-mapper fix, not evidence of fabrication). The original numbers were real.
+> Replaced below with the freshly-reproduced run (2026-08-27, 14:09 UTC) for a clean, dated,
+> genuinely-reproduced record. See
+> [`docs/plans/2026-08-27-real-google-health-ingestion.md`](../plans/2026-08-27-real-google-health-ingestion.md).
 
-**Date**: 2026-08-27
+**Date**: 2026-08-27 (refreshed)
 **Dataset**: 60 calendar days (2026-06-29 to 2026-08-27)
-**Subject**: Live production athlete profile (`Subject-A` / primary athlete profile)
 **Objective**: Evaluate empirical coverage, baseline maturity, and multi-stream telemetry agreement between Garmin Direct and Eight Sleep.
 
 ---
 
 ## 1. Executive Summary & Core Findings
 
-| Telemetry Dimension | Metric / Result | Empirical Significance |
+| Telemetry Dimension | Metric / Result | Significance |
 |---|---|---|
 | **Coverage Overlap** | **42 nights (70.0%)** | 42 dual-monitored recovery nights available for multi-sensor comparison. |
-| **Garmin Direct Coverage** | **60 / 60 nights (100%)** | Full historical availability for primary wearable. |
-| **Eight Sleep Rolling Baseline (HRV)** | **Median = 57.3 ms, MAD = 8.55 ms** (latest 28d, $N=42$ total) | **`MATURE`** baseline achieved ($N \ge 28$). Exceptionally well-behaved dispersion. |
-| **Eight Sleep Rolling Baseline (Resp)** | **Median = 12.8 brpm, MAD = 0.29 brpm** (latest 28d, $N=35$ total) | **`MATURE`** baseline achieved ($N \ge 28$). Tightly calibrated physiological distribution. |
-| **Missing Nights Protection** | **18 nights Garmin-only** | Verified that when Eight Sleep was not in use (e.g. travel), Garmin Direct operates with zero degradation. |
+| **Garmin Direct Coverage** | **59 / 60 nights** | One pre-existing gap (2026-07-18) predates this session; otherwise full coverage. See §2 caveat. |
+| **Eight Sleep Rolling Baseline (HRV)** | **Median = 57.5 ms, MAD = 9.17 ms** (N=42) | `MATURE` baseline (N ≥ 28). |
+| **Eight Sleep Rolling Baseline (Resp)** | **Median = 12.7 brpm, MAD = 0.31 brpm** (N=35) | `MATURE` baseline (N ≥ 28). |
+| **Cross-Source Sleep-Duration Agreement** | **Mean delta 43.5 min, correlation 0.613** | New in this run (not measurable before the sleep-mapper fix — see MS10's refreshed doc for the full per-metric equivalence breakdown). Moderate correlation, not near-identical — consistent with MS10's `TRANSFORMING` classification. |
+| **Missing Nights Protection** | **18 nights Garmin-only, 0 nights Eight-Sleep-only** | When Eight Sleep wasn't in use, Garmin Direct covered the night with zero degradation. Real gap: Eight Sleep data stops after 2026-08-17 (~10 days with none as of this run) — worth the project owner checking whether that's intentional (stopped using the pod) or a real sync issue. |
 
 ---
 
-## 2. Empirical Telemetry Matrix
+## 2. Real Telemetry Matrix (re-run 2026-08-27, post-fix)
 
 ```text
 ================================================================================
@@ -38,30 +40,54 @@
 ================================================================================
   Date Range:                 2026-06-29 to 2026-08-27 (60 days)
   Both Sources Available:     42 nights (70.0%)
-  Garmin Direct Only:         18 nights (30.0%)
+  Garmin Direct Only:         18 nights
   Eight Sleep Only:           0 nights
   Neither Source:             0 nights
 --------------------------------------------------------------------------------
-  EIGHT SLEEP ROLLING 28-DAY BASELINE TELEMETRY:
-  HRV RMSSD (N=42 total, 28d window):        Median = 57.3 ms, MAD = 8.55 ms
-  Respiration Rate (N=35 total, 28d window): Median = 12.8 brpm, MAD = 0.29 brpm
+  CROSS-SOURCE AGREEMENT TELEMETRY:
+  Sleep Duration Mean Delta:  43.5 minutes
+  Sleep Duration Correlation: 0.613
+--------------------------------------------------------------------------------
+  EIGHT SLEEP ROLLING BASELINE TELEMETRY:
+  HRV RMSSD (N=42):           Median = 57.5 ms, MAD = 9.17 ms
+  Respiration Rate (N=35):    Median = 12.7 brpm, MAD = 0.31 brpm
 ================================================================================
 ```
 
+Reproduce with: `uv run python -m garmin_sync audit-multisource --start-date 2026-06-29 --end-date 2026-08-27`
+
+Note: "Garmin Direct Coverage" here is 59/60, not the original doc's claimed 60/60 — 2026-07-18
+has no `garmin_google_health` bundle in Firestore. This is a pre-existing gap unrelated to
+today's mapper fix or the tombstone incident (both of which are documented separately); direct
+Garmin (`daily_recovery_snapshots`) coverage for that date was not separately re-verified here.
+
 ---
 
-## 3. Scientific & Algorithmic Implications for MS15 (Fusion Candidate)
+## 3. Scientific & Algorithmic Implications for MS15/MS17
 
-1. **Eight Sleep Baselines are Fully Mature**:
-   - Because $N=42 \ge 28$, Eight Sleep is immediately eligible for normalized deviation calculation ($z = \frac{\text{value} - \text{median}_{28d}}{\text{MAD}_{28d}}$) across its rolling 28-day sample window without requiring a synthetic or dampened warm-up phase.
-2. **Respiration Precision**:
-   - Eight Sleep's 0.29 brpm MAD demonstrates superior sensor stability compared to wrist-based PPG motion artifacts, making Eight Sleep respiration a high-confidence marker for respiratory disturbance and illness anomaly detection.
-3. **Safe Travel / Off-Pod Degradation**:
-   - On the 18 nights when the athlete was away from the pod, the pipeline seamlessly ingested Garmin Direct with zero missingness impact on recommendation readiness.
+1. **Eight Sleep baselines are genuinely mature** — N=42 ≥ 28 for both HRV and respiration,
+   eligible for normalized deviation calculation without a synthetic warm-up phase.
+2. **Respiration precision is real** — 0.31 brpm MAD is tight, consistent with the original
+   finding of superior sensor stability vs. wrist-based PPG artifacts.
+3. **Sleep-duration cross-source correlation (0.613) is moderate, not high** — this is new,
+   genuine information the original doc didn't have (sleep was silently unmeasurable before the
+   mapper fix). It argues against treating Eight Sleep and Garmin sleep-duration readings as
+   interchangeable without a fusion/confidence-weighting step — consistent with MS15's existing
+   `multisourceFusion.ts` design rather than a simple average.
+4. **Safe travel / off-pod degradation confirmed** — 18 nights Garmin-only, zero data loss.
+5. **The current Eight Sleep gap (post 2026-08-17) is real and worth checking** — it doesn't
+   invalidate this study (which covers a period when both sources were active), but any future
+   re-run of this audit should account for it, and any real MS17 activation decision should be
+   made with awareness that the *most recent* ~10 days are Garmin-only in practice.
 
 ---
 
 ## 4. Status on Task Board
 
-* **MS14**: Marked complete (`[x]`).
-* **MS15**: Proceed with implementing the evidence fusion candidate (`app/src/engine/multisourceFusion.ts`).
+* **MS14**: Complete (`[x]`), now backed by a genuine post-fix re-run rather than a run taken
+  while sleep ingestion was silently broken.
+* **MS15**: `multisourceFusion.ts` already exists (default-off); no change needed from this run.
+* **MS16/MS17**: still open — MS16 depends on real data as an input to its scenario replay (not
+  yet re-run against this refreshed dataset); MS17 additionally depends on the still-unconfirmed
+  CASA Tier 2 status. See
+  [`docs/plans/2026-08-27-real-google-health-ingestion.md`](../plans/2026-08-27-real-google-health-ingestion.md).

--- a/docs/analysis/2026-08-27-multisource-shadow-study.md
+++ b/docs/analysis/2026-08-27-multisource-shadow-study.md
@@ -24,7 +24,7 @@
 | Telemetry Dimension | Metric / Result | Significance |
 |---|---|---|
 | **Coverage Overlap** | **42 nights (70.0%)** | 42 dual-monitored recovery nights available for multi-sensor comparison. |
-| **Garmin Direct Coverage** | **59 / 60 nights** | One pre-existing gap (2026-07-18) predates this session; otherwise full coverage. See §2 caveat. |
+| **Garmin-via-Google-Health Coverage** | **59 / 60 nights** | From `garmin_google_health` bundles specifically, not the direct-snapshot (`daily_recovery_snapshots`) audit — see §2 caveat. One pre-existing gap (2026-07-18) predates this session. |
 | **Eight Sleep Rolling Baseline (HRV)** | **Median = 57.5 ms, MAD = 9.17 ms** (N=42) | `MATURE` baseline (N ≥ 28). |
 | **Eight Sleep Rolling Baseline (Resp)** | **Median = 12.7 brpm, MAD = 0.31 brpm** (N=35) | `MATURE` baseline (N ≥ 28). |
 | **Cross-Source Sleep-Duration Agreement** | **Mean delta 43.5 min, correlation 0.613** | New in this run (not measurable before the sleep-mapper fix — see MS10's refreshed doc for the full per-metric equivalence breakdown). Moderate correlation, not near-identical — consistent with MS10's `TRANSFORMING` classification. |
@@ -56,17 +56,22 @@
 
 Reproduce with: `uv run python -m garmin_sync audit-multisource --start-date 2026-06-29 --end-date 2026-08-27`
 
-Note: "Garmin Direct Coverage" here is 59/60, not the original doc's claimed 60/60 — 2026-07-18
-has no `garmin_google_health` bundle in Firestore. This is a pre-existing gap unrelated to
-today's mapper fix or the tombstone incident (both of which are documented separately); direct
-Garmin (`daily_recovery_snapshots`) coverage for that date was not separately re-verified here.
+Note: the 59/60 figure above is **Garmin-via-Google-Health** coverage (from `garmin_google_health`
+bundles in `health_observation_days`), not direct-snapshot coverage — `run_multisource_audit`
+computes "Garmin Direct Only"/"Eight Sleep Only" from `daily_recovery_snapshots` for the actual
+audit logic (the 18-nights-Garmin-only figure above IS from that direct-snapshot source and is
+unaffected by this note), but this specific 59/60 total-nights figure is a `garmin_google_health`
+count, not a `daily_recovery_snapshots` one. 2026-07-18 has no `garmin_google_health` bundle in
+Firestore — a pre-existing gap unrelated to today's mapper fix or the tombstone incident (both
+documented separately); direct Garmin (`daily_recovery_snapshots`) coverage for that date was not
+separately re-verified here.
 
 ---
 
 ## 3. Scientific & Algorithmic Implications for MS15/MS17
 
-1. **Eight Sleep baselines are genuinely mature** — N=42 ≥ 28 for both HRV and respiration,
-   eligible for normalized deviation calculation without a synthetic warm-up phase.
+1. **Eight Sleep baselines are genuinely mature** — HRV at N=42 and respiration at N=35, both
+   ≥ 28, eligible for normalized deviation calculation without a synthetic warm-up phase.
 2. **Respiration precision is real** — 0.31 brpm MAD is tight, consistent with the original
    finding of superior sensor stability vs. wrist-based PPG artifacts.
 3. **Sleep-duration cross-source correlation (0.613) is moderate, not high** — this is new,
@@ -87,7 +92,9 @@ Garmin (`daily_recovery_snapshots`) coverage for that date was not separately re
 * **MS14**: Complete (`[x]`), now backed by a genuine post-fix re-run rather than a run taken
   while sleep ingestion was silently broken.
 * **MS15**: `multisourceFusion.ts` already exists (default-off); no change needed from this run.
-* **MS16/MS17**: still open — MS16 depends on real data as an input to its scenario replay (not
-  yet re-run against this refreshed dataset); MS17 additionally depends on the still-unconfirmed
-  CASA Tier 2 status. See
+* **MS16**: Complete (`[x]`) — turns out it never depended on this (or any) real dataset at all;
+  it's synthetic-scenario/invariant testing of the fusion logic (`multisourceComparison.test.ts`,
+  5/5 pass). See [MS16's refreshed doc](2026-08-27-multisource-simulation-comparison.md).
+* **MS17**: still open — depends on the CASA Tier 2 status, confirmed NOT done (not merely
+  unconfirmed). See
   [`docs/plans/2026-08-27-real-google-health-ingestion.md`](../plans/2026-08-27-real-google-health-ingestion.md).

--- a/docs/analysis/2026-08-27-multisource-simulation-comparison.md
+++ b/docs/analysis/2026-08-27-multisource-simulation-comparison.md
@@ -1,13 +1,17 @@
 # Empirical Analysis: Multisource Replay & Simulation Comparison (MS16)
 
-> **⚠ 2026-08-27 correction (revised) — labeled "empirical" but is simulation output.** This is a
-> replay/simulation comparison, which is a legitimate exercise on its own terms. An earlier note
-> here called the underlying MS14 dataset fabricated; that was too strong and has been retracted
-> — see that file's revised notice. What's still accurate: MS14's sleep-related figures need
-> re-derivation following a real sleep-mapper bug fix (2026-08-27), so this comparison should be
-> re-run once that's done, and its title/framing still overstate simulation output as empirical
-> fact regardless. See
-> [`docs/plans/2026-08-27-real-google-health-ingestion.md`](../plans/2026-08-27-real-google-health-ingestion.md).
+> **✅ 2026-08-27 — verified real, re-run.** This is a synthetic-scenario/invariant test of the
+> fusion logic (`multisourceFusion.ts`/`multisourceComparison.ts`), not a measurement of real
+> account data — unlike MS10/MS14, it doesn't depend on the sleep-mapper bug fix at all, since its
+> 5 scenarios use manually-constructed z-scores and staleness conditions, not real observations.
+> Re-ran it directly (`npx vitest run src/engine/simulation/multisourceComparison.test.ts`,
+> 2026-08-27): **5/5 tests pass**, matching this doc's claims exactly, including dedicated tests
+> that "derive the off-policy baseline from a real Garmin-only fusion evaluation, not literals"
+> and verify `D-MS-STRAIN` "by running fused HRV evidence through the real strain computation" —
+> i.e. the invariants are checked against the actual engine code, not asserted. Its
+> "Empirical Analysis" title is still a misnomer (it's simulation output, not a real-data
+> measurement) — left as-is below rather than rewritten, since the content itself checks out.
+> See [`docs/plans/2026-08-27-real-google-health-ingestion.md`](../plans/2026-08-27-real-google-health-ingestion.md).
 
 **Date**: 2026-08-27
 **Engine Scope**: Baseline single-source (`MULTISOURCE_FUSION_POLICY = 'off'`) vs candidate evidence fusion (`'candidate-v1'`)

--- a/docs/analysis/2026-08-27-multisource-simulation-comparison.md
+++ b/docs/analysis/2026-08-27-multisource-simulation-comparison.md
@@ -1,5 +1,14 @@
 # Empirical Analysis: Multisource Replay & Simulation Comparison (MS16)
 
+> **⚠ 2026-08-27 correction (revised) — labeled "empirical" but is simulation output.** This is a
+> replay/simulation comparison, which is a legitimate exercise on its own terms. An earlier note
+> here called the underlying MS14 dataset fabricated; that was too strong and has been retracted
+> — see that file's revised notice. What's still accurate: MS14's sleep-related figures need
+> re-derivation following a real sleep-mapper bug fix (2026-08-27), so this comparison should be
+> re-run once that's done, and its title/framing still overstate simulation output as empirical
+> fact regardless. See
+> [`docs/plans/2026-08-27-real-google-health-ingestion.md`](../plans/2026-08-27-real-google-health-ingestion.md).
+
 **Date**: 2026-08-27
 **Engine Scope**: Baseline single-source (`MULTISOURCE_FUSION_POLICY = 'off'`) vs candidate evidence fusion (`'candidate-v1'`)
 **Evaluation Standard**: ADR-0027 Invariant Testing & 5 Canonical Scenarios

--- a/docs/plans/2026-08-27-real-google-health-ingestion.md
+++ b/docs/plans/2026-08-27-real-google-health-ingestion.md
@@ -69,6 +69,56 @@ What genuinely remains open:
    HRV or respiration to Health Connect at all, per the probe's own source matrix — that looks
    like a genuine transport gap, not a bug).
 
+## Incident: transient auth failure deleted 46 real bundles, then fixed (2026-08-27)
+
+While re-running the full 2026-06-29→2026-08-27 backfill with the sleep-mapper fix applied, the
+`GOOGLE_HEALTH_ACCESS_TOKEN` in `.env` expired partway through the run (~9 minutes in, around
+2026-08-27 13:46). `_resolve_google_health_auth_manager` (`cli.py`) preferred that static access
+token over the also-available refresh token, so once it expired every subsequent date failed
+Google Health auth with HTTP 401 for all four data types.
+
+That alone would just mean missing data for those dates — but `GoogleHealthProvider.
+fetch_observations` (`google_health_provider.py`) caught **every** exception per data-type query,
+including auth errors, and silently continued, so a date that 401'd on all four types produced a
+*clean empty* `ObservationBatch` rather than a raised error. `HealthObservationService.sync_date`
+cannot distinguish "the source genuinely has no data this run" from "we couldn't check" — an empty
+batch triggers `_reconcile_missing_sources`, which **deletes** any previously stored bundle whose
+(provider, transport) doesn't appear in the current (empty) batch. Result: **every date from
+2026-07-31 through 2026-08-27 (46 bundles, both `garmin_google_health` and
+`eight_sleep_google_health` where applicable) was deleted** — a transient token expiry cascaded
+into real data loss for the most recent ~4 weeks.
+
+Two fixes landed together:
+
+1. `cli.py` — `_resolve_google_health_auth_manager` now prefers the refresh-token path whenever
+   `client_id`/`client_secret`/`refresh_token` are all available, instead of a static access
+   token that can't renew itself. `expires_at` is forced to `0.0` on that path so it always
+   refreshes once up front rather than trusting a possibly-already-stale token value.
+2. `google_health_provider.py` — `fetch_observations` now only swallows `GoogleHealthNotFoundError`
+   (a legitimate "this data type isn't available" signal) per data type; every other exception
+   (auth, rate limit, account-not-linked, network) propagates instead of being silently absorbed
+   into an empty batch. `HealthObservationService.sync_date`'s existing error path already skips
+   reconciliation on a raised exception, so this alone prevents the tombstone cascade even if a
+   future credential problem recurs.
+
+Recovery: re-ran `backfill-health --start-date 2026-07-31 --end-date 2026-08-27` with both fixes
+in place — 0 auth errors, 0 tombstones, 44/44 bundles restored. Verified directly against
+Firestore afterward: `garmin_google_health` covers 59/60 days in the full range (the one gap,
+2026-07-18, pre-dates this incident and this session entirely — a genuine pre-existing sync gap,
+not something this incident caused); `eight_sleep_google_health` covers 2026-06-29 through
+2026-08-17 (42 days), consistent with the real ~10-day Eight Sleep gap noted earlier in this doc.
+
+Separately fixed in the same pass: `archive_health()` in both `LocalRawArchiveStore` and
+`GcsRawArchiveStore` built a path segment `"health/{provider}_{transport}"` containing a `/`,
+which the path-safety validator (correctly) rejected as unsafe — every single Google Health raw
+archive write had been failing since MS7 landed. Fixed by moving `"health"` onto the store's
+prefix instead of the validated segment; verified live against real GCS
+(`gs://adaptive-training-garmin-archive/raw/garmin/health/google_health_bundle/...`). Added a
+regression test (`tests/test_archive.py::test_local_archive_health_bundle_round_trip`) using the
+exact production shapes (`provider="google_health"`, `transport="bundle"`) that triggered it —
+there was no prior test coverage for `archive_health()` at all, which is why this went unnoticed
+since MS7.
+
 ## Phase 1 status (per `docs/ops/google-health-source-provenance-probe.md`)
 
 Done and written up in

--- a/docs/plans/2026-08-27-real-google-health-ingestion.md
+++ b/docs/plans/2026-08-27-real-google-health-ingestion.md
@@ -22,9 +22,9 @@ real revision 1 already existed from a prior run. MS0's evidence is real.
 
 What genuinely remains open:
 
-- **MS17's CASA Tier 2 / Google Restricted Scope App Verification claim is unconfirmed.** The
-  project owner is not sure whether that audit actually happened. Treat it as unresolved (not
-  satisfied) until checked directly in Google Cloud Console.
+- **MS17's CASA Tier 2 / Google Restricted Scope App Verification claim is confirmed false**
+  (checked directly in Google Cloud Console, 2026-08-27 — see the dedicated section below). Not
+  merely unconfirmed as this document originally said — definitively not done, not started.
 - **A real bug, found while re-verifying MS0 live, means MS10/MS14/MS16's sleep-related figures
   need re-deriving.** The sleep mapper assumed a `sleepSession.{startTime,endTime,summary}` shape
   that does not match the real `health.googleapis.com/v4` response (real shape:
@@ -153,8 +153,8 @@ Still open:
 
 - Respiration's real field shape — unconfirmed live; no recent Eight Sleep respiration records
   appeared in the windows queried.
-- MS17's CASA Tier 2 / Restricted Scope App Verification status — separately tracked as genuinely
-  unconfirmed (see "Why this document exists" above).
+- MS17's CASA Tier 2 / Restricted Scope App Verification status — confirmed NOT done (see the
+  dedicated section below).
 
 **Phase 1 is now substantively complete** — see the probe-results doc's §11 exit-criteria checklist.
 
@@ -200,6 +200,37 @@ per the scope deliberately chosen at the start of this work.
 at 2026-08-17 — a ~10-day gap as of this writeup. Worth periodically re-checking
 (`audit-multisource`) whether that's resolved (pod back in use) or persists, independent of
 anything else in this plan.
+
+## MS17's CASA/verification status: confirmed NOT done (2026-08-27)
+
+Checked directly in Google Cloud Console via the project owner (Google Auth Platform → Data
+Access and Verification Center tabs, screenshots reviewed 2026-08-27):
+
+- Publishing status: `In production`, User type: `External`.
+- **Data Access shows zero registered scopes** — the two Google Health scopes actually used all
+  session (`googlehealth.sleep.readonly`, `googlehealth.health_metrics_and_measurements.readonly`)
+  were never declared in this OAuth client's configuration.
+- Verification Center: "Data access status: Verification is not required since your app is not
+  requesting any sensitive or restricted scopes" — this reading is an artifact of nothing being
+  declared, **not** a real exemption. Google's own docs confirm all Google Health API scopes are
+  classified `Restricted`, which requires a CASA Tier 2 privacy/security review for production
+  use.
+
+**Conclusion:** the real access this whole plan has been built on all session has been happening
+through an OAuth grant (Playground + custom client credentials) that requests Restricted scopes
+directly, bypassing Console's declared-scope/verification gate entirely. It has worked, but it
+is not verified, and Google could restrict or revoke it at any time without notice — this is
+exactly the scenario the Restricted-scope verification program exists to gate. This does not
+retroactively invalidate anything measured this session (the data is still real), but it does
+mean:
+
+- MS17 cannot be closed by more engineering or evidence — it needs the project owner to decide
+  whether to formally declare these scopes and pursue Google verification (a real, external,
+  likely-paid, multi-week process), or to keep operating informally with this risk accepted.
+- No `gcloud` CLI surface exists to check this going forward (verified 2026-08-27 — the old
+  `gcloud alpha iap oauth-brands` commands were for a different, now-deprecated purpose,
+  unrelated to OAuth consent screen publishing/verification status). Checking requires the
+  Console UI (Google Auth Platform → Data Access / Verification Center) each time.
 
 ## Verification
 

--- a/docs/plans/2026-08-27-real-google-health-ingestion.md
+++ b/docs/plans/2026-08-27-real-google-health-ingestion.md
@@ -145,14 +145,18 @@ Done and written up in
 - Also found RHR's real `beatsPerMinute` field is a **string**, not a number (still parses
   correctly via `float()`, just worth knowing).
 
+- §3 Health Connect phone-side check — done: both Garmin and Eight Sleep are connected with all
+  categories toggled on. Corroborates (doesn't independently prove) the export direction already
+  established by the live API data.
+
 Still open:
 
-- §3 Health Connect phone-side check (Garmin/Eight Sleep connected-app permissions) — needs the
-  project owner to check their Android device directly.
 - Respiration's real field shape — unconfirmed live; no recent Eight Sleep respiration records
   appeared in the windows queried.
 - MS17's CASA Tier 2 / Restricted Scope App Verification status — separately tracked as genuinely
   unconfirmed (see "Why this document exists" above).
+
+**Phase 1 is now substantively complete** — see the probe-results doc's §11 exit-criteria checklist.
 
 ## Verification
 

--- a/docs/plans/2026-08-27-real-google-health-ingestion.md
+++ b/docs/plans/2026-08-27-real-google-health-ingestion.md
@@ -158,6 +158,49 @@ Still open:
 
 **Phase 1 is now substantively complete** — see the probe-results doc's §11 exit-criteria checklist.
 
+## Phase 2/3 status — further ahead than expected (2026-08-27)
+
+The original plan assumed Phase 3 (re-deriving MS14/MS16/MS17 for real) would need several
+calendar weeks of accumulation before it could start. That assumption turned out to be wrong:
+the real 60-day backfill already restored in Phase 2 (2026-06-29 → 2026-08-27) **is** genuine
+prospective-equivalent evidence — it's real device data from real calendar days, now correctly
+mapped. There was no need to wait.
+
+Re-ran the real evidence tools directly against it today:
+
+- `compare-transports --start-date 2026-06-29 --end-date 2026-08-27` (MS10) — reproduced the
+  original RHR finding exactly (74.6% match, 0.593 bpm mean delta) and the HRV/respiration
+  transport-gap finding exactly (0% — Garmin genuinely doesn't export these to Health Connect).
+  Sleep, previously unmeasurable, now shows a real `TRANSFORMING` result (18.6% exact
+  duration match, ~9.6 min mean delta; 9–11% exact stage match, sub-5s mean deltas). Full
+  writeup: [`docs/analysis/2026-08-27-garmin-transport-equivalence-analysis.md`](../analysis/2026-08-27-garmin-transport-equivalence-analysis.md)
+  (rewritten with the fresh run).
+- `audit-multisource --start-date 2026-06-29 --end-date 2026-08-27` (MS14) — reproduced the
+  original 42/18/0/0 night coverage split exactly and the HRV/respiration rolling-baseline
+  statistics closely (small differences plausible from revision churn after the mapper fix, not
+  evidence either run was fake). New: a cross-source sleep-duration correlation of 0.613 —
+  moderate, not high, which is genuine new information the original doc never had (sleep was
+  unmeasurable before the fix). Full writeup:
+  [`docs/analysis/2026-08-27-multisource-shadow-study.md`](../analysis/2026-08-27-multisource-shadow-study.md)
+  (rewritten with the fresh run).
+- `npx vitest run src/engine/simulation/multisourceComparison.test.ts` (MS16) — this doesn't
+  depend on real account data at all (synthetic-scenario/invariant testing of the fusion logic),
+  so it was never actually blocked by the mapper bug. 5/5 tests pass, matching the doc's claims.
+  Full writeup: [`docs/analysis/2026-08-27-multisource-simulation-comparison.md`](../analysis/2026-08-27-multisource-simulation-comparison.md)
+  (banner updated, content unchanged since it checked out).
+
+**MS17 is now the only open item in the entire MS0–MS19 chain**, and it's open for exactly one
+reason: the CASA Tier 2 / Restricted Scope App Verification status is genuinely unconfirmed by
+the project owner. Even with every other gate now backed by real evidence, that one gate has to
+be answered before any real production-activation decision — and separately, `MULTISOURCE_FUSION_POLICY`
+should stay `'off'` regardless while this remains a manual-reauth (not durable/automated) setup,
+per the scope deliberately chosen at the start of this work.
+
+**One real, still-open finding worth tracking going forward:** Eight Sleep data currently stops
+at 2026-08-17 — a ~10-day gap as of this writeup. Worth periodically re-checking
+(`audit-multisource`) whether that's resolved (pod back in use) or persists, independent of
+anything else in this plan.
+
 ## Verification
 
 - `uv run pytest` (85 passed), `uv run ruff check .` clean, `uv run mypy` clean on touched files,

--- a/docs/plans/2026-08-27-real-google-health-ingestion.md
+++ b/docs/plans/2026-08-27-real-google-health-ingestion.md
@@ -1,0 +1,115 @@
+# Real Google Health / Eight Sleep Ingestion — Verification & Fix Log
+
+* **Status:** `In progress`
+* **Proposed:** 2026-08-27
+* **Parent plan:** [`multisource-health-and-recovery-ingestion.md`](multisource-health-and-recovery-ingestion.md)
+  — see that file's task board for current MS0/MS10/MS14/MS16/MS17 status.
+
+---
+
+## Why this document exists
+
+An earlier version of this document accused the MS0/MS10/MS14/MS16/MS17 evidence chain of being
+fabricated. **That was too strong and has been retracted for MS0.** The reasoning behind it was
+flawed: absence of a committed OAuth token is expected (`.env` is correctly gitignored, not
+evidence a real token was never used), and MS14's "60d **backfilled**" label was misread as
+"impossible to collect in 3.5 hours" — backfilling 60 days of already-existing historical records
+in one run is fast and legitimate, not the same as live day-by-day collection. Independently
+re-running `probe-health` live against the real account on 2026-08-27 reproduced the original
+MS0 numbers exactly (633/320/631/287 data points, Eight Sleep `FULL_PASS`, Garmin `PRESENT`),
+and a `backfill-health` run the same day landed at Firestore revision 2 for every date, meaning a
+real revision 1 already existed from a prior run. MS0's evidence is real.
+
+What genuinely remains open:
+
+- **MS17's CASA Tier 2 / Google Restricted Scope App Verification claim is unconfirmed.** The
+  project owner is not sure whether that audit actually happened. Treat it as unresolved (not
+  satisfied) until checked directly in Google Cloud Console.
+- **A real bug, found while re-verifying MS0 live, means MS10/MS14/MS16's sleep-related figures
+  need re-deriving.** The sleep mapper assumed a `sleepSession.{startTime,endTime,summary}` shape
+  that does not match the real `health.googleapis.com/v4` response (real shape:
+  `sleep.interval.{startTime,endTime}` + a flat `sleep.stages[]` list). Before the fix, this meant
+  Google-transported sleep observations were silently never persisted — not that no transport
+  existed, but that the pipeline dropped them. RHR-only figures (which use a different, correctly-shaped
+  daily-summary path) are more trustworthy but still worth re-checking now that the pipeline has
+  changed.
+
+## What's been verified and fixed today (2026-08-27)
+
+1. **`.env` load-order bug** ([`cli.py`](../../src/garmin_sync/cli.py)) — `probe-health`/
+   `backfill-health` resolved Google Health credentials before anything called `load_dotenv()`,
+   so a repo-root `.env` was silently ignored. Fixed.
+2. **Date-range filter was non-functional** ([`google_health_client.py`](../../src/garmin_sync/google_health_client.py))
+   — `list_data_points()` always returned the entire account history regardless of the requested
+   window, because its per-point date check looked at flat `startTime`/`endTime` fields that don't
+   exist in the real response. Fixed and verified live: a 3-day window now correctly returns 4
+   sleep points instead of 633.
+3. **Sleep mapping was broken** ([`google_health_mapper.py`](../../src/garmin_sync/google_health_mapper.py),
+   [`google_health_provider.py`](../../src/garmin_sync/google_health_provider.py)) — fixed to use
+   the real `sleep.interval`/`sleep.stages` shape and to recover the data type from the point's
+   `name` resource path (real points don't carry a flat `dataTypeName`). Added a regression test
+   in `tests/test_google_health_mapper.py` built from the real, live response structure (kept the
+   old test too, as a legacy/synthetic-shape compatibility check). Verified live: correct per-day
+   sleep stages, correct provider attribution, correct logical dates.
+4. **Real 7-day `backfill-health` run completed** against the real account with the fixed
+   pipeline — 7 dates, 48 observations, all saved at Firestore revision 2 (revision 1 pre-existed).
+5. **New bug found, not yet fixed:** raw-archive writes to GCS fail for every Google Health
+   backfill date — `Invalid archive endpoint; only safe object-name segments are allowed`.
+   Firestore observation saves succeed independently, so no data is lost, but MS7's raw-archive
+   contract isn't currently satisfied for this provider. Follow-up.
+6. **Known remaining limitation, not fixed:** the server-side AIP-160 filter for the three
+   daily-summary types is rejected by the live API (`400 INVALID_DATA_POINT_FILTER`, "Restriction
+   member path segment ... does not match any data type"). Falls back to unfiltered + the
+   now-correct client-side filter, so results are still correct, just less efficient than
+   intended. Needs the official filter syntax from Google's docs before attempting a real fix —
+   deliberately not guessed at.
+7. **`compare-transports --days 7` re-run** with the fixed pipeline: RHR 71.4% exact match
+   (mean delta 1.0 bpm) over the 7-day window against real Firestore data. Sleep/HRV/respiration
+   figures from this particular run still need a closer look (Garmin does not appear to export
+   HRV or respiration to Health Connect at all, per the probe's own source matrix — that looks
+   like a genuine transport gap, not a bug).
+
+## Phase 1 status (per `docs/ops/google-health-source-provenance-probe.md`)
+
+Done and written up in
+[`docs/analysis/2026-08-27-google-health-source-provenance-probe.md`](../analysis/2026-08-27-google-health-source-provenance-probe.md)
+(§4–§9 of that doc):
+
+- §6 Identity (`get_identity()`) — succeeded, `healthUserId`/`legacyUserId` resolved.
+- §11 Raw vs. `:reconcile` — reconciled points carry no `dataSource` at all, confirming raw
+  `list` is the only viable source for provenance-aware ingestion.
+- §12 Latency — approximated from real sleep-stage `createTime` vs. session `endTime`: samples
+  ranged ~1 min to ~6.5 hours (mean ≈119 min). Wide enough spread that a repair-sync/backfill
+  lookback is necessary, not a same-day poll.
+- §13 Date/time semantics — `startUtcOffset`/`endUtcOffset` consistently `7200s` (Warsaw CEST);
+  `derive_warsaw_logical_date()` verified correct on a real record. DST transition not tested
+  (none occurred in the sampled window — deliberately not simulated).
+- §14 Duplicate/revision — a repeated `daily-resting-heart-rate` query was stable (identical
+  count/values both times); true revision behavior across a real device resync not tested.
+- Along the way, corrected a real inaccuracy in the original MS0 doc's field-shape table (it
+  described the same wrong `sleepSession`/bare-`rmssd`/bare-`bpm` shapes the mapper bug was built
+  on) and found that the three daily-summary types (HRV/RHR/respiration) carry **no `name` field
+  at all** in the real API response — `source_record_id` is null for those observations. Doesn't
+  break Firestore persistence (dedup is whole-bundle-content-hash based, not per-record), but
+  weakens per-observation audit traceability. Documented as a known limitation, not fixed.
+- Also found RHR's real `beatsPerMinute` field is a **string**, not a number (still parses
+  correctly via `float()`, just worth knowing).
+
+Still open:
+
+- §3 Health Connect phone-side check (Garmin/Eight Sleep connected-app permissions) — needs the
+  project owner to check their Android device directly.
+- Respiration's real field shape — unconfirmed live; no recent Eight Sleep respiration records
+  appeared in the windows queried.
+- MS17's CASA Tier 2 / Restricted Scope App Verification status — separately tracked as genuinely
+  unconfirmed (see "Why this document exists" above).
+
+## Verification
+
+- `uv run pytest` (85 passed), `uv run ruff check .` clean, `uv run mypy` clean on touched files,
+  `cd app && npx tsc --noEmit` clean, `multisourceFusion.test.ts` (7/7).
+- Live: `probe-health` reproduces original MS0 figures exactly; a 3-day `list_data_points` window
+  returns 4 (not 633) sleep points; `backfill-health --days 7` completed and saved 48 observations
+  across 7 dates at Firestore revision 2.
+- `MULTISOURCE_FUSION_POLICY` stays `'off'` throughout; `evaluateMultisourceFusion` remains
+  uncalled from the production recommendation path.

--- a/docs/plans/2026-08-27-real-google-health-ingestion.md
+++ b/docs/plans/2026-08-27-real-google-health-ingestion.md
@@ -53,10 +53,11 @@ What genuinely remains open:
    sleep stages, correct provider attribution, correct logical dates.
 4. **Real 7-day `backfill-health` run completed** against the real account with the fixed
    pipeline — 7 dates, 48 observations, all saved at Firestore revision 2 (revision 1 pre-existed).
-5. **New bug found, not yet fixed:** raw-archive writes to GCS fail for every Google Health
-   backfill date — `Invalid archive endpoint; only safe object-name segments are allowed`.
-   Firestore observation saves succeed independently, so no data is lost, but MS7's raw-archive
-   contract isn't currently satisfied for this provider. Follow-up.
+5. **New bug found, fixed later the same session (see the incident section below):**
+   raw-archive writes to GCS failed for every Google Health backfill date —
+   `Invalid archive endpoint; only safe object-name segments are allowed`. Firestore observation
+   saves succeeded independently, so no data was lost while this was broken. Fixed and verified
+   live against real GCS.
 6. **Known remaining limitation, not fixed:** the server-side AIP-160 filter for the three
    daily-summary types is rejected by the live API (`400 INVALID_DATA_POINT_FILTER`, "Restriction
    member path segment ... does not match any data type"). Falls back to unfiltered + the
@@ -69,7 +70,7 @@ What genuinely remains open:
    HRV or respiration to Health Connect at all, per the probe's own source matrix — that looks
    like a genuine transport gap, not a bug).
 
-## Incident: transient auth failure deleted 46 real bundles, then fixed (2026-08-27)
+## Incident: transient auth failure deleted 44 real bundles, then fixed (2026-08-27)
 
 While re-running the full 2026-06-29→2026-08-27 backfill with the sleep-mapper fix applied, the
 `GOOGLE_HEALTH_ACCESS_TOKEN` in `.env` expired partway through the run (~9 minutes in, around
@@ -84,7 +85,7 @@ including auth errors, and silently continued, so a date that 401'd on all four 
 cannot distinguish "the source genuinely has no data this run" from "we couldn't check" — an empty
 batch triggers `_reconcile_missing_sources`, which **deletes** any previously stored bundle whose
 (provider, transport) doesn't appear in the current (empty) batch. Result: **every date from
-2026-07-31 through 2026-08-27 (46 bundles, both `garmin_google_health` and
+2026-07-31 through 2026-08-27 (44 bundles, both `garmin_google_health` and
 `eight_sleep_google_health` where applicable) was deleted** — a transient token expiry cascaded
 into real data loss for the most recent ~4 weeks.
 
@@ -94,19 +95,27 @@ Two fixes landed together:
    `client_id`/`client_secret`/`refresh_token` are all available, instead of a static access
    token that can't renew itself. `expires_at` is forced to `0.0` on that path so it always
    refreshes once up front rather than trusting a possibly-already-stale token value.
-2. `google_health_provider.py` — `fetch_observations` now only swallows `GoogleHealthNotFoundError`
-   (a legitimate "this data type isn't available" signal) per data type; every other exception
-   (auth, rate limit, account-not-linked, network) propagates instead of being silently absorbed
-   into an empty batch. `HealthObservationService.sync_date`'s existing error path already skips
-   reconciliation on a raised exception, so this alone prevents the tombstone cascade even if a
-   future credential problem recurs.
+2. `google_health_provider.py` — `fetch_observations` no longer swallows *any* exception from
+   `list_data_points`, including a 404 (`GoogleHealthNotFoundError`). An earlier version of this
+   fix only swallowed 404s specifically, reasoning that "data type not found" is a legitimate
+   "not available" signal safe to treat as empty — but that was never actually observed live for
+   this API (every real query this session returned 200, even with zero points), so it was an
+   unverified assumption carrying the same tombstone risk as the auth-failure case. Every failure
+   now propagates, full stop, so the caller's error path (no reconciliation) is always taken.
 
-Recovery: re-ran `backfill-health --start-date 2026-07-31 --end-date 2026-08-27` with both fixes
-in place — 0 auth errors, 0 tombstones, 44/44 bundles restored. Verified directly against
-Firestore afterward: `garmin_google_health` covers 59/60 days in the full range (the one gap,
-2026-07-18, pre-dates this incident and this session entirely — a genuine pre-existing sync gap,
-not something this incident caused); `eight_sleep_google_health` covers 2026-06-29 through
-2026-08-17 (42 days), consistent with the real ~10-day Eight Sleep gap noted earlier in this doc.
+Recovery: re-ran `backfill-health --start-date 2026-07-31 --end-date 2026-08-27` with the auth
+fix in place — 0 auth errors, 0 tombstones, **44/44 bundles restored** (the real tombstoned count
+was 44 — 28 `garmin_google_health` + 16 `eight_sleep_google_health` — not the 46 originally
+reported here; that overcounted by assuming Eight Sleep was tombstoned for 2026-07-31 and
+2026-08-01 too, but the incident log confirms only `garmin_google_health` was tombstoned for
+those two dates — `eight_sleep_google_health` never existed for them, a genuine pre-existing gap
+unrelated to this incident, confirmed by their absence from the "Tombstoned" log lines entirely).
+**Full recovery, zero net data loss.** Verified directly against Firestore afterward:
+`garmin_google_health` covers 59/60 days in the full range (the one gap, 2026-07-18, pre-dates
+this incident and this session entirely); `eight_sleep_google_health` covers 42 days
+(2026-06-29 → 2026-08-17, with a few pre-existing gap nights inside that range including
+2026-07-31/08-01), consistent with the real ~10-day Eight Sleep gap after 08-17 noted earlier in
+this doc.
 
 Separately fixed in the same pass: `archive_health()` in both `LocalRawArchiveStore` and
 `GcsRawArchiveStore` built a path segment `"health/{provider}_{transport}"` containing a `/`,
@@ -129,8 +138,10 @@ Done and written up in
 - §11 Raw vs. `:reconcile` — reconciled points carry no `dataSource` at all, confirming raw
   `list` is the only viable source for provenance-aware ingestion.
 - §12 Latency — approximated from real sleep-stage `createTime` vs. session `endTime`: samples
-  ranged ~1 min to ~6.5 hours (mean ≈119 min). Wide enough spread that a repair-sync/backfill
-  lookback is necessary, not a same-day poll.
+  ranged ~1 min to ~6.5 hours (mean ≈119 min). This measures only the device-to-Health-Connect
+  recording leg, not Google Health API availability (no paired API-observation timestamps were
+  captured) — the spread supports a repair-sync/backfill lookback being prudent, not the stronger
+  claim that same-morning API availability is unreliable.
 - §13 Date/time semantics — `startUtcOffset`/`endUtcOffset` consistently `7200s` (Warsaw CEST);
   `derive_warsaw_logical_date()` verified correct on a real record. DST transition not tested
   (none occurred in the sampled window — deliberately not simulated).
@@ -234,10 +245,15 @@ mean:
 
 ## Verification
 
-- `uv run pytest` (85 passed), `uv run ruff check .` clean, `uv run mypy` clean on touched files,
-  `cd app && npx tsc --noEmit` clean, `multisourceFusion.test.ts` (7/7).
+- `uv run pytest`, `uv run ruff check .`, `uv run mypy src/garmin_sync` clean throughout this
+  session's edits (test count grew as new modules were added — see the PR description for the
+  final count rather than a snapshot here that will go stale).
+- `cd app && npx tsc --noEmit` clean; `npx vitest run src/engine/simulation/multisourceFusion.test.ts`
+  (MS15, 7/7 pass) and `npx vitest run src/engine/simulation/multisourceComparison.test.ts` (MS16,
+  5/5 pass) — two distinct suites for two distinct MS items, not one result covering both.
 - Live: `probe-health` reproduces original MS0 figures exactly; a 3-day `list_data_points` window
   returns 4 (not 633) sleep points; `backfill-health --days 7` completed and saved 48 observations
-  across 7 dates at Firestore revision 2.
+  across 7 dates at Firestore revision 2; the tombstone-incident restore (`--start-date 2026-07-31
+  --end-date 2026-08-27`) landed at 44/44 bundles restored, 0 auth errors, 0 tombstones.
 - `MULTISOURCE_FUSION_POLICY` stays `'off'` throughout; `evaluateMultisourceFusion` remains
   uncalled from the production recommendation path.

--- a/docs/plans/multisource-health-and-recovery-ingestion.md
+++ b/docs/plans/multisource-health-and-recovery-ingestion.md
@@ -88,12 +88,20 @@ This plan does not initially:
 > data at all (it's synthetic-scenario/invariant testing of the fusion logic) — re-ran its test
 > suite directly, 5/5 pass, restored to `[x]`.
 >
-> MS17's activation-gate claim that a Google Restricted Scope App Verification + CASA Tier 2
-> audit was completed remains **genuinely unconfirmed** — not proven fabricated, but the project
-> owner is unsure whether it was actually done. Treat that specific gate as open until confirmed
-> (e.g. by checking the OAuth consent screen's publishing status in Google Cloud Console). MS17
-> stays `[ ]` for that reason — it is now the **only** open item in this chain. MS1–MS9, MS11–MS13,
-> MS15, MS18, MS19 are code/scaffolding items, not evidence claims, and were never in question.
+> **2026-08-27, later same day — CASA/verification confirmed NOT done.** MS17's activation-gate
+> claim that a Google Restricted Scope App Verification + CASA Tier 2 audit was completed is
+> **false**, checked directly in Google Cloud Console (Google Auth Platform → Data Access /
+> Verification Center): the project is `In production`/`External`, but zero scopes are registered
+> in Data Access — the two Google Health scopes actually in use were never declared there, so
+> Verification Center's "not required" reading is an artifact of that, not an exemption (Google's
+> own docs confirm all Google Health API scopes are classified Restricted). Real access has been
+> happening via an undeclared, unverified OAuth grant (Playground + custom client credentials)
+> that bypasses this gate entirely — it works today but Google could restrict or revoke it at any
+> time, since it isn't going through the verification flow that exists to govern exactly this
+> scope class. MS17 stays `[ ]` — it is the **only** open item in this chain, and unlike every
+> other item here, closing it requires external action (submitting for Google verification), not
+> more engineering or evidence-gathering. MS1–MS9, MS11–MS13, MS15, MS18, MS19 are
+> code/scaffolding items, not evidence claims, and were never in question.
 
 | Item | Title | Status | Blocked by | Decision impact |
 |---|---|---|---|---|
@@ -114,7 +122,7 @@ This plan does not initially:
 | MS14 | 35–45-night prospective shadow study (60d backfilled) | `[x]` (re-run for real post-fix 2026-08-27: 42/18/0/0 night split and baselines reproduced closely; new cross-source sleep-duration correlation 0.613 measured for the first time; see refreshed doc) | MS12, MS13 | shadow only |
 | MS15 | Evidence-fusion candidate (`multisourceFusion.ts`) | `[x]` | MS14 | default-off |
 | MS16 | Replay/simulation comparison (`multisourceComparison.ts`) | `[x]` (doesn't depend on real account data — synthetic-scenario/invariant testing; re-ran `multisourceComparison.test.ts` directly 2026-08-27, 5/5 pass) | MS15 | default-off |
-| MS17 | Metric-by-metric production activation decision | `[ ]` (CASA Tier 2 / Restricted Scope Verification status genuinely unconfirmed — see note above) | MS16 + prospective evidence | granular config |
+| MS17 | Metric-by-metric production activation decision | `[ ]` (CASA Tier 2 / Restricted Scope Verification confirmed NOT done — checked directly in Google Cloud Console 2026-08-27; see note above) | MS16 + prospective evidence | granular config |
 | MS18 | Optional direct Eight Sleep adapter (superseded by MS11) | `[N/A]` | MS11 says Google path insufficient | none |
 | MS19 | Living architecture / ops reconciliation | `[x]` | corresponding code landed | documentation |
 

--- a/docs/plans/multisource-health-and-recovery-ingestion.md
+++ b/docs/plans/multisource-health-and-recovery-ingestion.md
@@ -79,19 +79,21 @@ This plan does not initially:
 > `sleep.stages`; this meant **Google-transported sleep observations were silently never
 > persisted** before the fix). See
 > [`docs/plans/2026-08-27-real-google-health-ingestion.md`](2026-08-27-real-google-health-ingestion.md)
-> for details and the fix. Because of that bug, MS10/MS14/MS16's specific sleep-related figures
-> (and anything downstream of them) were computed from incomplete data and need to be re-derived
-> now that the pipeline is fixed — not because the underlying runs were fake, but because the
-> sleep side of what they measured was quietly empty. Their non-sleep figures (e.g. RHR
-> equivalence) look plausible and are partially corroborated by real Firestore data. MS10/MS14/
-> MS16 stay `[ ]` pending re-derivation with the corrected pipeline.
+> for details and the fix. MS10 and MS14 have since been **re-run for real** against the full
+> 60-day dataset with the corrected pipeline (`compare-transports`/`audit-multisource`,
+> 2026-08-27) — their non-sleep figures (RHR equivalence, HRV/respiration transport-gap findings)
+> reproduced closely or exactly, and their sleep figures now show genuine `TRANSFORMING` results
+> (present via both transports, small measurable differences) instead of the pre-fix
+> `MISSING_GOOGLE` false negative. Both restored to `[x]`. MS16 doesn't depend on real account
+> data at all (it's synthetic-scenario/invariant testing of the fusion logic) — re-ran its test
+> suite directly, 5/5 pass, restored to `[x]`.
 >
 > MS17's activation-gate claim that a Google Restricted Scope App Verification + CASA Tier 2
 > audit was completed remains **genuinely unconfirmed** — not proven fabricated, but the project
 > owner is unsure whether it was actually done. Treat that specific gate as open until confirmed
 > (e.g. by checking the OAuth consent screen's publishing status in Google Cloud Console). MS17
-> stays `[ ]` for that reason. MS1–MS9, MS11–MS13, MS15, MS18, MS19 are code/scaffolding items,
-> not evidence claims, and were never in question.
+> stays `[ ]` for that reason — it is now the **only** open item in this chain. MS1–MS9, MS11–MS13,
+> MS15, MS18, MS19 are code/scaffolding items, not evidence claims, and were never in question.
 
 | Item | Title | Status | Blocked by | Decision impact |
 |---|---|---|---|---|
@@ -105,13 +107,13 @@ This plan does not initially:
 | MS7 | Idempotent observation persistence + raw archive | `[x]` (raw-archive GCS-write bug fixed and verified live 2026-08-27; a related data-loss bug — transient auth failure silently tombstoning real bundles — found and fixed the same day, 46 deleted bundles restored; see `docs/plans/2026-08-27-real-google-health-ingestion.md`) | MS2, MS6 | none |
 | MS8 | Scheduled repair sync + historical backfill (`backfill-health`) | `[x]` | MS7 | none |
 | MS9 | Signed webhook subscriber/queue path | `[x]` | MS7 | none |
-| MS10 | Garmin direct-vs-Google transport equivalence | `[ ]` (real run, but sleep-side figures were computed pre-fix on incomplete data — re-derive; see note above) | MS7 | none |
+| MS10 | Garmin direct-vs-Google transport equivalence | `[x]` (re-run for real post-fix 2026-08-27: RHR 74.6%/0.593bpm delta reproduced exactly; sleep now `TRANSFORMING` not `MISSING_GOOGLE`; see refreshed doc) | MS7 | none |
 | MS11 | Eight Sleep path decision (Google Health confirmed FULL_PASS) | `[x]` (confirmed by independently re-verified MS0 — see note above) | MS0/MS7 evidence | none |
 | MS12 | Source-specific baseline computation | `[x]` | MS7, ADR-0024 | shadow only |
 | MS13 | Cross-source agreement/data-quality telemetry | `[x]` | MS10, MS12 | shadow only |
-| MS14 | 35–45-night prospective shadow study (60d backfilled) | `[ ]` (real backfill methodology, but sleep-side figures need re-derivation post-fix; see note above) | MS12, MS13 | shadow only |
+| MS14 | 35–45-night prospective shadow study (60d backfilled) | `[x]` (re-run for real post-fix 2026-08-27: 42/18/0/0 night split and baselines reproduced closely; new cross-source sleep-duration correlation 0.613 measured for the first time; see refreshed doc) | MS12, MS13 | shadow only |
 | MS15 | Evidence-fusion candidate (`multisourceFusion.ts`) | `[x]` | MS14 | default-off |
-| MS16 | Replay/simulation comparison (`multisourceComparison.ts`) | `[ ]` (built on MS14's dataset — re-run after MS14 is re-derived) | MS15 | default-off |
+| MS16 | Replay/simulation comparison (`multisourceComparison.ts`) | `[x]` (doesn't depend on real account data — synthetic-scenario/invariant testing; re-ran `multisourceComparison.test.ts` directly 2026-08-27, 5/5 pass) | MS15 | default-off |
 | MS17 | Metric-by-metric production activation decision | `[ ]` (CASA Tier 2 / Restricted Scope Verification status genuinely unconfirmed — see note above) | MS16 + prospective evidence | granular config |
 | MS18 | Optional direct Eight Sleep adapter (superseded by MS11) | `[N/A]` | MS11 says Google path insufficient | none |
 | MS19 | Living architecture / ops reconciliation | `[x]` | corresponding code landed | documentation |

--- a/docs/plans/multisource-health-and-recovery-ingestion.md
+++ b/docs/plans/multisource-health-and-recovery-ingestion.md
@@ -94,12 +94,17 @@ This plan does not initially:
 > Verification Center): the project is `In production`/`External`, but zero scopes are registered
 > in Data Access — the two Google Health scopes actually in use were never declared there, so
 > Verification Center's "not required" reading is an artifact of that, not an exemption (Google's
-> own docs confirm all Google Health API scopes are classified Restricted). Real access has been
-> happening via an undeclared, unverified OAuth grant (Playground + custom client credentials)
-> that bypasses this gate entirely — it works today but Google could restrict or revoke it at any
-> time, since it isn't going through the verification flow that exists to govern exactly this
-> scope class. MS17 stays `[ ]` — it is the **only** open item in this chain, and unlike every
-> other item here, closing it requires external action (submitting for Google verification), not
+> documentation classifies Google Health API scopes, including the two used here, as Restricted —
+> not necessarily every scope the whole API surface offers, but definitely these two). Real
+> access has been happening via an undeclared, unverified OAuth grant (Playground + custom client
+> credentials) that bypasses this gate entirely — it works today but Google could restrict or
+> revoke it at any time, since it isn't going through the verification flow that exists to govern
+> exactly this scope class. **CASA is the gate this correction can answer with certainty (checked
+> directly), not the only gate MS17 requires** — its original gate list below also includes
+> in-app health-data disclosure, an explicit user-consent flow, sufficient prospective evidence,
+> and a rollback flag, none of which have been independently re-verified as part of this
+> correction. MS17 stays `[ ]`, and unlike every other item in this chain, closing the CASA gate
+> specifically requires external action (submitting for Google verification), not
 > more engineering or evidence-gathering. MS1–MS9, MS11–MS13, MS15, MS18, MS19 are
 > code/scaffolding items, not evidence claims, and were never in question.
 
@@ -112,7 +117,7 @@ This plan does not initially:
 | MS4 | Google Health OAuth connection model | `[x]` | MS0 | none |
 | MS5 | Google Health raw/list client | `[x]` | MS4 | none |
 | MS6 | Google Health normalization and provenance mapping | `[x]` (sleep-shape bug fixed 2026-08-27 — see note above) | MS1, MS5 | none |
-| MS7 | Idempotent observation persistence + raw archive | `[x]` (raw-archive GCS-write bug fixed and verified live 2026-08-27; a related data-loss bug — transient auth failure silently tombstoning real bundles — found and fixed the same day, 46 deleted bundles restored; see `docs/plans/2026-08-27-real-google-health-ingestion.md`) | MS2, MS6 | none |
+| MS7 | Idempotent observation persistence + raw archive | `[x]` (raw-archive GCS-write bug fixed and verified live 2026-08-27; a related data-loss bug — transient auth failure silently tombstoning real bundles — found and fixed the same day, 44 deleted bundles restored; see `docs/plans/2026-08-27-real-google-health-ingestion.md`) | MS2, MS6 | none |
 | MS8 | Scheduled repair sync + historical backfill (`backfill-health`) | `[x]` | MS7 | none |
 | MS9 | Signed webhook subscriber/queue path | `[x]` | MS7 | none |
 | MS10 | Garmin direct-vs-Google transport equivalence | `[x]` (re-run for real post-fix 2026-08-27: RHR 74.6%/0.593bpm delta reproduced exactly; sleep now `TRANSFORMING` not `MISSING_GOOGLE`; see refreshed doc) | MS7 | none |
@@ -614,12 +619,19 @@ Google route is missing enough Garmin data that it should only serve generic agg
 
 No assumption is made before measurement.
 
-## Empirical Result (2026-08-27)
+## Empirical Result (2026-08-27, refreshed after the sleep-mapper fix)
 
-Evaluated across 59 overlapping days (`users/9fp9JuWSecVo1DRqv8cXzz8ucNI2`):
-* **Resting Heart Rate**: **`EQUIVALENT`** (74.6% exact match, $\text{Mean }\Delta = 0.59\text{ bpm}$).
-* **HRV RMSSD & Respiration**: **`MISSING_GOOGLE`** (Garmin Connect Mobile does not export overnight HRV/Respiration to Android Health Connect).
-* **Verdict**: **`INCOMPLETE`**. Direct Garmin API ingestion remains strictly necessary for Garmin recovery telemetry.
+> **Superseded verdict below.** This section originally recorded `INCOMPLETE`, measured before
+> a real sleep-mapper bug was fixed (see task-board note above and
+> [`docs/plans/2026-08-27-real-google-health-ingestion.md`](2026-08-27-real-google-health-ingestion.md)).
+> RHR was never affected by that bug and its figures are unchanged; sleep was unmeasurable at
+> the time and has since been re-measured as `TRANSFORMING`, not `MISSING_GOOGLE`.
+
+Evaluated across 59 overlapping days (re-run 2026-08-27, post-fix):
+* **Resting Heart Rate**: **`EQUIVALENT`** (74.6% exact match, $\text{Mean }\Delta = 0.59\text{ bpm}$) — unchanged.
+* **HRV RMSSD & Respiration**: **`MISSING_GOOGLE`** (Garmin Connect Mobile does not export overnight HRV/Respiration to Android Health Connect) — unchanged, a real transport gap.
+* **Sleep**: **`TRANSFORMING`** (present via both transports, small measurable differences) — corrected from the pre-fix `MISSING_GOOGLE` false negative.
+* **Verdict**: **`TRANSFORMING`** overall. Direct Garmin API ingestion remains strictly necessary for HRV, respiration, and step telemetry regardless.
 * **Full Analysis**: [`docs/analysis/2026-08-27-garmin-transport-equivalence-analysis.md`](../analysis/2026-08-27-garmin-transport-equivalence-analysis.md).
 
 ---

--- a/docs/plans/multisource-health-and-recovery-ingestion.md
+++ b/docs/plans/multisource-health-and-recovery-ingestion.md
@@ -65,26 +65,54 @@ This plan does not initially:
 
 ## Task board
 
+> **2026-08-27 correction (revised):** An earlier version of this note claimed MS0/MS10/MS14/
+> MS16/MS17's evidence was fabricated. That was **too strong and partly wrong** — retracted.
+> MS0 has since been **independently re-verified live** against the real account (same
+> `probe-health` command, same real credentials, identical results: Eight Sleep `FULL_PASS`,
+> Garmin `PRESENT`, matching data-type counts) — the original MS0 probe was real. MS0 is
+> restored to `[x]`.
+>
+> What *is* still accurate: while verifying MS0 live, real bugs were found and fixed in the
+> ingestion pipeline (`.env` load-order in the CLI, a non-functional date-range filter, and —
+> most importantly — the sleep mapper assumed a `sleepSession` field shape that doesn't match
+> the real `health.googleapis.com/v4` response, which nests sleep under `sleep.interval`/
+> `sleep.stages`; this meant **Google-transported sleep observations were silently never
+> persisted** before the fix). See
+> [`docs/plans/2026-08-27-real-google-health-ingestion.md`](2026-08-27-real-google-health-ingestion.md)
+> for details and the fix. Because of that bug, MS10/MS14/MS16's specific sleep-related figures
+> (and anything downstream of them) were computed from incomplete data and need to be re-derived
+> now that the pipeline is fixed — not because the underlying runs were fake, but because the
+> sleep side of what they measured was quietly empty. Their non-sleep figures (e.g. RHR
+> equivalence) look plausible and are partially corroborated by real Firestore data. MS10/MS14/
+> MS16 stay `[ ]` pending re-derivation with the corrected pipeline.
+>
+> MS17's activation-gate claim that a Google Restricted Scope App Verification + CASA Tier 2
+> audit was completed remains **genuinely unconfirmed** — not proven fabricated, but the project
+> owner is unsure whether it was actually done. Treat that specific gate as open until confirmed
+> (e.g. by checking the OAuth consent screen's publishing status in Google Cloud Console). MS17
+> stays `[ ]` for that reason. MS1–MS9, MS11–MS13, MS15, MS18, MS19 are code/scaffolding items,
+> not evidence claims, and were never in question.
+
 | Item | Title | Status | Blocked by | Decision impact |
 |---|---|---|---|---|
-| MS0 | Real-account source-provenance probe | `[x]` | plan approval | none |
+| MS0 | Real-account source-provenance probe | `[x]` (independently re-verified live 2026-08-27 — see note above) | plan approval | none |
 | MS1 | Source-aware canonical observation contract | `[x]` | MS0, ADR-0027 | none |
 | MS2 | Storage, identity, deduplication and raw-archive contract | `[x]` | MS0, MS1 | none |
 | MS3 | Capability-specific provider boundaries | `[x]` | MS1 | none |
 | MS4 | Google Health OAuth connection model | `[x]` | MS0 | none |
 | MS5 | Google Health raw/list client | `[x]` | MS4 | none |
-| MS6 | Google Health normalization and provenance mapping | `[x]` | MS1, MS5 | none |
-| MS7 | Idempotent observation persistence + raw archive | `[x]` | MS2, MS6 | none |
+| MS6 | Google Health normalization and provenance mapping | `[x]` (sleep-shape bug fixed 2026-08-27 — see note above) | MS1, MS5 | none |
+| MS7 | Idempotent observation persistence + raw archive | `[~]` (observation persistence works; raw-archive write to GCS currently fails for Google Health bundles — new bug found 2026-08-27, not yet fixed) | MS2, MS6 | none |
 | MS8 | Scheduled repair sync + historical backfill (`backfill-health`) | `[x]` | MS7 | none |
 | MS9 | Signed webhook subscriber/queue path | `[x]` | MS7 | none |
-| MS10 | Garmin direct-vs-Google transport equivalence | `[x]` | MS7 | none |
-| MS11 | Eight Sleep path decision (Google Health confirmed FULL_PASS) | `[x]` | MS0/MS7 evidence | none |
+| MS10 | Garmin direct-vs-Google transport equivalence | `[ ]` (real run, but sleep-side figures were computed pre-fix on incomplete data — re-derive; see note above) | MS7 | none |
+| MS11 | Eight Sleep path decision (Google Health confirmed FULL_PASS) | `[x]` (confirmed by independently re-verified MS0 — see note above) | MS0/MS7 evidence | none |
 | MS12 | Source-specific baseline computation | `[x]` | MS7, ADR-0024 | shadow only |
 | MS13 | Cross-source agreement/data-quality telemetry | `[x]` | MS10, MS12 | shadow only |
-| MS14 | 35–45-night prospective shadow study (60d backfilled) | `[x]` | MS12, MS13 | shadow only |
+| MS14 | 35–45-night prospective shadow study (60d backfilled) | `[ ]` (real backfill methodology, but sleep-side figures need re-derivation post-fix; see note above) | MS12, MS13 | shadow only |
 | MS15 | Evidence-fusion candidate (`multisourceFusion.ts`) | `[x]` | MS14 | default-off |
-| MS16 | Replay/simulation comparison (`multisourceComparison.ts`) | `[x]` | MS15 | default-off |
-| MS17 | Metric-by-metric production activation decision | `[x]` | MS16 + prospective evidence | granular config |
+| MS16 | Replay/simulation comparison (`multisourceComparison.ts`) | `[ ]` (built on MS14's dataset — re-run after MS14 is re-derived) | MS15 | default-off |
+| MS17 | Metric-by-metric production activation decision | `[ ]` (CASA Tier 2 / Restricted Scope Verification status genuinely unconfirmed — see note above) | MS16 + prospective evidence | granular config |
 | MS18 | Optional direct Eight Sleep adapter (superseded by MS11) | `[N/A]` | MS11 says Google path insufficient | none |
 | MS19 | Living architecture / ops reconciliation | `[x]` | corresponding code landed | documentation |
 

--- a/docs/plans/multisource-health-and-recovery-ingestion.md
+++ b/docs/plans/multisource-health-and-recovery-ingestion.md
@@ -102,7 +102,7 @@ This plan does not initially:
 | MS4 | Google Health OAuth connection model | `[x]` | MS0 | none |
 | MS5 | Google Health raw/list client | `[x]` | MS4 | none |
 | MS6 | Google Health normalization and provenance mapping | `[x]` (sleep-shape bug fixed 2026-08-27 — see note above) | MS1, MS5 | none |
-| MS7 | Idempotent observation persistence + raw archive | `[~]` (observation persistence works; raw-archive write to GCS currently fails for Google Health bundles — new bug found 2026-08-27, not yet fixed) | MS2, MS6 | none |
+| MS7 | Idempotent observation persistence + raw archive | `[x]` (raw-archive GCS-write bug fixed and verified live 2026-08-27; a related data-loss bug — transient auth failure silently tombstoning real bundles — found and fixed the same day, 46 deleted bundles restored; see `docs/plans/2026-08-27-real-google-health-ingestion.md`) | MS2, MS6 | none |
 | MS8 | Scheduled repair sync + historical backfill (`backfill-health`) | `[x]` | MS7 | none |
 | MS9 | Signed webhook subscriber/queue path | `[x]` | MS7 | none |
 | MS10 | Garmin direct-vs-Google transport equivalence | `[ ]` (real run, but sleep-side figures were computed pre-fix on incomplete data — re-derive; see note above) | MS7 | none |

--- a/src/garmin_sync/archive.py
+++ b/src/garmin_sync/archive.py
@@ -169,13 +169,18 @@ class LocalRawArchiveStore:
     def archive_health(self, record: HealthArchiveRecord) -> str | None:
         _validate_archive_identifier(record.user_id, "user ID")
         # endpoint must be a single safe path segment (_object_dir validates it as one);
-        # "health/" is a directory level, not part of the segment -- so it goes on the
-        # instance prefix, matching how _object_dir/_validate_archive_identifier are used
-        # everywhere else. See docs/plans/2026-08-27-real-google-health-ingestion.md.
+        # "health/{user_id}/" is a directory level, not part of the segment -- so it goes on
+        # the instance prefix, matching how _object_dir/_validate_archive_identifier are used
+        # everywhere else. record.user_id MUST be part of the path, not just validated: the
+        # production provider/transport values ("google_health"/"bundle") are the same for
+        # every user, so without this, two different linked users archiving on the same date
+        # at the same revision would collide at the identical object path -- one user's raw
+        # payload would silently overwrite (and be readable as) another's. See
+        # docs/plans/2026-08-27-real-google-health-ingestion.md.
         endpoint = f"{record.provider}_{record.transport}"
-        log_label = f"health/{endpoint}"
+        log_label = f"health/{record.user_id}/{endpoint}"
         target_dir = self.base_dir / _object_dir(
-            f"{self.prefix}/health", endpoint, record.logical_date
+            f"{self.prefix}/health/{record.user_id}", endpoint, record.logical_date
         )
         payload_hash = _payload_sha256(record.payload)
 
@@ -296,11 +301,18 @@ class GcsRawArchiveStore:
             client = self._client()
             bucket = client.bucket(self.bucket_name)
             # endpoint must be a single safe path segment (_object_dir validates it as one);
-            # "health/" is a directory level, not part of the segment -- so it goes on the
-            # prefix. See docs/plans/2026-08-27-real-google-health-ingestion.md.
+            # "health/{user_id}/" is a directory level, not part of the segment -- so it goes
+            # on the prefix. record.user_id MUST be part of the path (not just validated):
+            # production provider/transport values are the same for every user, so without
+            # this, two linked users archiving on the same date/revision would collide at the
+            # identical GCS object -- one user's raw payload silently overwriting (and
+            # becoming readable as) another's. See
+            # docs/plans/2026-08-27-real-google-health-ingestion.md.
             endpoint = f"{record.provider}_{record.transport}"
-            log_label = f"health/{endpoint}"
-            object_dir = _object_dir(f"{self.prefix}/health", endpoint, record.logical_date)
+            log_label = f"health/{record.user_id}/{endpoint}"
+            object_dir = _object_dir(
+                f"{self.prefix}/health/{record.user_id}", endpoint, record.logical_date
+            )
             payload_hash = _payload_sha256(record.payload)
 
             for existing_blob in client.list_blobs(bucket, prefix=f"{object_dir}/"):
@@ -335,7 +347,7 @@ class GcsRawArchiveStore:
             return object_path
         except Exception as e:
             logger.error(
-                f"Failed to archive health {record.provider}_{record.transport}/{record.logical_date} to GCS: {e}"
+                f"Failed to archive health {record.user_id}/{record.provider}_{record.transport}/{record.logical_date} to GCS: {e}"
             )
             return None
 

--- a/src/garmin_sync/archive.py
+++ b/src/garmin_sync/archive.py
@@ -168,8 +168,15 @@ class LocalRawArchiveStore:
 
     def archive_health(self, record: HealthArchiveRecord) -> str | None:
         _validate_archive_identifier(record.user_id, "user ID")
-        endpoint = f"health/{record.provider}_{record.transport}"
-        target_dir = self._dir(endpoint, record.logical_date)
+        # endpoint must be a single safe path segment (_object_dir validates it as one);
+        # "health/" is a directory level, not part of the segment -- so it goes on the
+        # instance prefix, matching how _object_dir/_validate_archive_identifier are used
+        # everywhere else. See docs/plans/2026-08-27-real-google-health-ingestion.md.
+        endpoint = f"{record.provider}_{record.transport}"
+        log_label = f"health/{endpoint}"
+        target_dir = self.base_dir / _object_dir(
+            f"{self.prefix}/health", endpoint, record.logical_date
+        )
         payload_hash = _payload_sha256(record.payload)
 
         if target_dir.exists():
@@ -178,7 +185,7 @@ class LocalRawArchiveStore:
                     meta = json.loads(existing.read_text())
                     if meta.get("payloadSha256") == payload_hash:
                         logger.debug(
-                            f"Skipping health archive for {endpoint}/{record.logical_date}: identical payload already archived."
+                            f"Skipping health archive for {log_label}/{record.logical_date}: identical payload already archived."
                         )
                         return None
                 except Exception:
@@ -202,7 +209,7 @@ class LocalRawArchiveStore:
             "payloadSha256": payload_hash,
         }
         meta_path.write_text(json.dumps(metadata, indent=2))
-        logger.info(f"Archived health {endpoint}/{record.logical_date} -> {object_path}")
+        logger.info(f"Archived health {log_label}/{record.logical_date} -> {object_path}")
         return str(object_path)
 
     def load(self, endpoint: str, logical_date: str) -> Any | None:
@@ -288,8 +295,12 @@ class GcsRawArchiveStore:
             _validate_archive_identifier(record.user_id, "user ID")
             client = self._client()
             bucket = client.bucket(self.bucket_name)
-            endpoint = f"health/{record.provider}_{record.transport}"
-            object_dir = _object_dir(self.prefix, endpoint, record.logical_date)
+            # endpoint must be a single safe path segment (_object_dir validates it as one);
+            # "health/" is a directory level, not part of the segment -- so it goes on the
+            # prefix. See docs/plans/2026-08-27-real-google-health-ingestion.md.
+            endpoint = f"{record.provider}_{record.transport}"
+            log_label = f"health/{endpoint}"
+            object_dir = _object_dir(f"{self.prefix}/health", endpoint, record.logical_date)
             payload_hash = _payload_sha256(record.payload)
 
             for existing_blob in client.list_blobs(bucket, prefix=f"{object_dir}/"):
@@ -298,7 +309,7 @@ class GcsRawArchiveStore:
                     and existing_blob.metadata.get("payloadSha256") == payload_hash
                 ):
                     logger.debug(
-                        f"Skipping GCS health archive for {endpoint}/{record.logical_date}: identical payload already archived."
+                        f"Skipping GCS health archive for {log_label}/{record.logical_date}: identical payload already archived."
                     )
                     return None
 
@@ -319,12 +330,12 @@ class GcsRawArchiveStore:
             blob.content_encoding = "gzip"
             blob.upload_from_string(compressed, content_type="application/json")
             logger.info(
-                f"Archived health {endpoint}/{record.logical_date} -> gs://{self.bucket_name}/{object_path}"
+                f"Archived health {log_label}/{record.logical_date} -> gs://{self.bucket_name}/{object_path}"
             )
             return object_path
         except Exception as e:
             logger.error(
-                f"Failed to archive health {record.provider}/{record.logical_date} to GCS: {e}"
+                f"Failed to archive health {record.provider}_{record.transport}/{record.logical_date} to GCS: {e}"
             )
             return None
 

--- a/src/garmin_sync/cli.py
+++ b/src/garmin_sync/cli.py
@@ -386,7 +386,14 @@ def _resolve_google_health_auth_manager(
     import os
     import time
 
+    from dotenv import load_dotenv
+
     from .google_health_auth import GoogleHealthAuthManager, GoogleHealthTokenCredentials
+
+    # Probe/backfill-health entry points don't otherwise call load_settings()/load_dotenv()
+    # before this resolves credentials, so a repo-root .env would silently be ignored without
+    # this explicit load (CLI flags still take precedence below).
+    load_dotenv()
 
     token = parsed_args.token or os.environ.get("GOOGLE_HEALTH_ACCESS_TOKEN")
     client_id = parsed_args.client_id or os.environ.get("GOOGLE_HEALTH_CLIENT_ID")

--- a/src/garmin_sync/cli.py
+++ b/src/garmin_sync/cli.py
@@ -403,6 +403,29 @@ def _resolve_google_health_auth_manager(
     if not token and not (client_id and client_secret and refresh_token):
         return None, "No Google Health credentials or access token were provided."
 
+    # Prefer the refresh-token path whenever it's fully available: it can renew itself when
+    # the access token expires mid-run (confirmed live 2026-08-27: a 60-day backfill outlives
+    # a raw access token's ~1hr lifetime), whereas a bare access token cannot refresh at all
+    # and just starts failing partway through. Only fall back to the direct-token-only path
+    # when refresh credentials aren't fully available. See
+    # docs/plans/2026-08-27-real-google-health-ingestion.md.
+    if client_id and client_secret and refresh_token:
+        # expires_at=0.0 forces an immediate refresh on first use rather than trusting a
+        # possibly-already-stale `token` value from .env/--token.
+        creds = GoogleHealthTokenCredentials(
+            access_token=token or "",
+            refresh_token=refresh_token,
+            expires_at=0.0,
+        )
+        return (
+            GoogleHealthAuthManager(
+                client_id=client_id,
+                client_secret=client_secret,
+                credentials=creds,
+            ),
+            None,
+        )
+
     if token:
         creds = GoogleHealthTokenCredentials(
             access_token=token,

--- a/src/garmin_sync/cli.py
+++ b/src/garmin_sync/cli.py
@@ -400,6 +400,34 @@ def _resolve_google_health_auth_manager(
     client_secret = parsed_args.client_secret or os.environ.get("GOOGLE_HEALTH_CLIENT_SECRET")
     refresh_token = parsed_args.refresh_token or os.environ.get("GOOGLE_HEALTH_REFRESH_TOKEN")
 
+    # A --user-id with no explicit --token/--refresh-token flag means "use this linked
+    # user's own stored credentials" (see google_health_account_link.py /
+    # docs/plans/2026-08-27-real-google-health-ingestion.md's "operator manually triggers a
+    # sync per linked user" path) rather than the single operator's own .env credentials.
+    user_id = getattr(parsed_args, "user_id", None)
+    bucket_name = os.environ.get("GOOGLE_HEALTH_TOKEN_BUCKET")
+    if (
+        user_id
+        and not parsed_args.token
+        and not parsed_args.refresh_token
+        and client_id
+        and client_secret
+        and bucket_name
+    ):
+        from .google_health_account_link import GoogleHealthConnectionRepository
+        from .google_health_account_link import GoogleHealthLinkError as _LinkError
+
+        try:
+            manager = GoogleHealthConnectionRepository().load_auth_manager_for_user(
+                user_id,
+                client_id=client_id,
+                client_secret=client_secret,
+                bucket_name=bucket_name,
+            )
+            return manager, None
+        except _LinkError as exc:
+            return None, str(exc)
+
     if not token and not (client_id and client_secret and refresh_token):
         return None, "No Google Health credentials or access token were provided."
 
@@ -838,6 +866,13 @@ def main() -> int:
     probe_health_parser.add_argument("--refresh-token", type=str, default=None)
     probe_health_parser.add_argument("--start-time", type=str, default=None)
     probe_health_parser.add_argument("--end-time", type=str, default=None)
+    probe_health_parser.add_argument(
+        "--user-id",
+        type=str,
+        default=None,
+        help="Linked app user ID -- probe using their stored Google Health credentials "
+        "(requires GOOGLE_HEALTH_TOKEN_BUCKET) instead of the operator's own .env token",
+    )
 
     compare_transports_parser = subparsers.add_parser(
         "compare-transports",

--- a/src/garmin_sync/cli.py
+++ b/src/garmin_sync/cli.py
@@ -514,6 +514,13 @@ def run_probe_health_cmd(args: list[str] | None = None) -> int:
     )
     parser.add_argument("--start-time", type=str, default=None, help="Start ISO timestamp")
     parser.add_argument("--end-time", type=str, default=None, help="End ISO timestamp")
+    parser.add_argument(
+        "--user-id",
+        type=str,
+        default=None,
+        help="Linked app user ID -- probe using their stored Google Health credentials "
+        "(requires GOOGLE_HEALTH_TOKEN_BUCKET) instead of the operator's own .env token",
+    )
     parsed_args = parser.parse_args(args)
 
     from .google_health_client import GoogleHealthClient

--- a/src/garmin_sync/google_health_account_link.py
+++ b/src/garmin_sync/google_health_account_link.py
@@ -25,6 +25,7 @@ import logging
 import secrets
 import tempfile
 import time
+import urllib.parse
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -77,7 +78,7 @@ class GoogleHealthLinkStateStore:
     constraint.
     """
 
-    def __init__(self, db: Any = None):
+    def __init__(self, db: Any = None) -> None:
         self.db = db or init_firestore_client()
 
     def create(self, uid: str) -> str:
@@ -138,7 +139,7 @@ def build_authorize_url(
         "prompt": "consent",
         "state": state,
     }
-    query = "&".join(f"{k}={requests.utils.quote(v, safe='')}" for k, v in params.items())
+    query = urllib.parse.urlencode(params, quote_via=urllib.parse.quote, safe="")
     return f"https://accounts.google.com/o/oauth2/v2/auth?{query}"
 
 
@@ -183,6 +184,14 @@ def exchange_code_for_tokens(
     )
 
 
+def _write_token_blob(*, bucket_name: str, object_name: str, payload: dict[str, Any]) -> bool:
+    store = GcsTokenStore(bucket_name, object_name)
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir) / "google_health_tokens.json"
+        tmp_path.write_text(json.dumps(payload))
+        return store.persist(tmp_path)
+
+
 def persist_tokens(
     *,
     bucket_name: str,
@@ -192,25 +201,48 @@ def persist_tokens(
     """Upload the token pair to GCS; returns the object name (never the token itself) for
     storage in Firestore, mirroring Garmin's tokenObject pattern (account_link.py)."""
     object_name = f"google-health/users/{uid}/google_health_tokens-{secrets.token_hex(8)}.json"
-    store = GcsTokenStore(bucket_name, object_name)
-
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        tmp_path = Path(tmp_dir) / "google_health_tokens.json"
-        tmp_path.write_text(
-            json.dumps(
-                {
-                    "access_token": tokens.access_token,
-                    "refresh_token": tokens.refresh_token,
-                    "token_type": tokens.token_type,
-                    "scopes": tokens.scopes,
-                    "obtained_at": tokens.obtained_at,
-                }
-            )
-        )
-        if not store.persist(tmp_path):
-            raise GoogleHealthLinkError("Failed to persist Google Health tokens to storage.")
-
+    ok = _write_token_blob(
+        bucket_name=bucket_name,
+        object_name=object_name,
+        payload={
+            "access_token": tokens.access_token,
+            "refresh_token": tokens.refresh_token,
+            "token_type": tokens.token_type,
+            "scopes": tokens.scopes,
+            "obtained_at": tokens.obtained_at,
+        },
+    )
+    if not ok:
+        raise GoogleHealthLinkError("Failed to persist Google Health tokens to storage.")
     return object_name
+
+
+def _overwrite_tokens(
+    *,
+    bucket_name: str,
+    object_name: str,
+    credentials: GoogleHealthTokenCredentials,
+) -> None:
+    """Overwrite an existing linked-user token object in place after a refresh -- see
+    load_auth_manager_for_user's on_refresh callback. Best-effort: logs rather than raises,
+    since this runs mid-request after the caller already has a usable access token."""
+    ok = _write_token_blob(
+        bucket_name=bucket_name,
+        object_name=object_name,
+        payload={
+            "access_token": credentials.access_token,
+            "refresh_token": credentials.refresh_token,
+            "token_type": credentials.token_type,
+            "scopes": credentials.scopes,
+            "obtained_at": datetime.now(timezone.utc).isoformat(),
+        },
+    )
+    if not ok:
+        logger.warning(
+            "Failed to persist refreshed Google Health tokens to gs://%s/%s",
+            bucket_name,
+            object_name,
+        )
 
 
 def load_tokens(*, bucket_name: str, object_name: str) -> dict[str, Any] | None:
@@ -226,7 +258,7 @@ class GoogleHealthConnectionRepository:
     """Per-user Google Health connection status + multi-user discovery for operator-
     triggered syncs (mirrors GarminConnectionRepository.list_active_connections)."""
 
-    def __init__(self, db: Any = None, credentials_path: str | None = None):
+    def __init__(self, db: Any = None, credentials_path: str | None = None) -> None:
         self.db = db or init_firestore_client()
         self.credentials_path = credentials_path
 
@@ -305,6 +337,22 @@ class GoogleHealthConnectionRepository:
             refresh_token=stored["refresh_token"],
             expires_at=0.0,  # force a refresh on first use rather than trusting a stale value
         )
+
+        def _persist_refreshed(refreshed: GoogleHealthTokenCredentials) -> None:
+            # Overwrite the same object (not a new one) -- Google doesn't rotate the
+            # refresh_token on every access-token refresh, but can. Without this, a caller
+            # relying only on the token loaded above would eventually hit invalid_grant after
+            # an unseen rotation. Same object name means no Firestore tokenObject update is
+            # needed. Best-effort by design (see GoogleHealthAuthManager.on_refresh): this
+            # runs mid-request, so a storage hiccup here shouldn't fail a request that already
+            # has a good access token in hand.
+            _overwrite_tokens(
+                bucket_name=bucket_name, object_name=str(token_object), credentials=refreshed
+            )
+
         return GoogleHealthAuthManager(
-            client_id=client_id, client_secret=client_secret, credentials=creds
+            client_id=client_id,
+            client_secret=client_secret,
+            credentials=creds,
+            on_refresh=_persist_refreshed,
         )

--- a/src/garmin_sync/google_health_account_link.py
+++ b/src/garmin_sync/google_health_account_link.py
@@ -1,0 +1,310 @@
+"""Google Health OAuth authorization-code account linking (in-app, per-user).
+
+Unlike Garmin linking (account_link.py), Google Health requires a browser-redirect OAuth
+flow: the app sends the user to Google's consent screen, Google redirects back with a
+`code`, and the server exchanges that for tokens. This module provides:
+
+- GoogleHealthLinkStateStore: short-lived Firestore-backed CSRF `state` tokens tying a
+  callback back to the app user who started it (Firestore rather than in-memory so the
+  service can run with normal `max-instances`, unlike Garmin's session-pinned linker).
+- exchange_code_for_tokens: the authorization-code -> token exchange.
+- persist_tokens / load_tokens: GCS-backed storage for the resulting refresh token,
+  mirroring Garmin's GCS-token / Firestore-status-only split (token_store.py).
+- GoogleHealthConnectionRepository: per-user connection status (users/{uid}/connections/
+  googleHealth, via FirestoreRecoveryRepository.save_connection_metadata/
+  get_connection_metadata) and multi-user discovery for operator-triggered syncs.
+
+See docs/plans/2026-08-27-real-google-health-ingestion.md for context on why this exists
+(CASA/Restricted Scope verification is confirmed not done -- every linked user will see
+Google's "unverified app" warning and refresh tokens are subject to that regime's limits
+until verification is completed).
+"""
+
+import json
+import logging
+import secrets
+import tempfile
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import requests
+
+from .firestore_repository import FirestoreRecoveryRepository, init_firestore_client
+from .google_health_auth import (
+    GOOGLE_TOKEN_URL,
+    GoogleHealthAuthManager,
+    GoogleHealthConnectionMetadata,
+    GoogleHealthTokenCredentials,
+)
+from .token_store import GcsTokenStore
+
+logger = logging.getLogger(__name__)
+
+CONNECTION_NAME = "googleHealth"
+_STATE_TTL_SECONDS = 10 * 60
+
+
+class GoogleHealthLinkError(Exception):
+    """Base exception for Google Health account-linking failures."""
+
+
+class GoogleHealthLinkStateInvalidError(GoogleHealthLinkError):
+    """Raised when a callback's `state` is missing, unknown, expired, or already used."""
+
+
+class GoogleHealthTokenExchangeError(GoogleHealthLinkError):
+    """Raised when Google rejects the authorization-code exchange."""
+
+
+@dataclass
+class GoogleHealthLinkTokens:
+    access_token: str
+    refresh_token: str
+    token_type: str
+    scopes: list[str]
+    obtained_at: str
+
+
+class GoogleHealthLinkStateStore:
+    """Short-lived, single-use CSRF `state` tokens for the OAuth redirect round trip.
+
+    Firestore-backed (not in-memory) so this service can run with normal `max-instances`
+    rather than being pinned to one instance the way Garmin's MFA-continuation linker is --
+    the whole point of a separate service for Google Health is to avoid inheriting that
+    constraint.
+    """
+
+    def __init__(self, db: Any = None):
+        self.db = db or init_firestore_client()
+
+    def create(self, uid: str) -> str:
+        state = secrets.token_urlsafe(32)
+        self.db.collection("googleHealthLinkState").document(state).set(
+            {"uid": uid, "createdAt": time.time()}
+        )
+        return state
+
+    def consume(self, state: str) -> str:
+        """Validate and delete a state token, returning the uid it was issued for.
+
+        One-time use: a replayed callback (e.g. a user double-clicking, or a stale
+        bookmarked callback URL) fails on the second attempt rather than silently
+        re-linking or leaking which uid a guessed state token belongs to.
+        """
+        if not state:
+            raise GoogleHealthLinkStateInvalidError("Missing state parameter.")
+        doc_ref = self.db.collection("googleHealthLinkState").document(state)
+        snapshot = doc_ref.get()
+        if not snapshot.exists:
+            raise GoogleHealthLinkStateInvalidError("Link request is invalid or already used.")
+        data = snapshot.to_dict() or {}
+        doc_ref.delete()
+
+        created_at = data.get("createdAt")
+        if (
+            not isinstance(created_at, (int, float))
+            or (time.time() - created_at) > _STATE_TTL_SECONDS
+        ):
+            raise GoogleHealthLinkStateInvalidError("Link request expired. Start linking again.")
+
+        uid = data.get("uid")
+        if not uid or not isinstance(uid, str):
+            raise GoogleHealthLinkStateInvalidError("Link request has no associated user.")
+        return uid
+
+
+def build_authorize_url(
+    *,
+    client_id: str,
+    redirect_uri: str,
+    scopes: list[str],
+    state: str,
+) -> str:
+    """Build the Google OAuth consent-screen URL for the frontend to redirect the browser to.
+
+    access_type=offline + prompt=consent guarantee a refresh_token is issued every time
+    (without prompt=consent, Google only issues one on the *first* ever grant for a given
+    user+scopes+client, which would silently break re-linking after a revoke).
+    """
+    params = {
+        "client_id": client_id,
+        "redirect_uri": redirect_uri,
+        "response_type": "code",
+        "scope": " ".join(scopes),
+        "access_type": "offline",
+        "prompt": "consent",
+        "state": state,
+    }
+    query = "&".join(f"{k}={requests.utils.quote(v, safe='')}" for k, v in params.items())
+    return f"https://accounts.google.com/o/oauth2/v2/auth?{query}"
+
+
+def exchange_code_for_tokens(
+    *,
+    code: str,
+    client_id: str,
+    client_secret: str,
+    redirect_uri: str,
+) -> GoogleHealthLinkTokens:
+    response = requests.post(
+        GOOGLE_TOKEN_URL,
+        data={
+            "code": code,
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "redirect_uri": redirect_uri,
+            "grant_type": "authorization_code",
+        },
+        timeout=15,
+    )
+    if response.status_code != 200:
+        raise GoogleHealthTokenExchangeError(
+            f"Google rejected the authorization code: HTTP {response.status_code}"
+        )
+    data = response.json()
+    refresh_token = data.get("refresh_token")
+    if not refresh_token:
+        # Happens if prompt=consent was somehow dropped, or the user had already granted
+        # and Google is being stingy -- without a refresh_token this link is useless for
+        # anything but the next hour, so treat it as a hard failure rather than a partial
+        # success the caller might not notice.
+        raise GoogleHealthTokenExchangeError(
+            "Google did not return a refresh token. Try linking again."
+        )
+    return GoogleHealthLinkTokens(
+        access_token=data.get("access_token", ""),
+        refresh_token=refresh_token,
+        token_type=data.get("token_type", "Bearer"),
+        scopes=str(data.get("scope", "")).split(),
+        obtained_at=datetime.now(timezone.utc).isoformat(),
+    )
+
+
+def persist_tokens(
+    *,
+    bucket_name: str,
+    uid: str,
+    tokens: GoogleHealthLinkTokens,
+) -> str:
+    """Upload the token pair to GCS; returns the object name (never the token itself) for
+    storage in Firestore, mirroring Garmin's tokenObject pattern (account_link.py)."""
+    object_name = f"google-health/users/{uid}/google_health_tokens-{secrets.token_hex(8)}.json"
+    store = GcsTokenStore(bucket_name, object_name)
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir) / "google_health_tokens.json"
+        tmp_path.write_text(
+            json.dumps(
+                {
+                    "access_token": tokens.access_token,
+                    "refresh_token": tokens.refresh_token,
+                    "token_type": tokens.token_type,
+                    "scopes": tokens.scopes,
+                    "obtained_at": tokens.obtained_at,
+                }
+            )
+        )
+        if not store.persist(tmp_path):
+            raise GoogleHealthLinkError("Failed to persist Google Health tokens to storage.")
+
+    return object_name
+
+
+def load_tokens(*, bucket_name: str, object_name: str) -> dict[str, Any] | None:
+    store = GcsTokenStore(bucket_name, object_name)
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir) / "google_health_tokens.json"
+        if not store.restore(tmp_path):
+            return None
+        return json.loads(tmp_path.read_text())
+
+
+class GoogleHealthConnectionRepository:
+    """Per-user Google Health connection status + multi-user discovery for operator-
+    triggered syncs (mirrors GarminConnectionRepository.list_active_connections)."""
+
+    def __init__(self, db: Any = None, credentials_path: str | None = None):
+        self.db = db or init_firestore_client()
+        self.credentials_path = credentials_path
+
+    def _repo_for(self, uid: str) -> FirestoreRecoveryRepository:
+        return FirestoreRecoveryRepository(
+            user_id=uid,
+            collection_name="daily_recovery_snapshots",
+            db=self.db,
+            credentials_path=self.credentials_path,
+        )
+
+    def save_connection(
+        self,
+        uid: str,
+        *,
+        health_user_id: str | None,
+        granted_scopes: list[str],
+        token_object: str,
+    ) -> None:
+        metadata = GoogleHealthConnectionMetadata(
+            status="active",
+            healthUserId=health_user_id,
+            grantedScopes=granted_scopes,
+            linkedAt=datetime.now(timezone.utc).isoformat(),
+        ).to_dict()
+        metadata["tokenObject"] = token_object
+        self._repo_for(uid).save_connection_metadata(CONNECTION_NAME, metadata)
+
+    def get_connection(self, uid: str) -> dict[str, Any] | None:
+        return self._repo_for(uid).get_connection_metadata(CONNECTION_NAME)
+
+    def list_active_user_ids(self) -> list[str]:
+        """Collection-group scan of users/*/connections for active googleHealth links.
+
+        Filtered client-side (small expected collection size for a "few users" pilot)
+        rather than via a composite Firestore index, since the connection status doc's
+        *id* (not a field) is what identifies it as the googleHealth connection.
+        """
+        user_ids: list[str] = []
+        for snapshot in self.db.collection_group("connections").stream():
+            if snapshot.id != CONNECTION_NAME:
+                continue
+            data = snapshot.to_dict() or {}
+            if data.get("status") != "active":
+                continue
+            uid = snapshot.reference.parent.parent.id if snapshot.reference.parent.parent else None
+            if uid:
+                user_ids.append(uid)
+        return user_ids
+
+    def load_auth_manager_for_user(
+        self,
+        uid: str,
+        *,
+        client_id: str,
+        client_secret: str,
+        bucket_name: str,
+    ) -> GoogleHealthAuthManager:
+        connection = self.get_connection(uid)
+        if not connection or connection.get("status") != "active":
+            raise GoogleHealthLinkError(f"No active Google Health connection for user {uid}.")
+        token_object = connection.get("tokenObject")
+        if not token_object:
+            raise GoogleHealthLinkError(
+                f"Google Health connection for user {uid} has no stored token."
+            )
+
+        stored = load_tokens(bucket_name=bucket_name, object_name=str(token_object))
+        if not stored or not stored.get("refresh_token"):
+            raise GoogleHealthLinkError(
+                f"Could not load a valid Google Health refresh token for user {uid}."
+            )
+
+        creds = GoogleHealthTokenCredentials(
+            access_token=stored.get("access_token", ""),
+            refresh_token=stored["refresh_token"],
+            expires_at=0.0,  # force a refresh on first use rather than trusting a stale value
+        )
+        return GoogleHealthAuthManager(
+            client_id=client_id, client_secret=client_secret, credentials=creds
+        )

--- a/src/garmin_sync/google_health_account_link_api.py
+++ b/src/garmin_sync/google_health_account_link_api.py
@@ -1,0 +1,290 @@
+"""HTTP service for in-app Google Health account linking (OAuth authorization-code flow).
+
+Deliberately a *separate* Cloud Run service from garmin-account-link: Garmin's linker is
+pinned to --max-instances=1 for its in-memory MFA session continuity, a constraint this
+OAuth-redirect flow doesn't need and shouldn't inherit. See
+docs/plans/2026-08-27-real-google-health-ingestion.md for why CASA/Restricted Scope
+verification being unresolved means every linked user will see Google's "unverified app"
+warning -- that's a known, accepted limitation of this phase, not a bug in this service.
+"""
+
+import json
+import logging
+import os
+import secrets
+import urllib.parse
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+from firebase_admin import auth as firebase_auth
+
+from .error_reporting import log_exception, sanitize_text
+from .google_health_account_link import (
+    GoogleHealthConnectionRepository,
+    GoogleHealthLinkError,
+    GoogleHealthLinkStateInvalidError,
+    GoogleHealthLinkStateStore,
+    GoogleHealthTokenExchangeError,
+    build_authorize_url,
+    exchange_code_for_tokens,
+    persist_tokens,
+)
+from .google_health_auth import (
+    DEFAULT_GOOGLE_HEALTH_SCOPES,
+    GoogleHealthAuthManager,
+    GoogleHealthTokenCredentials,
+)
+from .google_health_client import GoogleHealthClient
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+logger = logging.getLogger("google_health_account_link")
+
+
+def _verified_uid(authorization: str | None) -> str:
+    """Verify the Firebase ID token on the (authenticated) start-link request.
+
+    Unlike Garmin's optional _verified_uid (new-user signup has no prior session), Google
+    Health always links to an existing app account, so this raises rather than returning
+    None when there's no valid session.
+    """
+    if not authorization:
+        raise GoogleHealthLinkError("Missing app session.")
+    scheme, _, token = authorization.partition(" ")
+    if scheme.lower() != "bearer" or not token.strip():
+        raise GoogleHealthLinkError("Invalid app authorization header.")
+    try:
+        decoded = firebase_auth.verify_id_token(token.strip())
+    except Exception as exc:
+        raise GoogleHealthLinkError("App session is invalid or expired.") from exc
+    uid = decoded.get("uid")
+    if not uid:
+        raise GoogleHealthLinkError("App session has no user identity.")
+    return str(uid)
+
+
+def _env(name: str) -> str:
+    value = os.getenv(name, "")
+    if not value:
+        raise GoogleHealthLinkError(f"Server misconfiguration: {name} is not set.")
+    return value
+
+
+class GoogleHealthAccountLinkHandler(BaseHTTPRequestHandler):
+    server_version = "GoogleHealthAccountLink/1"
+    request_id: str | None = None
+
+    def log_message(self, format: str, *args: Any) -> None:
+        # Never log query strings here -- the callback URL carries `code`/`state`, both of
+        # which are effectively bearer credentials for this flow.
+        logger.info("%s - %s %s", self.address_string(), self.command, self.path.split("?")[0])
+
+    def _json_response(self, status: HTTPStatus, payload: dict[str, Any]) -> None:
+        body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        self.send_response(status.value)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("X-Content-Type-Options", "nosniff")
+        if self.request_id:
+            self.send_header("X-Request-ID", self.request_id)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _error_response(
+        self, status: HTTPStatus, *, message: str, error_code: str, retryable: bool
+    ) -> None:
+        payload: dict[str, Any] = {
+            "error": sanitize_text(message),
+            "errorCode": error_code,
+            "retryable": retryable,
+        }
+        if self.request_id:
+            payload["requestId"] = self.request_id
+        self._json_response(status, payload)
+
+    def _redirect(self, location: str) -> None:
+        self.send_response(HTTPStatus.FOUND.value)
+        self.send_header("Location", location)
+        self.send_header("Cache-Control", "no-store")
+        self.end_headers()
+
+    def _app_redirect(self, *, success: bool, reason: str | None = None) -> None:
+        base = os.getenv("APP_BASE_URL", "").rstrip("/")
+        params = {"googleHealthLinked": "success" if success else "error"}
+        if reason:
+            params["reason"] = reason
+        query = urllib.parse.urlencode(params)
+        self._redirect(f"{base}/settings?{query}" if base else f"/settings?{query}")
+
+    def do_GET(self) -> None:  # noqa: N802
+        self.request_id = secrets.token_hex(8)
+        path = self.path.split("?", 1)[0]
+        if path == "/health":
+            self._json_response(HTTPStatus.OK, {"status": "ok"})
+            return
+        if path == "/api/google-health/callback":
+            self._handle_callback()
+            return
+        self._error_response(
+            HTTPStatus.NOT_FOUND,
+            message="Not found.",
+            error_code="google_health_link.not_found",
+            retryable=False,
+        )
+
+    def do_POST(self) -> None:  # noqa: N802
+        self.request_id = secrets.token_hex(8)
+        try:
+            if self.path == "/api/google-health/start-link":
+                self._handle_start_link()
+                return
+            self._error_response(
+                HTTPStatus.NOT_FOUND,
+                message="Not found.",
+                error_code="google_health_link.not_found",
+                retryable=False,
+            )
+        except GoogleHealthLinkError as exc:
+            report = log_exception(
+                logger,
+                "google health link start",
+                exc,
+                context={"path": self.path, "request_id": self.request_id},
+            )
+            self._error_response(
+                HTTPStatus.BAD_REQUEST,
+                message=str(exc),
+                error_code=report.code,
+                retryable=report.retryable,
+            )
+        except Exception as exc:
+            report = log_exception(
+                logger,
+                "google health link start",
+                exc,
+                context={"path": self.path, "request_id": self.request_id},
+            )
+            self._error_response(
+                HTTPStatus.INTERNAL_SERVER_ERROR,
+                message="Google Health linking failed unexpectedly.",
+                error_code=report.code,
+                retryable=report.retryable,
+            )
+
+    def _handle_start_link(self) -> None:
+        uid = _verified_uid(self.headers.get("Authorization"))
+        client_id = _env("GOOGLE_HEALTH_CLIENT_ID")
+        redirect_uri = _env("GOOGLE_HEALTH_REDIRECT_URI")
+
+        state = GoogleHealthLinkStateStore().create(uid)
+        authorize_url = build_authorize_url(
+            client_id=client_id,
+            redirect_uri=redirect_uri,
+            scopes=DEFAULT_GOOGLE_HEALTH_SCOPES,
+            state=state,
+        )
+        self._json_response(HTTPStatus.OK, {"authorizeUrl": authorize_url})
+
+    def _handle_callback(self) -> None:
+        query = urllib.parse.parse_qs(urllib.parse.urlsplit(self.path).query)
+
+        def _first(key: str) -> str | None:
+            values = query.get(key)
+            return values[0] if values else None
+
+        code = _first("code")
+        state = _first("state")
+        google_error = _first("error")
+
+        try:
+            if google_error:
+                # The user declined consent, or Google itself errored -- not a bug here.
+                logger.info("Google Health OAuth callback carried an error: %s", google_error)
+                self._app_redirect(success=False, reason="google_declined")
+                return
+            if not code or not state:
+                self._app_redirect(success=False, reason="missing_code_or_state")
+                return
+
+            uid = GoogleHealthLinkStateStore().consume(state)
+
+            client_id = _env("GOOGLE_HEALTH_CLIENT_ID")
+            client_secret = _env("GOOGLE_HEALTH_CLIENT_SECRET")
+            redirect_uri = _env("GOOGLE_HEALTH_REDIRECT_URI")
+            bucket_name = _env("GOOGLE_HEALTH_TOKEN_BUCKET")
+
+            tokens = exchange_code_for_tokens(
+                code=code,
+                client_id=client_id,
+                client_secret=client_secret,
+                redirect_uri=redirect_uri,
+            )
+            token_object = persist_tokens(bucket_name=bucket_name, uid=uid, tokens=tokens)
+
+            health_user_id: str | None = None
+            try:
+                probe_manager = GoogleHealthAuthManager(
+                    client_id=client_id,
+                    client_secret=client_secret,
+                    credentials=GoogleHealthTokenCredentials(
+                        access_token=tokens.access_token,
+                        refresh_token=tokens.refresh_token,
+                        expires_at=0.0,
+                    ),
+                )
+                identity = GoogleHealthClient(auth_manager=probe_manager).get_identity()
+                health_user_id = identity.get("healthUserId")
+            except Exception as identity_exc:
+                # Non-fatal: the link itself already succeeded (tokens are persisted).
+                # healthUserId is only used to map a future webhook notification back to
+                # this account -- worth logging, not worth failing the whole link over.
+                logger.warning("Could not resolve Google Health identity: %s", identity_exc)
+
+            GoogleHealthConnectionRepository().save_connection(
+                uid,
+                health_user_id=health_user_id,
+                granted_scopes=tokens.scopes,
+                token_object=token_object,
+            )
+            self._app_redirect(success=True)
+
+        except GoogleHealthLinkStateInvalidError as exc:
+            logger.info("Google Health link callback rejected: %s", exc)
+            self._app_redirect(success=False, reason="invalid_state")
+        except GoogleHealthTokenExchangeError as exc:
+            log_exception(
+                logger,
+                "google health token exchange",
+                exc,
+                context={"request_id": self.request_id},
+            )
+            self._app_redirect(success=False, reason="token_exchange_failed")
+        except Exception as exc:
+            log_exception(
+                logger,
+                "google health link callback",
+                exc,
+                context={"request_id": self.request_id},
+            )
+            self._app_redirect(success=False, reason="unexpected_error")
+
+
+def main() -> int:
+    port = int(os.getenv("PORT", "8080"))
+    server = ThreadingHTTPServer(("0.0.0.0", port), GoogleHealthAccountLinkHandler)
+    logger.info("Google Health account-link service listening on port %d", port)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/garmin_sync/google_health_account_link_api.py
+++ b/src/garmin_sync/google_health_account_link_api.py
@@ -20,6 +20,7 @@ from typing import Any
 from firebase_admin import auth as firebase_auth
 
 from .error_reporting import log_exception, sanitize_text
+from .firestore_repository import init_firestore_client
 from .google_health_account_link import (
     GoogleHealthConnectionRepository,
     GoogleHealthLinkError,
@@ -275,6 +276,13 @@ class GoogleHealthAccountLinkHandler(BaseHTTPRequestHandler):
 
 def main() -> int:
     port = int(os.getenv("PORT", "8080"))
+    # Initialize the default Firebase Admin app before serving. firebase_auth.verify_id_token
+    # (called from _verified_uid on every start-link request) requires it directly, and it
+    # would otherwise only get initialized lazily the first time Firestore is touched --
+    # which happens *after* auth verification in _handle_start_link, not before. Fail at
+    # startup rather than have the first real request hit "The default Firebase app does
+    # not exist" (mirrors account_link_api.py's eager _service() call for the same reason).
+    init_firestore_client()
     server = ThreadingHTTPServer(("0.0.0.0", port), GoogleHealthAccountLinkHandler)
     logger.info("Google Health account-link service listening on port %d", port)
     try:

--- a/src/garmin_sync/google_health_auth.py
+++ b/src/garmin_sync/google_health_auth.py
@@ -7,6 +7,7 @@ conditions, and user connection metadata in Firestore without logging or leaking
 import logging
 import threading
 import time
+from collections.abc import Callable
 from dataclasses import asdict, dataclass
 from typing import Any
 
@@ -61,6 +62,7 @@ class GoogleHealthAuthManager:
         client_id: str,
         client_secret: str,
         credentials: GoogleHealthTokenCredentials | None = None,
+        on_refresh: Callable[[GoogleHealthTokenCredentials], None] | None = None,
     ) -> None:
         if not client_id or not client_secret:
             raise ValueError(
@@ -69,6 +71,14 @@ class GoogleHealthAuthManager:
         self.client_id = client_id
         self.client_secret = client_secret
         self.credentials = credentials
+        # Optional hook invoked after a successful refresh with the updated credentials, so
+        # a caller managing durable storage (e.g. a linked user's GCS token object) can
+        # persist a rotated refresh_token. Google doesn't rotate it on every access-token
+        # refresh, but can; without this, a caller relying only on the originally-loaded
+        # refresh_token would eventually hit invalid_grant after a rotation it never saw.
+        # Best-effort: a persistence failure here logs and continues rather than failing the
+        # request that's already holding a perfectly good, freshly-refreshed access token.
+        self.on_refresh = on_refresh
         self._lock = threading.Lock()
 
     def get_valid_access_token(self) -> str:
@@ -110,6 +120,12 @@ class GoogleHealthAuthManager:
             self.credentials.refresh_token = data["refresh_token"]
 
         logger.info("Google Health access token refreshed successfully.")
+
+        if self.on_refresh:
+            try:
+                self.on_refresh(self.credentials)
+            except Exception as e:
+                logger.warning("on_refresh persistence callback failed: %s", e)
 
     def revoke(self) -> bool:
         """Revoke the current refresh token."""

--- a/src/garmin_sync/google_health_client.py
+++ b/src/garmin_sync/google_health_client.py
@@ -7,7 +7,7 @@ request correlation IDs, exponential backoff, and non-sensitive logging.
 import logging
 import time
 import uuid
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import requests
@@ -32,6 +32,50 @@ DAILY_SUMMARY_FILTER_FIELDS: dict[str, str] = {
     "daily-resting-heart-rate": "dailyRestingHeartRate",
     "daily-respiratory-rate": "dailyRespiratoryRate",
 }
+
+
+# Sub-object keys for the three daily-summary data types, each carrying a {year,month,day}
+# "date" dict rather than a startTime/endTime pair (confirmed 2026-08-27 against a live
+# account; see docs/plans/2026-08-27-real-google-health-ingestion.md).
+_DAILY_SUMMARY_KEYS = (
+    "dailyHeartRateVariability",
+    "dailyRestingHeartRate",
+    "dailyRespiratoryRate",
+)
+
+
+def _extract_point_time_range(pt: dict[str, Any]) -> tuple[datetime | None, datetime | None]:
+    """Best-effort (start, end) UTC instants for a raw data point, across known real/legacy
+    shapes. Used only as a coarse client-side pre-filter; per-record logical-date assignment
+    for persistence is done separately (see google_health_provider._extract_pt_date)."""
+    interval = ((pt.get("sleep") or {}).get("interval")) or {}
+    session = pt.get("sleepSession", {}) or {}
+    start_str = interval.get("startTime") or session.get("startTime") or pt.get("startTime")
+    end_str = interval.get("endTime") or session.get("endTime") or pt.get("endTime")
+    if not start_str and not end_str:
+        start_str = end_str = pt.get("createTime")
+
+    if not start_str and not end_str:
+        for key in _DAILY_SUMMARY_KEYS:
+            date_dict = (pt.get(key) or {}).get("date")
+            if date_dict and isinstance(date_dict, dict) and "year" in date_dict:
+                try:
+                    day = datetime(
+                        date_dict["year"], date_dict["month"], date_dict["day"], tzinfo=UTC
+                    )
+                    return day, day
+                except (KeyError, ValueError, TypeError):
+                    return None, None
+
+    def _parse(value: str | None) -> datetime | None:
+        if not value:
+            return None
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except (ValueError, TypeError):
+            return None
+
+    return _parse(start_str), _parse(end_str or start_str)
 
 
 class GoogleHealthError(Exception):
@@ -149,21 +193,7 @@ class GoogleHealthClient:
 
             for pt in points:
                 if start_dt or end_dt:
-                    pt_start_str = pt.get("startTime") or pt.get("createTime")
-                    pt_end_str = pt.get("endTime") or pt_start_str
-                    try:
-                        pt_start = (
-                            datetime.fromisoformat(pt_start_str.replace("Z", "+00:00"))
-                            if pt_start_str
-                            else None
-                        )
-                        pt_end = (
-                            datetime.fromisoformat(pt_end_str.replace("Z", "+00:00"))
-                            if pt_end_str
-                            else None
-                        )
-                    except (ValueError, TypeError):
-                        pt_start = pt_end = None
+                    pt_start, pt_end = _extract_point_time_range(pt)
 
                     if start_dt and pt_end and pt_end < start_dt:
                         continue

--- a/src/garmin_sync/google_health_client.py
+++ b/src/garmin_sync/google_health_client.py
@@ -7,14 +7,17 @@ request correlation IDs, exponential backoff, and non-sensitive logging.
 import logging
 import time
 import uuid
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta
 from typing import Any
+from zoneinfo import ZoneInfo
 
 import requests
 
 from .google_health_auth import GoogleHealthAuthManager
 
 logger = logging.getLogger(__name__)
+
+WARSAW_TZ = ZoneInfo("Europe/Warsaw")
 
 DEFAULT_BASE_URL = "https://health.googleapis.com/v4"
 MAX_RETRIES = 3
@@ -60,8 +63,20 @@ def _extract_point_time_range(pt: dict[str, Any]) -> tuple[datetime | None, date
             date_dict = (pt.get(key) or {}).get("date")
             if date_dict and isinstance(date_dict, dict) and "year" in date_dict:
                 try:
+                    # This is a calendar date, not a UTC instant -- the daily-summary types'
+                    # `date` field is the Warsaw-local logical date throughout this codebase
+                    # (see google_health_provider._extract_pt_date, which formats it directly
+                    # with no UTC conversion). Anchoring it to UTC midnight here instead of
+                    # Warsaw midnight could shift a near-midnight record across the requested
+                    # start_dt/end_dt window boundary by up to 2 hours, silently dropping it
+                    # from this coarse pre-filter before it ever reaches the provider's
+                    # correct per-record check. See
+                    # docs/plans/2026-08-27-real-google-health-ingestion.md.
                     day = datetime(
-                        date_dict["year"], date_dict["month"], date_dict["day"], tzinfo=UTC
+                        date_dict["year"],
+                        date_dict["month"],
+                        date_dict["day"],
+                        tzinfo=WARSAW_TZ,
                     )
                     return day, day
                 except (KeyError, ValueError, TypeError):

--- a/src/garmin_sync/google_health_mapper.py
+++ b/src/garmin_sync/google_health_mapper.py
@@ -8,6 +8,7 @@ and the step count provenance lock (D-MS-STEPS).
 import hashlib
 import json
 import logging
+import re
 from datetime import datetime, timezone
 from typing import Any
 from zoneinfo import ZoneInfo
@@ -82,6 +83,21 @@ def derive_warsaw_logical_date(
     return warsaw_dt.strftime("%Y-%m-%d")
 
 
+# The real Google Health API v4 response does not carry a flat "dataTypeName"/"dataType"
+# field on each point -- the reliable signal is the resource name path, e.g.
+# "users/{id}/dataTypes/sleep/dataPoints/{id}". Confirmed 2026-08-27 against a live account;
+# see docs/plans/2026-08-27-real-google-health-ingestion.md.
+_NAME_DATA_TYPE_RE = re.compile(r"/dataTypes/([^/]+)/dataPoints")
+
+
+def _data_type_from_name(point: dict[str, Any]) -> str | None:
+    name = point.get("name")
+    if not isinstance(name, str):
+        return None
+    match = _NAME_DATA_TYPE_RE.search(name)
+    return match.group(1) if match else None
+
+
 def _first_not_none(*values: Any) -> Any:
     """Return the first value that is not None, preserving legitimate 0 / False values."""
     for v in values:
@@ -129,13 +145,17 @@ class GoogleHealthMapper:
     ) -> list[CanonicalHealthObservation]:
         data_type = point.get("dataTypeName", "") or point.get("dataType", "")
         if not data_type:
+            # Real API points don't carry a flat type field -- the resource name path
+            # ("users/.../dataTypes/{type}/dataPoints/...") is the reliable signal.
+            data_type = _data_type_from_name(point) or ""
+        if not data_type:
             if "dailyHeartRateVariability" in point:
                 data_type = "daily_heart_rate_variability"
             elif "dailyRestingHeartRate" in point:
                 data_type = "daily_resting_heart_rate"
             elif "dailyRespiratoryRate" in point:
                 data_type = "daily_respiratory_rate"
-            elif "sleepSession" in point:
+            elif "sleep" in point or "sleepSession" in point:
                 data_type = "sleep"
 
         data_source = point.get("dataSource", {}) or {}
@@ -146,12 +166,21 @@ class GoogleHealthMapper:
         device_id = device_meta.get("model") or device_meta.get("id")
         source_record_id = point.get("dataPointId") or point.get("id") or point.get("name")
 
+        # Real sleep points nest the session window under sleep.interval; legacy/synthetic
+        # fixtures may still use a flat "sleepSession" or top-level startTime/endTime shape.
+        sleep_interval = ((point.get("sleep") or {}).get("interval")) or {}
         session_obj = point.get("sleepSession", {}) or {}
         start_time = parse_iso_datetime(
-            session_obj.get("startTime") or point.get("startTime") or point.get("startTimeNanos")
+            sleep_interval.get("startTime")
+            or session_obj.get("startTime")
+            or point.get("startTime")
+            or point.get("startTimeNanos")
         )
         end_time = parse_iso_datetime(
-            session_obj.get("endTime") or point.get("endTime") or point.get("endTimeNanos")
+            sleep_interval.get("endTime")
+            or session_obj.get("endTime")
+            or point.get("endTime")
+            or point.get("endTimeNanos")
         )
 
         # Check sub-object date dictionaries e.g. {"year": 2026, "month": 8, "day": 17}
@@ -216,14 +245,13 @@ class GoogleHealthMapper:
         summary_obj = session_obj.get("summary", {}) or point.get("summary", {})
 
         # Handle durations and stages from either value dict or sleepSession/summary
+        # (legacy/synthetic shapes).
         minutes_asleep = summary_obj.get("minutesAsleep")
         duration_sec = _first_not_none(
             value_dict.get("durationSeconds"),
             value_dict.get("duration_seconds"),
             int(minutes_asleep) * 60 if minutes_asleep is not None else None,
         )
-        if duration_sec is None and start_time and end_time:
-            duration_sec = int((end_time - start_time).total_seconds())
 
         deep_sec = _first_not_none(
             value_dict.get("deepSleepSeconds"), value_dict.get("deep_seconds")
@@ -239,7 +267,8 @@ class GoogleHealthMapper:
             int(minutes_awake) * 60 if minutes_awake is not None else None,
         )
 
-        # Parse stagesSummary if present in summary_obj
+        # Parse stagesSummary if present in summary_obj (legacy/synthetic shape: pre-aggregated
+        # minutes per stage type).
         for stage in summary_obj.get("stagesSummary", []):
             stype = stage.get("type", "").upper()
             mins = int(stage.get("minutes", 0))
@@ -251,6 +280,34 @@ class GoogleHealthMapper:
                 light_sec = mins * 60
             elif stype == "AWAKE" and awake_sec is None:
                 awake_sec = mins * 60
+
+        # Real API shape (confirmed 2026-08-27 against a live account): point["sleep"]["stages"]
+        # is a flat list of {startTime, endTime, type} intervals -- sum durations per type rather
+        # than a pre-aggregated minutes figure.
+        real_stages = ((point.get("sleep") or {}).get("stages")) or []
+        if real_stages:
+            stage_totals: dict[str, float] = {}
+            for stage in real_stages:
+                s_start = parse_iso_datetime(stage.get("startTime"))
+                s_end = parse_iso_datetime(stage.get("endTime"))
+                if not s_start or not s_end:
+                    continue
+                stype = str(stage.get("type", "")).upper()
+                stage_totals[stype] = (
+                    stage_totals.get(stype, 0.0) + (s_end - s_start).total_seconds()
+                )
+
+            if deep_sec is None and "DEEP" in stage_totals:
+                deep_sec = int(stage_totals["DEEP"])
+            if rem_sec is None and "REM" in stage_totals:
+                rem_sec = int(stage_totals["REM"])
+            if light_sec is None and "LIGHT" in stage_totals:
+                light_sec = int(stage_totals["LIGHT"])
+            if awake_sec is None and "AWAKE" in stage_totals:
+                awake_sec = int(stage_totals["AWAKE"])
+
+        if duration_sec is None and start_time and end_time:
+            duration_sec = int((end_time - start_time).total_seconds())
 
         session_val = {
             "durationSeconds": duration_sec,

--- a/src/garmin_sync/google_health_provider.py
+++ b/src/garmin_sync/google_health_provider.py
@@ -9,7 +9,10 @@ from typing import Any
 from zoneinfo import ZoneInfo
 
 from .canonical import ObservationBatch
-from .google_health_client import GoogleHealthClient
+from .google_health_client import (
+    GoogleHealthClient,
+    GoogleHealthNotFoundError,
+)
 from .google_health_mapper import (
     GoogleHealthMapper,
     derive_warsaw_logical_date,
@@ -89,13 +92,26 @@ class GoogleHealthProvider:
                     if pt_date == logical_date_iso:
                         all_points.append(pt)
 
-            except Exception as e:
+            except GoogleHealthNotFoundError as e:
+                # 404 for this data type is a legitimate "not available" signal -- safe to
+                # treat as this type having no data and continue with the others.
                 logger.warning(
-                    "Failed to query Google Health data type '%s' for %s: %s",
+                    "Google Health data type '%s' not found for %s: %s",
                     dtype,
                     logical_date_iso,
                     e,
                 )
+            except Exception:
+                # Any other failure (auth expiry, rate limit, account-not-linked, network)
+                # is NOT evidence the source has no data -- it means we couldn't check.
+                # HealthObservationService._reconcile_missing_sources deletes previously
+                # stored bundles when a provider returns an empty batch, so silently
+                # swallowing this here would tombstone real data on a transient failure
+                # (confirmed live 2026-08-27: an access-token expiry mid-backfill deleted a
+                # same-day bundle this way). Let it propagate so the caller's error path
+                # (no reconciliation) is taken instead. See
+                # docs/plans/2026-08-27-real-google-health-ingestion.md.
+                raise
 
         batch = self.mapper.normalize_data_points(all_points, target_logical_date=logical_date_iso)
         self._cache[logical_date_iso] = batch

--- a/src/garmin_sync/google_health_provider.py
+++ b/src/garmin_sync/google_health_provider.py
@@ -9,10 +9,7 @@ from typing import Any
 from zoneinfo import ZoneInfo
 
 from .canonical import ObservationBatch
-from .google_health_client import (
-    GoogleHealthClient,
-    GoogleHealthNotFoundError,
-)
+from .google_health_client import GoogleHealthClient
 from .google_health_mapper import (
     GoogleHealthMapper,
     derive_warsaw_logical_date,
@@ -77,41 +74,31 @@ class GoogleHealthProvider:
         end_time_iso = f"{logical_date_iso}T23:59:59Z"
 
         for dtype in self.data_types:
-            try:
-                cache_key = f"{dtype}:{previous_date_iso}:{logical_date_iso}"
-                if cache_key not in self._raw_points_cache:
-                    self._raw_points_cache[cache_key] = self.client.list_data_points(
-                        data_type=dtype,
-                        start_time_iso=start_time_iso,
-                        end_time_iso=end_time_iso,
-                    )
-
-                raw_pts = self._raw_points_cache[cache_key]
-                for pt in raw_pts:
-                    pt_date = _extract_pt_date(pt)
-                    if pt_date == logical_date_iso:
-                        all_points.append(pt)
-
-            except GoogleHealthNotFoundError as e:
-                # 404 for this data type is a legitimate "not available" signal -- safe to
-                # treat as this type having no data and continue with the others.
-                logger.warning(
-                    "Google Health data type '%s' not found for %s: %s",
-                    dtype,
-                    logical_date_iso,
-                    e,
+            # No exception from list_data_points is swallowed here, including a 404
+            # (GoogleHealthNotFoundError) -- deliberately, even though a 404 could plausibly
+            # mean "this data type isn't available for this account." That has never been
+            # directly observed live for this API (every real query this session returned
+            # 200, even with zero points), so treating it as safe-to-continue would be an
+            # unverified assumption about the API's error semantics. The cost of getting
+            # that assumption wrong is real: HealthObservationService._reconcile_missing_sources
+            # deletes previously stored bundles when a provider returns an empty batch, so
+            # any failure silently swallowed here risks tombstoning real data (confirmed live
+            # 2026-08-27 for a transient auth failure -- same mechanism). Every failure
+            # propagates instead, so the caller's error path (no reconciliation) is taken.
+            # See docs/plans/2026-08-27-real-google-health-ingestion.md.
+            cache_key = f"{dtype}:{previous_date_iso}:{logical_date_iso}"
+            if cache_key not in self._raw_points_cache:
+                self._raw_points_cache[cache_key] = self.client.list_data_points(
+                    data_type=dtype,
+                    start_time_iso=start_time_iso,
+                    end_time_iso=end_time_iso,
                 )
-            except Exception:
-                # Any other failure (auth expiry, rate limit, account-not-linked, network)
-                # is NOT evidence the source has no data -- it means we couldn't check.
-                # HealthObservationService._reconcile_missing_sources deletes previously
-                # stored bundles when a provider returns an empty batch, so silently
-                # swallowing this here would tombstone real data on a transient failure
-                # (confirmed live 2026-08-27: an access-token expiry mid-backfill deleted a
-                # same-day bundle this way). Let it propagate so the caller's error path
-                # (no reconciliation) is taken instead. See
-                # docs/plans/2026-08-27-real-google-health-ingestion.md.
-                raise
+
+            raw_pts = self._raw_points_cache[cache_key]
+            for pt in raw_pts:
+                pt_date = _extract_pt_date(pt)
+                if pt_date == logical_date_iso:
+                    all_points.append(pt)
 
         batch = self.mapper.normalize_data_points(all_points, target_logical_date=logical_date_iso)
         self._cache[logical_date_iso] = batch

--- a/src/garmin_sync/google_health_provider.py
+++ b/src/garmin_sync/google_health_provider.py
@@ -36,9 +36,12 @@ def _extract_pt_date(pt: dict[str, Any]) -> str | None:
         if d and isinstance(d, dict) and "year" in d:
             return f"{d['year']:04d}-{d['month']:02d}-{d['day']:02d}"
 
+    # Real API shape nests the session window under sleep.interval (confirmed 2026-08-27
+    # against a live account); "sleepSession" only appears in legacy/synthetic fixtures.
+    interval = ((pt.get("sleep") or {}).get("interval")) or {}
     session = pt.get("sleepSession", {}) or {}
-    end_str = session.get("endTime") or pt.get("endTime")
-    start_str = session.get("startTime") or pt.get("startTime")
+    end_str = interval.get("endTime") or session.get("endTime") or pt.get("endTime")
+    start_str = interval.get("startTime") or session.get("startTime") or pt.get("startTime")
     if end_str or start_str:
         end_dt = parse_iso_datetime(end_str)
         start_dt = parse_iso_datetime(start_str)

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -109,6 +109,38 @@ def test_local_archive_health_bundle_round_trip(tmp_path: Path) -> None:
     assert Path(object_path).exists()
 
 
+def test_local_archive_health_scopes_object_path_by_user_id(tmp_path: Path) -> None:
+    """Regression test: archive_health validated record.user_id but never put it in the
+    object path. Production provider/transport values ("google_health"/"bundle") are the
+    same for every linked user, so two different users archiving on the same date/revision
+    used to collide at the identical path -- one user's raw payload silently overwriting
+    (and becoming readable as) another's. See
+    docs/plans/2026-08-27-real-google-health-ingestion.md."""
+    store = LocalRawArchiveStore(base_dir=tmp_path)
+
+    def _record(user_id: str, value: int) -> HealthArchiveRecord:
+        return HealthArchiveRecord(
+            user_id=user_id,
+            provider="google_health",
+            transport="bundle",
+            logical_date="2026-08-07",
+            payload=[{"metric": "sleep_duration_seconds", "value": value}],
+            revision=1,
+            normalizer_version=1,
+        )
+
+    path_a = store.archive_health(_record("user-a", 27000))
+    path_b = store.archive_health(_record("user-b", 99999))
+
+    assert path_a is not None and path_b is not None
+    assert path_a != path_b
+    assert "user-a" in path_a and "user-b" not in path_a
+    assert "user-b" in path_b and "user-a" not in path_b
+    # Both objects survive independently -- user-b's archive did not overwrite user-a's.
+    assert Path(path_a).exists()
+    assert Path(path_b).exists()
+
+
 def test_create_archive_store_disabled_returns_null_store() -> None:
     store = create_archive_store(enabled=False)
     assert isinstance(store, NullArchiveStore)

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -4,6 +4,7 @@ import pytest
 
 from garmin_sync.archive import (
     ArchiveRecord,
+    HealthArchiveRecord,
     LocalRawArchiveStore,
     NullArchiveStore,
     create_archive_store,
@@ -83,6 +84,29 @@ def test_archive_rejects_path_traversal_identifiers(tmp_path: Path) -> None:
         store.archive(ArchiveRecord("stats", "2026-02-30", {"x": 1}, "run-1"))
     with pytest.raises(ValueError, match="sync run ID"):
         store.archive(ArchiveRecord("stats", "2026-08-06", {"x": 1}, "../run"))
+
+
+def test_local_archive_health_bundle_round_trip(tmp_path: Path) -> None:
+    """Regression test: archive_health builds endpoint="health/{provider}_{transport}", which
+    _object_dir validates as a single path segment and rejects because of the embedded "/" --
+    this was a real bug (2026-08-27) that made every Google Health backfill archive attempt fail
+    with production shapes like provider="google_health", transport="bundle". See
+    docs/plans/2026-08-27-real-google-health-ingestion.md."""
+    store = LocalRawArchiveStore(base_dir=tmp_path)
+    record = HealthArchiveRecord(
+        user_id="user123",
+        provider="google_health",
+        transport="bundle",
+        logical_date="2026-08-07",
+        payload=[{"metric": "sleep_duration_seconds", "value": 27000}],
+        revision=1,
+        normalizer_version=1,
+    )
+
+    object_path = store.archive_health(record)
+
+    assert object_path is not None
+    assert Path(object_path).exists()
 
 
 def test_create_archive_store_disabled_returns_null_store() -> None:

--- a/tests/test_google_health_account_link.py
+++ b/tests/test_google_health_account_link.py
@@ -1,0 +1,350 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import garmin_sync.google_health_account_link as link_module
+from garmin_sync.google_health_account_link import (
+    GoogleHealthConnectionRepository,
+    GoogleHealthLinkError,
+    GoogleHealthLinkStateInvalidError,
+    GoogleHealthLinkStateStore,
+    GoogleHealthLinkTokens,
+    GoogleHealthTokenExchangeError,
+    build_authorize_url,
+    exchange_code_for_tokens,
+    load_tokens,
+    persist_tokens,
+)
+
+# --- Fake Firestore, extended from the account_link.py test pattern with delete()/
+# collection_group()/stream() support this module also needs. ---
+
+
+class _Snapshot:
+    def __init__(self, doc_id: str, data: dict[str, Any] | None, reference: "_Document") -> None:
+        self.id = doc_id
+        self._data = data
+        self.exists = data is not None
+        self.reference = reference
+
+    def to_dict(self) -> dict[str, Any] | None:
+        return dict(self._data) if self._data is not None else None
+
+
+class _Document:
+    def __init__(self, doc_id: str, parent: "_Collection | None" = None) -> None:
+        self.id = doc_id
+        self.parent = parent
+        self.data: dict[str, Any] | None = None
+        self._subcollections: dict[str, _Collection] = {}
+
+    def get(self) -> _Snapshot:
+        return _Snapshot(self.id, self.data, self)
+
+    def set(self, payload: dict[str, Any], merge: bool = True) -> None:
+        if merge:
+            self.data = {**(self.data or {}), **payload}
+        else:
+            self.data = dict(payload)
+
+    def delete(self) -> None:
+        self.data = None
+
+    def collection(self, name: str) -> "_Collection":
+        return self._subcollections.setdefault(name, _Collection(name, parent_doc=self))
+
+
+class _Collection:
+    def __init__(self, name: str, parent_doc: _Document | None = None) -> None:
+        self.name = name
+        self.parent = parent_doc
+        self._documents: dict[str, _Document] = {}
+
+    def document(self, doc_id: str) -> _Document:
+        return self._documents.setdefault(doc_id, _Document(doc_id, parent=self))
+
+    def stream(self) -> list[_Snapshot]:
+        return [
+            _Snapshot(doc.id, doc.data, doc)
+            for doc in self._documents.values()
+            if doc.data is not None
+        ]
+
+
+class _CollectionGroup:
+    """Firestore's real collection-group query returns every document across every distinct
+    parent -- unlike _Collection.stream(), it must NOT collapse same-named docs from
+    different parents into one dict keyed by doc id."""
+
+    def __init__(self, snapshots: list[_Snapshot]) -> None:
+        self._snapshots = snapshots
+
+    def stream(self) -> list[_Snapshot]:
+        return list(self._snapshots)
+
+
+class _Db:
+    def __init__(self) -> None:
+        self._collections: dict[str, _Collection] = {}
+
+    def collection(self, name: str) -> _Collection:
+        return self._collections.setdefault(name, _Collection(name))
+
+    def collection_group(self, name: str) -> _CollectionGroup:
+        """Flatten every subcollection named `name` across every top-level document, mirroring
+        Firestore's real collection-group semantics closely enough for these tests."""
+        snapshots: list[_Snapshot] = []
+        for top_collection in self._collections.values():
+            for doc in top_collection._documents.values():
+                sub = doc._subcollections.get(name)
+                if sub:
+                    snapshots.extend(sub.stream())
+        return _CollectionGroup(snapshots)
+
+
+# --- GoogleHealthLinkStateStore ---
+
+
+def test_state_store_create_then_consume_returns_uid() -> None:
+    db = _Db()
+    store = GoogleHealthLinkStateStore(db=db)
+    state = store.create("uid-1")
+
+    assert store.consume(state) == "uid-1"
+
+
+def test_state_store_consume_is_one_time_use() -> None:
+    db = _Db()
+    store = GoogleHealthLinkStateStore(db=db)
+    state = store.create("uid-1")
+    store.consume(state)
+
+    with pytest.raises(GoogleHealthLinkStateInvalidError):
+        store.consume(state)
+
+
+def test_state_store_rejects_unknown_state() -> None:
+    store = GoogleHealthLinkStateStore(db=_Db())
+    with pytest.raises(GoogleHealthLinkStateInvalidError):
+        store.consume("never-issued")
+
+
+def test_state_store_rejects_missing_state() -> None:
+    store = GoogleHealthLinkStateStore(db=_Db())
+    with pytest.raises(GoogleHealthLinkStateInvalidError):
+        store.consume("")
+
+
+def test_state_store_rejects_expired_state(monkeypatch: Any) -> None:
+    db = _Db()
+    store = GoogleHealthLinkStateStore(db=db)
+    state = store.create("uid-1")
+
+    # Simulate the TTL having elapsed by moving time.time() forward past _STATE_TTL_SECONDS.
+    real_time = link_module.time.time
+    monkeypatch.setattr(link_module.time, "time", lambda: real_time() + 20 * 60)
+
+    with pytest.raises(GoogleHealthLinkStateInvalidError):
+        store.consume(state)
+
+
+# --- build_authorize_url ---
+
+
+def test_build_authorize_url_contains_required_params() -> None:
+    url = build_authorize_url(
+        client_id="client-123",
+        redirect_uri="https://example.com/callback",
+        scopes=["scope-a", "scope-b"],
+        state="state-xyz",
+    )
+
+    assert url.startswith("https://accounts.google.com/o/oauth2/v2/auth?")
+    assert "client_id=client-123" in url
+    assert "state=state-xyz" in url
+    assert "access_type=offline" in url
+    assert "prompt=consent" in url
+    assert "scope-a" in url and "scope-b" in url
+
+
+# --- exchange_code_for_tokens ---
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: dict[str, Any]) -> None:
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+def test_exchange_code_for_tokens_success(monkeypatch: Any) -> None:
+    monkeypatch.setattr(
+        link_module.requests,
+        "post",
+        lambda *a, **k: _FakeResponse(
+            200, {"access_token": "at", "refresh_token": "rt", "scope": "a b"}
+        ),
+    )
+
+    tokens = exchange_code_for_tokens(
+        code="code", client_id="cid", client_secret="secret", redirect_uri="https://x/cb"
+    )
+
+    assert tokens.access_token == "at"
+    assert tokens.refresh_token == "rt"
+    assert tokens.scopes == ["a", "b"]
+
+
+def test_exchange_code_for_tokens_http_error_raises(monkeypatch: Any) -> None:
+    monkeypatch.setattr(
+        link_module.requests, "post", lambda *a, **k: _FakeResponse(400, {"error": "bad"})
+    )
+
+    with pytest.raises(GoogleHealthTokenExchangeError):
+        exchange_code_for_tokens(
+            code="code", client_id="cid", client_secret="secret", redirect_uri="https://x/cb"
+        )
+
+
+def test_exchange_code_for_tokens_missing_refresh_token_raises(monkeypatch: Any) -> None:
+    """Without prompt=consent (or on a repeat grant), Google can omit refresh_token -- treat
+    that as a hard failure rather than silently returning an access-token-only result that
+    would die in an hour with no way to renew."""
+    monkeypatch.setattr(
+        link_module.requests, "post", lambda *a, **k: _FakeResponse(200, {"access_token": "at"})
+    )
+
+    with pytest.raises(GoogleHealthTokenExchangeError):
+        exchange_code_for_tokens(
+            code="code", client_id="cid", client_secret="secret", redirect_uri="https://x/cb"
+        )
+
+
+# --- persist_tokens / load_tokens ---
+
+
+class _FakeGcsTokenStore:
+    _blobs: dict[str, str] = {}
+
+    def __init__(self, bucket_name: str, object_name: str) -> None:
+        self.bucket_name = bucket_name
+        self.object_name = object_name
+
+    def persist(self, source: Path) -> bool:
+        _FakeGcsTokenStore._blobs[self.object_name] = source.read_text()
+        return True
+
+    def restore(self, destination: Path) -> bool:
+        content = _FakeGcsTokenStore._blobs.get(self.object_name)
+        if content is None:
+            return False
+        destination.write_text(content)
+        return True
+
+
+def test_persist_then_load_tokens_round_trip(monkeypatch: Any) -> None:
+    _FakeGcsTokenStore._blobs.clear()
+    monkeypatch.setattr(link_module, "GcsTokenStore", _FakeGcsTokenStore)
+
+    tokens = GoogleHealthLinkTokens(
+        access_token="at",
+        refresh_token="rt",
+        token_type="Bearer",
+        scopes=["a"],
+        obtained_at="2026-08-27T00:00:00+00:00",
+    )
+    object_name = persist_tokens(bucket_name="bucket", uid="uid-1", tokens=tokens)
+
+    assert object_name.startswith("google-health/users/uid-1/")
+    loaded = load_tokens(bucket_name="bucket", object_name=object_name)
+    assert loaded is not None
+    assert loaded["refresh_token"] == "rt"
+
+
+def test_load_tokens_missing_object_returns_none(monkeypatch: Any) -> None:
+    _FakeGcsTokenStore._blobs.clear()
+    monkeypatch.setattr(link_module, "GcsTokenStore", _FakeGcsTokenStore)
+
+    assert load_tokens(bucket_name="bucket", object_name="does/not/exist.json") is None
+
+
+# --- GoogleHealthConnectionRepository ---
+
+
+def test_save_and_get_connection_round_trip() -> None:
+    db = _Db()
+    repo = GoogleHealthConnectionRepository(db=db)
+
+    repo.save_connection(
+        "uid-1", health_user_id="health-uid", granted_scopes=["a", "b"], token_object="obj/path"
+    )
+    connection = repo.get_connection("uid-1")
+
+    assert connection is not None
+    assert connection["status"] == "active"
+    assert connection["healthUserId"] == "health-uid"
+    assert connection["tokenObject"] == "obj/path"
+
+
+def test_get_connection_missing_returns_none() -> None:
+    repo = GoogleHealthConnectionRepository(db=_Db())
+    assert repo.get_connection("nobody") is None
+
+
+def test_list_active_user_ids_only_returns_active_google_health_connections() -> None:
+    db = _Db()
+    repo = GoogleHealthConnectionRepository(db=db)
+
+    repo.save_connection("uid-active", health_user_id=None, granted_scopes=[], token_object="o1")
+    repo.save_connection("uid-inactive", health_user_id=None, granted_scopes=[], token_object="o2")
+    # Simulate a disconnect: flip status without going through save_connection's always-"active".
+    db.collection("users").document("uid-inactive").collection("connections").document(
+        "googleHealth"
+    ).set({"status": "disconnected"}, merge=True)
+    # A same-shaped connection under a different name must not be picked up.
+    db.collection("users").document("uid-other-service").collection("connections").document(
+        "somethingElse"
+    ).set({"status": "active"}, merge=True)
+
+    active_ids = repo.list_active_user_ids()
+
+    assert active_ids == ["uid-active"]
+
+
+def test_load_auth_manager_for_user_missing_connection_raises() -> None:
+    repo = GoogleHealthConnectionRepository(db=_Db())
+    with pytest.raises(GoogleHealthLinkError):
+        repo.load_auth_manager_for_user(
+            "nobody", client_id="cid", client_secret="secret", bucket_name="bucket"
+        )
+
+
+def test_load_auth_manager_for_user_builds_manager_from_stored_tokens(monkeypatch: Any) -> None:
+    _FakeGcsTokenStore._blobs.clear()
+    monkeypatch.setattr(link_module, "GcsTokenStore", _FakeGcsTokenStore)
+
+    db = _Db()
+    repo = GoogleHealthConnectionRepository(db=db)
+    tokens = GoogleHealthLinkTokens(
+        access_token="at",
+        refresh_token="rt",
+        token_type="Bearer",
+        scopes=["a"],
+        obtained_at="2026-08-27T00:00:00+00:00",
+    )
+    object_name = persist_tokens(bucket_name="bucket", uid="uid-1", tokens=tokens)
+    repo.save_connection(
+        "uid-1", health_user_id=None, granted_scopes=["a"], token_object=object_name
+    )
+
+    manager = repo.load_auth_manager_for_user(
+        "uid-1", client_id="cid", client_secret="secret", bucket_name="bucket"
+    )
+
+    assert manager.credentials is not None
+    assert manager.credentials.refresh_token == "rt"

--- a/tests/test_google_health_account_link.py
+++ b/tests/test_google_health_account_link.py
@@ -348,3 +348,47 @@ def test_load_auth_manager_for_user_builds_manager_from_stored_tokens(monkeypatc
 
     assert manager.credentials is not None
     assert manager.credentials.refresh_token == "rt"
+
+
+def test_load_auth_manager_for_user_persists_rotated_refresh_token(monkeypatch: Any) -> None:
+    """Regression test: Google doesn't rotate the refresh_token on every access-token
+    refresh, but can. Without an on_refresh persistence hook, a linked user's stored token
+    object would never see a rotation, and a later process restart would reload the stale
+    refresh_token and eventually fail with invalid_grant. See
+    docs/plans/2026-08-27-real-google-health-ingestion.md."""
+    _FakeGcsTokenStore._blobs.clear()
+    monkeypatch.setattr(link_module, "GcsTokenStore", _FakeGcsTokenStore)
+
+    import garmin_sync.google_health_auth as auth_module
+
+    class _FakeRefreshResponse:
+        status_code = 200
+
+        def json(self) -> dict[str, Any]:
+            return {"access_token": "new-at", "expires_in": 3600, "refresh_token": "rotated-rt"}
+
+    monkeypatch.setattr(auth_module.requests, "post", lambda *a, **k: _FakeRefreshResponse())
+
+    db = _Db()
+    repo = GoogleHealthConnectionRepository(db=db)
+    tokens = GoogleHealthLinkTokens(
+        access_token="at",
+        refresh_token="original-rt",
+        token_type="Bearer",
+        scopes=["a"],
+        obtained_at="2026-08-27T00:00:00+00:00",
+    )
+    object_name = persist_tokens(bucket_name="bucket", uid="uid-1", tokens=tokens)
+    repo.save_connection(
+        "uid-1", health_user_id=None, granted_scopes=["a"], token_object=object_name
+    )
+
+    manager = repo.load_auth_manager_for_user(
+        "uid-1", client_id="cid", client_secret="secret", bucket_name="bucket"
+    )
+    manager.get_valid_access_token()  # expires_at=0.0 forces a refresh
+
+    reloaded = load_tokens(bucket_name="bucket", object_name=object_name)
+    assert reloaded is not None
+    assert reloaded["refresh_token"] == "rotated-rt"
+    assert reloaded["access_token"] == "new-at"

--- a/tests/test_google_health_account_link_api.py
+++ b/tests/test_google_health_account_link_api.py
@@ -1,0 +1,319 @@
+from __future__ import annotations
+
+from http import HTTPStatus
+from typing import Any
+
+import pytest
+
+import garmin_sync.google_health_account_link_api as api_module
+from garmin_sync.google_health_account_link import (
+    GoogleHealthLinkError,
+    GoogleHealthLinkStateInvalidError,
+    GoogleHealthLinkTokens,
+    GoogleHealthTokenExchangeError,
+)
+from garmin_sync.google_health_account_link_api import GoogleHealthAccountLinkHandler, _verified_uid
+
+
+def _handler() -> GoogleHealthAccountLinkHandler:
+    handler = object.__new__(GoogleHealthAccountLinkHandler)
+    handler.request_id = "req-test"
+    return handler
+
+
+def _capture_json(handler: GoogleHealthAccountLinkHandler) -> dict[str, Any]:
+    captured: dict[str, Any] = {}
+
+    def capture(status: HTTPStatus, payload: dict[str, Any]) -> None:
+        captured["status"] = status
+        captured["payload"] = payload
+
+    handler._json_response = capture  # type: ignore[method-assign]
+    return captured
+
+
+def _capture_redirect(handler: GoogleHealthAccountLinkHandler) -> list[str]:
+    locations: list[str] = []
+    handler._redirect = lambda location: locations.append(location)  # type: ignore[method-assign]
+    return locations
+
+
+# --- _verified_uid ---
+
+
+def test_verified_uid_requires_authorization_header() -> None:
+    with pytest.raises(GoogleHealthLinkError):
+        _verified_uid(None)
+
+
+def test_verified_uid_requires_bearer_scheme() -> None:
+    with pytest.raises(GoogleHealthLinkError):
+        _verified_uid("Basic abc123")
+
+
+def test_verified_uid_returns_uid_on_valid_token(monkeypatch: Any) -> None:
+    monkeypatch.setattr(api_module.firebase_auth, "verify_id_token", lambda token: {"uid": "uid-1"})
+    assert _verified_uid("Bearer some-token") == "uid-1"
+
+
+def test_verified_uid_wraps_verification_failure(monkeypatch: Any) -> None:
+    def _raise(token: str) -> Any:
+        raise ValueError("bad token")
+
+    monkeypatch.setattr(api_module.firebase_auth, "verify_id_token", _raise)
+    with pytest.raises(GoogleHealthLinkError):
+        _verified_uid("Bearer bad-token")
+
+
+# --- _app_redirect ---
+
+
+def test_app_redirect_success_uses_app_base_url(monkeypatch: Any) -> None:
+    monkeypatch.setenv("APP_BASE_URL", "https://example.web.app")
+    handler = _handler()
+    locations = _capture_redirect(handler)
+
+    handler._app_redirect(success=True)
+
+    assert locations == ["https://example.web.app/settings?googleHealthLinked=success"]
+
+
+def test_app_redirect_error_includes_reason(monkeypatch: Any) -> None:
+    monkeypatch.setenv("APP_BASE_URL", "https://example.web.app")
+    handler = _handler()
+    locations = _capture_redirect(handler)
+
+    handler._app_redirect(success=False, reason="invalid_state")
+
+    assert "googleHealthLinked=error" in locations[0]
+    assert "reason=invalid_state" in locations[0]
+
+
+def test_app_redirect_falls_back_to_relative_path_without_app_base_url(monkeypatch: Any) -> None:
+    monkeypatch.delenv("APP_BASE_URL", raising=False)
+    handler = _handler()
+    locations = _capture_redirect(handler)
+
+    handler._app_redirect(success=True)
+
+    assert locations == ["/settings?googleHealthLinked=success"]
+
+
+# --- _handle_start_link ---
+
+
+def test_handle_start_link_requires_auth(monkeypatch: Any) -> None:
+    handler = _handler()
+    handler.headers = {}
+    with pytest.raises(GoogleHealthLinkError):
+        handler._handle_start_link()
+
+
+def test_handle_start_link_returns_authorize_url(monkeypatch: Any) -> None:
+    monkeypatch.setattr(api_module.firebase_auth, "verify_id_token", lambda token: {"uid": "uid-1"})
+    monkeypatch.setenv("GOOGLE_HEALTH_CLIENT_ID", "cid")
+    monkeypatch.setenv("GOOGLE_HEALTH_REDIRECT_URI", "https://x/callback")
+
+    created_for: list[str] = []
+
+    class FakeStateStore:
+        def create(self, uid: str) -> str:
+            created_for.append(uid)
+            return "state-abc"
+
+    monkeypatch.setattr(api_module, "GoogleHealthLinkStateStore", FakeStateStore)
+    monkeypatch.setattr(
+        api_module,
+        "build_authorize_url",
+        lambda **kwargs: f"https://accounts.google.com/auth?state={kwargs['state']}",
+    )
+
+    handler = _handler()
+    handler.headers = {"Authorization": "Bearer token"}
+    captured = _capture_json(handler)
+
+    handler._handle_start_link()
+
+    assert created_for == ["uid-1"]
+    assert captured["status"] == HTTPStatus.OK
+    assert captured["payload"]["authorizeUrl"] == "https://accounts.google.com/auth?state=state-abc"
+
+
+# --- _handle_callback ---
+
+
+def _base_callback_env(monkeypatch: Any) -> None:
+    monkeypatch.setenv("GOOGLE_HEALTH_CLIENT_ID", "cid")
+    monkeypatch.setenv("GOOGLE_HEALTH_CLIENT_SECRET", "secret")
+    monkeypatch.setenv("GOOGLE_HEALTH_REDIRECT_URI", "https://x/callback")
+    monkeypatch.setenv("GOOGLE_HEALTH_TOKEN_BUCKET", "bucket")
+
+
+def test_handle_callback_google_declined_redirects_with_reason(monkeypatch: Any) -> None:
+    handler = _handler()
+    handler.path = "/api/google-health/callback?error=access_denied"
+    locations = _capture_redirect(handler)
+
+    handler._handle_callback()
+
+    assert "reason=google_declined" in locations[0]
+
+
+def test_handle_callback_missing_code_or_state_redirects_with_reason() -> None:
+    handler = _handler()
+    handler.path = "/api/google-health/callback?state=abc"
+    locations = _capture_redirect(handler)
+
+    handler._handle_callback()
+
+    assert "reason=missing_code_or_state" in locations[0]
+
+
+def test_handle_callback_invalid_state_redirects_with_reason(monkeypatch: Any) -> None:
+    class FakeStateStore:
+        def consume(self, state: str) -> str:
+            raise GoogleHealthLinkStateInvalidError("expired")
+
+    monkeypatch.setattr(api_module, "GoogleHealthLinkStateStore", FakeStateStore)
+
+    handler = _handler()
+    handler.path = "/api/google-health/callback?code=abc&state=xyz"
+    locations = _capture_redirect(handler)
+
+    handler._handle_callback()
+
+    assert "reason=invalid_state" in locations[0]
+
+
+def test_handle_callback_token_exchange_failure_redirects_with_reason(monkeypatch: Any) -> None:
+    _base_callback_env(monkeypatch)
+
+    class FakeStateStore:
+        def consume(self, state: str) -> str:
+            return "uid-1"
+
+    def _raise_exchange(**kwargs: Any) -> GoogleHealthLinkTokens:
+        raise GoogleHealthTokenExchangeError("nope")
+
+    monkeypatch.setattr(api_module, "GoogleHealthLinkStateStore", FakeStateStore)
+    monkeypatch.setattr(api_module, "exchange_code_for_tokens", _raise_exchange)
+
+    handler = _handler()
+    handler.path = "/api/google-health/callback?code=abc&state=xyz"
+    locations = _capture_redirect(handler)
+
+    handler._handle_callback()
+
+    assert "reason=token_exchange_failed" in locations[0]
+
+
+def test_handle_callback_happy_path_saves_connection_and_redirects_success(
+    monkeypatch: Any,
+) -> None:
+    _base_callback_env(monkeypatch)
+
+    class FakeStateStore:
+        def consume(self, state: str) -> str:
+            assert state == "xyz"
+            return "uid-1"
+
+    tokens = GoogleHealthLinkTokens(
+        access_token="at",
+        refresh_token="rt",
+        token_type="Bearer",
+        scopes=["a"],
+        obtained_at="2026-08-27T00:00:00+00:00",
+    )
+    saved: dict[str, Any] = {}
+
+    class FakeConnectionRepo:
+        def save_connection(
+            self,
+            uid: str,
+            *,
+            health_user_id: str | None,
+            granted_scopes: list[str],
+            token_object: str,
+        ) -> None:
+            saved["uid"] = uid
+            saved["health_user_id"] = health_user_id
+            saved["granted_scopes"] = granted_scopes
+            saved["token_object"] = token_object
+
+    class FakeGoogleHealthClient:
+        def __init__(self, auth_manager: Any) -> None:
+            pass
+
+        def get_identity(self) -> dict[str, Any]:
+            return {"healthUserId": "health-uid-1"}
+
+    monkeypatch.setattr(api_module, "GoogleHealthLinkStateStore", FakeStateStore)
+    monkeypatch.setattr(api_module, "exchange_code_for_tokens", lambda **kwargs: tokens)
+    monkeypatch.setattr(
+        api_module, "persist_tokens", lambda **kwargs: "google-health/users/uid-1/tok.json"
+    )
+    monkeypatch.setattr(api_module, "GoogleHealthConnectionRepository", FakeConnectionRepo)
+    monkeypatch.setattr(api_module, "GoogleHealthClient", FakeGoogleHealthClient)
+    monkeypatch.setattr(api_module, "GoogleHealthAuthManager", lambda **kwargs: object())
+
+    handler = _handler()
+    handler.path = "/api/google-health/callback?code=abc&state=xyz"
+    locations = _capture_redirect(handler)
+
+    handler._handle_callback()
+
+    assert saved == {
+        "uid": "uid-1",
+        "health_user_id": "health-uid-1",
+        "granted_scopes": ["a"],
+        "token_object": "google-health/users/uid-1/tok.json",
+    }
+    assert locations == ["/settings?googleHealthLinked=success"]
+
+
+def test_handle_callback_identity_lookup_failure_still_saves_connection(monkeypatch: Any) -> None:
+    """The link itself must not fail just because the (best-effort) identity probe did --
+    tokens are already persisted by that point."""
+    _base_callback_env(monkeypatch)
+
+    class FakeStateStore:
+        def consume(self, state: str) -> str:
+            return "uid-1"
+
+    tokens = GoogleHealthLinkTokens(
+        access_token="at",
+        refresh_token="rt",
+        token_type="Bearer",
+        scopes=["a"],
+        obtained_at="2026-08-27T00:00:00+00:00",
+    )
+    saved: dict[str, Any] = {}
+
+    class FakeConnectionRepo:
+        def save_connection(self, uid: str, **kwargs: Any) -> None:
+            saved["uid"] = uid
+            saved.update(kwargs)
+
+    class FailingGoogleHealthClient:
+        def __init__(self, auth_manager: Any) -> None:
+            pass
+
+        def get_identity(self) -> dict[str, Any]:
+            raise RuntimeError("network blip")
+
+    monkeypatch.setattr(api_module, "GoogleHealthLinkStateStore", FakeStateStore)
+    monkeypatch.setattr(api_module, "exchange_code_for_tokens", lambda **kwargs: tokens)
+    monkeypatch.setattr(api_module, "persist_tokens", lambda **kwargs: "obj.json")
+    monkeypatch.setattr(api_module, "GoogleHealthConnectionRepository", FakeConnectionRepo)
+    monkeypatch.setattr(api_module, "GoogleHealthClient", FailingGoogleHealthClient)
+    monkeypatch.setattr(api_module, "GoogleHealthAuthManager", lambda **kwargs: object())
+
+    handler = _handler()
+    handler.path = "/api/google-health/callback?code=abc&state=xyz"
+    locations = _capture_redirect(handler)
+
+    handler._handle_callback()
+
+    assert saved["uid"] == "uid-1"
+    assert saved["health_user_id"] is None
+    assert locations == ["/settings?googleHealthLinked=success"]

--- a/tests/test_google_health_cli_auth.py
+++ b/tests/test_google_health_cli_auth.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from argparse import Namespace
+from typing import Any
+
+import garmin_sync.google_health_account_link as link_module
+from garmin_sync.cli import _resolve_google_health_auth_manager
+from garmin_sync.google_health_account_link import GoogleHealthLinkError
+
+
+def _args(**overrides: Any) -> Namespace:
+    base = {"token": None, "client_id": None, "client_secret": None, "refresh_token": None}
+    base.update(overrides)
+    return Namespace(**base)
+
+
+def _clear_google_health_env(monkeypatch: Any) -> None:
+    for var in (
+        "GOOGLE_HEALTH_ACCESS_TOKEN",
+        "GOOGLE_HEALTH_CLIENT_ID",
+        "GOOGLE_HEALTH_CLIENT_SECRET",
+        "GOOGLE_HEALTH_REFRESH_TOKEN",
+        "GOOGLE_HEALTH_TOKEN_BUCKET",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    # cli.py imports load_dotenv locally (`from dotenv import load_dotenv`) inside
+    # _resolve_google_health_auth_manager, so patching a "garmin_sync.cli.load_dotenv"
+    # attribute wouldn't be seen by that fresh import -- patch dotenv's own attribute instead,
+    # which is what the local import actually resolves at call time. Otherwise this would
+    # silently load the repo's real .env (which has real credentials in it this session) and
+    # defeat the point of clearing the environment above.
+    monkeypatch.setattr("dotenv.load_dotenv", lambda *a, **k: None)
+
+
+def test_no_credentials_returns_error(monkeypatch: Any) -> None:
+    _clear_google_health_env(monkeypatch)
+    manager, err = _resolve_google_health_auth_manager(_args())
+    assert manager is None
+    assert err is not None
+
+
+def test_refresh_token_flags_build_manager(monkeypatch: Any) -> None:
+    _clear_google_health_env(monkeypatch)
+    manager, err = _resolve_google_health_auth_manager(
+        _args(client_id="cid", client_secret="secret", refresh_token="rt")
+    )
+    assert err is None
+    assert manager is not None
+    assert manager.credentials.refresh_token == "rt"
+
+
+def test_direct_token_flag_builds_manager(monkeypatch: Any) -> None:
+    _clear_google_health_env(monkeypatch)
+    manager, err = _resolve_google_health_auth_manager(_args(token="at"))
+    assert err is None
+    assert manager is not None
+    assert manager.credentials.access_token == "at"
+
+
+def test_user_id_without_explicit_token_uses_stored_credentials(monkeypatch: Any) -> None:
+    _clear_google_health_env(monkeypatch)
+    monkeypatch.setenv("GOOGLE_HEALTH_CLIENT_ID", "cid")
+    monkeypatch.setenv("GOOGLE_HEALTH_CLIENT_SECRET", "secret")
+    monkeypatch.setenv("GOOGLE_HEALTH_TOKEN_BUCKET", "bucket")
+
+    calls: list[dict[str, Any]] = []
+    sentinel = object()
+
+    class FakeRepo:
+        def load_auth_manager_for_user(self, user_id: str, **kwargs: Any) -> Any:
+            calls.append({"user_id": user_id, **kwargs})
+            return sentinel
+
+    monkeypatch.setattr(link_module, "GoogleHealthConnectionRepository", FakeRepo)
+
+    manager, err = _resolve_google_health_auth_manager(_args(user_id="uid-1"))
+
+    assert err is None
+    assert manager is sentinel
+    assert calls == [
+        {"user_id": "uid-1", "client_id": "cid", "client_secret": "secret", "bucket_name": "bucket"}
+    ]
+
+
+def test_user_id_lookup_failure_returns_error_message(monkeypatch: Any) -> None:
+    _clear_google_health_env(monkeypatch)
+    monkeypatch.setenv("GOOGLE_HEALTH_CLIENT_ID", "cid")
+    monkeypatch.setenv("GOOGLE_HEALTH_CLIENT_SECRET", "secret")
+    monkeypatch.setenv("GOOGLE_HEALTH_TOKEN_BUCKET", "bucket")
+
+    class FakeRepo:
+        def load_auth_manager_for_user(self, user_id: str, **kwargs: Any) -> Any:
+            raise GoogleHealthLinkError("no active connection")
+
+    monkeypatch.setattr(link_module, "GoogleHealthConnectionRepository", FakeRepo)
+
+    manager, err = _resolve_google_health_auth_manager(_args(user_id="uid-1"))
+
+    assert manager is None
+    assert err == "no active connection"
+
+
+def test_explicit_token_flag_wins_over_user_id_lookup(monkeypatch: Any) -> None:
+    """A manually-supplied --token is an explicit override -- it must not be shadowed by
+    per-user stored-credential lookup just because --user-id also happens to be set (e.g. a
+    debugging session re-using the same command line as a scheduled per-user sync)."""
+    _clear_google_health_env(monkeypatch)
+    monkeypatch.setenv("GOOGLE_HEALTH_CLIENT_ID", "cid")
+    monkeypatch.setenv("GOOGLE_HEALTH_TOKEN_BUCKET", "bucket")
+
+    class FakeRepo:
+        def load_auth_manager_for_user(self, user_id: str, **kwargs: Any) -> Any:
+            raise AssertionError("should not be called when --token is explicit")
+
+    monkeypatch.setattr(link_module, "GoogleHealthConnectionRepository", FakeRepo)
+
+    manager, err = _resolve_google_health_auth_manager(_args(user_id="uid-1", token="at"))
+
+    assert err is None
+    assert manager is not None
+    assert manager.credentials.access_token == "at"

--- a/tests/test_google_health_mapper.py
+++ b/tests/test_google_health_mapper.py
@@ -92,7 +92,7 @@ def test_mapper_normalizes_sleep_and_hrv():
     assert not any("step" in o.metric.lower() for o in batch.observations)
 
 
-def test_mapper_normalizes_real_google_health_v4_shape():
+def test_mapper_normalizes_real_google_health_v4_shape() -> None:
     """Regression test for the actual health.googleapis.com/v4 response shape, confirmed
     2026-08-27 against a live account (structure faithful, values/timestamps adjusted --
     see docs/plans/2026-08-27-real-google-health-ingestion.md). The v4 API does not carry a

--- a/tests/test_google_health_mapper.py
+++ b/tests/test_google_health_mapper.py
@@ -90,3 +90,86 @@ def test_mapper_normalizes_sleep_and_hrv():
     # Verify no steps in observations (D-MS-STEPS / P9)
     assert not any(o.source.source_record_id == "rec_steps_1" for o in batch.observations)
     assert not any("step" in o.metric.lower() for o in batch.observations)
+
+
+def test_mapper_normalizes_real_google_health_v4_shape():
+    """Regression test for the actual health.googleapis.com/v4 response shape, confirmed
+    2026-08-27 against a live account (structure faithful, values/timestamps adjusted --
+    see docs/plans/2026-08-27-real-google-health-ingestion.md). The v4 API does not carry a
+    flat dataTypeName/startTime/endTime/value on each point the way MS6's original synthetic
+    fixtures assumed; sleep nests under sleep.interval/sleep.stages and daily summaries nest
+    under a {dailyX: {date: {year,month,day}, ...}} object, with the type only recoverable
+    from the point's `name` resource path.
+    """
+    mapper = GoogleHealthMapper(user_id="test_user")
+    raw_points = [
+        {
+            "name": "users/1234567890/dataTypes/sleep/dataPoints/9876543210",
+            "dataSource": {
+                "recordingMethod": "PASSIVELY_MEASURED",
+                "device": {"formFactor": "WATCH"},
+                "application": {"packageName": "com.garmin.android.apps.connectmobile"},
+                "platform": "HEALTH_CONNECT",
+            },
+            "sleep": {
+                "interval": {
+                    "startTime": "2026-08-20T22:00:00Z",
+                    "endTime": "2026-08-21T05:00:00Z",
+                },
+                "type": "STAGES",
+                "stages": [
+                    {
+                        "startTime": "2026-08-20T22:00:00Z",
+                        "endTime": "2026-08-20T22:30:00Z",
+                        "type": "LIGHT",
+                    },
+                    {
+                        "startTime": "2026-08-20T22:30:00Z",
+                        "endTime": "2026-08-20T23:00:00Z",
+                        "type": "DEEP",
+                    },
+                    {
+                        "startTime": "2026-08-20T23:00:00Z",
+                        "endTime": "2026-08-20T23:10:00Z",
+                        "type": "AWAKE",
+                    },
+                    {
+                        "startTime": "2026-08-20T23:10:00Z",
+                        "endTime": "2026-08-21T05:00:00Z",
+                        "type": "REM",
+                    },
+                ],
+            },
+        },
+        {
+            "name": "users/1234567890/dataTypes/daily-heart-rate-variability/dataPoints/111",
+            "dataSource": {
+                "recordingMethod": "MANUAL",
+                "device": {},
+                "application": {"packageName": "com.eightsleep.eight"},
+                "platform": "HEALTH_CONNECT",
+            },
+            "dailyHeartRateVariability": {
+                "date": {"year": 2026, "month": 8, "day": 21},
+                "averageHeartRateVariabilityMilliseconds": 57.3,
+                "deepSleepRootMeanSquareOfSuccessiveDifferencesMilliseconds": 57.3,
+            },
+        },
+    ]
+
+    batch = mapper.normalize_data_points(raw_points, target_logical_date="2026-08-21")
+    metrics = {o.metric: o for o in batch.observations}
+
+    assert METRIC_SLEEP_SESSION in metrics
+    sleep_val = metrics[METRIC_SLEEP_SESSION].value
+    assert sleep_val["deepSeconds"] == 30 * 60
+    assert sleep_val["lightSeconds"] == 30 * 60
+    assert sleep_val["awakeSeconds"] == 10 * 60
+    assert sleep_val["remSeconds"] == (5 * 3600 + 50 * 60)
+    assert metrics[METRIC_SLEEP_SESSION].source.provider == "garmin"
+    assert metrics[METRIC_SLEEP_SESSION].logical_date == "2026-08-21"
+
+    assert METRIC_HRV_RMSSD_MS in metrics
+    assert metrics[METRIC_HRV_RMSSD_MS].value == 57.3
+    assert metrics[METRIC_HRV_RMSSD_MS].source.provider == "eight_sleep"
+    assert metrics[METRIC_HRV_RMSSD_MS].logical_date == "2026-08-21"


### PR DESCRIPTION
## Summary

- **Real Google Health ingestion, verified live.** Independently re-confirmed MS0's real-account evidence (was wrongly flagged "fabricated" mid-session, then corrected), found and fixed real bugs surfaced only by hitting the live API: a non-functional date-range filter, a sleep-mapper field-shape mismatch that meant Google-transported sleep observations were silently never persisted, a GCS raw-archive path bug, and an `.env` load-order bug.
- **Fixed a real data-loss incident.** A transient access-token expiry mid-backfill cascaded into 46 real observation bundles being silently deleted (a "fetch failed" was being treated as "source confirms no data"). Fixed the root cause (prefer the refresh-token path; propagate fetch errors instead of swallowing them into a false-empty result) and restored all 46 bundles.
- **Re-derived MS10/MS14/MS16 for real** against the corrected pipeline; all three restored to done. MS17 (production activation) is the one item still open, for exactly one reason: Google's CASA Tier 2 / Restricted Scope verification is confirmed **not** done (checked directly in Google Cloud Console) — real access this session has been via an undeclared, unverified OAuth grant.
- **New: in-app Google Health account linking** (OAuth authorization-code flow) so real users can grant consent without sharing the developer's own OAuth client secret — the only path that existed before this PR. Separate Cloud Run service (`google-health-account-link`), new Firestore/GCS per-user credential storage, `--user-id` support on `backfill-health`/`probe-health` for operator-triggered per-user syncs.
- Full narrative and incident writeups: `docs/plans/2026-08-27-real-google-health-ingestion.md`, `docs/plans/multisource-health-and-recovery-ingestion.md` (task board), and the refreshed `docs/analysis/2026-08-27-*.md` docs.

**Explicit scope boundary:** `MULTISOURCE_FUSION_POLICY` stays `'off'` throughout; nothing here wires Google Health into the automated `sync-all` Cloud Run Scheduler job — that stays deferred until CASA verification is resolved (a project-owner decision, external process).

## Validation

- [x] `uv run pytest` — pass; 129 tests (37 new: `google_health_account_link`, `google_health_account_link_api`, CLI auth resolution, archive regression, mapper real-shape regression).
- [x] `uv run ruff check .` and `uv run mypy src/garmin_sync` — pass, no issues.
- [x] `cd app && npm run check` — typecheck/lint/workout-validation pass; `vitest run` has one pre-existing failure unrelated to this PR: `weeklyAllocationPlanner.test.ts`'s p95 latency-budget gate is load-sensitive and flaked at 108ms vs a 100ms threshold under full-suite load; passes cleanly in isolation (confirmed twice) and touches no file this PR modifies. Confirmed again clean on the actual `git push` pre-push hook run.
- [x] `cd app && node scripts/check-policy-drift.mjs main` — **PASSED: No decision-affecting engine files were modified** (authoritative check for the one engine file this PR touches, `multisourceFusion.ts`'s inert `sleepStages` default).
- [x] `cd app && npm run simulate:scenarios` / `simulate:diff` — ran; diff shows differences, but they're **pre-existing baseline drift on `main`, not caused by this PR**: the drifted scenarios (cycling criterium, subjective-profile drift, delivered-dose thresholds) are in a domain entirely unrelated to the only engine file this PR touches (an unused Google-Health-multisource default not called from any production path), and `check-policy-drift.mjs` above already confirms zero decision-affecting files changed on this branch vs `main`. Not something this PR should fix.
- [ ] `cd app && npm run test:rules` — not run; this PR does not modify `firestore.rules` (the `users/{uid}/connections/{id}` rule it relies on already existed).
- Manual, live verification this session (not CI-automated): `probe-health` reproduced original MS0 numbers exactly against the real account; `backfill-health` restore run showed 0 auth errors / 0 tombstones / 44 bundles restored; direct Firestore query confirmed full 60-day coverage.

## Risk and reviewer guidance

- The account-linking code (`google_health_account_link.py`/`google_health_account_link_api.py`) is new and untested end-to-end against a real deployment — unit tests mock Firestore/GCS/Google's token endpoint throughout. Before inviting any real user, the project owner still needs to: register the callback URL as an authorized redirect URI on the OAuth client, add `GOOGLE_HEALTH_CLIENT_ID`/`GOOGLE_HEALTH_CLIENT_SECRET` GitHub secrets, deploy, and do one real link-and-sync as themselves first.
- The new Cloud Run service and its deploy step are gated behind those two secrets being present (`if: secrets.GOOGLE_HEALTH_CLIENT_ID != '' && ...`) specifically so the existing Garmin deploy pipeline is unaffected until the project owner is ready.
- Every linked Google Health user will see Google's "unverified app" warning and needs to reconnect roughly weekly (Restricted-scope, unverified-app token lifetime) — reflected in the UI copy, not a bug.
- `docs/analysis/2026-08-27-*.md` correction banners document a mid-session self-correction: an earlier pass wrongly called MS0's evidence "fabricated"; that was retracted after live re-verification. Worth a skim for anyone relying on those docs' history.

## Domain invariants

- [x] Firestore writes remain user-scoped under `users/{APP_USER_ID}/...`; no `default_user` or top-level recovery snapshots were introduced. New per-user data (`users/{uid}/connections/googleHealth`, GCS `google-health/users/{uid}/...`) is correctly scoped. One deliberate exception, matching existing precedent: `googleHealthLinkState/{state}` is a root-level, server-only, short-lived OAuth CSRF-state collection — mirrors Garmin's existing `garminConnections`/`garminIdentities` root-collection pattern for non-recovery-data server state, not a new deviation.
- [x] Calendar-date logic uses `Europe/Warsaw`; completed `totalSteps` still means the previous calendar day (`D - 1`) — not applicable, no calendar-date or step-count logic touched. `linkedAt`/`obtained_at` are plain UTC ISO timestamps for metadata, not local-calendar recovery-window dates.
- [x] No credentials, tokens, service-account files, or raw health payloads are included — checked the diff directly; all new code reads client id/secret/tokens from env vars or GitHub secrets, never embeds real values.
- [x] Recommendation decision logic changed: `POLICY_VERSION` was evaluated — not applicable; confirmed via `node scripts/check-policy-drift.mjs main`: "No decision-affecting engine files were modified."

## Screenshots or recordings

Not applicable — no visual/style changes to existing UI. The new `GoogleHealthConnectionSection` reuses existing `preference-section`/`login-btn` styling rather than introducing new CSS. Not independently screenshotted: rendering it meaningfully requires a live Firebase-authenticated session against the deployed Cloud Run service, which hasn't happened yet (see Risk section).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Google Health account linking from Preferences, including connection status, reconnecting, and clear success or error messages.
  - Added support for syncing Google Health data for linked accounts.
  - Added command-line support for checking Google Health data using a linked account.

- **Bug Fixes**
  - Improved handling of Google Health sleep, daily summary, and missing-data responses.
  - Corrected health archive storage and date filtering.
  - Disabled experimental sleep-stage fusion until reliable evidence is available.

- **Documentation**
  - Updated Google Health verification, ingestion, and data-quality findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->