### PR TITLE
feat: add respiration elevation shadow evidence

### DIFF
--- a/app/firestore.rules
+++ b/app/firestore.rules
@@ -1255,7 +1255,6 @@ service cloud.firestore {
     function hasValidHealthAnomalyThresholdPolicy(policy) {
       return policy is map
         && policy.keys().hasOnly(['policyVersion', 'moderateDeviation', 'strongDeviation', 'minimumCoreSignalsForMultiSignal', 'persistenceDaysForEscalation', 'minimumHistoryCount', 'minimumRecentDayCoverage', 'maxBaselineAgeDays', 'estimatorBySignal'])
-        && policy.keys().hasAll(['policyVersion', 'moderateDeviation', 'strongDeviation', 'minimumCoreSignalsForMultiSignal', 'persistenceDaysForEscalation', 'minimumHistoryCount', 'minimumRecentDayCoverage', 'maxBaselineAgeDays', 'estimatorBySignal'])
         && policy.policyVersion is string && policy.policyVersion.size() > 0 && policy.policyVersion.size() <= 128
         && policy.moderateDeviation is number && policy.moderateDeviation > 0 && policy.moderateDeviation <= 20
         && policy.strongDeviation is number && policy.strongDeviation > policy.moderateDeviation && policy.strongDeviation <= 20
@@ -1278,7 +1277,6 @@ service cloud.firestore {
       let assessment = data.assessment;
       return isOwner(userId)
         && data.keys().hasOnly(['userId', 'date', 'revisionId', 'idempotencyKey', 'computedAt', 'policyVersion', 'thresholdPolicy', 'mode', 'source', 'assessment', 'schemaVersion'])
-        && data.keys().hasAll(['userId', 'date', 'revisionId', 'idempotencyKey', 'computedAt', 'policyVersion', 'thresholdPolicy', 'mode', 'source', 'assessment', 'schemaVersion'])
         && data.userId == userId
         && data.date == date
         && isValidActivityDate(data.date)
@@ -1302,7 +1300,7 @@ service cloud.firestore {
         && (source.travelContextRevision == null || source.travelContextRevision is string)
         && isValidActivityDate(source.persistenceLookbackStart)
         && assessment is map
-        && assessment.keys().hasOnly(['state', 'evidenceLevel', 'coreSignals', 'supportingSignals', 'explanations', 'unexplainedEvidence', 'persistenceDays', 'episodeId', 'episodeDay', 'dataQuality', 'rationale', 'policyVersion', 'thresholdPolicyVersion', 'mode'])
+        && assessment.keys().hasOnly(['state', 'evidenceLevel', 'coreSignals', 'supportingSignals', 'explanations', 'unexplainedEvidence', 'persistenceDays', 'episodeId', 'episodeDay', 'dataQuality', 'rationale', 'respirationElevation', 'policyVersion', 'thresholdPolicyVersion', 'mode'])
         && assessment.keys().hasAll(['state', 'evidenceLevel', 'coreSignals', 'supportingSignals', 'explanations', 'unexplainedEvidence', 'persistenceDays', 'episodeId', 'episodeDay', 'dataQuality', 'rationale', 'policyVersion', 'thresholdPolicyVersion', 'mode'])
         && assessment.state in ['normal', 'explained_recovery_strain', 'watch_unexplained', 'possible_illness_or_systemic_stress', 'symptoms_reported']
         && assessment.evidenceLevel in ['none', 'low', 'moderate', 'high']
@@ -1315,6 +1313,10 @@ service cloud.firestore {
         && (assessment.episodeDay == null || (assessment.episodeDay is int && assessment.episodeDay >= 1 && assessment.episodeDay <= 365))
         && assessment.dataQuality is list && assessment.dataQuality.size() <= 3
         && assessment.rationale is map
+        // The parent assessment rule is close to Firestore's 1,000-expression ceiling.
+        // Keep the server boundary bounded; the application parser validates every scalar.
+        && (!('respirationElevation' in assessment)
+          || (assessment.respirationElevation is map && assessment.respirationElevation.size() <= 11))
         && assessment.policyVersion == data.policyVersion
         && assessment.thresholdPolicyVersion == data.thresholdPolicy.policyVersion
         && assessment.mode == data.mode;

--- a/app/scripts/respiration-real-history-replay.mjs
+++ b/app/scripts/respiration-real-history-replay.mjs
@@ -68,7 +68,6 @@ function round(value) {
 function snapshotFor(date, raw, history) {
     const window7 = history.slice(-7);
     const window28 = history.slice(-28);
-    const values = field => history.map(item => item[field]);
     const values7 = field => window7.map(item => item[field]);
     const values28 = field => window28.map(item => item[field]);
 
@@ -278,9 +277,11 @@ const markdown = [
     '',
     '## Personal-delta threshold sweep',
     '',
-    '| Candidate | Minimum Δ28d | Minimum Δ7d | Matches | Actionable | Already conservative | 2-night persistent | Corroborated | Isolated | Resolving tails |',
+    '- Existing readiness-strain overlap uses the production aggregate metric strain (sleep + RHR + HRV). It is descriptive overlap, not adverse RHR/low-HRV physiological corroboration.',
+    '',
+    '| Candidate | Minimum Δ28d | Minimum Δ7d | Matches | Actionable | Already conservative | 2-night persistent | Existing readiness-strain overlap | No readiness-strain overlap | Resolving tails |',
     '|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|',
-    ...report.thresholdSweep.map(candidate => `| ${candidate.id} | ${candidate.minimumDelta28d} | ${candidate.minimumDelta7d} | ${candidate.matchedDays} | ${candidate.actionableMatchedDays} | ${candidate.actionableDaysAlreadyConservative} | ${candidate.persistentTwoNightDays} | ${candidate.corroboratedByExistingMetricStrainDays} | ${candidate.isolatedFromExistingMetricStrainDays} | ${candidate.resolvingTailDays} |`),
+    ...report.thresholdSweep.map(candidate => `| ${candidate.id} | ${candidate.minimumDelta28d} | ${candidate.minimumDelta7d} | ${candidate.matchedDays} | ${candidate.actionableMatchedDays} | ${candidate.actionableDaysAlreadyConservative} | ${candidate.persistentTwoNightDays} | ${candidate.existingReadinessStrainOverlapDays} | ${candidate.noExistingReadinessStrainOverlapDays} | ${candidate.resolvingTailDays} |`),
     '',
     '## False positives',
     '',

--- a/app/scripts/respiration-real-history-replay.mjs
+++ b/app/scripts/respiration-real-history-replay.mjs
@@ -1,0 +1,306 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createServer } from 'vite';
+import {
+    assessLabelledFalsePositives,
+    buildRespirationThresholdSweep,
+    summarizeCounterfactualRows,
+} from './respirationReplayAnalysis.mjs';
+
+const appRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const repoRoot = resolve(appRoot, '..');
+function argument(name) {
+    const index = process.argv.indexOf(name);
+    return index >= 0 ? process.argv[index + 1] ?? null : null;
+}
+
+const inputPath = resolve(repoRoot, argument('--input') ?? 'raw_cache.json');
+const outputDir = resolve(repoRoot, argument('--out-dir') ?? 'artifacts/respiration-real-history-replay/latest');
+const labelsArgument = argument('--labels');
+const labelsPath = labelsArgument ? resolve(repoRoot, labelsArgument) : null;
+
+if (!existsSync(inputPath)) {
+    throw new Error(`Real-history input not found: ${inputPath}`);
+}
+
+function valid(values) {
+    return values.filter(value => value !== null && value !== undefined);
+}
+
+function average(values, minimum) {
+    const valuesValid = valid(values);
+    return valuesValid.length >= minimum
+        ? valuesValid.reduce((sum, value) => sum + value, 0) / valuesValid.length
+        : null;
+}
+
+function median(values, minimum) {
+    const valuesValid = [...valid(values)].sort((a, b) => a - b);
+    if (valuesValid.length < minimum) return null;
+    const middle = Math.floor(valuesValid.length / 2);
+    return valuesValid.length % 2 === 0
+        ? (valuesValid[middle - 1] + valuesValid[middle]) / 2
+        : valuesValid[middle];
+}
+
+function populationStdev(values, minimum) {
+    const valuesValid = valid(values);
+    if (valuesValid.length < minimum) return null;
+    const mean = valuesValid.reduce((sum, value) => sum + value, 0) / valuesValid.length;
+    return Math.sqrt(valuesValid.reduce((sum, value) => sum + ((value - mean) ** 2), 0) / valuesValid.length);
+}
+
+function mad(values, minimum) {
+    const center = median(values, minimum);
+    if (center === null) return null;
+    return median(values.map(value => Math.abs(value - center)), minimum) * 1.4826;
+}
+
+function delta(current, baseline) {
+    return current !== null && baseline !== null ? current - baseline : null;
+}
+
+function round(value) {
+    return value === null ? null : Math.round(value * 10000) / 10000;
+}
+
+function snapshotFor(date, raw, history) {
+    const window7 = history.slice(-7);
+    const window28 = history.slice(-28);
+    const values = field => history.map(item => item[field]);
+    const values7 = field => window7.map(item => item[field]);
+    const values28 = field => window28.map(item => item[field]);
+
+    const current = {
+        sleepScore: raw.sleepScore ?? null,
+        restingHr: raw.restingHr ?? null,
+        hrvOvernightAvg: raw.hrvOvernightAvg ?? null,
+        respirationAvg: raw.respirationAvg ?? null,
+        totalSteps: raw.totalSteps ?? null,
+    };
+    const sleep7 = average(values7('sleepScore'), 4);
+    const sleep28 = average(values28('sleepScore'), 14);
+    const rhr7 = average(values7('restingHr'), 4);
+    const rhr28 = average(values28('restingHr'), 14);
+    const hrv7 = average(values7('hrvOvernightAvg'), 4);
+    const hrv28 = average(values28('hrvOvernightAvg'), 14);
+    const resp7 = median(values7('respirationAvg'), 4);
+    const resp28 = median(values28('respirationAvg'), 14);
+    const steps7 = average(values7('totalSteps'), 4);
+    const steps28 = average(values28('totalSteps'), 14);
+
+    return {
+        userId: 'real-history-replay',
+        date,
+        source: { garminSyncedAt: `${date}T08:00:00.000Z`, sourceSchemaVersion: 3 },
+        raw: {
+            sleepScore: current.sleepScore,
+            sleepDurationSec: raw.sleepDurationSec ?? null,
+            restingHr: current.restingHr,
+            hrvOvernightAvg: current.hrvOvernightAvg,
+            hrvStatus: raw.hrvStatus ?? null,
+            respirationAvg: current.respirationAvg,
+            bodyBatteryWake: raw.bodyBatteryWake ?? null,
+            bodyBatteryChange: raw.bodyBatteryChange ?? null,
+            totalSteps: current.totalSteps,
+            last3DaysHardSessionsCount: raw.last3DaysHardSessionsCount ?? 0,
+            yesterdayTraining: raw.yesterdayTraining ?? null,
+            todayTraining: raw.todayTraining ?? null,
+        },
+        derived: {
+            baselineComputationVersion: 3,
+            sleepScore7dAvg: round(sleep7),
+            sleepScore28dAvg: round(sleep28),
+            restingHr7dAvg: round(rhr7),
+            restingHr28dAvg: round(rhr28),
+            hrv7dAvg: round(hrv7),
+            hrv28dAvg: round(hrv28),
+            respiration7dAvg: round(resp7),
+            respiration28dAvg: round(resp28),
+            hrv28dStdev: round(populationStdev(values28('hrvOvernightAvg'), 14)),
+            restingHr28dStdev: round(populationStdev(values28('restingHr'), 14)),
+            sleepScore28dStdev: round(populationStdev(values28('sleepScore'), 14)),
+            respiration28dMad: round(mad(values28('respirationAvg'), 14)),
+            steps7dAvg: round(steps7),
+            steps28dAvg: round(steps28),
+            steps28dStdev: round(populationStdev(values28('totalSteps'), 14)),
+            deltas: {
+                sleepScoreVs7d: round(delta(current.sleepScore, sleep7)),
+                sleepScoreVs28d: round(delta(current.sleepScore, sleep28)),
+                restingHrVs7d: round(delta(current.restingHr, rhr7)),
+                restingHrVs28d: round(delta(current.restingHr, rhr28)),
+                hrvVs7d: round(delta(current.hrvOvernightAvg, hrv7)),
+                hrvVs28d: round(delta(current.hrvOvernightAvg, hrv28)),
+                respirationVs7d: round(delta(current.respirationAvg, resp7)),
+                respirationVs28d: round(delta(current.respirationAvg, resp28)),
+                stepsVs7d: round(delta(current.totalSteps, steps7)),
+                stepsVs28d: round(delta(current.totalSteps, steps28)),
+            },
+        },
+        dataQuality: {
+            sleepScoreAvailable: current.sleepScore !== null,
+            restingHrAvailable: current.restingHr !== null,
+            hrvAvailable: current.hrvOvernightAvg !== null,
+            baseline7dReady: sleep7 !== null && rhr7 !== null && hrv7 !== null && resp7 !== null,
+            baseline28dReady: sleep28 !== null && rhr28 !== null && hrv28 !== null && resp28 !== null,
+        },
+        createdAt: `${date}T08:00:00.000Z`,
+        updatedAt: `${date}T08:00:00.000Z`,
+    };
+}
+
+const cache = JSON.parse(readFileSync(inputPath, 'utf8'));
+const labelsByDate = labelsPath ? JSON.parse(readFileSync(labelsPath, 'utf8')) : null;
+const dates = Object.keys(cache).sort();
+const snapshots = dates.map((date, index) => snapshotFor(date, cache[date], dates.slice(0, index).map(item => cache[item])));
+
+const server = await createServer({
+    configFile: false,
+    root: appRoot,
+    logLevel: 'warn',
+    server: { middlewareMode: true },
+    appType: 'custom',
+});
+
+let adapters;
+let rules;
+try {
+    adapters = await server.ssrLoadModule('/src/engine/adapters.ts');
+    rules = await server.ssrLoadModule('/src/engine/rules.ts');
+} finally {
+    await server.close();
+}
+
+const subjective = {
+    readiness: 9,
+    sleepQuality: 9,
+    fatigue: 2,
+    soreness: 2,
+    stress: 2,
+    motivation: 9,
+    timeAvailable: 60,
+    painFlag: false,
+    alreadyTrainedToday: false,
+    preferredModalityToday: null,
+};
+const context = {
+    goals: { shortTerm: '', midTerm: '', longTerm: '' },
+    constraints: {
+        hasCableMachine: false,
+        hasFreeWeights: true,
+        hasTreadmill: false,
+        hasIndoorBike: false,
+        restrictedModalities: [],
+        maxTimeMinutes: 90,
+    },
+    preferences: {
+        avoidedModalities: [],
+        deprioritizedModalities: [],
+        preferredModalities: [],
+        conservativeBias: false,
+    },
+};
+
+const rows = snapshots.slice(28).map(snapshot => {
+    const productionInput = adapters.mapSnapshotToEngineInput(snapshot, 'off');
+    const respirationInput = adapters.mapSnapshotToEngineInput(snapshot, 'median-mad-v1');
+    const production = rules.evaluateTraining({ subjective, objective: productionInput }, context, snapshot.date);
+    const candidate = rules.evaluateTraining({ subjective, objective: respirationInput }, context, snapshot.date);
+    return {
+        date: snapshot.date,
+        respiration: snapshot.raw.respirationAvg,
+        respirationDelta7d: snapshot.derived.deltas.respirationVs7d,
+        respirationDelta28d: snapshot.derived.deltas.respirationVs28d,
+        respirationMad28d: snapshot.derived.respiration28dMad,
+        productionMode: production.mode,
+        candidateMode: candidate.mode,
+        productionScore: production.telemetry?.totalDecisionScore ?? null,
+        candidateScore: candidate.telemetry?.totalDecisionScore ?? null,
+        productionMetricStrain: production.telemetry?.metricStrain.totalMetricStrain ?? null,
+        respirationAddedStrain: round((candidate.telemetry?.metricStrain.totalMetricStrain ?? 0) - (production.telemetry?.metricStrain.totalMetricStrain ?? 0)),
+        modeFlip: production.mode !== candidate.mode,
+        todayTrainingPresent: snapshot.raw.todayTraining !== null,
+        actionableMorning: snapshot.raw.todayTraining === null,
+    };
+});
+
+const flips = rows.filter(row => row.modeFlip);
+const respirationReady = rows.filter(row => row.respirationMad28d !== null);
+const actionableRows = rows.filter(row => row.actionableMorning);
+const alreadyTrainedRows = rows.filter(row => !row.actionableMorning);
+const counterfactual = summarizeCounterfactualRows(rows);
+const actionableCounterfactual = summarizeCounterfactualRows(actionableRows);
+const alreadyTrainedCounterfactual = summarizeCounterfactualRows(alreadyTrainedRows);
+
+const report = {
+    generatedFrom: 'real-history-replay',
+    input: inputPath,
+    dateRange: { start: dates[0] ?? null, end: dates.at(-1) ?? null },
+    totalInputDays: dates.length,
+    evaluatedDays: rows.length,
+    warmupDays: Math.min(28, dates.length),
+    respirationCoverage: {
+        inputDaysWithRespiration: dates.filter(date => cache[date].respirationAvg !== null && cache[date].respirationAvg !== undefined).length,
+        evaluatedDaysWithMeasuredMad: respirationReady.length,
+    },
+    counterfactual: {
+        subjectiveContext: 'fixed green check-in (readiness/sleep quality/motivation 9; fatigue/soreness/stress 2)',
+        productionPolicy: 'off',
+        candidatePolicy: 'median-mad-v1',
+        ...counterfactual,
+    },
+    actionableCounterfactual,
+    alreadyTrainedCounterfactual,
+    thresholdSweep: buildRespirationThresholdSweep(rows),
+    falsePositiveAssessment: assessLabelledFalsePositives(rows, labelsByDate),
+    rows,
+};
+
+mkdirSync(outputDir, { recursive: true });
+writeFileSync(resolve(outputDir, 'report.json'), `${JSON.stringify(report, null, 2)}\n`);
+const markdown = [
+    '# Respiration real-history counterfactual replay',
+    '',
+    `- Input range: ${report.dateRange.start} to ${report.dateRange.end}`,
+    `- Input days: ${report.totalInputDays}; evaluated after 28-day warmup: ${report.evaluatedDays}`,
+    `- Respiration coverage: ${report.respirationCoverage.inputDaysWithRespiration}/${report.totalInputDays} input days`,
+    `- Candidate policy: ${report.counterfactual.candidatePolicy}`,
+    '',
+    '## Recommendation counterfactual',
+    '',
+    `- Actionable morning mode flips: ${report.actionableCounterfactual.modeFlipCount}/${report.actionableCounterfactual.evaluatedDays} (${report.actionableCounterfactual.modeFlipRate === null ? 'n/a' : `${(report.actionableCounterfactual.modeFlipRate * 100).toFixed(1)}%`})`,
+    `- Actionable flip directions: ${JSON.stringify(report.actionableCounterfactual.flipDirections)}`,
+    `- Aggregate mode flips (includes already-trained days): ${report.counterfactual.modeFlipCount}/${report.evaluatedDays} (${report.counterfactual.modeFlipRate === null ? 'n/a' : `${(report.counterfactual.modeFlipRate * 100).toFixed(1)}%`})`,
+    `- Already-trained rows: ${report.alreadyTrainedCounterfactual.evaluatedDays}`,
+    `- Mean added respiration strain on actionable mornings: ${report.actionableCounterfactual.meanRespirationAddedStrain}`,
+    `- Maximum added respiration strain on actionable mornings: ${report.actionableCounterfactual.maxRespirationAddedStrain}`,
+    '',
+    '## Personal-delta threshold sweep',
+    '',
+    '| Candidate | Minimum Δ28d | Minimum Δ7d | Matches | Actionable | Already conservative | 2-night persistent | Corroborated | Isolated | Resolving tails |',
+    '|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|',
+    ...report.thresholdSweep.map(candidate => `| ${candidate.id} | ${candidate.minimumDelta28d} | ${candidate.minimumDelta7d} | ${candidate.matchedDays} | ${candidate.actionableMatchedDays} | ${candidate.actionableDaysAlreadyConservative} | ${candidate.persistentTwoNightDays} | ${candidate.corroboratedByExistingMetricStrainDays} | ${candidate.isolatedFromExistingMetricStrainDays} | ${candidate.resolvingTailDays} |`),
+    '',
+    '## False positives',
+    '',
+    `- ${report.falsePositiveAssessment.note}`,
+    '',
+    '## Flipped days',
+    '',
+    '| Date | Respiration | Δ7d | Δ28d | MAD28d | Production | Candidate | Added strain |',
+    '|---|---:|---:|---:|---:|---|---|---:|',
+    ...flips.map(row => `| ${row.date} | ${row.respiration ?? '—'} | ${row.respirationDelta7d ?? '—'} | ${row.respirationDelta28d ?? '—'} | ${row.respirationMad28d ?? '—'} | ${row.productionMode} | ${row.candidateMode} | ${row.respirationAddedStrain} |`),
+    '',
+    '> This is a real-history counterfactual, not a clinical validation study. The subjective context is held green and no illness labels are available.',
+].join('\n') + '\n';
+writeFileSync(resolve(outputDir, 'report.md'), markdown);
+console.log(`Replay report written to ${outputDir}`);
+console.log(JSON.stringify({
+    evaluatedDays: report.evaluatedDays,
+    actionableDays: report.actionableCounterfactual.evaluatedDays,
+    actionableModeFlipCount: report.actionableCounterfactual.modeFlipCount,
+    actionableModeFlipRate: report.actionableCounterfactual.modeFlipRate,
+    aggregateModeFlipCount: report.counterfactual.modeFlipCount,
+    falsePositiveRate: report.falsePositiveAssessment.rate,
+}, null, 2));

--- a/app/scripts/respirationReplayAnalysis.mjs
+++ b/app/scripts/respirationReplayAnalysis.mjs
@@ -1,0 +1,122 @@
+export const RESPIRATION_ELEVATION_CANDIDATES = Object.freeze([
+    { id: 'E1', minimumDelta28d: 0.75, minimumDelta7d: 0.25 },
+    { id: 'E2', minimumDelta28d: 1, minimumDelta7d: 0.5 },
+    { id: 'E3', minimumDelta28d: 1.25, minimumDelta7d: 0.75 },
+    { id: 'S1', minimumDelta28d: 2, minimumDelta7d: 1 },
+]);
+
+function modeCounts(values) {
+    return values.reduce((counts, value) => {
+        counts[value] = (counts[value] ?? 0) + 1;
+        return counts;
+    }, {});
+}
+
+function round(value) {
+    return value === null ? null : Math.round(value * 10000) / 10000;
+}
+
+function mean(values) {
+    return values.length > 0
+        ? values.reduce((sum, value) => sum + value, 0) / values.length
+        : null;
+}
+
+export function summarizeCounterfactualRows(rows) {
+    const flips = rows.filter(row => row.modeFlip);
+    const addedStrain = rows
+        .map(row => row.respirationAddedStrain)
+        .filter(value => Number.isFinite(value));
+    return {
+        evaluatedDays: rows.length,
+        productionModeCounts: modeCounts(rows.map(row => row.productionMode)),
+        candidateModeCounts: modeCounts(rows.map(row => row.candidateMode)),
+        modeFlipCount: flips.length,
+        modeFlipRate: rows.length > 0 ? flips.length / rows.length : null,
+        flipDirections: modeCounts(flips.map(row => `${row.productionMode}->${row.candidateMode}`)),
+        meanRespirationAddedStrain: round(mean(addedStrain)),
+        maxRespirationAddedStrain: round(addedStrain.length > 0 ? Math.max(...addedStrain) : null),
+        flippedDates: flips.map(row => row.date),
+    };
+}
+
+function hasMeasuredDeltas(row) {
+    return Number.isFinite(row.respirationDelta7d) && Number.isFinite(row.respirationDelta28d);
+}
+
+function previousCalendarDate(date) {
+    const parsed = new Date(`${date}T00:00:00Z`);
+    parsed.setUTCDate(parsed.getUTCDate() - 1);
+    return parsed.toISOString().slice(0, 10);
+}
+
+export function classifyRespirationThreshold(row, candidate) {
+    if (!hasMeasuredDeltas(row)) return 'unavailable';
+    if (row.respirationDelta7d <= 0 && row.respirationDelta28d > 0) return 'resolving';
+    if (
+        row.respirationDelta28d >= candidate.minimumDelta28d
+        && row.respirationDelta7d >= candidate.minimumDelta7d
+    ) return 'elevated';
+    return 'normal';
+}
+
+export function buildRespirationThresholdSweep(rows, candidates = RESPIRATION_ELEVATION_CANDIDATES) {
+    return candidates.map(candidate => {
+        const classified = rows.map(row => ({ row, status: classifyRespirationThreshold(row, candidate) }));
+        const matched = classified.filter(item => item.status === 'elevated').map(item => item.row);
+        const actionable = matched.filter(row => row.actionableMorning);
+        const alreadyConservative = actionable.filter(row => row.productionMode !== 'train');
+        const matchedDates = new Set(matched.map(row => row.date));
+        const persistent = matched.filter(row => matchedDates.has(previousCalendarDate(row.date)));
+        const corroborated = matched.filter(row => (row.productionMetricStrain ?? 0) > 0);
+        const isolated = matched.filter(row => (row.productionMetricStrain ?? 0) <= 0);
+        const resolving = classified.filter(item => item.status === 'resolving').map(item => item.row);
+        return {
+            ...candidate,
+            matchedDays: matched.length,
+            matchedDates: matched.map(row => row.date),
+            actionableMatchedDays: actionable.length,
+            actionableMatchedDates: actionable.map(row => row.date),
+            matchedDaysWithoutSameDayTraining: matched.filter(row => !row.todayTrainingPresent).length,
+            actionableDaysAlreadyConservative: alreadyConservative.length,
+            actionableDaysAlreadyConservativeRate: actionable.length > 0
+                ? alreadyConservative.length / actionable.length
+                : null,
+            persistentTwoNightDays: persistent.length,
+            persistentTwoNightDates: persistent.map(row => row.date),
+            corroboratedByExistingMetricStrainDays: corroborated.length,
+            isolatedFromExistingMetricStrainDays: isolated.length,
+            resolvingTailDays: resolving.length,
+            resolvingTailDates: resolving.map(row => row.date),
+        };
+    });
+}
+
+export function assessLabelledFalsePositives(rows, labelsByDate) {
+    if (!labelsByDate) {
+        return {
+            labelledSubjectiveCheckins: false,
+            labelledIllnessOutcomes: false,
+            labelledActionableDays: 0,
+            labelledHealthyActionableDays: 0,
+            count: null,
+            rate: null,
+            note: 'No symptom, illness, or follow-up labels were supplied; conservative days are unlabelled signals, not measurable false positives.',
+        };
+    }
+    const labelledActionable = rows.filter(row => row.actionableMorning && labelsByDate[row.date]);
+    const healthy = labelledActionable.filter(row => labelsByDate[row.date].healthy === true);
+    const falsePositives = healthy.filter(row => row.modeFlip);
+    return {
+        labelledSubjectiveCheckins: labelledActionable.some(row => labelsByDate[row.date].symptomsReported !== undefined),
+        labelledIllnessOutcomes: labelledActionable.some(row => labelsByDate[row.date].healthy !== undefined),
+        labelledActionableDays: labelledActionable.length,
+        labelledHealthyActionableDays: healthy.length,
+        count: falsePositives.length,
+        rate: healthy.length > 0 ? falsePositives.length / healthy.length : null,
+        dates: falsePositives.map(row => row.date),
+        note: healthy.length > 0
+            ? 'A false positive is an actionable, labelled-healthy day where the broad counterfactual changed recommendation mode.'
+            : 'Labels were supplied, but none identify an actionable day as healthy; false-positive rate remains unavailable.',
+    };
+}

--- a/app/scripts/respirationReplayAnalysis.mjs
+++ b/app/scripts/respirationReplayAnalysis.mjs
@@ -68,8 +68,11 @@ export function buildRespirationThresholdSweep(rows, candidates = RESPIRATION_EL
         const alreadyConservative = actionable.filter(row => row.productionMode !== 'train');
         const matchedDates = new Set(matched.map(row => row.date));
         const persistent = matched.filter(row => matchedDates.has(previousCalendarDate(row.date)));
-        const corroborated = matched.filter(row => (row.productionMetricStrain ?? 0) > 0);
-        const isolated = matched.filter(row => (row.productionMetricStrain ?? 0) <= 0);
+        // `productionMetricStrain` is the existing aggregate readiness strain (sleep + RHR + HRV),
+        // not physiological corroboration. Keep this overlap descriptive and separate from the
+        // health-anomaly replay's adverse RHR/low-HRV corroboration predicate.
+        const existingReadinessStrainOverlap = matched.filter(row => (row.productionMetricStrain ?? 0) > 0);
+        const noExistingReadinessStrainOverlap = matched.filter(row => (row.productionMetricStrain ?? 0) <= 0);
         const resolving = classified.filter(item => item.status === 'resolving').map(item => item.row);
         return {
             ...candidate,
@@ -84,8 +87,10 @@ export function buildRespirationThresholdSweep(rows, candidates = RESPIRATION_EL
                 : null,
             persistentTwoNightDays: persistent.length,
             persistentTwoNightDates: persistent.map(row => row.date),
-            corroboratedByExistingMetricStrainDays: corroborated.length,
-            isolatedFromExistingMetricStrainDays: isolated.length,
+            existingReadinessStrainOverlapDays: existingReadinessStrainOverlap.length,
+            existingReadinessStrainOverlapDates: existingReadinessStrainOverlap.map(row => row.date),
+            noExistingReadinessStrainOverlapDays: noExistingReadinessStrainOverlap.length,
+            noExistingReadinessStrainOverlapDates: noExistingReadinessStrainOverlap.map(row => row.date),
             resolvingTailDays: resolving.length,
             resolvingTailDates: resolving.map(row => row.date),
         };

--- a/app/scripts/respirationReplayAnalysis.test.mjs
+++ b/app/scripts/respirationReplayAnalysis.test.mjs
@@ -45,7 +45,7 @@ describe('respiration replay analysis', () => {
         expect(classifyRespirationThreshold(row({ respiration: 16, respirationDelta7d: 0.2, respirationDelta28d: 0.4 }), e2)).toBe('normal');
     });
 
-    it('reports threshold matches, conservative overlap and resolving tails', () => {
+    it('reports threshold matches, conservative overlap, readiness-strain overlap and resolving tails', () => {
         const sweep = buildRespirationThresholdSweep([
             row(),
             row({ date: '2026-08-02', productionMode: 'modify', candidateMode: 'modify', modeFlip: false, productionMetricStrain: 1 }),
@@ -56,10 +56,18 @@ describe('respiration replay analysis', () => {
             actionableMatchedDays: 2,
             actionableDaysAlreadyConservative: 1,
             persistentTwoNightDays: 1,
-            corroboratedByExistingMetricStrainDays: 1,
-            isolatedFromExistingMetricStrainDays: 1,
+            existingReadinessStrainOverlapDays: 1,
+            noExistingReadinessStrainOverlapDays: 1,
             resolvingTailDays: 1,
         });
+    });
+
+    it('does not expose aggregate readiness strain under physiological corroboration names', () => {
+        const result = buildRespirationThresholdSweep([row({ productionMetricStrain: 1 })])
+            .find(candidate => candidate.id === 'E2');
+        expect(result).not.toHaveProperty('corroboratedByExistingMetricStrainDays');
+        expect(result).not.toHaveProperty('isolatedFromExistingMetricStrainDays');
+        expect(result).toMatchObject({ existingReadinessStrainOverlapDays: 1 });
     });
 
     it('keeps false-positive rate null without labels and computes only labelled healthy days', () => {

--- a/app/scripts/respirationReplayAnalysis.test.mjs
+++ b/app/scripts/respirationReplayAnalysis.test.mjs
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import {
+    assessLabelledFalsePositives,
+    buildRespirationThresholdSweep,
+    classifyRespirationThreshold,
+    RESPIRATION_ELEVATION_CANDIDATES,
+    summarizeCounterfactualRows,
+} from './respirationReplayAnalysis.mjs';
+
+function row(overrides = {}) {
+    return {
+        date: '2026-08-01',
+        respirationDelta7d: 0.5,
+        respirationDelta28d: 1,
+        productionMode: 'train',
+        candidateMode: 'modify',
+        respirationAddedStrain: 1,
+        productionMetricStrain: 0,
+        modeFlip: true,
+        actionableMorning: true,
+        todayTrainingPresent: false,
+        ...overrides,
+    };
+}
+
+describe('respiration replay analysis', () => {
+    it('uses the actionable-morning denominator independently from aggregate rows', () => {
+        const rows = [
+            row(),
+            row({ date: '2026-08-02', actionableMorning: false, todayTrainingPresent: true }),
+            row({ date: '2026-08-03', candidateMode: 'train', modeFlip: false }),
+        ];
+        expect(summarizeCounterfactualRows(rows)).toMatchObject({ evaluatedDays: 3, modeFlipCount: 2 });
+        expect(summarizeCounterfactualRows(rows.filter(value => value.actionableMorning))).toMatchObject({
+            evaluatedDays: 2,
+            modeFlipCount: 1,
+            modeFlipRate: 0.5,
+        });
+    });
+
+    it('classifies rising and resolving deltas without treating absolute respiration as a threshold', () => {
+        const e2 = RESPIRATION_ELEVATION_CANDIDATES.find(candidate => candidate.id === 'E2');
+        expect(classifyRespirationThreshold(row({ respirationDelta7d: 0.5, respirationDelta28d: 1 }), e2)).toBe('elevated');
+        expect(classifyRespirationThreshold(row({ respiration: 15, respirationDelta7d: -0.1, respirationDelta28d: 1.2 }), e2)).toBe('resolving');
+        expect(classifyRespirationThreshold(row({ respiration: 16, respirationDelta7d: 0.2, respirationDelta28d: 0.4 }), e2)).toBe('normal');
+    });
+
+    it('reports threshold matches, conservative overlap and resolving tails', () => {
+        const sweep = buildRespirationThresholdSweep([
+            row(),
+            row({ date: '2026-08-02', productionMode: 'modify', candidateMode: 'modify', modeFlip: false, productionMetricStrain: 1 }),
+            row({ date: '2026-08-03', respirationDelta7d: -0.1, respirationDelta28d: 1.2 }),
+        ]);
+        expect(sweep.find(candidate => candidate.id === 'E2')).toMatchObject({
+            matchedDays: 2,
+            actionableMatchedDays: 2,
+            actionableDaysAlreadyConservative: 1,
+            persistentTwoNightDays: 1,
+            corroboratedByExistingMetricStrainDays: 1,
+            isolatedFromExistingMetricStrainDays: 1,
+            resolvingTailDays: 1,
+        });
+    });
+
+    it('keeps false-positive rate null without labels and computes only labelled healthy days', () => {
+        const rows = [row(), row({ date: '2026-08-02', modeFlip: false, candidateMode: 'train' })];
+        expect(assessLabelledFalsePositives(rows, null).rate).toBeNull();
+        expect(assessLabelledFalsePositives(rows, {
+            '2026-08-01': { healthy: true, symptomsReported: false },
+            '2026-08-02': { healthy: true, symptomsReported: false },
+        })).toMatchObject({ count: 1, rate: 0.5, labelledHealthyActionableDays: 2 });
+    });
+});

--- a/app/src/emulator/healthAnomalyAssessmentRules.emulator.test.ts
+++ b/app/src/emulator/healthAnomalyAssessmentRules.emulator.test.ts
@@ -69,6 +69,19 @@ function revision() {
             episodeDay: 1,
             dataQuality: [],
             rationale: { facts: [], explanations: [], cautions: ['NOT_A_DIAGNOSIS'] },
+            respirationElevation: {
+                status: 'elevated',
+                currentValue: 14,
+                baseline7dValue: 13.5,
+                baseline28dValue: 13,
+                deltaVs7d: 0.5,
+                deltaVs28d: 1,
+                baselineVersion: 5,
+                historyCount: 28,
+                recentDayCoverage: 1,
+                reasonCodes: ['ABOVE_ELEVATED_PERSONAL_DELTAS'],
+                policyVersion: 'respiration-elevation/shadow-e2-s1-v1',
+            },
             policyVersion: 'health-anomaly/ha3-v1',
             thresholdPolicyVersion: 'health-anomaly-thresholds/shadow-candidate-v1',
             mode: 'shadow-v1',
@@ -123,6 +136,13 @@ emulatorDescribe('Health anomaly assessment revision rules (HA4)', () => {
         await assertFails(setDoc(doc(db, revisionPath), {
             ...base,
             assessment: { ...base.assessment, state: 'diagnosed_flu' },
+        }));
+        await assertFails(setDoc(doc(db, revisionPath), {
+            ...base,
+            assessment: {
+                ...base.assessment,
+                respirationElevation: { ...base.assessment.respirationElevation, unexpected: true },
+            },
         }));
         await assertFails(setDoc(doc(db, revisionPath), {
             ...base,

--- a/app/src/engine/healthAnomaly.ts
+++ b/app/src/engine/healthAnomaly.ts
@@ -12,8 +12,9 @@ import {
     type PhysiologicalAnomalyAssessment,
     type SupportingSignalEvidence,
 } from './healthAnomalyModels';
+import { evaluateRespirationElevation } from './respirationElevation';
 
-export const HEALTH_ANOMALY_POLICY_VERSION = 'health-anomaly/ha3-v1';
+export const HEALTH_ANOMALY_POLICY_VERSION = 'health-anomaly/ha9-respiration-shadow-v1';
 
 /** Candidate values for shadow replay only; HA7 evidence, not architecture preference, decides cutover. */
 export const SHADOW_V1_HEALTH_ANOMALY_THRESHOLDS: HealthAnomalyThresholdPolicy = {
@@ -433,6 +434,20 @@ export function evaluatePhysiologicalAnomaly(
     const dataQuality = CORE_SIGNALS
         .map(signal => qualityForSignal(input, signal, featuresForSignal(input, signal)))
         .filter((quality): quality is CoreSignalDataQuality => quality !== null);
+    const respirationQuality = dataQuality.find(quality => quality.signal === 'respiration');
+    const respirationElevation = evaluateRespirationElevation({
+        targetDate: input.date,
+        measurementDate: input.recoverySnapshot?.date ?? null,
+        timezone: input.timezone,
+        currentValue: input.recoverySnapshot?.raw.respirationAvg ?? null,
+        baseline7dValue: input.recoverySnapshot?.derived.respiration7dAvg ?? null,
+        baseline28dValue: input.recoverySnapshot?.derived.respiration28dAvg ?? null,
+        baselineVersion: input.recoverySnapshot?.derived.baselineComputationVersion ?? null,
+        historyCount: respirationQuality?.historyCount ?? 0,
+        recentDayCoverage: respirationQuality?.recentDayCoverage ?? 0,
+        measurementEligible: (input.recoverySnapshot?.source.sourceSchemaVersion ?? 0) >= 3
+            && input.recoverySnapshot?.source.timezone === 'Europe/Warsaw',
+    });
     const supportingSignals = deriveSupportingSignals(input);
     const explanations = resolveExplanations(input);
     const adverseAnomalies = coreSignals.filter(isAdverseCoreSignalEvidence);
@@ -482,10 +497,25 @@ export function evaluatePhysiologicalAnomaly(
         episodeDay: episode.episodeDay,
         dataQuality,
         rationale: {
-            facts: rationaleFacts(coreSignals, persistenceDays, symptomsReported, supportingSignals),
+            facts: [
+                ...rationaleFacts(coreSignals, persistenceDays, symptomsReported, supportingSignals),
+                ...(respirationElevation.status === 'elevated' || respirationElevation.status === 'strongly_elevated'
+                    ? [{
+                        code: respirationElevation.status === 'strongly_elevated'
+                            ? 'RESPIRATION_STRONGLY_ELEVATED'
+                            : 'RESPIRATION_ELEVATED',
+                        value: respirationElevation.deltaVs28d,
+                        unit: 'breaths/min above 28d median',
+                    }]
+                    : []),
+                ...(respirationElevation.status === 'resolving'
+                    ? [{ code: 'RESPIRATION_RESOLVING', value: respirationElevation.deltaVs7d, unit: 'breaths/min vs 7d median' }]
+                    : []),
+            ],
             explanations: explanations.map(explanation => explanation.kind.toUpperCase()),
             cautions: state === 'normal' ? [] : ['NOT_A_DIAGNOSIS'],
         },
+        respirationElevation,
         policyVersion: HEALTH_ANOMALY_POLICY_VERSION,
         thresholdPolicyVersion: thresholds.policyVersion,
         mode: policy,

--- a/app/src/engine/healthAnomaly.ts
+++ b/app/src/engine/healthAnomaly.ts
@@ -437,7 +437,7 @@ export function evaluatePhysiologicalAnomaly(
     const respirationQuality = dataQuality.find(quality => quality.signal === 'respiration');
     const respirationElevation = evaluateRespirationElevation({
         targetDate: input.date,
-        measurementDate: input.recoverySnapshot?.date ?? null,
+        measurementDate: input.recoverySnapshot?.source.metricDates?.sleep ?? null,
         timezone: input.timezone,
         currentValue: input.recoverySnapshot?.raw.respirationAvg ?? null,
         baseline7dValue: input.recoverySnapshot?.derived.respiration7dAvg ?? null,

--- a/app/src/engine/healthAnomalyFeatures.test.ts
+++ b/app/src/engine/healthAnomalyFeatures.test.ts
@@ -35,6 +35,7 @@ function makeSnapshot(
             garminSyncedAt: `${date}T06:00:00Z`,
             sourceSchemaVersion: 3,
             timezone: 'Europe/Warsaw',
+            metricDates: { sleep: date },
         },
         raw: {
             sleepScore: null,
@@ -125,7 +126,7 @@ describe('mapRecoverySnapshotToHealthAnomalyFeatures HA2', () => {
         expect(result.candidates[1].standardizedDeviation).toBeCloseTo((56 - 49) / 1.5);
     });
 
-    it('uses respiration median/MAD only for baseline v3+ and preserves unknown provenance', () => {
+    it('uses respiration median/MAD only for baseline v3+ and preserves selected-sleep provenance', () => {
         const current = makeSnapshot('2026-07-29', {
             respiration: 15.5,
             respirationMedian: 14,
@@ -140,7 +141,7 @@ describe('mapRecoverySnapshotToHealthAnomalyFeatures HA2', () => {
             scaleValue: 0.5,
             standardizedDeviation: 3,
         });
-        expect(compatible.measurementProvenance).toBeNull();
+        expect(compatible.measurementProvenance).toBe('garmin:sleep:2026-07-29');
 
         const legacy = makeSnapshot('2026-07-29', {
             respiration: 15.5,
@@ -152,6 +153,42 @@ describe('mapRecoverySnapshotToHealthAnomalyFeatures HA2', () => {
             status: 'unavailable',
             unavailableReason: 'incompatible_baseline_version',
             standardizedDeviation: null,
+        });
+    });
+
+    it('fails current respiration closed when selected sleep belongs to another date', () => {
+        const current = makeSnapshot('2026-07-29', {
+            respiration: 15.5,
+            respirationMedian: 14,
+            respirationMad: 0.5,
+        });
+        current.source.metricDates = { sleep: '2026-07-28' };
+
+        const result = signal(current, 'respiration');
+        expect(result.dataQuality.currentValueMissing).toBe(true);
+        expect(result.measurementProvenance).toBe('garmin:sleep:2026-07-28');
+        expect(result.candidates[0]).toMatchObject({
+            status: 'unavailable',
+            unavailableReason: 'missing_current',
+            standardizedDeviation: null,
+        });
+    });
+
+    it('keys respiration history by selected sleep date and does not double-count a fallback night', () => {
+        const current = makeSnapshot('2026-07-29', {
+            respiration: 14.8,
+            respirationMedian: 14,
+            respirationMad: 0.4,
+        });
+        const first = makeSnapshot('2026-07-27', { respiration: 14.0 });
+        const fallback = makeSnapshot('2026-07-28', { respiration: 14.2 });
+        fallback.source.metricDates = { sleep: '2026-07-27' };
+
+        const result = signal(current, 'respiration', [first, fallback]);
+        expect(result.dataQuality).toMatchObject({
+            historyCount: 1,
+            recentDayCoverage: 1 / 7,
+            baselineAgeDays: 2,
         });
     });
 

--- a/app/src/engine/healthAnomalyFeatures.ts
+++ b/app/src/engine/healthAnomalyFeatures.ts
@@ -67,7 +67,9 @@ export type ExtractedSignalObservations = {
 /**
  * Extract deduplicated, date-sorted observations for all core signals in a single pass.
  * Current/future rows are discarded, preserving the invariant that the current day
- * never enters its own reference baseline.
+ * never enters its own reference baseline. Respiration is keyed by the selected sleep
+ * record's metric date rather than the recovery document date so a D-1 sleep fallback is
+ * never silently re-labelled as a D observation.
  */
 export function extractSignalObservations(
     currentDate: string,
@@ -92,8 +94,20 @@ export function extractSignalObservations(
             byDateRhr.set(snapshot.date, { date: snapshot.date, day, value: rhrVal });
         }
         const respVal = finiteNumber(snapshot.raw.respirationAvg);
-        if (respVal !== null) {
-            byDateResp.set(snapshot.date, { date: snapshot.date, day, value: respVal });
+        const respirationDate = snapshot.source.metricDates?.sleep ?? null;
+        const respirationDay = respirationDate === null ? null : parseEpochDay(respirationDate);
+        if (
+            respVal !== null
+            && respirationDate !== null
+            && respirationDay !== null
+            && respirationDay >= startDay
+            && respirationDay < currentDay
+        ) {
+            byDateResp.set(respirationDate, {
+                date: respirationDate,
+                day: respirationDay,
+                value: respVal,
+            });
         }
         const hrvVal = finiteNumber(snapshot.raw.hrvOvernightAvg);
         if (hrvVal !== null) {
@@ -333,7 +347,10 @@ function buildRespirationFeatures(
     baselineVersion: number | null,
     preExtractedObservations?: SignalObservation[],
 ): HealthCoreSignalFeatures {
-    const current = finiteNumber(snapshot.raw.respirationAvg);
+    const measurementDate = snapshot.source.metricDates?.sleep ?? null;
+    const current = measurementDate === snapshot.date
+        ? finiteNumber(snapshot.raw.respirationAvg)
+        : null;
     const observations = preExtractedObservations ?? historyForSignal(snapshot.date, history, 'respiration');
     const scale = finiteNumber(snapshot.derived.respiration28dMad);
     const compatible = baselineVersion !== null && baselineVersion >= 3;
@@ -357,9 +374,10 @@ function buildRespirationFeatures(
             observations,
             [scale],
         ),
-        // The canonical snapshot currently stores the precise-or-fallback nightly value but
-        // not which path produced it. HA2 must preserve that missingness rather than guess.
-        measurementProvenance: null,
+        // Garmin respirationAvg is selected from the same sleep record as sleepScore;
+        // metricDates.sleep therefore supplies the bounded logical-date provenance needed
+        // to distinguish a target-date night from the backend's D-1 sleep fallback.
+        measurementProvenance: measurementDate === null ? null : `garmin:sleep:${measurementDate}`,
     };
 }
 

--- a/app/src/engine/healthAnomalyModels.ts
+++ b/app/src/engine/healthAnomalyModels.ts
@@ -201,6 +201,66 @@ export interface HealthAnomalyRationaleTokens {
     cautions: string[];
 }
 
+export type RespirationElevationStatus =
+    | 'unavailable'
+    | 'normal'
+    | 'elevated'
+    | 'strongly_elevated'
+    | 'resolving';
+
+export type RespirationElevationReasonCode =
+    | 'MEASUREMENT_INELIGIBLE'
+    | 'MISSING_CURRENT'
+    | 'INVALID_CURRENT'
+    | 'DATE_PROVENANCE_MISMATCH'
+    | 'INCOMPATIBLE_BASELINE_VERSION'
+    | 'INSUFFICIENT_HISTORY'
+    | 'INSUFFICIENT_RECENT_COVERAGE'
+    | 'MISSING_7D_BASELINE'
+    | 'MISSING_28D_BASELINE'
+    | 'ABOVE_ELEVATED_PERSONAL_DELTAS'
+    | 'ABOVE_STRONG_PERSONAL_DELTAS'
+    | 'RECENT_DELTA_NON_POSITIVE'
+    | 'BELOW_ELEVATION_BOUNDARY';
+
+export interface RespirationElevationPolicy {
+    policyVersion: string;
+    minimumBaselineVersion: number;
+    minimumHistoryCount: number;
+    minimumRecentDayCoverage: number;
+    elevatedDeltaVs28d: number;
+    elevatedDeltaVs7d: number;
+    strongDeltaVs28d: number;
+    strongDeltaVs7d: number;
+}
+
+export interface RespirationElevationInput {
+    targetDate: string;
+    measurementDate: string | null;
+    timezone: 'Europe/Warsaw';
+    currentValue: number | null;
+    baseline7dValue: number | null;
+    baseline28dValue: number | null;
+    baselineVersion: number | null;
+    historyCount: number;
+    recentDayCoverage: number;
+    measurementEligible: boolean;
+}
+
+export interface RespirationElevationEvidence {
+    status: RespirationElevationStatus;
+    currentValue: number | null;
+    baseline7dValue: number | null;
+    baseline28dValue: number | null;
+    deltaVs7d: number | null;
+    deltaVs28d: number | null;
+    baselineVersion: number | null;
+    historyCount: number;
+    recentDayCoverage: number;
+    reasonCodes: RespirationElevationReasonCode[];
+    policyVersion: string;
+}
+
 export interface HealthAnomalyPersistenceInput {
     previousState: PhysiologicalAnomalyState | null;
     previousEpisodeId: string | null;
@@ -237,6 +297,8 @@ export interface PhysiologicalAnomalyAssessment {
     episodeDay: number | null;
     dataQuality: CoreSignalDataQuality[];
     rationale: HealthAnomalyRationaleTokens;
+    /** Observation-only HA9 evidence. It is not an input to the live training selector. */
+    respirationElevation?: RespirationElevationEvidence;
     policyVersion: string;
     thresholdPolicyVersion: string;
     mode: Exclude<HealthAnomalyPolicy, 'off'>;

--- a/app/src/engine/healthAnomalyReplay.test.ts
+++ b/app/src/engine/healthAnomalyReplay.test.ts
@@ -115,6 +115,37 @@ describe('health anomaly replay', () => {
         expect(Object.values(symptomatic?.assessmentStates ?? {})[0]?.state).toBe('symptoms_reported');
     });
 
+    it('does not count unusually high HRV as adverse corroboration for elevated respiration', () => {
+        const history = Array.from({ length: 20 }, (_, index) => ({
+            date: dateAt(index),
+            recoverySnapshot: snapshot(dateAt(index), 50, 58 + (index % 5), 13.8 + (index % 4) * 0.1),
+            subjectiveCheckin: checkin(dateAt(index)),
+        }));
+        const elevatedDate = dateAt(20);
+        const report = runHealthAnomalyReplay({
+            days: [
+                ...history,
+                {
+                    date: elevatedDate,
+                    recoverySnapshot: snapshot(elevatedDate, 50, 95, 15.5),
+                    subjectiveCheckin: checkin(elevatedDate),
+                },
+            ],
+        });
+
+        const elevated = report.rows.find(row => row.date === elevatedDate);
+        expect(elevated?.respirationElevation?.status).toBe('elevated');
+        expect(elevated?.coreEvidence.find(item => item.signal === 'hrv')).toMatchObject({
+            status: 'strong_anomaly',
+            direction: 'two_sided',
+        });
+        expect(report.respirationElevationSummary).toMatchObject({
+            elevatedOrStrongDays: 1,
+            corroboratedDays: 0,
+            isolatedDays: 1,
+        });
+    });
+
     it('exports estimator candidates, context and machine-readable plus markdown states', () => {
         const days = Array.from({ length: 21 }, (_, index) => ({
             date: dateAt(index),

--- a/app/src/engine/healthAnomalyReplay.test.ts
+++ b/app/src/engine/healthAnomalyReplay.test.ts
@@ -126,12 +126,19 @@ describe('health anomaly replay', () => {
         const last = report.rows.at(-1);
         expect(report.candidatePolicyVersions).toHaveLength(1);
         expect(last?.candidateEstimators.map(item => item.signal)).toEqual(['rhr', 'respiration', 'hrv']);
+        expect(last?.respirationElevation).toMatchObject({
+            status: expect.stringMatching(/^(normal|elevated|strongly_elevated|resolving)$/),
+            policyVersion: 'respiration-elevation/shadow-e2-s1-v1',
+        });
         expect(last?.healthContext.authoredTravelActive).toBe(true);
         expect(Object.keys(last?.assessmentStates ?? {})).toEqual(report.candidatePolicyVersions);
+        expect(report.respirationElevationSummary.statusCounts).toBeDefined();
+        expect(report.respirationElevationSummary.elevatedOrStrongDays).toBeGreaterThanOrEqual(0);
 
         const markdown = renderHealthAnomalyReplayMarkdown(report);
         expect(markdown).toContain('# Health anomaly shadow replay');
-        expect(markdown).toContain('| Date | RHR | Respiration | HRV |');
+        expect(markdown).toContain('| Date | RHR | Respiration | Resp. delta status | HRV |');
         expect(markdown).toContain('retrospective labels');
+        expect(markdown).toContain('Respiration elevation statuses:');
     });
 });

--- a/app/src/engine/healthAnomalyReplay.test.ts
+++ b/app/src/engine/healthAnomalyReplay.test.ts
@@ -7,7 +7,12 @@ function snapshot(date: string, rhr = 50, hrv = 60, respiration = 14): DailyReco
     return {
         userId: 'u1',
         date,
-        source: { garminSyncedAt: `${date}T06:00:00Z`, sourceSchemaVersion: 3, timezone: 'Europe/Warsaw' },
+        source: {
+            garminSyncedAt: `${date}T06:00:00Z`,
+            sourceSchemaVersion: 3,
+            timezone: 'Europe/Warsaw',
+            metricDates: { sleep: date },
+        },
         raw: {
             sleepScore: 85,
             sleepDurationSec: 8 * 3600,
@@ -144,6 +149,31 @@ describe('health anomaly replay', () => {
             corroboratedDays: 0,
             isolatedDays: 1,
         });
+    });
+
+    it('fails respiration closed when the selected sleep record belongs to another date', () => {
+        const history = Array.from({ length: 20 }, (_, index) => ({
+            date: dateAt(index),
+            recoverySnapshot: snapshot(dateAt(index), 50, 58 + (index % 5), 13.8 + (index % 4) * 0.1),
+            subjectiveCheckin: checkin(dateAt(index)),
+        }));
+        const targetDate = dateAt(20);
+        const stale = snapshot(targetDate, 50, 60, 15.5);
+        stale.source.metricDates = { sleep: dateAt(19) };
+        const report = runHealthAnomalyReplay({
+            days: [
+                ...history,
+                { date: targetDate, recoverySnapshot: stale, subjectiveCheckin: checkin(targetDate) },
+            ],
+        });
+
+        const row = report.rows.find(item => item.date === targetDate);
+        expect(row?.respirationElevation).toMatchObject({
+            status: 'unavailable',
+            reasonCodes: ['DATE_PROVENANCE_MISMATCH'],
+        });
+        expect(row?.coreEvidence.find(item => item.signal === 'respiration')?.status).toBe('unavailable');
+        expect(report.respirationElevationSummary.elevatedOrStrongDays).toBe(0);
     });
 
     it('exports estimator candidates, context and machine-readable plus markdown states', () => {

--- a/app/src/engine/healthAnomalyReplay.test.ts
+++ b/app/src/engine/healthAnomalyReplay.test.ts
@@ -148,6 +148,12 @@ describe('health anomaly replay', () => {
             elevatedOrStrongDays: 1,
             corroboratedDays: 0,
             isolatedDays: 1,
+            robustDeviation: {
+                elevatedAvailableDays: 1,
+                elevatedMedian: expect.any(Number),
+                elevatedMin: expect.any(Number),
+                elevatedMax: expect.any(Number),
+            },
         });
     });
 
@@ -174,6 +180,9 @@ describe('health anomaly replay', () => {
         });
         expect(row?.coreEvidence.find(item => item.signal === 'respiration')?.status).toBe('unavailable');
         expect(report.respirationElevationSummary.elevatedOrStrongDays).toBe(0);
+        expect(report.respirationElevationSummary.unavailableDays).toBeGreaterThan(0);
+        expect(report.respirationElevationSummary.unavailableRate).toBeGreaterThan(0);
+        expect(report.respirationElevationSummary.unavailableReasonCounts.DATE_PROVENANCE_MISMATCH).toBe(1);
     });
 
     it('exports estimator candidates, context and machine-readable plus markdown states', () => {
@@ -195,11 +204,14 @@ describe('health anomaly replay', () => {
         expect(Object.keys(last?.assessmentStates ?? {})).toEqual(report.candidatePolicyVersions);
         expect(report.respirationElevationSummary.statusCounts).toBeDefined();
         expect(report.respirationElevationSummary.elevatedOrStrongDays).toBeGreaterThanOrEqual(0);
+        expect(report.respirationElevationSummary.robustDeviation.availableDays).toBeGreaterThan(0);
 
         const markdown = renderHealthAnomalyReplayMarkdown(report);
         expect(markdown).toContain('# Health anomaly shadow replay');
         expect(markdown).toContain('| Date | RHR | Respiration | Resp. delta status | HRV |');
         expect(markdown).toContain('retrospective labels');
         expect(markdown).toContain('Respiration elevation statuses:');
+        expect(markdown).toContain('Respiration unavailable:');
+        expect(markdown).toContain('MAD-normalized respiration deviation:');
     });
 });

--- a/app/src/engine/healthAnomalyReplay.ts
+++ b/app/src/engine/healthAnomalyReplay.ts
@@ -1,4 +1,8 @@
-import { evaluatePhysiologicalAnomaly, SHADOW_V1_HEALTH_ANOMALY_THRESHOLDS } from './healthAnomaly';
+import {
+    evaluatePhysiologicalAnomaly,
+    isAdverseCoreSignalEvidence,
+    SHADOW_V1_HEALTH_ANOMALY_THRESHOLDS,
+} from './healthAnomaly';
 import { HEALTH_ANOMALY_BASELINE_WINDOW_DAYS, mapRecoverySnapshotToHealthAnomalyFeatures } from './healthAnomalyFeatures';
 import type {
     CoreSignalEvidence,
@@ -133,8 +137,7 @@ function summarizeRespirationElevation(rows: HealthAnomalyReplayRow[]): HealthAn
     const byDate = new Map(rows.map(row => [row.date, row]));
     const elevated = rows.filter(isElevatedRespiration);
     const corroborated = elevated.filter(row => row.coreEvidence.some(
-        evidence => evidence.signal !== 'respiration'
-            && (evidence.status === 'moderate_anomaly' || evidence.status === 'strong_anomaly'),
+        evidence => evidence.signal !== 'respiration' && isAdverseCoreSignalEvidence(evidence),
     ));
     return {
         statusCounts,
@@ -258,6 +261,7 @@ export function runHealthAnomalyReplay(
         limitations: [
             'Future 24/48/72h symptom flags are retrospective labels joined after evaluation and are never live evaluator input.',
             'Candidate thresholds are shadow calibration parameters, not validated diagnostic cutoffs.',
+            'Respiration corroboration counts only adverse non-respiratory core evidence; unusually high HRV is retained as telemetry but is not an adverse illness vote.',
             'Replay quality is limited by the completeness and correctness of supplied canonical recovery/check-in history.',
         ],
         rows,

--- a/app/src/engine/healthAnomalyReplay.ts
+++ b/app/src/engine/healthAnomalyReplay.ts
@@ -5,6 +5,7 @@ import type {
     HealthAnomalyFeatureSet,
     HealthAnomalyThresholdPolicy,
     PhysiologicalAnomalyAssessment,
+    RespirationElevationEvidence,
 } from './healthAnomalyModels';
 import type { DailyRecoverySnapshot, DailySubjectiveCheckin } from './models';
 import { addDaysToLocalDateString } from '../utils/localDate';
@@ -33,6 +34,7 @@ export interface HealthAnomalyReplayPolicyResult {
 
 export interface HealthAnomalyReplayRow {
     date: string;
+    respirationElevation: RespirationElevationEvidence | null;
     coreEvidence: CoreSignalEvidence[];
     candidateEstimators: HealthAnomalyFeatureSet['coreSignals'];
     hardSessionContext: {
@@ -69,6 +71,14 @@ export interface HealthAnomalyReplayReport {
     evaluatorMode: 'shadow-v1';
     candidatePolicyVersions: string[];
     observedDays: number;
+    respirationElevationSummary: {
+        statusCounts: Record<string, number>;
+        elevatedOrStrongDays: number;
+        persistentTwoNightDays: number;
+        corroboratedDays: number;
+        isolatedDays: number;
+        resolvingDays: number;
+    };
     limitations: string[];
     rows: HealthAnomalyReplayRow[];
 }
@@ -107,6 +117,36 @@ function futureSymptoms(
         if (symptomDates.has(addDaysToLocalDateString(date, offset))) return true;
     }
     return false;
+}
+
+function isElevatedRespiration(row: HealthAnomalyReplayRow): boolean {
+    return row.respirationElevation?.status === 'elevated'
+        || row.respirationElevation?.status === 'strongly_elevated';
+}
+
+function summarizeRespirationElevation(rows: HealthAnomalyReplayRow[]): HealthAnomalyReplayReport['respirationElevationSummary'] {
+    const statusCounts = rows.reduce<Record<string, number>>((counts, row) => {
+        const status = row.respirationElevation?.status ?? 'unavailable';
+        counts[status] = (counts[status] ?? 0) + 1;
+        return counts;
+    }, {});
+    const byDate = new Map(rows.map(row => [row.date, row]));
+    const elevated = rows.filter(isElevatedRespiration);
+    const corroborated = elevated.filter(row => row.coreEvidence.some(
+        evidence => evidence.signal !== 'respiration'
+            && (evidence.status === 'moderate_anomaly' || evidence.status === 'strong_anomaly'),
+    ));
+    return {
+        statusCounts,
+        elevatedOrStrongDays: elevated.length,
+        persistentTwoNightDays: elevated.filter(row => {
+            const previous = byDate.get(addDaysToLocalDateString(row.date, -1));
+            return previous ? isElevatedRespiration(previous) : false;
+        }).length,
+        corroboratedDays: corroborated.length,
+        isolatedDays: elevated.length - corroborated.length,
+        resolvingDays: statusCounts.resolving ?? 0,
+    };
 }
 
 /**
@@ -169,6 +209,7 @@ export function runHealthAnomalyReplay(
         const health = checkin?.healthContext;
         rowsWithoutLabels.push({
             date: day.date,
+            respirationElevation: representativeAssessment?.respirationElevation ?? null,
             coreEvidence: representativeAssessment?.coreSignals ?? [],
             candidateEstimators: features?.coreSignals ?? [],
             hardSessionContext: {
@@ -213,6 +254,7 @@ export function runHealthAnomalyReplay(
         evaluatorMode: 'shadow-v1',
         candidatePolicyVersions: policies.map(policy => policy.policyVersion),
         observedDays: rows.length,
+        respirationElevationSummary: summarizeRespirationElevation(rows),
         limitations: [
             'Future 24/48/72h symptom flags are retrospective labels joined after evaluation and are never live evaluator input.',
             'Candidate thresholds are shadow calibration parameters, not validated diagnostic cutoffs.',
@@ -238,16 +280,18 @@ export function renderHealthAnomalyReplayMarkdown(report: HealthAnomalyReplayRep
         `- Observed days: ${report.observedDays}`,
         `- Evaluator mode: ${report.evaluatorMode}`,
         `- Candidate policies: ${report.candidatePolicyVersions.join(', ') || 'none'}`,
+        `- Respiration elevation statuses: ${JSON.stringify(report.respirationElevationSummary.statusCounts)}`,
+        `- Elevated/strong days: ${report.respirationElevationSummary.elevatedOrStrongDays}; two-night persistent: ${report.respirationElevationSummary.persistentTwoNightDays}; corroborated: ${report.respirationElevationSummary.corroboratedDays}; isolated: ${report.respirationElevationSummary.isolatedDays}; resolving: ${report.respirationElevationSummary.resolvingDays}`,
         '',
         '## Evidence framing',
         '',
         ...report.limitations.map(item => `- ${item}`),
         '',
-        '| Date | RHR | Respiration | HRV | Hard 3d | Sleep | Stress | State | Symptoms | +24h | +48h | +72h |',
-        '| --- | --- | --- | --- | ---: | ---: | ---: | --- | --- | --- | --- | --- |',
+        '| Date | RHR | Respiration | Resp. delta status | HRV | Hard 3d | Sleep | Stress | State | Symptoms | +24h | +48h | +72h |',
+        '| --- | --- | --- | --- | --- | ---: | ---: | ---: | --- | --- | --- | --- | --- |',
         ...report.rows.map(row => {
             const state = primaryPolicy ? row.assessmentStates[primaryPolicy]?.state ?? 'N/A' : 'N/A';
-            return `| ${row.date} | ${evidenceCell(row.coreEvidence.find(item => item.signal === 'rhr'))} | ${evidenceCell(row.coreEvidence.find(item => item.signal === 'respiration'))} | ${evidenceCell(row.coreEvidence.find(item => item.signal === 'hrv'))} | ${row.hardSessionContext.last3DaysHardSessionsCount} | ${row.sleepStressContext.sleepScore ?? 'N/A'} | ${row.sleepStressContext.garminStressAvg ?? 'N/A'} | ${state} | ${row.symptomsReported ? 'yes' : 'no'} | ${row.futureSymptoms24h ? 'yes' : 'no'} | ${row.futureSymptoms48h ? 'yes' : 'no'} | ${row.futureSymptoms72h ? 'yes' : 'no'} |`;
+            return `| ${row.date} | ${evidenceCell(row.coreEvidence.find(item => item.signal === 'rhr'))} | ${evidenceCell(row.coreEvidence.find(item => item.signal === 'respiration'))} | ${row.respirationElevation?.status ?? 'unavailable'} | ${evidenceCell(row.coreEvidence.find(item => item.signal === 'hrv'))} | ${row.hardSessionContext.last3DaysHardSessionsCount} | ${row.sleepStressContext.sleepScore ?? 'N/A'} | ${row.sleepStressContext.garminStressAvg ?? 'N/A'} | ${state} | ${row.symptomsReported ? 'yes' : 'no'} | ${row.futureSymptoms24h ? 'yes' : 'no'} | ${row.futureSymptoms48h ? 'yes' : 'no'} | ${row.futureSymptoms72h ? 'yes' : 'no'} |`;
         }),
         '',
     ];

--- a/app/src/engine/healthAnomalyReplay.ts
+++ b/app/src/engine/healthAnomalyReplay.ts
@@ -82,6 +82,17 @@ export interface HealthAnomalyReplayReport {
         corroboratedDays: number;
         isolatedDays: number;
         resolvingDays: number;
+        unavailableDays: number;
+        unavailableRate: number;
+        unavailableReasonCounts: Record<string, number>;
+        robustDeviation: {
+            /** 28-day median/MAD standardized respiration evidence available for replay calibration. */
+            availableDays: number;
+            elevatedAvailableDays: number;
+            elevatedMedian: number | null;
+            elevatedMin: number | null;
+            elevatedMax: number | null;
+        };
     };
     limitations: string[];
     rows: HealthAnomalyReplayRow[];
@@ -128,10 +139,31 @@ function isElevatedRespiration(row: HealthAnomalyReplayRow): boolean {
         || row.respirationElevation?.status === 'strongly_elevated';
 }
 
+function respirationStandardizedDeviation(row: HealthAnomalyReplayRow): number | null {
+    const deviation = row.coreEvidence.find(evidence => evidence.signal === 'respiration')?.standardizedDeviation ?? null;
+    return deviation !== null && Number.isFinite(deviation) ? deviation : null;
+}
+
+function median(values: readonly number[]): number | null {
+    if (values.length === 0) return null;
+    const sorted = [...values].sort((left, right) => left - right);
+    const middle = Math.floor(sorted.length / 2);
+    return sorted.length % 2 === 0
+        ? (sorted[middle - 1] + sorted[middle]) / 2
+        : sorted[middle];
+}
+
 function summarizeRespirationElevation(rows: HealthAnomalyReplayRow[]): HealthAnomalyReplayReport['respirationElevationSummary'] {
     const statusCounts = rows.reduce<Record<string, number>>((counts, row) => {
         const status = row.respirationElevation?.status ?? 'unavailable';
         counts[status] = (counts[status] ?? 0) + 1;
+        return counts;
+    }, {});
+    const unavailableReasonCounts = rows.reduce<Record<string, number>>((counts, row) => {
+        if (row.respirationElevation?.status !== 'unavailable') return counts;
+        for (const reason of row.respirationElevation.reasonCodes) {
+            counts[reason] = (counts[reason] ?? 0) + 1;
+        }
         return counts;
     }, {});
     const byDate = new Map(rows.map(row => [row.date, row]));
@@ -139,6 +171,13 @@ function summarizeRespirationElevation(rows: HealthAnomalyReplayRow[]): HealthAn
     const corroborated = elevated.filter(row => row.coreEvidence.some(
         evidence => evidence.signal !== 'respiration' && isAdverseCoreSignalEvidence(evidence),
     ));
+    const robustAvailable = rows
+        .map(respirationStandardizedDeviation)
+        .filter((value): value is number => value !== null);
+    const robustElevated = elevated
+        .map(respirationStandardizedDeviation)
+        .filter((value): value is number => value !== null);
+    const unavailableDays = statusCounts.unavailable ?? 0;
     return {
         statusCounts,
         elevatedOrStrongDays: elevated.length,
@@ -149,6 +188,16 @@ function summarizeRespirationElevation(rows: HealthAnomalyReplayRow[]): HealthAn
         corroboratedDays: corroborated.length,
         isolatedDays: elevated.length - corroborated.length,
         resolvingDays: statusCounts.resolving ?? 0,
+        unavailableDays,
+        unavailableRate: rows.length > 0 ? unavailableDays / rows.length : 0,
+        unavailableReasonCounts,
+        robustDeviation: {
+            availableDays: robustAvailable.length,
+            elevatedAvailableDays: robustElevated.length,
+            elevatedMedian: median(robustElevated),
+            elevatedMin: robustElevated.length > 0 ? Math.min(...robustElevated) : null,
+            elevatedMax: robustElevated.length > 0 ? Math.max(...robustElevated) : null,
+        },
     };
 }
 
@@ -262,6 +311,7 @@ export function runHealthAnomalyReplay(
             'Future 24/48/72h symptom flags are retrospective labels joined after evaluation and are never live evaluator input.',
             'Candidate thresholds are shadow calibration parameters, not validated diagnostic cutoffs.',
             'Respiration corroboration counts only adverse non-respiratory core evidence; unusually high HRV is retained as telemetry but is not an adverse illness vote.',
+            'MAD-normalized respiration deviation is descriptive calibration telemetry only; it is not an additional decision threshold or permission to tighten training.',
             'Replay quality is limited by the completeness and correctness of supplied canonical recovery/check-in history.',
         ],
         rows,
@@ -276,16 +326,24 @@ function evidenceCell(evidence: CoreSignalEvidence | undefined): string {
     return `${evidence.status}${evidence.direction ? `/${evidence.direction}` : ''}${deviation}`;
 }
 
+function numberOrNa(value: number | null, digits = 2): string {
+    return value === null ? 'N/A' : value.toFixed(digits);
+}
+
 export function renderHealthAnomalyReplayMarkdown(report: HealthAnomalyReplayReport): string {
     const primaryPolicy = report.candidatePolicyVersions[0];
+    const summary = report.respirationElevationSummary;
+    const robust = summary.robustDeviation;
     const lines = [
         '# Health anomaly shadow replay',
         '',
         `- Observed days: ${report.observedDays}`,
         `- Evaluator mode: ${report.evaluatorMode}`,
         `- Candidate policies: ${report.candidatePolicyVersions.join(', ') || 'none'}`,
-        `- Respiration elevation statuses: ${JSON.stringify(report.respirationElevationSummary.statusCounts)}`,
-        `- Elevated/strong days: ${report.respirationElevationSummary.elevatedOrStrongDays}; two-night persistent: ${report.respirationElevationSummary.persistentTwoNightDays}; corroborated: ${report.respirationElevationSummary.corroboratedDays}; isolated: ${report.respirationElevationSummary.isolatedDays}; resolving: ${report.respirationElevationSummary.resolvingDays}`,
+        `- Respiration elevation statuses: ${JSON.stringify(summary.statusCounts)}`,
+        `- Respiration unavailable: ${summary.unavailableDays}/${report.observedDays} (${(summary.unavailableRate * 100).toFixed(1)}%); reasons: ${JSON.stringify(summary.unavailableReasonCounts)}`,
+        `- Elevated/strong days: ${summary.elevatedOrStrongDays}; two-night persistent: ${summary.persistentTwoNightDays}; corroborated: ${summary.corroboratedDays}; isolated: ${summary.isolatedDays}; resolving: ${summary.resolvingDays}`,
+        `- Robust 28d MAD-normalized respiration deviation: available ${robust.availableDays}/${report.observedDays}; elevated-with-scale ${robust.elevatedAvailableDays}/${summary.elevatedOrStrongDays}; elevated median ${numberOrNa(robust.elevatedMedian)}z (range ${numberOrNa(robust.elevatedMin)} to ${numberOrNa(robust.elevatedMax)}z)`,
         '',
         '## Evidence framing',
         '',

--- a/app/src/engine/respirationElevation.test.ts
+++ b/app/src/engine/respirationElevation.test.ts
@@ -78,18 +78,29 @@ describe('respiration elevation evidence', () => {
 
     it.each([
         [{ currentValue: null }, 'MISSING_CURRENT'],
+        [{ currentValue: Number.NaN }, 'INVALID_CURRENT'],
         [{ currentValue: 40 }, 'INVALID_CURRENT'],
         [{ measurementDate: '2026-08-20' }, 'DATE_PROVENANCE_MISMATCH'],
         [{ baselineVersion: 2 }, 'INCOMPATIBLE_BASELINE_VERSION'],
         [{ historyCount: 13 }, 'INSUFFICIENT_HISTORY'],
         [{ recentDayCoverage: 0.5 }, 'INSUFFICIENT_RECENT_COVERAGE'],
         [{ baseline7dValue: null }, 'MISSING_7D_BASELINE'],
+        [{ baseline7dValue: 0 }, 'MISSING_7D_BASELINE'],
+        [{ baseline7dValue: -1 }, 'MISSING_7D_BASELINE'],
         [{ baseline28dValue: null }, 'MISSING_28D_BASELINE'],
+        [{ baseline28dValue: 100 }, 'MISSING_28D_BASELINE'],
         [{ measurementEligible: false }, 'MEASUREMENT_INELIGIBLE'],
     ] as const)('fails closed for %o', (overrides, reason) => {
-        expect(evaluateRespirationElevation(input(overrides))).toMatchObject({
+        const evidence = evaluateRespirationElevation(input(overrides));
+        expect(evidence).toMatchObject({
             status: 'unavailable',
             reasonCodes: expect.arrayContaining([reason]),
         });
+        if ('baseline7dValue' in overrides && overrides.baseline7dValue !== 13.5) {
+            expect(evidence.baseline7dValue).toBeNull();
+        }
+        if ('baseline28dValue' in overrides && overrides.baseline28dValue !== 13) {
+            expect(evidence.baseline28dValue).toBeNull();
+        }
     });
 });

--- a/app/src/engine/respirationElevation.test.ts
+++ b/app/src/engine/respirationElevation.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { evaluateRespirationElevation } from './respirationElevation';
+import type { RespirationElevationInput, RespirationElevationPolicy } from './healthAnomalyModels';
+
+function input(overrides: Partial<RespirationElevationInput> = {}): RespirationElevationInput {
+    return {
+        targetDate: '2026-08-21',
+        measurementDate: '2026-08-21',
+        timezone: 'Europe/Warsaw',
+        currentValue: 14,
+        baseline7dValue: 13.5,
+        baseline28dValue: 13,
+        baselineVersion: 3,
+        historyCount: 28,
+        recentDayCoverage: 1,
+        measurementEligible: true,
+        ...overrides,
+    };
+}
+
+describe('respiration elevation evidence', () => {
+    it.each([
+        ['E1', 0.75, 0.25],
+        ['E2', 1, 0.5],
+        ['E3', 1.25, 0.75],
+    ] as const)('classifies %s immediately below and at its boundary', (_name, delta28d, delta7d) => {
+        const policy: RespirationElevationPolicy = {
+            policyVersion: `test-${_name}`,
+            minimumBaselineVersion: 3,
+            minimumHistoryCount: 14,
+            minimumRecentDayCoverage: 4 / 7,
+            elevatedDeltaVs28d: delta28d,
+            elevatedDeltaVs7d: delta7d,
+            strongDeltaVs28d: 2,
+            strongDeltaVs7d: 1,
+        };
+        expect(evaluateRespirationElevation(input({
+            currentValue: 13 + delta28d - 0.001,
+            baseline7dValue: 13 + delta28d - delta7d,
+        }), policy).status).toBe('normal');
+        expect(evaluateRespirationElevation(input({
+            currentValue: 13 + delta28d,
+            baseline7dValue: 13 + delta28d - delta7d,
+        }), policy).status).toBe('elevated');
+    });
+
+    it('classifies the S1 strong boundary inclusively', () => {
+        expect(evaluateRespirationElevation(input({
+            currentValue: 15,
+            baseline7dValue: 14,
+            baseline28dValue: 13,
+        })).status).toBe('strongly_elevated');
+    });
+
+    it('requires both personal deltas even when the absolute value is high', () => {
+        expect(evaluateRespirationElevation(input({
+            currentValue: 16,
+            baseline7dValue: 15.8,
+            baseline28dValue: 15.7,
+        }))).toMatchObject({ status: 'normal', reasonCodes: ['BELOW_ELEVATION_BOUNDARY'] });
+    });
+
+    it('marks an elevated long-baseline value as resolving when it is no longer above 7d', () => {
+        expect(evaluateRespirationElevation(input({
+            currentValue: 14,
+            baseline7dValue: 14.1,
+            baseline28dValue: 12.8,
+        }))).toMatchObject({ status: 'resolving', reasonCodes: ['RECENT_DELTA_NON_POSITIVE'] });
+    });
+
+    it('never treats lower respiration as adverse evidence', () => {
+        expect(evaluateRespirationElevation(input({
+            currentValue: 12,
+            baseline7dValue: 13,
+            baseline28dValue: 13.5,
+        })).status).toBe('normal');
+    });
+
+    it.each([
+        [{ currentValue: null }, 'MISSING_CURRENT'],
+        [{ currentValue: 40 }, 'INVALID_CURRENT'],
+        [{ measurementDate: '2026-08-20' }, 'DATE_PROVENANCE_MISMATCH'],
+        [{ baselineVersion: 2 }, 'INCOMPATIBLE_BASELINE_VERSION'],
+        [{ historyCount: 13 }, 'INSUFFICIENT_HISTORY'],
+        [{ recentDayCoverage: 0.5 }, 'INSUFFICIENT_RECENT_COVERAGE'],
+        [{ baseline7dValue: null }, 'MISSING_7D_BASELINE'],
+        [{ baseline28dValue: null }, 'MISSING_28D_BASELINE'],
+        [{ measurementEligible: false }, 'MEASUREMENT_INELIGIBLE'],
+    ] as const)('fails closed for %o', (overrides, reason) => {
+        expect(evaluateRespirationElevation(input(overrides))).toMatchObject({
+            status: 'unavailable',
+            reasonCodes: expect.arrayContaining([reason]),
+        });
+    });
+});

--- a/app/src/engine/respirationElevation.test.ts
+++ b/app/src/engine/respirationElevation.test.ts
@@ -96,10 +96,10 @@ describe('respiration elevation evidence', () => {
             status: 'unavailable',
             reasonCodes: expect.arrayContaining([reason]),
         });
-        if ('baseline7dValue' in overrides && overrides.baseline7dValue !== 13.5) {
+        if ('baseline7dValue' in overrides) {
             expect(evidence.baseline7dValue).toBeNull();
         }
-        if ('baseline28dValue' in overrides && overrides.baseline28dValue !== 13) {
+        if ('baseline28dValue' in overrides) {
             expect(evidence.baseline28dValue).toBeNull();
         }
     });

--- a/app/src/engine/respirationElevation.ts
+++ b/app/src/engine/respirationElevation.ts
@@ -23,8 +23,21 @@ function finiteOrNull(value: number | null): number | null {
     return value !== null && Number.isFinite(value) ? value : null;
 }
 
-function invalidCurrent(value: number | null): boolean {
-    return value !== null && (value < MIN_VALID_SLEEP_RESPIRATION || value > MAX_VALID_SLEEP_RESPIRATION);
+function invalidRespirationValue(value: number | null): boolean {
+    return value !== null && (
+        !Number.isFinite(value)
+        || value < MIN_VALID_SLEEP_RESPIRATION
+        || value > MAX_VALID_SLEEP_RESPIRATION
+    );
+}
+
+/**
+ * A baseline outside the same broad ingestion plausibility envelope as the current night is not
+ * usable evidence. `MISSING_*_BASELINE` is intentionally the persisted reason for both absent and
+ * unusable baselines so older readers fail closed without a reason-code schema migration.
+ */
+function usableBaselineOrNull(value: number | null): number | null {
+    return invalidRespirationValue(value) ? null : finiteOrNull(value);
 }
 
 function unavailable(
@@ -35,8 +48,8 @@ function unavailable(
     return {
         status: 'unavailable',
         currentValue: finiteOrNull(input.currentValue),
-        baseline7dValue: finiteOrNull(input.baseline7dValue),
-        baseline28dValue: finiteOrNull(input.baseline28dValue),
+        baseline7dValue: usableBaselineOrNull(input.baseline7dValue),
+        baseline28dValue: usableBaselineOrNull(input.baseline28dValue),
         deltaVs7d: null,
         deltaVs28d: null,
         baselineVersion: input.baselineVersion,
@@ -59,8 +72,8 @@ export function evaluateRespirationElevation(
     const unavailableReasons: RespirationElevationReasonCode[] = [];
     if (!input.measurementEligible) unavailableReasons.push('MEASUREMENT_INELIGIBLE');
     if (input.measurementDate !== input.targetDate) unavailableReasons.push('DATE_PROVENANCE_MISMATCH');
-    if (finiteOrNull(input.currentValue) === null) unavailableReasons.push('MISSING_CURRENT');
-    else if (invalidCurrent(input.currentValue)) unavailableReasons.push('INVALID_CURRENT');
+    if (input.currentValue === null) unavailableReasons.push('MISSING_CURRENT');
+    else if (invalidRespirationValue(input.currentValue)) unavailableReasons.push('INVALID_CURRENT');
     if (input.baselineVersion === null || input.baselineVersion < policy.minimumBaselineVersion) {
         unavailableReasons.push('INCOMPATIBLE_BASELINE_VERSION');
     }
@@ -70,8 +83,8 @@ export function evaluateRespirationElevation(
     if (!Number.isFinite(input.recentDayCoverage) || input.recentDayCoverage < policy.minimumRecentDayCoverage) {
         unavailableReasons.push('INSUFFICIENT_RECENT_COVERAGE');
     }
-    if (finiteOrNull(input.baseline7dValue) === null) unavailableReasons.push('MISSING_7D_BASELINE');
-    if (finiteOrNull(input.baseline28dValue) === null) unavailableReasons.push('MISSING_28D_BASELINE');
+    if (usableBaselineOrNull(input.baseline7dValue) === null) unavailableReasons.push('MISSING_7D_BASELINE');
+    if (usableBaselineOrNull(input.baseline28dValue) === null) unavailableReasons.push('MISSING_28D_BASELINE');
     if (unavailableReasons.length > 0) return unavailable(input, policy, unavailableReasons);
 
     const currentValue = input.currentValue as number;

--- a/app/src/engine/respirationElevation.ts
+++ b/app/src/engine/respirationElevation.ts
@@ -1,0 +1,118 @@
+import type {
+    RespirationElevationEvidence,
+    RespirationElevationInput,
+    RespirationElevationPolicy,
+    RespirationElevationReasonCode,
+} from './healthAnomalyModels';
+
+export const SHADOW_RESPIRATION_ELEVATION_POLICY: RespirationElevationPolicy = Object.freeze({
+    policyVersion: 'respiration-elevation/shadow-e2-s1-v1',
+    minimumBaselineVersion: 3,
+    minimumHistoryCount: 14,
+    minimumRecentDayCoverage: 4 / 7,
+    elevatedDeltaVs28d: 1,
+    elevatedDeltaVs7d: 0.5,
+    strongDeltaVs28d: 2,
+    strongDeltaVs7d: 1,
+});
+
+const MIN_VALID_SLEEP_RESPIRATION = 6;
+const MAX_VALID_SLEEP_RESPIRATION = 35;
+
+function finiteOrNull(value: number | null): number | null {
+    return value !== null && Number.isFinite(value) ? value : null;
+}
+
+function invalidCurrent(value: number | null): boolean {
+    return value !== null && (value < MIN_VALID_SLEEP_RESPIRATION || value > MAX_VALID_SLEEP_RESPIRATION);
+}
+
+function unavailable(
+    input: RespirationElevationInput,
+    policy: RespirationElevationPolicy,
+    reasonCodes: RespirationElevationReasonCode[],
+): RespirationElevationEvidence {
+    return {
+        status: 'unavailable',
+        currentValue: finiteOrNull(input.currentValue),
+        baseline7dValue: finiteOrNull(input.baseline7dValue),
+        baseline28dValue: finiteOrNull(input.baseline28dValue),
+        deltaVs7d: null,
+        deltaVs28d: null,
+        baselineVersion: input.baselineVersion,
+        historyCount: input.historyCount,
+        recentDayCoverage: input.recentDayCoverage,
+        reasonCodes,
+        policyVersion: policy.policyVersion,
+    };
+}
+
+/**
+ * HA9 personal-delta classifier. Absolute respiration is deliberately not a decision boundary;
+ * evidence must be elevated against both the recent and longer personal baseline. A non-positive
+ * recent delta is resolving evidence and cannot newly tighten training.
+ */
+export function evaluateRespirationElevation(
+    input: RespirationElevationInput,
+    policy: RespirationElevationPolicy = SHADOW_RESPIRATION_ELEVATION_POLICY,
+): RespirationElevationEvidence {
+    const unavailableReasons: RespirationElevationReasonCode[] = [];
+    if (!input.measurementEligible) unavailableReasons.push('MEASUREMENT_INELIGIBLE');
+    if (input.measurementDate !== input.targetDate) unavailableReasons.push('DATE_PROVENANCE_MISMATCH');
+    if (finiteOrNull(input.currentValue) === null) unavailableReasons.push('MISSING_CURRENT');
+    else if (invalidCurrent(input.currentValue)) unavailableReasons.push('INVALID_CURRENT');
+    if (input.baselineVersion === null || input.baselineVersion < policy.minimumBaselineVersion) {
+        unavailableReasons.push('INCOMPATIBLE_BASELINE_VERSION');
+    }
+    if (!Number.isInteger(input.historyCount) || input.historyCount < policy.minimumHistoryCount) {
+        unavailableReasons.push('INSUFFICIENT_HISTORY');
+    }
+    if (!Number.isFinite(input.recentDayCoverage) || input.recentDayCoverage < policy.minimumRecentDayCoverage) {
+        unavailableReasons.push('INSUFFICIENT_RECENT_COVERAGE');
+    }
+    if (finiteOrNull(input.baseline7dValue) === null) unavailableReasons.push('MISSING_7D_BASELINE');
+    if (finiteOrNull(input.baseline28dValue) === null) unavailableReasons.push('MISSING_28D_BASELINE');
+    if (unavailableReasons.length > 0) return unavailable(input, policy, unavailableReasons);
+
+    const currentValue = input.currentValue as number;
+    const baseline7dValue = input.baseline7dValue as number;
+    const baseline28dValue = input.baseline28dValue as number;
+    const deltaVs7d = currentValue - baseline7dValue;
+    const deltaVs28d = currentValue - baseline28dValue;
+    let status: RespirationElevationEvidence['status'];
+    let reasonCodes: RespirationElevationReasonCode[];
+
+    if (deltaVs7d <= 0 && deltaVs28d > 0) {
+        status = 'resolving';
+        reasonCodes = ['RECENT_DELTA_NON_POSITIVE'];
+    } else if (
+        deltaVs28d >= policy.strongDeltaVs28d
+        && deltaVs7d >= policy.strongDeltaVs7d
+    ) {
+        status = 'strongly_elevated';
+        reasonCodes = ['ABOVE_STRONG_PERSONAL_DELTAS'];
+    } else if (
+        deltaVs28d >= policy.elevatedDeltaVs28d
+        && deltaVs7d >= policy.elevatedDeltaVs7d
+    ) {
+        status = 'elevated';
+        reasonCodes = ['ABOVE_ELEVATED_PERSONAL_DELTAS'];
+    } else {
+        status = 'normal';
+        reasonCodes = ['BELOW_ELEVATION_BOUNDARY'];
+    }
+
+    return {
+        status,
+        currentValue,
+        baseline7dValue,
+        baseline28dValue,
+        deltaVs7d,
+        deltaVs28d,
+        baselineVersion: input.baselineVersion,
+        historyCount: input.historyCount,
+        recentDayCoverage: input.recentDayCoverage,
+        reasonCodes,
+        policyVersion: policy.policyVersion,
+    };
+}

--- a/app/src/services/healthAnomalyPersistence.test.ts
+++ b/app/src/services/healthAnomalyPersistence.test.ts
@@ -50,6 +50,20 @@ const assessment: PhysiologicalAnomalyAssessment = {
     mode: 'shadow-v1',
 };
 
+const respirationElevation = {
+    status: 'elevated' as const,
+    currentValue: 14,
+    baseline7dValue: 13.5,
+    baseline28dValue: 13,
+    deltaVs7d: 0.5,
+    deltaVs28d: 1,
+    baselineVersion: 5,
+    historyCount: 28,
+    recentDayCoverage: 1,
+    reasonCodes: ['ABOVE_ELEVATED_PERSONAL_DELTAS' as const],
+    policyVersion: 'respiration-elevation/shadow-e2-s1-v1',
+};
+
 function revision(
     computedAt = '2026-08-21T06:30:00Z',
     recoverySnapshotRevision = source.recoverySnapshotRevision,
@@ -90,6 +104,27 @@ describe('health anomaly immutable persistence identity', () => {
         const record = revision();
         expect(() => parseHealthAnomalyAssessmentRevision({ ...record, revisionId: 'ha-0000000000000000' }, 'u1', '2026-08-21'))
             .toThrow('identity mismatch');
+    });
+
+    it('accepts valid optional respiration elevation evidence and rejects malformed evidence', () => {
+        const record = buildHealthAnomalyAssessmentRevision({
+            userId: 'u1',
+            date: '2026-08-21',
+            computedAt: '2026-08-21T06:30:00Z',
+            mode: 'shadow-v1',
+            thresholdPolicy: SHADOW_V1_HEALTH_ANOMALY_THRESHOLDS,
+            source,
+            assessment: { ...assessment, respirationElevation },
+        });
+        expect(parseHealthAnomalyAssessmentRevision(record).assessment.respirationElevation)
+            .toEqual(respirationElevation);
+        expect(() => parseHealthAnomalyAssessmentRevision({
+            ...record,
+            assessment: {
+                ...record.assessment,
+                respirationElevation: { ...respirationElevation, recentDayCoverage: 2 },
+            },
+        })).toThrow('Invalid respiration elevation evidence');
     });
 
     it('returns the existing immutable revision on an exact idempotent retry', async () => {

--- a/app/src/services/healthAnomalyPersistence.ts
+++ b/app/src/services/healthAnomalyPersistence.ts
@@ -17,6 +17,28 @@ const ASSESSMENT_STATES = [
 ] as const;
 const EVIDENCE_LEVELS = ['none', 'low', 'moderate', 'high'] as const;
 const NON_OFF_MODES = ['shadow-v1', 'visible-v1', 'tighten-v1'] as const;
+const RESPIRATION_ELEVATION_STATUSES = [
+    'unavailable',
+    'normal',
+    'elevated',
+    'strongly_elevated',
+    'resolving',
+] as const;
+const RESPIRATION_ELEVATION_REASONS = [
+    'MEASUREMENT_INELIGIBLE',
+    'MISSING_CURRENT',
+    'INVALID_CURRENT',
+    'DATE_PROVENANCE_MISMATCH',
+    'INCOMPATIBLE_BASELINE_VERSION',
+    'INSUFFICIENT_HISTORY',
+    'INSUFFICIENT_RECENT_COVERAGE',
+    'MISSING_7D_BASELINE',
+    'MISSING_28D_BASELINE',
+    'ABOVE_ELEVATED_PERSONAL_DELTAS',
+    'ABOVE_STRONG_PERSONAL_DELTAS',
+    'RECENT_DELTA_NON_POSITIVE',
+    'BELOW_ELEVATION_BOUNDARY',
+] as const;
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
     return !!value && typeof value === 'object' && !Array.isArray(value);
@@ -108,6 +130,32 @@ function isSourceIdentity(value: unknown): value is HealthAnomalySourceIdentity 
         && typeof item.revision === 'string');
 }
 
+function isNullableFiniteNumber(value: unknown): boolean {
+    return value === null || (typeof value === 'number' && Number.isFinite(value));
+}
+
+function isRespirationElevationEvidence(value: unknown): boolean {
+    if (!isPlainObject(value)) return false;
+    return (RESPIRATION_ELEVATION_STATUSES as readonly unknown[]).includes(value.status)
+        && isNullableFiniteNumber(value.currentValue)
+        && isNullableFiniteNumber(value.baseline7dValue)
+        && isNullableFiniteNumber(value.baseline28dValue)
+        && isNullableFiniteNumber(value.deltaVs7d)
+        && isNullableFiniteNumber(value.deltaVs28d)
+        && (value.baselineVersion === null || (Number.isInteger(value.baselineVersion) && (value.baselineVersion as number) >= 0))
+        && Number.isInteger(value.historyCount)
+        && (value.historyCount as number) >= 0
+        && typeof value.recentDayCoverage === 'number'
+        && Number.isFinite(value.recentDayCoverage)
+        && value.recentDayCoverage >= 0
+        && value.recentDayCoverage <= 1
+        && Array.isArray(value.reasonCodes)
+        && value.reasonCodes.length <= RESPIRATION_ELEVATION_REASONS.length
+        && value.reasonCodes.every(reason => (RESPIRATION_ELEVATION_REASONS as readonly unknown[]).includes(reason))
+        && typeof value.policyVersion === 'string'
+        && value.policyVersion.length > 0;
+}
+
 export function parseHealthAnomalyAssessmentRevision(
     value: unknown,
     expectedUserId?: string,
@@ -132,6 +180,10 @@ export function parseHealthAnomalyAssessmentRevision(
     if (revision.assessment.policyVersion !== revision.policyVersion) throw new Error('Health anomaly policy version mismatch');
     if (revision.assessment.thresholdPolicyVersion !== revision.thresholdPolicy.policyVersion) throw new Error('Health anomaly threshold version mismatch');
     if (revision.assessment.mode !== revision.mode) throw new Error('Health anomaly mode mismatch');
+    if (
+        revision.assessment.respirationElevation !== undefined
+        && !isRespirationElevationEvidence(revision.assessment.respirationElevation)
+    ) throw new Error('Invalid respiration elevation evidence');
     if (!Array.isArray(revision.assessment.coreSignals) || revision.assessment.coreSignals.length !== 3) throw new Error('Health anomaly revision requires three core signal traces');
     for (const signal of revision.assessment.coreSignals) {
         if (!['rhr', 'respiration', 'hrv'].includes(signal.signal)) throw new Error('Invalid health anomaly core signal');

--- a/docs/analysis/2026-08-30-pr-306-respiration-calibration-addendum.md
+++ b/docs/analysis/2026-08-30-pr-306-respiration-calibration-addendum.md
@@ -1,0 +1,64 @@
+# PR #306 respiration calibration addendum
+
+**Date:** 2026-08-30  
+**Scope:** compliance check against the canonical cardiorespiratory knowledge pack plus targeted external-evidence review.  
+**Decision effect:** none; respiration remains shadow/observation evidence.
+
+## Compliance verdict
+
+PR #306 is compliant with the repository's current respiration evidence boundary provided the feature remains shadow-only until prospective labelled validation is complete.
+
+The implementation matches the canonical policy in the important ways:
+
+- it uses nocturnal respiration as a **longitudinal personal-baseline signal**, not a bedside diagnosis;
+- it compares the current night with backward-looking personal baselines rather than a population cutoff;
+- it fails closed for incompatible baseline versions, insufficient history/coverage, source/date provenance problems, and invalid/missing measurements;
+- a resolving current value cannot newly tighten training;
+- persistence and adverse RHR/low-HRV corroboration are measured separately;
+- exact E1/E2/E3/S1 values are explicitly product calibration candidates rather than scientific constants;
+- no current recommendation selector consumes `RespirationElevationEvidence`.
+
+The numeric `6–35 br/min` acceptance range in `respirationElevation.ts` is an ingestion/QA plausibility guard only. It must not be documented or surfaced as a clinical normal range, disease threshold, or training-action threshold.
+
+## External evidence cross-check
+
+The research supports the architecture more strongly than it supports any exact threshold.
+
+1. Longitudinal nocturnal respiratory rate can be estimated from wearables and can change during respiratory infection. A 2021 validation/infection study reported wearable-derived RR agreement around MAE 0.46 breaths/min and used longitudinal nocturnal changes to study COVID-19. This supports trend monitoring, while also showing that changes near fractions of a breath/min are close enough to measurement uncertainty that they should not be treated as universal clinical cut-points.  
+   https://pubmed.ncbi.nlm.nih.gov/34526602/
+2. A 2022 systematic review/meta-analysis of wearable/contactless RR validation found pooled wearable RR bias around 0.68 breaths/min with wide pooled limits of agreement and substantial study heterogeneity. Device-specific error therefore cannot be assumed away or transferred blindly between wearable platforms.  
+   https://pubmed.ncbi.nlm.nih.gov/35947876/
+3. A prospective 2024 respiratory-infection validation study used **resting HR + respiratory rate + HRV during sleep** rather than respiration in isolation. This is directionally consistent with ADR-0025 and with treating corroborated/persistent cases differently from isolated one-night elevations.  
+   https://pubmed.ncbi.nlm.nih.gov/39018555/
+4. Broader reviews of wearable infection detection conclude that physiological deviations can be useful early digital biomarkers, but real-world infection detection and generalizability remain imperfect. That supports a labelled prospective release gate rather than retrospective threshold fitting.  
+   https://pubmed.ncbi.nlm.nih.gov/35461692/  
+   https://pubmed.ncbi.nlm.nih.gov/34932906/
+
+## Additional hardening in this commit
+
+The replay previously exposed the canonical median/MAD standardized respiration deviation only at row level. That made E2/S1 calibration harder to review because an absolute +1 br/min change can represent very different departures from an athlete's own normal nightly variability.
+
+The replay summary now additionally reports:
+
+- classifier-unavailable days and rate;
+- unavailable reason counts, so warm-up/history limitations can be distinguished from provenance/data failures;
+- count of days with usable 28-day median/MAD standardized respiration evidence;
+- among discrete elevated/strong days, the robust standardized-deviation median and range.
+
+These values are **calibration telemetry only**. They do not modify E2/S1, do not add another decision boundary, and do not change live readiness.
+
+## Release gate remains unchanged
+
+Do not authorize `tighten-v1` from this PR's retrospective history alone. Before any live training authority, HA9-R3 still needs a prospective dataset with enough labelled healthy and illness/systemic-stress periods to estimate false-alert burden and useful detection performance. At minimum, the release report should stratify:
+
+- one-night vs persistent elevation;
+- isolated respiration vs adverse RHR/low-HRV/symptom corroboration;
+- E1/E2/E3/S1 sensitivity;
+- absolute delta and robust median/MAD deviation;
+- unavailable reason/rate;
+- source/device/firmware changes when known;
+- confounders such as hard training, sleep disruption, alcohol, travel/altitude, heat/dehydration, vaccination/medication, and allergy/respiratory context;
+- 24/48/72-hour symptom/outcome labels and lead time;
+- whether the existing readiness decision was already `modify`/`recover`.
+
+Until those labels exist, `falsePositiveRate` must remain `null`; absence of a symptom label is not evidence of a healthy true negative unless the prospective labelling protocol establishes that interpretation.

--- a/docs/analysis/2026-08-30-pr-306-respiration-calibration-addendum.md
+++ b/docs/analysis/2026-08-30-pr-306-respiration-calibration-addendum.md
@@ -1,7 +1,7 @@
 # PR #306 respiration calibration addendum
 
-**Date:** 2026-08-30  
-**Scope:** compliance check against the canonical cardiorespiratory knowledge pack plus targeted external-evidence review.  
+**Date:** 2026-08-30
+**Scope:** compliance check against the canonical cardiorespiratory knowledge pack plus targeted external-evidence review.
 **Decision effect:** none; respiration remains shadow/observation evidence.
 
 ## Compliance verdict
@@ -24,14 +24,14 @@ The numeric `6–35 br/min` acceptance range in `respirationElevation.ts` is an 
 
 The research supports the architecture more strongly than it supports any exact threshold.
 
-1. Longitudinal nocturnal respiratory rate can be estimated from wearables and can change during respiratory infection. A 2021 validation/infection study reported wearable-derived RR agreement around MAE 0.46 breaths/min and used longitudinal nocturnal changes to study COVID-19. This supports trend monitoring, while also showing that changes near fractions of a breath/min are close enough to measurement uncertainty that they should not be treated as universal clinical cut-points.  
+1. Longitudinal nocturnal respiratory rate can be estimated from wearables and can change during respiratory infection. A 2021 validation/infection study reported wearable-derived RR agreement around MAE 0.46 breaths/min and used longitudinal nocturnal changes to study COVID-19. This supports trend monitoring, while also showing that changes near fractions of a breath/min are close enough to measurement uncertainty that they should not be treated as universal clinical cut-points.
    https://pubmed.ncbi.nlm.nih.gov/34526602/
-2. A 2022 systematic review/meta-analysis of wearable/contactless RR validation found pooled wearable RR bias around 0.68 breaths/min with wide pooled limits of agreement and substantial study heterogeneity. Device-specific error therefore cannot be assumed away or transferred blindly between wearable platforms.  
+2. A 2022 systematic review/meta-analysis of wearable/contactless RR validation found pooled wearable RR bias around 0.68 breaths/min with wide pooled limits of agreement and substantial study heterogeneity. Device-specific error therefore cannot be assumed away or transferred blindly between wearable platforms.
    https://pubmed.ncbi.nlm.nih.gov/35947876/
-3. A prospective 2024 respiratory-infection validation study used **resting HR + respiratory rate + HRV during sleep** rather than respiration in isolation. This is directionally consistent with ADR-0025 and with treating corroborated/persistent cases differently from isolated one-night elevations.  
+3. A prospective 2024 respiratory-infection validation study used **resting HR + respiratory rate + HRV during sleep** rather than respiration in isolation. This is directionally consistent with ADR-0025 and with treating corroborated/persistent cases differently from isolated one-night elevations.
    https://pubmed.ncbi.nlm.nih.gov/39018555/
-4. Broader reviews of wearable infection detection conclude that physiological deviations can be useful early digital biomarkers, but real-world infection detection and generalizability remain imperfect. That supports a labelled prospective release gate rather than retrospective threshold fitting.  
-   https://pubmed.ncbi.nlm.nih.gov/35461692/  
+4. Broader reviews of wearable infection detection conclude that physiological deviations can be useful early digital biomarkers, but real-world infection detection and generalizability remain imperfect. That supports a labelled prospective release gate rather than retrospective threshold fitting.
+   https://pubmed.ncbi.nlm.nih.gov/35461692/
    https://pubmed.ncbi.nlm.nih.gov/34932906/
 
 ## Additional hardening in this commit

--- a/docs/analysis/2026-08-30-pr-306-respiration-calibration-addendum.md
+++ b/docs/analysis/2026-08-30-pr-306-respiration-calibration-addendum.md
@@ -12,13 +12,13 @@ The implementation matches the canonical policy in the important ways:
 
 - it uses nocturnal respiration as a **longitudinal personal-baseline signal**, not a bedside diagnosis;
 - it compares the current night with backward-looking personal baselines rather than a population cutoff;
-- it fails closed for incompatible baseline versions, insufficient history/coverage, source/date provenance problems, and invalid/missing measurements;
+- it fails closed for incompatible baseline versions, insufficient history/coverage, source/date provenance problems, invalid/missing measurements, and unusable personal baselines;
 - a resolving current value cannot newly tighten training;
-- persistence and adverse RHR/low-HRV corroboration are measured separately;
+- persistence and adverse RHR/low-HRV corroboration are measured separately in the health-anomaly replay;
 - exact E1/E2/E3/S1 values are explicitly product calibration candidates rather than scientific constants;
 - no current recommendation selector consumes `RespirationElevationEvidence`.
 
-The numeric `6–35 br/min` acceptance range in `respirationElevation.ts` is an ingestion/QA plausibility guard only. It must not be documented or surfaced as a clinical normal range, disease threshold, or training-action threshold.
+The numeric `6–35 br/min` acceptance range in `respirationElevation.ts` is an ingestion/QA plausibility guard only. It must not be documented or surfaced as a clinical normal range, disease threshold, or training-action threshold. Current and baseline respiration values now use the same broad plausibility envelope before personal-delta classification; an out-of-envelope baseline is treated as unusable and the classifier fails closed.
 
 ## External evidence cross-check
 
@@ -34,11 +34,11 @@ The research supports the architecture more strongly than it supports any exact 
    https://pubmed.ncbi.nlm.nih.gov/35461692/
    https://pubmed.ncbi.nlm.nih.gov/34932906/
 
-## Additional hardening in this commit
+## Additional hardening
 
 The replay previously exposed the canonical median/MAD standardized respiration deviation only at row level. That made E2/S1 calibration harder to review because an absolute +1 br/min change can represent very different departures from an athlete's own normal nightly variability.
 
-The replay summary now additionally reports:
+The health-anomaly replay summary additionally reports:
 
 - classifier-unavailable days and rate;
 - unavailable reason counts, so warm-up/history limitations can be distinguished from provenance/data failures;
@@ -46,6 +46,8 @@ The replay summary now additionally reports:
 - among discrete elevated/strong days, the robust standardized-deviation median and range.
 
 These values are **calibration telemetry only**. They do not modify E2/S1, do not add another decision boundary, and do not change live readiness.
+
+A review follow-up also corrected terminology in the standalone real-history counterfactual. `productionMetricStrain` is the existing aggregate readiness strain and can include sleep as well as RHR and HRV. It is therefore reported as **existing readiness-strain overlap**, not physiological corroboration. True physiological corroboration for release analysis is the health-anomaly replay's shared adverse-evidence semantics (adverse RHR and low HRV, with symptoms/context evaluated separately).
 
 ## Release gate remains unchanged
 

--- a/docs/analysis/2026-08-30-pr-306-respiration-shadow-review.md
+++ b/docs/analysis/2026-08-30-pr-306-respiration-shadow-review.md
@@ -1,0 +1,152 @@
+# PR #306 review — respiration shadow-evidence hardening
+
+**Date:** 2026-08-30  
+**PR:** #306 — `fix: add respiration shadow evidence and replay`  
+**Scope:** engineering review, evidence interpretation, replay semantics, provenance, and release-readiness implications.  
+**Decision effect:** none. Respiration elevation remains shadow/observation evidence and does not gain live training authority.
+
+## Review conclusion
+
+The PR's evidence-first direction is appropriate: personal nocturnal respiration elevation is a plausible health-anomaly signal, but the current evidence does not justify turning an in-sample personal-delta threshold into a clinical cutoff or an independent live training gate.
+
+Two implementation issues were found and corrected during review:
+
+1. replay corroboration could count unusually **high** HRV as corroborating adverse physiology even though the live HA evaluator correctly treats high-HRV `two_sided` anomalies as non-adverse telemetry;
+2. the discrete respiration-elevation classifier's same-day provenance check compared the recovery document date to the evaluation date, even though `respirationAvg` can come from the backend's D-1 sleep fallback.
+
+The fixes deliberately tighten evidence quality without changing recommendation behavior.
+
+## Finding 1 — replay corroboration had drifted from evaluator semantics
+
+### Before
+
+`healthAnomalyReplay.ts` considered an elevated-respiration day corroborated whenever any non-respiration core signal had `moderate_anomaly` or `strong_anomaly` status.
+
+That is broader than the actual HA evaluator. `healthAnomaly.ts:isAdverseCoreSignalEvidence` treats:
+
+- high RHR as adverse;
+- high respiration as adverse;
+- **low** HRV as adverse;
+- unusually high HRV as `two_sided` out-of-range telemetry, not an illness/adverse vote.
+
+The replay therefore could overstate the number of corroborated respiration events and understate isolated-alert burden.
+
+### Fix
+
+Replay now calls the same exported `isAdverseCoreSignalEvidence` authority used by the evaluator. A regression fixture creates strongly high HRV alongside elevated respiration and verifies that the event remains **isolated**, not corroborated.
+
+This is important for HA9-R3 because isolated-versus-corroborated performance is one of the principal release slices. A semantic mismatch in that denominator would bias the eventual ship/no-ship decision.
+
+## Finding 2 — current-day respiration provenance was nominal rather than source-derived
+
+### Backend semantics
+
+The Garmin canonicalizer establishes the relevant source truth:
+
+- target-date sleep is preferred;
+- when target-date sleep is unavailable, the selected sleep record may fall back to D-1;
+- `respiration_rate_brpm` follows the selected sleep record;
+- the precise respiration-endpoint average is used only against the target-date sleep window;
+- `mapper.py:_build_metric_dates` persists the selected sleep record's logical date as `source.metricDates.sleep`.
+
+Therefore the existing snapshot already carries the bounded logical-date provenance needed by this PR. A new schema field is unnecessary.
+
+### Before
+
+The discrete classifier received:
+
+```ts
+measurementDate: recoverySnapshot.date
+```
+
+For a D-day assessment this made the date check effectively tautological even if the underlying sleep/respiration value had fallen back to D-1.
+
+The older HA core-feature mapper also keyed historical respiration observations by the recovery **document** date, which could silently relabel a fallback night and inflate apparent current-day coverage.
+
+### Fix
+
+The shadow path now uses `source.metricDates.sleep` consistently:
+
+- `evaluatePhysiologicalAnomaly` passes `metricDates.sleep` into `evaluateRespirationElevation`;
+- a missing or mismatched sleep date makes discrete respiration evidence unavailable with `DATE_PROVENANCE_MISMATCH`;
+- `buildRespirationFeatures` exposes a current respiration value only when the selected sleep date equals the recovery snapshot date;
+- historical respiration observations are keyed/deduplicated by the selected sleep date rather than the document date;
+- feature provenance records `garmin:sleep:<logical-date>` when available.
+
+A regression test verifies that D-1 fallback respiration cannot become a D-day core anomaly or elevated-respiration event.
+
+## Scientific evidence update
+
+The implementation should continue to distinguish **signal plausibility** from **validated release thresholds**.
+
+### Longitudinal respiratory rate can be informative
+
+A wearable respiratory-rate validation/COVID-19 study reported good agreement for its tested wearable algorithm and showed that some infected participants exhibited nocturnal respiratory-rate elevations relative to their regular rate. Importantly, the signal was not universal: only a subset of symptomatic and asymptomatic cases crossed a large personal increase. This supports personal longitudinal monitoring, not a universal diagnostic threshold.
+
+- https://pubmed.ncbi.nlm.nih.gov/34526602/
+
+A prospective validation study in health-care workers used a **multi-signal** wearable model including resting heart rate, respiratory rate, and HRV during sleep. That is directionally consistent with ADR-0025's multi-channel design and with requiring prospective validation before visible or training-authoritative use.
+
+- https://pubmed.ncbi.nlm.nih.gov/39018555/
+
+### Device/measurement uncertainty matters
+
+Systematic-review evidence shows that wearable/cardiorespiratory measurement accuracy varies by device, population, context, and validation design. A numerical error estimate from one wearable algorithm must not be transferred to Garmin as if it were a Garmin specification.
+
+- https://pubmed.ncbi.nlm.nih.gov/35947876/
+- https://pubmed.ncbi.nlm.nih.gov/36292252/
+
+Other longitudinal sleep-monitor validation work further supports the usefulness of individualized respiratory-rate baselines, but it remains device-specific rather than evidence for these exact E1/E2/E3/S1 boundaries.
+
+- https://pubmed.ncbi.nlm.nih.gov/38875674/
+
+### Consequence for E1/E2/E3/S1
+
+The current personal-delta boundaries remain **shadow calibration candidates**:
+
+| Candidate | vs 28d median | vs 7d median |
+|---|---:|---:|
+| E1 | >= +0.75 br/min | >= +0.25 br/min |
+| E2 | >= +1.00 br/min | >= +0.50 br/min |
+| E3 | >= +1.25 br/min | >= +0.75 br/min |
+| S1 | >= +2.00 br/min | >= +1.00 br/min |
+
+E2's separation of the currently observed high nights is in-sample evidence. It is not a physiological law, a disease cutoff, or permission to tighten training.
+
+## Release implications
+
+This review does **not** authorize any of the following:
+
+- enabling `RespirationStrainPolicy='median-mad-v1'` in normal readiness calls;
+- changing `DecisionScoreTelemetry.totalDecisionScore` from respiration elevation;
+- showing diagnostic or pseudo-probabilistic illness wording;
+- changing a training recommendation from respiration alone;
+- promoting E2/S1 from candidate thresholds to product truth.
+
+HA9-R3 should continue prospectively and should report, at minimum:
+
+1. labelled elevated and normal healthy periods;
+2. false-alert burden per observed days and per episode;
+3. measurement/provenance-unavailable rate;
+4. E1/E2/E3/S1 sensitivity to threshold choice;
+5. one-night versus persistent variants;
+6. isolated respiration versus corroborated **adverse** RHR/low-HRV cases;
+7. whether existing readiness was already conservative;
+8. 24/48/72-hour symptom/outcome labels and lead time;
+9. confounders such as hard training, poor sleep, stress, alcohol, travel, heat/dehydration, vaccination/medication, and allergy context;
+10. resolving-tail behavior so recovery is not punished by stale drift.
+
+A future `tighten-v1` decision should be a separate, explicit release decision based on that prospective evidence.
+
+## Verification added in this review
+
+Regression coverage now asserts that:
+
+- unusually high HRV does not count as adverse corroboration for elevated respiration;
+- D-1 sleep-fallback respiration is unavailable for a D-day elevation assessment;
+- D-1 fallback respiration is also unavailable as the D-day core respiration anomaly channel;
+- historical respiration coverage follows the selected sleep date rather than blindly following the recovery document date.
+
+The intended invariant remains:
+
+> Better provenance can remove unsupported evidence, but shadow respiration work must not silently gain live training authority.

--- a/docs/analysis/2026-08-30-pr-306-respiration-shadow-review.md
+++ b/docs/analysis/2026-08-30-pr-306-respiration-shadow-review.md
@@ -19,6 +19,17 @@ Two implementation issues were found and corrected during review:
 
 The fixes deliberately tighten evidence quality without changing recommendation behavior.
 
+## Cross-PR boundary with #305
+
+PR #305 and PR #306 are complementary rather than competing implementations.
+
+- PR #305 owns the canonical **external-evidence boundary**. Its respiration claim should describe the evidence as moderate-certainty for longitudinal/anomaly detection but informational for training action: the literature supports an early, nonspecific signal, not a validated training prescription.
+- PR #306 owns the **local product-validation boundary**. E1/E2/E3/S1, persistence/corroboration rules, replay slices, and any future `tighten-v1` behavior are product calibration and must earn authority prospectively.
+- The existing rules engine contains respiration strain arithmetic, but normal snapshot mapping defaults `RespirationStrainPolicy` to `off`; only an explicit comparison policy forwards the respiration deltas/MAD. Therefore the dormant `0.3` weight and `1 br/min` floor must not be described as current live respiration authority.
+- PR #306 must not inherit recommendation authority merely because PR #305 establishes that respiration is a useful physiological-anomaly signal. Scientific signal validity and product action validity remain separate gates.
+
+There is no hard code dependency or overlapping changed production file between the two PRs. Landing #305 first is cleaner for evidence lineage, but #306's shadow implementation remains valid independently as long as this authority separation is preserved.
+
 ## Finding 1 — replay corroboration had drifted from evaluator semantics
 
 ### Before

--- a/docs/analysis/2026-08-30-pr-306-respiration-shadow-review.md
+++ b/docs/analysis/2026-08-30-pr-306-respiration-shadow-review.md
@@ -1,8 +1,11 @@
 # PR #306 review — respiration shadow-evidence hardening
 
-**Date:** 2026-08-30  
-**PR:** #306 — `fix: add respiration shadow evidence and replay`  
-**Scope:** engineering review, evidence interpretation, replay semantics, provenance, and release-readiness implications.  
+**Date:** 2026-08-30
+
+**PR:** #306 — `fix: add respiration shadow evidence and replay`
+
+**Scope:** engineering review, evidence interpretation, replay semantics, provenance, and release-readiness implications.
+
 **Decision effect:** none. Respiration elevation remains shadow/observation evidence and does not gain live training authority.
 
 ## Review conclusion

--- a/docs/plans/health-anomaly-and-illness-risk-alerting.md
+++ b/docs/plans/health-anomaly-and-illness-risk-alerting.md
@@ -950,7 +950,15 @@ known.
 
 ## HA9 — tighten-only training integration
 
-**Status:** blocked by visible-mode prospective evidence and a recorded release decision
+**Status:** respiration shadow evidence implemented through HA9-R2; live tightening remains
+blocked by labelled prospective evidence and a recorded release decision
+
+The scoped implementation decomposition and current personal-history replay findings are in
+[`respiration-elevation-training-tightening.md`](./respiration-elevation-training-tightening.md).
+That addendum refines how respiration may contribute to HA9: a discrete current-elevation
+signal is evaluated in shadow first, while the rejected broad
+`RespirationStrainPolicy='median-mad-v1'` production shortcut remains off. The addendum does
+not authorize `tighten-v1`; HA7/HA9 evidence and a separate release decision still govern.
 
 ### HA9.1 Add a health gate after readiness evaluation
 

--- a/docs/plans/respiration-elevation-training-tightening.md
+++ b/docs/plans/respiration-elevation-training-tightening.md
@@ -1,0 +1,477 @@
+# Respiration elevation as tighten-only training evidence — HA9 implementation addendum
+
+* **Capability owner:** `HA` — this refines
+  [`health-anomaly-and-illness-risk-alerting.md`](./health-anomaly-and-illness-risk-alerting.md)
+  `HA7`/`HA9`; it is not a parallel capability or status board.
+* **Status:** `Active — HA9-R0 through HA9-R2 implemented on 2026-08-30; HA9-R3 collecting evidence`
+* **Blocked by:** nothing for the implemented evidence-harness correction and shadow-only
+  signal work (`HA9-R0`–`HA9-R2`); any user-visible wording remains blocked by the `HA7` release report,
+  and any recommendation change remains blocked by labelled prospective evidence plus a
+  separate recorded `tighten-v1` release decision.
+* **Unlocks:** an evidence-backed decision on whether personally elevated sleeping
+  respiration should explain, cap, or tighten a live training recommendation.
+* **Decision basis:** ADR-0024 and ADR-0025. In particular, this plan does **not** revive the
+  rejected shortcut of enabling `RespirationStrainPolicy='median-mad-v1'` in production.
+* **Replay tool:**
+  [`app/scripts/respiration-real-history-replay.mjs`](../../app/scripts/respiration-real-history-replay.mjs).
+  It generates the local, uncommitted `artifacts/respiration-real-history-replay/latest/`
+  Markdown and JSON reports used below.
+
+## 1. Problem and current evidence
+
+Garmin sleeping respiration is already ingested, persisted with personal 7-day/28-day
+median baselines, mapped into the health-anomaly feature set, and available to the latent
+training-strain comparison path. None of those facts establishes that the current broad
+additive strain candidate should become live.
+
+The updated local replay covers 90 days from 2026-06-02 through 2026-08-30:
+
+* respiration exists on 88/90 input days;
+* 62 days remain after the 28-day baseline warm-up;
+* 35/62 evaluated snapshots already contain `todayTraining`, which forces the existing
+  engine into its post-training recovery behavior and must not dilute the denominator for
+  a morning-decision comparison;
+* the actionable morning subset is therefore 27 days;
+* five evaluated days have both respiration above 13 br/min and at least +1.0 br/min versus
+  the personal 28-day median; all five have no Garmin-recorded same-day training;
+* the existing engine already returns `modify` or `recover` on all five, so their current
+  incremental decision value is explanatory/corroborative rather than a demonstrated mode
+  correction;
+* the broad `median-mad-v1` candidate changes 4/27 actionable recommendations: three
+  `train -> modify` and one `modify -> recover`;
+* every flip starts only 0.07–0.12 below an existing mode threshold, so respiration acts as
+  a borderline tipping term rather than an independent high-elevation gate;
+* all four flips occur at 12.2–12.8 br/min, not on the five high-respiration days;
+* every evaluated 28-day respiration MAD is below the current 1.0 br/min scoring floor
+  (observed range 0.2224–0.7413), so that heuristic floor—not measured personal
+  variability—controls every candidate score;
+* 6/27 actionable days receive positive respiration strain while the current value is
+  already below the 7-day median; one such resolving day flips `train -> modify`;
+* no symptom, illness, healthy-period, or follow-up labels are present in `raw_cache.json`,
+  so a false-positive rate is unavailable rather than zero.
+
+This is useful personal evidence: clearly elevated nights align with not training. It is
+not yet evidence that the current additive formula isolates the right days or adds value
+beyond HRV, RHR, sleep, Body Battery, symptoms, and the athlete's own decision.
+
+## 2. Proposed decisions for plan approval
+
+### D-RESP-1 — do not activate the additive respiration strain candidate
+
+Normal production calls keep `RespirationStrainPolicy='off'`. Do not pass
+`'median-mad-v1'` from `Home`, `PlanView`, the planner, or external/authored adjudication.
+
+Reasons:
+
+* the current candidate flips lower, borderline days rather than the empirically high days;
+* its denominator is entirely floor-dominated in the available history;
+* its chronic term can remain positive while current respiration is resolving;
+* false-positive and incremental-value labels do not exist yet.
+
+### D-RESP-2 — represent current elevation as a discrete health signal
+
+Add a pure, versioned `RespirationElevationEvidence` classifier under the health-anomaly
+capability. It answers one bounded question:
+
+> Is last night's respiration currently and materially above both the athlete's recent and
+> longer personal baseline, with enough data quality to trust the comparison?
+
+It does not add directly to `DecisionScoreTelemetry.totalDecisionScore`, does not modify
+`metricStrain`, and does not diagnose illness.
+
+Candidate evidence shape:
+
+```ts
+type RespirationElevationStatus =
+  | 'unavailable'
+  | 'normal'
+  | 'elevated'
+  | 'strongly_elevated'
+  | 'resolving';
+
+interface RespirationElevationEvidence {
+  status: RespirationElevationStatus;
+  currentValue: number | null;
+  baseline7dValue: number | null;
+  baseline28dValue: number | null;
+  deltaVs7d: number | null;
+  deltaVs28d: number | null;
+  baselineVersion: number | null;
+  historyCount: number;
+  recentDayCoverage: number;
+  reasonCodes: string[];
+  policyVersion: string;
+}
+```
+
+The persisted health-anomaly assessment may retain this bounded derived evidence. The
+recommendation audit should reference the immutable assessment revision rather than copy raw
+respiration measurements into every recommendation.
+
+### D-RESP-3 — use personal deltas, not an absolute 13 br/min cutoff
+
+`13 br/min` is meaningful in this athlete's current history because the personal center is
+lower. It is not a portable population threshold. Shadow policy compares the current value
+to the athlete's own 7-day and 28-day medians.
+
+The first replay sweep must evaluate, rather than silently adopt, at least these candidate
+boundaries:
+
+| Candidate | `deltaVs28dMedian` | `deltaVs7dMedian` | Intended interpretation |
+|---|---:|---:|---|
+| E1 | >= 0.75 | >= 0.25 | sensitive exploratory boundary |
+| E2 | >= 1.00 | >= 0.50 | current personal-history candidate |
+| E3 | >= 1.25 | >= 0.75 | more specific single-night boundary |
+| S1 | >= 2.00 | >= 1.00 | strongly elevated candidate |
+
+`E2` exactly separates the five currently high evaluated nights, but that is an in-sample
+observation, not permission to ship it. The release report must compare all candidates on
+new labelled days and report threshold sensitivity.
+
+### D-RESP-4 — resolving respiration cannot newly tighten training
+
+If the current value is at or below the 7-day median, classify the signal as `resolving` or
+`normal`; it cannot independently tighten today's recommendation. This prevents the current
+broad candidate's chronic-drift tail from turning a recovered reading into a new training
+restriction.
+
+The health-anomaly assessment may still preserve episode continuity and explain that a
+recent elevation existed. Explanation and episode continuity are not the same authority as
+a current-day training gate.
+
+### D-RESP-5 — training effects are monotonic and bounded
+
+If a later release decision authorizes `tighten-v1`:
+
+* health evidence may only make a decision more conservative;
+* respiration alone may at most change `train -> modify` in version 1;
+* respiration alone may not change `modify -> recover`;
+* a single merely `elevated` night is rationale/shadow evidence only;
+* a `strongly_elevated` night or persistent elevation may cap hard/maximal work only when
+  the release policy's corroboration requirements are met;
+* `possible_illness_or_systemic_stress`, symptoms, or corroborating adverse RHR/HRV may use
+  the broader HA9 health gate, but those are health-anomaly state decisions—not a raw
+  respiration weight;
+* if readiness already returns `modify` or `recover`, respiration records corroboration and
+  rationale without applying a second penalty;
+* no future forecast day inherits today's signal, and one elevated night does not rewrite
+  the week or macrocycle;
+* events remain advisory under ADR-0019; the gate reports concern but does not instruct the
+  athlete to skip an event.
+
+## 3. Target architecture
+
+```text
+Garmin nightly respiration
+  -> DailyRecoverySnapshot raw + 7d/28d medians
+  -> healthAnomalyFeatures threshold-free evidence
+  -> RespirationElevationEvidence (personal-delta classifier)
+  -> PhysiologicalAnomalyAssessment + immutable revision
+  -> HealthTighteningDirective (off/shadow until release)
+  -> shared readiness envelope
+       -> catalog/intent-aware selection
+       -> external-session adjudication
+       -> authored-session adjudication
+  -> compact RecommendationAudit reference + replay
+```
+
+The health assessment must be composed before a `tighten-v1` recommendation is selected.
+The current `App` fire-and-forget shadow call is appropriate for shadow evidence but cannot
+become a live gate: it races after decision composition and is deliberately disconnected from
+selection.
+
+Refactor the health-anomaly composition boundary so it can:
+
+1. consume the already composed current snapshot/check-in rather than re-reading them;
+2. read only the bounded history, travel context, and previous assessment needed for episode
+   continuity;
+3. return the exact assessment revision used by the decision;
+4. persist that revision idempotently;
+5. preserve the current zero-read/zero-write behavior when policy is `off`;
+6. preserve fire-and-forget behavior for `shadow-v1` until live integration is explicitly
+   authorized.
+
+## 4. Delivery graph and work items
+
+```text
+HA9-R0 replay correctness
+  -> HA9-R1 pure elevation classifier
+  -> HA9-R2 shadow persistence/reporting
+  -> HA9-R3 prospective labels and incremental-value report
+  -> HA9-R4 explicit ship/no-ship decision
+  -> HA9-R5 shared tighten-only gate
+  -> HA9-R6 audit/replay/rules hardening
+  -> HA9-R7 rollout and architecture documentation
+```
+
+### HA9-R0 — correct and harden the replay harness
+
+**Status:** implemented 2026-08-30. **Behavior change:** none.
+
+Update `app/scripts/respiration-real-history-replay.mjs` and its report contract:
+
+* separate all evaluated rows from actionable morning rows (`todayTraining == null`);
+* make 4/27, not 4/62, the primary decision-flip denominator for the current dataset;
+* report already-trained rows separately and never count their forced-recovery invariance as
+  evidence that a candidate is harmless;
+* distinguish absolute display values from personal `Vs7d`/`Vs28d` deltas;
+* report the E1/E2/E3/S1 threshold sweep, persistence variants, and resolving tails;
+* report how often existing readiness already chose `modify`/`recover` on elevated days;
+* report single-signal versus corroborated cases;
+* accept optional real check-in and health-outcome input; when labels are absent, emit
+  `falsePositiveRate: null` with a limitation instead of inferring healthy;
+* keep raw health rows local/ignored and emit only the bounded report needed for review;
+* add deterministic fixture tests for denominators, threshold boundaries, and missing labels.
+
+Acceptance evidence:
+
+* the current dataset reports 27 actionable rows and four broad-candidate flips;
+* the five E2 high-elevation rows are reported separately and all show no same-day training;
+* no current report labels those five as true positives or the lower flips as false positives.
+
+Implementation evidence: `respirationReplayAnalysis.mjs` now owns deterministic denominator,
+threshold, persistence, corroboration, resolving-tail, and optional-label summaries. The current
+E1/E2/E3/S1 match counts are 6/5/4/3; actionable counts are 5/5/4/3. Every E2/E3/S1 match is
+corroborated by existing metric strain and already has a conservative production mode. The
+broad additive candidate still flips 4/27 actionable mornings, while false-positive rate is
+explicitly `null` because no labels were supplied.
+
+### HA9-R1 — implement the pure personal-elevation classifier
+
+**Status:** implemented 2026-08-30. **Behavior change:** none.
+
+Add `app/src/engine/respirationElevation.ts` with a pure function receiving bounded snapshot
+features and a versioned `RespirationElevationPolicy`.
+
+Fail closed when any of these is true:
+
+* current respiration is missing or physiologically invalid;
+* `baselineComputationVersion < 3`;
+* 7-day or 28-day median is missing;
+* history count or recent-day coverage is below policy minimum;
+* the measurement is ineligible under identity/source-quality policy;
+* date provenance does not match the target Warsaw calendar date.
+
+Do not divide by the current 1.0 br/min training floor. MAD remains useful data-quality and
+anomaly-estimator evidence, but the discrete training candidate is defined by explicit
+personal deltas until replay justifies a scale-normalized boundary.
+
+Tests cover:
+
+* every E1/E2/E3/S1 boundary immediately below/at/above the threshold;
+* old mean-baseline snapshots remain unavailable;
+* missing current/7d/28d/history/identity evidence is unavailable, never normal;
+* current below 7-day median resolves rather than tightens;
+* absolute 13 br/min is not special across athletes with different baselines;
+* lower respiration never produces adverse evidence.
+
+### HA9-R2 — add shadow evidence to HA assessment and replay
+
+**Status:** implemented 2026-08-30. **Behavior change:** none.
+
+Tentative files:
+
+| File | Change |
+|---|---|
+| `healthAnomalyModels.ts` | Add optional bounded respiration-elevation evidence and its policy identity. |
+| `healthAnomalyFeatures.ts` | No change was needed: canonical v3+ snapshots already preserve both median baselines; the classifier recomputes bounded deltas from those values. |
+| `healthAnomaly.ts` | Attach the classifier result to rationale facts; do not change training or visible wording. |
+| `healthAnomalyService.ts` | Persist the bounded evidence in the immutable assessment revision. |
+| `healthAnomalyPersistence.ts` | Strictly parse the additive evidence and retain legacy revision compatibility; the bumped HA policy version gives the deterministic revision a new identity. |
+| `healthAnomalyReplay.ts` | Render threshold, persistence, corroboration, and resolving-tail comparisons. |
+| `firestore.rules` | Allow only a bounded optional map under the existing assessment key allow-list. Strict scalar/policy validation remains in the application parser because expanding the already-large server rule exceeded Firestore's 1,000-expression limit; emulator tests cover the bounded server contract. |
+
+Prefer an additive optional field under schema version 1 only if old/new revision identity and
+rules remain unambiguous. Otherwise bump the health-assessment schema and retain an explicit
+legacy reader; do not silently reinterpret an old revision under new policy semantics.
+
+The implementation uses the additive schema-version-1 option. Legacy records without the
+field still parse. New assessments use `health-anomaly/ha9-respiration-shadow-v1`, and the
+classifier policy is `respiration-elevation/shadow-e2-s1-v1`. Shadow reports now include status
+counts, two-night persistence, corroborated versus isolated evidence, and resolving tails.
+
+### HA9-R3 — collect labels and measure incremental value
+
+**Status:** evidence collection active; blocked on enough labelled prospective days/episodes for a release-quality estimate. **Behavior change:** none.
+
+Reuse HA6 outcomes, the decision journal, adherence/completed-session history, and existing
+confounder context. Do not treat “no Garmin activity” as an illness label; it is an athlete
+decision/outcome that may have many causes.
+
+For each candidate boundary report:
+
+* elevated nights and unique episodes per 30 observed days;
+* same-day athlete decision: train as planned / scale / substitute / rest;
+* whether existing readiness was already `modify`/`recover`;
+* RHR/HRV/sleep/symptom corroboration;
+* hard-training, travel, alcohol, heat/dehydration, allergy, vaccination/medication context;
+* symptoms and outcome explanations at 24/48/72 hours;
+* healthy-period false-alert burden;
+* lead time before labelled symptoms;
+* isolated-respiration versus multi-signal decision flips;
+* resolving-tail days and whether a proposed gate would have remained conservative after the
+  athlete considered the event resolved;
+* threshold sensitivity for E1/E2/E3/S1 and one-night versus persistent variants.
+
+The release dataset must include both elevated and normal healthy periods. A handful of
+high nights with no training is useful evidence but cannot estimate specificity or PPV.
+
+### HA9-R4 — record the release decision
+
+**Status:** blocked by HA9-R3. **Behavior change:** none by itself.
+
+Write a dated analysis document that chooses exactly one:
+
+1. **No ship:** remain shadow; respiration only supports developer evidence.
+2. **Explain only:** show personal elevation in visible HA rationale but do not change training.
+3. **Corroborated cap:** allow persistent/strong respiration plus defined corroboration to
+   cap `train` at `modify`.
+4. **Recalibrate:** change candidate boundaries and run a new prospective segment.
+
+The report must name the chosen `RespirationElevationPolicy` and
+`HealthTrainingGatePolicy` versions, expected flip burden per 30 actionable mornings, measured
+false-alert ceiling, rollback trigger, and decision owner. If it authorizes semantics outside
+ADR-0025/HA9, record a new ADR before implementation.
+
+### HA9-R5 — implement the shared tighten-only gate
+
+**Status:** blocked by an HA9-R4 “corroborated cap” decision. **Behavior change:** yes.
+
+Introduce a compact directive rather than passing the whole assessment into ranking:
+
+```ts
+interface HealthTighteningDirective {
+  action: 'none' | 'cap_hard' | 'require_recovery';
+  assessmentRevisionId: string;
+  healthPolicyVersion: string;
+  gatePolicyVersion: string;
+  reasonCodes: string[];
+}
+```
+
+`require_recovery` is reserved for the broader evidence-backed health-anomaly state; version
+1 respiration-only evidence cannot emit it.
+
+Apply the directive to the shared envelope state after
+`rules.ts` `evaluateReadinessAndSafetyEnvelope` and before any candidate/session decision.
+Internal intent-aware selection, external-session adjudication, and authored-session
+adjudication already consume that shared envelope shape; do not add three independent health
+rules.
+
+Production composition requirements:
+
+* extend the composed decision input with the immutable assessment revision/directive;
+* await the assessment only under explicitly authorized `tighten-v1`;
+* do not use a stale persisted same-day assessment when current snapshot/check-in revisions
+  differ;
+* keep `off` bit-identical and preserve current shadow behavior;
+* do not project today's directive into next-day branches or future planner days;
+* if the required live health input is unavailable, fail closed to the existing readiness
+  result—not to fabricated normal physiology and not to an unexplained new restriction.
+
+### HA9-R6 — provenance, replay, Firestore, and policy drift
+
+**Status:** blocked by HA9-R5. **Behavior change:** part of the same atomic release.
+
+Add compact `HealthTighteningAudit` provenance to `Recommendation.decisionTrace` and
+`RecommendationAudit`:
+
+* health assessment revision ID and content identity/hash;
+* health/gate policy versions;
+* pre-gate and post-gate mode/tier;
+* action and bounded reason codes;
+* no raw payloads, notes, or duplicated health history.
+
+Update `provenance.ts`, `replay.ts`, persistence validation, and Firestore rules so a changed
+decision cannot replay without the exact immutable health assessment it referenced. Add the
+new recommendation `POLICY_VERSION` to historical versions when superseded.
+
+Production activation and audit/rules changes ship atomically; there must be no deployment in
+which recommendations change but provenance silently omits why.
+
+### HA9-R7 — rollout, rollback, and living documentation
+
+**Status:** blocked by HA9-R5/HA9-R6.
+
+Rollout order:
+
+1. `off` — unchanged production behavior;
+2. `shadow-v1` — classifier/reporting only;
+3. `visible-v1` — only if HA7 separately authorizes wording;
+4. `tighten-v1` for the intended user/environment after HA9-R4;
+5. review after the first 14 and 30 actionable mornings, then per rolling 30-day window.
+
+Rollback is one configuration change back to `visible-v1` or `shadow-v1`; old recommendation
+and assessment revisions remain immutable and readable. Roll back immediately if the reviewed
+unnecessary-tightening rate exceeds HA9-R4's ceiling, source/identity eligibility regresses,
+or replay cannot reproduce a changed recommendation.
+
+Update:
+
+* `docs/architecture/health-anomaly-shadow.md` when live composition exists;
+* `docs/architecture/recommendation-engine.md` when the shared envelope gains the health gate;
+* the canonical HA plan status and next-agent handoff;
+* operational feature-flag and rollback documentation.
+
+## 5. Cross-path acceptance criteria
+
+The implementation is not complete unless all of these hold:
+
+1. `off` and `shadow-v1` produce byte-equivalent recommendation decisions to current
+   production.
+2. A normal or resolving respiration signal never tightens training.
+3. Respiration-only version 1 can produce `train -> modify` but never `modify -> recover`.
+4. No health path can produce `recover -> modify/train` or `modify -> train`.
+5. If existing readiness is already equally/more conservative, the mode is unchanged and
+   only corroboration/rationale is recorded.
+6. Internal catalog, external plan, and authored occurrence paths consume one shared directive
+   and agree on the effective envelope.
+7. Events remain advisory.
+8. Future planner days do not inherit current-day health evidence.
+9. Missing/invalid/stale/identity-ineligible respiration cannot fabricate normal or adverse
+   training authority.
+10. Every changed recommendation names the health gate in rationale and has replayable audit
+    provenance.
+11. User isolation remains under `users/{APP_USER_ID}/...`; no default user or root recovery
+    path is introduced.
+12. Warsaw local-date semantics are preserved for snapshot, assessment, history, and decision
+    dates.
+
+## 6. Verification commands
+
+Evidence-only work:
+
+```bash
+node app/scripts/respiration-real-history-replay.mjs
+cd app && npm test -- --run src/engine/healthAnomalyFeatures.test.ts src/engine/healthAnomalyReplay.test.ts
+cd app && npm run typecheck
+cd app && npm run lint
+```
+
+Any live decision change additionally requires:
+
+```bash
+cd app && npm run check
+cd app && npm run test:rules
+cd app && npm run simulate:scenarios
+cd app && npm run simulate:diff
+cd app && node scripts/check-policy-drift.mjs <base-sha>
+cd app && npm run build
+```
+
+Review the semantic simulation diff, all mode flips in the prospective replay, and exact
+audit replay—not only command exit codes—before enabling `tighten-v1`.
+
+## 7. Explicit non-goals
+
+This addendum does not:
+
+* diagnose respiratory infection, asthma, allergy, or any specific condition;
+* treat “no training” as proof that a high respiration night was pathological;
+* use an absolute population cutoff as the primary rule;
+* activate Garmin Training Readiness, stress, or other correlated composites as extra
+  additive penalties;
+* authorize the current 1.0 br/min MAD floor;
+* infer labels from free-text notes;
+* loosen a recommendation because respiration is low;
+* ship visible alerts or training changes merely because the classifier and tests exist.


### PR DESCRIPTION
## Summary
- add a fail-closed personal-delta respiration classifier for health-anomaly shadow assessments
- correct the real-history replay denominator and add E1/E2/E3/S1 threshold, persistence, corroboration, resolving-tail, and optional-label reporting
- persist and replay bounded shadow evidence without wiring it into the live recommendation selector
- document the release gate: live tightening remains blocked on prospective labelled evidence and an explicit release decision

## Evidence
- actionable replay flips: 4/27 (14.8%); aggregate 4/62
- E2 identifies five actionable mornings, all already modify/recover under the existing engine
- false-positive rate is null because the supplied history has no healthy or illness labels

## Validation
- npm run build
- npm run test:rules
- real-history replay: node scripts/respiration-real-history-replay.mjs

No live training-recommendation behavior is changed.