### PR TITLE
feat: export recent activity detailed telemetry to JSON for AI agent planning

### DIFF
--- a/app/src/components/ActivityTelemetry.css
+++ b/app/src/components/ActivityTelemetry.css
@@ -42,6 +42,15 @@
   gap: 0.5rem;
 }
 
+.activity-card-actions {
+  display: flex;
+  gap: 0.4rem;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.btn-copy-activity-json,
 .btn-reclassify-activity {
   background: var(--bg-surface-elevated, #27272a);
   border: 1px solid var(--border-subtle, #3f3f46);
@@ -52,11 +61,37 @@
   border-radius: 6px;
   cursor: pointer;
   transition: all 0.15s ease;
+  white-space: nowrap;
+}
+
+.btn-copy-activity-json:hover {
+  background: rgba(16, 185, 129, 0.15);
+  border-color: var(--success, #10b981);
+  color: #10b981;
 }
 
 .btn-reclassify-activity:hover {
   background: rgba(56, 189, 248, 0.15);
   border-color: var(--primary, #38bdf8);
+  color: #38bdf8;
+}
+
+.activity-telemetry-badges {
+  display: flex;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+  margin-top: 0.45rem;
+}
+
+.activity-telemetry-badge {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.7rem;
+  font-weight: 500;
+  padding: 0.15rem 0.45rem;
+  border-radius: 999px;
+  background: rgba(56, 189, 248, 0.1);
+  border: 1px solid rgba(56, 189, 248, 0.25);
   color: #38bdf8;
 }
 

--- a/app/src/components/ActivityTelemetry.test.tsx
+++ b/app/src/components/ActivityTelemetry.test.tsx
@@ -127,4 +127,20 @@ describe('ActivityTelemetry', () => {
     expect(html).toContain('35s');
     expect(html).toContain('90s rest');
   });
+
+  it('renders Copy JSON button and capability badges for detailed telemetry', () => {
+    const html = renderToStaticMarkup(<ActivityTelemetry state={{
+      status: 'AVAILABLE', revision: null, data: [{
+        ...base,
+        powerInZones: [{ zoneNumber: 2, secondsInZone: 1200, lowBoundary: 150 }],
+        hrInZones: [{ zoneNumber: 3, secondsInZone: 600, lowBoundary: 140 }],
+        laps: [{ lapIndex: 1, durationSeconds: 1800 }],
+      }],
+    }} />);
+    expect(html).toContain('btn-copy-activity-json');
+    expect(html).toContain('Copy JSON');
+    expect(html).toContain('⚡ Power');
+    expect(html).toContain('❤️ HR Zones');
+    expect(html).toContain('⏱️ Laps');
+  });
 });

--- a/app/src/components/ActivityTelemetry.tsx
+++ b/app/src/components/ActivityTelemetry.tsx
@@ -1,5 +1,7 @@
+import { useState } from 'react';
 import type { DataState } from '../engine/dataState';
 import type { ActivityZoneBucket, NormalizedGarminActivity, RunningDynamics } from '../engine/models';
+import { copyActivityJsonToClipboard } from '../utils/activityJsonExport';
 import './ActivityTelemetry.css';
 
 interface ActivityTelemetryProps {
@@ -56,10 +58,24 @@ function ZoneBars({ title, unit, zones }: { title: string; unit: string; zones: 
 }
 
 export function ActivityTelemetry({ state, onReclassify }: ActivityTelemetryProps) {
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+
   if (state === null) return <p className="activity-telemetry-state">Loading recent activities…</p>;
   if (state.status === 'INVALID') return <p className="activity-telemetry-state error">Stored activity data is malformed and needs repair.</p>;
   if (state.status === 'UNAVAILABLE') return <p className="activity-telemetry-state error">Activity telemetry is temporarily unavailable. Retry the dashboard refresh.</p>;
   if (state.status === 'MISSING' || state.data.length === 0) return <p className="activity-telemetry-state">No activities were recorded in the last seven days.</p>;
+
+  const handleCopyActivityJson = async (activity: NormalizedGarminActivity) => {
+    try {
+      await copyActivityJsonToClipboard(activity);
+      setCopiedId(activity.activityId);
+      window.setTimeout(() => {
+        setCopiedId((curr) => (curr === activity.activityId ? null : curr));
+      }, 2000);
+    } catch (err) {
+      console.error('Failed to copy activity JSON', err);
+    }
+  };
 
   return (
     <div className="activity-telemetry-list">
@@ -84,6 +100,13 @@ export function ActivityTelemetry({ state, onReclassify }: ActivityTelemetryProp
           activity.recoveryTimeHours != null ? `Rec ${activity.recoveryTimeHours}h` : null,
         ].filter((metric): metric is string => metric !== null);
 
+        const telemetryBadges: string[] = [];
+        if ((activity.powerInZones?.length ?? 0) > 0 || activity.normalizedPower !== undefined) telemetryBadges.push('⚡ Power');
+        if ((activity.hrInZones?.length ?? 0) > 0) telemetryBadges.push('❤️ HR Zones');
+        if (runningDynamics !== undefined) telemetryBadges.push('🏃 Dynamics');
+        if ((activity.exerciseSets?.length ?? 0) > 0) telemetryBadges.push('🏋️ Sets & Reps');
+        if ((activity.laps?.length ?? 0) > 0) telemetryBadges.push('⏱️ Laps');
+
         return (
           <article className="activity-telemetry-card" key={activity.activityId}>
             <header>
@@ -100,6 +123,13 @@ export function ActivityTelemetry({ state, onReclassify }: ActivityTelemetryProp
                     {trainingResponseMetrics.join(' · ')}
                   </p>
                 )}
+                {telemetryBadges.length > 0 && (
+                  <div className="activity-telemetry-badges" aria-label="Detailed telemetry categories">
+                    {telemetryBadges.map((badge) => (
+                      <span key={badge} className="activity-telemetry-badge">{badge}</span>
+                    ))}
+                  </div>
+                )}
               </div>
               <div className="activity-header-right">
                 {activity.normalizedPower !== undefined && (
@@ -109,16 +139,27 @@ export function ActivityTelemetry({ state, onReclassify }: ActivityTelemetryProp
                     {activity.variabilityIndex !== undefined && <span><strong>{activity.variabilityIndex.toFixed(2)}</strong> VI</span>}
                   </div>
                 )}
-                {onReclassify && (
+                <div className="activity-card-actions">
                   <button
                     type="button"
-                    className="btn-reclassify-activity"
-                    onClick={() => onReclassify(activity.activityId)}
-                    aria-label={`Correct or reclassify ${activity.type} from ${activity.date}`}
+                    className="btn-copy-activity-json"
+                    onClick={() => handleCopyActivityJson(activity)}
+                    aria-label={`Copy JSON for ${activity.type} from ${activity.date}`}
+                    title="Copy structured activity JSON to clipboard for AI agent planning"
                   >
-                    ✏️ Correct
+                    {copiedId === activity.activityId ? '✓ Copied JSON' : '📋 Copy JSON'}
                   </button>
-                )}
+                  {onReclassify && (
+                    <button
+                      type="button"
+                      className="btn-reclassify-activity"
+                      onClick={() => onReclassify(activity.activityId)}
+                      aria-label={`Correct or reclassify ${activity.type} from ${activity.date}`}
+                    >
+                      ✏️ Correct
+                    </button>
+                  )}
+                </div>
               </div>
             </header>
 

--- a/app/src/components/DataView.css
+++ b/app/src/components/DataView.css
@@ -267,3 +267,25 @@
   overflow-wrap: normal;
   overflow-x: auto;
 }
+
+.activities-tab-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+  flex-wrap: wrap;
+}
+
+.activities-tab-subtitle {
+  margin: 0.25rem 0 0;
+  font-size: 0.85rem;
+  color: var(--text-secondary, #a1a1aa);
+}
+
+.activities-header-actions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  flex-wrap: wrap;
+}

--- a/app/src/components/DataView.tsx
+++ b/app/src/components/DataView.tsx
@@ -6,7 +6,12 @@ import { activityOverrideService } from '../services/activityOverrideService';
 import { recommendationService } from '../services/recommendationService';
 import { contextBriefService, type ContextBriefResult } from '../services/contextBriefService';
 import { briefWindowDaysFor, type BriefWindowPreset } from '../engine/contextBrief';
-import { addDaysToLocalDateString } from '../utils/localDate';
+import { addDaysToLocalDateString, getLocalDateString } from '../utils/localDate';
+import {
+  copyActivitiesBundleToClipboard,
+  downloadActivitiesJsonFile,
+  exportActivitiesBundleToJson,
+} from '../utils/activityJsonExport';
 import { ActivityTelemetry } from './ActivityTelemetry';
 import { ActivityReclassificationModal } from './ActivityReclassificationModal';
 import { StrengthOverloadHistory } from './StrengthOverloadHistory';
@@ -97,6 +102,7 @@ export function DataView({ decisionInput, userId, initialTab = 'recovery' }: Dat
   } | null>(null);
   const [reclassifyModalOpen, setReclassifyModalOpen] = useState(false);
   const [activityOverrides, setActivityOverrides] = useState<Record<string, ActivityOverride>>({});
+  const [allActivitiesCopied, setAllActivitiesCopied] = useState(false);
 
   const loadOverrides = useCallback(() => {
     activityOverrideService.getAllOverrides(userId).then(setActivityOverrides);
@@ -172,6 +178,36 @@ export function DataView({ decisionInput, userId, initialTab = 'recovery' }: Dat
       setBriefCopied(false);
       setBriefError({ date: brief.asOfDate, message: 'Copy was blocked. Select the text below and copy it manually.' });
     }
+  };
+
+  const handleCopyAllActivities = async () => {
+    if (!activityWindow || activityWindow.state.status !== 'AVAILABLE' || activityWindow.state.data.length === 0) return;
+    const startInclusive = addDaysToLocalDateString(briefDate ?? getLocalDateString(), -6);
+    const throughDateExclusive = addDaysToLocalDateString(briefDate ?? getLocalDateString(), 1);
+    try {
+      await copyActivitiesBundleToClipboard(activityWindow.state.data, {
+        userId,
+        startDateInclusive: startInclusive,
+        throughDateExclusive,
+      });
+      setAllActivitiesCopied(true);
+      window.setTimeout(() => setAllActivitiesCopied(false), 2000);
+    } catch (err) {
+      console.error('Failed to copy activities bundle to clipboard', err);
+    }
+  };
+
+  const handleDownloadActivities = () => {
+    if (!activityWindow || activityWindow.state.status !== 'AVAILABLE' || activityWindow.state.data.length === 0) return;
+    const startInclusive = addDaysToLocalDateString(briefDate ?? getLocalDateString(), -6);
+    const throughDateExclusive = addDaysToLocalDateString(briefDate ?? getLocalDateString(), 1);
+    const bundle = exportActivitiesBundleToJson(activityWindow.state.data, {
+      userId,
+      startDateInclusive: startInclusive,
+      throughDateExclusive,
+    });
+    const filename = `activities_${userId}_${startInclusive}_to_${throughDateExclusive}`;
+    downloadActivitiesJsonFile(filename, bundle);
   };
 
   if (!decisionInput) {
@@ -965,17 +1001,42 @@ export function DataView({ decisionInput, userId, initialTab = 'recovery' }: Dat
         {activeTab === 'recovery' && renderRecoveryData()}
         {activeTab === 'activities' && (
           <div className="data-section">
-            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '0.75rem' }}>
-              <h3 style={{ margin: 0 }}>Recent activity telemetry</h3>
+            <div className="activities-tab-header">
+              <div>
+                <h3 style={{ margin: 0 }}>Recent activity telemetry</h3>
+                <p className="activities-tab-subtitle">
+                  Inspect detailed Garmin telemetry. Export structured JSON for external AI agent planning.
+                </p>
+              </div>
               {activityWindow?.state.status === 'AVAILABLE' && activityWindow.state.data.length > 0 && (
-                <button
-                  type="button"
-                  className="quick-action-btn secondary"
-                  style={{ width: 'auto', padding: '0.4rem 0.8rem', fontSize: '0.85rem' }}
-                  onClick={() => setReclassifyModalOpen(true)}
-                >
-                  ✏️ Correct / Reclassify Activity
-                </button>
+                <div className="activities-header-actions">
+                  <button
+                    type="button"
+                    className="quick-action-btn secondary"
+                    style={{ width: 'auto', padding: '0.4rem 0.8rem', fontSize: '0.85rem' }}
+                    onClick={handleCopyAllActivities}
+                    title="Copy all recent activities with detailed telemetry as JSON for AI planning"
+                  >
+                    {allActivitiesCopied ? '✓ Copied All JSON' : '📋 Copy All (JSON)'}
+                  </button>
+                  <button
+                    type="button"
+                    className="quick-action-btn secondary"
+                    style={{ width: 'auto', padding: '0.4rem 0.8rem', fontSize: '0.85rem' }}
+                    onClick={handleDownloadActivities}
+                    title="Download recent activities JSON bundle file"
+                  >
+                    💾 Download JSON
+                  </button>
+                  <button
+                    type="button"
+                    className="quick-action-btn secondary"
+                    style={{ width: 'auto', padding: '0.4rem 0.8rem', fontSize: '0.85rem' }}
+                    onClick={() => setReclassifyModalOpen(true)}
+                  >
+                    ✏️ Correct / Reclassify
+                  </button>
+                </div>
               )}
             </div>
             <ActivityTelemetry

--- a/app/src/persistence/parsers/trainingHistory.test.ts
+++ b/app/src/persistence/parsers/trainingHistory.test.ts
@@ -151,6 +151,80 @@ describe('training-history persistence parsers', () => {
         expect(parsed.data.laps).toBeUndefined();
     });
 
+    it('preserves valid strength exercise sets and training effect metadata', () => {
+        const parsed = parseNormalizedGarminActivity({
+            ...activity,
+            type: 'strength_training',
+            primaryBenefit: 'TEMPO',
+            trainingEffectLabel: 'AEROBIC_BASE',
+            epoc: 42,
+            recoveryTimeHours: 24,
+            exerciseSets: [
+                {
+                    setOrder: 0,
+                    setType: 'warmup',
+                    repetitionCount: 10,
+                    weightKg: 20,
+                    exerciseCategory: 'bench_press',
+                    exerciseName: 'barbell_bench_press',
+                    durationSeconds: 30,
+                    restDurationSeconds: 60,
+                },
+                {
+                    setOrder: 1,
+                    setType: 'active',
+                    repetitionCount: 5,
+                    weightKg: 80,
+                    exerciseName: 'bench_press',
+                },
+            ],
+        }, 'users/u1/activities/a-1', 'a-1');
+
+        expect(parsed).toMatchObject({
+            status: 'AVAILABLE',
+            data: {
+                activityId: 'a-1',
+                primaryBenefit: 'TEMPO',
+                trainingEffectLabel: 'AEROBIC_BASE',
+                epoc: 42,
+                recoveryTimeHours: 24,
+                exerciseSets: [
+                    {
+                        setOrder: 0,
+                        setType: 'warmup',
+                        repetitionCount: 10,
+                        weightKg: 20,
+                        exerciseCategory: 'bench_press',
+                        exerciseName: 'barbell_bench_press',
+                        durationSeconds: 30,
+                        restDurationSeconds: 60,
+                    },
+                    {
+                        setOrder: 1,
+                        setType: 'active',
+                        repetitionCount: 5,
+                        weightKg: 80,
+                        exerciseName: 'bench_press',
+                    },
+                ],
+            },
+        });
+    });
+
+    it('drops corrupt exercise sets while preserving the base activity', () => {
+        const parsed = parseNormalizedGarminActivity({
+            ...activity,
+            type: 'strength_training',
+            exerciseSets: [
+                { setOrder: 'not-a-number' },
+            ],
+        }, 'users/u1/activities/a-1', 'a-1');
+
+        expect(parsed).toMatchObject({ status: 'AVAILABLE', data: { activityId: 'a-1' } });
+        if (parsed.status !== 'AVAILABLE') throw new Error('expected available activity');
+        expect(parsed.data.exerciseSets).toBeUndefined();
+    });
+
     it('parses supported recommendation schemas and rejects future ones', () => {
         expect(parseDailyRecommendation(recommendation, 'users/u1/daily_recommendations/2026-08-06')).toMatchObject({ status: 'AVAILABLE', data: { date: '2026-08-06' } });
         expect(parseDailyRecommendation({ ...recommendation, schemaVersion: 3 }, 'users/u1/daily_recommendations/2026-08-06'))

--- a/app/src/persistence/parsers/trainingHistory.ts
+++ b/app/src/persistence/parsers/trainingHistory.ts
@@ -134,6 +134,41 @@ function parseRunningDynamics(value: unknown, activityType: string): RunningDyna
     return Object.keys(parsed).length > 0 ? parsed : undefined;
 }
 
+function parseExerciseSets(value: unknown): NormalizedGarminActivity['exerciseSets'] | undefined {
+    if (!Array.isArray(value)) return undefined;
+    const parsed = value.map((entry) => {
+        if (!isObject(entry)) return undefined;
+        const setOrder = typeof entry.setOrder === 'number' && Number.isInteger(entry.setOrder) && entry.setOrder >= 0 ? entry.setOrder : undefined;
+        if (setOrder === undefined) return undefined;
+        const setType = typeof entry.setType === 'string' ? entry.setType : undefined;
+        const repetitionCount = typeof entry.repetitionCount === 'number' && Number.isFinite(entry.repetitionCount) && entry.repetitionCount >= 0 ? entry.repetitionCount : undefined;
+        const weightKg = typeof entry.weightKg === 'number' && Number.isFinite(entry.weightKg) && entry.weightKg >= 0 ? entry.weightKg : undefined;
+        const exerciseCategory = typeof entry.exerciseCategory === 'string' ? entry.exerciseCategory : undefined;
+        const exerciseName = typeof entry.exerciseName === 'string' ? entry.exerciseName : undefined;
+        const durationSeconds = typeof entry.durationSeconds === 'number' && Number.isFinite(entry.durationSeconds) && entry.durationSeconds >= 0 ? entry.durationSeconds : undefined;
+        const restDurationSeconds = typeof entry.restDurationSeconds === 'number' && Number.isFinite(entry.restDurationSeconds) && entry.restDurationSeconds >= 0 ? entry.restDurationSeconds : undefined;
+        return {
+            setOrder,
+            ...(setType !== undefined ? { setType } : {}),
+            ...(repetitionCount !== undefined ? { repetitionCount } : {}),
+            ...(weightKg !== undefined ? { weightKg } : {}),
+            ...(exerciseCategory !== undefined ? { exerciseCategory } : {}),
+            ...(exerciseName !== undefined ? { exerciseName } : {}),
+            ...(durationSeconds !== undefined ? { durationSeconds } : {}),
+            ...(restDurationSeconds !== undefined ? { restDurationSeconds } : {}),
+        };
+    });
+    return parsed.every((entry) => entry !== undefined)
+        ? parsed as NonNullable<NormalizedGarminActivity['exerciseSets']>
+        : undefined;
+}
+
+function parseOptionalString(value: unknown): string | null | undefined {
+    if (value === undefined) return undefined;
+    if (value === null) return null;
+    return typeof value === 'string' ? value : undefined;
+}
+
 function isShadowVerdict(value: unknown): value is ShadowVerdict {
     return typeof value === 'string' && (SHADOW_VERDICTS as readonly string[]).includes(value);
 }
@@ -174,6 +209,11 @@ export function parseNormalizedGarminActivity(
     const variabilityIndex = telemetryNumber(raw.variabilityIndex);
     const laps = parseLaps(raw.laps);
     const runningDynamics = parseRunningDynamics(raw.runningDynamics, raw.type);
+    const primaryBenefit = parseOptionalString(raw.primaryBenefit);
+    const trainingEffectLabel = parseOptionalString(raw.trainingEffectLabel);
+    const epoc = optionalNonNegativeNumber(raw.epoc);
+    const recoveryTimeHours = optionalNonNegativeNumber(raw.recoveryTimeHours);
+    const exerciseSets = parseExerciseSets(raw.exerciseSets);
 
     return {
         status: 'AVAILABLE',
@@ -187,6 +227,10 @@ export function parseNormalizedGarminActivity(
             averageHr: averageHr ?? null,
             activityTrainingLoad: activityTrainingLoad ?? null,
             intensityTag: raw.intensityTag,
+            ...(primaryBenefit !== undefined ? { primaryBenefit } : {}),
+            ...(trainingEffectLabel !== undefined ? { trainingEffectLabel } : {}),
+            ...(epoc !== undefined ? { epoc } : {}),
+            ...(recoveryTimeHours !== undefined ? { recoveryTimeHours } : {}),
             ...(powerInZones !== undefined ? { powerInZones } : {}),
             ...(hrInZones !== undefined ? { hrInZones } : {}),
             ...(normalizedPower !== undefined ? { normalizedPower } : {}),
@@ -194,6 +238,7 @@ export function parseNormalizedGarminActivity(
             ...(variabilityIndex !== undefined ? { variabilityIndex } : {}),
             ...(laps !== undefined ? { laps } : {}),
             ...(runningDynamics !== undefined ? { runningDynamics } : {}),
+            ...(exerciseSets !== undefined ? { exerciseSets } : {}),
             ...(typeof raw.syncRunId === 'string' ? { syncRunId: raw.syncRunId } : {}),
             ...(typeof raw.syncedAt === 'string' ? { syncedAt: raw.syncedAt } : {}),
         },

--- a/app/src/utils/activityJsonExport.test.ts
+++ b/app/src/utils/activityJsonExport.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { NormalizedGarminActivity } from '../engine/models';
+import {
+    exportActivityToJson,
+    exportActivitiesBundleToJson,
+    formatActivityJson,
+    formatActivitiesBundleJson,
+    copyActivityJsonToClipboard,
+    copyActivitiesBundleToClipboard,
+    downloadActivitiesJsonFile,
+} from './activityJsonExport';
+
+const sampleActivity: NormalizedGarminActivity = {
+    activityId: '12345',
+    date: '2026-08-25',
+    type: 'road_biking',
+    durationMin: 75,
+    intensityTag: 'hard',
+    trainingEffectAerobic: 3.8,
+    trainingEffectAnaerobic: 1.2,
+    averageHr: 155,
+    activityTrainingLoad: 160,
+    primaryBenefit: 'TEMPO',
+    trainingEffectLabel: 'AEROBIC_BASE',
+    epoc: 95,
+    recoveryTimeHours: 36,
+    normalizedPower: 245,
+    intensityFactor: 0.85,
+    variabilityIndex: 1.08,
+    powerInZones: [
+        { zoneNumber: 1, secondsInZone: 600, lowBoundary: 0 },
+        { zoneNumber: 2, secondsInZone: 2400, lowBoundary: 150 },
+        { zoneNumber: 3, secondsInZone: 1500, lowBoundary: 210 },
+    ],
+    hrInZones: [
+        { zoneNumber: 1, secondsInZone: 300, lowBoundary: 100 },
+        { zoneNumber: 2, secondsInZone: 1800, lowBoundary: 130 },
+        { zoneNumber: 3, secondsInZone: 2400, lowBoundary: 150 },
+    ],
+    laps: [
+        { lapIndex: 1, durationSeconds: 1800, averagePowerWatts: 230, averageHrBpm: 150 },
+        { lapIndex: 2, durationSeconds: 2700, averagePowerWatts: 255, averageHrBpm: 158 },
+    ],
+};
+
+const sampleStrengthActivity: NormalizedGarminActivity = {
+    activityId: '67890',
+    date: '2026-08-26',
+    type: 'strength_training',
+    durationMin: 50,
+    intensityTag: 'moderate',
+    trainingEffectAerobic: 2.1,
+    trainingEffectAnaerobic: 0.5,
+    averageHr: 125,
+    activityTrainingLoad: 75,
+    exerciseSets: [
+        {
+            setOrder: 0,
+            setType: 'warmup',
+            repetitionCount: 12,
+            weightKg: 20,
+            exerciseName: 'bench_press',
+            durationSeconds: 30,
+            restDurationSeconds: 60,
+        },
+        {
+            setOrder: 1,
+            setType: 'active',
+            repetitionCount: 6,
+            weightKg: 85,
+            exerciseName: 'bench_press',
+            durationSeconds: 25,
+            restDurationSeconds: 90,
+        },
+    ],
+};
+
+describe('activityJsonExport', () => {
+    it('wraps a single activity into an activity_export_v1 envelope', () => {
+        const result = exportActivityToJson(sampleActivity);
+        expect(result.schemaVersion).toBe('activity_export_v1');
+        expect(result.exportedAt).toBeDefined();
+        expect(result.activity).toEqual(sampleActivity);
+    });
+
+    it('formats a single activity as formatted JSON string', () => {
+        const json = formatActivityJson(sampleActivity);
+        const parsed = JSON.parse(json);
+        expect(parsed.schemaVersion).toBe('activity_export_v1');
+        expect(parsed.activity.activityId).toBe('12345');
+        expect(parsed.activity.normalizedPower).toBe(245);
+        expect(parsed.activity.powerInZones).toHaveLength(3);
+    });
+
+    it('packages multiple activities into recent_activities_bundle_v1 with metadata', () => {
+        const bundle = exportActivitiesBundleToJson(
+            [sampleStrengthActivity, sampleActivity],
+            {
+                userId: 'user-42',
+                startDateInclusive: '2026-08-20',
+                throughDateExclusive: '2026-08-27',
+            },
+        );
+
+        expect(bundle.schemaVersion).toBe('recent_activities_bundle_v1');
+        expect(bundle.metadata.totalActivities).toBe(2);
+        expect(bundle.metadata.userId).toBe('user-42');
+        expect(bundle.metadata.dateRange).toEqual({
+            startDateInclusive: '2026-08-20',
+            throughDateExclusive: '2026-08-27',
+        });
+        // Sorts chronologically by date
+        expect(bundle.activities[0].activityId).toBe('12345');
+        expect(bundle.activities[1].activityId).toBe('67890');
+    });
+
+    it('formats activities bundle as formatted JSON string', () => {
+        const json = formatActivitiesBundleJson([sampleActivity, sampleStrengthActivity]);
+        const parsed = JSON.parse(json);
+        expect(parsed.schemaVersion).toBe('recent_activities_bundle_v1');
+        expect(parsed.activities).toHaveLength(2);
+        expect(parsed.activities[1].exerciseSets).toHaveLength(2);
+    });
+
+    it('copies single activity JSON to clipboard', async () => {
+        const writeTextMock = vi.fn().mockResolvedValue(undefined);
+        Object.assign(navigator, {
+            clipboard: { writeText: writeTextMock },
+        });
+
+        await copyActivityJsonToClipboard(sampleActivity);
+        expect(writeTextMock).toHaveBeenCalledOnce();
+        const writtenPayload = JSON.parse(writeTextMock.mock.calls[0][0]);
+        expect(writtenPayload.schemaVersion).toBe('activity_export_v1');
+        expect(writtenPayload.activity.activityId).toBe('12345');
+    });
+
+    it('copies activities bundle JSON to clipboard', async () => {
+        const writeTextMock = vi.fn().mockResolvedValue(undefined);
+        Object.assign(navigator, {
+            clipboard: { writeText: writeTextMock },
+        });
+
+        await copyActivitiesBundleToClipboard([sampleActivity], { userId: 'u1' });
+        expect(writeTextMock).toHaveBeenCalledOnce();
+        const writtenPayload = JSON.parse(writeTextMock.mock.calls[0][0]);
+        expect(writtenPayload.schemaVersion).toBe('recent_activities_bundle_v1');
+        expect(writtenPayload.metadata.userId).toBe('u1');
+    });
+
+    it('downloads JSON file through DOM link click', () => {
+        const createObjectURLMock = vi.fn().mockReturnValue('blob:test');
+        const revokeObjectURLMock = vi.fn();
+        const clickMock = vi.fn();
+        const appendChildMock = vi.fn();
+        const removeChildMock = vi.fn();
+
+        const fakeAnchor: Record<string, unknown> = {
+            href: '',
+            download: '',
+            click: clickMock,
+        };
+
+        const originalUrl = globalThis.URL;
+        const originalDocument = globalThis.document;
+
+        globalThis.URL.createObjectURL = createObjectURLMock;
+        globalThis.URL.revokeObjectURL = revokeObjectURLMock;
+
+        globalThis.document = {
+            createElement: vi.fn().mockReturnValue(fakeAnchor),
+            body: {
+                appendChild: appendChildMock,
+                removeChild: removeChildMock,
+            },
+        } as unknown as Document;
+
+        try {
+            downloadActivitiesJsonFile('recent-activities', { test: true });
+            expect(createObjectURLMock).toHaveBeenCalledOnce();
+            expect(fakeAnchor.download).toBe('recent-activities.json');
+            expect(appendChildMock).toHaveBeenCalledWith(fakeAnchor);
+            expect(clickMock).toHaveBeenCalledOnce();
+            expect(removeChildMock).toHaveBeenCalledWith(fakeAnchor);
+            expect(revokeObjectURLMock).toHaveBeenCalledWith('blob:test');
+        } finally {
+            globalThis.URL = originalUrl;
+            globalThis.document = originalDocument;
+        }
+    });
+});

--- a/app/src/utils/activityJsonExport.ts
+++ b/app/src/utils/activityJsonExport.ts
@@ -1,0 +1,111 @@
+import type { NormalizedGarminActivity } from '../engine/models';
+
+export interface ActivityExportMetadata {
+    exportedAt: string;
+    format: 'activity_export_v1' | 'recent_activities_bundle_v1';
+    userId?: string;
+    dateRange?: {
+        startDateInclusive: string;
+        throughDateExclusive: string;
+    };
+    totalActivities: number;
+}
+
+export interface SingleActivityExport {
+    schemaVersion: 'activity_export_v1';
+    exportedAt: string;
+    activity: NormalizedGarminActivity;
+}
+
+export interface RecentActivitiesBundleExport {
+    schemaVersion: 'recent_activities_bundle_v1';
+    metadata: ActivityExportMetadata;
+    activities: NormalizedGarminActivity[];
+}
+
+/**
+ * Normalizes a single activity into an AI-ready export envelope.
+ */
+export function exportActivityToJson(activity: NormalizedGarminActivity): SingleActivityExport {
+    return {
+        schemaVersion: 'activity_export_v1',
+        exportedAt: new Date().toISOString(),
+        activity,
+    };
+}
+
+/**
+ * Packages a list of activities (e.g. recent 7-day window) into a structured AI bundle.
+ */
+export function exportActivitiesBundleToJson(
+    activities: readonly NormalizedGarminActivity[],
+    metadata?: {
+        userId?: string;
+        startDateInclusive?: string;
+        throughDateExclusive?: string;
+    },
+): RecentActivitiesBundleExport {
+    return {
+        schemaVersion: 'recent_activities_bundle_v1',
+        metadata: {
+            exportedAt: new Date().toISOString(),
+            format: 'recent_activities_bundle_v1',
+            ...(metadata?.userId ? { userId: metadata.userId } : {}),
+            ...(metadata?.startDateInclusive && metadata?.throughDateExclusive
+                ? {
+                    dateRange: {
+                        startDateInclusive: metadata.startDateInclusive,
+                        throughDateExclusive: metadata.throughDateExclusive,
+                    },
+                }
+                : {}),
+            totalActivities: activities.length,
+        },
+        activities: [...activities].sort((a, b) => a.date.localeCompare(b.date) || a.activityId.localeCompare(b.activityId)),
+    };
+}
+
+export function formatActivityJson(activity: NormalizedGarminActivity): string {
+    return JSON.stringify(exportActivityToJson(activity), null, 2);
+}
+
+export function formatActivitiesBundleJson(
+    activities: readonly NormalizedGarminActivity[],
+    metadata?: {
+        userId?: string;
+        startDateInclusive?: string;
+        throughDateExclusive?: string;
+    },
+): string {
+    return JSON.stringify(exportActivitiesBundleToJson(activities, metadata), null, 2);
+}
+
+export async function copyActivityJsonToClipboard(activity: NormalizedGarminActivity): Promise<void> {
+    const jsonStr = formatActivityJson(activity);
+    await navigator.clipboard.writeText(jsonStr);
+}
+
+export async function copyActivitiesBundleToClipboard(
+    activities: readonly NormalizedGarminActivity[],
+    metadata?: {
+        userId?: string;
+        startDateInclusive?: string;
+        throughDateExclusive?: string;
+    },
+): Promise<void> {
+    const jsonStr = formatActivitiesBundleJson(activities, metadata);
+    await navigator.clipboard.writeText(jsonStr);
+}
+
+export function downloadActivitiesJsonFile(filename: string, data: unknown): void {
+    const jsonStr = JSON.stringify(data, null, 2);
+    const blob = new Blob([jsonStr], { type: 'application/json;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename.endsWith('.json') ? filename : `${filename}.json`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+}

--- a/src/garmin_sync/cli.py
+++ b/src/garmin_sync/cli.py
@@ -822,9 +822,86 @@ def run_audit_multisource_cmd(args: list[str] | None = None) -> int:
         return 1
 
 
+def run_export_activities_cmd(args: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Export recent activity telemetry to JSON for AI agent planning."
+    )
+    parser.add_argument("--days", type=int, default=7, help="Number of trailing days (default 7)")
+    parser.add_argument("--start-date", type=str, default=None, help="Start date YYYY-MM-DD")
+    parser.add_argument("--end-date", type=str, default=None, help="End date YYYY-MM-DD")
+    parser.add_argument(
+        "--output",
+        "-o",
+        type=str,
+        default=None,
+        help="Output file path (default: stdout)",
+    )
+    parser.add_argument(
+        "--user-id",
+        type=str,
+        default=None,
+        help="Target application User ID (or APP_USER_ID env var)",
+    )
+    parsed_args = parser.parse_args(args)
+
+    import json
+    import os
+
+    if parsed_args.user_id:
+        os.environ["APP_USER_ID"] = parsed_args.user_id
+
+    start_date_str, end_date_str = _resolve_date_range(parsed_args, default_days=7)
+
+    try:
+        settings = load_settings()
+        service = GarminSyncService(settings)
+        bundle = service.export_activities_json(start_date_str, end_date_str)
+        json_output = json.dumps(bundle, indent=2)
+
+        if parsed_args.output:
+            with open(parsed_args.output, "w", encoding="utf-8") as f:
+                f.write(json_output)
+            logger.info(
+                f"Exported {bundle['metadata']['totalActivities']} activities to {parsed_args.output}"
+            )
+        else:
+            print(json_output)
+        return 0
+    except Exception as error:
+        log_exception(logger, "export activities", error)
+        return 1
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Garmin Sync Pipeline CLI")
     subparsers = parser.add_subparsers(dest="command", required=True)
+
+    export_activities_parser = subparsers.add_parser(
+        "export-activities",
+        help="Export recent activity telemetry to JSON for AI agent planning",
+    )
+    export_activities_parser.add_argument(
+        "--days", type=int, default=7, help="Number of trailing days (default 7)"
+    )
+    export_activities_parser.add_argument(
+        "--start-date", type=str, default=None, help="Start date YYYY-MM-DD"
+    )
+    export_activities_parser.add_argument(
+        "--end-date", type=str, default=None, help="End date YYYY-MM-DD"
+    )
+    export_activities_parser.add_argument(
+        "--output",
+        "-o",
+        type=str,
+        default=None,
+        help="Output file path (default: stdout)",
+    )
+    export_activities_parser.add_argument(
+        "--user-id",
+        type=str,
+        default=None,
+        help="Target application User ID (or APP_USER_ID env var)",
+    )
 
     sync_parser = subparsers.add_parser("sync", help="Run daily sync for APP_USER_ID")
     sync_parser.add_argument("--date", type=str, default=None, help="Target date YYYY-MM-DD")
@@ -922,6 +999,8 @@ def main() -> int:
 
     args = parser.parse_args()
 
+    if args.command == "export-activities":
+        return run_export_activities_cmd(sys.argv[2:])
     if args.command == "sync":
         return run_daily_sync(sys.argv[2:])
     if args.command == "sync-all":

--- a/src/garmin_sync/firestore_repository.py
+++ b/src/garmin_sync/firestore_repository.py
@@ -230,6 +230,22 @@ class FirestoreRecoveryRepository:
                 batch.set(doc_ref, payload, merge=True)
             batch.commit()
 
+    def get_activities_in_range(
+        self, start_date_iso: str, end_date_iso: str
+    ) -> list[dict[str, Any]]:
+        """Fetch normalized activities in range [start_date_iso, end_date_iso]."""
+        db = self._get_db()
+        docs = (
+            db.collection("users")
+            .document(self.user_id)
+            .collection("activities")
+            .where(filter=FieldFilter("date", ">=", start_date_iso))
+            .where(filter=FieldFilter("date", "<=", end_date_iso))
+            .order_by("date")
+            .stream()
+        )
+        return [doc.to_dict() for doc in docs]
+
     def upsert_garmin_performance_targets(self, targets: Any) -> None:
         """Merge Garmin's current targets into the user's preference profile.
 

--- a/src/garmin_sync/service.py
+++ b/src/garmin_sync/service.py
@@ -1195,3 +1195,24 @@ class GarminSyncService:
             )
 
         finish(self.repository.db.transaction())
+
+    def export_activities_json(self, start_date_iso: str, end_date_iso: str) -> dict[str, Any]:
+        """Export normalized activities with detailed telemetry in date range."""
+        activities = self.repository.get_activities_in_range(start_date_iso, end_date_iso)
+        return {
+            "schemaVersion": "recent_activities_bundle_v1",
+            "metadata": {
+                "exportedAt": datetime.now(timezone.utc).isoformat(),
+                "format": "recent_activities_bundle_v1",
+                "userId": self.settings.app_user_id,
+                "dateRange": {
+                    "startDateInclusive": start_date_iso,
+                    "throughDateInclusive": end_date_iso,
+                },
+                "totalActivities": len(activities),
+            },
+            "activities": sorted(
+                activities,
+                key=lambda a: (str(a.get("date", "")), str(a.get("activityId", ""))),
+            ),
+        }

--- a/tests/test_activity_export.py
+++ b/tests/test_activity_export.py
@@ -1,0 +1,138 @@
+import json
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from garmin_sync.cli import main, run_export_activities_cmd
+from garmin_sync.service import GarminSyncService
+
+
+@pytest.fixture
+def sample_activity_records() -> list[dict[str, Any]]:
+    return [
+        {
+            "activityId": "1002",
+            "date": "2026-08-26",
+            "type": "strength_training",
+            "durationMin": 45,
+            "intensityTag": "moderate",
+            "exerciseSets": [
+                {
+                    "setOrder": 0,
+                    "setType": "active",
+                    "repetitionCount": 8,
+                    "weightKg": 70.0,
+                    "exerciseName": "bench_press",
+                }
+            ],
+        },
+        {
+            "activityId": "1001",
+            "date": "2026-08-25",
+            "type": "cycling",
+            "durationMin": 60,
+            "intensityTag": "hard",
+            "normalizedPower": 240.0,
+            "powerInZones": [{"zoneNumber": 2, "secondsInZone": 1800}],
+        },
+    ]
+
+
+def test_service_export_activities_json(sample_activity_records: list[dict[str, Any]]) -> None:
+    mock_settings = MagicMock()
+    mock_settings.app_user_id = "test-user-123"
+    mock_repo = MagicMock()
+    mock_repo.get_activities_in_range.return_value = sample_activity_records
+
+    with patch.object(GarminSyncService, "__init__", lambda self, settings: None):
+        service = GarminSyncService(mock_settings)
+        service.settings = mock_settings
+        service.repository = mock_repo
+
+        bundle = service.export_activities_json("2026-08-20", "2026-08-27")
+
+        assert bundle["schemaVersion"] == "recent_activities_bundle_v1"
+        assert bundle["metadata"]["userId"] == "test-user-123"
+        assert bundle["metadata"]["totalActivities"] == 2
+        assert bundle["metadata"]["dateRange"] == {
+            "startDateInclusive": "2026-08-20",
+            "throughDateInclusive": "2026-08-27",
+        }
+        # Check chronological sorting
+        assert bundle["activities"][0]["activityId"] == "1001"
+        assert bundle["activities"][1]["activityId"] == "1002"
+        mock_repo.get_activities_in_range.assert_called_once_with("2026-08-20", "2026-08-27")
+
+
+def test_cli_export_activities_stdout(
+    sample_activity_records: list[dict[str, Any]], capsys: pytest.CaptureFixture[str]
+) -> None:
+    mock_settings = MagicMock()
+    mock_settings.app_user_id = "test-user-123"
+
+    with (
+        patch("garmin_sync.cli.load_settings", return_value=mock_settings),
+        patch("garmin_sync.cli.GarminSyncService") as mock_service_cls,
+    ):
+        mock_service = mock_service_cls.return_value
+        mock_service.export_activities_json.return_value = {
+            "schemaVersion": "recent_activities_bundle_v1",
+            "metadata": {"totalActivities": 2, "userId": "test-user-123"},
+            "activities": sample_activity_records,
+        }
+
+        exit_code = run_export_activities_cmd(
+            ["--start-date", "2026-08-20", "--end-date", "2026-08-27"]
+        )
+
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        parsed = json.loads(captured.out)
+        assert parsed["schemaVersion"] == "recent_activities_bundle_v1"
+        assert parsed["metadata"]["totalActivities"] == 2
+        mock_service.export_activities_json.assert_called_once_with("2026-08-20", "2026-08-27")
+
+
+def test_cli_export_activities_to_file(
+    tmp_path: Any, sample_activity_records: list[dict[str, Any]]
+) -> None:
+    output_file = tmp_path / "exported_activities.json"
+    mock_settings = MagicMock()
+    mock_settings.app_user_id = "test-user-123"
+
+    with (
+        patch("garmin_sync.cli.load_settings", return_value=mock_settings),
+        patch("garmin_sync.cli.GarminSyncService") as mock_service_cls,
+    ):
+        mock_service = mock_service_cls.return_value
+        mock_service.export_activities_json.return_value = {
+            "schemaVersion": "recent_activities_bundle_v1",
+            "metadata": {"totalActivities": 2, "userId": "test-user-123"},
+            "activities": sample_activity_records,
+        }
+
+        exit_code = run_export_activities_cmd(
+            [
+                "--start-date",
+                "2026-08-20",
+                "--end-date",
+                "2026-08-27",
+                "--output",
+                str(output_file),
+            ]
+        )
+
+        assert exit_code == 0
+        assert output_file.exists()
+        content = json.loads(output_file.read_text(encoding="utf-8"))
+        assert content["schemaVersion"] == "recent_activities_bundle_v1"
+        assert content["metadata"]["totalActivities"] == 2
+
+
+def test_cli_main_export_activities_routing() -> None:
+    with patch("garmin_sync.cli.run_export_activities_cmd", return_value=0) as mock_cmd:
+        with patch("sys.argv", ["cli.py", "export-activities", "--days", "7"]):
+            exit_code = main()
+            assert exit_code == 0
+            mock_cmd.assert_called_once_with(["--days", "7"])


### PR DESCRIPTION
## Summary of Changes

This PR implements full structured JSON export for recent activities and detailed telemetry (power zones, HR zones, laps, running dynamics, and strength sets/reps) across the web app and Python backend CLI. This enables feeding exact activity data directly into external AI planning agents.

---

### 1. Persistence & Parser Hydration
- **\pp/src/persistence/parsers/trainingHistory.ts\**:
  - Added parser support for \exerciseSets\, \primaryBenefit\, \	rainingEffectLabel\, \epoc\, and \ecoveryTimeHours\ so detailed activity telemetry stored in Firestore is never dropped when hydrated by the frontend client.
  - Added test coverage in \pp/src/persistence/parsers/trainingHistory.test.ts\.

### 2. Activity JSON Export Utilities
- **\pp/src/utils/activityJsonExport.ts\** (NEW):
  - Schemas: \ctivity_export_v1\ (single activity) and \ecent_activities_bundle_v1\ (batch bundle).
  - Helpers: \exportActivityToJson\, \exportActivitiesBundleToJson\, \copyActivityJsonToClipboard\, \copyActivitiesBundleToClipboard\, \downloadActivitiesJsonFile\.
  - Comprehensive unit tests in \pp/src/utils/activityJsonExport.test.ts\.

### 3. Web UI Integration
- **\pp/src/components/ActivityTelemetry.tsx\ & \.css\**:
  - Added **📋 Copy JSON** button on each activity card header with instant \✓ Copied JSON\ feedback.
  - Added capability badges (\⚡ Power\, \❤️ HR Zones\, \🏃 Dynamics\, \🏋️ Sets & Reps\, \⏱️ Laps\) to show available detailed telemetry at a glance.
- **\pp/src/components/DataView.tsx\ & \.css\**:
  - Added **📋 Copy All (JSON)** and **💾 Download JSON** action buttons to the Recent Activity Telemetry tab header.
  - Updated \ActivityTelemetry.test.tsx\ to verify button and badge rendering.

### 4. Backend Python CLI Subcommand
- **\src/garmin_sync/firestore_repository.py\**: Added \get_activities_in_range(start_date, end_date)\.
- **\src/garmin_sync/service.py\**: Added \export_activities_json(start_date, end_date)\ returning \ecent_activities_bundle_v1\.
- **\src/garmin_sync/cli.py\**: Added \export-activities\ subcommand:
  \\\ash
  uv run python -m garmin_sync export-activities --days 7 [--output activities.json]
  \\\
- **\	ests/test_activity_export.py\** (NEW): Pytest tests verifying JSON export structure, date resolution, stdout streaming, and file output.

---

### Verification
- **Frontend**:
  - \
pm run check\: 2643 passed across 280 test files (TypeScript, ESLint, Vitest, and workout catalog contracts).
  - \
pm run build\: Production bundle built cleanly with 0 errors.
- **Backend**:
  - \uv run pytest\: 446 passed.
  - \uv run ruff check .\ & \uv run ruff format --check .\: All checks passed.
  - \uv run mypy src/garmin_sync\: 0 issues in 37 source files.
- **Pre-commit & Pre-push hooks**: All passed.