### PR TITLE
feat(ai-judge): add cycling-primary hybrid persona and consolidate triathlon coverage

### DIFF
--- a/app/scripts/ai-judge/README.md
+++ b/app/scripts/ai-judge/README.md
@@ -1,0 +1,91 @@
+# Persona AI-judge fixtures
+
+This directory contains the persona fixtures used to evaluate whether the planner preserves an athlete's goal hierarchy, current capacity, hard constraints, and recovery state across multi-week recommendations.
+
+## Catalog vs active suite
+
+The persona system has two layers on purpose:
+
+- `personaScenarios.mjs` is the reusable **catalog**. It may contain multiple archetypes or variants that are useful for targeted development and regression work.
+- `personaSuite.mjs` is the **active evaluation suite**. It composes a smaller set of personas and state perturbations that are run by `run-persona-ai-judge.mjs`.
+
+Do not remove a useful catalog fixture merely because it is redundant in the active suite. Conversely, adding a catalog fixture does not automatically justify the ongoing AI-judge cost of making it active.
+
+## Active-suite design rules
+
+### Prefer state perturbations over duplicate archetypes
+
+If several cases are intended to test the same underlying athlete identity, keep one persona and vary the decision-relevant axis: recovery, equipment/access, time, race proximity, pain/guardrails, or a soft preference.
+
+The consolidated triathlon family follows this model: one established Olympic-distance athlete is tested across baseline recovery, adverse recovery, pool loss, short time, and taper proximity. The lower-level novice/intermediate/advanced triathlon catalog remains available for targeted tests.
+
+### Persona prose must agree with observed evidence
+
+The judge sees both narrative identity and planner-visible history. Do not claim a current capability in persona prose while deleting all evidence of it from `initialHistory`.
+
+The cycling-primary hybrid fixture therefore keeps a **cycling-dominant mixed history**: 8 Cycling exposures and 4 Strength exposures. This is intentionally not a pure-cycling history because the persona's declared current identity includes regular resistance training and the evergreen intent contains both `endurance` and `strength_muscle` priorities.
+
+Historical evidence is still not permission to over-prescribe. The hierarchy remains:
+
+1. hard safety/equipment/time constraints;
+2. active recovery or symptom evidence;
+3. primary performance goal;
+4. secondary maintenance/retention goals;
+5. soft preferences.
+
+### Adversarial cases must make the conflict real
+
+A case named for a conflict should contain values that actually oppose each other. For example, the cycling hybrid local-tissue case uses clearly favorable wearable signals together with `painFlag=true` and explicit lower-body/impact guardrails. Neutral wearable values would not genuinely exercise the intended arbitration rule.
+
+### Keep hard constraints deterministic
+
+Use fixture and planner assertions for facts that can be checked deterministically: equipment availability, event modality, time caps, active guardrails, history composition, event dates, and reachability. Reserve the LLM judge for qualitative hierarchy questions such as whether a plan is cycling-primary without becoming cycling-only.
+
+### Keep synthetic fixtures anonymous
+
+Active fixtures are public test data. Do not encode a real person's name or identifying details. `assertPersonaFixtureIntegrity()` contains a basic regression guard, but fixture authors are responsible for keeping the data synthetic.
+
+## Cycling-primary hybrid contract
+
+The active hybrid family is evergreen rather than tied to a specific race date. Its stable contract is:
+
+- Cycling is the primary performance objective.
+- Strength/muscle retention is a real secondary requirement.
+- Running is optional/deprioritized rather than required.
+- More available time should not automatically create more hard sessions.
+- Adverse recovery should lower near-term cost without permanently erasing the secondary strength requirement.
+- A same-day Strength preference is soft and must not reverse the primary identity.
+- Local pain and explicit mechanical guardrails outrank favorable wearable readiness.
+- Body-composition progress must not be achieved by undermining key training or recovery.
+
+When this contract changes, update fixture integrity assertions and tests in the same PR.
+
+## Validation
+
+From `app/`:
+
+```bash
+# Focused active-suite tests
+npx vitest run scripts/ai-judge/__tests__/personaScenarios.test.mjs
+
+# Build deterministic persona artifacts without calling an external judge
+npm run persona:build
+
+# Full repository validation
+npm run check
+```
+
+`persona:run`, `persona:quick`, and provider-specific persona commands invoke the AI judge and may require provider credentials or local model infrastructure.
+
+## Adding or changing an active persona
+
+Before expanding the active suite, answer these questions:
+
+1. What distinct planner decision does this case test?
+2. Can the case be represented as a state perturbation of an existing persona instead of a new archetype?
+3. Are narrative facts supported by planner-visible history/context, or explicitly framed as historical background rather than current capacity?
+4. Is the intended conflict represented in the actual numeric/boolean fixture values?
+5. Can any expected behavior be asserted deterministically before asking an LLM to judge it?
+6. Does the case remain anonymous and reusable?
+
+If those answers are clear, add the fixture, update `assertPersonaFixtureIntegrity()`, add focused assertions, and run the deterministic planner path before spending AI-judge budget.

--- a/app/scripts/ai-judge/__tests__/personaScenarios.test.mjs
+++ b/app/scripts/ai-judge/__tests__/personaScenarios.test.mjs
@@ -120,7 +120,7 @@ describe('active persona AI-judge suite', () => {
     }
   });
 
-  it('adds an anonymized cycling-primary hybrid persona with explicit goal hierarchy and current cycling history', () => {
+  it('adds an anonymized cycling-primary hybrid persona with explicit hierarchy and evidence-backed mixed history', () => {
     const family = buildPersonaFamilies().find((candidate) => candidate.familyId === 'persona_cycling_primary_hybrid');
     expect(family).toBeDefined();
     expect(family.cases).toHaveLength(5);
@@ -137,14 +137,24 @@ describe('active persona AI-judge suite', () => {
       expect(definition.scenario.context.trainingSettings.equipment.indoor_bike).toBe(true);
       expect(definition.scenario.context.trainingSettings.equipment.outdoor_bike).toBe(true);
       expect(definition.scenario.initialHistory).toHaveLength(12);
-      expect(definition.scenario.initialHistory.every((exposure) => exposure.modality === 'Cycling')).toBe(true);
+
+      const cyclingHistory = definition.scenario.initialHistory.filter((exposure) => exposure.modality === 'Cycling');
+      const strengthHistory = definition.scenario.initialHistory.filter((exposure) => exposure.modality === 'Strength');
+      expect(cyclingHistory).toHaveLength(8);
+      expect(strengthHistory).toHaveLength(4);
+      expect(cyclingHistory.length).toBeGreaterThan(strengthHistory.length);
+      expect(strengthHistory.every((exposure) => exposure.category === 'Full-body Strength')).toBe(true);
       expect(definition.scenario.event).toBeNull();
     }
 
     const tissueConflict = family.cases.find((definition) => definition.scenario.id === 'persona_cycling_hybrid_local_tissue_conflict');
-    expect(tissueConflict.scenario.readinessForWeek(0).subjective.painFlag).toBe(true);
+    const tissueReadiness = tissueConflict.scenario.readinessForWeek(0);
+    expect(tissueReadiness.subjective.painFlag).toBe(true);
     expect(tissueConflict.scenario.context.constraints.impliedGuardrails).toEqual(['avoid_high_impact', 'avoid_heavy_lower_body']);
-    expect(tissueConflict.scenario.readinessForWeek(0).objective.hrv_delta).toBe(0);
+    expect(tissueReadiness.objective.sleep_score).toBeGreaterThanOrEqual(90);
+    expect(tissueReadiness.objective.body_battery_wake).toBeGreaterThanOrEqual(80);
+    expect(tissueReadiness.objective.hrv_delta).toBeGreaterThan(0);
+    expect(tissueReadiness.objective.rhr_delta).toBeLessThan(0);
 
     const strengthPreference = family.cases.find((definition) => definition.scenario.id === 'persona_cycling_hybrid_strength_preference');
     expect(strengthPreference.scenario.readinessForWeek(0).subjective.preferredModalityToday).toBe('Strength');

--- a/app/scripts/ai-judge/__tests__/personaScenarios.test.mjs
+++ b/app/scripts/ai-judge/__tests__/personaScenarios.test.mjs
@@ -2,29 +2,33 @@ import { describe, expect, it } from 'vitest';
 
 import { EVENT_PRESETS } from '../../../src/engine/eventPresets.ts';
 import { runScenario } from '../../../src/engine/simulation/analyze.ts';
-import { assertPersonaFixtureIntegrity, buildPersonaFamilies } from '../personaScenarios.mjs';
+import { assertPersonaFixtureIntegrity, buildPersonaFamilies } from '../personaSuite.mjs';
 
-const EXPECTED_FAMILY_IDS = [
-  'persona_strength_no_wearable',
-  'persona_health_fat_loss',
-  'persona_former_elite_return',
-  'persona_balanced_performance',
-  'persona_stacked_constraints',
-  'persona_walking_preferred',
-  'persona_established_history',
-  'persona_triathlon_novice_eighth',
-  'persona_triathlon_intermediate_olympic',
-  'persona_triathlon_advanced_half_iron',
-];
+const EXPECTED_FAMILY_CASE_COUNTS = new Map([
+  ['persona_strength_no_wearable', 3],
+  ['persona_health_fat_loss', 3],
+  ['persona_former_elite_return', 3],
+  ['persona_balanced_performance', 3],
+  ['persona_stacked_constraints', 3],
+  ['persona_walking_preferred', 3],
+  ['persona_established_history', 3],
+  ['persona_cycling_primary_hybrid', 5],
+  ['persona_triathlon_established_olympic', 5],
+]);
 
-describe('persona AI-judge fixtures', () => {
-  it('keeps the expected anonymized persona families with three state perturbations each', () => {
+const EXPECTED_FAMILY_IDS = [...EXPECTED_FAMILY_CASE_COUNTS.keys()];
+const EXPECTED_CASE_COUNT = [...EXPECTED_FAMILY_CASE_COUNTS.values()].reduce((sum, count) => sum + count, 0);
+
+describe('active persona AI-judge suite', () => {
+  it('keeps the expected anonymized persona families and state coverage', () => {
     const families = buildPersonaFamilies();
     const summary = assertPersonaFixtureIntegrity(families);
 
-    expect(summary).toEqual({ familyCount: EXPECTED_FAMILY_IDS.length, caseCount: EXPECTED_FAMILY_IDS.length * 3 });
+    expect(summary).toEqual({ familyCount: EXPECTED_FAMILY_IDS.length, caseCount: EXPECTED_CASE_COUNT });
     expect(families.map((family) => family.familyId)).toEqual(EXPECTED_FAMILY_IDS);
-    expect(families.every((family) => family.cases.length === 3)).toBe(true);
+    for (const family of families) {
+      expect(family.cases.length, family.familyId).toBe(EXPECTED_FAMILY_CASE_COUNTS.get(family.familyId));
+    }
   });
 
   it('represents wearable absence as null rather than invented normal values', () => {
@@ -116,41 +120,68 @@ describe('persona AI-judge fixtures', () => {
     }
   });
 
-  it('models the 1/8, Olympic, and 70.3 triathlon ladder with authoritative demand profiles and current-history evidence', () => {
-    const expected = [
-      ['persona_triathlon_novice_eighth', 'eighth_im', 0],
-      ['persona_triathlon_intermediate_olympic', 'olympic', 12],
-      ['persona_triathlon_advanced_half_iron', 'half_iron', 18],
-    ];
+  it('adds an anonymized cycling-primary hybrid persona with explicit goal hierarchy and current cycling history', () => {
+    const family = buildPersonaFamilies().find((candidate) => candidate.familyId === 'persona_cycling_primary_hybrid');
+    expect(family).toBeDefined();
+    expect(family.cases).toHaveLength(5);
 
-    for (const [familyId, presetId, historyCount] of expected) {
-      const family = buildPersonaFamilies().find((candidate) => candidate.familyId === familyId);
-      expect(family, familyId).toBeDefined();
-      const expectedPreset = EVENT_PRESETS.triathlon.find((preset) => preset.id === presetId);
-      for (const definition of family.cases) {
-        expect(definition.scenario.event).toMatchObject({ category: 'triathlon', priority: 'A' });
-        expect(definition.scenario.event.demandProfile).toEqual(expectedPreset.demandProfile);
-        expect(definition.scenario.trainingIntentProfile).toBeNull();
-        expect(definition.scenario.initialHistory).toHaveLength(historyCount);
-        expect(definition.scenario.preferences.preferredModalities).toEqual(['Swimming', 'Cycling', 'Running']);
-        expect(definition.scenario.context.trainingSettings.equipment.outdoor_bike).toBe(true);
-      }
+    for (const definition of family.cases) {
+      expect(definition.persona.personaId).toBe('cycling_primary_hybrid_advanced');
+      expect(definition.persona.goalHierarchy).toContain('cycling performance is primary');
+      expect(definition.scenario.trainingIntentProfile).toMatchObject({
+        planningMode: 'evergreen',
+        priorities: ['endurance', 'strength_muscle'],
+      });
+      expect(definition.scenario.preferences.preferredModalities).toEqual(['Cycling', 'Strength']);
+      expect(definition.scenario.preferences.deprioritizedModalities).toEqual(['Running']);
+      expect(definition.scenario.context.trainingSettings.equipment.indoor_bike).toBe(true);
+      expect(definition.scenario.context.trainingSettings.equipment.outdoor_bike).toBe(true);
+      expect(definition.scenario.initialHistory).toHaveLength(12);
+      expect(definition.scenario.initialHistory.every((exposure) => exposure.modality === 'Cycling')).toBe(true);
+      expect(definition.scenario.event).toBeNull();
+    }
+
+    const tissueConflict = family.cases.find((definition) => definition.scenario.id === 'persona_cycling_hybrid_local_tissue_conflict');
+    expect(tissueConflict.scenario.readinessForWeek(0).subjective.painFlag).toBe(true);
+    expect(tissueConflict.scenario.context.constraints.impliedGuardrails).toEqual(['avoid_high_impact', 'avoid_heavy_lower_body']);
+    expect(tissueConflict.scenario.readinessForWeek(0).objective.hrv_delta).toBe(0);
+
+    const strengthPreference = family.cases.find((definition) => definition.scenario.id === 'persona_cycling_hybrid_strength_preference');
+    expect(strengthPreference.scenario.readinessForWeek(0).subjective.preferredModalityToday).toBe('Strength');
+  });
+
+  it('exposes exactly one established Olympic-distance triathlon persona while preserving the unique triathlon edge cases', () => {
+    const families = buildPersonaFamilies();
+    const triathlonFamilies = families.filter((candidate) => candidate.familyId.startsWith('persona_triathlon_'));
+    expect(triathlonFamilies).toHaveLength(1);
+
+    const family = triathlonFamilies[0];
+    expect(family.familyId).toBe('persona_triathlon_established_olympic');
+    expect(family.cases).toHaveLength(5);
+    const expectedPreset = EVENT_PRESETS.triathlon.find((preset) => preset.id === 'olympic');
+
+    for (const definition of family.cases) {
+      expect(definition.persona.personaId).toBe('triathlon_established_olympic');
+      expect(definition.scenario.event).toMatchObject({ category: 'triathlon', priority: 'A' });
+      expect(definition.scenario.event.demandProfile).toEqual(expectedPreset.demandProfile);
+      expect(definition.scenario.trainingIntentProfile).toBeNull();
+      expect(definition.scenario.initialHistory).toHaveLength(12);
+      expect(definition.scenario.preferences.preferredModalities).toEqual(['Swimming', 'Cycling', 'Running']);
+      expect(definition.scenario.context.trainingSettings.equipment.outdoor_bike).toBe(true);
     }
   });
 
-  it('keeps pool-access loss explicit and reserves the advanced triathlon case for the final 14 days before its event', () => {
-    const families = buildPersonaFamilies();
-    const novice = families.find((candidate) => candidate.familyId === 'persona_triathlon_novice_eighth');
-    const poolUnavailable = novice.cases.find((definition) => definition.scenario.id === 'persona_triathlon_novice_eighth_pool_unavailable');
+  it('keeps pool-access loss and taper proximity explicit on the same triathlon persona', () => {
+    const family = buildPersonaFamilies().find((candidate) => candidate.familyId === 'persona_triathlon_established_olympic');
+    const poolUnavailable = family.cases.find((definition) => definition.scenario.id === 'persona_triathlon_established_olympic_pool_unavailable');
     expect(poolUnavailable.scenario.context.trainingSettings.equipment.swim_access).toBe(false);
 
-    const advanced = families.find((candidate) => candidate.familyId === 'persona_triathlon_advanced_half_iron');
-    const taper = advanced.cases.find((definition) => definition.scenario.id === 'persona_triathlon_advanced_half_iron_taper');
+    const taper = family.cases.find((definition) => definition.scenario.id === 'persona_triathlon_established_olympic_taper');
     expect(taper.scenario.event.date).toBe('2026-09-14');
     expect(taper.scenario.weeks).toBe(2);
   });
 
-  it('executes every persona state through the real multi-week planner without hard-constraint violations', async () => {
+  it('executes every active persona state through the real multi-week planner without hard-constraint violations', async () => {
     const definitions = buildPersonaFamilies().flatMap((family) => family.cases);
 
     for (const definition of definitions) {
@@ -161,19 +192,19 @@ describe('persona AI-judge fixtures', () => {
     }
   });
 
-  it('keeps all three race disciplines reachable when access exists and never fabricates swimming without a pool', async () => {
-    const definitions = buildPersonaFamilies().flatMap((family) => family.cases);
-    for (const definition of definitions.filter((item) => item.persona.personaId.startsWith('triathlon_'))) {
+  it('keeps all three triathlon race disciplines reachable when access exists and never fabricates swimming without a pool', async () => {
+    const family = buildPersonaFamilies().find((candidate) => candidate.familyId === 'persona_triathlon_established_olympic');
+    for (const definition of family.cases) {
       const result = await runScenario(definition.scenario);
       const selectedModalities = new Set(result.decisionTraces.map((trace) => trace.selected.modality));
-      if (definition.scenario.id === 'persona_triathlon_novice_eighth_pool_unavailable') {
+      if (definition.scenario.id === 'persona_triathlon_established_olympic_pool_unavailable') {
         expect(selectedModalities.has('Swimming'), definition.scenario.id).toBe(false);
       } else if (!definition.scenario.id.endsWith('_adverse_recovery')) {
         for (const modality of ['Swimming', 'Cycling', 'Running']) {
           expect(selectedModalities.has(modality), definition.scenario.id).toBe(true);
         }
       }
-      if (definition.scenario.id === 'persona_triathlon_advanced_half_iron_taper') {
+      if (definition.scenario.id === 'persona_triathlon_established_olympic_taper') {
         expect(result.decisionTraces.every((trace) => trace.date < definition.scenario.event.date), definition.scenario.id).toBe(true);
       }
     }

--- a/app/scripts/ai-judge/personaSuite.mjs
+++ b/app/scripts/ai-judge/personaSuite.mjs
@@ -1,0 +1,377 @@
+import {
+  assertPersonaFixtureIntegrity as assertCatalogIntegrity,
+  buildPersonaFamilies as buildCatalogFamilies,
+} from './personaScenarios.mjs';
+
+const ACTIVE_TRIATHLON_FAMILY_ID = 'persona_triathlon_established_olympic';
+const ACTIVE_TRIATHLON_PERSONA_ID = 'triathlon_established_olympic';
+const CYCLING_HYBRID_FAMILY_ID = 'persona_cycling_primary_hybrid';
+const CYCLING_HYBRID_PERSONA_ID = 'cycling_primary_hybrid_advanced';
+
+function clone(value) {
+  return value === undefined ? undefined : JSON.parse(JSON.stringify(value));
+}
+
+function requireFamily(families, familyId) {
+  const family = families.find((candidate) => candidate.familyId === familyId);
+  if (!family) throw new Error(`Persona catalog is missing required family: ${familyId}`);
+  return family;
+}
+
+function requireCase(family, caseId) {
+  const definition = family.cases.find((candidate) => candidate.scenario.id === caseId);
+  if (!definition) throw new Error(`Persona catalog family ${family.familyId} is missing required case: ${caseId}`);
+  return definition;
+}
+
+function staticReadiness(readiness) {
+  const snapshot = clone(readiness);
+  return {
+    readinessForWeek: () => clone(snapshot),
+    readinessForDate: () => clone(snapshot),
+  };
+}
+
+function replaceReadiness(definition, readiness) {
+  return {
+    ...definition,
+    scenario: {
+      ...definition.scenario,
+      ...staticReadiness(readiness),
+    },
+  };
+}
+
+function buildActiveTriathlonFamily(catalogFamilies) {
+  const noviceFamily = requireFamily(catalogFamilies, 'persona_triathlon_novice_eighth');
+  const intermediateFamily = requireFamily(catalogFamilies, 'persona_triathlon_intermediate_olympic');
+  const advancedFamily = requireFamily(catalogFamilies, 'persona_triathlon_advanced_half_iron');
+
+  const baselineSource = requireCase(intermediateFamily, 'persona_triathlon_intermediate_olympic_baseline');
+  const adverseSource = requireCase(intermediateFamily, 'persona_triathlon_intermediate_olympic_adverse_recovery');
+  const shortTimeSource = requireCase(intermediateFamily, 'persona_triathlon_intermediate_olympic_short_time');
+  const poolLossSource = requireCase(noviceFamily, 'persona_triathlon_novice_eighth_pool_unavailable');
+  const taperSource = requireCase(advancedFamily, 'persona_triathlon_advanced_half_iron_taper');
+
+  const persona = {
+    ...clone(baselineSource.persona),
+    personaId: ACTIVE_TRIATHLON_PERSONA_ID,
+    primaryGoal: 'prepare for an Olympic-distance triathlon from an established current mixed-discipline base',
+    currentTrainingIdentity: 'established recreational triathlete with current swimming, cycling and running exposure',
+    judgeExpectations: [
+      'Use recent mixed-discipline history as current capacity evidence, but never as permission to override adverse recovery.',
+      'Preserve Swimming, Cycling and Running when access exists; if pool access disappears, do not fabricate swimming or claim another modality fully substitutes for it.',
+      'A short weekday window should reduce dose while preserving event relevance and hard feasibility.',
+      'In the final 14 days before the A-event, show taper restraint rather than ordinary build volume.',
+      'Do not invent brick requirements, swim pace/CSS anchors, open-water competence, or specialist long-course assumptions that are absent from the modeled evidence.',
+    ],
+  };
+
+  const baseEvent = clone(baselineSource.scenario.event);
+  const baseContext = clone(baselineSource.scenario.context);
+  const basePreferences = clone(baselineSource.scenario.preferences);
+  const baseHistory = clone(baselineSource.scenario.initialHistory);
+
+  function normalizeCase(source, { id, label, context = baseContext, event = baseEvent, readiness } = {}) {
+    const normalizedEvent = clone(event);
+    const scenario = {
+      ...source.scenario,
+      id,
+      label,
+      description: `Synthetic persona evaluation case for ${ACTIVE_TRIATHLON_PERSONA_ID}. No real person's name or identifying data is persisted.`,
+      context: clone(context),
+      event: normalizedEvent,
+      events: normalizedEvent ? [clone(normalizedEvent)] : [],
+      trainingIntentProfile: null,
+      preferences: clone(basePreferences),
+      initialHistory: clone(baseHistory),
+      tags: ['ai-plan-judge', 'persona-evaluation', ACTIVE_TRIATHLON_PERSONA_ID],
+      ...(readiness ? staticReadiness(readiness) : {}),
+    };
+    return { persona: clone(persona), scenario };
+  }
+
+  const poolUnavailableContext = clone(baseContext);
+  poolUnavailableContext.trainingSettings.equipment.swim_access = false;
+
+  const taperEvent = clone(baseEvent);
+  taperEvent.date = '2026-09-14';
+
+  return {
+    familyId: ACTIVE_TRIATHLON_FAMILY_ID,
+    changedAxis: 'recovery, pool access, weekday capacity, and race proximity for one established Olympic-distance triathlete',
+    comparisonInstruction: 'Compare one established Olympic-distance triathlete across normal recovery, adverse recovery, pool-access loss, a 45-minute weekday cap, and the final 14-day taper window. Current training history supports meaningful work but never weakens recovery or equipment gates; all three race disciplines remain distinct requirements when access exists.',
+    cases: [
+      normalizeCase(baselineSource, {
+        id: 'persona_triathlon_established_olympic_baseline',
+        label: 'Established triathlon persona — Olympic distance, normal recovery',
+      }),
+      normalizeCase(adverseSource, {
+        id: 'persona_triathlon_established_olympic_adverse_recovery',
+        label: 'Established triathlon persona — Olympic distance, adverse recovery',
+      }),
+      normalizeCase(poolLossSource, {
+        id: 'persona_triathlon_established_olympic_pool_unavailable',
+        label: 'Established triathlon persona — Olympic distance, pool unavailable',
+        context: poolUnavailableContext,
+        readiness: poolLossSource.scenario.readinessForWeek(0),
+      }),
+      normalizeCase(shortTimeSource, {
+        id: 'persona_triathlon_established_olympic_short_time',
+        label: 'Established triathlon persona — Olympic distance, 45-minute weekday cap',
+      }),
+      normalizeCase(taperSource, {
+        id: 'persona_triathlon_established_olympic_taper',
+        label: 'Established triathlon persona — Olympic distance, final 14-day taper window',
+        event: taperEvent,
+        readiness: taperSource.scenario.readinessForWeek(0),
+      }),
+    ],
+  };
+}
+
+function buildCyclingPrimaryHybridFamily(catalogFamilies) {
+  const balancedFamily = requireFamily(catalogFamilies, 'persona_balanced_performance');
+  const establishedFamily = requireFamily(catalogFamilies, 'persona_established_history');
+  const triathlonFamily = requireFamily(catalogFamilies, 'persona_triathlon_intermediate_olympic');
+
+  const balancedBaseline = requireCase(balancedFamily, 'persona_balanced_performance_baseline');
+  const establishedBaseline = requireCase(establishedFamily, 'persona_established_history_baseline');
+  const triathlonBaseline = requireCase(triathlonFamily, 'persona_triathlon_intermediate_olympic_baseline');
+  const triathlonAdverse = requireCase(triathlonFamily, 'persona_triathlon_intermediate_olympic_adverse_recovery');
+
+  const context = clone(balancedBaseline.scenario.context);
+  context.goals = {
+    shortTerm: 'Improve cycling performance while retaining meaningful strength and muscle with sustainable recovery.',
+    midTerm: 'Build aerobic durability and cycling-specific quality without allowing secondary training to compromise key cycling work.',
+    longTerm: 'Become a stronger, faster and durable cyclist while preserving general athletic capability and improving body composition gradually.',
+  };
+  context.constraints.hasFreeWeights = true;
+  context.constraints.hasIndoorBike = true;
+  context.constraints.maxTimeMinutes = 90;
+  context.constraints.restrictedModalities = [];
+  context.preferences.preferredModalities = ['Cycling', 'Strength'];
+  context.preferences.deprioritizedModalities = ['Running'];
+  context.trainingSettings.equipment.free_weights = true;
+  context.trainingSettings.equipment.indoor_bike = true;
+  context.trainingSettings.equipment.outdoor_bike = true;
+  context.trainingSettings.equipment.swim_access = false;
+  context.trainingSettings.defaults.weekdayMaxMinutes = 90;
+  context.trainingSettings.defaults.weekendMaxMinutes = 120;
+
+  const intent = clone(balancedBaseline.scenario.trainingIntentProfile);
+  intent.priorities = ['endurance', 'strength_muscle'];
+  intent.weeklyCommitment = { minSessions: 5, targetSessions: 6, maxSessions: 7 };
+
+  const preferences = clone(balancedBaseline.scenario.preferences);
+  preferences.defaultWeekdayTimeMin = 90;
+  preferences.defaultWeekendTimeMin = 120;
+  preferences.preferredModalities = ['Cycling', 'Strength'];
+  preferences.deprioritizedModalities = ['Running'];
+
+  const currentHistory = clone(establishedBaseline.scenario.initialHistory).map((exposure, index) => ({
+    ...exposure,
+    occurrenceKey: `persona-cycling-hybrid-${index}`,
+    modality: 'Cycling',
+    category: 'Easy Endurance',
+    costProfile: {
+      systemic: 0.25,
+      cardiovascular: 0.35,
+      lowerBody: 0.2,
+      upperBody: 0,
+      impactTissue: 0.03,
+      neuromuscular: 0.08,
+    },
+    trainingRecordLike: {
+      ...exposure.trainingRecordLike,
+      type: 'Cycling aerobic endurance',
+      duration_min: 60,
+      training_effect: 2,
+      intensity_tag: 'easy',
+    },
+  }));
+
+  const persona = {
+    personaId: CYCLING_HYBRID_PERSONA_ID,
+    dataAvailability: 'garmin_plus_subjective_checkin',
+    primaryGoal: 'maximize cycling performance while retaining strength, muscle and broad athletic capability',
+    currentTrainingIdentity: 'established cycling-primary hybrid athlete with a current aerobic base and regular resistance training',
+    goalHierarchy: 'cycling performance is primary; strength and muscle are retention goals; body-composition progress must not compromise key training',
+    constraintContext: 'high training willingness and access to indoor/outdoor cycling plus free weights; running is secondary rather than required',
+    judgeExpectations: [
+      'When goals compete, protect key cycling adaptation first while retaining enough resistance training to preserve strength and muscle.',
+      'Good wearable readiness must not override active pain or mechanical guardrails; local symptom evidence is decision-relevant even when HRV, sleep and resting heart rate look normal.',
+      'Prefer cycling-specific aerobic work over unnecessary running when both satisfy endurance development and cycling is the declared primary sport.',
+      'Adverse recovery should reduce near-term training cost without erasing the longer-horizon requirement for both cycling and resistance exposure.',
+      'A strength preference today is a soft preference, not authority to turn the week into strength-primary programming.',
+      'More available training time is not automatically a reason to add another hard session; inexpensive aerobic volume is preferable to gratuitous intensity when progression is otherwise appropriate.',
+    ],
+  };
+
+  function readinessFrom(definition, overrides = {}) {
+    const readiness = clone(definition.scenario.readinessForWeek(0));
+    readiness.subjective = { ...readiness.subjective, ...overrides };
+    return readiness;
+  }
+
+  function makeCase({ id, label, readiness, caseContext = context }) {
+    return {
+      persona: clone(persona),
+      scenario: {
+        ...balancedBaseline.scenario,
+        id,
+        label,
+        description: `Synthetic persona evaluation case for ${CYCLING_HYBRID_PERSONA_ID}. No real person's name or identifying data is persisted.`,
+        context: clone(caseContext),
+        event: null,
+        events: [],
+        trainingIntentProfile: clone(intent),
+        preferences: clone(preferences),
+        initialHistory: clone(currentHistory),
+        fixedActivities: [],
+        tags: ['ai-plan-judge', 'persona-evaluation', CYCLING_HYBRID_PERSONA_ID],
+        weeks: 2,
+        ...staticReadiness(readiness),
+      },
+    };
+  }
+
+  const tissueConflictContext = clone(context);
+  tissueConflictContext.constraints.impliedGuardrails = ['avoid_high_impact', 'avoid_heavy_lower_body'];
+  tissueConflictContext.trainingSettings.guardrails.avoid_high_impact = true;
+  tissueConflictContext.trainingSettings.guardrails.avoid_heavy_lower_body = true;
+
+  const lowTimeContext = clone(context);
+  lowTimeContext.constraints.maxTimeMinutes = 35;
+  lowTimeContext.trainingSettings.defaults.weekdayMaxMinutes = 35;
+
+  const baselineReadiness = readinessFrom(triathlonBaseline, {
+    readiness: 8,
+    fatigue: 2,
+    soreness: 2,
+    motivation: 9,
+    timeAvailable: 90,
+    painFlag: false,
+    preferredModalityToday: 'Cycling',
+  });
+  const adverseReadiness = readinessFrom(triathlonAdverse, {
+    readiness: 4,
+    fatigue: 7,
+    soreness: 5,
+    motivation: 7,
+    timeAvailable: 75,
+    painFlag: false,
+    preferredModalityToday: 'Cycling',
+  });
+  const tissueConflictReadiness = readinessFrom(triathlonBaseline, {
+    readiness: 6,
+    fatigue: 3,
+    soreness: 6,
+    motivation: 8,
+    timeAvailable: 75,
+    painFlag: true,
+    preferredModalityToday: 'Cycling',
+  });
+  const strengthPreferenceReadiness = readinessFrom(triathlonBaseline, {
+    readiness: 8,
+    fatigue: 2,
+    soreness: 2,
+    motivation: 9,
+    timeAvailable: 90,
+    painFlag: false,
+    preferredModalityToday: 'Strength',
+  });
+  const lowTimeReadiness = readinessFrom(triathlonBaseline, {
+    readiness: 8,
+    fatigue: 2,
+    soreness: 2,
+    motivation: 9,
+    timeAvailable: 35,
+    painFlag: false,
+    preferredModalityToday: 'Cycling',
+  });
+
+  return {
+    familyId: CYCLING_HYBRID_FAMILY_ID,
+    changedAxis: 'recovery, local mechanical constraint, today-specific modality preference, and time availability for a cycling-primary hybrid athlete',
+    comparisonInstruction: 'Compare one established cycling-primary hybrid athlete across normal recovery, adverse recovery, a good-wearable/local-tissue conflict, a strength preference today, and a short weekday window. Cycling remains the primary performance objective, resistance training remains a real retention requirement, and active pain/guardrails outrank apparently favorable wearable readiness.',
+    cases: [
+      makeCase({ id: 'persona_cycling_hybrid_baseline', label: 'Cycling-primary hybrid persona — normal recovery', readiness: baselineReadiness }),
+      makeCase({ id: 'persona_cycling_hybrid_adverse_recovery', label: 'Cycling-primary hybrid persona — adverse recovery', readiness: adverseReadiness }),
+      makeCase({ id: 'persona_cycling_hybrid_local_tissue_conflict', label: 'Cycling-primary hybrid persona — good wearable signals with active local-tissue guardrails', readiness: tissueConflictReadiness, caseContext: tissueConflictContext }),
+      makeCase({ id: 'persona_cycling_hybrid_strength_preference', label: 'Cycling-primary hybrid persona — strength preference today', readiness: strengthPreferenceReadiness }),
+      makeCase({ id: 'persona_cycling_hybrid_low_time', label: 'Cycling-primary hybrid persona — only 35 minutes today', readiness: lowTimeReadiness, caseContext: lowTimeContext }),
+    ],
+  };
+}
+
+export function buildPersonaFamilies() {
+  const catalogFamilies = buildCatalogFamilies();
+  assertCatalogIntegrity(catalogFamilies);
+
+  const nonTriathlonFamilies = catalogFamilies.filter((family) => !family.familyId.startsWith('persona_triathlon_'));
+  return [
+    ...nonTriathlonFamilies,
+    buildCyclingPrimaryHybridFamily(catalogFamilies),
+    buildActiveTriathlonFamily(catalogFamilies),
+  ];
+}
+
+export function assertPersonaFixtureIntegrity(families) {
+  const failures = [];
+  const allCases = families.flatMap((family) => family.cases);
+  const caseIds = new Set();
+
+  for (const definition of allCases) {
+    const { scenario, persona } = definition;
+    if (caseIds.has(scenario.id)) failures.push(`Duplicate active persona case id: ${scenario.id}`);
+    caseIds.add(scenario.id);
+
+    const serialized = JSON.stringify({ persona, label: scenario.label, description: scenario.description }).toLowerCase();
+    for (const realName of ['adrian', 'rafal', 'rafał', 'ola', 'aleksandra', 'marcin']) {
+      if (serialized.includes(realName)) failures.push(`${scenario.id}: active public fixture contains a real-person name (${realName}).`);
+    }
+  }
+
+  const triathlonFamilies = families.filter((family) => family.familyId.startsWith('persona_triathlon_'));
+  if (triathlonFamilies.length !== 1) failures.push(`Active suite must expose exactly one triathlon persona family, found ${triathlonFamilies.length}.`);
+  const triathlon = triathlonFamilies[0];
+  if (triathlon?.familyId !== ACTIVE_TRIATHLON_FAMILY_ID) failures.push(`Unexpected active triathlon family: ${triathlon?.familyId ?? 'missing'}.`);
+  if (triathlon?.cases.length !== 5) failures.push(`Active triathlon persona must have exactly 5 state cases, found ${triathlon?.cases.length ?? 0}.`);
+  for (const definition of triathlon?.cases ?? []) {
+    const { scenario, persona } = definition;
+    if (persona.personaId !== ACTIVE_TRIATHLON_PERSONA_ID) failures.push(`${scenario.id}: active triathlon case drifted to persona ${persona.personaId}.`);
+    if (scenario.event?.category !== 'triathlon' || scenario.event?.priority !== 'A') failures.push(`${scenario.id}: active triathlon case must carry an A-priority triathlon event.`);
+    if (scenario.trainingIntentProfile !== null) failures.push(`${scenario.id}: active triathlon case must remain event-directed.`);
+    if (!scenario.context.trainingSettings.equipment.outdoor_bike) failures.push(`${scenario.id}: active triathlon case must retain outdoor bike access.`);
+    if ((scenario.initialHistory ?? []).length !== 12) failures.push(`${scenario.id}: active triathlon case must retain the same 12-exposure current base.`);
+    for (const modality of ['Swimming', 'Cycling', 'Running']) {
+      if (!scenario.preferences.preferredModalities.includes(modality)) failures.push(`${scenario.id}: active triathlon case is missing ${modality} preference.`);
+    }
+  }
+  const poolUnavailable = triathlon?.cases.find((definition) => definition.scenario.id === 'persona_triathlon_established_olympic_pool_unavailable');
+  if (poolUnavailable?.scenario.context.trainingSettings.equipment.swim_access !== false) failures.push('Active triathlon pool-loss case must set swim_access=false.');
+  const taper = triathlon?.cases.find((definition) => definition.scenario.id === 'persona_triathlon_established_olympic_taper');
+  if (taper?.scenario.event?.date !== '2026-09-14') failures.push('Active triathlon taper case must place the A-event at the 14-day boundary.');
+
+  const cyclingHybrid = families.find((family) => family.familyId === CYCLING_HYBRID_FAMILY_ID);
+  if (!cyclingHybrid) failures.push('Active suite is missing the cycling-primary hybrid persona.');
+  if (cyclingHybrid?.cases.length !== 5) failures.push(`Cycling-primary hybrid persona must have exactly 5 state cases, found ${cyclingHybrid?.cases.length ?? 0}.`);
+  for (const definition of cyclingHybrid?.cases ?? []) {
+    const { scenario, persona } = definition;
+    if (persona.personaId !== CYCLING_HYBRID_PERSONA_ID) failures.push(`${scenario.id}: cycling-primary hybrid case drifted to persona ${persona.personaId}.`);
+    if (scenario.event !== null || (scenario.events ?? []).length !== 0) failures.push(`${scenario.id}: cycling-primary hybrid must remain evergreen.`);
+    if (scenario.trainingIntentProfile?.planningMode !== 'evergreen') failures.push(`${scenario.id}: cycling-primary hybrid must carry evergreen training intent.`);
+    if (!scenario.trainingIntentProfile?.priorities.includes('endurance') || !scenario.trainingIntentProfile?.priorities.includes('strength_muscle')) failures.push(`${scenario.id}: cycling-primary hybrid must preserve endurance and strength_muscle priorities.`);
+    if (!scenario.preferences.preferredModalities.includes('Cycling') || !scenario.preferences.preferredModalities.includes('Strength')) failures.push(`${scenario.id}: cycling-primary hybrid must prefer Cycling and Strength.`);
+    if ((scenario.initialHistory ?? []).length !== 12 || scenario.initialHistory.some((item) => item.modality !== 'Cycling')) failures.push(`${scenario.id}: cycling-primary hybrid must seed the same 12-exposure cycling base.`);
+  }
+  const tissueConflict = cyclingHybrid?.cases.find((definition) => definition.scenario.id === 'persona_cycling_hybrid_local_tissue_conflict');
+  if (!tissueConflict?.scenario.readinessForWeek(0).subjective.painFlag) failures.push('Cycling-primary hybrid local-tissue case must set painFlag=true.');
+  for (const guardrail of ['avoid_high_impact', 'avoid_heavy_lower_body']) {
+    if (!(tissueConflict?.scenario.context.constraints.impliedGuardrails ?? []).includes(guardrail)) failures.push(`Cycling-primary hybrid local-tissue case must activate ${guardrail}.`);
+  }
+
+  if (failures.length) throw new Error(`Active persona suite integrity failed:\n- ${failures.join('\n- ')}`);
+  return { familyCount: families.length, caseCount: allCases.length };
+}

--- a/app/scripts/ai-judge/personaSuite.mjs
+++ b/app/scripts/ai-judge/personaSuite.mjs
@@ -8,22 +8,26 @@ const ACTIVE_TRIATHLON_PERSONA_ID = 'triathlon_established_olympic';
 const CYCLING_HYBRID_FAMILY_ID = 'persona_cycling_primary_hybrid';
 const CYCLING_HYBRID_PERSONA_ID = 'cycling_primary_hybrid_advanced';
 
+/** Return a detached JSON-safe copy of fixture data. */
 function clone(value) {
   return value === undefined ? undefined : JSON.parse(JSON.stringify(value));
 }
 
+/** Find a required source family or fail fast with a fixture-specific error. */
 function requireFamily(families, familyId) {
   const family = families.find((candidate) => candidate.familyId === familyId);
   if (!family) throw new Error(`Persona catalog is missing required family: ${familyId}`);
   return family;
 }
 
+/** Find a required source case within a catalog family or fail fast. */
 function requireCase(family, caseId) {
   const definition = family.cases.find((candidate) => candidate.scenario.id === caseId);
   if (!definition) throw new Error(`Persona catalog family ${family.familyId} is missing required case: ${caseId}`);
   return definition;
 }
 
+/** Adapt one readiness snapshot to the week- and date-based scenario interfaces. */
 function staticReadiness(readiness) {
   const snapshot = clone(readiness);
   return {
@@ -32,6 +36,7 @@ function staticReadiness(readiness) {
   };
 }
 
+/** Compose the single active Olympic-distance triathlon family from reusable catalog cases. */
 function buildActiveTriathlonFamily(catalogFamilies) {
   const noviceFamily = requireFamily(catalogFamilies, 'persona_triathlon_novice_eighth');
   const intermediateFamily = requireFamily(catalogFamilies, 'persona_triathlon_intermediate_olympic');
@@ -62,6 +67,7 @@ function buildActiveTriathlonFamily(catalogFamilies) {
   const basePreferences = clone(baselineSource.scenario.preferences);
   const baseHistory = clone(baselineSource.scenario.initialHistory);
 
+  /** Normalize a catalog case onto the shared active triathlon identity and baseline evidence. */
   function normalizeCase(source, { id, label, context = baseContext, event = baseEvent, readiness } = {}) {
     const normalizedEvent = clone(event);
     const scenario = {
@@ -120,6 +126,7 @@ function buildActiveTriathlonFamily(catalogFamilies) {
   };
 }
 
+/** Compose the active cycling-primary hybrid identity and its decision-state perturbations. */
 function buildCyclingPrimaryHybridFamily(catalogFamilies) {
   const balancedFamily = requireFamily(catalogFamilies, 'persona_balanced_performance');
   const establishedFamily = requireFamily(catalogFamilies, 'persona_established_history');
@@ -239,6 +246,7 @@ function buildCyclingPrimaryHybridFamily(catalogFamilies) {
     ],
   };
 
+  /** Clone a catalog readiness state and override only the fields relevant to one perturbation. */
   function readinessFrom(definition, subjectiveOverrides = {}, objectiveOverrides = {}) {
     const readiness = clone(definition.scenario.readinessForWeek(0));
     readiness.subjective = { ...readiness.subjective, ...subjectiveOverrides };
@@ -246,6 +254,7 @@ function buildCyclingPrimaryHybridFamily(catalogFamilies) {
     return readiness;
   }
 
+  /** Materialize one evergreen hybrid case from shared identity, history, and intent. */
   function makeCase({ id, label, readiness, caseContext = context }) {
     return {
       persona: clone(persona),
@@ -350,6 +359,7 @@ function buildCyclingPrimaryHybridFamily(catalogFamilies) {
   };
 }
 
+/** Build the active judge suite from the larger reusable persona catalog. */
 export function buildPersonaFamilies() {
   const catalogFamilies = buildCatalogFamilies();
   assertCatalogIntegrity(catalogFamilies);
@@ -362,6 +372,7 @@ export function buildPersonaFamilies() {
   ];
 }
 
+/** Validate active-suite privacy, composition, evidence, and adversarial-case invariants. */
 export function assertPersonaFixtureIntegrity(families) {
   const failures = [];
   const allCases = families.flatMap((family) => family.cases);

--- a/app/scripts/ai-judge/personaSuite.mjs
+++ b/app/scripts/ai-judge/personaSuite.mjs
@@ -32,16 +32,6 @@ function staticReadiness(readiness) {
   };
 }
 
-function replaceReadiness(definition, readiness) {
-  return {
-    ...definition,
-    scenario: {
-      ...definition.scenario,
-      ...staticReadiness(readiness),
-    },
-  };
-}
-
 function buildActiveTriathlonFamily(catalogFamilies) {
   const noviceFamily = requireFamily(catalogFamilies, 'persona_triathlon_novice_eighth');
   const intermediateFamily = requireFamily(catalogFamilies, 'persona_triathlon_intermediate_olympic');
@@ -169,27 +159,68 @@ function buildCyclingPrimaryHybridFamily(catalogFamilies) {
   preferences.preferredModalities = ['Cycling', 'Strength'];
   preferences.deprioritizedModalities = ['Running'];
 
-  const currentHistory = clone(establishedBaseline.scenario.initialHistory).map((exposure, index) => ({
-    ...exposure,
-    occurrenceKey: `persona-cycling-hybrid-${index}`,
-    modality: 'Cycling',
-    category: 'Easy Endurance',
-    costProfile: {
-      systemic: 0.25,
-      cardiovascular: 0.35,
-      lowerBody: 0.2,
-      upperBody: 0,
-      impactTissue: 0.03,
-      neuromuscular: 0.08,
-    },
-    trainingRecordLike: {
-      ...exposure.trainingRecordLike,
-      type: 'Cycling aerobic endurance',
-      duration_min: 60,
-      training_effect: 2,
-      intensity_tag: 'easy',
-    },
-  }));
+  // Keep the fixture's observed history aligned with the identity the judge is asked to
+  // evaluate. A cycling-primary hybrid can be cycling-dominant without erasing recent
+  // resistance exposure from the evidence available to the planner.
+  const strengthHistoryIndexes = new Set([2, 5, 8, 11]);
+  const cyclingQualityIndexes = new Set([3, 7]);
+  const currentHistory = clone(establishedBaseline.scenario.initialHistory).map((exposure, index) => {
+    if (strengthHistoryIndexes.has(index)) {
+      return {
+        ...exposure,
+        occurrenceKey: `persona-cycling-hybrid-${index}`,
+        modality: 'Strength',
+        category: 'Full-body Strength',
+        costProfile: {
+          systemic: 0.35,
+          cardiovascular: 0.12,
+          lowerBody: 0.42,
+          upperBody: 0.32,
+          impactTissue: 0.02,
+          neuromuscular: 0.42,
+        },
+        trainingRecordLike: {
+          ...exposure.trainingRecordLike,
+          type: 'Full-body resistance training',
+          duration_min: 50,
+          training_effect: 2,
+          intensity_tag: 'moderate',
+        },
+      };
+    }
+
+    const isQuality = cyclingQualityIndexes.has(index);
+    return {
+      ...exposure,
+      occurrenceKey: `persona-cycling-hybrid-${index}`,
+      modality: 'Cycling',
+      category: isQuality ? 'Tempo' : 'Easy Endurance',
+      costProfile: isQuality
+        ? {
+            systemic: 0.45,
+            cardiovascular: 0.58,
+            lowerBody: 0.3,
+            upperBody: 0,
+            impactTissue: 0.03,
+            neuromuscular: 0.16,
+          }
+        : {
+            systemic: 0.25,
+            cardiovascular: 0.35,
+            lowerBody: 0.2,
+            upperBody: 0,
+            impactTissue: 0.03,
+            neuromuscular: 0.08,
+          },
+      trainingRecordLike: {
+        ...exposure.trainingRecordLike,
+        type: isQuality ? 'Cycling tempo endurance' : 'Cycling aerobic endurance',
+        duration_min: 60,
+        training_effect: isQuality ? 3 : 2,
+        intensity_tag: isQuality ? 'moderate' : 'easy',
+      },
+    };
+  });
 
   const persona = {
     personaId: CYCLING_HYBRID_PERSONA_ID,
@@ -200,7 +231,7 @@ function buildCyclingPrimaryHybridFamily(catalogFamilies) {
     constraintContext: 'high training willingness and access to indoor/outdoor cycling plus free weights; running is secondary rather than required',
     judgeExpectations: [
       'When goals compete, protect key cycling adaptation first while retaining enough resistance training to preserve strength and muscle.',
-      'Good wearable readiness must not override active pain or mechanical guardrails; local symptom evidence is decision-relevant even when HRV, sleep and resting heart rate look normal.',
+      'Good wearable readiness must not override active pain or mechanical guardrails; local symptom evidence is decision-relevant even when HRV, sleep and resting heart rate look favorable.',
       'Prefer cycling-specific aerobic work over unnecessary running when both satisfy endurance development and cycling is the declared primary sport.',
       'Adverse recovery should reduce near-term training cost without erasing the longer-horizon requirement for both cycling and resistance exposure.',
       'A strength preference today is a soft preference, not authority to turn the week into strength-primary programming.',
@@ -208,9 +239,10 @@ function buildCyclingPrimaryHybridFamily(catalogFamilies) {
     ],
   };
 
-  function readinessFrom(definition, overrides = {}) {
+  function readinessFrom(definition, subjectiveOverrides = {}, objectiveOverrides = {}) {
     const readiness = clone(definition.scenario.readinessForWeek(0));
-    readiness.subjective = { ...readiness.subjective, ...overrides };
+    readiness.subjective = { ...readiness.subjective, ...subjectiveOverrides };
+    readiness.objective = { ...readiness.objective, ...objectiveOverrides };
     return readiness;
   }
 
@@ -263,15 +295,28 @@ function buildCyclingPrimaryHybridFamily(catalogFamilies) {
     painFlag: false,
     preferredModalityToday: 'Cycling',
   });
-  const tissueConflictReadiness = readinessFrom(triathlonBaseline, {
-    readiness: 6,
-    fatigue: 3,
-    soreness: 6,
-    motivation: 8,
-    timeAvailable: 75,
-    painFlag: true,
-    preferredModalityToday: 'Cycling',
-  });
+  const tissueConflictReadiness = readinessFrom(
+    triathlonBaseline,
+    {
+      readiness: 6,
+      fatigue: 3,
+      soreness: 6,
+      motivation: 8,
+      timeAvailable: 75,
+      painFlag: true,
+      preferredModalityToday: 'Cycling',
+    },
+    {
+      sleep_score: 92,
+      sleep_duration_min: 500,
+      rhr: 54,
+      rhr_delta: -4,
+      hrv_last_night: 51,
+      hrv_delta: 9,
+      body_battery_wake: 88,
+      sleep_score_delta_7d: 10,
+    },
+  );
   const strengthPreferenceReadiness = readinessFrom(triathlonBaseline, {
     readiness: 8,
     fatigue: 2,
@@ -294,13 +339,13 @@ function buildCyclingPrimaryHybridFamily(catalogFamilies) {
   return {
     familyId: CYCLING_HYBRID_FAMILY_ID,
     changedAxis: 'recovery, local mechanical constraint, today-specific modality preference, and time availability for a cycling-primary hybrid athlete',
-    comparisonInstruction: 'Compare one established cycling-primary hybrid athlete across normal recovery, adverse recovery, a good-wearable/local-tissue conflict, a strength preference today, and a short weekday window. Cycling remains the primary performance objective, resistance training remains a real retention requirement, and active pain/guardrails outrank apparently favorable wearable readiness.',
+    comparisonInstruction: 'Compare one established cycling-primary hybrid athlete across normal recovery, adverse recovery, a genuinely favorable-wearable/local-tissue conflict, a strength preference today, and a short training window. Cycling remains the primary performance objective, resistance training remains a real retention requirement backed by observed history, and active pain/guardrails outrank favorable wearable readiness.',
     cases: [
       makeCase({ id: 'persona_cycling_hybrid_baseline', label: 'Cycling-primary hybrid persona — normal recovery', readiness: baselineReadiness }),
       makeCase({ id: 'persona_cycling_hybrid_adverse_recovery', label: 'Cycling-primary hybrid persona — adverse recovery', readiness: adverseReadiness }),
-      makeCase({ id: 'persona_cycling_hybrid_local_tissue_conflict', label: 'Cycling-primary hybrid persona — good wearable signals with active local-tissue guardrails', readiness: tissueConflictReadiness, caseContext: tissueConflictContext }),
+      makeCase({ id: 'persona_cycling_hybrid_local_tissue_conflict', label: 'Cycling-primary hybrid persona — favorable wearable signals with active local-tissue guardrails', readiness: tissueConflictReadiness, caseContext: tissueConflictContext }),
       makeCase({ id: 'persona_cycling_hybrid_strength_preference', label: 'Cycling-primary hybrid persona — strength preference today', readiness: strengthPreferenceReadiness }),
-      makeCase({ id: 'persona_cycling_hybrid_low_time', label: 'Cycling-primary hybrid persona — only 35 minutes today', readiness: lowTimeReadiness, caseContext: lowTimeContext }),
+      makeCase({ id: 'persona_cycling_hybrid_low_time', label: 'Cycling-primary hybrid persona — 35-minute training window', readiness: lowTimeReadiness, caseContext: lowTimeContext }),
     ],
   };
 }
@@ -364,14 +409,24 @@ export function assertPersonaFixtureIntegrity(families) {
     if (scenario.trainingIntentProfile?.planningMode !== 'evergreen') failures.push(`${scenario.id}: cycling-primary hybrid must carry evergreen training intent.`);
     if (!scenario.trainingIntentProfile?.priorities.includes('endurance') || !scenario.trainingIntentProfile?.priorities.includes('strength_muscle')) failures.push(`${scenario.id}: cycling-primary hybrid must preserve endurance and strength_muscle priorities.`);
     if (!scenario.preferences.preferredModalities.includes('Cycling') || !scenario.preferences.preferredModalities.includes('Strength')) failures.push(`${scenario.id}: cycling-primary hybrid must prefer Cycling and Strength.`);
-    if ((scenario.initialHistory ?? []).length !== 12 || scenario.initialHistory.some((item) => item.modality !== 'Cycling')) failures.push(`${scenario.id}: cycling-primary hybrid must seed the same 12-exposure cycling base.`);
+
+    const history = scenario.initialHistory ?? [];
+    const cyclingCount = history.filter((item) => item.modality === 'Cycling').length;
+    const strengthCount = history.filter((item) => item.modality === 'Strength').length;
+    if (history.length !== 12 || cyclingCount !== 8 || strengthCount !== 4) failures.push(`${scenario.id}: cycling-primary hybrid must seed a 12-exposure cycling-dominant mixed history (8 Cycling, 4 Strength).`);
   }
   const tissueConflict = cyclingHybrid?.cases.find((definition) => definition.scenario.id === 'persona_cycling_hybrid_local_tissue_conflict');
-  if (!tissueConflict?.scenario.readinessForWeek(0).subjective.painFlag) failures.push('Cycling-primary hybrid local-tissue case must set painFlag=true.');
+  const tissueReadiness = tissueConflict?.scenario.readinessForWeek(0);
+  if (!tissueReadiness?.subjective.painFlag) failures.push('Cycling-primary hybrid local-tissue case must set painFlag=true.');
+  if (!(tissueReadiness?.objective.hrv_delta > 0) || !(tissueReadiness?.objective.rhr_delta < 0) || !(tissueReadiness?.objective.sleep_score >= 90) || !(tissueReadiness?.objective.body_battery_wake >= 80)) {
+    failures.push('Cycling-primary hybrid local-tissue case must contain clearly favorable wearable signals so symptom-over-wearable arbitration is actually exercised.');
+  }
   for (const guardrail of ['avoid_high_impact', 'avoid_heavy_lower_body']) {
     if (!(tissueConflict?.scenario.context.constraints.impliedGuardrails ?? []).includes(guardrail)) failures.push(`Cycling-primary hybrid local-tissue case must activate ${guardrail}.`);
   }
 
-  if (failures.length) throw new Error(`Active persona suite integrity failed:\n- ${failures.join('\n- ')}`);
+  if (failures.length) throw new Error(`Active persona suite integrity failed:\
+- ${failures.join('\
+- ')}`);
   return { familyCount: families.length, caseCount: allCases.length };
 }

--- a/app/scripts/run-persona-ai-judge.mjs
+++ b/app/scripts/run-persona-ai-judge.mjs
@@ -2,7 +2,7 @@ import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { createServer } from 'vite';
 
-import { buildPersonaFamilies, assertPersonaFixtureIntegrity } from './ai-judge/personaScenarios.mjs';
+import { buildPersonaFamilies, assertPersonaFixtureIntegrity } from './ai-judge/personaSuite.mjs';
 import { resolveJudgeConfig } from './ai-judge/config.mjs';
 import { generateFamilyResponseSchema } from './ai-judge/schema.mjs';
 import { validateAndNormalizeJudgeRow } from './ai-judge/validation.mjs';
@@ -75,7 +75,7 @@ function packetFromResult(definition, result, templatesById) {
 
 const PROMPT = `# Persona plan judge instructions
 
-You are an independent evaluator of adaptive training recommendations across strength, health/general-fitness and endurance personas. The planner output is a candidate, not ground truth. Judge only the user-facing evidence and plan in the packet. Planner utility, projected-cost/stimulus diagnostics, rejection codes and per-template safety tags are deliberately withheld so they cannot become an answer key.
+You are an independent evaluator of adaptive training recommendations across strength, health/general-fitness, cycling-hybrid and endurance personas. The planner output is a candidate, not ground truth. Judge only the user-facing evidence and plan in the packet. Planner utility, projected-cost/stimulus diagnostics, rejection codes and per-template safety tags are deliberately withheld so they cannot become an answer key.
 
 Score each case 0-10 on the existing schema dimensions using these meanings:
 - safety_recovery_fit: respects current pain, fatigue, soreness, recovery signals and active guardrails without over-medicalizing normal variation.
@@ -90,7 +90,8 @@ Persona-specific calibration:
 1. Check-in-only strength persona: subjective readiness/fatigue/soreness/pain are legitimate evidence. A physically demanding job contributes real non-training load through the check-in. Strength specificity should be preserved when safe; cardio is not the primary performance objective. An active shoulder/back flare should tighten the plan and active guardrails must be respected. Do not diagnose an injury.
 2. Health/fat-loss persona: prefer a sustainable combination of aerobic and resistance training with adherence-friendly progression. Garmin can inform recovery but should not turn the plan into event-style performance training. Training can support fat loss, but absent nutrition data do not justify invented calorie targets or crash-diet assumptions.
 3. Former high-level endurance persona: historical competitive achievement is context, not present-day load tolerance. Current recent training and current recovery govern dose. A good Garmin day alone does not justify an elite workload after intermittent current training.
-4. Triathlon personas: Swimming, Cycling and Running are separate race disciplines. When pool and bicycle access exist, do not accept a single discipline as a silent substitute for the others. When access is absent, never reward an unsafe or fabricated session for closing the gap. Do not invent a brick workout, swim pace/CSS anchor, or open-water competence that is absent from the input. A novice has no implied proficiency; an advanced athlete's current history supports capacity but never overrides adverse recovery or taper needs.
+4. Cycling-primary hybrid persona: cycling performance is the primary performance objective, while resistance training remains a real retention requirement for strength and muscle. Prefer cycling-specific aerobic work over gratuitous running when both could satisfy generic endurance development. Favor inexpensive aerobic volume over adding unnecessary hard-session frequency. A good wearable day must not override current pain or active mechanical guardrails, and a strength preference today must not silently turn the week into strength-primary programming.
+5. Established Olympic triathlon persona: Swimming, Cycling and Running are separate race disciplines. When pool and bicycle access exist, do not accept a single discipline as a silent substitute for the others. When pool access is absent, never reward a fabricated swim for closing the gap. A short weekday window should reduce dose rather than bypass hard feasibility. In the final 14 days before the A-event, taper restraint is expected. Do not invent a brick workout, swim pace/CSS anchor, open-water competence, or long-course specialist assumptions that are absent from the input.
 
 Judge methodology:
 - Missing data are different from adverse data.

--- a/app/scripts/run-persona-ai-judge.mjs
+++ b/app/scripts/run-persona-ai-judge.mjs
@@ -12,15 +12,18 @@ import { aggregateFamilySamples, deriveSampleSeed } from './ai-judge/aggregate.m
 const OUTPUT_DIR = resolve('artifacts/persona-plan-judge/latest');
 const BUILD_ONLY = process.argv.includes('--build-only');
 
+/** Return a detached JSON-safe copy of fixture data. */
 function clone(value) {
   return value === undefined ? undefined : JSON.parse(JSON.stringify(value));
 }
 
+/** Expose stable persona facts to the judge while withholding expectation text. */
 function personaFacts(persona) {
   const { judgeExpectations: _judgeExpectations, ...facts } = persona;
   return clone(facts);
 }
 
+/** Reduce an event to the user-visible facts needed by the persona judge. */
 function eventFacts(event) {
   if (!event) return null;
   return {
@@ -31,6 +34,7 @@ function eventFacts(event) {
   };
 }
 
+/** Convert deterministic planner traces into the blinded plan representation judged by the LLM. */
 function planFromResult(result, templatesById) {
   return result.decisionTraces.map((trace) => {
     const template = templatesById.get(trace.selected.templateId);
@@ -50,6 +54,7 @@ function planFromResult(result, templatesById) {
   });
 }
 
+/** Build one judge packet from synthetic persona input plus deterministic planner output. */
 function packetFromResult(definition, result, templatesById) {
   const scenario = definition.scenario;
   const readiness = scenario.readinessForDate?.(scenario.startDate, 0) ?? scenario.readinessForWeek(0);
@@ -103,6 +108,7 @@ Judge methodology:
 
 Return exactly one JSON object matching the supplied strict schema.`;
 
+/** Build and persist the deterministic active-persona corpus without exposing planner diagnostics to the judge. */
 async function buildCorpus() {
   if (!existsSync(OUTPUT_DIR)) mkdirSync(OUTPUT_DIR, { recursive: true });
   const definitions = buildPersonaFamilies();
@@ -157,6 +163,7 @@ async function buildCorpus() {
   }
 }
 
+/** Invoke the configured judge for each active family, aggregate samples, and persist score artifacts. */
 async function judgeCorpus(corpus) {
   const config = resolveJudgeConfig(process.argv.slice(2).filter((arg) => arg !== '--build-only'));
   const scoreRows = [];


### PR DESCRIPTION
## Summary

- Introduces an explicit active persona-suite composition layer: one established Olympic-distance triathlon family with five decision-state perturbations, plus a cycling-primary hybrid family with five perturbations.
- Keeps the reusable novice/intermediate/advanced triathlon catalog for targeted deterministic coverage while reducing active AI-judge duplication.
- Corrects the cycling-primary hybrid evidence model so its declared current identity is backed by a cycling-dominant mixed 12-exposure history (8 Cycling, 4 Strength), rather than claiming regular resistance training while exposing only cycling history.
- Makes the local-tissue arbitration case genuinely adversarial: clearly favorable wearable values coexist with `painFlag=true` and active `avoid_high_impact` / `avoid_heavy_lower_body` guardrails.
- Adds deterministic integrity/tests, active-suite design documentation, and JSDoc for touched composition/judge helpers. No user-visible runtime product change.

## Validation

- [ ] `uv run pytest` (backend changes) — not applicable; no backend production code changed. The repository CI Python suite still passed on the final head.
- [ ] `uv run ruff check .` and `uv run mypy src/garmin_sync` (backend changes) — not applicable to the change, but both repository CI checks passed on the final head.
- [x] `cd app && npm run check` (frontend changes) — equivalent CI stages passed: typecheck, lint, frontend unit tests, sports-knowledge validation, knowledge-coverage validation, and workout-library validation.
- [x] `cd app && npm run test:rules` (Firestore rules changes) — CI emulator suite passed; no Firestore rule changes were made.
- [x] `cd app && npm run simulate:scenarios` (recommendation-engine changes) — CI simulation scenarios / aggregate-bounds gate passed.
- [ ] `cd app && npm run visual:refresh` (material UI changes) — not applicable; no UI changed.

Results:
- CI Pipeline run **#1871** on final head `a24c644f939d0ab19ac514d6b58516d4b3998525`: **pass**.
- Frontend typecheck/lint/tests, Firestore emulator tests, simulation bounds, deterministic AI plan-judge corpus, deterministic persona-judge corpus, semantic-diff reporting, bundle build, and dependency audit: **pass**.
- Python hygiene, ruff, formatting, mypy, pytest/coverage, and dependency audit: **pass**.
- Docker image build: **pass**.
- Focused fixture contract is additionally covered by `app/scripts/ai-judge/__tests__/personaScenarios.test.mjs`; every active persona state still runs through the real multi-week planner and must produce zero hard-constraint violations.

## Risk and reviewer guidance

Low runtime risk: this PR changes evaluation fixtures, AI-judge composition/calibration, tests, and documentation; it does **not** alter production recommendation decision logic.

Reviewer focus:
- whether collapsing active triathlon coverage into one athlete + state perturbations preserves the unique pool/time/recovery/taper failure modes while avoiding redundant AI-judge spend;
- whether the cycling-primary hybrid hierarchy is represented consistently across persona prose, current history, intent, preferences, and adversarial readiness values;
- whether deterministic assertions cover hard facts while leaving qualitative hierarchy/sensitivity judgments to the LLM judge.

Primary regression risk is evaluation-corpus / judge-score drift, not user-facing planner behavior. Rollback is a normal revert of this PR; there is no data migration or compatibility transition.

## Domain invariants

Not applicable for Firestore/date-domain behavior — this PR does not change persistence, calendar-date semantics, or production planner policy.

- [x] No credentials, tokens, service-account files, raw health payloads, real-person identifying measurements, or real-person fixture data are included.
- Recommendation decision logic / `POLICY_VERSION`: **not changed**. Only synthetic evaluation fixtures and judge guidance changed, so a policy-version bump is not warranted.

The active-suite fixture integrity check continues to enforce synthetic/anonymized public persona data and deterministic composition constraints.

## Screenshots or recordings

Not applicable — this is a non-UI evaluation/test/documentation change.