### PR TITLE
feat(knowledge): evidence pack for taper and fueling

### DIFF
--- a/app/src/knowledge/sportsKnowledgeRegistry.ts
+++ b/app/src/knowledge/sportsKnowledgeRegistry.ts
@@ -17,6 +17,11 @@ import {
     STRENGTH_CONCURRENT_CLAIMS,
     STRENGTH_CONCURRENT_SOURCES,
 } from './strengthConcurrentKnowledge.ts';
+import {
+    TAPER_FUELING_CLAIM_IDS,
+    TAPER_FUELING_CLAIMS,
+    TAPER_FUELING_SOURCES,
+} from './taperFuelingKnowledge.ts';
 
 /**
  * Canonical aggregate registry.
@@ -30,18 +35,21 @@ export const SPORTS_KNOWLEDGE_SOURCES: readonly KnowledgeSource[] = [
     ...CORE_SPORTS_KNOWLEDGE_SOURCES,
     ...READINESS_CARDIORESPIRATORY_SOURCES,
     ...STRENGTH_CONCURRENT_SOURCES,
+    ...TAPER_FUELING_SOURCES,
 ];
 
 export const SPORTS_KNOWLEDGE_CLAIMS: readonly KnowledgeClaim[] = [
     ...CORE_SPORTS_KNOWLEDGE_CLAIMS,
     ...READINESS_CARDIORESPIRATORY_CLAIMS,
     ...STRENGTH_CONCURRENT_CLAIMS,
+    ...TAPER_FUELING_CLAIMS,
 ];
 
 export const KNOWLEDGE_CLAIM_IDS = {
     ...CORE_KNOWLEDGE_CLAIM_IDS,
     ...READINESS_CARDIORESPIRATORY_CLAIM_IDS,
     ...STRENGTH_CONCURRENT_CLAIM_IDS,
+    ...TAPER_FUELING_CLAIM_IDS,
 } as const;
 
 /** Validate the complete cross-domain registry, including duplicate identifiers and lineage. */

--- a/app/src/knowledge/taperFuelingKnowledge.test.ts
+++ b/app/src/knowledge/taperFuelingKnowledge.test.ts
@@ -65,8 +65,21 @@ describe('taper and fueling evidence pack', () => {
         expect(dose.statement).toContain('30-60 g/h');
         expect(dose.statement).toContain('90 g/h');
         expect(dose.statement).toContain('not mandatory universal doses');
+        expect(dose.limitations.join(' ')).toContain('120 g/h');
+        expect(dose.limitations.join(' ')).toContain('not sufficiently substantiated');
+
         const meta = getKnowledgeSource('RAMOS-CAMPO-2024-CARBOHYDRATE-META');
+        expect(meta.publishedOn).toBe('2023-07-14');
         expect(meta.notes).toContain('136 studies');
+
+        const contemporary = getKnowledgeSource('MORTON-2026-ENDURANCE-CARBOHYDRATE-REVIEW');
+        expect(contemporary.sourceType).toBe('expert_practice');
+        expect(contemporary.externalIds).toEqual(expect.arrayContaining([
+            { type: 'pmid', value: '41759826' },
+            { type: 'pmcid', value: 'PMC13197957' },
+            { type: 'doi', value: '10.1016/j.tjnut.2026.101442' },
+        ]));
+        expect(contemporary.notes).toContain('not yet substantiated');
     });
 
     it('treats avoidance of overdrinking as a high-safety hydration boundary', () => {

--- a/app/src/knowledge/taperFuelingKnowledge.test.ts
+++ b/app/src/knowledge/taperFuelingKnowledge.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import { ENGINE_KNOWLEDGE_COVERAGE } from './knowledgeCoverage';
+import {
+    getActiveKnowledgeClaim,
+    getKnowledgeSource,
+    KNOWLEDGE_CLAIM_IDS,
+    validateCanonicalSportsKnowledgeRegistry,
+} from './sportsKnowledgeRegistry';
+
+const coverageById = (id: string) => ENGINE_KNOWLEDGE_COVERAGE.find(item => item.id === id);
+
+describe('taper and fueling evidence pack', () => {
+    it('keeps the canonical registry structurally valid', () => {
+        const result = validateCanonicalSportsKnowledgeRegistry();
+        expect(result.errors).toEqual([]);
+        expect(result.valid).toBe(true);
+    });
+
+    it('supports pre-event volume reduction with maintained intensity without validating the app exact windows', () => {
+        const claim = getActiveKnowledgeClaim(KNOWLEDGE_CLAIM_IDS.endurancePreEventTaper);
+        expect(claim).toMatchObject({
+            claimType: 'intervention',
+            evidenceCertainty: 'moderate',
+            recommendationStrength: 'conditional',
+        });
+        expect(claim.statement).toContain('41-60%');
+        expect(claim.statement).toContain('athlete- and event-dependent');
+        expect(claim.limitations.join(' ')).toContain('14 days');
+        expect(claim.limitations.join(' ')).toContain('post-event');
+    });
+
+    it('records both modern and classic taper meta-analyses with stable identifiers', () => {
+        const modern = getKnowledgeSource('WANG-2023-ENDURANCE-TAPER-META');
+        const classic = getKnowledgeSource('BOSQUET-2007-TAPER-META');
+        expect(modern.sourceType).toBe('systematic_review');
+        expect(modern.synthesisMethods).toContain('meta_analysis');
+        expect(modern.externalIds).toEqual(expect.arrayContaining([
+            { type: 'pmid', value: '37163550' },
+            { type: 'pmcid', value: 'PMC10171681' },
+            { type: 'doi', value: '10.1371/journal.pone.0282838' },
+        ]));
+        expect(classic.externalIds).toEqual(expect.arrayContaining([
+            { type: 'pmid', value: '17762369' },
+            { type: 'doi', value: '10.1249/mss.0b013e31806010e0' },
+        ]));
+    });
+
+    it('keeps exact taper timing, pre-event blocks and sharpening values as product heuristics', () => {
+        expect(getActiveKnowledgeClaim(KNOWLEDGE_CLAIM_IDS.taperWindowsVolumePolicy)).toMatchObject({
+            claimType: 'heuristic', evidenceCertainty: 'not_applicable', maturity: 'heuristic',
+        });
+        expect(getActiveKnowledgeClaim(KNOWLEDGE_CLAIM_IDS.preEventRestrictionsPolicy)).toMatchObject({
+            claimType: 'heuristic', evidenceCertainty: 'not_applicable',
+        });
+        expect(getActiveKnowledgeClaim(KNOWLEDGE_CLAIM_IDS.taperSharpeningPolicy)).toMatchObject({
+            claimType: 'heuristic', evidenceCertainty: 'not_applicable',
+        });
+    });
+
+    it('supports carbohydrate during endurance exercise while keeping dose bands contextual', () => {
+        const efficacy = getActiveKnowledgeClaim(KNOWLEDGE_CLAIM_IDS.carbohydrateDuringExercise);
+        const dose = getActiveKnowledgeClaim(KNOWLEDGE_CLAIM_IDS.carbohydrateEventScaledDose);
+        expect(efficacy).toMatchObject({ evidenceCertainty: 'high', recommendationStrength: 'strong' });
+        expect(dose).toMatchObject({ evidenceCertainty: 'moderate', recommendationStrength: 'conditional' });
+        expect(dose.statement).toContain('30-60 g/h');
+        expect(dose.statement).toContain('90 g/h');
+        expect(dose.statement).toContain('not mandatory universal doses');
+        const meta = getKnowledgeSource('RAMOS-CAMPO-2024-CARBOHYDRATE-META');
+        expect(meta.notes).toContain('136 studies');
+    });
+
+    it('treats avoidance of overdrinking as a high-safety hydration boundary', () => {
+        const claim = getActiveKnowledgeClaim(KNOWLEDGE_CLAIM_IDS.hydrationAvoidOverdrinking);
+        expect(claim).toMatchObject({
+            claimType: 'safety', evidenceCertainty: 'high', recommendationStrength: 'strong', safetyImpact: 'high',
+        });
+        expect(claim.statement).toContain('excessive fluid');
+        expect(claim.statement).toContain('hyponatremia');
+        expect(claim.limitations.join(' ')).toContain('no single mL/h');
+    });
+
+    it('does not pretend fueling has live engine decision authority or that the bundled taper inventory is fully migrated', () => {
+        expect(ENGINE_KNOWLEDGE_COVERAGE.some(item => item.domain === 'periodization_taper')).toBe(true);
+        expect(coverageById('periodization.taper_windows_volume')).toMatchObject({ coverage: 'uncovered', researchPriority: 'p0' });
+        expect(ENGINE_KNOWLEDGE_COVERAGE.some(item => item.id.includes('fuel'))).toBe(false);
+    });
+});

--- a/app/src/knowledge/taperFuelingKnowledge.test.ts
+++ b/app/src/knowledge/taperFuelingKnowledge.test.ts
@@ -67,6 +67,7 @@ describe('taper and fueling evidence pack', () => {
         expect(dose.statement).toContain('not mandatory universal doses');
         expect(dose.limitations.join(' ')).toContain('120 g/h');
         expect(dose.limitations.join(' ')).toContain('not sufficiently substantiated');
+        expect(dose.limitations.join(' ')).toContain('amateur/recreational');
 
         const meta = getKnowledgeSource('RAMOS-CAMPO-2024-CARBOHYDRATE-META');
         expect(meta.publishedOn).toBe('2023-07-14');
@@ -80,6 +81,15 @@ describe('taper and fueling evidence pack', () => {
             { type: 'doi', value: '10.1016/j.tjnut.2026.101442' },
         ]));
         expect(contemporary.notes).toContain('not yet substantiated');
+
+        const ultraHigh = getKnowledgeSource('PLEWS-2026-ULTRA-HIGH-CARBOHYDRATE-OPINION');
+        expect(ultraHigh.sourceType).toBe('expert_practice');
+        expect(ultraHigh.externalIds).toEqual(expect.arrayContaining([
+            { type: 'pmid', value: '42258036' },
+            { type: 'doi', value: '10.1007/s40279-026-02462-z' },
+        ]));
+        expect(ultraHigh.notes).toContain('supporting context rather than primary efficacy evidence');
+        expect(ultraHigh.notes).toContain('amateur and recreational');
     });
 
     it('treats avoidance of overdrinking as a high-safety hydration boundary', () => {

--- a/app/src/knowledge/taperFuelingKnowledge.ts
+++ b/app/src/knowledge/taperFuelingKnowledge.ts
@@ -15,6 +15,7 @@ const BOSQUET_TAPER_SOURCE = 'BOSQUET-2007-TAPER-META';
 const THOMAS_NUTRITION_SOURCE = 'THOMAS-2016-NUTRITION-POSITION';
 const BURKE_CARBOHYDRATE_SOURCE = 'BURKE-2011-CARBOHYDRATE-PRACTICE';
 const RAMOS_CAMPO_CARBOHYDRATE_SOURCE = 'RAMOS-CAMPO-2024-CARBOHYDRATE-META';
+const MORTON_CARBOHYDRATE_SOURCE = 'MORTON-2026-ENDURANCE-CARBOHYDRATE-REVIEW';
 const HEW_BUTLER_HYPONATREMIA_SOURCE = 'HEW-BUTLER-2015-HYPONATREMIA-CONSENSUS';
 const TAPER_PRODUCT_POLICY_SOURCE = 'PRODUCT-TAPER-POLICY-V1';
 
@@ -78,15 +79,29 @@ export const TAPER_FUELING_SOURCES: readonly KnowledgeSource[] = [
         id: RAMOS_CAMPO_CARBOHYDRATE_SOURCE,
         title: 'The ergogenic effects of acute carbohydrate feeding on endurance performance: a systematic review, meta-analysis and meta-regression',
         sourceType: 'systematic_review',
-        citation: 'Ramos-Campo DJ, et al. Crit Rev Food Sci Nutr. 2024. doi:10.1080/10408398.2023.2233633.',
+        citation: 'Ramos-Campo DJ, et al. Crit Rev Food Sci Nutr. 2024;64(30):11196-11205. doi:10.1080/10408398.2023.2233633.',
         url: 'https://pubmed.ncbi.nlm.nih.gov/37449467/',
-        publishedOn: '2023-07-13',
+        publishedOn: '2023-07-14',
         externalIds: [
             { type: 'pmid', value: '37449467' },
             { type: 'doi', value: '10.1080/10408398.2023.2233633' },
         ],
         synthesisMethods: ['meta_analysis'],
         notes: 'Meta-analysis of 136 studies found carbohydrate ingestion during endurance exercise improved performance versus placebo/control, with larger benefit as event duration increased. This supports the ergogenic direction, not one universal gram-per-hour target.',
+    },
+    {
+        id: MORTON_CARBOHYDRATE_SOURCE,
+        title: 'From Metabolism to Medals: Contemporary Perspectives and Revisiting Carbohydrate Guidelines for Fueling Endurance Athletes during Exercise',
+        sourceType: 'expert_practice',
+        citation: 'Morton JP, Fell JM, Gonzalez JT, Hearris MA, Podlogar T, Pugh JN, Wallis GA. J Nutr. 2026;156(5):101442. doi:10.1016/j.tjnut.2026.101442.',
+        url: 'https://pubmed.ncbi.nlm.nih.gov/41759826/',
+        publishedOn: '2026-02-25',
+        externalIds: [
+            { type: 'pmid', value: '41759826' },
+            { type: 'pmcid', value: 'PMC13197957' },
+            { type: 'doi', value: '10.1016/j.tjnut.2026.101442' },
+        ],
+        notes: 'Contemporary narrative review supports the established <=90 g/h framework for prolonged endurance exercise while noting that 120 g/h can raise exogenous/whole-body carbohydrate oxidation in trained athletes. It explicitly states that performance efficacy above 90 g/h is not yet substantiated well enough to make very-high intake a general recommendation.',
     },
     {
         id: HEW_BUTLER_HYPONATREMIA_SOURCE,
@@ -152,10 +167,12 @@ export const TAPER_FUELING_CLAIMS: readonly KnowledgeClaim[] = [
             { sourceId: BURKE_CARBOHYDRATE_SOURCE, directness: 'direct' },
             { sourceId: THOMAS_NUTRITION_SOURCE, directness: 'direct' },
             { sourceId: RAMOS_CAMPO_CARBOHYDRATE_SOURCE, directness: 'partially_direct', note: 'Supports performance benefit and duration dependence more strongly than exact dose bands.' },
+            { sourceId: MORTON_CARBOHYDRATE_SOURCE, directness: 'partially_direct', note: 'Updates the practical boundary: >90 g/h may raise carbohydrate oxidation in trained athletes, but performance superiority and generalizability remain insufficiently established.' },
         ],
         limitations: [
             'The gram-per-hour ranges are practical guidance synthesized across heterogeneous exercise contexts; athletes should individualize by body size only where evidence/guidance specifically calls for it rather than mechanically converting these rates to g/kg/h.',
             'High intakes require gastrointestinal tolerance and often gut-training/practice; the upper range should not be introduced for the first time on race day.',
+            'Recent 2026 evidence reviews describe 120 g/h as physiologically plausible for some trained endurance athletes, but performance benefit beyond the established <=90 g/h framework is not sufficiently substantiated to make >90 g/h a general recommendation.',
             'Shorter/easier sessions may not require exogenous carbohydrate for performance, and training goals can intentionally alter carbohydrate availability.',
         ], reviewedOn: '2026-08-30', version: 1,
     },

--- a/app/src/knowledge/taperFuelingKnowledge.ts
+++ b/app/src/knowledge/taperFuelingKnowledge.ts
@@ -16,6 +16,7 @@ const THOMAS_NUTRITION_SOURCE = 'THOMAS-2016-NUTRITION-POSITION';
 const BURKE_CARBOHYDRATE_SOURCE = 'BURKE-2011-CARBOHYDRATE-PRACTICE';
 const RAMOS_CAMPO_CARBOHYDRATE_SOURCE = 'RAMOS-CAMPO-2024-CARBOHYDRATE-META';
 const MORTON_CARBOHYDRATE_SOURCE = 'MORTON-2026-ENDURANCE-CARBOHYDRATE-REVIEW';
+const PLEWS_ULTRA_HIGH_CARBOHYDRATE_SOURCE = 'PLEWS-2026-ULTRA-HIGH-CARBOHYDRATE-OPINION';
 const HEW_BUTLER_HYPONATREMIA_SOURCE = 'HEW-BUTLER-2015-HYPONATREMIA-CONSENSUS';
 const TAPER_PRODUCT_POLICY_SOURCE = 'PRODUCT-TAPER-POLICY-V1';
 
@@ -104,6 +105,19 @@ export const TAPER_FUELING_SOURCES: readonly KnowledgeSource[] = [
         notes: 'Contemporary narrative review supports the established <=90 g/h framework for prolonged endurance exercise while noting that 120 g/h can raise exogenous/whole-body carbohydrate oxidation in trained athletes. It explicitly states that performance efficacy above 90 g/h is not yet substantiated well enough to make very-high intake a general recommendation.',
     },
     {
+        id: PLEWS_ULTRA_HIGH_CARBOHYDRATE_SOURCE,
+        title: 'Fuelled or Fooled? Examining the Evidence and Mechanisms Behind Ultra-High Carbohydrate Intake in Endurance Athletes',
+        sourceType: 'expert_practice',
+        citation: 'Plews DJ, Booth PD, Krieger T, Maunder E. Sports Med. 2026. doi:10.1007/s40279-026-02462-z.',
+        url: 'https://pubmed.ncbi.nlm.nih.gov/42258036/',
+        publishedOn: '2026-06-08',
+        externalIds: [
+            { type: 'pmid', value: '42258036' },
+            { type: 'doi', value: '10.1007/s40279-026-02462-z' },
+        ],
+        notes: 'Current-opinion review focused on ultra-high carbohydrate intake (>90 g/h). It finds limited direct performance evidence, diminishing returns beyond roughly 60-90 g/h in most studied settings, and concludes that broad ultra-high-carbohydrate recommendations are premature, particularly for amateur and recreational athletes. It is supporting context rather than primary efficacy evidence.',
+    },
+    {
         id: HEW_BUTLER_HYPONATREMIA_SOURCE,
         title: 'Statement of the Third International Exercise-Associated Hyponatremia Consensus Development Conference, Carlsbad, California, 2015',
         sourceType: 'consensus',
@@ -168,11 +182,12 @@ export const TAPER_FUELING_CLAIMS: readonly KnowledgeClaim[] = [
             { sourceId: THOMAS_NUTRITION_SOURCE, directness: 'direct' },
             { sourceId: RAMOS_CAMPO_CARBOHYDRATE_SOURCE, directness: 'partially_direct', note: 'Supports performance benefit and duration dependence more strongly than exact dose bands.' },
             { sourceId: MORTON_CARBOHYDRATE_SOURCE, directness: 'partially_direct', note: 'Updates the practical boundary: >90 g/h may raise carbohydrate oxidation in trained athletes, but performance superiority and generalizability remain insufficiently established.' },
+            { sourceId: PLEWS_ULTRA_HIGH_CARBOHYDRATE_SOURCE, directness: 'partially_direct', note: 'Focused current-opinion review concludes that evidence for broad >90 g/h performance recommendations remains insufficient, especially outside selected elite contexts.' },
         ],
         limitations: [
             'The gram-per-hour ranges are practical guidance synthesized across heterogeneous exercise contexts; athletes should individualize by body size only where evidence/guidance specifically calls for it rather than mechanically converting these rates to g/kg/h.',
             'High intakes require gastrointestinal tolerance and often gut-training/practice; the upper range should not be introduced for the first time on race day.',
-            'Recent 2026 evidence reviews describe 120 g/h as physiologically plausible for some trained endurance athletes, but performance benefit beyond the established <=90 g/h framework is not sufficiently substantiated to make >90 g/h a general recommendation.',
+            'Recent 2026 reviews describe 120 g/h as physiologically plausible for some trained endurance athletes, but performance benefit beyond the established <=90 g/h framework is not sufficiently substantiated to make >90 g/h a general recommendation; the most recent focused opinion review explicitly cautions against treating ultra-high intake as a gold standard for amateur/recreational athletes.',
             'Shorter/easier sessions may not require exogenous carbohydrate for performance, and training goals can intentionally alter carbohydrate availability.',
         ], reviewedOn: '2026-08-30', version: 1,
     },

--- a/app/src/knowledge/taperFuelingKnowledge.ts
+++ b/app/src/knowledge/taperFuelingKnowledge.ts
@@ -1,0 +1,200 @@
+import type { KnowledgeClaim, KnowledgeSource } from './sportsKnowledge';
+
+export const TAPER_FUELING_CLAIM_IDS = {
+    endurancePreEventTaper: 'performance.taper.endurance.pre_event_volume_reduction',
+    carbohydrateDuringExercise: 'nutrition.endurance.carbohydrate_during_exercise.performance',
+    carbohydrateEventScaledDose: 'nutrition.endurance.carbohydrate_during_exercise.event_scaled_dose',
+    hydrationAvoidOverdrinking: 'nutrition.endurance.hydration.avoid_overdrinking',
+    taperWindowsVolumePolicy: 'policy.taper.windows_volume_v1',
+    preEventRestrictionsPolicy: 'policy.taper.pre_event_restrictions_v1',
+    taperSharpeningPolicy: 'policy.taper.sharpening_targets_v1',
+} as const;
+
+const WANG_TAPER_SOURCE = 'WANG-2023-ENDURANCE-TAPER-META';
+const BOSQUET_TAPER_SOURCE = 'BOSQUET-2007-TAPER-META';
+const THOMAS_NUTRITION_SOURCE = 'THOMAS-2016-NUTRITION-POSITION';
+const BURKE_CARBOHYDRATE_SOURCE = 'BURKE-2011-CARBOHYDRATE-PRACTICE';
+const RAMOS_CAMPO_CARBOHYDRATE_SOURCE = 'RAMOS-CAMPO-2024-CARBOHYDRATE-META';
+const HEW_BUTLER_HYPONATREMIA_SOURCE = 'HEW-BUTLER-2015-HYPONATREMIA-CONSENSUS';
+const TAPER_PRODUCT_POLICY_SOURCE = 'PRODUCT-TAPER-POLICY-V1';
+
+export const TAPER_FUELING_SOURCES: readonly KnowledgeSource[] = [
+    {
+        id: WANG_TAPER_SOURCE,
+        title: 'Effects of tapering on performance in endurance athletes: A systematic review and meta-analysis',
+        sourceType: 'systematic_review',
+        citation: 'Wang Z, Wang YT, Gao W, Zhong Y. PLoS One. 2023;18(5):e0282838. doi:10.1371/journal.pone.0282838.',
+        url: 'https://pubmed.ncbi.nlm.nih.gov/37163550/',
+        publishedOn: '2023-05-10',
+        externalIds: [
+            { type: 'pmid', value: '37163550' },
+            { type: 'pmcid', value: 'PMC10171681' },
+            { type: 'doi', value: '10.1371/journal.pone.0282838' },
+        ],
+        synthesisMethods: ['meta_analysis'],
+        notes: 'Fourteen studies. Endurance performance improved with taper strategies that reduced volume while maintaining intensity/frequency; subgroup results supported roughly 41-60% volume reduction and tapers up to 21 days, but did not establish one event- or athlete-independent taper schedule.',
+    },
+    {
+        id: BOSQUET_TAPER_SOURCE,
+        title: 'Effects of tapering on performance: a meta-analysis',
+        sourceType: 'systematic_review',
+        citation: 'Bosquet L, Montpetit J, Arvisais D, Mujika I. Med Sci Sports Exerc. 2007;39(8):1358-1365. doi:10.1249/mss.0b013e31806010e0.',
+        url: 'https://pubmed.ncbi.nlm.nih.gov/17762369/',
+        publishedOn: '2007-08-01',
+        externalIds: [
+            { type: 'pmid', value: '17762369' },
+            { type: 'doi', value: '10.1249/mss.0b013e31806010e0' },
+        ],
+        synthesisMethods: ['meta_analysis'],
+        notes: 'Classic meta-analysis of 27 studies identified an approximately two-week taper with 41-60% volume reduction and maintained intensity/frequency as an effective average strategy. It should be interpreted as population-level guidance, not an exact per-event rule.',
+    },
+    {
+        id: THOMAS_NUTRITION_SOURCE,
+        title: 'Position of the Academy of Nutrition and Dietetics, Dietitians of Canada, and the American College of Sports Medicine: Nutrition and Athletic Performance',
+        sourceType: 'guideline',
+        citation: 'Thomas DT, Erdman KA, Burke LM. J Acad Nutr Diet. 2016;116(3):501-528. doi:10.1016/j.jand.2015.12.006.',
+        url: 'https://pubmed.ncbi.nlm.nih.gov/26920240/',
+        publishedOn: '2016-03-01',
+        externalIds: [
+            { type: 'pmid', value: '26920240' },
+            { type: 'doi', value: '10.1016/j.jand.2015.12.006' },
+        ],
+        notes: 'Joint sports-nutrition position statement supporting individualized type, amount and timing of food/fluid intake for training, competition and recovery. It provides context for event-specific fueling rather than one universal prescription.',
+    },
+    {
+        id: BURKE_CARBOHYDRATE_SOURCE,
+        title: 'Carbohydrates for training and competition',
+        sourceType: 'expert_practice',
+        citation: 'Burke LM, Hawley JA, Wong SH, Jeukendrup AE. J Sports Sci. 2011;29 Suppl 1:S17-S27. doi:10.1080/02640414.2011.585473.',
+        url: 'https://pubmed.ncbi.nlm.nih.gov/21660838/',
+        publishedOn: '2011-06-09',
+        externalIds: [
+            { type: 'pmid', value: '21660838' },
+            { type: 'doi', value: '10.1080/02640414.2011.585473' },
+        ],
+        notes: 'Widely used event-scaled carbohydrate framework: small amounts can help around one hour, 30-60 g/h is appropriate for longer events, and events >2.5 h may benefit from intakes up to about 90 g/h using multiple transportable carbohydrates. Individual tolerance and event demands matter.',
+    },
+    {
+        id: RAMOS_CAMPO_CARBOHYDRATE_SOURCE,
+        title: 'The ergogenic effects of acute carbohydrate feeding on endurance performance: a systematic review, meta-analysis and meta-regression',
+        sourceType: 'systematic_review',
+        citation: 'Ramos-Campo DJ, et al. Crit Rev Food Sci Nutr. 2024. doi:10.1080/10408398.2023.2233633.',
+        url: 'https://pubmed.ncbi.nlm.nih.gov/37449467/',
+        publishedOn: '2023-07-13',
+        externalIds: [
+            { type: 'pmid', value: '37449467' },
+            { type: 'doi', value: '10.1080/10408398.2023.2233633' },
+        ],
+        synthesisMethods: ['meta_analysis'],
+        notes: 'Meta-analysis of 136 studies found carbohydrate ingestion during endurance exercise improved performance versus placebo/control, with larger benefit as event duration increased. This supports the ergogenic direction, not one universal gram-per-hour target.',
+    },
+    {
+        id: HEW_BUTLER_HYPONATREMIA_SOURCE,
+        title: 'Statement of the Third International Exercise-Associated Hyponatremia Consensus Development Conference, Carlsbad, California, 2015',
+        sourceType: 'consensus',
+        citation: 'Hew-Butler T, et al. Clin J Sport Med. 2015;25(4):303-320. doi:10.1097/JSM.0000000000000221.',
+        url: 'https://pubmed.ncbi.nlm.nih.gov/26102445/',
+        publishedOn: '2015-07-01',
+        externalIds: [
+            { type: 'pmid', value: '26102445' },
+            { type: 'doi', value: '10.1097/JSM.0000000000000221' },
+        ],
+        notes: 'Consensus emphasizes excessive fluid intake as the principal behavioral driver of exercise-associated hyponatremia and supports avoiding overdrinking rather than prescribing one universal fluid-replacement number.',
+    },
+    {
+        id: TAPER_PRODUCT_POLICY_SOURCE,
+        title: 'Adaptive Training Recommender taper calibration policy v1',
+        sourceType: 'product_policy',
+        citation: 'Adaptive Training Recommender product policy, reviewed 2026-08-30.',
+        publishedOn: '2026-08-30',
+        notes: 'Registers exact taper windows, volume curve, pre-event blocking windows and sharpening target values as product calibration. These values remain distinct from the scientific taper principle.',
+    },
+];
+
+export const TAPER_FUELING_CLAIMS: readonly KnowledgeClaim[] = [
+    {
+        id: TAPER_FUELING_CLAIM_IDS.endurancePreEventTaper,
+        statement: 'A pre-event taper can improve endurance performance by substantially reducing training volume while preserving meaningful training intensity and generally maintaining frequency; population-level syntheses commonly support roughly 41-60% volume reduction over a taper of up to about 21 days, with an approximately two-week taper often effective, but optimal duration and shape remain athlete- and event-dependent.',
+        claimType: 'intervention', maturity: 'established', status: 'active', evidenceCertainty: 'moderate', recommendationStrength: 'conditional', safetyImpact: 'moderate',
+        applicability: { contexts: ['pre_event_taper', 'endurance_competition'], sports: ['cycling', 'running', 'endurance_multisport'], populations: ['trained_endurance_athletes'], outcomes: ['competition_performance', 'fatigue_reduction', 'fitness_preservation'], horizon: 'acute' },
+        evidence: [
+            { sourceId: WANG_TAPER_SOURCE, directness: 'direct' },
+            { sourceId: BOSQUET_TAPER_SOURCE, directness: 'direct' },
+        ],
+        limitations: [
+            'The evidence supports a population-level taper strategy, not the product rule that every A event starts 14 days out or every B event five days out.',
+            'The current cycling-A race-week-Monday rule and three-day minimum are product scheduling choices rather than directly validated scientific boundaries.',
+            'Maintaining intensity means preserving some quality stimulus while volume falls; it does not validate the product internal intensityScale of exactly 1.0 or every sharpening target value.',
+            'This claim addresses pre-event tapering only and does not justify the product three-day post-event recovery period at volume/intensity 0.4.',
+        ], reviewedOn: '2026-08-30', version: 1,
+    },
+    {
+        id: TAPER_FUELING_CLAIM_IDS.carbohydrateDuringExercise,
+        statement: 'Carbohydrate ingestion during endurance exercise can improve performance compared with placebo or no carbohydrate, with the average ergogenic benefit becoming more relevant as exercise duration increases.',
+        claimType: 'intervention', maturity: 'established', status: 'active', evidenceCertainty: 'high', recommendationStrength: 'strong', safetyImpact: 'low',
+        applicability: { contexts: ['endurance_training', 'endurance_competition'], sports: ['cycling', 'running', 'endurance_multisport'], populations: ['healthy_adult_athletes'], outcomes: ['endurance_performance'], horizon: 'acute' },
+        evidence: [
+            { sourceId: RAMOS_CAMPO_CARBOHYDRATE_SOURCE, directness: 'direct' },
+            { sourceId: THOMAS_NUTRITION_SOURCE, directness: 'direct' },
+        ],
+        limitations: [
+            'Magnitude varies with exercise duration, intensity, pre-exercise carbohydrate availability, feeding strategy and performance-test design.',
+            'This claim supports carbohydrate availability during relevant endurance work; it does not establish one dose for every session or athlete.',
+            'Gastrointestinal tolerance, diabetes/metabolic conditions and individual medical/nutrition needs require personalization.',
+        ], reviewedOn: '2026-08-30', version: 1,
+    },
+    {
+        id: TAPER_FUELING_CLAIM_IDS.carbohydrateEventScaledDose,
+        statement: 'Carbohydrate intake during endurance exercise should be scaled to event duration and demands: approximately 30-60 g/h is a common target for longer-duration exercise, while events beyond about 2.5 hours may benefit from intakes up to roughly 90 g/h when multiple transportable carbohydrates are tolerated; these are practical ranges, not mandatory universal doses.',
+        claimType: 'intervention', maturity: 'established', status: 'active', evidenceCertainty: 'moderate', recommendationStrength: 'conditional', safetyImpact: 'low',
+        applicability: { contexts: ['endurance_competition', 'long_endurance_training'], sports: ['cycling', 'running', 'endurance_multisport'], populations: ['healthy_adult_endurance_athletes'], outcomes: ['carbohydrate_availability', 'endurance_performance', 'fueling_tolerance'], horizon: 'acute' },
+        evidence: [
+            { sourceId: BURKE_CARBOHYDRATE_SOURCE, directness: 'direct' },
+            { sourceId: THOMAS_NUTRITION_SOURCE, directness: 'direct' },
+            { sourceId: RAMOS_CAMPO_CARBOHYDRATE_SOURCE, directness: 'partially_direct', note: 'Supports performance benefit and duration dependence more strongly than exact dose bands.' },
+        ],
+        limitations: [
+            'The gram-per-hour ranges are practical guidance synthesized across heterogeneous exercise contexts; athletes should individualize by body size only where evidence/guidance specifically calls for it rather than mechanically converting these rates to g/kg/h.',
+            'High intakes require gastrointestinal tolerance and often gut-training/practice; the upper range should not be introduced for the first time on race day.',
+            'Shorter/easier sessions may not require exogenous carbohydrate for performance, and training goals can intentionally alter carbohydrate availability.',
+        ], reviewedOn: '2026-08-30', version: 1,
+    },
+    {
+        id: TAPER_FUELING_CLAIM_IDS.hydrationAvoidOverdrinking,
+        statement: 'Endurance hydration strategies should prevent both meaningful hypohydration and excessive fluid intake; athletes should not routinely drink beyond losses or pursue blanket replacement targets that create weight gain, because overdrinking is a primary modifiable risk for exercise-associated hyponatremia.',
+        claimType: 'safety', maturity: 'established', status: 'active', evidenceCertainty: 'high', recommendationStrength: 'strong', safetyImpact: 'high',
+        applicability: { contexts: ['endurance_training', 'endurance_competition', 'hot_environment'], sports: ['all_supported_sports'], populations: ['physically_active_adults'], outcomes: ['hydration_safety', 'exercise_associated_hyponatremia_risk'], horizon: 'acute' },
+        evidence: [
+            { sourceId: HEW_BUTLER_HYPONATREMIA_SOURCE, directness: 'direct' },
+            { sourceId: THOMAS_NUTRITION_SOURCE, directness: 'partially_direct', note: 'Supports individualized fluid strategy in sport.' },
+        ],
+        limitations: [
+            'Sweat rate, heat, altitude, duration, body size, acclimatization and access to fluid vary substantially; no single mL/h rate is appropriate for all athletes.',
+            'This registry claim is preventive guidance, not diagnosis or treatment of suspected hyponatremia or heat illness.',
+        ], reviewedOn: '2026-08-30', version: 1,
+    },
+    {
+        id: TAPER_FUELING_CLAIM_IDS.taperWindowsVolumePolicy,
+        statement: 'Product taper v1: cycling A events default to race-week Monday with at least three days; other A/B competition defaults use 14/5 days; taper intensityScale remains 1.0 while volumeScale falls linearly toward 0.6.',
+        claimType: 'heuristic', maturity: 'heuristic', status: 'active', evidenceCertainty: 'not_applicable', recommendationStrength: 'conditional', safetyImpact: 'moderate',
+        applicability: { contexts: ['pre_event_taper'], sports: ['all_supported_sports'], populations: ['app_users_with_target_events'], outcomes: ['planner_taper_state'], horizon: 'acute' },
+        evidence: [{ sourceId: TAPER_PRODUCT_POLICY_SOURCE, directness: 'direct' }],
+        limitations: ['Exact event-priority windows, race-week alignment, linear curve and 0.6 endpoint are product calibration, not direct effect estimates from taper meta-analysis.', 'Post-event recovery is intentionally excluded from this claim.'], reviewedOn: '2026-08-30', version: 1,
+    },
+    {
+        id: TAPER_FUELING_CLAIM_IDS.preEventRestrictionsPolicy,
+        statement: 'Product pre-event restriction v1: for A/B cycling/running events, strength is blocked 1-3 days before the event, hard work 1-2 days, and exhaustive work 3-7 days according to current event-priority logic.',
+        claimType: 'heuristic', maturity: 'heuristic', status: 'active', evidenceCertainty: 'not_applicable', recommendationStrength: 'conditional', safetyImpact: 'moderate',
+        applicability: { contexts: ['pre_event_taper'], sports: ['cycling', 'running'], populations: ['app_users_with_A_or_B_events'], outcomes: ['session_eligibility'], horizon: 'acute' },
+        evidence: [{ sourceId: TAPER_PRODUCT_POLICY_SOURCE, directness: 'direct' }],
+        limitations: ['Taper evidence supports freshness and preserved quality while volume falls; it does not directly validate each 1/2/3/7-day block as a universal biological recovery threshold.'], reviewedOn: '2026-08-30', version: 1,
+    },
+    {
+        id: TAPER_FUELING_CLAIM_IDS.taperSharpeningPolicy,
+        statement: 'Product taper sharpening v1: cycling sharpening targets thresholdPower 0.5/repeatedSurges 0.4 with threshold qualification 0.3, while the strength primer targets maxStrength 0.3/hypertrophy 0.2.',
+        claimType: 'heuristic', maturity: 'heuristic', status: 'active', evidenceCertainty: 'not_applicable', recommendationStrength: 'conditional', safetyImpact: 'moderate',
+        applicability: { contexts: ['pre_event_taper'], sports: ['cycling', 'running', 'endurance_multisport'], populations: ['app_users_in_taper'], outcomes: ['weekly_objective_calibration'], horizon: 'acute' },
+        evidence: [{ sourceId: TAPER_PRODUCT_POLICY_SOURCE, directness: 'direct' }],
+        limitations: ['Maintaining useful intensity during taper is evidence-consistent, but these internal 0..1 stimulus values are product semantics, not physiological effect sizes.'], reviewedOn: '2026-08-30', version: 1,
+    },
+];

--- a/docs/analysis/2026-08-30-evidence-pack-taper-fueling.md
+++ b/docs/analysis/2026-08-30-evidence-pack-taper-fueling.md
@@ -10,9 +10,9 @@
 
 ## Evidence appraisal
 
-The taper review prioritized endurance-specific systematic reviews/meta-analyses. Fueling used a large acute-carbohydrate meta-analysis, recognized sports-nutrition guidance, a 2026 contemporary endurance-carbohydrate review and the international exercise-associated hyponatremia consensus. The review kept intervention efficacy separate from practical dose guidance and from safety boundaries.
+The taper review prioritized endurance-specific systematic reviews/meta-analyses. Fueling used a large acute-carbohydrate meta-analysis, recognized sports-nutrition guidance, two contemporary 2026 reviews of higher carbohydrate intake and the international exercise-associated hyponatremia consensus. The review kept intervention efficacy separate from practical dose guidance and from safety boundaries.
 
-A specific 2026 update was important because current elite endurance practice increasingly experiments with >90 g/h carbohydrate intake. Contemporary review evidence supports greater carbohydrate oxidation at some higher intakes in trained athletes, but does **not** yet establish a general performance advantage above the established <=90 g/h framework. The registry therefore keeps 30-60 / up-to-90 g/h as contextual practice guidance and records >90 g/h as an emerging, athlete-specific boundary rather than silently treating current peloton practice as validated universal dosing.
+A specific 2026 update was important because current elite endurance practice increasingly experiments with >90 g/h carbohydrate intake. Contemporary reviews support greater carbohydrate oxidation at some higher intakes in trained athletes, but do **not** establish a general performance advantage above the established <=90 g/h framework. A June 2026 Sports Medicine current-opinion review focused specifically on ultra-high intake likewise concludes that broad >90 g/h recommendations are premature, particularly for amateur/recreational athletes. The registry therefore keeps 30-60 / up-to-90 g/h as contextual practice guidance and records >90 g/h as an emerging, athlete-specific boundary rather than silently treating current elite practice as validated universal dosing.
 
 ## Taper
 
@@ -62,7 +62,7 @@ A follow-up inventory refactor should split the family into `periodization.pre_e
 **Ramos-Campo et al., 2024 — systematic review/meta-analysis/meta-regression**  
 PMID 37449467; DOI `10.1080/10408398.2023.2233633`.
 
-The analysis included 136 studies and found carbohydrate ingestion during endurance exercise improved performance compared with placebo/control. Benefits were larger as event duration increased. PubMed records the electronic publication date as **2023-07-14**; the final journal issue is 2024, and the registry now stores those two facts consistently rather than using an off-by-one date.
+The analysis included 136 studies and found carbohydrate ingestion during endurance exercise improved performance compared with placebo/control. Benefits were larger as event duration increased. PubMed records the electronic publication date as **2023-07-14**; the final journal issue is 2024, and the registry stores those two facts consistently.
 
 This supports:
 
@@ -87,6 +87,11 @@ PMID 41759826; PMCID PMC13197957; DOI `10.1016/j.tjnut.2026.101442`.
 
 The review explicitly revisits the <=90 g/h framework in light of current practice. It notes that 120 g/h can increase exogenous and whole-body carbohydrate oxidation in some trained athletes, but that the **performance efficacy of doses above 90 g/h is not yet sufficiently substantiated** to support a broad recommendation. It also highlights limited female evidence and the need for ecologically valid research.
 
+**Plews et al., 2026 — focused current opinion on ultra-high carbohydrate intake**  
+PMID 42258036; DOI `10.1007/s40279-026-02462-z`.
+
+This June 2026 Sports Medicine paper defines ultra-high intake as >90 g/h and audits why such strategies have spread among elite endurance athletes. It finds a mismatch between real-world adoption and direct performance evidence: higher intakes can increase exogenous carbohydrate oxidation, but studies do not show a consistent dose-response performance benefit beyond roughly 60-90 g/h. The authors conclude that broad ultra-high recommendations are premature, especially for amateur/recreational athletes, while acknowledging possible niche use in selected elite athletes or recovery/multistage contexts. Because this is a current-opinion/narrative synthesis rather than a meta-analysis or guideline, the registry uses it as **supporting context**, not primary efficacy evidence.
+
 Together these support:
 
 `nutrition.endurance.carbohydrate_during_exercise.event_scaled_dose`
@@ -97,7 +102,8 @@ The updated evidence boundary is deliberate:
 
 - the registry does **not** downgrade the established up-to-90 g/h guidance merely because elite cyclists increasingly report 90-120+ g/h;
 - the registry also does **not** claim that 90 g/h is a proven physiological ceiling;
-- >90 g/h is represented as a plausible specialist strategy for selected trained athletes, with performance superiority and generalizability still uncertain.
+- >90 g/h is represented as a plausible specialist strategy for selected trained athletes, with performance superiority and generalizability still uncertain;
+- the newest focused review explicitly argues against copying ultra-high intake as a default gold standard for amateur/recreational athletes.
 
 This prevents a future runtime consumer from turning elite-practice observations into a universal 120 g/h prescription.
 
@@ -137,6 +143,7 @@ Tests verify:
 - carbohydrate efficacy is separated from event-scaled dose guidance;
 - the corrected Ramos-Campo electronic-publication date;
 - contemporary 2026 carbohydrate lineage and the explicit >90 g/h uncertainty boundary;
+- the focused June 2026 ultra-high-carbohydrate source remains supporting context and explicitly cautions against an amateur/recreational 120 g/h default;
 - the hydration safety claim explicitly rejects blanket fluid rates;
 - fueling is not inserted into the current engine coverage inventory;
 - the still-bundled taper family remains uncovered until pre- and post-event policies are separated.

--- a/docs/analysis/2026-08-30-evidence-pack-taper-fueling.md
+++ b/docs/analysis/2026-08-30-evidence-pack-taper-fueling.md
@@ -10,18 +10,20 @@
 
 ## Evidence appraisal
 
-The taper review prioritized endurance-specific systematic reviews/meta-analyses. Fueling used a large acute-carbohydrate meta-analysis, recognized sports-nutrition guidance and the international exercise-associated hyponatremia consensus. The review kept intervention efficacy separate from practical dose guidance and from safety boundaries.
+The taper review prioritized endurance-specific systematic reviews/meta-analyses. Fueling used a large acute-carbohydrate meta-analysis, recognized sports-nutrition guidance, a 2026 contemporary endurance-carbohydrate review and the international exercise-associated hyponatremia consensus. The review kept intervention efficacy separate from practical dose guidance and from safety boundaries.
+
+A specific 2026 update was important because current elite endurance practice increasingly experiments with >90 g/h carbohydrate intake. Contemporary review evidence supports greater carbohydrate oxidation at some higher intakes in trained athletes, but does **not** yet establish a general performance advantage above the established <=90 g/h framework. The registry therefore keeps 30-60 / up-to-90 g/h as contextual practice guidance and records >90 g/h as an emerging, athlete-specific boundary rather than silently treating current peloton practice as validated universal dosing.
 
 ## Taper
 
 ### Evidence
 
-**Wang et al., 2023 — endurance taper systematic review/meta-analysis**
+**Wang et al., 2023 — endurance taper systematic review/meta-analysis**  
 PMID 37163550; PMCID PMC10171681; DOI `10.1371/journal.pone.0282838`.
 
 Fourteen studies were included. Time-trial and time-to-exhaustion performance improved after tapering. Subgroup analyses supported reducing training volume by roughly 41-60% while maintaining intensity/frequency, with effective tapers observed across <=7, 8-14 and 15-21 day windows. The authors concluded that a progressive volume reduction over <=21 days is effective on average.
 
-**Bosquet et al., 2007 — taper meta-analysis**
+**Bosquet et al., 2007 — taper meta-analysis**  
 PMID 17762369; DOI `10.1249/mss.0b013e31806010e0`.
 
 Across 27 studies, the best average strategy was approximately two weeks with an exponential 41-60% volume reduction and no reduction in training intensity or frequency.
@@ -57,10 +59,10 @@ A follow-up inventory refactor should split the family into `periodization.pre_e
 
 ### Carbohydrate efficacy
 
-**Ramos-Campo et al., 2024 — systematic review/meta-analysis/meta-regression**
+**Ramos-Campo et al., 2024 — systematic review/meta-analysis/meta-regression**  
 PMID 37449467; DOI `10.1080/10408398.2023.2233633`.
 
-The analysis included 136 studies and found carbohydrate ingestion during endurance exercise improved performance compared with placebo/control. Benefits were larger as event duration increased.
+The analysis included 136 studies and found carbohydrate ingestion during endurance exercise improved performance compared with placebo/control. Benefits were larger as event duration increased. PubMed records the electronic publication date as **2023-07-14**; the final journal issue is 2024, and the registry now stores those two facts consistently rather than using an off-by-one date.
 
 This supports:
 
@@ -70,15 +72,20 @@ The claim is **high-certainty / strong** for the direction that carbohydrate dur
 
 ### Event-scaled carbohydrate dose
 
-**Burke et al., 2011 — carbohydrate training/competition practice framework**
+**Burke et al., 2011 — carbohydrate training/competition practice framework**  
 PMID 21660838; DOI `10.1080/02640414.2011.585473`.
 
 The framework recommends scaling intake to event demands: small amounts can help around one hour, approximately 30-60 g/h is appropriate for longer events, and events beyond about 2.5 hours may benefit from intakes up to roughly 90 g/h using multiple transportable carbohydrates.
 
-**Thomas, Erdman & Burke, 2016 — joint sports-nutrition position statement**
+**Thomas, Erdman & Burke, 2016 — joint sports-nutrition position statement**  
 PMID 26920240; DOI `10.1016/j.jand.2015.12.006`.
 
 The position statement supports individualized selection, amount and timing of food and fluid across training and competition contexts.
+
+**Morton et al., 2026 — contemporary endurance-carbohydrate review**  
+PMID 41759826; PMCID PMC13197957; DOI `10.1016/j.tjnut.2026.101442`.
+
+The review explicitly revisits the <=90 g/h framework in light of current practice. It notes that 120 g/h can increase exogenous and whole-body carbohydrate oxidation in some trained athletes, but that the **performance efficacy of doses above 90 g/h is not yet sufficiently substantiated** to support a broad recommendation. It also highlights limited female evidence and the need for ecologically valid research.
 
 Together these support:
 
@@ -86,9 +93,17 @@ Together these support:
 
 The practical dose claim is **moderate-certainty / conditional**, not a hard dosing algorithm. Gastrointestinal tolerance, intensity, duration, prior carbohydrate availability and athlete experience remain relevant; high race-day intake should be practiced rather than introduced for the first time during competition.
 
+The updated evidence boundary is deliberate:
+
+- the registry does **not** downgrade the established up-to-90 g/h guidance merely because elite cyclists increasingly report 90-120+ g/h;
+- the registry also does **not** claim that 90 g/h is a proven physiological ceiling;
+- >90 g/h is represented as a plausible specialist strategy for selected trained athletes, with performance superiority and generalizability still uncertain.
+
+This prevents a future runtime consumer from turning elite-practice observations into a universal 120 g/h prescription.
+
 ### Hydration safety
 
-**Hew-Butler et al., 2015 — Third International Exercise-Associated Hyponatremia Consensus**
+**Hew-Butler et al., 2015 — Third International Exercise-Associated Hyponatremia Consensus**  
 PMID 26102445; DOI `10.1097/JSM.0000000000000221`.
 
 The key safety boundary is not “replace every millilitre lost.” Excessive fluid consumption is the principal modifiable behavioral driver of exercise-associated hyponatremia. Fluid strategy must account for sweat rate, environment, duration and individual context without encouraging weight gain from overdrinking.
@@ -120,6 +135,8 @@ Tests verify:
 - 41-60% / <=21-day taper evidence without treating exact app windows as scientific;
 - exact taper windows/restrictions/sharpening remain heuristic product claims;
 - carbohydrate efficacy is separated from event-scaled dose guidance;
+- the corrected Ramos-Campo electronic-publication date;
+- contemporary 2026 carbohydrate lineage and the explicit >90 g/h uncertainty boundary;
 - the hydration safety claim explicitly rejects blanket fluid rates;
 - fueling is not inserted into the current engine coverage inventory;
 - the still-bundled taper family remains uncovered until pre- and post-event policies are separated.

--- a/docs/analysis/2026-08-30-evidence-pack-taper-fueling.md
+++ b/docs/analysis/2026-08-30-evidence-pack-taper-fueling.md
@@ -1,0 +1,131 @@
+# Evidence Pack — Taper + Fueling
+
+**Date:** 2026-08-30
+**Status:** Implemented as an SKR3 evidence migration; recommendation behavior intentionally unchanged.
+
+## Decision questions
+
+1. Which pre-event taper principles are sufficiently established to become reusable sports-knowledge claims, and which exact app taper windows/targets remain product calibration?
+2. Which endurance-fueling principles should be available to future prescriptions without pretending the current engine already has fueling decision authority?
+
+## Evidence appraisal
+
+The taper review prioritized endurance-specific systematic reviews/meta-analyses. Fueling used a large acute-carbohydrate meta-analysis, recognized sports-nutrition guidance and the international exercise-associated hyponatremia consensus. The review kept intervention efficacy separate from practical dose guidance and from safety boundaries.
+
+## Taper
+
+### Evidence
+
+**Wang et al., 2023 — endurance taper systematic review/meta-analysis**
+PMID 37163550; PMCID PMC10171681; DOI `10.1371/journal.pone.0282838`.
+
+Fourteen studies were included. Time-trial and time-to-exhaustion performance improved after tapering. Subgroup analyses supported reducing training volume by roughly 41-60% while maintaining intensity/frequency, with effective tapers observed across <=7, 8-14 and 15-21 day windows. The authors concluded that a progressive volume reduction over <=21 days is effective on average.
+
+**Bosquet et al., 2007 — taper meta-analysis**
+PMID 17762369; DOI `10.1249/mss.0b013e31806010e0`.
+
+Across 27 studies, the best average strategy was approximately two weeks with an exponential 41-60% volume reduction and no reduction in training intensity or frequency.
+
+### Scientific claim
+
+`performance.taper.endurance.pre_event_volume_reduction`
+
+The registered claim supports a substantial pre-event reduction in training volume while meaningful intensity is preserved, generally without sharply reducing frequency. It records the commonly effective 41-60% and <=21-day ranges while explicitly rejecting those averages as universal per-event boundaries.
+
+### Product claims
+
+Exact current app behavior remains separately registered as heuristic policy:
+
+- `policy.taper.windows_volume_v1`: cycling-A race-week-Monday/three-day-minimum logic, A/B 14/5-day fallbacks, intensityScale 1.0 and linear volumeScale toward 0.6;
+- `policy.taper.pre_event_restrictions_v1`: current 1-3 / 1-2 / 3-7 day blocks for strength, hard and exhaustive work;
+- `policy.taper.sharpening_targets_v1`: current internal sharpening/strength-primer target values.
+
+The evidence supports the concepts of fatigue reduction and preserved quality, not those exact internal numbers.
+
+### Important inventory boundary
+
+`periodization.taper_windows_volume` currently bundles two different policies:
+
+1. **pre-event taper**, for which this pack now has direct scientific + product-policy lineage;
+2. **post-event recovery**, where an A event receives three days at volume/intensity 0.4.
+
+This PR intentionally does **not** mark that bundled inventory family covered. Doing so would imply the taper meta-analysis validates the post-event recovery rule, which it does not.
+
+A follow-up inventory refactor should split the family into `periodization.pre_event_taper` and `periodization.post_event_recovery`. The former can then become covered by the claims in this pack; the latter should remain explicit research/product-calibration debt. This is an inventory-model change, not a reason to weaken the epistemic boundary inside the evidence pack.
+
+## Fueling
+
+### Carbohydrate efficacy
+
+**Ramos-Campo et al., 2024 — systematic review/meta-analysis/meta-regression**
+PMID 37449467; DOI `10.1080/10408398.2023.2233633`.
+
+The analysis included 136 studies and found carbohydrate ingestion during endurance exercise improved performance compared with placebo/control. Benefits were larger as event duration increased.
+
+This supports:
+
+`nutrition.endurance.carbohydrate_during_exercise.performance`
+
+The claim is **high-certainty / strong** for the direction that carbohydrate during relevant endurance exercise can improve performance. It deliberately does not turn the pooled result into one universal intake rate.
+
+### Event-scaled carbohydrate dose
+
+**Burke et al., 2011 — carbohydrate training/competition practice framework**
+PMID 21660838; DOI `10.1080/02640414.2011.585473`.
+
+The framework recommends scaling intake to event demands: small amounts can help around one hour, approximately 30-60 g/h is appropriate for longer events, and events beyond about 2.5 hours may benefit from intakes up to roughly 90 g/h using multiple transportable carbohydrates.
+
+**Thomas, Erdman & Burke, 2016 — joint sports-nutrition position statement**
+PMID 26920240; DOI `10.1016/j.jand.2015.12.006`.
+
+The position statement supports individualized selection, amount and timing of food and fluid across training and competition contexts.
+
+Together these support:
+
+`nutrition.endurance.carbohydrate_during_exercise.event_scaled_dose`
+
+The practical dose claim is **moderate-certainty / conditional**, not a hard dosing algorithm. Gastrointestinal tolerance, intensity, duration, prior carbohydrate availability and athlete experience remain relevant; high race-day intake should be practiced rather than introduced for the first time during competition.
+
+### Hydration safety
+
+**Hew-Butler et al., 2015 — Third International Exercise-Associated Hyponatremia Consensus**
+PMID 26102445; DOI `10.1097/JSM.0000000000000221`.
+
+The key safety boundary is not “replace every millilitre lost.” Excessive fluid consumption is the principal modifiable behavioral driver of exercise-associated hyponatremia. Fluid strategy must account for sweat rate, environment, duration and individual context without encouraging weight gain from overdrinking.
+
+This supports:
+
+`nutrition.endurance.hydration.avoid_overdrinking`
+
+The claim is **high-certainty / strong / high-safety**. It explicitly rejects one universal mL/h prescription.
+
+## Why fueling does not enter engine coverage
+
+Repository review found no live engine policy that currently decides carbohydrate grams/hour, fluid volume, sodium intake or race fueling. Therefore adding a `fueling` coverage family now would confuse “science available for a future feature” with “science consumed by current recommendation authority.”
+
+The registry claims are reusable building blocks. A future fueling feature should reference these claim IDs and register any exact product translations separately—for example event-duration bins, chosen g/h targets, tolerance caps or hydration prompts.
+
+## Behavior and policy version
+
+No executable recommendation policy is changed in this PR. It does not modify taper timing, taper volume, pre-event eligibility, sharpening targets, post-event recovery, carbohydrate prescriptions or hydration UI/runtime behavior.
+
+`POLICY_VERSION` remains unchanged.
+
+## Tests
+
+Tests verify:
+
+- canonical registry validity;
+- stable PMID/PMCID/DOI source identity;
+- 41-60% / <=21-day taper evidence without treating exact app windows as scientific;
+- exact taper windows/restrictions/sharpening remain heuristic product claims;
+- carbohydrate efficacy is separated from event-scaled dose guidance;
+- the hydration safety claim explicitly rejects blanket fluid rates;
+- fueling is not inserted into the current engine coverage inventory;
+- the still-bundled taper family remains uncovered until pre- and post-event policies are separated.
+
+## Follow-up
+
+The next small registry-maintenance step should split `periodization.taper_windows_volume` into pre-event taper and post-event recovery coverage families. That will allow the pre-event half to consume this pack honestly without falsely granting evidence authority to the post-event 0.4/0.4 recovery rule.
+
+The high-safety subjective/injury evidence backlog remains separate and unresolved; this pack does not reduce that debt.

--- a/docs/plans/sports-knowledge-registry-follow-up.md
+++ b/docs/plans/sports-knowledge-registry-follow-up.md
@@ -93,12 +93,14 @@ This pack should separate validated symptom/return-to-sport principles from cons
 
 Analysis: `docs/analysis/2026-08-30-evidence-pack-strength-concurrent-training.md`
 
-Added two focused scientific claims:
+Added two focused scientific claims with deliberately different evidence boundaries:
 
-- supplemental strength training can improve endurance performance and economy/efficiency in trained runners and cyclists without reliably increasing VO2max;
-- concurrent endurance and resistance training can develop both domains, while exercise order should be goal/session-quality aware rather than treated as one universal sequence rule.
+- supplemental strength training can improve endurance performance and economy/efficiency in trained runners and cyclists without reliably increasing VO2max; the cross-sport claim is **low-certainty / conditional** because cycling certainty is low, running evidence ranges from very low to moderate, and the umbrella review reports low or critically low confidence for most included reviews;
+- concurrent endurance and resistance training can develop both domains; for chronic adaptation, resistance-before-endurance is the better-supported order when lower-body strength or hypertrophy is the primary target, while sequence appears less important for aerobic development. The evidence does not establish one universal order or a full-calendar-day separation requirement.
 
-The pack adds current running, cycling and umbrella-review evidence while preserving the existing scientific/product boundary. It does **not** relabel the product's three-session strength upper target, 0–1-day heavy-strength/key-cycling exclusion, systemic-cost thresholds, or workout recovery metadata as scientific constants.
+The concurrent claim is explicitly **chronic**. Acute residual fatigue and the quality of a subsequent key cycling/running session are separate questions and are not treated as directly quantified by the umbrella/sequence syntheses. The pack also links the existing elite-athlete consensus as partially direct support for individualized same-day multimodal programming without converting consensus into a fixed recovery interval.
+
+The pack preserves the existing scientific/product boundary. It does **not** relabel the product's three-session strength upper target, 0–1-day heavy-strength/key-cycling exclusion, systemic-cost thresholds, or workout recovery metadata as scientific constants.
 
 This is a lineage-deepening pack rather than a coverage-inflation pack. `spacing.hard_lower_body_recovery` remains **partial / P1** because workout-specific recovery metadata still requires catalog-level audit, and `optimizer.stimulus_benefit_weights` remains **uncovered / P2** because pooled strength-training effects are not optimizer utility coefficients.
 

--- a/docs/plans/sports-knowledge-registry-follow-up.md
+++ b/docs/plans/sports-knowledge-registry-follow-up.md
@@ -106,22 +106,15 @@ Post-pack inventory therefore remains 15 covered / 1 partial / 26 uncovered / 5 
 
 ### Evidence Pack 5 — Taper + Fueling
 
-**Status:** Next
+**Status:** Complete (2026-08-30)
 
-Taper scope:
+Analysis: `docs/analysis/2026-08-30-evidence-pack-taper-fueling.md`
 
-- start with `periodization.taper_windows_volume`, the remaining non-injury P0 family;
-- separate evidence-supported **pre-event taper** from the current product's distinct post-event recovery rule rather than laundering both through one claim;
-- reconcile pre-event strength/hard/exhaustive restrictions and taper-sharpening targets against taper evidence while keeping exact day windows/thresholds explicit product calibration;
-- leave unrelated phase-boundary and multi-event heuristics visible if the taper evidence does not directly answer them.
+Taper work separates direct scientific support for a pre-event volume-reduction taper from the app's exact scheduling, restriction windows and sharpening values. The bundled `periodization.taper_windows_volume` family intentionally remains uncovered because it also contains an independently calibrated three-day post-event recovery rule that taper meta-analysis does not justify.
 
-Fueling scope:
+Fueling work establishes reusable claims for carbohydrate efficacy, event-scaled carbohydrate intake and hydration/overdrinking safety without pretending that the current recommendation engine already has fueling decision authority. The dose boundary now includes contemporary 2026 evidence: >90 g/h can be physiologically plausible for selected trained endurance athletes, but performance superiority is not sufficiently established to make 120 g/h a universal recommendation.
 
-- establish reusable endurance-fueling claims for carbohydrate during exercise, event-duration-scaled carbohydrate intake and hydration/overdrinking safety;
-- distinguish consensus/guideline recommendations from intervention effect evidence and from exact athlete-specific tolerance;
-- do **not** mark an engine policy covered merely because fueling science is strong: the current recommendation engine does not yet give fueling advice decision authority.
-
-A fueling feature can later consume these claims with explicit lineage instead of embedding uncited numbers in UI or prescription text.
+No executable recommendation behavior changes are made and `POLICY_VERSION` remains unchanged.
 
 ### Later SKR3 packs
 


### PR DESCRIPTION
## Summary

- Add SKR3 Evidence Pack 5 for endurance taper and future fueling authority.
- Register one pre-event taper scientific claim, three fueling/hydration scientific claims and three exact taper product-policy claims.
- Keep pre-event taper science separate from exact app scheduling/target values.
- Keep fueling as reusable knowledge only: the current engine has no live carbohydrate/fluid prescription authority, so this PR does not invent a coverage family or runtime consumer.
- Preserve recommendation behavior and `POLICY_VERSION`.

## Stack

This PR is intentionally stacked on #309 (`feat/evidence-pack-strength-concurrent`). Its base is that branch so review shows only the Taper + Fueling delta. The branch has been reconciled with the latest #309 head and is mergeable. Once #309 lands, this PR can be retargeted to `main` without changing Pack 5 semantics.

## Taper evidence boundary

Wang et al. 2023 (PMID 37163550 / PMC10171681) and Bosquet et al. 2007 (PMID 17762369) support a pre-event taper that substantially reduces volume while preserving meaningful intensity and generally frequency. Population-level evidence commonly supports roughly 41–60% volume reduction and tapers up to about 21 days, with an approximately two-week taper often effective.

That does **not** scientifically validate the app's exact:

- cycling-A race-week-Monday / three-day-minimum start;
- A/B 14/5-day defaults;
- linear `volumeScale` endpoint of 0.6;
- `intensityScale` exactly 1.0;
- 1–3 / 1–2 / 3–7 day pre-event blocking windows;
- internal sharpening and strength-primer stimulus values.

Those are registered separately as heuristic product-policy claims.

### Important inventory decision

The current `periodization.taper_windows_volume` coverage family also includes **three days of post-A-event recovery at volume/intensity 0.4**. Taper meta-analysis does not justify that post-event rule.

Therefore this PR deliberately leaves the bundled family uncovered/P0 rather than falsely marking both halves covered. The analysis documents the small follow-up inventory refactor: split pre-event taper from post-event recovery; then the pre-event family can consume this pack while post-event recovery remains explicit debt.

## Fueling evidence boundary

### Carbohydrate during endurance exercise

Ramos-Campo et al. 2024 meta-analysis/meta-regression (PMID 37449467) included 136 studies and found carbohydrate ingestion during endurance exercise improved performance, with greater benefit as duration increased. The registry now records the PubMed electronic-publication date correctly as 2023-07-14 while retaining the 2024 journal issue citation.

Registered claim: `nutrition.endurance.carbohydrate_during_exercise.performance` — high certainty / strong direction of effect.

### Event-scaled carbohydrate intake

Burke et al. 2011 (PMID 21660838) supports duration-scaled practice ranges: commonly ~30–60 g/h for longer events and up to ~90 g/h beyond ~2.5 h when multiple transportable carbohydrates are tolerated. Thomas/Erdman/Burke 2016 (PMID 26920240) reinforces individualized sport-nutrition planning.

The follow-up review also adds Morton et al. 2026 (PMID 41759826 / PMC13197957), which revisits current >90 g/h practice. It supports the important boundary that 120 g/h can increase carbohydrate oxidation in some trained athletes, but performance superiority above the established <=90 g/h framework is **not sufficiently substantiated** to make >90 g/h a general recommendation.

Registered claim: `nutrition.endurance.carbohydrate_during_exercise.event_scaled_dose` — moderate / conditional, explicitly not a mandatory universal dose and explicitly not a universal 120 g/h prescription.

### Hydration safety

The 2015 Exercise-Associated Hyponatremia consensus (PMID 26102445) supports avoiding excessive fluid intake rather than blanket full-replacement rules.

Registered claim: `nutrition.endurance.hydration.avoid_overdrinking` — high certainty / strong / high-safety, with no universal mL/h target.

## Runtime / coverage impact

No executable taper or fueling behavior changes.

- current taper inventory totals remain unchanged because the existing family is epistemically bundled;
- no fueling coverage row is added because no live engine policy currently consumes fueling knowledge;
- no carbohydrate grams/hour, fluid amount or sodium target is introduced into recommendations;
- `POLICY_VERSION` remains unchanged.

## Review follow-up improvements

- corrected Ramos-Campo source metadata (`publishedOn` 2023-07-14 and full 2024 issue/pages);
- added Morton et al. 2026 as contemporary lineage for the >90 g/h evidence boundary;
- added regression tests for stable source IDs, corrected publication date and the explicit 120 g/h uncertainty boundary;
- marked Evidence Pack 5 complete in the SKR roadmap;
- reconciled the stacked branch with all latest #309 follow-up commits while preserving a five-file Pack 5 diff.

## Validation

Added tests cover registry integrity, stable source identities, scientific-vs-product taper boundaries, carbohydrate efficacy vs dose guidance, contemporary >90 g/h uncertainty, hydration overdrinking safety and the absence of fake fueling runtime coverage.

The repository CI workflow is configured for `pull_request.branches: [main]`, so GitHub does not launch CI while this PR is intentionally stacked on the #309 feature branch. A local clone/test attempt from this environment was also blocked by DNS resolution to `github.com`; no test result is being claimed that did not run. Once #309 lands and this PR is retargeted to `main`, normal CI will run.

## Domain invariants

Athlete data handling, Firestore schema/paths, recommendation persistence, event/calendar semantics and numeric recommendation behavior remain unchanged.

## Screenshots or recordings

Not applicable — no UI changes.