### PR TITLE
🧹 [code health] Remove unused future annotations import

### DIFF
--- a/src/garmin_sync/error_reporting.py
+++ b/src/garmin_sync/error_reporting.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import json
 import logging
 import re


### PR DESCRIPTION
🎯 **What:** Removed unused `from __future__ import annotations` from `src/garmin_sync/error_reporting.py`.
💡 **Why:** This import is no longer required in Python 3.12+ (which this project targets) and its removal cleans up the file by getting rid of an unneeded, flagged line.
✅ **Verification:** Verified by running `uv run ruff check .`, `uv run ruff format .`, and `uv run pytest`. All tests passed.
✨ **Result:** Improved file cleanliness and readability by removing a redundant statement.

---
*PR created automatically by Jules for task [18226710323292682938](https://jules.google.com/task/18226710323292682938) started by @Szczepanov*