### PR TITLE
🔒 Fix insufficient logging redaction in account link API

### DIFF
--- a/src/garmin_sync/account_link_api.py
+++ b/src/garmin_sync/account_link_api.py
@@ -101,7 +101,11 @@ class GarminAccountLinkHandler(BaseHTTPRequestHandler):
     def log_message(self, format: str, *args: Any) -> None:
         # BaseHTTPRequestHandler includes the path but never request bodies. Keep logs
         # intentionally free of Garmin email, password, MFA code, challenge ID and tokens.
-        logger.info("%s - %s", self.address_string(), format % args)
+        message = format % args
+        if hasattr(self, "path") and self.path and "?" in self.path:
+            sanitized_path = self.path.split("?", 1)[0]
+            message = message.replace(self.path, sanitized_path)
+        logger.info("%s - %s", self.address_string(), message)
 
     def _json_response(self, status: HTTPStatus, payload: dict[str, Any]) -> None:
         body = json.dumps(payload, separators=(",", ":")).encode("utf-8")

--- a/tests/test_account_link_api.py
+++ b/tests/test_account_link_api.py
@@ -95,3 +95,23 @@ def test_handle_login_enforces_per_account_rate_limiting(monkeypatch: Any) -> No
     assert len(captured_errors) == 1
     assert captured_errors[0]["status"] == HTTPStatus.TOO_MANY_REQUESTS
     assert captured_errors[0]["error_code"] == "garmin_link.rate_limited"
+
+
+def test_log_message_redacts_query_parameters(monkeypatch: Any) -> None:
+    handler = object.__new__(GarminAccountLinkHandler)
+    handler.client_address = ("127.0.0.1", 12345)
+    handler.path = "/api/garmin/login?token=secret123"
+
+    captured_logs: list[str] = []
+
+    def mock_info(msg: str, *args: Any) -> None:
+        captured_logs.append(msg % args)
+
+    monkeypatch.setattr(account_link_api.logger, "info", mock_info)
+
+    handler.log_message("GET %s HTTP/1.1", handler.path)
+
+    assert len(captured_logs) == 1
+    log = captured_logs[0]
+    assert "/api/garmin/login" in log
+    assert "secret123" not in log


### PR DESCRIPTION
🎯 **What:** Modified `log_message` in `src/garmin_sync/account_link_api.py` to strip query parameters from the logged request path. This prevents tokens or query arguments passed in the URL from being unintentionally logged to stdout by `BaseHTTPRequestHandler`. Also added a test in `tests/test_account_link_api.py` to assert correct sanitization.

⚠️ **Risk:** BaseHTTPRequestHandler's default `log_request` automatically logs the full request string (e.g. `GET /api/garmin/login?token=abc HTTP/1.1`). This can result in leaking sensitive information such as authentication tokens directly into application logs, leading to credential exposure.

🛡️ **Solution:** Overrode `log_message` in `GarminAccountLinkHandler` to detect if the log message contains a path with query parameters. If it does, it splits the path at the `?` and replaces the full path in the log message with the sanitized version, ensuring logs only reflect the base path without secrets.

---
*PR created automatically by Jules for task [10679978361366610580](https://jules.google.com/task/10679978361366610580) started by @Szczepanov*