### PR TITLE
🔒 Fix TOCTOU vulnerability in file permission setting

### DIFF
--- a/src/garmin_sync/token_store.py
+++ b/src/garmin_sync/token_store.py
@@ -47,10 +47,11 @@ def _chmod_secure(path: Path, mode: int) -> None:
             pass
 
     # Fallback if fchmod/O_NOFOLLOW isn't supported and symlinks exist
-    if path.is_symlink():
-        logger.debug(f"Refusing to chmod symlink '{path}' directly.")
-        return
-    os.chmod(path, mode)
+    logger.warning(
+        f"Secure file permission setting (fchmod/O_NOFOLLOW) is not supported on this platform. "
+        f"Skipping chmod for '{path}' to avoid TOCTOU vulnerability."
+    )
+    return
 
 
 def _set_secure_permissions(file_path: Path) -> None:


### PR DESCRIPTION
🎯 **What:** Addressed a Time-of-Check to Time-of-Use (TOCTOU) vulnerability in `src/garmin_sync/token_store.py` where a fallback permission mechanism checked for a symlink and then executed `os.chmod()`.

⚠️ **Risk:** An attacker could replace the file with a symlink between the check (`path.is_symlink()`) and the permission modification (`os.chmod()`). This race condition could potentially allow an attacker to modify permissions of arbitrary files the application has access to.

🛡️ **Solution:** Removed the insecure fallback completely. The code now only relies on secure file permission mechanisms (like `fchmod` with `O_NOFOLLOW` or `os.chmod` with `follow_symlinks=False`). On platforms lacking those, it safely skips the `chmod` operation and logs a warning to avoid the vulnerability.

---
*PR created automatically by Jules for task [10657405553361384322](https://jules.google.com/task/10657405553361384322) started by @Szczepanov*