### PR TITLE
docs(hrf): fix embedded Python formatting

### DIFF
--- a/docs/plans/activity-heart-rate-measurement-fidelity.md
+++ b/docs/plans/activity-heart-rate-measurement-fidelity.md
@@ -407,12 +407,14 @@ HrSummaryCompatibility = Literal[
     "unknown",
 ]
 
+
 @dataclass(frozen=True)
 class CanonicalHrSourceEvidence:
     external_hr_sensor_present: bool | None
     source_for_activity: HrSourceForActivity
     provenance_confidence: HrProvenanceConfidence
     sensor_technology: HrSensorTechnology
+
 
 @dataclass(frozen=True)
 class CanonicalHrMeasurementQuality:


### PR DESCRIPTION
## Summary

Fixes the Python-formatting CI failure from merged PR #280 by adding the two blank lines Ruff requires between the embedded dataclass declarations.

## Validation

- `uv run ruff format --check .`
- repository pre-commit hooks

No runtime or schema changes.