### PR TITLE
🧹 [Group raw Garmin telemetry payloads to avoid long parameter lists]

### DIFF
--- a/src/garmin_sync/garmin_provider.py
+++ b/src/garmin_sync/garmin_provider.py
@@ -5,6 +5,7 @@ recommendation engine) operates on canonical.py types only."""
 
 import logging
 import math
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Callable, TypeVar
 
@@ -1081,45 +1082,52 @@ def extract_gear_items(raw_gear: Any) -> list[CanonicalGearItem]:
     return items
 
 
+@dataclass(frozen=True)
+class RawGarminTelemetry:
+    """Groups raw Garmin telemetry payloads to avoid excessively long parameter lists."""
+
+    stats_today: dict[str, Any]
+    stats_fallback: dict[str, Any] | None
+    sleep_today: dict[str, Any] | None
+    sleep_fallback: dict[str, Any] | None
+    hrv_today: dict[str, Any] | None
+    stress_today: dict[str, Any] | None = None
+    body_battery_today: list[dict[str, Any]] | None = None
+    training_readiness_today: list[dict[str, Any]] | None = None
+    training_status_today: dict[str, Any] | None = None
+    heart_rate_zones: list[dict[str, Any]] | None = None
+    respiration_today: dict[str, Any] | None = None
+    body_composition_today: dict[str, Any] | list[dict[str, Any]] | None = None
+    spo2_today: dict[str, Any] | None = None
+
+
 def canonicalize_from_raw(
-    stats_today: dict[str, Any],
-    stats_fallback: dict[str, Any] | None,
-    sleep_today: dict[str, Any] | None,
-    sleep_fallback: dict[str, Any] | None,
-    hrv_today: dict[str, Any] | None,
+    telemetry: RawGarminTelemetry,
     target_date_iso: str,
     yesterday_iso: str,
-    stress_today: dict[str, Any] | None = None,
-    body_battery_today: list[dict[str, Any]] | None = None,
-    training_readiness_today: list[dict[str, Any]] | None = None,
-    training_status_today: dict[str, Any] | None = None,
-    heart_rate_zones: list[dict[str, Any]] | None = None,
-    respiration_today: dict[str, Any] | None = None,
-    body_composition_today: dict[str, Any] | list[dict[str, Any]] | None = None,
-    spo2_today: dict[str, Any] | None = None,
 ) -> CanonicalDailyMetrics:
     """Pure Garmin-shape parsing + fallback logic, producing a provider-neutral
     CanonicalDailyMetrics. Shared by GarminProviderAdapter.fetch_daily_metrics (live
     fetch) and service.rebuild() (archive replay) so both paths can never drift from
     each other -- same guarantee normalize_current_metrics gave the pre-canonical code."""
     # RHR & waking Body Battery
-    rhr = stats_today.get("restingHeartRate")
+    rhr = telemetry.stats_today.get("restingHeartRate")
     rhr_date = target_date_iso
-    if rhr is None and stats_fallback:
-        rhr = stats_fallback.get("restingHeartRate")
+    if rhr is None and telemetry.stats_fallback:
+        rhr = telemetry.stats_fallback.get("restingHeartRate")
         rhr_date = yesterday_iso
 
-    bb_wake = stats_today.get("bodyBatteryAtWakeTime")
+    bb_wake = telemetry.stats_today.get("bodyBatteryAtWakeTime")
     bb_wake_date = target_date_iso
-    if bb_wake is None and stats_fallback:
-        bb_wake = stats_fallback.get("bodyBatteryAtWakeTime")
+    if bb_wake is None and telemetry.stats_fallback:
+        bb_wake = telemetry.stats_fallback.get("bodyBatteryAtWakeTime")
         bb_wake_date = yesterday_iso
 
     # Steps semantics: use D-1 completed day steps
     steps_date = yesterday_iso
-    total_steps = stats_fallback.get("totalSteps") if stats_fallback else None
+    total_steps = telemetry.stats_fallback.get("totalSteps") if telemetry.stats_fallback else None
     if total_steps is None:
-        total_steps = stats_today.get("totalSteps")
+        total_steps = telemetry.stats_today.get("totalSteps")
         steps_date = target_date_iso
 
     # Sleep
@@ -1132,10 +1140,10 @@ def canonicalize_from_raw(
         light_sec,
         awake_sec,
         restless_count,
-    ) = extract_sleep_metrics(sleep_today)
+    ) = extract_sleep_metrics(telemetry.sleep_today)
     sleep_date = target_date_iso
     used_sleep_fallback = False
-    if sleep_score is None and sleep_fallback:
+    if sleep_score is None and telemetry.sleep_fallback:
         (
             fb_score,
             fb_sec,
@@ -1145,7 +1153,7 @@ def canonicalize_from_raw(
             fb_light,
             fb_awake,
             fb_restless,
-        ) = extract_sleep_metrics(sleep_fallback)
+        ) = extract_sleep_metrics(telemetry.sleep_fallback)
         if fb_score is not None:
             sleep_score, sleep_sec, avg_resp = fb_score, fb_sec, fb_resp
             deep_sec, rem_sec, light_sec, awake_sec, restless_count = (
@@ -1160,36 +1168,42 @@ def canonicalize_from_raw(
 
     # Prefer a precise average computed from the dedicated respiration endpoint's raw
     # per-interval readings over dailySleepDTO's own (coarser) summary value -- see
-    # average_sleep_respiration_from_intervals. Only attempted against sleep_today's own
-    # window: respiration_today is fetched for target_date_iso, so it has no
-    # correspondence to sleep_fallback's (D-1) window.
+    # average_sleep_respiration_from_intervals. Only attempted against telemetry.sleep_today's own
+    # window: telemetry.respiration_today is fetched for target_date_iso, so it has no
+    # correspondence to telemetry.sleep_fallback's (D-1) window.
     if not used_sleep_fallback:
-        sleep_start_gmt_ms, sleep_end_gmt_ms = _sleep_window_gmt_ms(sleep_today or {})
+        sleep_start_gmt_ms, sleep_end_gmt_ms = _sleep_window_gmt_ms(telemetry.sleep_today or {})
         precise_avg_resp = average_sleep_respiration_from_intervals(
-            respiration_today, sleep_start_gmt_ms, sleep_end_gmt_ms
+            telemetry.respiration_today, sleep_start_gmt_ms, sleep_end_gmt_ms
         )
         if precise_avg_resp is not None:
             avg_resp = precise_avg_resp
 
     # HRV
-    hrv_summary = hrv_today.get("hrvSummary", {}) if hrv_today else {}
+    hrv_summary = telemetry.hrv_today.get("hrvSummary", {}) if telemetry.hrv_today else {}
     hrv_last = hrv_summary.get("lastNightAvg")
     hrv_status = hrv_summary.get("status")
     hrv_date = target_date_iso if hrv_last is not None else None
 
     # Weight / Body Composition
-    weight_kg, body_fat_pct, weight_date = extract_body_composition(body_composition_today)
+    weight_kg, body_fat_pct, weight_date = extract_body_composition(
+        telemetry.body_composition_today
+    )
     if weight_kg is not None and weight_date is None:
         weight_date = target_date_iso
 
     # Overnight metrics must follow the same selected sleep record. If target-date sleep
     # is unavailable and D-1 is selected, combining target-date Pulse Ox with D-1 sleep
     # fields would create a single CanonicalSpo2 containing values from two dates.
-    selected_sleep = sleep_fallback if used_sleep_fallback else sleep_today
-    canonical_spo2 = extract_spo2(None if used_sleep_fallback else spo2_today, selected_sleep)
+    selected_sleep = telemetry.sleep_fallback if used_sleep_fallback else telemetry.sleep_today
+    canonical_spo2 = extract_spo2(
+        None if used_sleep_fallback else telemetry.spo2_today, selected_sleep
+    )
     skin_temp_dev = extract_skin_temp_deviation(selected_sleep)
 
-    daily_rec_hours = _daily_recovery_time_hours(training_readiness_today, stats_today)
+    daily_rec_hours = _daily_recovery_time_hours(
+        telemetry.training_readiness_today, telemetry.stats_today
+    )
 
     return CanonicalDailyMetrics(
         date=target_date_iso,
@@ -1214,11 +1228,11 @@ def canonicalize_from_raw(
         weight_kg=weight_kg,
         body_fat_pct=body_fat_pct,
         weight_date=weight_date,
-        stress=_canonicalize_stress(stress_today),
-        body_battery=_canonicalize_body_battery(body_battery_today),
-        training_readiness=_canonicalize_training_readiness(training_readiness_today),
-        training_status=_canonicalize_training_status(training_status_today),
-        heart_rate_zones=_canonicalize_heart_rate_zones(heart_rate_zones),
+        stress=_canonicalize_stress(telemetry.stress_today),
+        body_battery=_canonicalize_body_battery(telemetry.body_battery_today),
+        training_readiness=_canonicalize_training_readiness(telemetry.training_readiness_today),
+        training_status=_canonicalize_training_status(telemetry.training_status_today),
+        heart_rate_zones=_canonicalize_heart_rate_zones(telemetry.heart_rate_zones),
         spo2=canonical_spo2,
         skin_temp_deviation_celsius=skin_temp_dev,
         recovery_time_hours=daily_rec_hours,
@@ -1490,14 +1504,12 @@ class GarminProviderAdapter:
             fatal_exceptions=(AttributeError,),
         )
 
-        canonical = canonicalize_from_raw(
+        telemetry = RawGarminTelemetry(
             stats_today=stats_today,
             stats_fallback=stats_fallback,
             sleep_today=sleep_today,
             sleep_fallback=sleep_fallback,
             hrv_today=hrv_today,
-            target_date_iso=target_date_iso,
-            yesterday_iso=yesterday_iso,
             stress_today=stress_today,
             body_battery_today=body_battery_today,
             training_readiness_today=training_readiness_today,
@@ -1506,6 +1518,12 @@ class GarminProviderAdapter:
             respiration_today=respiration_today,
             body_composition_today=body_comp_today,
             spo2_today=spo2_today,
+        )
+
+        canonical = canonicalize_from_raw(
+            telemetry=telemetry,
+            target_date_iso=target_date_iso,
+            yesterday_iso=yesterday_iso,
         )
 
         raw_payloads: dict[str, Any] = {

--- a/src/garmin_sync/service.py
+++ b/src/garmin_sync/service.py
@@ -18,6 +18,7 @@ from .firestore_repository import FirestoreRecoveryRepository
 from .garmin_client import GarminClientWrapper
 from .garmin_provider import (
     GarminProviderAdapter,
+    RawGarminTelemetry,
     canonicalize_activities,
     canonicalize_from_raw,
     qualifies_for_activity_detail,
@@ -812,14 +813,12 @@ class GarminSyncService:
             spo2_today = self.archive_store.load("spo2", target_iso)
 
             try:
-                canonical = canonicalize_from_raw(
+                telemetry = RawGarminTelemetry(
                     stats_today=raw_stats,
                     stats_fallback=stats_fallback,
                     sleep_today=raw_sleep,
                     sleep_fallback=sleep_fallback,
                     hrv_today=raw_hrv,
-                    target_date_iso=target_iso,
-                    yesterday_iso=yesterday_iso,
                     stress_today=stress_today,
                     body_battery_today=body_battery_today,
                     training_readiness_today=training_readiness_today,
@@ -828,6 +827,12 @@ class GarminSyncService:
                     respiration_today=respiration_today,
                     body_composition_today=body_composition_today,
                     spo2_today=spo2_today,
+                )
+
+                canonical = canonicalize_from_raw(
+                    telemetry=telemetry,
+                    target_date_iso=target_iso,
+                    yesterday_iso=yesterday_iso,
                 )
                 zone4_floor = (
                     canonical.heart_rate_zones.zone4_floor if canonical.heart_rate_zones else None

--- a/tests/test_failure_modes.py
+++ b/tests/test_failure_modes.py
@@ -1,5 +1,9 @@
 from garmin_sync.canonical import CanonicalDailyMetrics
-from garmin_sync.garmin_provider import canonicalize_activities, canonicalize_from_raw
+from garmin_sync.garmin_provider import (
+    RawGarminTelemetry,
+    canonicalize_activities,
+    canonicalize_from_raw,
+)
 from garmin_sync.metrics import (
     calculate_average,
     calculate_delta,
@@ -12,11 +16,13 @@ from garmin_sync.metrics import (
 def test_failure_mode_missing_keys_in_raw_payload() -> None:
     corrupt_payload = {"unexpectedKey": 123}
     canonical = canonicalize_from_raw(
-        stats_today=corrupt_payload,
-        stats_fallback=None,
-        sleep_today=corrupt_payload,
-        sleep_fallback=None,
-        hrv_today=corrupt_payload,
+        telemetry=RawGarminTelemetry(
+            stats_today=corrupt_payload,
+            stats_fallback=None,
+            sleep_today=corrupt_payload,
+            sleep_fallback=None,
+            hrv_today=corrupt_payload,
+        ),
         target_date_iso="2026-08-26",
         yesterday_iso="2026-08-25",
     )

--- a/tests/test_garmin_provider.py
+++ b/tests/test_garmin_provider.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 
 from garmin_sync.garmin_provider import (
     GarminProviderAdapter,
+    RawGarminTelemetry,
     canonicalize_activities,
     canonicalize_activity_detail,
     canonicalize_from_raw,
@@ -135,11 +136,13 @@ def test_canonicalize_from_raw_using_fixtures():
     stats_fallback = {"totalSteps": 8420, "restingHeartRate": 51}
 
     canonical = canonicalize_from_raw(
-        stats_today=stats,
-        stats_fallback=stats_fallback,
-        sleep_today=sleep,
-        sleep_fallback=None,
-        hrv_today=hrv,
+        telemetry=RawGarminTelemetry(
+            stats_today=stats,
+            stats_fallback=stats_fallback,
+            sleep_today=sleep,
+            sleep_fallback=None,
+            hrv_today=hrv,
+        ),
         target_date_iso="2026-08-06",
         yesterday_iso="2026-08-05",
     )
@@ -163,11 +166,13 @@ def test_canonicalize_from_raw_fallback_consistency():
     hrv_today = {"hrvSummary": {"lastNightAvg": 62, "status": "BALANCED"}}
 
     canonical = canonicalize_from_raw(
-        stats_today=stats_today,
-        stats_fallback=stats_fallback,
-        sleep_today=sleep_today,
-        sleep_fallback=sleep_fallback,
-        hrv_today=hrv_today,
+        telemetry=RawGarminTelemetry(
+            stats_today=stats_today,
+            stats_fallback=stats_fallback,
+            sleep_today=sleep_today,
+            sleep_fallback=sleep_fallback,
+            hrv_today=hrv_today,
+        ),
         target_date_iso="2026-08-06",
         yesterday_iso="2026-08-05",
     )
@@ -288,14 +293,16 @@ def test_canonicalize_from_raw_prefers_precise_respiration_average_when_availabl
     respiration_today = {"respirationValuesArray": _respiration_array(40)}
 
     canonical = canonicalize_from_raw(
-        stats_today={},
-        stats_fallback=None,
-        sleep_today=sleep_today,
-        sleep_fallback=None,
-        hrv_today={},
+        telemetry=RawGarminTelemetry(
+            stats_today={},
+            stats_fallback=None,
+            sleep_today=sleep_today,
+            sleep_fallback=None,
+            hrv_today={},
+            respiration_today=respiration_today,
+        ),
         target_date_iso="2026-08-06",
         yesterday_iso="2026-08-05",
-        respiration_today=respiration_today,
     )
 
     assert canonical.respiration_rate_brpm == 12.5  # precise, not the coarse 12
@@ -311,11 +318,13 @@ def test_canonicalize_from_raw_falls_back_to_sleep_dto_respiration_without_inter
     }
 
     canonical = canonicalize_from_raw(
-        stats_today={},
-        stats_fallback=None,
-        sleep_today=sleep_today,
-        sleep_fallback=None,
-        hrv_today={},
+        telemetry=RawGarminTelemetry(
+            stats_today={},
+            stats_fallback=None,
+            sleep_today=sleep_today,
+            sleep_fallback=None,
+            hrv_today={},
+        ),
         target_date_iso="2026-08-06",
         yesterday_iso="2026-08-05",
     )
@@ -338,14 +347,16 @@ def test_canonicalize_from_raw_skips_precise_respiration_on_sleep_fallback_day()
     respiration_today = {"respirationValuesArray": _respiration_array(40)}
 
     canonical = canonicalize_from_raw(
-        stats_today={},
-        stats_fallback=None,
-        sleep_today={},
-        sleep_fallback=sleep_fallback,
-        hrv_today={},
+        telemetry=RawGarminTelemetry(
+            stats_today={},
+            stats_fallback=None,
+            sleep_today={},
+            sleep_fallback=sleep_fallback,
+            hrv_today={},
+            respiration_today=respiration_today,
+        ),
         target_date_iso="2026-08-06",
         yesterday_iso="2026-08-05",
-        respiration_today=respiration_today,
     )
 
     assert canonical.respiration_rate_brpm == 13
@@ -575,17 +586,19 @@ def test_canonicalize_from_raw_populates_stress_body_battery_readiness_status():
         training_status = json.load(f)
 
     canonical = canonicalize_from_raw(
-        stats_today=stats,
-        stats_fallback=None,
-        sleep_today=sleep,
-        sleep_fallback=None,
-        hrv_today=hrv,
+        telemetry=RawGarminTelemetry(
+            stats_today=stats,
+            stats_fallback=None,
+            sleep_today=sleep,
+            sleep_fallback=None,
+            hrv_today=hrv,
+            stress_today=stress,
+            body_battery_today=body_battery,
+            training_readiness_today=training_readiness,
+            training_status_today=training_status,
+        ),
         target_date_iso="2026-08-06",
         yesterday_iso="2026-08-05",
-        stress_today=stress,
-        body_battery_today=body_battery,
-        training_readiness_today=training_readiness,
-        training_status_today=training_status,
     )
 
     assert canonical.stress is not None
@@ -625,14 +638,16 @@ def test_canonicalize_from_raw_uses_precise_respiration_fixture_over_sleep_dto_a
         respiration = json.load(f)
 
     canonical = canonicalize_from_raw(
-        stats_today=stats,
-        stats_fallback=None,
-        sleep_today=sleep,
-        sleep_fallback=None,
-        hrv_today=hrv,
+        telemetry=RawGarminTelemetry(
+            stats_today=stats,
+            stats_fallback=None,
+            sleep_today=sleep,
+            sleep_fallback=None,
+            hrv_today=hrv,
+            respiration_today=respiration,
+        ),
         target_date_iso="2026-08-06",
         yesterday_iso="2026-08-05",
-        respiration_today=respiration,
     )
 
     assert canonical.respiration_rate_brpm == 12.2  # not sleep.json's coarser 14.5
@@ -645,11 +660,13 @@ def test_canonicalize_from_raw_enrichment_fields_absent_when_not_provided():
         stats = json.load(f)
 
     canonical = canonicalize_from_raw(
-        stats_today=stats,
-        stats_fallback=None,
-        sleep_today={},
-        sleep_fallback=None,
-        hrv_today={},
+        telemetry=RawGarminTelemetry(
+            stats_today=stats,
+            stats_fallback=None,
+            sleep_today={},
+            sleep_fallback=None,
+            hrv_today={},
+        ),
         target_date_iso="2026-08-06",
         yesterday_iso="2026-08-05",
     )
@@ -688,14 +705,16 @@ def test_canonicalize_from_raw_populates_heart_rate_zones_from_default_sport():
         zones = json.load(f)
 
     canonical = canonicalize_from_raw(
-        stats_today=stats,
-        stats_fallback=None,
-        sleep_today=sleep,
-        sleep_fallback=None,
-        hrv_today=hrv,
+        telemetry=RawGarminTelemetry(
+            stats_today=stats,
+            stats_fallback=None,
+            sleep_today=sleep,
+            sleep_fallback=None,
+            hrv_today=hrv,
+            heart_rate_zones=zones,
+        ),
         target_date_iso="2026-08-06",
         yesterday_iso="2026-08-05",
-        heart_rate_zones=zones,
     )
 
     assert canonical.heart_rate_zones is not None
@@ -745,11 +764,13 @@ def test_canonicalize_from_raw_heart_rate_zones_absent_when_not_provided():
         stats = json.load(f)
 
     canonical = canonicalize_from_raw(
-        stats_today=stats,
-        stats_fallback=None,
-        sleep_today={},
-        sleep_fallback=None,
-        hrv_today={},
+        telemetry=RawGarminTelemetry(
+            stats_today=stats,
+            stats_fallback=None,
+            sleep_today={},
+            sleep_fallback=None,
+            hrv_today={},
+        ),
         target_date_iso="2026-08-06",
         yesterday_iso="2026-08-05",
     )
@@ -972,11 +993,13 @@ def test_canonicalize_activities_extracts_training_effect_and_recovery():
 def test_canonicalize_from_raw_extracts_daily_recovery_time():
     stats = {"recoveryTime": 18, "restingHeartRate": 52}
     canonical = canonicalize_from_raw(
-        stats_today=stats,
-        stats_fallback=None,
-        sleep_today=None,
-        sleep_fallback=None,
-        hrv_today=None,
+        telemetry=RawGarminTelemetry(
+            stats_today=stats,
+            stats_fallback=None,
+            sleep_today=None,
+            sleep_fallback=None,
+            hrv_today=None,
+        ),
         target_date_iso="2026-08-23",
         yesterday_iso="2026-08-22",
     )

--- a/tests/test_garmin_recovery_telemetry.py
+++ b/tests/test_garmin_recovery_telemetry.py
@@ -1,16 +1,22 @@
-from garmin_sync.garmin_provider import canonicalize_activities, canonicalize_from_raw
+from garmin_sync.garmin_provider import (
+    RawGarminTelemetry,
+    canonicalize_activities,
+    canonicalize_from_raw,
+)
 
 
 def _daily_metrics(*, readiness: list[dict[str, object]] | None, stats: dict[str, object]):
     return canonicalize_from_raw(
-        stats_today=stats,
-        stats_fallback=None,
-        sleep_today={},
-        sleep_fallback=None,
-        hrv_today={},
+        telemetry=RawGarminTelemetry(
+            stats_today=stats,
+            stats_fallback=None,
+            sleep_today={},
+            sleep_fallback=None,
+            hrv_today={},
+            training_readiness_today=readiness,
+        ),
         target_date_iso="2026-08-23",
         yesterday_iso="2026-08-22",
-        training_readiness_today=readiness,
     )
 
 

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -2,7 +2,11 @@ import json
 from pathlib import Path
 
 from garmin_sync.canonical import CanonicalActivity, CanonicalDailyMetrics
-from garmin_sync.garmin_provider import canonicalize_activities, canonicalize_from_raw
+from garmin_sync.garmin_provider import (
+    RawGarminTelemetry,
+    canonicalize_activities,
+    canonicalize_from_raw,
+)
 from garmin_sync.mapper import build_snapshot_from_canonical, normalize_activity
 from garmin_sync.models import DerivedMetrics
 
@@ -26,11 +30,13 @@ def test_build_snapshot_from_canonical_using_real_fixture_shapes():
     stats_fallback = {"totalSteps": 8420, "restingHeartRate": 51}
 
     canonical = canonicalize_from_raw(
-        stats_today=stats,
-        stats_fallback=stats_fallback,
-        sleep_today=sleep,
-        sleep_fallback=None,
-        hrv_today=hrv,
+        telemetry=RawGarminTelemetry(
+            stats_today=stats,
+            stats_fallback=stats_fallback,
+            sleep_today=sleep,
+            sleep_fallback=None,
+            hrv_today=hrv,
+        ),
         target_date_iso="2026-08-06",
         yesterday_iso="2026-08-05",
     )

--- a/tests/test_spo2_skin_temp_sync.py
+++ b/tests/test_spo2_skin_temp_sync.py
@@ -5,6 +5,7 @@ import pytest
 from garmin_sync.canonical import CanonicalDailyMetrics, CanonicalSpo2
 from garmin_sync.garmin_provider import (
     GarminProviderAdapter,
+    RawGarminTelemetry,
     canonicalize_from_raw,
     extract_skin_temp_deviation,
     extract_spo2,
@@ -80,16 +81,18 @@ def test_sleep_fallback_keeps_overnight_metrics_on_one_logical_date():
     }
 
     canonical = canonicalize_from_raw(
-        stats_today={},
-        stats_fallback=None,
-        sleep_today={},
-        sleep_fallback=fallback_sleep,
-        hrv_today={},
+        telemetry=RawGarminTelemetry(
+            stats_today={},
+            stats_fallback=None,
+            sleep_today={},
+            sleep_fallback=fallback_sleep,
+            hrv_today={},
+            # This belongs to the target date and must not be mixed into the selected
+            # D-1 sleep record.
+            spo2_today={"averageSpO2": 99.0, "lowestSpO2": 98.0},
+        ),
         target_date_iso="2026-08-23",
         yesterday_iso="2026-08-22",
-        # This belongs to the target date and must not be mixed into the selected
-        # D-1 sleep record.
-        spo2_today={"averageSpO2": 99.0, "lowestSpO2": 98.0},
     )
 
     assert canonical.sleep_date == "2026-08-22"


### PR DESCRIPTION
🎯 **What:** Grouped raw Garmin telemetry payload dictionary parameters in `canonicalize_from_raw` into a `RawGarminTelemetry` dataclass context object.
💡 **Why:** Functions with 15 parameters are difficult to read and error-prone to call. Encapsulating the raw telemetry dicts inside a unified context object improves code readability, maintainability and standardizes parameter passing to parsing routines.
✅ **Verification:** Used automated syntax parsing tests across all touched Python files. Verified that all unit tests still pass via `uv run pytest tests/`, and confirmed the modifications strictly satisfy `uv run mypy src tests` and `uv run ruff check .` validation rules.
✨ **Result:** Improved code health and maintainability of the central backend ingestion routines by decreasing argument list lengths while retaining absolute behavior equivalence.

---
*PR created automatically by Jules for task [9535813762096706404](https://jules.google.com/task/9535813762096706404) started by @Szczepanov*