### PR TITLE
✍️ Scribe: update docs/README.md routing table with missing ADRs and analysis documents

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -85,6 +85,7 @@ Architectural choices, system invariants, and technical trade-offs are documente
 * [**ADR-0030: Direct Read-Only Eight Sleep Private-API Transport**](./adr/0030-eight-sleep-direct-private-api-transport.md) — *Proposed.* Direct read-only observation ingestion as `provider=eight_sleep`, `transport=eight_sleep_direct` using an owned minimal private-API connector; keeps Google Health as non-authoritative fallback and requires separate evidence for baseline/fusion activation under ADR-0027.
 * [**ADR-0031: Activity Heart-Rate Measurement Fidelity and Evidence Authority**](./adr/0031-activity-heart-rate-measurement-fidelity-and-evidence-authority.md) — *Accepted.* Separates HR sensor/source provenance from technical signal quality and makes downstream authority use-case-specific; low measurement confidence removes or bounds evidence rather than lowering athlete readiness.
 
+* [**ADR-0032: Cause-Aware Subjective Symptom Gating**](./adr/0032-cause-aware-subjective-symptom-gating.md) — *Accepted.* Connects subjective symptom check-ins to engine-aware cause categories to safely differentiate ambient fatigue from illness risk.
 ---
 
 ### 🔍 Reviews & Analysis
@@ -129,6 +130,24 @@ Point-in-time assessments of the system as built, including gaps between documen
 * [**AI plan judge tooling**](./analysis/ai-plan-judge.md) — Offline evaluation harness around the deterministic training-plan simulator to verify safety/capacity invariants and establish baselines.
 * [**AI plan judge: pairwise sensitivity contract**](./analysis/ai-plan-judge-pairwise.md) — Runtime contract for the pairwise sensitivity path introduced by `--pairwise` to evaluate structural quality over point-in-time invariants.
 * [**Phase 9.4 Subjective history integration**](./analysis/phase-9-4-subjective-history-integration.md) — Integration analysis for composition-boundary range reads and data-quality handling.
+
+* [**2026-08-28 Eight Sleep Extended Metrics Analysis**](./analysis/2026-08-28-eight-sleep-extended-metrics-analysis.md) — Evaluation of private API metrics against original ingestion schema.
+* [**2026-08-28 Garmin vs Eight Sleep Cross-Device Agreement**](./analysis/2026-08-28-garmin-eight-sleep-cross-device-agreement.md) — Cross-device agreement study for overlapping metrics.
+* [**2026-08-29 Eight Sleep Stage Sum Invariant Check**](./analysis/2026-08-29-eight-sleep-stage-sum-invariant-check.md) — Validates the sum of stage durations against total sleep duration.
+* [**2026-08-29 Eight Sleep WASO Reinstated**](./analysis/2026-08-29-eight-sleep-waso-reinstated.md) — Verification of Wake After Sleep Onset metric restoration.
+* [**2026-08-29 Garmin Activity HR FIT Provenance Spike**](./analysis/2026-08-29-garmin-activity-hr-fit-provenance-spike.md) — FIT file trace analysis for sensor provenance.
+* [**2026-08-29 HRF3 Trace Diagnostics Hardening Review**](./analysis/2026-08-29-hrf3-trace-diagnostics-hardening-review.md) — Code review and hardening validation for HRF3 trace artifact diagnostics.
+* [**2026-08-29 HRF4 Persistence Review**](./analysis/2026-08-29-hrf4-persistence-review.md) — Code review for the HRF4 persistence layer.
+* [**2026-08-29 HRF5 Authority Review**](./analysis/2026-08-29-hrf5-authority-review.md) — Verification of downstream authority boundaries for HR fidelity.
+* [**2026-08-29 HRF6 HR Consumer Lineage Audit**](./analysis/2026-08-29-hrf6-hr-consumer-lineage-audit.md) — Traceability audit for HR measurement consumption and lineage.
+* [**2026-08-29 HRF7 Shadow Observability Review**](./analysis/2026-08-29-hrf7-shadow-observability-review.md) — Verification of shadow mode observability and telemetry.
+* [**2026-08-29 HRF8 Bounded Replay & Decoder Qualification**](./analysis/2026-08-29-hrf8-bounded-replay-and-decoder-qualification.md) — Validation of bounded replay logic and HR decoder behavior.
+* [**2026-08-29 PR #292 Evergreen Priority Time Cap Review**](./analysis/2026-08-29-pr-292-evergreen-priority-time-cap-review.md) — Code review of the priority time cap logic implemented in PR #292.
+* [**2026-08-29 PR #292 Finding 8 Health/Strength Floor**](./analysis/2026-08-29-pr-292-finding-8-health-strength-floor.md) — Resolution analysis for Finding 8 regarding the health/strength baseline floor.
+* [**2026-08-29 Sleep Data & Training Recommendations Analysis**](./analysis/2026-08-29-sleep-data-training-recommendations-analysis.md) — Cross-correlation analysis of sleep architectures vs optimal training outcomes.
+* [**2026-08-29 Sleep Decision Authority Phase 2 Implementation**](./analysis/2026-08-29-sleep-decision-authority-phase-2-implementation.md) — Progress review for Phase 2 of sleep decision authority decoupling.
+* [**2026-08-29 Sleep Decision Authority Phase 3 Implementation**](./analysis/2026-08-29-sleep-decision-authority-phase-3-implementation.md) — Progress review for Phase 3 of sleep decision authority decoupling.
+* [**2026-08-29 Sleep Decision Authority Phase 4 Status**](./analysis/2026-08-29-sleep-decision-authority-phase-4-status.md) — Status report for Phase 4 of sleep decision authority decoupling.
 
 ---
 

--- a/docs/adr/0032-cause-aware-subjective-symptom-gating.md
+++ b/docs/adr/0032-cause-aware-subjective-symptom-gating.md
@@ -1,4 +1,4 @@
-# ADR-0031: Cause-Aware Subjective Symptom Gating
+# ADR-0032: Cause-Aware Subjective Symptom Gating
 
 * **Status:** Accepted
 * **Date:** 2026-08-29

--- a/docs/plans/allergy-and-cause-aware-symptom-reporting.md
+++ b/docs/plans/allergy-and-cause-aware-symptom-reporting.md
@@ -3,7 +3,7 @@
 Status: **implemented**. Worktree: `.claude/worktrees/symptom-reporting`,
 branch `feat/subjective-symptom-reporting`. See §7 for what shipped and how it differs from
 this document's original sketch. The final safety decision is recorded in
-[ADR-0031](../adr/0031-cause-aware-subjective-symptom-gating.md).
+[ADR-0032](../adr/0032-cause-aware-subjective-symptom-gating.md).
 
 ## 1. The gap, precisely
 
@@ -54,7 +54,7 @@ need to change how the engine reacts.
 like an injury.** Use the new cause/severity/type detail to soften the
 `painFlag`/`clinicalFlagActive` path only when the report is explicit enough to pass a
 fail-closed predicate. This changes actual recommendation output, so it requires a policy
-version, targeted regression coverage and policy-drift checks. See §5 and ADR-0031.
+version, targeted regression coverage and policy-drift checks. See §5 and ADR-0032.
 
 ## 3. Phase 1 — file-by-file
 
@@ -86,7 +86,7 @@ version, targeted regression coverage and policy-drift checks. See §5 and ADR-0
   explanation/label.
 - `feedbackValidation.test.ts` — covers the new `ModificationReason`.
 - [`adapters.test.ts`](../../app/src/engine/adapters.test.ts) — covers the complete decision
-  predicate described in §5/ADR-0031.
+  predicate described in §5/ADR-0032.
 
 A future cross-check test could additionally parse `firestore.rules` and compare its hardcoded
 symptom/explanation allow-lists with the TypeScript constants. Rules cannot import TypeScript,
@@ -146,7 +146,7 @@ early infection or an airway condition. IOC guidance explicitly distinguishes in
 non-infective respiratory illness in athletes, while EAACI guidance emphasizes accurate
 diagnosis and the possible coexistence of allergic rhinitis with asthma/exercise-induced
 bronchoconstriction. The app does not yet model enough respiratory red flags to safely relax
-cough/sore-throat/other presentations. ADR-0031 records that evidence and the resulting product
+cough/sore-throat/other presentations. ADR-0032 records that evidence and the resulting product
 boundary.
 
 ## 6. Suggested sequencing
@@ -159,7 +159,7 @@ The implementation followed this sequence:
 4. Add targeted decision and Firestore-rule tests.
 5. Add `adapters.ts` to the policy-drift decision-affecting file set and bump `POLICY_VERSION`.
 6. Deep-review the safety predicate, harden missing-detail and symptom-shape behavior, and record
-   the final decision in ADR-0031.
+   the final decision in ADR-0032.
 
 ## 7. What actually shipped
 
@@ -180,7 +180,7 @@ The review also closed the policy-drift coverage gap exposed by this feature:
 
 - `app/src/engine/adapters.ts` is now in `decisionAffectingFiles`.
 - `POLICY_VERSION` is `2026-08-allergy-symptom-gating-v1`.
-- [ADR-0031](../adr/0031-cause-aware-subjective-symptom-gating.md) records the final safety
+- [ADR-0032](../adr/0032-cause-aware-subjective-symptom-gating.md) records the final safety
   policy and evidence rationale.
 
 The initial implementation passed the full app and Firestore-rule suites before review. The


### PR DESCRIPTION
**📄 What:** 
1. Fixed an ADR numbering conflict where two ADRs shared `0031`. Renamed the symptom gating ADR to `ADR-0032` and updated related plans.
2. Appended 17 recently added analysis documents and the missing ADR to the index in `docs/README.md`.

**⚠️ Problem:** 
1. `ADR-0031` was duplicated, causing confusion.
2. The documentation hub routing table (`docs/README.md`) was missing several newly created analysis files and an ADR, leading to documentation drift.

**📚 Source of truth:** 
The actual files in `docs/adr/` and `docs/analysis/`. Validated using a custom filesystem audit script.

**✅ Verification:** 
* Ran `make check` to confirm documentation link linters and full project formatting remain clean.

**🎯 Impact:** 
Engineers and AI agents using `docs/README.md` as the main routing table can now reliably discover recent structural and analytical decisions, preventing duplicated investigations.

**🔒 Governance:** 
No product scope, architectural authority, or operational limits were changed. Pure index alignment.

---
*PR created automatically by Jules for task [7574556712551052819](https://jules.google.com/task/7574556712551052819) started by @Szczepanov*