### PR TITLE
fix(google-health): log every exit path of the OAuth link callback

### DIFF
--- a/src/garmin_sync/google_health_account_link.py
+++ b/src/garmin_sync/google_health_account_link.py
@@ -97,23 +97,45 @@ class GoogleHealthLinkStateStore:
         """
         if not state:
             raise GoogleHealthLinkStateInvalidError("Missing state parameter.")
+        # Log only a short, non-reversible fingerprint of the state token -- never the token
+        # itself, which is a bearer credential for this flow (see the request-log comment in
+        # google_health_account_link_api.py making the same call for the callback URL).
+        state_fingerprint = f"{state[:6]}...({len(state)} chars)"
         doc_ref = self.db.collection("googleHealthLinkState").document(state)
         snapshot = doc_ref.get()
         if not snapshot.exists:
+            logger.warning(
+                "Google Health link state %s: no matching document found (never created, "
+                "already consumed by a prior callback, or a stale/duplicate replay).",
+                state_fingerprint,
+            )
             raise GoogleHealthLinkStateInvalidError("Link request is invalid or already used.")
         data = snapshot.to_dict() or {}
         doc_ref.delete()
 
         created_at = data.get("createdAt")
-        if (
-            not isinstance(created_at, (int, float))
-            or (time.time() - created_at) > _STATE_TTL_SECONDS
-        ):
+        age_seconds = time.time() - created_at if isinstance(created_at, (int, float)) else None
+        if age_seconds is None or age_seconds > _STATE_TTL_SECONDS:
+            logger.warning(
+                "Google Health link state %s: expired (age=%s, ttl=%ss).",
+                state_fingerprint,
+                round(age_seconds, 1) if age_seconds is not None else "unknown",
+                _STATE_TTL_SECONDS,
+            )
             raise GoogleHealthLinkStateInvalidError("Link request expired. Start linking again.")
 
         uid = data.get("uid")
         if not uid or not isinstance(uid, str):
+            logger.warning(
+                "Google Health link state %s: document has no valid uid field.", state_fingerprint
+            )
             raise GoogleHealthLinkStateInvalidError("Link request has no associated user.")
+        logger.info(
+            "Google Health link state %s: consumed for uid=%s (age=%.1fs).",
+            state_fingerprint,
+            uid,
+            age_seconds,
+        )
         return uid
 
 

--- a/src/garmin_sync/google_health_account_link_api.py
+++ b/src/garmin_sync/google_health_account_link_api.py
@@ -201,6 +201,19 @@ class GoogleHealthAccountLinkHandler(BaseHTTPRequestHandler):
         state = _first("state")
         google_error = _first("error")
 
+        # Every exit path below logs something -- this handler previously had a silent path
+        # (no log line on any branch) that made a real production failure undiagnosable (see
+        # docs/analysis/2026-08-28-identity-passport-replay-evidence.md's session notes on the
+        # 2026-08-27 callback investigation). request_id ties this to the access-style log line
+        # already emitted by log_message() for the same request.
+        logger.info(
+            "Google Health callback received (request_id=%s, has_code=%s, has_state=%s, google_error=%s)",
+            self.request_id,
+            bool(code),
+            bool(state),
+            google_error,
+        )
+
         try:
             if google_error:
                 # The user declined consent, or Google itself errored -- not a bug here.
@@ -208,6 +221,12 @@ class GoogleHealthAccountLinkHandler(BaseHTTPRequestHandler):
                 self._app_redirect(success=False, reason="google_declined")
                 return
             if not code or not state:
+                logger.info(
+                    "Google Health OAuth callback missing code/state (request_id=%s, has_code=%s, has_state=%s).",
+                    self.request_id,
+                    bool(code),
+                    bool(state),
+                )
                 self._app_redirect(success=False, reason="missing_code_or_state")
                 return
 
@@ -250,6 +269,12 @@ class GoogleHealthAccountLinkHandler(BaseHTTPRequestHandler):
                 health_user_id=health_user_id,
                 granted_scopes=tokens.scopes,
                 token_object=token_object,
+            )
+            logger.info(
+                "Google Health link succeeded (request_id=%s, uid=%s, health_user_id_resolved=%s).",
+                self.request_id,
+                uid,
+                health_user_id is not None,
             )
             self._app_redirect(success=True)
 


### PR DESCRIPTION
## Summary

The in-app Google Health account linking flow has failed on every real attempt so far. Real Cloud Run logs (2026-08-27) show two callback requests, neither producing a working connection:
- `users/{uid}/connections/googleHealth` still doesn't exist for the linked user.
- One attempt was explicitly rejected: `Link request is invalid or already used.`
- The other logged **nothing on any exit path** — impossible to diagnose.

This PR doesn't fix the underlying failure (not yet root-caused — TTL expiry and missing code/state were both ruled out by the evidence). It makes the next real attempt fully diagnosable:

- `GoogleHealthLinkStateStore.consume()` now logs a warning on every rejection branch (not-found, expired, missing-uid) with a short non-reversible fingerprint of the state token (never the token itself — it's a bearer credential) and enough detail (age vs TTL) to actually diagnose it, plus an info line on success.
- `_handle_callback()` now logs on entry (whether code/state/error were present) and explicitly on success — previously the success path had no logging at all.

## Verification

- `uv run pytest tests/test_google_health_account_link.py tests/test_google_health_account_link_api.py` — 32 passed.
- `uv run ruff check`, `uv run ruff format --check`, `uv run mypy src/garmin_sync` — clean.
- Pre-commit hooks (ruff, mypy, secret detection) all passed on commit.

## Context

Separately (not part of this PR): the real data gap since 2026-08-17 was independently backfilled for 2026-08-18–2026-08-28 using the still-valid legacy manual credential — Garmin-via-Google-Health data is now current, but Eight Sleep specifically has zero data for the entire window, including a confirmed device-side pod-use night (2026-08-22). That's an on-device Health Connect sync issue, not something this PR or the pipeline can fix.