### PR TITLE
🧹 [Remove unreachable code in error_reporting.py]

### DIFF
--- a/src/garmin_sync/error_reporting.py
+++ b/src/garmin_sync/error_reporting.py
@@ -92,7 +92,6 @@ def _sanitize_context_value(key: str, value: Any) -> Any:
     if isinstance(value, (list, tuple, set)):
         return [_sanitize_context_value("", item) for item in value]
     return sanitize_text(value)
-    return sanitize_text(value)
 
 
 def sanitize_context(context: Mapping[str, Any] | None) -> dict[str, Any]:


### PR DESCRIPTION
🎯 **What:** Removed duplicate `return sanitize_text(value)` line in `_sanitize_context_value` function within `src/garmin_sync/error_reporting.py`.
💡 **Why:** The duplicated line was entirely unreachable because an identical return statement appeared immediately before it. Removing dead code avoids confusion and improves maintainability and overall code health.
✅ **Verification:** Verified by running linting (`uv run ruff check .`), formatting (`uv run ruff format .`), and running the full pytest suite (`uv run pytest`), all of which passed successfully. 
✨ **Result:** Cleaned up code that is safer, cleaner, and strictly functionally identical.

---
*PR created automatically by Jules for task [12655691557133349698](https://jules.google.com/task/12655691557133349698) started by @Szczepanov*