### PR TITLE
🧪 Add tests for run_daily_sync_all

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,6 +9,7 @@ from garmin_sync.cli import (
     run_audit_cmd,
     run_backfill,
     run_daily_sync,
+    run_daily_sync_all,
     run_poll_manual_sync_cmd,
     run_rebuild_cmd,
 )
@@ -111,6 +112,33 @@ def test_run_daily_sync_exception(mock_settings: Any, mock_service: Any) -> None
     exit_code = run_daily_sync([])
 
     assert exit_code == 1
+
+
+@patch("garmin_sync.cli._run_for_all_users")
+def test_run_daily_sync_all_success(mock_run_for_all_users: Any, mock_service: Any) -> None:
+    mock_run_for_all_users.return_value = 0
+    mock_service_instance = mock_service.return_value
+
+    args = ["--date", "2023-10-27", "--force", "--resync-days", "2"]
+    exit_code = run_daily_sync_all(args)
+
+    assert exit_code == 0
+    mock_run_for_all_users.assert_called_once()
+
+    # Check that _run_for_all_users was called with the correct operation name and a lambda
+    call_args = mock_run_for_all_users.call_args[0]
+    assert call_args[0] == "daily sync"
+    operation_lambda = call_args[1]
+
+    # Execute the lambda to verify its behavior
+    operation_lambda(mock_service_instance)
+
+    mock_service_instance.sync_daily.assert_called_once_with(
+        target_date_str="2023-10-27",
+        force=True,
+        resync_lookback_days=2,
+        auto_backfill_cold_start=True,
+    )
 
 
 def test_run_backfill_success(mock_settings: Any, mock_service: Any) -> None:
@@ -274,6 +302,17 @@ def test_main_sync(mock_run_daily_sync: Any) -> None:
 
     assert exit_code == 0
     mock_run_daily_sync.assert_called_once_with(["--date", "2023-10-27"])
+
+
+@patch("garmin_sync.cli.run_daily_sync_all")
+def test_main_sync_all(mock_run_daily_sync_all: Any) -> None:
+    mock_run_daily_sync_all.return_value = 0
+
+    with patch.object(sys, "argv", ["garmin_sync", "sync-all", "--date", "2023-10-27"]):
+        exit_code = main()
+
+    assert exit_code == 0
+    mock_run_daily_sync_all.assert_called_once_with(["--date", "2023-10-27"])
 
 
 @patch("garmin_sync.cli.run_backfill")


### PR DESCRIPTION
🎯 **What:** The `run_daily_sync_all` function in `src/garmin_sync/cli.py` and its corresponding CLI route (`sync-all`) in `main` lacked unit test coverage. This gap has been addressed.

📊 **Coverage:** Added test cases to cover the successful execution of `run_daily_sync_all`, ensuring it correctly configures a lambda that calls `sync_daily`. Also added a test case ensuring the `main` function correctly routes the `sync-all` argument to `run_daily_sync_all`. 

✨ **Result:** Increased test coverage and confidence in the multi-user scheduled sync logic. Code reliability is improved without changing existing functionality.

---
*PR created automatically by Jules for task [9563460374096644615](https://jules.google.com/task/9563460374096644615) started by @Szczepanov*