### PR TITLE
fix(garmin): show real connection status in Coach Preferences

### DIFF
--- a/app/src/components/preferences/GarminConnectionSection.tsx
+++ b/app/src/components/preferences/GarminConnectionSection.tsx
@@ -4,11 +4,12 @@ import { doc, onSnapshot } from 'firebase/firestore';
 import { getAuthInstance, getDb } from '../../firebase';
 import { garminAuthService } from '../../services/garminAuthService';
 import { getErrorMessage } from '../../utils/errors';
+import { firestoreDateToDate, type FirestoreDateValue } from '../../utils/firestoreDate';
 import { getLocalDateString } from '../../utils/localDate';
 
 interface GarminConnection {
   status?: string;
-  linkedAt?: string;
+  linkedAt?: FirestoreDateValue;
 }
 
 interface GarminConnectionSectionProps {
@@ -18,6 +19,7 @@ interface GarminConnectionSectionProps {
 export function GarminConnectionSection({ userId }: GarminConnectionSectionProps) {
   const [connection, setConnection] = useState<GarminConnection | null>(null);
   const [loadingConnection, setLoadingConnection] = useState(true);
+  const [connectionError, setConnectionError] = useState<string | null>(null);
   const [showForm, setShowForm] = useState(false);
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -28,23 +30,67 @@ export function GarminConnectionSection({ userId }: GarminConnectionSectionProps
   const [success, setSuccess] = useState(false);
 
   useEffect(() => {
+    let cancelled = false;
+    let reconciliationStarted = false;
+    setLoadingConnection(true);
+    setConnectionError(null);
+
+    const reconcileWithServer = async () => {
+      if (reconciliationStarted) return;
+      reconciliationStarted = true;
+      try {
+        const status = await garminAuthService.getConnectionStatus();
+        if (cancelled) return;
+        setConnection(status.status === 'active' ? status : null);
+        setConnectionError(null);
+      } catch (err: unknown) {
+        if (cancelled) return;
+        setConnectionError(getErrorMessage(err) || 'Could not verify Garmin connection status.');
+      } finally {
+        if (!cancelled) setLoadingConnection(false);
+      }
+    };
+
     const ref = doc(getDb(), 'users', userId, 'connections', 'garmin');
-    return onSnapshot(
+    const unsubscribe = onSnapshot(
       ref,
       (snap) => {
-        setConnection(snap.exists() ? (snap.data() as GarminConnection) : null);
-        setLoadingConnection(false);
+        if (snap.exists() && snap.data().status === 'active') {
+          setConnection(snap.data() as GarminConnection);
+          setConnectionError(null);
+          setLoadingConnection(false);
+          return;
+        }
+        // Older links have no mirror. Ask the authenticated backend for canonical state;
+        // it transactionally repairs the non-secret mirror so subsequent loads are direct.
+        void reconcileWithServer();
       },
-      () => setLoadingConnection(false),
+      () => {
+        // Firestore may be temporarily unavailable or the mirror may not exist yet. The
+        // canonical server-only connection record remains the authority for this fallback.
+        void reconcileWithServer();
+      },
     );
+
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
   }, [userId]);
 
   const isConnected = connection?.status === 'active';
+  const linkedAtDate = firestoreDateToDate(connection?.linkedAt);
+  const linkedAtLabel = linkedAtDate ? getLocalDateString(linkedAtDate) : null;
 
   const finish = async (customToken: string) => {
     // The backend only issues a token for the same Firebase UID when this form is used
     // from an authenticated session. Signing it in refreshes auth without changing owner.
     await signInWithCustomToken(getAuthInstance(), customToken);
+    // commit_link() has already committed canonical + mirror status before issuing the token.
+    // Mark this render connected immediately rather than flashing the login form while the
+    // Firestore listener catches up.
+    setConnection({ status: 'active' });
+    setConnectionError(null);
     setSuccess(true);
     setChallengeId(null);
     setMfaCode('');
@@ -89,7 +135,9 @@ export function GarminConnectionSection({ userId }: GarminConnectionSectionProps
     }
   };
 
-  const formVisible = !loadingConnection && (!isConnected || showForm);
+  // An unknown status is intentionally not rendered as "disconnected". Presenting the
+  // credential form after a verification failure would recreate the original false-status UX.
+  const formVisible = !loadingConnection && !connectionError && (!isConnected || showForm);
 
   return (
     <section className="preference-section">
@@ -99,9 +147,14 @@ export function GarminConnectionSection({ userId }: GarminConnectionSectionProps
         the app keeps the resulting refreshable session token, not the password.
       </p>
 
+      {loadingConnection && <p className="preference-desc">Checking Garmin connection…</p>}
+      {!loadingConnection && connectionError && (
+        <p className="error-message">{connectionError} Refresh the page before reconnecting.</p>
+      )}
+
       {!loadingConnection && isConnected && (
         <p className="preference-success-note">
-          Connected{connection?.linkedAt ? ` since ${getLocalDateString(new Date(connection.linkedAt))}` : ''}.
+          Connected{linkedAtLabel ? ` since ${linkedAtLabel}` : ''}.
         </p>
       )}
 
@@ -112,74 +165,74 @@ export function GarminConnectionSection({ userId }: GarminConnectionSectionProps
       )}
 
       {formVisible && (
-      <form onSubmit={submit}>
-        {challengeId ? (
-          <div className="form-group">
-            <input
-              type="text"
-              inputMode="numeric"
-              autoComplete="one-time-code"
-              placeholder="Garmin verification code"
-              value={mfaCode}
-              onChange={(event) => setMfaCode(event.target.value)}
-              required
-            />
-          </div>
-        ) : (
-          <>
+        <form onSubmit={submit}>
+          {challengeId ? (
             <div className="form-group">
               <input
-                type="email"
-                autoComplete="username"
-                placeholder="Garmin email"
-                value={email}
-                onChange={(event) => setEmail(event.target.value)}
+                type="text"
+                inputMode="numeric"
+                autoComplete="one-time-code"
+                placeholder="Garmin verification code"
+                value={mfaCode}
+                onChange={(event) => setMfaCode(event.target.value)}
                 required
               />
             </div>
-            <div className="form-group">
-              <input
-                type="password"
-                autoComplete="current-password"
-                placeholder="Garmin password"
-                value={password}
-                onChange={(event) => setPassword(event.target.value)}
-                required
-              />
-            </div>
-          </>
-        )}
-        {error && <p className="error-message">{error}</p>}
-        {success && <p className="preference-success-note">Garmin is connected to this app account.</p>}
-        <button type="submit" className="login-btn" disabled={loading}>
-          {loading ? 'Connecting...' : challengeId ? 'Verify Garmin' : 'Connect Garmin'}
-        </button>
-        {challengeId && (
-          <button
-            type="button"
-            className="auth-secondary-btn"
-            onClick={() => {
-              setChallengeId(null);
-              setMfaCode('');
-              setError(null);
-            }}
-          >
-            Restart login
+          ) : (
+            <>
+              <div className="form-group">
+                <input
+                  type="email"
+                  autoComplete="username"
+                  placeholder="Garmin email"
+                  value={email}
+                  onChange={(event) => setEmail(event.target.value)}
+                  required
+                />
+              </div>
+              <div className="form-group">
+                <input
+                  type="password"
+                  autoComplete="current-password"
+                  placeholder="Garmin password"
+                  value={password}
+                  onChange={(event) => setPassword(event.target.value)}
+                  required
+                />
+              </div>
+            </>
+          )}
+          {error && <p className="error-message">{error}</p>}
+          {success && <p className="preference-success-note">Garmin is connected to this app account.</p>}
+          <button type="submit" className="login-btn" disabled={loading}>
+            {loading ? 'Connecting...' : challengeId ? 'Verify Garmin' : 'Connect Garmin'}
           </button>
-        )}
-        {isConnected && !challengeId && (
-          <button
-            type="button"
-            className="auth-secondary-btn"
-            onClick={() => {
-              setShowForm(false);
-              setError(null);
-            }}
-          >
-            Cancel
-          </button>
-        )}
-      </form>
+          {challengeId && (
+            <button
+              type="button"
+              className="auth-secondary-btn"
+              onClick={() => {
+                setChallengeId(null);
+                setMfaCode('');
+                setError(null);
+              }}
+            >
+              Restart login
+            </button>
+          )}
+          {isConnected && !challengeId && (
+            <button
+              type="button"
+              className="auth-secondary-btn"
+              onClick={() => {
+                setShowForm(false);
+                setError(null);
+              }}
+            >
+              Cancel
+            </button>
+          )}
+        </form>
       )}
     </section>
   );

--- a/app/src/components/preferences/GarminConnectionSection.tsx
+++ b/app/src/components/preferences/GarminConnectionSection.tsx
@@ -1,10 +1,24 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { signInWithCustomToken } from 'firebase/auth';
-import { getAuthInstance } from '../../firebase';
+import { doc, onSnapshot } from 'firebase/firestore';
+import { getAuthInstance, getDb } from '../../firebase';
 import { garminAuthService } from '../../services/garminAuthService';
 import { getErrorMessage } from '../../utils/errors';
+import { getLocalDateString } from '../../utils/localDate';
 
-export function GarminConnectionSection() {
+interface GarminConnection {
+  status?: string;
+  linkedAt?: string;
+}
+
+interface GarminConnectionSectionProps {
+  userId: string;
+}
+
+export function GarminConnectionSection({ userId }: GarminConnectionSectionProps) {
+  const [connection, setConnection] = useState<GarminConnection | null>(null);
+  const [loadingConnection, setLoadingConnection] = useState(true);
+  const [showForm, setShowForm] = useState(false);
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [challengeId, setChallengeId] = useState<string | null>(null);
@@ -13,6 +27,20 @@ export function GarminConnectionSection() {
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
 
+  useEffect(() => {
+    const ref = doc(getDb(), 'users', userId, 'connections', 'garmin');
+    return onSnapshot(
+      ref,
+      (snap) => {
+        setConnection(snap.exists() ? (snap.data() as GarminConnection) : null);
+        setLoadingConnection(false);
+      },
+      () => setLoadingConnection(false),
+    );
+  }, [userId]);
+
+  const isConnected = connection?.status === 'active';
+
   const finish = async (customToken: string) => {
     // The backend only issues a token for the same Firebase UID when this form is used
     // from an authenticated session. Signing it in refreshes auth without changing owner.
@@ -20,6 +48,7 @@ export function GarminConnectionSection() {
     setSuccess(true);
     setChallengeId(null);
     setMfaCode('');
+    setShowForm(false);
   };
 
   const submit = async (event: React.FormEvent) => {
@@ -60,6 +89,8 @@ export function GarminConnectionSection() {
     }
   };
 
+  const formVisible = !loadingConnection && (!isConnected || showForm);
+
   return (
     <section className="preference-section">
       <h2>Garmin account</h2>
@@ -67,6 +98,20 @@ export function GarminConnectionSection() {
         Connect Garmin to this app account. Your password is used only for Garmin authentication;
         the app keeps the resulting refreshable session token, not the password.
       </p>
+
+      {!loadingConnection && isConnected && (
+        <p className="preference-success-note">
+          Connected{connection?.linkedAt ? ` since ${getLocalDateString(new Date(connection.linkedAt))}` : ''}.
+        </p>
+      )}
+
+      {!loadingConnection && isConnected && !showForm && (
+        <button type="button" className="auth-secondary-btn" onClick={() => setShowForm(true)}>
+          Reconnect Garmin
+        </button>
+      )}
+
+      {formVisible && (
       <form onSubmit={submit}>
         {challengeId ? (
           <div className="form-group">
@@ -122,7 +167,20 @@ export function GarminConnectionSection() {
             Restart login
           </button>
         )}
+        {isConnected && !challengeId && (
+          <button
+            type="button"
+            className="auth-secondary-btn"
+            onClick={() => {
+              setShowForm(false);
+              setError(null);
+            }}
+          >
+            Cancel
+          </button>
+        )}
       </form>
+      )}
     </section>
   );
 }

--- a/app/src/components/preferences/index.tsx
+++ b/app/src/components/preferences/index.tsx
@@ -76,7 +76,7 @@ export function Preferences({ userId }: PreferencesProps) {
       )}
 
       <div className="preferences-content">
-        <GarminConnectionSection />
+        <GarminConnectionSection userId={userId} />
 
         <GoogleHealthConnectionSection userId={userId} />
 

--- a/app/src/services/garminAuthService.ts
+++ b/app/src/services/garminAuthService.ts
@@ -4,6 +4,11 @@ export type GarminAuthResult =
   | { status: 'mfa_required'; challengeId: string }
   | { status: 'authenticated'; customToken: string; isNewUser: boolean };
 
+export interface GarminConnectionStatus {
+  status: 'active' | 'disconnected';
+  linkedAt?: string;
+}
+
 interface GarminErrorOptions {
   code: string;
   status?: number;
@@ -52,26 +57,32 @@ async function request(path: string, init: RequestInit): Promise<Response> {
   }
 }
 
+function responseError(
+  response: Response,
+  payload: Record<string, unknown>,
+  fallbackMessage: string,
+): GarminAuthError {
+  const message = typeof payload.error === 'string' ? payload.error : fallbackMessage;
+  const code = typeof payload.errorCode === 'string'
+    ? payload.errorCode
+    : `garmin_link.http_${response.status}`;
+  const retryable = typeof payload.retryable === 'boolean'
+    ? payload.retryable
+    : response.status === 429 || response.status >= 500;
+  return new GarminAuthError(message, {
+    code,
+    status: response.status,
+    retryable,
+    requestId: responseRequestId(response, payload),
+  });
+}
+
 async function parseResponse(response: Response): Promise<GarminAuthResult> {
   const payload = asRecord(await response.json().catch(() => null));
   const requestId = responseRequestId(response, payload);
 
   if (!response.ok) {
-    const message = typeof payload.error === 'string'
-      ? payload.error
-      : 'Garmin authentication failed.';
-    const code = typeof payload.errorCode === 'string'
-      ? payload.errorCode
-      : `garmin_link.http_${response.status}`;
-    const retryable = typeof payload.retryable === 'boolean'
-      ? payload.retryable
-      : response.status === 429 || response.status >= 500;
-    throw new GarminAuthError(message, {
-      code,
-      status: response.status,
-      retryable,
-      requestId,
-    });
+    throw responseError(response, payload, 'Garmin authentication failed.');
   }
 
   if (payload.status === 'mfa_required' && typeof payload.challengeId === 'string') {
@@ -96,18 +107,54 @@ async function parseResponse(response: Response): Promise<GarminAuthResult> {
   });
 }
 
+async function appAuthorizationHeader(): Promise<Record<string, string>> {
+  const currentUser = getAuthInstance().currentUser;
+  if (!currentUser) {
+    throw new GarminAuthError('Your app session expired. Sign in again first.', {
+      code: 'garmin_link.app_session_expired',
+      retryable: false,
+    });
+  }
+  return { Authorization: `Bearer ${await currentUser.getIdToken()}` };
+}
+
+async function parseConnectionStatus(response: Response): Promise<GarminConnectionStatus> {
+  const payload = asRecord(await response.json().catch(() => null));
+  if (!response.ok) {
+    throw responseError(response, payload, 'Could not verify Garmin connection status.');
+  }
+
+  if (payload.status === 'disconnected') {
+    return { status: 'disconnected' };
+  }
+  if (payload.status === 'active') {
+    return {
+      status: 'active',
+      linkedAt: typeof payload.linkedAt === 'string' ? payload.linkedAt : undefined,
+    };
+  }
+
+  throw new GarminAuthError('Garmin status returned an unexpected response.', {
+    code: 'garmin_link.invalid_status_response',
+    status: response.status,
+    retryable: false,
+    requestId: responseRequestId(response, payload),
+  });
+}
+
 export const garminAuthService = {
+  async getConnectionStatus(): Promise<GarminConnectionStatus> {
+    const response = await request('/api/garmin/status', {
+      method: 'POST',
+      headers: await appAuthorizationHeader(),
+    });
+    return parseConnectionStatus(response);
+  },
+
   async startLogin(email: string, password: string, linkCurrentUser = false): Promise<GarminAuthResult> {
     const headers: Record<string, string> = { 'Content-Type': 'application/json' };
     if (linkCurrentUser) {
-      const currentUser = getAuthInstance().currentUser;
-      if (!currentUser) {
-        throw new GarminAuthError('Your app session expired. Sign in again first.', {
-          code: 'garmin_link.app_session_expired',
-          retryable: false,
-        });
-      }
-      headers.Authorization = `Bearer ${await currentUser.getIdToken()}`;
+      Object.assign(headers, await appAuthorizationHeader());
     }
     const response = await request('/api/garmin/login', {
       method: 'POST',

--- a/app/src/utils/firestoreDate.test.ts
+++ b/app/src/utils/firestoreDate.test.ts
@@ -1,0 +1,20 @@
+import { Timestamp } from 'firebase/firestore';
+import { describe, expect, it } from 'vitest';
+import { firestoreDateToDate } from './firestoreDate';
+
+describe('firestoreDateToDate', () => {
+  it('converts a Firestore Timestamp to Date', () => {
+    const expected = new Date('2026-08-01T12:30:00.000Z');
+    expect(firestoreDateToDate(Timestamp.fromDate(expected))).toEqual(expected);
+  });
+
+  it('accepts an ISO timestamp from the authenticated status endpoint', () => {
+    expect(firestoreDateToDate('2026-08-01T12:30:00+00:00')?.toISOString())
+      .toBe('2026-08-01T12:30:00.000Z');
+  });
+
+  it('returns null for absent or invalid values', () => {
+    expect(firestoreDateToDate(undefined)).toBeNull();
+    expect(firestoreDateToDate('not-a-date')).toBeNull();
+  });
+});

--- a/app/src/utils/firestoreDate.ts
+++ b/app/src/utils/firestoreDate.ts
@@ -1,0 +1,13 @@
+import { Timestamp } from 'firebase/firestore';
+
+export type FirestoreDateValue = Timestamp | Date | string | null | undefined;
+
+export function firestoreDateToDate(value: FirestoreDateValue): Date | null {
+  if (!value) return null;
+  const date = value instanceof Timestamp
+    ? value.toDate()
+    : value instanceof Date
+      ? value
+      : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}

--- a/docs/adr/0029-client-visible-provider-connection-status.md
+++ b/docs/adr/0029-client-visible-provider-connection-status.md
@@ -1,6 +1,6 @@
 # ADR-0029: Client-visible provider connection status mirrors
 
-**Status:** Accepted  
+**Status:** Accepted
 **Date:** 2026-08-27
 
 ## Context

--- a/docs/adr/0029-client-visible-provider-connection-status.md
+++ b/docs/adr/0029-client-visible-provider-connection-status.md
@@ -1,0 +1,66 @@
+# ADR-0029: Client-visible provider connection status mirrors
+
+**Status:** Accepted  
+**Date:** 2026-08-27
+
+## Context
+
+Provider connection records can contain server-only credentials or identifiers that must not be readable by the web client. Garmin is one example: `garminConnections/{uid}` contains the token-object pointer and identity digest used by backend synchronization, while Coach Preferences only needs to know whether the provider is connected and when the link was established.
+
+Reading the canonical document from the browser would widen the Firestore security boundary. Conversely, showing a connection form without consulting canonical state creates a false-disconnected UX, especially for links created before a client-visible status document existed.
+
+## Decision
+
+For Garmin, keep `garminConnections/{uid}` authoritative and server-only. Project only non-secret connection metadata to:
+
+`users/{uid}/connections/garmin`
+
+The projection contains only:
+
+- `status`
+- `identityKind` when available
+- `linkedAt`
+- `updatedAt`
+
+It must never contain `tokenObject`, `identityDigest`, credentials, session tokens, or provider payloads.
+
+New Garmin links write the canonical record and the client projection in the same Firestore transaction.
+
+Coach Preferences listens to the projection for low-latency UI updates. If the projection is missing or cannot be read, the client calls authenticated `POST /api/garmin/status`. The endpoint verifies the Firebase user ID, reads only that user's canonical Garmin record, and transactionally reconciles the projection. This is a lazy migration path for links that predate the mirror; users do not need to relink.
+
+The reconciliation transaction also deletes a stale active projection when canonical state is absent or not active. Keeping the canonical read and mirror write/delete in one transaction prevents an unlink/relink race from resurrecting stale status.
+
+## Timestamp contract
+
+Backend Firestore writes use server timestamps. Browser Firestore listeners therefore receive `Timestamp` values, not JSON strings. UI code must handle native Firestore `Timestamp` values. The authenticated HTTP fallback serializes `linkedAt` as ISO-8601 JSON.
+
+## Failure semantics
+
+Connection state is tri-state in the UI:
+
+1. connected;
+2. disconnected, after canonical verification;
+3. unknown, when both mirror observation and canonical verification fail.
+
+An unknown state must not be rendered as disconnected and must not automatically prompt the user to relink, because doing so would recreate the misleading behavior this design is intended to remove.
+
+## Security consequences
+
+- Canonical Garmin token metadata remains server-only.
+- The status endpoint requires a valid Firebase ID token and derives the UID from that token; it does not accept an arbitrary UID from the request body.
+- The mirror is a deliberately minimal projection and is safe for the existing owner-scoped `users/{uid}/connections/*` read policy.
+- The reconciliation function is responsible for an explicit allow-list of projected fields rather than copying the canonical document wholesale.
+
+## Operational consequences
+
+No bulk migration or one-off backfill job is required. Existing linked users are repaired on the first Coach Preferences status check after deployment. New links remain atomic with their mirror write.
+
+## Tests
+
+Regression coverage must verify that:
+
+- an active canonical link backfills the mirror;
+- secret canonical fields never enter the mirror;
+- a stale mirror is deleted when canonical state is disconnected;
+- the status endpoint requires an authenticated app user;
+- the frontend accepts both Firestore `Timestamp` and HTTP ISO timestamp representations.

--- a/src/garmin_sync/account_link.py
+++ b/src/garmin_sync/account_link.py
@@ -171,6 +171,13 @@ class GarminConnectionRepository:
         """
         identity_ref = self.db.collection("garminIdentities").document(identity_digest)
         connection_ref = self.db.collection("garminConnections").document(uid)
+        # Non-secret mirror of connection_ref, under the user's own tree so the frontend can
+        # read its own status directly (see users/{userId}/connections/{connectionId} in
+        # firestore.rules, the same MS4/ADR-0027 path Google Health's connection status uses).
+        # garminConnections itself stays server-only because it also holds tokenObject.
+        client_status_ref = (
+            self.db.collection("users").document(uid).collection("connections").document("garmin")
+        )
         transaction = self.db.transaction()
         server_timestamp = google_firestore.SERVER_TIMESTAMP
 
@@ -222,6 +229,17 @@ class GarminConnectionRepository:
                     "identityKind": identity_kind,
                     "tokenObject": token_object,
                     "source": "garmin-connect-unofficial",
+                    "linkedAt": server_timestamp,
+                    "updatedAt": server_timestamp,
+                },
+                merge=True,
+            )
+            # Client-readable status only -- no tokenObject/identityDigest.
+            transaction_obj.set(
+                client_status_ref,
+                {
+                    "status": "active",
+                    "identityKind": identity_kind,
                     "linkedAt": server_timestamp,
                     "updatedAt": server_timestamp,
                 },

--- a/src/garmin_sync/account_link_api.py
+++ b/src/garmin_sync/account_link_api.py
@@ -19,6 +19,7 @@ from .account_link import (
     GarminLinkConfigurationError,
     GarminLinkConflictError,
 )
+from .connection_status import reconcile_garmin_connection_status
 from .error_reporting import log_exception, sanitize_text
 
 logging.basicConfig(
@@ -178,6 +179,9 @@ class GarminAccountLinkHandler(BaseHTTPRequestHandler):
     def do_POST(self) -> None:  # noqa: N802
         self.request_id = secrets.token_hex(8)
         try:
+            if self.path == "/api/garmin/status":
+                self._handle_status()
+                return
             if self.path == "/api/garmin/login":
                 self._handle_login()
                 return
@@ -264,6 +268,13 @@ class GarminAccountLinkHandler(BaseHTTPRequestHandler):
                 error_code=report.code,
                 retryable=report.retryable,
             )
+
+    def _handle_status(self) -> None:
+        uid = _verified_uid(self.headers.get("Authorization"))
+        if not uid:
+            raise GarminConnectAuthenticationError("App authentication is required.")
+        result = reconcile_garmin_connection_status(uid)
+        self._json_response(HTTPStatus.OK, result)
 
     def _handle_login(self) -> None:
         client_key = self._client_key()

--- a/src/garmin_sync/connection_status.py
+++ b/src/garmin_sync/connection_status.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from typing import Any
+
+from google.cloud import firestore as google_firestore
+
+from .firestore_repository import init_firestore_client
+
+
+def _linked_at_json(value: Any) -> str | None:
+    """Return a JSON-safe timestamp without exposing Firestore implementation details."""
+    isoformat = getattr(value, "isoformat", None)
+    if callable(isoformat):
+        return str(isoformat())
+    return None
+
+
+def reconcile_garmin_connection_status(uid: str, db: Any = None) -> dict[str, Any]:
+    """Read canonical Garmin link state and repair the client-readable mirror atomically.
+
+    ``garminConnections/{uid}`` remains server-only because it contains ``tokenObject`` and
+    identity metadata. The frontend reads ``users/{uid}/connections/garmin`` instead. Older
+    links predate that mirror, so this authenticated reconciliation path lazily backfills the
+    non-secret projection on first status check rather than requiring users to relink.
+
+    The canonical read and mirror write/delete share one Firestore transaction so a concurrent
+    relink cannot resurrect stale status after an unlink or overwrite a newer link state.
+    """
+    if not uid:
+        raise ValueError("uid is required")
+
+    client = db or init_firestore_client()
+    canonical_ref = client.collection("garminConnections").document(uid)
+    mirror_ref = (
+        client.collection("users").document(uid).collection("connections").document("garmin")
+    )
+    transaction = client.transaction()
+
+    @google_firestore.transactional
+    def reconcile(transaction_obj: Any) -> dict[str, Any]:
+        snapshot = canonical_ref.get(transaction=transaction_obj)
+        data = snapshot.to_dict() if snapshot.exists else None
+        if not data or data.get("status") != "active":
+            # Delete a stale projection if canonical state says the account is not linked.
+            transaction_obj.delete(mirror_ref)
+            return {"status": "disconnected", "linkedAt": None}
+
+        linked_at = data.get("linkedAt")
+        mirror: dict[str, Any] = {
+            "status": "active",
+            "updatedAt": google_firestore.SERVER_TIMESTAMP,
+        }
+        identity_kind = data.get("identityKind")
+        if identity_kind:
+            mirror["identityKind"] = identity_kind
+        mirror["linkedAt"] = linked_at or google_firestore.SERVER_TIMESTAMP
+
+        # Deliberately project only non-secret fields. Never copy tokenObject,
+        # identityDigest, source credentials, or other canonical-only metadata.
+        transaction_obj.set(mirror_ref, mirror, merge=True)
+        return {
+            "status": "active",
+            "linkedAt": _linked_at_json(linked_at),
+        }
+
+    return reconcile(transaction)
+
+
+__all__ = ["reconcile_garmin_connection_status"]

--- a/tests/test_account_link.py
+++ b/tests/test_account_link.py
@@ -513,6 +513,16 @@ def test_commit_link_returns_exactly_the_tokenObject_it_overwrote(monkeypatch: A
     assert connection is not None
     assert connection["tokenObject"] == "garmin/users/uid-1/garmin_tokens-ccc.json"
 
+    # commit_link also mirrors non-secret status onto users/{uid}/connections/garmin so the
+    # frontend can read its own connection state without server-only garminConnections access.
+    client_status = (
+        db.collection("users").document("uid-1").collection("connections").document("garmin").data
+    )
+    assert client_status is not None
+    assert client_status["status"] == "active"
+    assert "tokenObject" not in client_status
+    assert "identityDigest" not in client_status
+
 
 def test_finalize_queues_initial_backfill_request(
     monkeypatch: Any,

--- a/tests/test_garmin_connection_status.py
+++ b/tests/test_garmin_connection_status.py
@@ -127,9 +127,11 @@ def test_status_handler_returns_reconciled_status(monkeypatch: Any) -> None:
     monkeypatch.setattr(
         account_link_api,
         "reconcile_garmin_connection_status",
-        lambda uid: {"status": "active", "linkedAt": "2026-08-01T12:30:00+00:00"}
-        if uid == "uid-1"
-        else {"status": "disconnected", "linkedAt": None},
+        lambda uid: (
+            {"status": "active", "linkedAt": "2026-08-01T12:30:00+00:00"}
+            if uid == "uid-1"
+            else {"status": "disconnected", "linkedAt": None}
+        ),
     )
 
     handler._handle_status()  # noqa: SLF001 - endpoint contract regression

--- a/tests/test_garmin_connection_status.py
+++ b/tests/test_garmin_connection_status.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from http import HTTPStatus
+from typing import Any
+
+import pytest
+
+import garmin_sync.account_link_api as account_link_api
+import garmin_sync.connection_status as connection_status
+
+
+class _Snapshot:
+    def __init__(self, data: dict[str, Any] | None) -> None:
+        self._data = data
+        self.exists = data is not None
+
+    def to_dict(self) -> dict[str, Any] | None:
+        return dict(self._data) if self._data is not None else None
+
+
+class _Document:
+    def __init__(self, data: dict[str, Any] | None = None) -> None:
+        self.data = data
+        self._collections: dict[str, _Collection] = {}
+
+    def get(self, transaction: Any = None) -> _Snapshot:
+        return _Snapshot(self.data)
+
+    def collection(self, name: str) -> _Collection:
+        return self._collections.setdefault(name, _Collection())
+
+
+class _Collection:
+    def __init__(self) -> None:
+        self._documents: dict[str, _Document] = {}
+
+    def document(self, doc_id: str) -> _Document:
+        return self._documents.setdefault(doc_id, _Document())
+
+
+class _Transaction:
+    def set(self, doc_ref: _Document, payload: dict[str, Any], merge: bool = False) -> None:
+        if merge:
+            doc_ref.data = {**(doc_ref.data or {}), **payload}
+        else:
+            doc_ref.data = dict(payload)
+
+    def delete(self, doc_ref: _Document) -> None:
+        doc_ref.data = None
+
+
+class _Db:
+    def __init__(self) -> None:
+        self._collections: dict[str, _Collection] = {}
+
+    def collection(self, name: str) -> _Collection:
+        return self._collections.setdefault(name, _Collection())
+
+    def transaction(self) -> _Transaction:
+        return _Transaction()
+
+
+def _mirror(db: _Db, uid: str) -> _Document:
+    return db.collection("users").document(uid).collection("connections").document("garmin")
+
+
+def test_reconcile_backfills_only_non_secret_active_status(monkeypatch: Any) -> None:
+    monkeypatch.setattr(connection_status.google_firestore, "transactional", lambda fn: fn)
+    db = _Db()
+    linked_at = datetime(2026, 8, 1, 12, 30, tzinfo=timezone.utc)
+    db.collection("garminConnections").document("uid-1").data = {
+        "userId": "uid-1",
+        "status": "active",
+        "identityKind": "garmin_guid",
+        "identityDigest": "secret-identity-digest",
+        "tokenObject": "garmin/users/uid-1/private-token.json",
+        "linkedAt": linked_at,
+    }
+
+    result = connection_status.reconcile_garmin_connection_status("uid-1", db=db)
+
+    assert result == {"status": "active", "linkedAt": linked_at.isoformat()}
+    mirror = _mirror(db, "uid-1").data
+    assert mirror is not None
+    assert mirror["status"] == "active"
+    assert mirror["identityKind"] == "garmin_guid"
+    assert mirror["linkedAt"] == linked_at
+    assert "updatedAt" in mirror
+    assert "tokenObject" not in mirror
+    assert "identityDigest" not in mirror
+
+
+def test_reconcile_deletes_stale_mirror_when_canonical_is_not_active(monkeypatch: Any) -> None:
+    monkeypatch.setattr(connection_status.google_firestore, "transactional", lambda fn: fn)
+    db = _Db()
+    _mirror(db, "uid-1").data = {"status": "active"}
+
+    result = connection_status.reconcile_garmin_connection_status("uid-1", db=db)
+
+    assert result == {"status": "disconnected", "linkedAt": None}
+    assert _mirror(db, "uid-1").data is None
+
+
+def test_status_handler_requires_authenticated_app_user(monkeypatch: Any) -> None:
+    handler = account_link_api.GarminAccountLinkHandler.__new__(
+        account_link_api.GarminAccountLinkHandler
+    )
+    handler.headers = {}  # type: ignore[assignment]
+    monkeypatch.setattr(account_link_api, "_verified_uid", lambda _authorization: None)
+
+    with pytest.raises(account_link_api.GarminConnectAuthenticationError, match="required"):
+        handler._handle_status()  # noqa: SLF001 - endpoint contract regression
+
+
+def test_status_handler_returns_reconciled_status(monkeypatch: Any) -> None:
+    handler = account_link_api.GarminAccountLinkHandler.__new__(
+        account_link_api.GarminAccountLinkHandler
+    )
+    handler.headers = {"Authorization": "Bearer app-token"}  # type: ignore[assignment]
+    captured: list[tuple[HTTPStatus, dict[str, Any]]] = []
+    handler._json_response = lambda status, payload: captured.append(  # type: ignore[method-assign]
+        (status, payload)
+    )
+
+    monkeypatch.setattr(account_link_api, "_verified_uid", lambda _authorization: "uid-1")
+    monkeypatch.setattr(
+        account_link_api,
+        "reconcile_garmin_connection_status",
+        lambda uid: {"status": "active", "linkedAt": "2026-08-01T12:30:00+00:00"}
+        if uid == "uid-1"
+        else {"status": "disconnected", "linkedAt": None},
+    )
+
+    handler._handle_status()  # noqa: SLF001 - endpoint contract regression
+
+    assert captured == [
+        (HTTPStatus.OK, {"status": "active", "linkedAt": "2026-08-01T12:30:00+00:00"})
+    ]


### PR DESCRIPTION
## Problem

Coach Preferences always showed the Garmin credential form even for an already-linked account because `GarminConnectionSection` had no trustworthy client-visible link state. This was both confusing and materially different from the Google Health UX.

## Root cause

Garmin's canonical link state lives in server-only `garminConnections/{uid}`. That document also contains `tokenObject` and `identityDigest`, so allowing the browser to read it would widen the security boundary.

The initial implementation added a non-secret mirror at `users/{uid}/connections/garmin`, but a deeper review found two remaining correctness gaps:

1. links created before the mirror existed would still look disconnected until the user relinked;
2. Firestore `linkedAt` is delivered to the browser as a native `Timestamp`, while the UI typed it as a string.

## Fix

- `GarminConnectionRepository.commit_link()` writes the canonical Garmin link and the non-secret client projection in the **same Firestore transaction**.
- The client projection contains only `status`, `identityKind`, `linkedAt`, and `updatedAt`; it never contains `tokenObject`, `identityDigest`, credentials, or provider payloads.
- Added authenticated `POST /api/garmin/status`. The endpoint derives the UID from the Firebase ID token, reads only that user's canonical Garmin connection, and transactionally reconciles the client projection.
- Existing linked users therefore self-heal on their first Coach Preferences status check after deployment; **no relink or one-off bulk migration is required**.
- Reconciliation deletes a stale active mirror when canonical state is absent/inactive, keeping canonical state authoritative.
- `GarminConnectionSection` listens to the mirror for normal low-latency updates and falls back to the authenticated status endpoint when the mirror is missing or unreadable.
- The UI now has explicit connected / disconnected / unknown semantics, so a verification failure is not rendered as a false disconnected state.
- Added a shared Firestore-date normalizer so the UI safely handles both native Firestore `Timestamp` values and ISO timestamps returned by the HTTP fallback.
- Added ADR-0029 documenting the security, consistency, migration, timestamp, and failure-state contract.

## Security properties

- `garminConnections/{uid}` remains server-only.
- `/api/garmin/status` accepts no caller-provided UID; ownership comes from the verified Firebase token.
- Client-visible data is projected through an explicit field allow-list rather than copied from the canonical document.
- Secret fields are regression-tested to remain absent from the mirror.

## Regression coverage

- atomic mirror write during new/relinked Garmin account commit;
- lazy backfill for a legacy active canonical link;
- stale mirror deletion for disconnected canonical state;
- no `tokenObject` / `identityDigest` in the mirror;
- authenticated status endpoint contract;
- Firestore `Timestamp` and HTTP ISO timestamp conversion;
- existing frontend, Firestore-rule, simulation, Python, and Docker CI suites.

## Review notes

CodeRabbit review was explicitly requested on the final implementation. The bot reported its repository review quota was temporarily rate-limited; there are currently no actionable inline review threads to resolve.

🤖 Initial change generated with Claude Code; follow-up review and hardening applied on this PR.