### PR TITLE
Add allergy-aware symptom reporting and cause-based training gating

### DIFF
--- a/app/firestore.rules
+++ b/app/firestore.rules
@@ -269,7 +269,7 @@ service cloud.firestore {
 
     function hasValidHealthSymptoms(symptoms) {
       return symptoms is map
-        && symptoms.keys().hasOnly(['present', 'onset', 'severity', 'types'])
+        && symptoms.keys().hasOnly(['present', 'onset', 'severity', 'types', 'suspectedCause'])
         && symptoms.keys().hasAll(['present'])
         && symptoms.present is bool
         && (!('onset' in symptoms)
@@ -278,11 +278,14 @@ service cloud.firestore {
         && (!('severity' in symptoms)
           || (symptoms.present && (symptoms.severity == null || symptoms.severity in ['mild', 'moderate', 'severe']))
           || (!symptoms.present && symptoms.severity == null))
+        && (!('suspectedCause' in symptoms)
+          || (symptoms.present && (symptoms.suspectedCause == null || symptoms.suspectedCause in ['infectious', 'allergy', 'unsure']))
+          || (!symptoms.present && symptoms.suspectedCause == null))
         && (!('types' in symptoms)
           || (symptoms.present && (symptoms.types == null || (
             symptoms.types is list
-            && symptoms.types.size() <= 8
-            && symptoms.types.hasOnly(['sore_throat', 'congestion', 'cough', 'fever_or_chills', 'headache_or_body_aches', 'gastrointestinal', 'unusual_fatigue', 'other'])
+            && symptoms.types.size() <= 10
+            && symptoms.types.hasOnly(['sore_throat', 'congestion', 'runny_nose', 'sneezing', 'cough', 'fever_or_chills', 'headache_or_body_aches', 'gastrointestinal', 'unusual_fatigue', 'other'])
           )))
           || (!symptoms.present && symptoms.types == null));
     }
@@ -1341,7 +1344,7 @@ service cloud.firestore {
         && sourceAssessment.revisionId is string && sourceAssessment.revisionId.matches('^ha-[0-9a-f]{16}$')
         && exists(assessmentPath)
         && get(assessmentPath).data.assessment.episodeId == episodeId
-        && data.explanation in ['illness_symptoms', 'hard_training_recovery', 'poor_sleep', 'alcohol', 'travel_jetlag', 'stress', 'heat_dehydration', 'vaccination_medication', 'nothing_obvious', 'other_not_sure']
+        && data.explanation in ['illness_symptoms', 'allergy_or_hay_fever', 'hard_training_recovery', 'poor_sleep', 'alcohol', 'travel_jetlag', 'stress', 'heat_dehydration', 'vaccination_medication', 'nothing_obvious', 'other_not_sure']
         && (symptomOnset == null || (
           symptomOnset is map
           && symptomOnset.keys().hasOnly(['date', 'precision'])

--- a/app/scripts/check-policy-drift.mjs
+++ b/app/scripts/check-policy-drift.mjs
@@ -47,6 +47,11 @@ const decisionAffectingFiles = [
   // estimator here is policy even though it sits upstream of the ranking modules.
   'app/src/engine/completedTraining.ts',
   'app/src/engine/garminTelemetryEvidence.ts',
+  // adapters.ts maps the persisted check-in/goals/settings into the engine's SubjectiveInput
+  // and UserContext -- painFlag, restrictedModalities and clinicalFlagActive all derive from
+  // it before rules.ts ever runs, so a change here can alter a persisted decision exactly as
+  // a change to rules.ts does, even though it sits upstream of the ranking modules.
+  'app/src/engine/adapters.ts',
   // ADR-0019: adjudication decides what an externally-planned athlete is told to do, so a
   // change here alters a persisted decision exactly as a change to rules.ts does. The
   // profile derivation is included because the cost it produces feeds the ceilings.

--- a/app/src/components/HealthAnomalyFollowupCard.test.tsx
+++ b/app/src/components/HealthAnomalyFollowupCard.test.tsx
@@ -15,6 +15,7 @@ describe('HealthAnomalyFollowupForm', () => {
         );
         expect(html).toContain('Recovery follow-up (shadow)');
         expect(html).toContain('I developed illness symptoms');
+        expect(html).toContain('Seasonal allergy / hay fever');
         expect(html).toContain('Hard training / recovery');
         expect(html).toContain('Nothing obvious');
         expect(html).toContain('Other / not sure');

--- a/app/src/components/HealthAnomalyFollowupCard.tsx
+++ b/app/src/components/HealthAnomalyFollowupCard.tsx
@@ -16,6 +16,7 @@ import './HealthAnomalyFollowupCard.css';
 
 const EXPLANATION_LABELS: Record<HealthAnomalyOutcomeExplanation, string> = {
     illness_symptoms: 'I developed illness symptoms',
+    allergy_or_hay_fever: 'Seasonal allergy / hay fever',
     hard_training_recovery: 'Hard training / recovery',
     poor_sleep: 'Poor sleep',
     alcohol: 'Alcohol',
@@ -97,7 +98,7 @@ export function HealthAnomalyFollowupForm({ candidate, existing, onSave }: Healt
                     </select>
                 </div>
 
-                {(explanation === 'illness_symptoms' || !!existing?.symptomOnset) && (
+                {(explanation === 'illness_symptoms' || explanation === 'allergy_or_hay_fever' || !!existing?.symptomOnset) && (
                     <div className="ha-followup-field">
                         <label htmlFor="ha-followup-onset">Approximate symptom onset date</label>
                         <input

--- a/app/src/components/checkin/HealthContextSection.tsx
+++ b/app/src/components/checkin/HealthContextSection.tsx
@@ -57,6 +57,8 @@ const SEVERITIES = [
 const SYMPTOM_TYPES: Array<{ value: HealthSymptomType; label: string }> = [
     { value: 'sore_throat', label: 'Sore throat' },
     { value: 'congestion', label: 'Congestion' },
+    { value: 'runny_nose', label: 'Runny nose' },
+    { value: 'sneezing', label: 'Sneezing' },
     { value: 'cough', label: 'Cough' },
     { value: 'fever_or_chills', label: 'Fever / chills' },
     { value: 'headache_or_body_aches', label: 'Headache / body aches' },
@@ -64,6 +66,12 @@ const SYMPTOM_TYPES: Array<{ value: HealthSymptomType; label: string }> = [
     { value: 'unusual_fatigue', label: 'Unusual fatigue' },
     { value: 'other', label: 'Other symptom' },
 ];
+
+const SUSPECTED_CAUSES = [
+    ['infectious', 'Cold / infection'],
+    ['allergy', 'Allergy'],
+    ['unsure', 'Not sure'],
+] as const;
 
 function hasUnusualContext(value: HealthContextCheckin | undefined, symptomsPresent: boolean): boolean {
     if (symptomsPresent) return true;
@@ -236,6 +244,23 @@ export function HealthContextSection({
                                         className={`health-context__chip ${symptoms.severity === severity ? 'is-selected' : ''}`}
                                         aria-pressed={symptoms.severity === severity}
                                         onClick={() => updateSymptoms({ severity: symptoms.severity === severity ? null : severity })}
+                                    >
+                                        {label}
+                                    </button>
+                                ))}
+                            </div>
+                        </div>
+
+                        <div className="health-context__row">
+                            <span className="health-context__label">Likely cause</span>
+                            <div className="health-context__chips" role="group" aria-label="Suspected symptom cause">
+                                {SUSPECTED_CAUSES.map(([cause, label]) => (
+                                    <button
+                                        key={cause}
+                                        type="button"
+                                        className={`health-context__chip ${symptoms.suspectedCause === cause ? 'is-selected' : ''}`}
+                                        aria-pressed={symptoms.suspectedCause === cause}
+                                        onClick={() => updateSymptoms({ suspectedCause: symptoms.suspectedCause === cause ? null : cause })}
                                     >
                                         {label}
                                     </button>

--- a/app/src/emulator/healthAnomalyOutcomeRules.emulator.test.ts
+++ b/app/src/emulator/healthAnomalyOutcomeRules.emulator.test.ts
@@ -104,6 +104,12 @@ emulatorDescribe('Health anomaly prospective outcome rules (HA6)', () => {
         await assertFails(updateDoc(doc(db, outcomePath), { episodeId: 'different-episode' }));
     });
 
+    it('allows the allergy_or_hay_fever explanation', async () => {
+        await seedAssessment();
+        const db = testEnvironment.authenticatedContext(ownerId).firestore();
+        await assertSucceeds(setDoc(doc(db, outcomePath), { ...outcome(), explanation: 'allergy_or_hay_fever' }));
+    });
+
     it('rejects malformed explanation, onset and respiratory-test labels', async () => {
         await seedAssessment();
         const db = testEnvironment.authenticatedContext(ownerId).firestore();

--- a/app/src/emulator/healthContextRules.emulator.test.ts
+++ b/app/src/emulator/healthContextRules.emulator.test.ts
@@ -65,6 +65,29 @@ emulatorDescribe('Daily subjective check-in health-context rules (HA1)', () => {
         }));
     });
 
+    it('allows the allergy-oriented symptom types and a suspected cause', async () => {
+        const db = testEnvironment.authenticatedContext(ownerId).firestore();
+        await assertSucceeds(setDoc(doc(db, checkinPath), {
+            ...contextOnlyCheckin(),
+            healthContext: {
+                symptoms: {
+                    present: true,
+                    severity: 'mild',
+                    types: ['sneezing', 'runny_nose'],
+                    suspectedCause: 'allergy',
+                },
+            },
+        }));
+    });
+
+    it('rejects an unrecognized suspectedCause value', async () => {
+        const db = testEnvironment.authenticatedContext(ownerId).firestore();
+        await assertFails(setDoc(doc(db, checkinPath), {
+            ...contextOnlyCheckin(),
+            healthContext: { symptoms: { present: true, suspectedCause: 'viral' } },
+        }));
+    });
+
     it('allows a shape-valid conflicting legacy value because app/parser precedence is authoritative', async () => {
         const db = testEnvironment.authenticatedContext(ownerId).firestore();
         await assertSucceeds(setDoc(doc(db, checkinPath), {
@@ -117,12 +140,13 @@ emulatorDescribe('Daily subjective check-in health-context rules (HA1)', () => {
         }));
     });
 
-    it('rejects onset, severity, or types when symptoms are false', async () => {
+    it('rejects onset, severity, types, or suspectedCause when symptoms are false', async () => {
         const db = testEnvironment.authenticatedContext(ownerId).firestore();
         for (const symptoms of [
             { present: false, onset: 'today' },
             { present: false, severity: 'mild' },
             { present: false, types: ['cough'] },
+            { present: false, suspectedCause: 'allergy' },
         ]) {
             await assertFails(setDoc(doc(db, checkinPath), {
                 ...baseCheckin(),

--- a/app/src/engine/adapters.test.ts
+++ b/app/src/engine/adapters.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { mapContextFromGoalsAndTrainingSettings, mapSnapshotToEngineInput } from './adapters';
+import { mapCheckinToSubjectiveInput, mapContextFromGoalsAndTrainingSettings, mapSnapshotToEngineInput } from './adapters';
 import type {
     DailyRecoverySnapshot,
     DailySubjectiveCheckin,
@@ -179,5 +179,76 @@ describe('mapContextFromGoalsAndTrainingSettings (Phase 5.4 tissue response wiri
 
         const forecastContext = mapContextFromGoalsAndTrainingSettings([], settings, null, '2026-08-08', null);
         expect(forecastContext.constraints.restrictedModalities).not.toContain('Running');
+    });
+});
+
+describe('mapCheckinToSubjectiveInput painFlag (allergy-aware illness gating)', () => {
+    it('sets painFlag when illnessSymptoms is true and no healthContext detail is supplied (unchanged default)', () => {
+        const checkin = testCheckin({ illnessSymptoms: true });
+        expect(mapCheckinToSubjectiveInput(checkin).painFlag).toBe(true);
+    });
+
+    it('clears painFlag for a mild, allergy-attributed, purely upper-respiratory symptom day', () => {
+        const checkin = testCheckin({
+            illnessSymptoms: true,
+            healthContext: {
+                symptoms: {
+                    present: true,
+                    severity: 'mild',
+                    types: ['sneezing', 'runny_nose'],
+                    suspectedCause: 'allergy',
+                },
+            },
+        });
+        expect(mapCheckinToSubjectiveInput(checkin).painFlag).toBe(false);
+    });
+
+    it('keeps painFlag set for a severe allergy-attributed day', () => {
+        const checkin = testCheckin({
+            illnessSymptoms: true,
+            healthContext: {
+                symptoms: { present: true, severity: 'severe', suspectedCause: 'allergy' },
+            },
+        });
+        expect(mapCheckinToSubjectiveInput(checkin).painFlag).toBe(true);
+    });
+
+    it('keeps painFlag set when an allergy-attributed day also reports a systemic symptom type', () => {
+        const checkin = testCheckin({
+            illnessSymptoms: true,
+            healthContext: {
+                symptoms: {
+                    present: true,
+                    severity: 'mild',
+                    types: ['sneezing', 'fever_or_chills'],
+                    suspectedCause: 'allergy',
+                },
+            },
+        });
+        expect(mapCheckinToSubjectiveInput(checkin).painFlag).toBe(true);
+    });
+
+    it.each(['unsure', 'infectious', undefined] as const)(
+        'keeps painFlag set when suspectedCause is %s (fail-safe default)',
+        suspectedCause => {
+            const checkin = testCheckin({
+                illnessSymptoms: true,
+                healthContext: {
+                    symptoms: { present: true, severity: 'mild', ...(suspectedCause ? { suspectedCause } : {}) },
+                },
+            });
+            expect(mapCheckinToSubjectiveInput(checkin).painFlag).toBe(true);
+        },
+    );
+
+    it('keeps painFlag set for painOrInjury regardless of allergy attribution', () => {
+        const checkin = testCheckin({
+            painOrInjury: true,
+            illnessSymptoms: true,
+            healthContext: {
+                symptoms: { present: true, severity: 'mild', suspectedCause: 'allergy' },
+            },
+        });
+        expect(mapCheckinToSubjectiveInput(checkin).painFlag).toBe(true);
     });
 });

--- a/app/src/engine/adapters.test.ts
+++ b/app/src/engine/adapters.test.ts
@@ -188,7 +188,7 @@ describe('mapCheckinToSubjectiveInput painFlag (allergy-aware illness gating)', 
         expect(mapCheckinToSubjectiveInput(checkin).painFlag).toBe(true);
     });
 
-    it('clears painFlag for a mild, allergy-attributed, purely upper-respiratory symptom day', () => {
+    it('clears painFlag for a mild, allergy-attributed nasal symptom day', () => {
         const checkin = testCheckin({
             illnessSymptoms: true,
             healthContext: {
@@ -203,24 +203,28 @@ describe('mapCheckinToSubjectiveInput painFlag (allergy-aware illness gating)', 
         expect(mapCheckinToSubjectiveInput(checkin).painFlag).toBe(false);
     });
 
-    it('keeps painFlag set for a severe allergy-attributed day', () => {
-        const checkin = testCheckin({
-            illnessSymptoms: true,
-            healthContext: {
-                symptoms: { present: true, severity: 'severe', suspectedCause: 'allergy' },
-            },
-        });
-        expect(mapCheckinToSubjectiveInput(checkin).painFlag).toBe(true);
-    });
-
-    it('keeps painFlag set when an allergy-attributed day also reports a systemic symptom type', () => {
+    it('also permits an explicitly moderate allergy day when every reported symptom remains nasal', () => {
         const checkin = testCheckin({
             illnessSymptoms: true,
             healthContext: {
                 symptoms: {
                     present: true,
-                    severity: 'mild',
-                    types: ['sneezing', 'fever_or_chills'],
+                    severity: 'moderate',
+                    types: ['congestion', 'sneezing'],
+                    suspectedCause: 'allergy',
+                },
+            },
+        });
+        expect(mapCheckinToSubjectiveInput(checkin).painFlag).toBe(false);
+    });
+
+    it('keeps painFlag set when allergy-attributed severity is missing', () => {
+        const checkin = testCheckin({
+            illnessSymptoms: true,
+            healthContext: {
+                symptoms: {
+                    present: true,
+                    types: ['sneezing'],
                     suspectedCause: 'allergy',
                 },
             },
@@ -228,13 +232,84 @@ describe('mapCheckinToSubjectiveInput painFlag (allergy-aware illness gating)', 
         expect(mapCheckinToSubjectiveInput(checkin).painFlag).toBe(true);
     });
 
+    it('keeps painFlag set when allergy-attributed severity is explicitly null', () => {
+        const checkin = testCheckin({
+            illnessSymptoms: true,
+            healthContext: {
+                symptoms: {
+                    present: true,
+                    severity: null,
+                    types: ['sneezing'],
+                    suspectedCause: 'allergy',
+                },
+            },
+        });
+        expect(mapCheckinToSubjectiveInput(checkin).painFlag).toBe(true);
+    });
+
+    it('keeps painFlag set when an allergy cause is selected without symptom types', () => {
+        const checkin = testCheckin({
+            illnessSymptoms: true,
+            healthContext: {
+                symptoms: { present: true, severity: 'mild', suspectedCause: 'allergy' },
+            },
+        });
+        expect(mapCheckinToSubjectiveInput(checkin).painFlag).toBe(true);
+    });
+
+    it('keeps painFlag set for a severe allergy-attributed day', () => {
+        const checkin = testCheckin({
+            illnessSymptoms: true,
+            healthContext: {
+                symptoms: {
+                    present: true,
+                    severity: 'severe',
+                    types: ['sneezing'],
+                    suspectedCause: 'allergy',
+                },
+            },
+        });
+        expect(mapCheckinToSubjectiveInput(checkin).painFlag).toBe(true);
+    });
+
+    it.each([
+        'sore_throat',
+        'cough',
+        'fever_or_chills',
+        'headache_or_body_aches',
+        'gastrointestinal',
+        'unusual_fatigue',
+        'other',
+    ] as const)(
+        'keeps painFlag set when an allergy-attributed day includes non-nasal symptom type %s',
+        symptomType => {
+            const checkin = testCheckin({
+                illnessSymptoms: true,
+                healthContext: {
+                    symptoms: {
+                        present: true,
+                        severity: 'mild',
+                        types: ['sneezing', symptomType],
+                        suspectedCause: 'allergy',
+                    },
+                },
+            });
+            expect(mapCheckinToSubjectiveInput(checkin).painFlag).toBe(true);
+        },
+    );
+
     it.each(['unsure', 'infectious', undefined] as const)(
         'keeps painFlag set when suspectedCause is %s (fail-safe default)',
         suspectedCause => {
             const checkin = testCheckin({
                 illnessSymptoms: true,
                 healthContext: {
-                    symptoms: { present: true, severity: 'mild', ...(suspectedCause ? { suspectedCause } : {}) },
+                    symptoms: {
+                        present: true,
+                        severity: 'mild',
+                        types: ['sneezing'],
+                        ...(suspectedCause ? { suspectedCause } : {}),
+                    },
                 },
             });
             expect(mapCheckinToSubjectiveInput(checkin).painFlag).toBe(true);
@@ -246,7 +321,12 @@ describe('mapCheckinToSubjectiveInput painFlag (allergy-aware illness gating)', 
             painOrInjury: true,
             illnessSymptoms: true,
             healthContext: {
-                symptoms: { present: true, severity: 'mild', suspectedCause: 'allergy' },
+                symptoms: {
+                    present: true,
+                    severity: 'mild',
+                    types: ['sneezing'],
+                    suspectedCause: 'allergy',
+                },
             },
         });
         expect(mapCheckinToSubjectiveInput(checkin).painFlag).toBe(true);

--- a/app/src/engine/adapters.ts
+++ b/app/src/engine/adapters.ts
@@ -16,21 +16,29 @@ import { goalToUserEvent } from './periodization';
 import { getLocalDateString } from '../utils/localDate';
 import type { HealthSymptomType } from './healthAnomalyModels';
 
-/** Symptom types that indicate more than a purely upper-respiratory/allergy presentation --
- *  any of these keeps today's conservative illness treatment regardless of suspected cause. */
-const NON_ALLERGY_SYMPTOM_TYPES: readonly HealthSymptomType[] = ['fever_or_chills', 'gastrointestinal', 'unusual_fatigue'];
+/**
+ * Deliberately narrow presentation for which an athlete's self-attributed allergy cause may
+ * soften the legacy illness gate. Broader respiratory or systemic symptoms stay conservative:
+ * the check-in does not diagnose allergy or rule out infection/EIB/asthma.
+ */
+const ALLERGY_COMPATIBLE_SYMPTOM_TYPES: readonly HealthSymptomType[] = [
+    'congestion',
+    'runny_nose',
+    'sneezing',
+];
 
 /**
- * Mild/moderate, purely upper-respiratory symptoms the athlete has explicitly attributed to
- * allergy don't get the same clinical restriction as an injury or systemic illness. Unknown
- * cause, unknown/severe severity, or any systemic symptom type keeps today's conservative
- * `painFlag` behavior unchanged -- this only softens the narrow, explicit case.
+ * Explicit mild/moderate nasal allergy symptoms don't get the same clinical restriction as an
+ * injury or undifferentiated illness. This is intentionally fail-closed: unknown severity,
+ * absent symptom detail, any non-nasal symptom type, an uncertain/infectious cause, or severe
+ * symptoms keep today's conservative `painFlag` behavior unchanged.
  */
 function isAllergyLikeSymptomDay(checkin: DailySubjectiveCheckin): boolean {
     const symptoms = checkin.healthContext?.symptoms;
     if (!symptoms?.present || symptoms.suspectedCause !== 'allergy') return false;
-    if (symptoms.severity === 'severe') return false;
-    if (symptoms.types?.some(type => NON_ALLERGY_SYMPTOM_TYPES.includes(type))) return false;
+    if (symptoms.severity !== 'mild' && symptoms.severity !== 'moderate') return false;
+    if (!symptoms.types || symptoms.types.length === 0) return false;
+    if (!symptoms.types.every(type => ALLERGY_COMPATIBLE_SYMPTOM_TYPES.includes(type))) return false;
     return true;
 }
 

--- a/app/src/engine/adapters.ts
+++ b/app/src/engine/adapters.ts
@@ -14,6 +14,25 @@ import type {
 import { resolveInjuryRestrictions, resolveEffectiveInjuryConstraints } from './injuryPolicy';
 import { goalToUserEvent } from './periodization';
 import { getLocalDateString } from '../utils/localDate';
+import type { HealthSymptomType } from './healthAnomalyModels';
+
+/** Symptom types that indicate more than a purely upper-respiratory/allergy presentation --
+ *  any of these keeps today's conservative illness treatment regardless of suspected cause. */
+const NON_ALLERGY_SYMPTOM_TYPES: readonly HealthSymptomType[] = ['fever_or_chills', 'gastrointestinal', 'unusual_fatigue'];
+
+/**
+ * Mild/moderate, purely upper-respiratory symptoms the athlete has explicitly attributed to
+ * allergy don't get the same clinical restriction as an injury or systemic illness. Unknown
+ * cause, unknown/severe severity, or any systemic symptom type keeps today's conservative
+ * `painFlag` behavior unchanged -- this only softens the narrow, explicit case.
+ */
+function isAllergyLikeSymptomDay(checkin: DailySubjectiveCheckin): boolean {
+    const symptoms = checkin.healthContext?.symptoms;
+    if (!symptoms?.present || symptoms.suspectedCause !== 'allergy') return false;
+    if (symptoms.severity === 'severe') return false;
+    if (symptoms.types?.some(type => NON_ALLERGY_SYMPTOM_TYPES.includes(type))) return false;
+    return true;
+}
 
 /** Normalizes a raw Garmin per-day activity summary (yesterday's or today's) into the
  * engine's TrainingRecord shape, or null if no qualifying activity data is present. */
@@ -149,7 +168,7 @@ export function mapCheckinToSubjectiveInput(checkin: DailySubjectiveCheckin | nu
         stress: checkin.mentalStress ?? NEUTRAL_SCALE_VALUE,
         motivation: checkin.motivation ?? NEUTRAL_SCALE_VALUE,
         timeAvailable: checkin.availability?.timeAvailableMin ?? DEFAULT_TIME_AVAILABLE_MIN,
-        painFlag: checkin.painOrInjury || checkin.illnessSymptoms,
+        painFlag: checkin.painOrInjury || (checkin.illnessSymptoms && !isAllergyLikeSymptomDay(checkin)),
         alreadyTrainedToday: checkin.alreadyTrainedToday ?? false,
         preferredModalityToday: checkin.availability?.preferredModalityToday ?? null,
     };

--- a/app/src/engine/healthAnomalyModels.ts
+++ b/app/src/engine/healthAnomalyModels.ts
@@ -35,11 +35,16 @@ export interface HealthSymptomsCheckin {
     severity?: 'mild' | 'moderate' | 'severe' | null;
     /** Null is accepted as an explicit clear for migration/update symmetry. */
     types?: HealthSymptomType[] | null;
+    /** Athlete's own best guess at cause. Unset/'unsure' keeps the conservative default
+     *  treatment; only an explicit 'allergy' can soften engine gating (see adapters.ts). */
+    suspectedCause?: 'infectious' | 'allergy' | 'unsure' | null;
 }
 
 export type HealthSymptomType =
     | 'sore_throat'
     | 'congestion'
+    | 'runny_nose'
+    | 'sneezing'
     | 'cough'
     | 'fever_or_chills'
     | 'headache_or_body_aches'

--- a/app/src/engine/healthAnomalyOutcome.test.ts
+++ b/app/src/engine/healthAnomalyOutcome.test.ts
@@ -71,6 +71,18 @@ describe('HealthAnomalyEpisodeOutcome (HA6)', () => {
         })).toThrow(/respiratory test/);
     });
 
+    it('accepts the allergy_or_hay_fever explanation', () => {
+        const result = buildHealthAnomalyEpisodeOutcome({
+            userId: 'u1',
+            episodeId: 'health-anomaly:2026-08-20',
+            sourceAssessment,
+            explanation: 'allergy_or_hay_fever',
+            now: '2026-08-21T06:00:00.000Z',
+        });
+        expect(result.explanation).toBe('allergy_or_hay_fever');
+        expect(() => parseHealthAnomalyEpisodeOutcome(result)).not.toThrow();
+    });
+
     it('bounds free text and trims an empty note to null', () => {
         const empty = buildHealthAnomalyEpisodeOutcome({
             userId: 'u1', episodeId: 'episode-1', sourceAssessment,

--- a/app/src/engine/healthAnomalyOutcome.ts
+++ b/app/src/engine/healthAnomalyOutcome.ts
@@ -1,5 +1,6 @@
 export const HEALTH_ANOMALY_OUTCOME_EXPLANATIONS = [
     'illness_symptoms',
+    'allergy_or_hay_fever',
     'hard_training_recovery',
     'poor_sleep',
     'alcohol',

--- a/app/src/engine/healthContextContract.test.ts
+++ b/app/src/engine/healthContextContract.test.ts
@@ -151,6 +151,35 @@ describe('HA1 validateCheckin migration contract', () => {
             healthContext: { symptoms: { present: false, types: ['cough'] } },
         })).isValid).toBe(false);
     });
+
+    it('accepts the allergy-oriented symptom types and a suspected cause', () => {
+        const result = validateCheckin(writePayload({
+            healthContext: {
+                symptoms: {
+                    present: true,
+                    severity: 'mild',
+                    types: ['sneezing', 'runny_nose'],
+                    suspectedCause: 'allergy',
+                },
+            },
+        }));
+        expect(result.isValid).toBe(true);
+        expect(result.data?.healthContext?.symptoms).toEqual({
+            present: true,
+            severity: 'mild',
+            types: ['sneezing', 'runny_nose'],
+            suspectedCause: 'allergy',
+        });
+    });
+
+    it('rejects an unrecognized suspectedCause and a stale one on a cleared symptom', () => {
+        expect(validateCheckin(writePayload({
+            healthContext: { symptoms: { present: true, suspectedCause: 'viral' } },
+        })).isValid).toBe(false);
+        expect(validateCheckin(writePayload({
+            healthContext: { symptoms: { present: false, suspectedCause: 'allergy' } },
+        })).isValid).toBe(false);
+    });
 });
 
 describe('HA1 parseSubjectiveCheckin migration contract', () => {
@@ -221,5 +250,20 @@ describe('HA1 parseSubjectiveCheckin migration contract', () => {
             healthContext: { timezoneShiftHours: 15 },
         }), PATH, 'u1', DATE);
         expect(invalidRange.status).toBe('INVALID');
+    });
+
+    it('round-trips the allergy-oriented symptom types and suspected cause on read', () => {
+        const parsed = parseSubjectiveCheckin(storedPayload({
+            healthContext: {
+                symptoms: { present: true, types: ['sneezing', 'runny_nose'], suspectedCause: 'allergy' },
+            },
+        }), PATH, 'u1', DATE);
+        expect(parsed.status).toBe('AVAILABLE');
+        if (parsed.status !== 'AVAILABLE') throw new Error('expected available');
+        expect(parsed.data.healthContext?.symptoms).toEqual({
+            present: true,
+            types: ['sneezing', 'runny_nose'],
+            suspectedCause: 'allergy',
+        });
     });
 });

--- a/app/src/engine/healthContextValidation.ts
+++ b/app/src/engine/healthContextValidation.ts
@@ -16,9 +16,12 @@ export const HEALTH_TRAVEL_DISRUPTIONS = [
 
 export const HEALTH_SYMPTOM_ONSETS = ['today', 'yesterday', '2_3_days', 'earlier'] as const;
 export const HEALTH_SYMPTOM_SEVERITIES = ['mild', 'moderate', 'severe'] as const;
+export const HEALTH_SYMPTOM_SUSPECTED_CAUSES = ['infectious', 'allergy', 'unsure'] as const;
 export const HEALTH_SYMPTOM_TYPES: readonly HealthSymptomType[] = [
     'sore_throat',
     'congestion',
+    'runny_nose',
+    'sneezing',
     'cough',
     'fever_or_chills',
     'headache_or_body_aches',
@@ -46,7 +49,7 @@ const HEALTH_CONTEXT_KEYS = new Set([
     'symptoms',
 ]);
 
-const HEALTH_SYMPTOM_KEYS = new Set(['present', 'onset', 'severity', 'types']);
+const HEALTH_SYMPTOM_KEYS = new Set(['present', 'onset', 'severity', 'types', 'suspectedCause']);
 
 export interface HealthContextValidationError {
     field: string;
@@ -96,7 +99,7 @@ function validateSymptoms(
         return undefined;
     }
 
-    const nestedFields = ['onset', 'severity', 'types'] as const;
+    const nestedFields = ['onset', 'severity', 'types', 'suspectedCause'] as const;
     if (!raw.present) {
         for (const field of nestedFields) {
             if (raw[field] !== undefined && raw[field] !== null) {
@@ -126,6 +129,14 @@ function validateSymptoms(
             value: raw.severity,
         });
     }
+    if (raw.suspectedCause !== undefined && raw.suspectedCause !== null
+        && !isOneOf(raw.suspectedCause, HEALTH_SYMPTOM_SUSPECTED_CAUSES)) {
+        errors.push({
+            field: 'healthContext.symptoms.suspectedCause',
+            message: `suspectedCause must be one of: ${HEALTH_SYMPTOM_SUSPECTED_CAUSES.join(', ')}`,
+            value: raw.suspectedCause,
+        });
+    }
 
     let types: HealthSymptomType[] | null | undefined;
     if (raw.types === null) {
@@ -149,6 +160,7 @@ function validateSymptoms(
         ...(raw.onset === null ? { onset: null } : isOneOf(raw.onset, HEALTH_SYMPTOM_ONSETS) ? { onset: raw.onset } : {}),
         ...(raw.severity === null ? { severity: null } : isOneOf(raw.severity, HEALTH_SYMPTOM_SEVERITIES) ? { severity: raw.severity } : {}),
         ...(types !== undefined ? { types } : {}),
+        ...(raw.suspectedCause === null ? { suspectedCause: null } : isOneOf(raw.suspectedCause, HEALTH_SYMPTOM_SUSPECTED_CAUSES) ? { suspectedCause: raw.suspectedCause } : {}),
     };
 }
 

--- a/app/src/engine/policy.ts
+++ b/app/src/engine/policy.ts
@@ -1,5 +1,5 @@
 /** Increment whenever a change can alter a persisted recommendation decision. (Refactoring does not require a bump) */
-export const POLICY_VERSION = '2026-08-recovery-window-propagation-v1';
+export const POLICY_VERSION = '2026-08-allergy-symptom-gating-v1';
 
 /** Historical versions are intentionally not re-executed by this build. Their compact
  * audits remain readable evidence, but replay is rejected explicitly because the old

--- a/app/src/feedback/feedbackModels.ts
+++ b/app/src/feedback/feedbackModels.ts
@@ -12,6 +12,7 @@ export type ModificationReason =
     | 'feeling_strong'
     | 'muscle_joint_pain'
     | 'illness_symptoms'
+    | 'allergy_symptoms'
     | 'weather_equipment'
     | 'social_group_ride'
     | 'other';

--- a/app/src/feedback/feedbackValidation.test.ts
+++ b/app/src/feedback/feedbackValidation.test.ts
@@ -27,6 +27,18 @@ describe('feedbackValidation', () => {
             expect(parsed.reasons).toEqual(['feeling_fatigued', 'time_constraint']);
         });
 
+        it('accepts the allergy_symptoms reason', () => {
+            const valid = {
+                date: '2026-08-26',
+                recommendationRef: { recommendationId: 'rec-123', revision: 1 },
+                action: 'scaled_down',
+                reasons: ['allergy_symptoms'],
+                note: null,
+                decidedAt: '2026-08-26T07:30:00Z',
+            };
+            expect(parseAthleteDecisionLog(valid).reasons).toEqual(['allergy_symptoms']);
+        });
+
         it('rejects invalid action', () => {
             const invalid = {
                 date: '2026-08-26',

--- a/app/src/feedback/feedbackValidation.ts
+++ b/app/src/feedback/feedbackValidation.ts
@@ -33,6 +33,7 @@ const VALID_REASONS: readonly ModificationReason[] = [
     'feeling_strong',
     'muscle_joint_pain',
     'illness_symptoms',
+    'allergy_symptoms',
     'weather_equipment',
     'social_group_ride',
     'other',

--- a/app/src/services/checkinHealthContext.test.ts
+++ b/app/src/services/checkinHealthContext.test.ts
@@ -66,6 +66,7 @@ describe('CheckinService HA1 health-context persistence', () => {
             onset: DELETE_FIELD_SENTINEL,
             severity: DELETE_FIELD_SENTINEL,
             types: DELETE_FIELD_SENTINEL,
+            suspectedCause: DELETE_FIELD_SENTINEL,
         });
     });
 
@@ -101,6 +102,7 @@ describe('CheckinService HA1 health-context persistence', () => {
             onset: DELETE_FIELD_SENTINEL,
             severity: DELETE_FIELD_SENTINEL,
             types: DELETE_FIELD_SENTINEL,
+            suspectedCause: DELETE_FIELD_SENTINEL,
         });
     });
 
@@ -122,8 +124,33 @@ describe('CheckinService HA1 health-context persistence', () => {
             onset: DELETE_FIELD_SENTINEL,
             severity: DELETE_FIELD_SENTINEL,
             types: DELETE_FIELD_SENTINEL,
+            suspectedCause: DELETE_FIELD_SENTINEL,
         });
         expect(firestore.setDoc.mock.calls[0][2]).toEqual({ merge: true });
+    });
+
+    it('persists an allergy-attributed symptom report with its suspected cause and types', async () => {
+        await new CheckinService().upsertCheckin('u1', {
+            ...baseCheckin,
+            illnessSymptoms: true,
+            healthContext: {
+                symptoms: {
+                    present: true,
+                    severity: 'mild',
+                    types: ['sneezing', 'runny_nose'],
+                    suspectedCause: 'allergy',
+                },
+            },
+        });
+
+        const payload = firestore.setDoc.mock.calls[0][1] as { healthContext: { symptoms: Record<string, unknown> } };
+        expect(payload.healthContext.symptoms).toEqual({
+            present: true,
+            onset: DELETE_FIELD_SENTINEL,
+            severity: 'mild',
+            types: ['sneezing', 'runny_nose'],
+            suspectedCause: 'allergy',
+        });
     });
 
     it('rejects a clear carrying stale symptom details before writing', async () => {

--- a/app/src/services/checkinService.ts
+++ b/app/src/services/checkinService.ts
@@ -29,6 +29,7 @@ function healthContextMergeValue(context: DailySubjectiveCheckin['healthContext'
                 onset: valueOrDelete(symptoms.onset),
                 severity: valueOrDelete(symptoms.severity),
                 types: valueOrDelete(symptoms.types),
+                suspectedCause: valueOrDelete(symptoms.suspectedCause),
             }
             : deleteField(),
     };

--- a/docs/adr/0031-cause-aware-subjective-symptom-gating.md
+++ b/docs/adr/0031-cause-aware-subjective-symptom-gating.md
@@ -1,0 +1,53 @@
+# ADR-0031: Cause-Aware Subjective Symptom Gating
+
+* **Status:** Accepted
+* **Date:** 2026-08-29
+* **Deciders:** Core Engineering Team
+
+## Context
+
+The morning check-in historically collapsed both `painOrInjury` and `illnessSymptoms` into the engine's `SubjectiveInput.painFlag`. In `rules.ts`, that flag is intentionally conservative: it activates the clinical safety envelope, adds a Running restriction, and caps the plan at Mobility. That is appropriate for undifferentiated illness or injury, but it also treated athlete-reported hay-fever symptoms exactly like systemic infection.
+
+PR #282 adds a richer symptom vocabulary (`congestion`, `runny_nose`, `sneezing`, etc.) and an athlete-reported `suspectedCause`. That makes a narrow allergy exception possible, but it also creates a false-negative risk: selecting `allergy` is a self-report, not a diagnosis, and clearing `painFlag` removes a strong training restriction.
+
+Sports-medicine guidance supports distinguishing non-infective respiratory illness from acute respiratory infection, while also emphasizing diagnostic uncertainty and overlap between allergic rhinitis, asthma and exercise-induced bronchoconstriction. The app currently has no dedicated wheeze, chest-tightness, dyspnoea, exercise-induced bronchoconstriction or objective allergy-diagnosis fields, so ambiguous respiratory presentations cannot safely be inferred to be benign allergy.
+
+Research anchors:
+
+- IOC consensus on acute respiratory illness in athletes, part 1 (acute respiratory infections): https://pubmed.ncbi.nlm.nih.gov/35863871/
+- IOC consensus on acute respiratory illness in athletes, part 2 (non-infective respiratory illness): https://pubmed.ncbi.nlm.nih.gov/35623888/
+- EAACI position paper on allergy and respiratory disorders in sport: https://pubmed.ncbi.nlm.nih.gov/35809082/
+- Polish Society of Allergology / Polish Society of Sports Medicine position paper on asthma and exercise-induced respiratory disorders in athletes: https://pubmed.ncbi.nlm.nih.gov/30858772/
+
+## Decision
+
+- **D-ALLERGY-SELF-REPORT:** `suspectedCause` records the athlete's own attribution. It is never treated as a diagnosis and is never inferred from symptom types or wearable physiology.
+- **D-ALLERGY-FAIL-CLOSED:** the legacy illness safety behavior remains the default. Missing or ambiguous detail must not soften `painFlag`.
+- **D-ALLERGY-EXPLICIT-SEVERITY:** an allergy-attributed day may soften the illness contribution to `painFlag` only when severity is explicitly `mild` or `moderate`. Missing, `null` or `severe` severity remains conservative.
+- **D-ALLERGY-NASAL-SHAPE:** symptom types must be present and non-empty, and every reported type must be one of `congestion`, `runny_nose`, or `sneezing`.
+- **D-ALLERGY-BROAD-SYMPTOMS:** `sore_throat`, `cough`, `fever_or_chills`, `headache_or_body_aches`, `gastrointestinal`, `unusual_fatigue`, `other`, or any future type not added deliberately to the allow-list keeps the existing illness gate active even when the athlete selects `allergy`.
+- **D-ALLERGY-INJURY-AUTHORITY:** `painOrInjury` remains unconditional. Allergy attribution can only remove the `illnessSymptoms` contribution; it can never loosen an injury/tissue restriction.
+- **D-ALLERGY-BOUNDARY:** the decision stays in `adapters.ts::mapCheckinToSubjectiveInput`. `rules.ts` continues to consume a simple `painFlag` and owns the safety-envelope consequence. This keeps persistence vocabulary separate from the narrower decision-eligible subset.
+- **D-ALLERGY-ANOMALY-ORTHOGONAL:** physiological-anomaly reporting may retain symptom/cause context independently. The real-time training exception does not erase abnormal measurements, prove an allergy diagnosis, or reclassify an anomaly as infectious/non-infectious disease.
+
+## Consequences
+
+The rule intentionally prefers false positives (an unnecessary conservative day) over false negatives at the clinical-gating boundary. A real allergy presentation that includes cough, sore throat or another broader symptom will still be restricted until the health-context model can represent the respiratory red flags and/or stronger diagnostic evidence needed to distinguish allergic rhinitis from infection or exercise-induced airway disease.
+
+The positive allow-list is also safer under schema evolution than a blacklist: a newly added symptom type remains conservative automatically until the decision policy explicitly reviews it.
+
+`POLICY_VERSION` remains `2026-08-allergy-symptom-gating-v1` because this hardening is part of the same unmerged policy change introduced by PR #282, not a post-release policy revision.
+
+## Verification
+
+`adapters.test.ts` must cover at least:
+
+- the valid mild and moderate nasal-allergy paths;
+- missing and `null` severity;
+- missing symptom types;
+- severe symptoms;
+- every current non-nasal symptom type;
+- `infectious`, `unsure` and absent cause;
+- unconditional `painOrInjury` authority.
+
+Firestore validation remains permissive enough to store honest athlete reports; the adapter is responsible for deciding whether that report is sufficiently specific to relax the recommendation safety gate. Policy-drift checks must continue to treat `adapters.ts` as decision-affecting.

--- a/docs/plans/allergy-and-cause-aware-symptom-reporting.md
+++ b/docs/plans/allergy-and-cause-aware-symptom-reporting.md
@@ -1,0 +1,166 @@
+# Allergy / cause-aware symptom reporting — implementation plan
+
+Status: **proposed, not yet implemented**. Worktree: `.claude/worktrees/symptom-reporting`,
+branch `feat/subjective-symptom-reporting`.
+
+## 1. The gap, precisely
+
+You've had 2 days of sneezing + runny/stuffed nose and can't log it. This isn't a missing
+"symptoms" field in general — the app already has a fairly rich subjective symptom pipeline
+(`DailySubjectiveCheckin.illnessSymptoms` boolean → `healthContext.symptoms` detail block with
+onset/severity/types). The actual gaps are narrower and land in three places:
+
+1. **Symptom vocabulary is missing exactly your symptoms.** `HealthSymptomType`
+   ([healthAnomalyModels.ts:40-48](app/src/engine/healthAnomalyModels.ts:40)) only has:
+   `sore_throat, congestion, cough, fever_or_chills, headache_or_body_aches, gastrointestinal,
+   unusual_fatigue, other`. There's no `sneezing`, and `congestion` only weakly covers a stuffy
+   nose — it doesn't capture a *runny* nose, which is a distinct and common allergy symptom.
+
+2. **No way to say "this is allergy, not infection."** The only lever is the top-level
+   `illnessSymptoms` boolean, and today it is undifferentiated:
+   - [adapters.ts:152](app/src/engine/adapters.ts:152) — `painFlag: checkin.painOrInjury ||
+     checkin.illnessSymptoms` — folds "I have hay fever" into the exact same flag as a
+     diagnosed injury.
+   - [rules.ts:744-748](app/src/engine/rules.ts:744) — that `painFlag` (as `isPain`) sets
+     `clinicalFlagActive = true`, **restricts Running**, and caps `maxAllowableTier`. Two days
+     of sneezing gets the same modality restriction and tier cap as a torn muscle or the flu.
+   - [healthAnomaly.ts:445-446](app/src/engine/healthAnomaly.ts:445) — any `symptoms.present`
+     marks today's physiological anomaly (elevated RHR/suppressed HRV, etc.) as "explained by
+     illness," which pollutes the HA6 evidence dataset if the real cause was pollen, not a
+     virus.
+   - The after-the-fact anomaly explanation flow (`HEALTH_ANOMALY_OUTCOME_EXPLANATIONS` in
+     [healthAnomalyOutcome.ts:1-12](app/src/engine/healthAnomalyOutcome.ts:1)) offers 10 causes
+     — `illness_symptoms, hard_training_recovery, poor_sleep, alcohol, travel_jetlag, stress,
+     heat_dehydration, vaccination_medication, nothing_obvious, other_not_sure` — again no
+     allergy option, forcing either a false `illness_symptoms` label or a signal-losing
+     `other_not_sure`.
+
+3. **Same gap in the athlete-decision-feedback vocabulary.** `ModificationReason` in
+   [feedbackModels.ts:12-18](app/src/feedback/feedbackModels.ts:12) (used when logging why you
+   scaled down/rejected a recommendation) has `illness_symptoms` and `muscle_joint_pain` but no
+   allergy option either. Independent subsystem, same root cause.
+
+## 2. Two phases — a vocabulary fix, and an optional behavior fix
+
+**Phase 1 (recommended, low risk): let you say what's happening.** Add the missing symptom
+types and an allergy cause option everywhere the vocabulary is enumerated. Zero change to how
+the engine reacts — `illnessSymptoms: true` still triggers today's clinical-flag/Running-
+restriction path exactly as now. This alone unblocks logging.
+
+**Phase 2 (optional — needs your explicit go-ahead, not bundled by default): stop treating mild
+hay fever like an injury.** Use the new cause/severity detail to soften the
+`painFlag`/`clinicalFlagActive` gate specifically for mild, purely-upper-respiratory,
+allergy-attributed days. This changes actual recommendation output, so it needs a product
+decision and a simulation baseline diff, not just a data-model add. See §5.
+
+I'd suggest shipping Phase 1 now regardless of what you decide on Phase 2 — it's what's
+actually blocking you today.
+
+## 3. Phase 1 — file-by-file
+
+| # | File | Change |
+|---|------|--------|
+| 1 | [app/src/engine/healthAnomalyModels.ts](app/src/engine/healthAnomalyModels.ts:40) | Add `'sneezing'`, `'runny_nose'` to the `HealthSymptomType` union. |
+| 2 | [app/src/engine/healthContextValidation.ts](app/src/engine/healthContextValidation.ts:19) | Add the same two values to `HEALTH_SYMPTOM_TYPES`. The max-length check at line 135 (`raw.types.length > HEALTH_SYMPTOM_TYPES.length`) is already derived from this array's length, so no separate cap to update here. |
+| 3 | [app/firestore.rules](app/firestore.rules:285) | `hasValidHealthSymptoms.types.hasOnly([...])` — add `'sneezing'`, `'runny_nose'`; bump the hardcoded `symptoms.types.size() <= 8` to `<= 10`. Also extend the `data.explanation in [...]` enum at line ~1344 with the new cause value (see row 5). |
+| 4 | [app/src/engine/healthAnomalyOutcome.ts](app/src/engine/healthAnomalyOutcome.ts:1) | Add `'allergy_or_hay_fever'` to `HEALTH_ANOMALY_OUTCOME_EXPLANATIONS`. |
+| 5 | [app/src/components/checkin/HealthContextSection.tsx](app/src/components/checkin/HealthContextSection.tsx:57) | Add `{ value: 'sneezing', label: 'Sneezing' }` and `{ value: 'runny_nose', label: 'Runny nose' }` to `SYMPTOM_TYPES`. Keep "Congestion" — the three together describe hay fever precisely (stuffy vs. runny vs. sneeze are genuinely distinct and can occur independently). |
+| 6 | [app/src/components/HealthAnomalyFollowupCard.tsx](app/src/components/HealthAnomalyFollowupCard.tsx:17) | Add `allergy_or_hay_fever: 'Seasonal allergy / hay fever'` to `EXPLANATION_LABELS`. Because this is a `Record<HealthAnomalyOutcomeExplanation, string>` over the exact union, TypeScript will hard-fail `npm run check` if this is forgotten once row 4 lands — a free safety net, not extra work to verify separately. |
+| 7 (optional, separate subsystem) | [app/src/feedback/feedbackModels.ts](app/src/feedback/feedbackModels.ts:12) + [feedbackValidation.ts](app/src/feedback/feedbackValidation.ts:29) | Add `'allergy_symptoms'` to `ModificationReason` + `VALID_REASONS`, so "I scaled this down because of allergies" doesn't have to misreport as `illness_symptoms`. Independent of rows 1-6; can ship in the same PR or later. |
+
+### Naming to confirm before I implement
+- Explanation value: `allergy_or_hay_fever` vs. `seasonal_allergy` vs. `allergies` — I lean
+  toward `allergy_or_hay_fever` to match the existing style (`heat_dehydration`,
+  `vaccination_medication` are already compound).
+- Whether to keep `sneezing`/`runny_nose` as two separate types (my preference, consistent with
+  the existing fine-grained split of `cough`/`sore_throat`/`congestion` rather than one combined
+  `rhinitis` type) or merge them.
+
+### Tests to add/update
+- `healthContextDefaults.test.ts`, `healthContextContract.test.ts`,
+  `checkinHealthContext.test.ts` — new types round-trip through
+  `normalizeHealthContext`/the parser.
+- `app/src/emulator/healthContextRules.emulator.test.ts` — accept a doc with
+  `types: ['sneezing','runny_nose']`; keep the existing over-length rejection case correct
+  against the new cap.
+- `app/src/emulator/healthAnomalyOutcomeRules.emulator.test.ts` — accept
+  `explanation: 'allergy_or_hay_fever'`.
+- `healthAnomalyOutcome.test.ts` — any test iterating `HEALTH_ANOMALY_OUTCOME_EXPLANATIONS`
+  picks the new value up automatically; add one explicit case.
+- `HealthAnomalyFollowupCard.test.tsx` — label rendering for the new option.
+- `decisionInputs.test.ts` / `checkinService.test.ts` — parser round-trip for the two new
+  symptom types.
+- `wellnessLanguageAudit.test.ts` — re-run as-is to confirm the new copy doesn't trip the
+  no-diagnostic-language checks (it audits existing rationale/label strings; new UI-only labels
+  should already comply if phrased as self-report, e.g. avoid asserting anything the user didn't
+  say).
+- If row 7 is included: `feedbackValidation.test.ts` for the new `ModificationReason`.
+- New cross-check test worth adding: assert `firestore.rules`' hardcoded symptom-type list/size
+  and explanation enum stay in sync with `HEALTH_SYMPTOM_TYPES` /
+  `HEALTH_ANOMALY_OUTCOME_EXPLANATIONS` — rules can't import TS constants, so this pairing is a
+  manual-sync risk today (nothing currently catches drift between them the way
+  `decisionJournal.test.ts` guards `SHADOW_VERDICTS` against `externalSession.ts`). A simple
+  test that reads `firestore.rules` as text and regex-extracts the enum list, then diffs it
+  against the TS constant, would close this permanently rather than just for this change.
+
+### Rollout checklist (Phase 1)
+```bash
+cd app && npm run check        # TS/ESLint/Vitest/workout catalog
+cd app && npm run test:rules   # Firestore emulator rules tests — mandatory, firestore.rules changed
+```
+Then `make check` before opening a PR per repo convention.
+
+## 4. What Phase 1 deliberately does *not* change
+
+- `DailySubjectiveCheckin.illnessSymptoms` semantics — still the single top-level safety gate,
+  unchanged.
+- Any recommendation/engine behavior — `rules.ts`, `adapters.ts` untouched in Phase 1.
+- No retroactive fix for the 2 days already passed — this only unblocks logging from today
+  onward. Backfilling those two days isn't proposed here; say if you want it and I'll size it
+  separately (it'd mean writing historical `daily_subjective_checkins` docs by hand for
+  yesterday and the day before, which is a data-integrity call worth its own confirmation, not
+  a side effect of this feature).
+
+## 5. Phase 2 (optional) — cause-aware gating, only if you want it
+
+The real behavioral complaint underneath the missing fields: right now, ticking
+"illness symptoms" for 2 days of mild sneezing gets you the *same* Running restriction and tier
+cap as a flu or an injury. If you want that softened specifically for mild,
+allergy-attributed, purely-upper-respiratory days:
+
+1. Add `suspectedCause?: 'infectious' | 'allergy' | 'unsure' | null` to `HealthSymptomsCheckin`
+   ([healthAnomalyModels.ts:32](app/src/engine/healthAnomalyModels.ts:32)), threaded through
+   `healthContextValidation.ts`, `firestore.rules`, and a third chip row in
+   `HealthContextSection.tsx` (shown once symptoms are present).
+2. In [adapters.ts:152](app/src/engine/adapters.ts:152), change `painFlag` to fold in
+   `illnessSymptoms` only when NOT (`suspectedCause === 'allergy'` AND `severity !== 'severe'`
+   AND no `fever_or_chills`/`gastrointestinal`/`unusual_fatigue` type reported). Keep
+   `painOrInjury` unconditional — that boolean is untouched either way. Doing the judgment call
+   here, in the adapter, rather than in `rules.ts`, keeps `evaluateEnvelopes`'s
+   `isPain = readiness.subjective.painFlag` contract exactly as simple as it is today.
+3. Decide (this is the actual product call, not an engineering one): should an
+   allergy-explained physiological anomaly still count as "explained" in `healthAnomaly.ts:445`?
+   Probably yes — allergies genuinely can elevate RHR/suppress HRV — but you may want the HA6
+   *evidence label* to record cause separately from the real-time *state machine* treatment, so
+   future model tuning can tell allergy-explained days from virus-explained days even though
+   both currently short-circuit to "explained."
+4. Tests: `rules.test.ts`, `adapters.test.ts`, `healthAnomaly.test.ts`,
+   `wellnessLanguageAudit.test.ts` (new rationale copy must stay self-reported, not diagnostic —
+   e.g. "You're flagging allergy symptoms today" not "You have allergies").
+5. Because this changes recommendation output for a real subset of scenarios, run
+   `npm run simulate:scenarios && npm run simulate:diff` and
+   `node scripts/check-policy-drift.mjs <base-sha>` before merging — this is exactly the kind of
+   policy drift those scripts exist to catch.
+
+**Why I'm not just building this by default:** under-restricting someone whose "probably
+allergies" is actually early-stage flu is the real failure mode here, and it's a judgment call
+about how much slack to give, not something to bake in opportunistically alongside a vocabulary
+fix. If you want Phase 2, say so and I'll turn §5 into the same level of file-by-file detail as
+§3 before touching code.
+
+## 6. Suggested sequencing
+
+1. Confirm naming (§3) and whether row 7 (feedback vocabulary) is in scope.
+2. Implement Phase 1 in this worktree, on `feat/subjective-symptom-reporting`.
+3. `npm run check` + `npm run test:rules`, fix any fallout.
+4. Decide on Phase 2 separately, as its own follow-up if wanted.

--- a/docs/plans/allergy-and-cause-aware-symptom-reporting.md
+++ b/docs/plans/allergy-and-cause-aware-symptom-reporting.md
@@ -2,7 +2,8 @@
 
 Status: **implemented**. Worktree: `.claude/worktrees/symptom-reporting`,
 branch `feat/subjective-symptom-reporting`. See §7 for what shipped and how it differs from
-this document's original sketch.
+this document's original sketch. The final safety decision is recorded in
+[ADR-0031](../adr/0031-cause-aware-subjective-symptom-gating.md).
 
 ## 1. The gap, precisely
 
@@ -11,177 +12,177 @@ You've had 2 days of sneezing + runny/stuffed nose and can't log it. This isn't 
 (`DailySubjectiveCheckin.illnessSymptoms` boolean → `healthContext.symptoms` detail block with
 onset/severity/types). The actual gaps are narrower and land in three places:
 
-1. **Symptom vocabulary is missing exactly your symptoms.** `HealthSymptomType`
-   ([healthAnomalyModels.ts:40-48](app/src/engine/healthAnomalyModels.ts:40)) only has:
+1. **Symptom vocabulary is missing exactly your symptoms.**
+   [`HealthSymptomType`](../../app/src/engine/healthAnomalyModels.ts) originally only had:
    `sore_throat, congestion, cough, fever_or_chills, headache_or_body_aches, gastrointestinal,
-   unusual_fatigue, other`. There's no `sneezing`, and `congestion` only weakly covers a stuffy
-   nose — it doesn't capture a *runny* nose, which is a distinct and common allergy symptom.
+   unusual_fatigue, other`. There was no `sneezing`, and `congestion` only weakly covered a
+   stuffy nose — it did not capture a *runny* nose, which is a distinct and common allergy
+   symptom.
 
-2. **No way to say "this is allergy, not infection."** The only lever is the top-level
-   `illnessSymptoms` boolean, and today it is undifferentiated:
-   - [adapters.ts:152](app/src/engine/adapters.ts:152) — `painFlag: checkin.painOrInjury ||
-     checkin.illnessSymptoms` — folds "I have hay fever" into the exact same flag as a
-     diagnosed injury.
-   - [rules.ts:744-748](app/src/engine/rules.ts:744) — that `painFlag` (as `isPain`) sets
-     `clinicalFlagActive = true`, **restricts Running**, and caps `maxAllowableTier`. Two days
-     of sneezing gets the same modality restriction and tier cap as a torn muscle or the flu.
-   - [healthAnomaly.ts:445-446](app/src/engine/healthAnomaly.ts:445) — any `symptoms.present`
-     marks today's physiological anomaly (elevated RHR/suppressed HRV, etc.) as "explained by
-     illness," which pollutes the HA6 evidence dataset if the real cause was pollen, not a
-     virus.
-   - The after-the-fact anomaly explanation flow (`HEALTH_ANOMALY_OUTCOME_EXPLANATIONS` in
-     [healthAnomalyOutcome.ts:1-12](app/src/engine/healthAnomalyOutcome.ts:1)) offers 10 causes
-     — `illness_symptoms, hard_training_recovery, poor_sleep, alcohol, travel_jetlag, stress,
-     heat_dehydration, vaccination_medication, nothing_obvious, other_not_sure` — again no
-     allergy option, forcing either a false `illness_symptoms` label or a signal-losing
+2. **No way to say "this is allergy, not infection."** The only lever was the top-level
+   `illnessSymptoms` boolean, and it was undifferentiated:
+   - [`mapCheckinToSubjectiveInput`](../../app/src/engine/adapters.ts) mapped
+     `painFlag: checkin.painOrInjury || checkin.illnessSymptoms`, folding "I have hay fever"
+     into the exact same flag as a diagnosed injury.
+   - [`evaluateEnvelopes`](../../app/src/engine/rules.ts) consumes that `painFlag` as `isPain`,
+     activates `clinicalFlagActive`, **restricts Running**, and caps `maxAllowableTier`. Two
+     days of sneezing therefore got the same modality restriction and tier cap as a torn
+     muscle or undifferentiated illness.
+   - [`evaluatePhysiologicalAnomaly`](../../app/src/engine/healthAnomaly.ts) separately records
+     whether symptoms were reported as part of the physiological-anomaly state. That subsystem
+     must retain observed physiology/context independently of whether the real-time training
+     gate is softened.
+   - The after-the-fact anomaly explanation flow,
+     [`HEALTH_ANOMALY_OUTCOME_EXPLANATIONS`](../../app/src/engine/healthAnomalyOutcome.ts), had
+     `illness_symptoms, hard_training_recovery, poor_sleep, alcohol, travel_jetlag, stress,
+     heat_dehydration, vaccination_medication, nothing_obvious, other_not_sure` — no allergy
+     option, forcing either a false `illness_symptoms` label or a signal-losing
      `other_not_sure`.
 
-3. **Same gap in the athlete-decision-feedback vocabulary.** `ModificationReason` in
-   [feedbackModels.ts:12-18](app/src/feedback/feedbackModels.ts:12) (used when logging why you
-   scaled down/rejected a recommendation) has `illness_symptoms` and `muscle_joint_pain` but no
-   allergy option either. Independent subsystem, same root cause.
+3. **Same gap in the athlete-decision-feedback vocabulary.**
+   [`ModificationReason`](../../app/src/feedback/feedbackModels.ts), used when logging why an
+   athlete scaled down/rejected a recommendation, had `illness_symptoms` and
+   `muscle_joint_pain` but no allergy option either. Independent subsystem, same root cause.
 
-## 2. Two phases — a vocabulary fix, and an optional behavior fix
+## 2. Two phases — a vocabulary fix, and a behavior fix
 
-**Phase 1 (recommended, low risk): let you say what's happening.** Add the missing symptom
-types and an allergy cause option everywhere the vocabulary is enumerated. Zero change to how
-the engine reacts — `illnessSymptoms: true` still triggers today's clinical-flag/Running-
-restriction path exactly as now. This alone unblocks logging.
+**Phase 1 (low risk): let the athlete say what's happening.** Add the missing symptom types
+and an allergy cause option everywhere the vocabulary is enumerated. By itself this does not
+need to change how the engine reacts.
 
-**Phase 2 (optional — needs your explicit go-ahead, not bundled by default): stop treating mild
-hay fever like an injury.** Use the new cause/severity detail to soften the
-`painFlag`/`clinicalFlagActive` gate specifically for mild, purely-upper-respiratory,
-allergy-attributed days. This changes actual recommendation output, so it needs a product
-decision and a simulation baseline diff, not just a data-model add. See §5.
-
-I'd suggest shipping Phase 1 now regardless of what you decide on Phase 2 — it's what's
-actually blocking you today.
+**Phase 2 (decision-affecting): stop treating a narrowly defined allergic-rhinitis-style day
+like an injury.** Use the new cause/severity/type detail to soften the
+`painFlag`/`clinicalFlagActive` path only when the report is explicit enough to pass a
+fail-closed predicate. This changes actual recommendation output, so it requires a policy
+version, targeted regression coverage and policy-drift checks. See §5 and ADR-0031.
 
 ## 3. Phase 1 — file-by-file
 
 | # | File | Change |
 |---|------|--------|
-| 1 | [app/src/engine/healthAnomalyModels.ts](app/src/engine/healthAnomalyModels.ts:40) | Add `'sneezing'`, `'runny_nose'` to the `HealthSymptomType` union. |
-| 2 | [app/src/engine/healthContextValidation.ts](app/src/engine/healthContextValidation.ts:19) | Add the same two values to `HEALTH_SYMPTOM_TYPES`. The max-length check at line 135 (`raw.types.length > HEALTH_SYMPTOM_TYPES.length`) is already derived from this array's length, so no separate cap to update here. |
-| 3 | [app/firestore.rules](app/firestore.rules:285) | `hasValidHealthSymptoms.types.hasOnly([...])` — add `'sneezing'`, `'runny_nose'`; bump the hardcoded `symptoms.types.size() <= 8` to `<= 10`. Also extend the `data.explanation in [...]` enum at line ~1344 with the new cause value (see row 5). |
-| 4 | [app/src/engine/healthAnomalyOutcome.ts](app/src/engine/healthAnomalyOutcome.ts:1) | Add `'allergy_or_hay_fever'` to `HEALTH_ANOMALY_OUTCOME_EXPLANATIONS`. |
-| 5 | [app/src/components/checkin/HealthContextSection.tsx](app/src/components/checkin/HealthContextSection.tsx:57) | Add `{ value: 'sneezing', label: 'Sneezing' }` and `{ value: 'runny_nose', label: 'Runny nose' }` to `SYMPTOM_TYPES`. Keep "Congestion" — the three together describe hay fever precisely (stuffy vs. runny vs. sneeze are genuinely distinct and can occur independently). |
-| 6 | [app/src/components/HealthAnomalyFollowupCard.tsx](app/src/components/HealthAnomalyFollowupCard.tsx:17) | Add `allergy_or_hay_fever: 'Seasonal allergy / hay fever'` to `EXPLANATION_LABELS`. Because this is a `Record<HealthAnomalyOutcomeExplanation, string>` over the exact union, TypeScript will hard-fail `npm run check` if this is forgotten once row 4 lands — a free safety net, not extra work to verify separately. |
-| 7 (optional, separate subsystem) | [app/src/feedback/feedbackModels.ts](app/src/feedback/feedbackModels.ts:12) + [feedbackValidation.ts](app/src/feedback/feedbackValidation.ts:29) | Add `'allergy_symptoms'` to `ModificationReason` + `VALID_REASONS`, so "I scaled this down because of allergies" doesn't have to misreport as `illness_symptoms`. Independent of rows 1-6; can ship in the same PR or later. |
+| 1 | [`healthAnomalyModels.ts`](../../app/src/engine/healthAnomalyModels.ts) | Add `'sneezing'`, `'runny_nose'` to `HealthSymptomType`. |
+| 2 | [`healthContextValidation.ts`](../../app/src/engine/healthContextValidation.ts) | Add the same values to `HEALTH_SYMPTOM_TYPES`; `validateSymptoms` derives its type-count bound from that array. |
+| 3 | [`firestore.rules`](../../app/firestore.rules) | Extend `hasValidHealthSymptoms` with the two types, update the hardcoded maximum from 8 to 10, add `suspectedCause`, and extend the health-anomaly outcome explanation allow-list. |
+| 4 | [`healthAnomalyOutcome.ts`](../../app/src/engine/healthAnomalyOutcome.ts) | Add `'allergy_or_hay_fever'` to `HEALTH_ANOMALY_OUTCOME_EXPLANATIONS`. |
+| 5 | [`HealthContextSection.tsx`](../../app/src/components/checkin/HealthContextSection.tsx) | Add `Sneezing` and `Runny nose` to `SYMPTOM_TYPES`. Keep `Congestion` — stuffy, runny and sneezing are useful distinct self-report signals. |
+| 6 | [`HealthAnomalyFollowupCard.tsx`](../../app/src/components/HealthAnomalyFollowupCard.tsx) | Add `allergy_or_hay_fever: 'Seasonal allergy / hay fever'` to `EXPLANATION_LABELS`. Its `Record<HealthAnomalyOutcomeExplanation, string>` type keeps the UI mapping exhaustive. |
+| 7 | [`feedbackModels.ts`](../../app/src/feedback/feedbackModels.ts) + [`feedbackValidation.ts`](../../app/src/feedback/feedbackValidation.ts) | Add `'allergy_symptoms'` to `ModificationReason` + `VALID_REASONS`, so allergy-driven athlete adjustments do not have to be mislabeled as illness. |
 
-### Naming to confirm before I implement
-- Explanation value: `allergy_or_hay_fever` vs. `seasonal_allergy` vs. `allergies` — I lean
-  toward `allergy_or_hay_fever` to match the existing style (`heat_dehydration`,
-  `vaccination_medication` are already compound).
-- Whether to keep `sneezing`/`runny_nose` as two separate types (my preference, consistent with
-  the existing fine-grained split of `cough`/`sore_throat`/`congestion` rather than one combined
-  `rhinitis` type) or merge them.
+### Naming decisions
 
-### Tests to add/update
-- `healthContextDefaults.test.ts`, `healthContextContract.test.ts`,
-  `checkinHealthContext.test.ts` — new types round-trip through
-  `normalizeHealthContext`/the parser.
-- `app/src/emulator/healthContextRules.emulator.test.ts` — accept a doc with
-  `types: ['sneezing','runny_nose']`; keep the existing over-length rejection case correct
-  against the new cap.
-- `app/src/emulator/healthAnomalyOutcomeRules.emulator.test.ts` — accept
-  `explanation: 'allergy_or_hay_fever'`.
-- `healthAnomalyOutcome.test.ts` — any test iterating `HEALTH_ANOMALY_OUTCOME_EXPLANATIONS`
-  picks the new value up automatically; add one explicit case.
-- `HealthAnomalyFollowupCard.test.tsx` — label rendering for the new option.
-- `decisionInputs.test.ts` / `checkinService.test.ts` — parser round-trip for the two new
-  symptom types.
-- `wellnessLanguageAudit.test.ts` — re-run as-is to confirm the new copy doesn't trip the
-  no-diagnostic-language checks (it audits existing rationale/label strings; new UI-only labels
-  should already comply if phrased as self-report, e.g. avoid asserting anything the user didn't
-  say).
-- If row 7 is included: `feedbackValidation.test.ts` for the new `ModificationReason`.
-- New cross-check test worth adding: assert `firestore.rules`' hardcoded symptom-type list/size
-  and explanation enum stay in sync with `HEALTH_SYMPTOM_TYPES` /
-  `HEALTH_ANOMALY_OUTCOME_EXPLANATIONS` — rules can't import TS constants, so this pairing is a
-  manual-sync risk today (nothing currently catches drift between them the way
-  `decisionJournal.test.ts` guards `SHADOW_VERDICTS` against `externalSession.ts`). A simple
-  test that reads `firestore.rules` as text and regex-extracts the enum list, then diffs it
-  against the TS constant, would close this permanently rather than just for this change.
+- Explanation value: `allergy_or_hay_fever`.
+- `sneezing` and `runny_nose` remain separate types, consistent with the existing fine-grained
+  symptom vocabulary.
 
-### Rollout checklist (Phase 1)
+### Tests added/updated
+
+- `healthContextContract.test.ts`, `checkinHealthContext.test.ts` — new symptom/cause values
+  round-trip through the health-context contract/parser.
+- [`healthContextRules.emulator.test.ts`](../../app/src/emulator/healthContextRules.emulator.test.ts)
+  — accepts the allergy-oriented types/cause and rejects invalid or contradictory shapes.
+- [`healthAnomalyOutcomeRules.emulator.test.ts`](../../app/src/emulator/healthAnomalyOutcomeRules.emulator.test.ts)
+  — accepts `explanation: 'allergy_or_hay_fever'`.
+- `healthAnomalyOutcome.test.ts` and `HealthAnomalyFollowupCard.test.tsx` — cover the new
+  explanation/label.
+- `feedbackValidation.test.ts` — covers the new `ModificationReason`.
+- [`adapters.test.ts`](../../app/src/engine/adapters.test.ts) — covers the complete decision
+  predicate described in §5/ADR-0031.
+
+A future cross-check test could additionally parse `firestore.rules` and compare its hardcoded
+symptom/explanation allow-lists with the TypeScript constants. Rules cannot import TypeScript,
+so that remains a manual-sync risk outside the core behavior of this PR.
+
+### Rollout checklist
+
 ```bash
-cd app && npm run check        # TS/ESLint/Vitest/workout catalog
-cd app && npm run test:rules   # Firestore emulator rules tests — mandatory, firestore.rules changed
+cd app && npm run check
+cd app && npm run test:rules
+node scripts/check-policy-drift.mjs main
 ```
-Then `make check` before opening a PR per repo convention.
+
+Because Phase 2 changes recommendation output, scenario simulation is useful additional
+regression evidence when available. The PR's GitHub Actions checks are the authoritative final
+status for the branch.
 
 ## 4. What Phase 1 deliberately does *not* change
 
-- `DailySubjectiveCheckin.illnessSymptoms` semantics — still the single top-level safety gate,
-  unchanged.
-- Any recommendation/engine behavior — `rules.ts`, `adapters.ts` untouched in Phase 1.
-- No retroactive fix for the 2 days already passed — this only unblocks logging from today
-  onward. Backfilling those two days isn't proposed here; say if you want it and I'll size it
-  separately (it'd mean writing historical `daily_subjective_checkins` docs by hand for
-  yesterday and the day before, which is a data-integrity call worth its own confirmation, not
-  a side effect of this feature).
+- `DailySubjectiveCheckin.illnessSymptoms` remains the top-level athlete report.
+- Phase 1 alone does not alter recommendation behavior; the behavior change belongs to Phase 2.
+- No retroactive historical check-ins are created as a side effect of adding the vocabulary.
 
-## 5. Phase 2 (optional) — cause-aware gating, only if you want it
+## 5. Phase 2 — cause-aware gating
 
-The real behavioral complaint underneath the missing fields: right now, ticking
-"illness symptoms" for 2 days of mild sneezing gets you the *same* Running restriction and tier
-cap as a flu or an injury. If you want that softened specifically for mild,
-allergy-attributed, purely-upper-respiratory days:
+The behavioral complaint underneath the missing fields was that ticking "illness symptoms"
+for a day of mild hay-fever-style sneezing got the same Running restriction and tier cap as a
+systemic illness or injury. The implemented rule is intentionally narrower than merely
+trusting `suspectedCause: 'allergy'`.
 
-1. Add `suspectedCause?: 'infectious' | 'allergy' | 'unsure' | null` to `HealthSymptomsCheckin`
-   ([healthAnomalyModels.ts:32](app/src/engine/healthAnomalyModels.ts:32)), threaded through
-   `healthContextValidation.ts`, `firestore.rules`, and a third chip row in
-   `HealthContextSection.tsx` (shown once symptoms are present).
-2. In [adapters.ts:152](app/src/engine/adapters.ts:152), change `painFlag` to fold in
-   `illnessSymptoms` only when NOT (`suspectedCause === 'allergy'` AND `severity !== 'severe'`
-   AND no `fever_or_chills`/`gastrointestinal`/`unusual_fatigue` type reported). Keep
-   `painOrInjury` unconditional — that boolean is untouched either way. Doing the judgment call
-   here, in the adapter, rather than in `rules.ts`, keeps `evaluateEnvelopes`'s
-   `isPain = readiness.subjective.painFlag` contract exactly as simple as it is today.
-3. Decide (this is the actual product call, not an engineering one): should an
-   allergy-explained physiological anomaly still count as "explained" in `healthAnomaly.ts:445`?
-   Probably yes — allergies genuinely can elevate RHR/suppress HRV — but you may want the HA6
-   *evidence label* to record cause separately from the real-time *state machine* treatment, so
-   future model tuning can tell allergy-explained days from virus-explained days even though
-   both currently short-circuit to "explained."
-4. Tests: `rules.test.ts`, `adapters.test.ts`, `healthAnomaly.test.ts`,
-   `wellnessLanguageAudit.test.ts` (new rationale copy must stay self-reported, not diagnostic —
-   e.g. "You're flagging allergy symptoms today" not "You have allergies").
-5. Because this changes recommendation output for a real subset of scenarios, run
-   `npm run simulate:scenarios && npm run simulate:diff` and
-   `node scripts/check-policy-drift.mjs <base-sha>` before merging — this is exactly the kind of
-   policy drift those scripts exist to catch.
+1. [`HealthSymptomsCheckin`](../../app/src/engine/healthAnomalyModels.ts) adds
+   `suspectedCause?: 'infectious' | 'allergy' | 'unsure' | null`, threaded through
+   [`healthContextValidation.ts`](../../app/src/engine/healthContextValidation.ts),
+   [`firestore.rules`](../../app/firestore.rules), persistence, and the check-in UI.
+2. [`mapCheckinToSubjectiveInput`](../../app/src/engine/adapters.ts) softens the
+   `illnessSymptoms` contribution to `painFlag` only when **all** are true:
+   - `healthContext.symptoms.present === true`;
+   - `suspectedCause === 'allergy'`;
+   - severity is explicitly `mild` or `moderate`;
+   - symptom types are present and non-empty;
+   - every type is one of `congestion`, `runny_nose`, `sneezing`.
+3. Missing/`null` severity, missing types, `severe`, `infectious`, `unsure`, or any broader
+   symptom (`sore_throat`, `cough`, `fever_or_chills`, `headache_or_body_aches`,
+   `gastrointestinal`, `unusual_fatigue`, `other`) keeps the previous conservative illness
+   behavior. A future symptom type is conservative automatically until explicitly reviewed.
+4. `painOrInjury` remains unconditional. Allergy attribution can never loosen a tissue/injury
+   restriction.
+5. The judgment stays in the adapter. [`evaluateEnvelopes`](../../app/src/engine/rules.ts)
+   retains its simple `isPain = readiness.subjective.painFlag` contract.
+6. Physiological anomaly evidence remains orthogonal: the exception changes today's training
+   gate, not the observed measurements and not an illness/allergy diagnosis.
 
-**Why I'm not just building this by default:** under-restricting someone whose "probably
-allergies" is actually early-stage flu is the real failure mode here, and it's a judgment call
-about how much slack to give, not something to bake in opportunistically alongside a vocabulary
-fix. If you want Phase 2, say so and I'll turn §5 into the same level of file-by-file detail as
-§3 before touching code.
+### Why fail closed?
+
+The meaningful failure mode is under-restricting someone whose self-attributed "allergy" is an
+early infection or an airway condition. IOC guidance explicitly distinguishes infective and
+non-infective respiratory illness in athletes, while EAACI guidance emphasizes accurate
+diagnosis and the possible coexistence of allergic rhinitis with asthma/exercise-induced
+bronchoconstriction. The app does not yet model enough respiratory red flags to safely relax
+cough/sore-throat/other presentations. ADR-0031 records that evidence and the resulting product
+boundary.
 
 ## 6. Suggested sequencing
 
-1. Confirm naming (§3) and whether row 7 (feedback vocabulary) is in scope.
-2. Implement Phase 1 in this worktree, on `feat/subjective-symptom-reporting`.
-3. `npm run check` + `npm run test:rules`, fix any fallout.
-4. Decide on Phase 2 separately, as its own follow-up if wanted.
+The implementation followed this sequence:
+
+1. Add the symptom/cause vocabulary and persistence validation.
+2. Add outcome/feedback vocabulary and UI support.
+3. Add the adapter behavior behind an explicit fail-closed predicate.
+4. Add targeted decision and Firestore-rule tests.
+5. Add `adapters.ts` to the policy-drift decision-affecting file set and bump `POLICY_VERSION`.
+6. Deep-review the safety predicate, harden missing-detail and symptom-shape behavior, and record
+   the final decision in ADR-0031.
 
 ## 7. What actually shipped
 
-Both phases were approved and implemented together (naming: `allergy_or_hay_fever`; row 7
-included). Phase 2 landed exactly as designed here — entirely inside
-`adapters.ts::mapCheckinToSubjectiveInput` via a new `isAllergyLikeSymptomDay` helper, with
-`rules.ts` untouched. No changes beyond this document's scope.
+Both phases shipped together (naming: `allergy_or_hay_fever`; feedback reason included).
+Phase 2 remains entirely inside `adapters.ts::mapCheckinToSubjectiveInput` via
+`isAllergyLikeSymptomDay`, with `rules.ts` untouched.
 
-One thing this document didn't anticipate, caught while preparing the PR: `adapters.ts` was
-missing from `scripts/check-policy-drift.mjs`'s `decisionAffectingFiles` allow-list, even
-though it clearly determines `painFlag`/`clinicalFlagActive` before `rules.ts` ever runs (the
-same reasoning already applied there to `subjectiveBaseline.ts` and `authoredSessionGates.ts`).
-Fixed as part of this PR:
-- Added `app/src/engine/adapters.ts` to `decisionAffectingFiles`.
-- Bumped `POLICY_VERSION` to `2026-08-allergy-symptom-gating-v1` (single-line bump only, per
-  repo convention — `HISTORICAL_POLICY_VERSIONS` is not touched on every bump).
+The review pass made two important hardening changes beyond the original sketch:
 
-Verification (final, after both commits): `npm run check` (typecheck + lint + `npm test` 2680
-passed + `npm run validate:workouts`), `npm run test:rules` (140 Firestore-emulator tests), and
-`node scripts/check-policy-drift.mjs main` all pass.
+- **Missing severity is no longer fail-open.** `null`/absent severity cannot clear the illness
+  safety gate; it must be explicitly `mild` or `moderate`.
+- **A positive nasal-symptom allow-list replaces the original systemic-symptom blacklist.**
+  Symptom types must be present and every type must be `congestion`, `runny_nose`, or
+  `sneezing`. This prevents `headache_or_body_aches`, `other`, cough/sore throat and future
+  schema additions from silently qualifying.
+
+The review also closed the policy-drift coverage gap exposed by this feature:
+
+- `app/src/engine/adapters.ts` is now in `decisionAffectingFiles`.
+- `POLICY_VERSION` is `2026-08-allergy-symptom-gating-v1`.
+- [ADR-0031](../adr/0031-cause-aware-subjective-symptom-gating.md) records the final safety
+  policy and evidence rationale.
+
+The initial implementation passed the full app and Firestore-rule suites before review. The
+post-review branch must pass the PR's GitHub Actions checks; those checks remain the
+source-of-truth rather than embedding a permanently stale test count in this design document.

--- a/docs/plans/allergy-and-cause-aware-symptom-reporting.md
+++ b/docs/plans/allergy-and-cause-aware-symptom-reporting.md
@@ -1,7 +1,8 @@
 # Allergy / cause-aware symptom reporting — implementation plan
 
-Status: **proposed, not yet implemented**. Worktree: `.claude/worktrees/symptom-reporting`,
-branch `feat/subjective-symptom-reporting`.
+Status: **implemented**. Worktree: `.claude/worktrees/symptom-reporting`,
+branch `feat/subjective-symptom-reporting`. See §7 for what shipped and how it differs from
+this document's original sketch.
 
 ## 1. The gap, precisely
 
@@ -164,3 +165,23 @@ fix. If you want Phase 2, say so and I'll turn §5 into the same level of file-b
 2. Implement Phase 1 in this worktree, on `feat/subjective-symptom-reporting`.
 3. `npm run check` + `npm run test:rules`, fix any fallout.
 4. Decide on Phase 2 separately, as its own follow-up if wanted.
+
+## 7. What actually shipped
+
+Both phases were approved and implemented together (naming: `allergy_or_hay_fever`; row 7
+included). Phase 2 landed exactly as designed here — entirely inside
+`adapters.ts::mapCheckinToSubjectiveInput` via a new `isAllergyLikeSymptomDay` helper, with
+`rules.ts` untouched. No changes beyond this document's scope.
+
+One thing this document didn't anticipate, caught while preparing the PR: `adapters.ts` was
+missing from `scripts/check-policy-drift.mjs`'s `decisionAffectingFiles` allow-list, even
+though it clearly determines `painFlag`/`clinicalFlagActive` before `rules.ts` ever runs (the
+same reasoning already applied there to `subjectiveBaseline.ts` and `authoredSessionGates.ts`).
+Fixed as part of this PR:
+- Added `app/src/engine/adapters.ts` to `decisionAffectingFiles`.
+- Bumped `POLICY_VERSION` to `2026-08-allergy-symptom-gating-v1` (single-line bump only, per
+  repo convention — `HISTORICAL_POLICY_VERSIONS` is not touched on every bump).
+
+Verification (final, after both commits): `npm run check` (typecheck + lint + `npm test` 2680
+passed + `npm run validate:workouts`), `npm run test:rules` (140 Firestore-emulator tests), and
+`node scripts/check-policy-drift.mjs main` all pass.


### PR DESCRIPTION
## Summary

- Adds the missing hay-fever-oriented symptom vocabulary: `sneezing`, `runny_nose`, a self-reported `suspectedCause`, `allergy_or_hay_fever` anomaly explanation, and `allergy_symptoms` modification reason across model, validation, Firestore, persistence, UI, outcomes, and feedback.
- Adds **cause-aware recommendation gating** without changing `rules.ts`: `mapCheckinToSubjectiveInput` may stop the `illnessSymptoms` boolean from forcing `painFlag`, but only for a narrow, explicit allergic-rhinitis-style report.
- Keeps `painOrInjury` unconditional and keeps ambiguous/broad/systemic symptom reports on the existing conservative path.
- Adds policy-drift coverage for `adapters.ts` and bumps `POLICY_VERSION` to `2026-08-allergy-symptom-gating-v1`.
- Records the final fail-closed decision and sports-medicine rationale in [`docs/adr/0031-cause-aware-subjective-symptom-gating.md`](../blob/feat/subjective-symptom-reporting/docs/adr/0031-cause-aware-subjective-symptom-gating.md). The implementation plan is updated at [`docs/plans/allergy-and-cause-aware-symptom-reporting.md`](../blob/feat/subjective-symptom-reporting/docs/plans/allergy-and-cause-aware-symptom-reporting.md).

## Final gating rule

```ts
painFlag: checkin.painOrInjury || (checkin.illnessSymptoms && !isAllergyLikeSymptomDay(checkin)),
```

`isAllergyLikeSymptomDay` returns `true` only when **all** are true:

1. `healthContext.symptoms.present === true`
2. `suspectedCause === 'allergy'`
3. severity is explicitly `mild` or `moderate`
4. symptom types are present and non-empty
5. **every** symptom type is one of `congestion`, `runny_nose`, `sneezing`

The predicate is intentionally fail-closed. Missing/`null` severity, missing types, `severe`, `infectious`, `unsure`, or any broader type (`sore_throat`, `cough`, `fever_or_chills`, `headache_or_body_aches`, `gastrointestinal`, `unusual_fatigue`, `other`) preserves the old illness gate. A future symptom type also remains conservative until explicitly reviewed.

`painOrInjury` always wins; allergy attribution can never loosen an injury/tissue restriction.

## Why the narrow allow-list

The original implementation used a blacklist and accepted every severity except `severe`. Deep review found two false-negative paths:

- missing severity could clear `painFlag` even though the code comment said unknown severity should remain conservative;
- `headache_or_body_aches`, `other`, and other broad respiratory types could pass the blacklist despite the code claiming a purely upper-respiratory/allergy presentation.

The fix uses explicit known severity plus a positive nasal-symptom allow-list. This is deliberately stricter than treating any self-attributed allergy as a diagnosis. IOC guidance distinguishes infective from non-infective respiratory illness in athletes, while EAACI/sports-respiratory guidance emphasizes diagnostic uncertainty and coexistence of allergic rhinitis with asthma/exercise-induced bronchoconstriction. The app does not yet model wheeze, chest tightness, dyspnoea, EIB, or objective allergy diagnosis, so cough/sore-throat/other presentations remain conservative.

Research references are captured in ADR-0031.

## Files changed

| Area | Main changes |
|---|---|
| `healthAnomalyModels.ts`, `healthContextValidation.ts`, `firestore.rules` | symptom/cause schema and validation |
| `HealthContextSection.tsx`, `HealthAnomalyFollowupCard.tsx` | capture/render allergy-oriented context |
| `checkinService.ts` | persist/delete `suspectedCause` consistently |
| `healthAnomalyOutcome.ts`, feedback models/validation | allergy explanation/feedback vocabulary |
| `adapters.ts` | fail-closed cause-aware `painFlag` mapping |
| `adapters.test.ts` | valid nasal paths + missing/null severity + missing types + every current non-nasal type + cause defaults + unconditional injury authority |
| `policy.ts`, `check-policy-drift.mjs` | policy version + decision-affecting adapter coverage |
| `docs/adr/0031-...`, implementation plan | final decision, evidence, consequences, symbol-based docs references |

## Validation

Final head: `7f54bf4ce288d33aea4032631b7ae91177a8083d`

- [x] **CI Pipeline #1626** — completed successfully.
- [x] Frontend typecheck — pass.
- [x] Frontend test suite with coverage — pass.
- [x] Firestore security-rule emulator suite — pass.
- [x] Engine policy-version drift check — pass.
- [x] Simulation scenarios + aggregate bounds gate — pass.
- [x] AI plan judge deterministic corpus gate — pass.
- [x] Persona judge deterministic corpus — pass.
- [x] Simulation semantic diff — pass.
- [x] Frontend bundle build — pass.
- [x] Python test suite + dependency audit — pass.
- [x] Docker image build — pass.
- [x] Node dependency audit — pass.

The original implementation had also passed `cd app && npm run check`, `cd app && npm run test:rules`, and `node scripts/check-policy-drift.mjs main`; the final GitHub Actions run above is the authoritative validation after review hardening.

Per review scope, lint/static-analysis findings are not treated as the focus unless they expose a correctness issue. CI lint steps happen to be green as well.

## Risk and reviewer guidance

- **Primary behavioral risk:** a user may self-attribute early infection or an airway disorder to allergy. The final predicate therefore fails closed on missing detail and accepts only an explicit mild/moderate nasal symptom shape.
- **Moderate allergy remains allowed** only when the entire reported symptom set is nasal (`congestion`, `runny_nose`, `sneezing`). Any broad/systemic symptom restores the conservative gate.
- **Schema evolution is safe by default:** new symptom types do not silently qualify because the predicate is a positive allow-list.
- **Injury authority is unchanged:** `painOrInjury` and tissue restrictions cannot be softened by allergy attribution.
- **Review focus:** `app/src/engine/adapters.ts::isAllergyLikeSymptomDay`, the adapter regression matrix, and the Firestore/TypeScript vocabulary consistency are the highest-value places to inspect.
- No backend/Python behavior, migration, or deployment change is required.

## Review status

CodeRabbit raised two major correctness findings (allow-list and missing severity) plus one docs-maintainability finding. All three were addressed, replied to, resolved, and CodeRabbit confirmed the fixes. The two correctness findings matched the independent deep-review findings and now have explicit regression coverage.

## Domain invariants

- [x] Firestore writes remain user-scoped; verified no ingestion path/user-scope changes in the diff.
- [x] Calendar/date semantics are untouched; verified no date/step logic changed.
- [x] No credentials, tokens, service-account files, or raw health payloads are included.
- [x] Recommendation policy changed intentionally and is covered by `POLICY_VERSION` + policy-drift detection.
- [x] No backend/Python behavior or migration is required; Python CI remains green.

## Screenshots or recordings

Not applicable. The UI additions use the existing health-context chip-button pattern (`HealthContextSection.tsx`) with no new layout/CSS or interaction model; the substantive review risk is recommendation gating, not visual rendering.
