### PR TITLE
✍️ Scribe: Index recent analysis documents in docs hub

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -162,6 +162,11 @@ Point-in-time assessments of the system as built, including gaps between documen
 * [**2026-08-30 PR #306 Respiration Shadow-Evidence Hardening**](./analysis/2026-08-30-pr-306-respiration-shadow-review.md) — Engineering and replay semantics review for respiration elevation shadow evidence.
 * [**2026-08-31 Safety Evidence Pack Implementation-Plan Review**](./analysis/2026-08-31-safety-evidence-pack-plan-review.md) — Normative amendments for subjective readiness and injury/pain safety evidence implementation.
 * [**2026-08-31 SKR1 — Persisted Recommendation Knowledge Lineage**](./analysis/2026-08-31-skr1-persisted-knowledge-lineage.md) — Architecture analysis for persisting sports-knowledge identity in historical recommendation audits.
+* [**2026-09-01 Evidence Pack — Injury + Pain**](./analysis/2026-09-01-evidence-pack-injury-pain.md) — SKR3 evidence migration covering injury-constraint, tissue-response, and clinical-symptom policy.
+* [**2026-09-01 Evidence Pack — Subjective Readiness**](./analysis/2026-09-01-evidence-pack-subjective-readiness.md) — Targeted evidence appraisal for the live current-day subjective classifier.
+* [**2026-09-01 PR #321 Structured Strength Warm-ups Review**](./analysis/2026-09-01-pr-321-structured-strength-warmups-review.md) — Follow-up review of structured strength warm-ups and concurrent rest logging.
+* [**2026-09-01 SEP-C1 — Contextual Clinical Envelope Remediation**](./analysis/2026-09-01-sep-c1-contextual-clinical-envelope-remediation.md) — Remediation for decoupling non-allergy illness from the generic Running restriction.
+* [**Structured Strength and Garmin Activity Reconciliation Analysis**](./analysis/structured-strength-garmin-activity-reconciliation-analysis.md) — Architectural analysis for reconciling structured strength executions and Garmin activities into a canonical training occurrence.
 
 ---
 


### PR DESCRIPTION
* **📄 What:** Added five recent analysis and review documents to the `docs/README.md` index under the "Reviews & Analysis" section.
* **⚠️ Problem:** The `docs/README.md` documentation hub acts as the routing table for the project, but five newly added analysis files (including Evidence Packs and SEP-C1 remediation) were missing from the index, making them hard to discover.
* **📚 Source of truth:** The actual `.md` files present in the `docs/analysis/` directory.
* **✅ Verification:** Used `grep` to verify the modified `docs/README.md` and successfully ran the `make check` suite to ensure no regressions were introduced.
* **🎯 Impact:** Documentation users, developers, and AI agents can now discover these critical architectural review and evidence validation documents through the central routing table.
* **🔒 Governance:** This change only updates documentation indices. No product scope, authority, privacy, licensing, or operational limits are changed.

---
*PR created automatically by Jules for task [5503301592466562095](https://jules.google.com/task/5503301592466562095) started by @Szczepanov*