### PR TITLE
docs(hrf): record bounded HRF8 replay and decoder gaps

### DIFF
--- a/docs/analysis/2026-08-29-hrf8-bounded-replay-and-decoder-qualification.md
+++ b/docs/analysis/2026-08-29-hrf8-bounded-replay-and-decoder-qualification.md
@@ -4,7 +4,7 @@
 **Scope:** bounded, read-only HRF8 evidence run against real-account activity originals
 **Evidence status:** partial D-HRF-DECODER qualification plus a bounded replay smoke check
 **Decision posture:** no ship; HRF remains shadow-only
-**Runtime code revision:** `5ebea4f93146386359103be49f73a49e3f42e8ca` (the PR base; this PR changes documentation only)
+**Repository code baseline reviewed here:** `5ebea4f93146386359103be49f73a49e3f42e8ca` (the PR base; the bounded run did not record a separate execution commit SHA)
 
 ## Scope and privacy boundary
 

--- a/docs/analysis/2026-08-29-hrf8-bounded-replay-and-decoder-qualification.md
+++ b/docs/analysis/2026-08-29-hrf8-bounded-replay-and-decoder-qualification.md
@@ -44,6 +44,7 @@ was present in every file or record.
 | HRF-consumed surface | Bounded comparison | Qualification status | Limitation |
 |---|---:|---|---|
 | record data-frame count | 7 / 7 match | covered for count | no value-level trace equivalence claim |
+| HRF-relevant message cardinality | only selected device/timer/lap counts or presence were retained | partial | complete per-message cardinality parity, including session multiplicity, was not retained |
 | HR/cadence/power sample presence | 7 / 7 match for each field | partial | aggregate non-null coverage/value parity was not retained |
 | device-inventory entry count | 7 / 7 match | partial | source-reasoning field values (`device_index`, manufacturer, product, device type, source type) were not retained as a parity result |
 | timer-event count | 7 / 7 match | partial | event-state sequence and timestamp ordering/window parity were not retained |
@@ -61,20 +62,21 @@ source-lineage claim.
 No disagreement was observed on the comparisons actually performed. However, the prior
 report overstated that result by calling the complete HRF-consumed decoder surface
 qualified. Counts alone cannot establish semantic parity for device fields that drive
-source reasoning, timer state that defines active analysis windows, or lap values used in
-summary reconciliation. This bounded run therefore provides **partial decoder
-qualification evidence**, not complete D-HRF-DECODER qualification.
+source reasoning, timer state that defines active analysis windows, session multiplicity,
+or lap values used in summary reconciliation. This bounded run therefore provides
+**partial decoder qualification evidence**, not complete D-HRF-DECODER qualification.
 
 Before this decoder qualification is treated as complete for HRF8 activation evidence, a
 future transient comparison should additionally record sanitized equality results for:
 
-1. non-null HR/cadence/power sample counts and aggregate coverage;
-2. non-identifying device-source tuples used by HRF source reasoning;
-3. timer event-type/state sequence and ordering/window semantics without persisting exact timestamps;
-4. per-lap average-HR values, not only lap counts;
-5. session-scoped zone-array shape and values;
-6. decoder failure classification on controlled truncated/CRC-invalid synthetic inputs;
-7. the selection rule, sanitized activity classes, original-download availability denominator,
+1. recognized HRF-relevant message counts, including session multiplicity;
+2. non-null HR/cadence/power sample counts and aggregate coverage;
+3. non-identifying device-source tuples used by HRF source reasoning;
+4. timer event-type/state sequence and ordering/window semantics without persisting exact timestamps;
+5. per-lap average-HR values, not only lap counts;
+6. session-scoped zone-array shape and values;
+7. decoder failure classification on controlled truncated/CRC-invalid synthetic inputs;
+8. the selection rule, sanitized activity classes, original-download availability denominator,
    runtime commit, decoder versions, and profile generations.
 
 Qualification must also be repeated after a material runtime decoder/profile change or

--- a/docs/analysis/2026-08-29-hrf8-bounded-replay-and-decoder-qualification.md
+++ b/docs/analysis/2026-08-29-hrf8-bounded-replay-and-decoder-qualification.md
@@ -1,0 +1,99 @@
+# HRF8 Bounded Replay and Decoder Qualification
+
+**Date:** 2026-08-29
+**Scope:** bounded, read-only HRF8 evidence run against real-account activity originals
+**Decision posture:** no ship; HRF remains shadow-only
+
+## Scope and privacy boundary
+
+The operator ran a bounded 42-day query, which listed 36 activities. One available
+original was selected from each of seven distinct activity classes. Original downloads
+were decoded only in memory and discarded per activity. This report records only
+aggregate counts and structural decoder comparisons: it contains no FIT bytes, HR sample
+arrays, GPS, timestamps, activity IDs, owner IDs, sensor serials, or credentials.
+
+The sample is useful for qualifying the currently consumed decoder surface and locating
+obvious replay behavior. It is not a calibrated accuracy study, a prevalence estimate, or
+a substitute for the independent paired-reference evidence required by ADR-0031.
+
+## Runtime/reference decoder qualification
+
+The runtime decoder was `fitdecode 0.11.0`. The ephemeral reference decoder was
+`garmin-fit-sdk 21.214.0`; it was invoked outside the normal dependency graph and was
+not added to `pyproject.toml` or the shipped image.
+
+All seven selected originals decoded successfully under both decoders. The comparison
+used the exact HRF-consumed semantic surface from `fit_activity.py`:
+
+| Surface | Matching originals | Result |
+|---|---:|---|
+| record count | 7 / 7 | match |
+| HR, cadence and power sample presence | 7 / 7 each | match |
+| device-inventory entry count | 7 / 7 | match |
+| timer-event count | 7 / 7 | match |
+| session average HR presence/value | 7 / 7 | match |
+| lap average-HR count | 7 / 7 | match |
+| session-scoped HR-zone arrays | 7 / 7 | match |
+
+The zone comparison initially appeared to disagree when only the official SDK's
+`session_mesgs` was inspected. Six of seven files expose the session-scoped zone array
+through `time_in_zone_mesgs` instead. Applying the same session-scoped fallback as
+`fit_activity.py` reconciled all seven. This is an API-shape observation, not a new
+source-lineage claim.
+
+For this bounded sample, no decoder disagreement capable of changing HRF provenance,
+quality, timer windows, summary compatibility, or authority was observed. Qualification
+must be repeated after a material runtime decoder/profile change or before consuming a
+new FIT field.
+
+## Historical HRF replay
+
+Running `assess_activity_hr_fidelity` over the same seven transient originals produced:
+
+| Measure | Result |
+|---|---:|
+| assessable traces | 6 |
+| partially assessable traces | 1 |
+| moderate-confidence traces | 6 |
+| unreliable traces | 1 |
+| dropout artifact flags | 1 |
+| `mixed_possible` source classifications | 3 |
+| `unknown` source classifications | 4 |
+
+All seven activity-list `averageHr` values were numerically within 1 bpm of the
+FIT-derived session average. This is recorded as **consistent but unproven**, not
+`verified_same_effective_trace`: a numerical match cannot establish that every existing
+summary, lap, zone array, or vendor metric descends from the assessed effective trace.
+The existing fail-closed `summaryCompatibility` behavior therefore remains correct.
+
+The single unreliable/dropout result is a manual-review candidate. This aggregate run
+does not expose raw traces, so it does not claim a false-positive determination.
+
+## Paired-reference evidence
+
+No independently recorded wrist-versus-electrode-chest-strap session manifest was
+available in this workspace. Consequently there is no valid paired accuracy result,
+no alignment analysis, and no personal/device reliability claim.
+
+Per ADR-0031 `D-HRF-REFERENCE`, a Garmin activity that might dynamically substitute the
+connected strap into the watch stream is not an independent wrist/reference pair. A
+future included session must document its recording arrangement, source-switching
+protection, clock synchronization, shared analysis window, pause handling, resampling
+rule, and alignment uncertainty before it is analysed. Samples lacking that evidence are
+rejected rather than treated as supportive agreement.
+
+## Activation recommendation
+
+**Do not activate HRF authority in production.** The bounded decoder qualification and
+historical replay support continued shadow observability only. HRF9 remains blocked until
+there is independently recorded paired-reference evidence, the unreliable/dropout case
+is manually reviewed, and a separate activation decision accepts the resulting evidence.
+
+## Follow-up
+
+1. Collect representative, independently recorded wrist/reference sessions using the
+   protocol in [the approved HRF plan](../plans/activity-heart-rate-measurement-fidelity.md).
+2. Review the bounded replay's unreliable/dropout case without retaining its raw trace
+   in Firestore or the repository.
+3. Rerun the decoder qualification and a wider stratified historical replay when the
+   paired-reference corpus is available.

--- a/docs/analysis/2026-08-29-hrf8-bounded-replay-and-decoder-qualification.md
+++ b/docs/analysis/2026-08-29-hrf8-bounded-replay-and-decoder-qualification.md
@@ -2,38 +2,55 @@
 
 **Date:** 2026-08-29
 **Scope:** bounded, read-only HRF8 evidence run against real-account activity originals
+**Evidence status:** partial D-HRF-DECODER qualification plus a bounded replay smoke check
 **Decision posture:** no ship; HRF remains shadow-only
+**Runtime code revision:** `5ebea4f93146386359103be49f73a49e3f42e8ca` (the PR base; this PR changes documentation only)
 
 ## Scope and privacy boundary
 
 The operator ran a bounded 42-day query, which listed 36 activities. One available
-original was selected from each of seven distinct activity classes. Original downloads
-were decoded only in memory and discarded per activity. This report records only
-aggregate counts and structural decoder comparisons: it contains no FIT bytes, HR sample
-arrays, GPS, timestamps, activity IDs, owner IDs, sensor serials, or credentials.
+original was selected from each of seven distinct activity classes, so 7 of the 36 listed
+activities (19.4%) were replayed. Original downloads were decoded only in memory and
+discarded per activity. This report records only aggregate counts and structural decoder
+comparisons: it contains no FIT bytes, HR sample arrays, GPS, timestamps, activity IDs,
+owner IDs, sensor serials, or credentials.
 
-The sample is useful for qualifying the currently consumed decoder surface and locating
-obvious replay behavior. It is not a calibrated accuracy study, a prevalence estimate, or
-a substitute for the independent paired-reference evidence required by ADR-0031.
+This was a coverage-oriented convenience sample, not a random sample and not a
+prevalence-estimating cohort. The committed aggregate report does not retain the seven
+class labels or the denominator of activities for which an original download was
+available. Consequently it cannot independently demonstrate class stratification,
+original-FIT availability, or population coverage. Those are evidence limitations, not
+negative findings.
+
+The sample is useful for reducing decoder-risk and locating obvious replay behavior. It
+is not a calibrated accuracy study, a complete HRF8 historical replay, a prevalence
+estimate, or a substitute for the independent paired-reference evidence required by
+ADR-0031.
 
 ## Runtime/reference decoder qualification
 
-The runtime decoder was `fitdecode 0.11.0`. The ephemeral reference decoder was
+The runtime decoder was `fitdecode 0.11.0`, whose generated FIT profile is based on
+FIT SDK profile `21.171.0`. The ephemeral reference decoder was
 `garmin-fit-sdk 21.214.0`; it was invoked outside the normal dependency graph and was
-not added to `pyproject.toml` or the shipped image.
+not added to `pyproject.toml` or the shipped image. Recording both decoder versions and
+profile generations is required by D-HRF-DECODER because the runtime profile is older
+than the vendor reference profile.
 
-All seven selected originals decoded successfully under both decoders. The comparison
-used the exact HRF-consumed semantic surface from `fit_activity.py`:
+All seven selected originals decoded successfully under both decoders. The bounded
+comparison recorded the following results. Here, `7 / 7 match` means both decoders agreed
+on the comparison that was actually recorded; it does **not** mean every optional field
+was present in every file or record.
 
-| Surface | Matching originals | Result |
-|---|---:|---|
-| record count | 7 / 7 | match |
-| HR, cadence and power sample presence | 7 / 7 each | match |
-| device-inventory entry count | 7 / 7 | match |
-| timer-event count | 7 / 7 | match |
-| session average HR presence/value | 7 / 7 | match |
-| lap average-HR count | 7 / 7 | match |
-| session-scoped HR-zone arrays | 7 / 7 | match |
+| HRF-consumed surface | Bounded comparison | Qualification status | Limitation |
+|---|---:|---|---|
+| record data-frame count | 7 / 7 match | covered for count | no value-level trace equivalence claim |
+| HR/cadence/power sample presence | 7 / 7 match for each field | partial | aggregate non-null coverage/value parity was not retained |
+| device-inventory entry count | 7 / 7 match | partial | source-reasoning field values (`device_index`, manufacturer, product, device type, source type) were not retained as a parity result |
+| timer-event count | 7 / 7 match | partial | event-state sequence and timestamp ordering/window parity were not retained |
+| session average HR presence/value | 7 / 7 match | covered | numerical equality does not prove upstream summary lineage |
+| lap average-HR count | 7 / 7 match | partial | per-lap average-HR value parity was not retained |
+| session-scoped HR-zone arrays | 7 / 7 match | covered for the compared arrays | summary compatibility remains a separate lineage question |
+| decode/CRC failure classification | not exercised in this healthy-file comparison | open | strict runtime failure behavior is tested separately; cross-decoder failure-class parity was not established here |
 
 The zone comparison initially appeared to disagree when only the official SDK's
 `session_mesgs` was inspected. Six of seven files expose the session-scoped zone array
@@ -41,12 +58,29 @@ through `time_in_zone_mesgs` instead. Applying the same session-scoped fallback 
 `fit_activity.py` reconciled all seven. This is an API-shape observation, not a new
 source-lineage claim.
 
-For this bounded sample, no decoder disagreement capable of changing HRF provenance,
-quality, timer windows, summary compatibility, or authority was observed. Qualification
-must be repeated after a material runtime decoder/profile change or before consuming a
-new FIT field.
+No disagreement was observed on the comparisons actually performed. However, the prior
+report overstated that result by calling the complete HRF-consumed decoder surface
+qualified. Counts alone cannot establish semantic parity for device fields that drive
+source reasoning, timer state that defines active analysis windows, or lap values used in
+summary reconciliation. This bounded run therefore provides **partial decoder
+qualification evidence**, not complete D-HRF-DECODER qualification.
 
-## Historical HRF replay
+Before this decoder qualification is treated as complete for HRF8 activation evidence, a
+future transient comparison should additionally record sanitized equality results for:
+
+1. non-null HR/cadence/power sample counts and aggregate coverage;
+2. non-identifying device-source tuples used by HRF source reasoning;
+3. timer event-type/state sequence and ordering/window semantics without persisting exact timestamps;
+4. per-lap average-HR values, not only lap counts;
+5. session-scoped zone-array shape and values;
+6. decoder failure classification on controlled truncated/CRC-invalid synthetic inputs;
+7. the selection rule, sanitized activity classes, original-download availability denominator,
+   runtime commit, decoder versions, and profile generations.
+
+Qualification must also be repeated after a material runtime decoder/profile change or
+before HRF begins consuming a new FIT field whose semantics depend on a newer profile.
+
+## Bounded historical replay smoke check
 
 Running `assess_activity_hr_fidelity` over the same seven transient originals produced:
 
@@ -69,11 +103,18 @@ The existing fail-closed `summaryCompatibility` behavior therefore remains corre
 The single unreliable/dropout result is a manual-review candidate. This aggregate run
 does not expose raw traces, so it does not claim a false-positive determination.
 
+This seven-activity smoke check does **not** satisfy the plan's full historical replay
+requirements. In particular, it does not report the required stratification by source
+evidence, motion risk, intensity, recording-device period and summary compatibility; it
+does not quantify original-FIT/unknown-assessment coverage across the 42-day cohort; and
+it does not yet report per-use authority changes, affected downstream features, or manual
+false-positive review. HRF8 therefore remains open.
+
 ## Paired-reference evidence
 
 No independently recorded wrist-versus-electrode-chest-strap session manifest was
-available in this workspace. Consequently there is no valid paired accuracy result,
-no alignment analysis, and no personal/device reliability claim.
+available in this workspace. Consequently there is no valid paired accuracy result, no
+alignment analysis, and no personal/device reliability claim.
 
 Per ADR-0031 `D-HRF-REFERENCE`, a Garmin activity that might dynamically substitute the
 connected strap into the watch stream is not an independent wrist/reference pair. A
@@ -84,16 +125,22 @@ rejected rather than treated as supportive agreement.
 
 ## Activation recommendation
 
-**Do not activate HRF authority in production.** The bounded decoder qualification and
-historical replay support continued shadow observability only. HRF9 remains blocked until
-there is independently recorded paired-reference evidence, the unreliable/dropout case
-is manually reviewed, and a separate activation decision accepts the resulting evidence.
+**Do not activate HRF authority in production.** The bounded partial decoder-parity
+evidence and replay smoke check support continued shadow observability only. HRF9 remains
+blocked until complete D-HRF-DECODER qualification is recorded for the replayed semantic
+surface, a wider stratified historical replay and manual review are complete,
+independently recorded paired-reference evidence exists for the activation scope, and a
+separate activation decision accepts the resulting evidence.
 
 ## Follow-up
 
-1. Collect representative, independently recorded wrist/reference sessions using the
+1. Complete the missing decoder-semantic checks listed above while keeping all real FIT
+   bytes and identifying values transient.
+2. Run the wider stratified historical replay required by the approved HRF plan, including
+   original-FIT availability/unknown-assessment coverage and per-use authority deltas.
+3. Review the bounded replay's unreliable/dropout case without retaining its raw trace in
+   Firestore or the repository.
+4. Collect representative, independently recorded wrist/reference sessions using the
    protocol in [the approved HRF plan](../plans/activity-heart-rate-measurement-fidelity.md).
-2. Review the bounded replay's unreliable/dropout case without retaining its raw trace
-   in Firestore or the repository.
-3. Rerun the decoder qualification and a wider stratified historical replay when the
-   paired-reference corpus is available.
+5. Repeat the decoder qualification whenever the runtime decoder/profile or the consumed
+   field surface materially changes.

--- a/docs/plans/activity-heart-rate-measurement-fidelity.md
+++ b/docs/plans/activity-heart-rate-measurement-fidelity.md
@@ -6,7 +6,6 @@
 * **Unlocks:** source-aware HR trust, artifact-resistant HR-zone/load interpretation, safe max-HR/threshold/decoupling gating, and athlete/device/activity-specific HR reliability calibration
 * **Source analysis:** [`2026-08-29-activity-hr-measurement-confidence-analysis.md`](../analysis/2026-08-29-activity-hr-measurement-confidence-analysis.md)
 * **HRF0 evidence:** [`2026-08-29-garmin-activity-hr-fit-provenance-spike.md`](../analysis/2026-08-29-garmin-activity-hr-fit-provenance-spike.md)
-* **HRF8 bounded evidence:** [`2026-08-29-hrf8-bounded-replay-and-decoder-qualification.md`](../analysis/2026-08-29-hrf8-bounded-replay-and-decoder-qualification.md) — decoder surface qualified on a bounded sample; no paired-reference evidence, no ship
 * **Decision record:** [ADR-0031](../adr/0031-activity-heart-rate-measurement-fidelity-and-evidence-authority.md)
 * **Related plans:** [`garmin-activity-telemetry-ingestion.md`](./garmin-activity-telemetry-ingestion.md), [`physiological-identity-passport-and-measurement-trust.md`](./physiological-identity-passport-and-measurement-trust.md), [`scientific-validation-and-feedback-loop.md`](./scientific-validation-and-feedback-loop.md), [`health-anomaly-and-illness-risk-alerting.md`](./health-anomaly-and-illness-risk-alerting.md)
 

--- a/docs/plans/activity-heart-rate-measurement-fidelity.md
+++ b/docs/plans/activity-heart-rate-measurement-fidelity.md
@@ -6,6 +6,7 @@
 * **Unlocks:** source-aware HR trust, artifact-resistant HR-zone/load interpretation, safe max-HR/threshold/decoupling gating, and athlete/device/activity-specific HR reliability calibration
 * **Source analysis:** [`2026-08-29-activity-hr-measurement-confidence-analysis.md`](../analysis/2026-08-29-activity-hr-measurement-confidence-analysis.md)
 * **HRF0 evidence:** [`2026-08-29-garmin-activity-hr-fit-provenance-spike.md`](../analysis/2026-08-29-garmin-activity-hr-fit-provenance-spike.md)
+* **HRF8 bounded evidence:** [`2026-08-29-hrf8-bounded-replay-and-decoder-qualification.md`](../analysis/2026-08-29-hrf8-bounded-replay-and-decoder-qualification.md) — decoder surface qualified on a bounded sample; no paired-reference evidence, no ship
 * **Decision record:** [ADR-0031](../adr/0031-activity-heart-rate-measurement-fidelity-and-evidence-authority.md)
 * **Related plans:** [`garmin-activity-telemetry-ingestion.md`](./garmin-activity-telemetry-ingestion.md), [`physiological-identity-passport-and-measurement-trust.md`](./physiological-identity-passport-and-measurement-trust.md), [`scientific-validation-and-feedback-loop.md`](./scientific-validation-and-feedback-loop.md), [`health-anomaly-and-illness-risk-alerting.md`](./health-anomaly-and-illness-risk-alerting.md)
 


### PR DESCRIPTION
## Summary

- Records a bounded, privacy-preserving HRF8 evidence run against seven transient real-account originals selected from a 42-day / 36-activity query.
- Narrows the decoder claim to **partial D-HRF-DECODER qualification**: the run showed parity for the comparisons actually recorded, but count/presence-only checks do not establish semantic parity for device-source fields, timer state, lap values, aggregate sample coverage, or cross-decoder CRC/failure classification.
- Records the full decoder/profile context: `fitdecode 0.11.0` / FIT profile `21.171.0` versus ephemeral `garmin-fit-sdk 21.214.0`.
- Reclassifies the seven-activity historical run as a **bounded replay smoke check**, not the complete stratified HRF8 replay required by the approved plan.
- Preserves the conservative lineage result: Garmin `averageHr` is numerically consistent with the FIT session average in the sample, but remains `consistent_unproven`, not verified lineage.
- Documents the single dropout/unreliable review candidate, the missing independent paired-reference corpus, and an explicit **no-ship** recommendation.
- Leaves HRF8 open and HRF9 blocked until decoder qualification is complete, the wider stratified replay/manual review is done, independent paired-reference evidence exists for the activation scope, and a separate activation decision is accepted.

## Review-driven improvements

The original report overstated the bounded decoder evidence as qualification of the entire HRF-consumed surface. The follow-up review tightened that claim because HRF consumes semantics that were only compared by count/presence in the original run:

- device inventory **field values** affect source/provenance reasoning;
- timer event **state/order** affects active analysis windows;
- lap-average **values** affect summary reconciliation;
- HR/cadence/power aggregate non-null coverage was not retained;
- decoder/CRC failure-class parity was not exercised in the healthy-file comparison.

The report now has an explicit qualification matrix and a concrete checklist for the next transient rerun without persisting sensitive FIT data.

## Validation

- Documentation-only PR; no runtime, schema, persistence, recommendation, or UI behavior changed.
- Existing runtime parser tests were reviewed, including the generated valid synthetic FIT path, optional-field handling, session-scoped `time_in_zone` fallback, multi-session fail-closed behavior, non-timer event filtering, decoder-error isolation, and transient resource limits.
- The approved HRF plan and ADR-0031 were cross-checked against the report's claims.
- Garmin's FIT documentation identifies the release FIT Profile as the authoritative message/type reference; `fitdecode 0.11.0` documents its generated profile as FIT SDK `21.171.0`, which is why the profile generation is now explicit in the evidence report.
- No raw FIT bytes, HR samples, GPS, timestamps, activity IDs, owner IDs, sensor serials, or credentials are committed.

## Risk and reviewer guidance

Low runtime risk because this is documentation-only, but high evidence-governance importance. Review the qualification matrix rather than treating `7 / 7 match` as blanket decoder equivalence. The key invariant is that missing comparison evidence remains an open qualification gap rather than being silently promoted to scientific/activation evidence.

## Domain invariants

- [x] No Firestore writes or paths changed.
- [x] No calendar-date logic changed.
- [x] No credentials or raw/identifying activity data committed.
- [x] Recommendation decision logic and `POLICY_VERSION` unchanged.
- [x] `UNKNOWN` remains distinct from assessed `UNRELIABLE`.
- [x] Numerical summary consistency is not treated as trace lineage proof.
- [x] Independent paired-reference evidence remains mandatory before production activation.

## Screenshots or recordings

Not applicable — documentation-only change.