### PR TITLE
🧪 [testing improvement] Add missing verify_id_token exception test in account_link_api

### DIFF
--- a/tests/test_account_link_api.py
+++ b/tests/test_account_link_api.py
@@ -3,8 +3,14 @@ from __future__ import annotations
 from http import HTTPStatus
 from typing import Any
 
+import pytest
+
 import garmin_sync.account_link_api as account_link_api
-from garmin_sync.account_link_api import GarminAccountLinkHandler, LoginRateLimiter
+from garmin_sync.account_link_api import (
+    GarminAccountLinkHandler,
+    GarminConnectAuthenticationError,
+    LoginRateLimiter,
+)
 
 
 def _handler_with_forwarded_for(value: str) -> GarminAccountLinkHandler:
@@ -95,3 +101,17 @@ def test_handle_login_enforces_per_account_rate_limiting(monkeypatch: Any) -> No
     assert len(captured_errors) == 1
     assert captured_errors[0]["status"] == HTTPStatus.TOO_MANY_REQUESTS
     assert captured_errors[0]["error_code"] == "garmin_link.rate_limited"
+
+
+def test_verified_uid_raises_authentication_error_on_verify_id_token_exception(
+    monkeypatch: Any,
+) -> None:
+    def mock_verify_id_token(token: str) -> dict[str, Any]:
+        raise Exception("Firebase verification failed")
+
+    monkeypatch.setattr(account_link_api.firebase_auth, "verify_id_token", mock_verify_id_token)
+
+    with pytest.raises(
+        GarminConnectAuthenticationError, match="App session is invalid or expired."
+    ):
+        account_link_api._verified_uid("Bearer any-token")  # noqa: SLF001


### PR DESCRIPTION
🎯 **What:** Addresses the testing gap in `account_link_api.py` by adding a test that mocks `firebase_auth.verify_id_token` to throw an exception, and asserts that a `GarminConnectAuthenticationError` is appropriately raised.
📊 **Coverage:** The exception block when token verification fails is now covered.
✨ **Result:** Improved test reliability by ensuring exceptions from the external `verify_id_token` call are caught and transformed as expected during the authentication flow.

---
*PR created automatically by Jules for task [6225809248203536448](https://jules.google.com/task/6225809248203536448) started by @Szczepanov*