### PR TITLE
🧹 [Remove unused future import from user data migration]

### DIFF
--- a/src/garmin_sync/migrate_user_data.py
+++ b/src/garmin_sync/migrate_user_data.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import argparse
 import hashlib
 import logging


### PR DESCRIPTION
🎯 What: Removed the unused `from __future__ import annotations` import from `src/garmin_sync/migrate_user_data.py`.
💡 Why: This future import is flagged as unused and is generally unnecessary in newer Python versions (3.12+). Removing it improves code health and reduces clutter without changing runtime behavior.
✅ Verification: Ran `uv run ruff check .`, `uv run ruff format .`, and `uv run pytest` to ensure no linting, formatting, or test regressions were introduced.
✨ Result: The codebase is cleaner and an unused import has been removed.

---
*PR created automatically by Jules for task [16399907654834917308](https://jules.google.com/task/16399907654834917308) started by @Szczepanov*