### PR TITLE
docs: analyze strength occurrence credit gap and canonical recommender cutover

### DIFF
--- a/docs/analysis/strength-recommendation-occurrence-credit-gap-2026-09-02.md
+++ b/docs/analysis/strength-recommendation-occurrence-credit-gap-2026-09-02.md
@@ -1,0 +1,359 @@
+# Strength recommendation occurrence-credit gap — 2026-09-02
+
+**Status:** analysis / production reproduction
+**Related architecture:** ADR-0016 (adaptation credit and weekly coverage), ADR-0023 (version-neutral session execution), ADR-0034 (canonical performed-training occurrence)
+**Related PRs:** #321 structured strength execution/logging; #324 canonical multi-source performed-training-occurrence reconciliation
+
+## Executive summary
+
+A real 77-minute strength session performed on 2026-09-01 is visible in Activities as Garmin `strength_training`, and the athlete also recorded sets/reps/RPE/rest in the app. On 2026-09-02 the recommender nevertheless proposes **Reduced Full-body Strength Maintenance** and cites **Weekly Stimulus Target (Full-body Strength)**.
+
+The failure is not that Garmin strength is completely ignored. The current live recommendation history path in `app/src/engine/completedTraining.ts` recognizes a Garmin `strength_training` activity as generic `Strength` and assigns generic inferred strength cost/stimulus. The failure is that this path still reconstructs completed training from two legacy inputs only:
+
+1. raw Garmin activities; and
+2. answered `DailyRecommendation.adherence` records.
+
+It does **not** consume `SessionExecution`, legacy app strength logs normalized through `legacyStrengthAdapter.ts`, or the ADR-0034 `PerformedTrainingOccurrence` projection. Consequently, data can be present in the app's History/Activities UI while remaining unavailable to the recommender's weekly-coverage and recency reasoning.
+
+There are therefore two distinct product questions that are currently conflated:
+
+- **Role fulfillment:** did the athlete perform a session with enough semantic identity to satisfy the exact `primary_strength` weekly role?
+- **Recent exposure / spacing:** did meaningful strength training occur recently, irrespective of whether its exact catalog identity is known?
+
+The existing exact-role rule is intentional and should be preserved. `EVERGREEN_SESSION_COVERAGE.primary_strength` is fulfilled only by `strength_full_body_maintenance_01` or `strength_bodyweight_full_body_01`; arbitrary generic strength must not silently replace it. But a high-confidence strength occurrence yesterday must still influence spacing and recommendation selection. Otherwise the engine can schedule a duplicate full-body strength exposure simply because exact role credit is unresolved.
+
+The recommended fix is therefore **not** “map every Garmin strength activity to `primary_strength`.” It is to cut recommendation history over to the canonical occurrence model and derive two separate facts from each occurrence:
+
+1. `recent_strength_exposure` (broad, occurrence-level, provenance-aware); and
+2. exact weekly-role credit (narrow, semantic-identity-driven).
+
+When app detail exists, app semantics should be authoritative; Garmin should enrich the same occurrence with sensor/timing data. When only sparse Garmin strength exists, the engine should recognize recent strength exposure without fabricating full-body-role completion or strength volume from weak Garmin set metadata.
+
+---
+
+## Production reproduction
+
+### Athlete-observed behavior
+
+**Performed:** 2026-09-01 strength workout, started/logged in the app and also recorded on a Garmin watch.
+
+**Observed on 2026-09-02:** recommender proposes `Reduced Full-body Strength Maintenance` with reasons including:
+
+1. Stable Overnight HRV Signal
+2. Weekly Stimulus Target (Full-body Strength)
+3. Sleep Architecture
+
+**History:** the session is visible as `strength training`.
+
+### Garmin export supplied for the incident
+
+Relevant fields:
+
+| Field | Value |
+|---|---|
+| activityId | `24197884873` |
+| date | `2026-09-01` |
+| type | `strength_training` |
+| durationMin | `77` |
+| averageHr | `85` |
+| trainingEffectAerobic | `0.2` |
+| trainingEffectAnaerobic | `0` |
+| activityTrainingLoad | `2.90245` |
+| intensityTag | `easy` |
+| trainingEffectLabel | `UNKNOWN` |
+| exerciseSets | 15 active set records |
+| syncRunId | `2026-09-02-a86dfbff` |
+| syncedAt | `2026-09-02T06:30:20.797802+00:00` |
+
+The Garmin set payload is sparse:
+
+- only two set rows include an `exerciseCategory` (`SQUAT`, `DEADLIFT`);
+- only one set row includes a concrete `exerciseName` (`BARBELL_DEADLIFT`);
+- many rows have no exercise identity;
+- several rows have missing repetition counts;
+- recorded durations include repeated 120-second values and very long values (for example ~504 s, ~684 s and ~1567 s), which are not safe to interpret as active lifting time per set.
+
+The athlete also reports that the app itself contains the richer set/repetition/RPE/rest log, entered before #321's structured-strength changes were merged.
+
+### What this evidence safely tells us
+
+The Garmin record provides **strong evidence that a strength exposure occurred** on 2026-09-01 and that it occupied approximately 77 minutes of elapsed activity time.
+
+It does **not** provide sufficiently reliable set-level semantics to infer exact full-body role, exercise volume, hard-set count, tonnage, or a precise strength stimulus dose. Garmin's low aerobic training effect / training load also must not be interpreted as “almost no strength stimulus”; those metrics are not a substitute for resistance-training volume/intensity semantics.
+
+The richer app-side log is the preferred source for exercises, sets, reps, load, RPE/rest, and any recoverable prescription identity.
+
+---
+
+## Expected behavior
+
+For this incident, the system should reach one of two safe outcomes depending on what can be recovered from the app record.
+
+### If the app record can be linked to the prescribed/full-body session
+
+- App log + Garmin activity reconcile to **one** `PerformedTrainingOccurrence`.
+- The occurrence receives exact `primary_strength` weekly-role credit **once**.
+- A `recent_strength_exposure` fact is also emitted.
+- The 2026-09-02 recommender should not propose another full-body strength session merely because it believes the weekly strength role is missing.
+- Garmin HR/timing/device information enriches the occurrence; it does not duplicate load or adaptation credit.
+
+### If exact app workout identity cannot be recovered
+
+- App log + Garmin activity still reconcile to **one** occurrence when matching evidence is sufficient.
+- The occurrence is recognized as recent strength training.
+- No fabricated exact `primary_strength` completion is granted merely from `type=strength_training`.
+- The next-day recommender applies strength-spacing/recovery logic and should strongly down-rank or suppress another full-body strength exposure unless there is an explicit policy reason to override that spacing.
+- Weekly role can remain technically unfulfilled/uncertain, but that uncertainty must not be converted into a harmful “do full-body strength again today” default.
+
+---
+
+## Current architecture trace
+
+### 1. Structured execution and legacy strength detail exist outside the live recommender history path
+
+`app/src/services/sessionExecutionService.ts` persists and reads normalized `SessionExecution` plus entries.
+
+`app/src/sessions/legacyStrengthAdapter.ts` already provides a permanent pure read adapter:
+
+`adaptStrengthSessionToNormalizedExecution(session)`
+
+It converts ADR-0021 `StrengthSession` v1 records into a version-neutral execution + entries representation, preserving:
+
+- date/start/completion timestamps;
+- state;
+- session RPE;
+- notes;
+- exercise references/free text;
+- per-set reps;
+- weight;
+- warm-up status;
+- gauge/RPE-like set metadata where present.
+
+This is exactly the kind of data needed to avoid relying on sparse Garmin exercise sets.
+
+However, the adapter deliberately does not invent missing provenance. Its generated session source is generic `legacy_strength`; therefore it cannot, by itself, prove that an arbitrary legacy session was the exact catalog workout `strength_full_body_maintenance_01`.
+
+### 2. ADR-0034 already establishes the canonical physical-workout identity
+
+`app/src/training-occurrence/models.ts` defines `PerformedTrainingOccurrence` as the provider-neutral projection/linkage record for **one physical workout actually performed**.
+
+A canonical occurrence can link:
+
+- one structured execution source; and
+- zero or more provider activities.
+
+`projectionBuilder.ts` explicitly gives structured execution precedence for identity/semantic summary when present.
+
+`activitiesReadModelService.ts` already hydrates canonical occurrences for Activities:
+
+- structured execution + definition + entries provide structured semantics;
+- Garmin provides provider telemetry;
+- Garmin exercise sets are explicitly marked diagnostic-only when a structured source exists.
+
+This is the correct architectural direction for the recommendation system too.
+
+### 3. The live recommendation history path still performs a second reconciliation
+
+`app/src/engine/completedTraining.ts` contains `reconcileCompletedTrainingEvents(...)`.
+
+Its own comment accurately describes the current contract:
+
+> Reconciles Garmin activities with answered adherence records into one real-world training event per session.
+
+Matching is still heuristic:
+
+- same recommendation/activity local date;
+- same inferred modality;
+- event has not already consumed adherence;
+- duration difference <= `ADHERENCE_DURATION_TOLERANCE_MIN`, currently 20 minutes;
+- closest duration wins.
+
+That function does not receive canonical occurrences or `SessionExecution` records. Therefore a session started/logged in the app through the newer execution model can be absent from recommendation history even while it is visible through another read model.
+
+### 4. Generic Garmin strength and exact weekly coverage are deliberately different
+
+`modalityFromActivityType()` maps Garmin types containing `strength`, `weight`, or `lift` to `Strength`, so this incident's Garmin activity is not “unknown.” It receives a generic strength cost/stimulus profile.
+
+But `app/src/workouts/event-plan.ts` defines evergreen `primary_strength` as an **exact workout-role mapping**:
+
+- `strength_full_body_maintenance_01`
+- `strength_bodyweight_full_body_01`
+
+The notes explicitly state that this is an exact full-body resistance exposure. `compact_strength` is also explicitly forbidden from silently replacing the required full-body role.
+
+This exactness is a good invariant. The defect is that generic recent strength exposure currently has no separate authority in recommendation spacing/selection.
+
+---
+
+## Root-cause chain
+
+1. The athlete performs one physical strength session.
+2. App-side strength detail is stored in a session/legacy strength model.
+3. Garmin later syncs a `strength_training` activity for the same physical workout.
+4. ADR-0034 can represent these as one canonical occurrence, and Activities is moving to that read model.
+5. Recommendation history still reads raw Garmin + answered `DailyRecommendation.adherence` instead of the occurrence projection.
+6. If the app session is not represented as the expected adherence record, recommendation history sees only a generic Garmin Strength event.
+7. Generic Garmin Strength cannot satisfy the exact `primary_strength` coverage role.
+8. The weekly-role planner concludes that full-body strength coverage is missing.
+9. No independent canonical “strength happened yesterday” spacing fact blocks or down-ranks a next-day full-body prescription.
+10. Healthy HRV/sleep then make the otherwise-eligible strength candidate look attractive, producing the observed recommendation.
+
+This is a **read-model authority split**, not merely a Garmin set-parsing defect.
+
+---
+
+## Failure matrix
+
+| Performed evidence | Current risk | Required behavior |
+|---|---|---|
+| DailyRecommendation adherence + matching Garmin | Legacy path can merge; closest to intended behavior | One occurrence; one dose/credit |
+| Structured `SessionExecution` + matching Garmin | Activities/canonical layer can know both; live recommendation history may not | Recommender reads canonical occurrence |
+| Legacy app strength log + matching Garmin | Rich app semantics can exist but be invisible to live recommendation history | Normalize legacy log, reconcile once, consume canonical facts |
+| Garmin-only sparse strength | Generic Strength recognized, exact role unresolved | Recent-strength spacing yes; exact `primary_strength` no |
+| Structured strength after #321 + Garmin | New execution detail exists; #321 explicitly did not change recommendation stimulus credit | Canonical occurrence becomes recommendation authority |
+| Two real same-day strength sessions | Duration/date heuristic can be fragile | Preserve two occurrences unless source linkage actually supports merge |
+| Late Garmin sync after recommendation calculation | Recommendation can remain stale | Invalidate/recompute affected daily facts/recommendation |
+
+---
+
+## Why “just trust Garmin sets” is the wrong fix
+
+The incident payload itself demonstrates why.
+
+The 15 Garmin rows do not reliably encode 15 conventional working sets. Exercise identity is mostly missing and elapsed durations are inconsistent with a normal per-set active-duration interpretation. If we translated these fields directly into hard-set count, exercise-region coverage, or volume, the engine could create false certainty.
+
+Recommended evidence policy:
+
+| Fact | Preferred source | Garmin-only fallback |
+|---|---|---|
+| physical strength occurrence happened | canonical occurrence with any trustworthy source | `type=strength_training` is sufficient |
+| exact prescribed workout identity | structured/app prescription link | no fabrication |
+| exercises / sets / reps / load | structured/app entries | diagnostic only unless separately validated |
+| session RPE / rest log | structured/app | absent unless explicitly available |
+| elapsed timing / HR / device telemetry | Garmin/provider | authoritative/enriching where valid |
+| exact weekly `primary_strength` role | known workout identity or explicit semantic classifier with audited confidence | no blanket generic-strength mapping |
+| recent strength spacing | canonical occurrence modality + completion state | yes |
+
+---
+
+## Proposed domain facts
+
+The recommendation engine should stop forcing one boolean to answer both “coverage” and “recent load.”
+
+### A. Broad exposure fact
+
+Conceptual shape:
+
+```ts
+interface RecentStrengthExposureFact {
+  performedOccurrenceId: string;
+  localDate: string;
+  endedAt?: string;
+  confidence: 'exact' | 'high' | 'inferred';
+  provenance: Array<'structured_execution' | 'legacy_strength' | 'garmin'>;
+  completed: boolean;
+}
+```
+
+This fact answers **when strength last happened**. A Garmin-only `strength_training` occurrence can legitimately produce it.
+
+### B. Exact role-credit fact
+
+Conceptual shape:
+
+```ts
+interface WeeklyRoleCreditFact {
+  performedOccurrenceId: string;
+  coverageKey: PlanCoverageKey;
+  workoutId?: string;
+  credit: 'exact' | 'semantic_confident' | 'none';
+  reason: string;
+  provenance: string[];
+}
+```
+
+Initial rollout should remain conservative: exact known workout identity earns exact role credit; generic Garmin modality does not.
+
+A later semantic classifier could grant role credit from sufficiently complete app-side exercise detail, but only under an explicit policy/ADR with tests and provenance. That is not necessary to fix next-day duplicate scheduling.
+
+---
+
+## Legacy strength records from before #321
+
+The incident is particularly important because it crossed a migration boundary: the session was logged before today's structured-strength merge.
+
+The repository already has `adaptStrengthSessionToNormalizedExecution()`. The implementation should reuse it rather than create a third strength-session representation.
+
+However, the adapter's generic `legacy_strength` source means migration logic must distinguish:
+
+1. **what definitely happened** — the detailed strength execution; from
+2. **which catalog/prescribed identity it represented** — recover only when a durable link such as `sourceRecommendationDate`, recommendation/workout metadata, occurrence linkage, or another explicit mapping is available.
+
+If exact identity is absent, preserve uncertainty. The session still protects spacing.
+
+---
+
+## Late-arrival and staleness risk
+
+The supplied Garmin activity was synced at `2026-09-02T06:30:20Z`, after the performed local date of 2026-09-01. Depending on when the morning recommendation was materialized, this may be a second independent failure mode:
+
+- recommendation snapshot calculated before Garmin sync;
+- canonical occurrence is later created/enriched;
+- recommendation cache/facts are not invalidated;
+- UI keeps showing a now-stale recommendation.
+
+The cutover therefore needs an explicit invalidation contract. Any completed-occurrence creation, source attachment, merge, unlink, material semantic edit, or relevant late provider sync within the active lookback/current-decision horizon must invalidate/recompute affected recommendation facts.
+
+The canonical occurrence's athlete-local performed time/date, not provider sync date, must drive weekly windows and spacing.
+
+---
+
+## Invariants that must not regress
+
+1. **One physical workout -> one adaptation/recovery dose.** App + Garmin must never double-count.
+2. **Source semantics have field-level precedence.** App/structured data owns intent/exercises/sets/RPE; Garmin enriches telemetry.
+3. **Generic strength does not silently become exact `primary_strength`.** Preserve ADR-0016/event-plan semantics.
+4. **Recent strength still affects spacing even when role identity is unresolved.** This is the missing behavior in the incident.
+5. **Garmin cardio-oriented load metrics do not erase a resistance-training exposure.** Low TE/load is not evidence that no meaningful strength session occurred.
+6. **Sparse Garmin set rows are diagnostic, not authoritative strength volume.** Existing Activities policy already points this way.
+7. **Late sync changes current facts.** Recommendation state cannot remain indefinitely stale after new performed-training evidence arrives.
+8. **Same-day doubles remain representable.** Avoid reverting to date-only identity.
+9. **Manual reconciliation decisions stay sticky.** Recommender consumes canonical linkage; it does not invent another matcher.
+10. **Historical pre-#321 app logs remain usable.** Reuse the legacy adapter/read-through path.
+
+---
+
+## Observability requirements
+
+For every recommendation reason involving weekly coverage or recency, debug/telemetry should make the evidence legible:
+
+- `performedOccurrenceId`;
+- attached source kinds and stable source IDs;
+- local performed date/time;
+- canonical modality;
+- exact workout identity if known;
+- coverage role credited/not credited;
+- reason for no credit;
+- recent-exposure fact and age;
+- confidence/provenance;
+- recommendation invalidation/recompute version or occurrence watermark.
+
+A future support/debug view should be able to answer, for this incident:
+
+> “We saw one strength occurrence yesterday from app + Garmin. It counts as recent strength. It [does/does not] satisfy `primary_strength` because … . Therefore today’s full-body candidate was [suppressed/eligible] because … .”
+
+---
+
+## Recommended decision
+
+Proceed with a staged recommendation cutover to ADR-0034 rather than patching `completedTraining.ts` with another special-case match.
+
+1. Introduce a canonical occurrence -> recommendation-facts adapter.
+2. Use canonical broad exposure facts for recency/spacing first.
+3. Use structured/app semantic identity for exact weekly-role credit.
+4. Include legacy strength records via the existing normalized adapter/read-through.
+5. Add late-arrival invalidation/recomputation.
+6. Run dual-read parity diagnostics against the old completed-training path.
+7. Remove the raw Garmin + adherence reconciliation path after parity gates pass.
+
+This fixes the reported next-day duplicate-strength behavior while preserving the planner's deliberate distinction between “some resistance training happened” and “the exact required full-body role was fulfilled.”

--- a/docs/plans/strength-recommendation-canonical-occurrence-cutover-plan.md
+++ b/docs/plans/strength-recommendation-canonical-occurrence-cutover-plan.md
@@ -1,0 +1,696 @@
+# Canonical strength occurrence -> recommendation credit cutover
+
+**Status:** implementation plan
+**Motivating incident:** 2026-09-01 strength session followed by a 2026-09-02 duplicate full-body-strength recommendation
+**Depends on:** ADR-0016, ADR-0023, ADR-0034; PR #321 and PR #324
+
+## Goal
+
+Make performed-training evidence used by the recommender consistent with the canonical Activities/history model, so a strength session logged in the app and/or Garmin:
+
+- is represented once;
+- affects next-session spacing even when its exact catalog identity is uncertain;
+- earns exact weekly `primary_strength` credit only when semantics justify it;
+- preserves app-side sets/reps/load/RPE/rest when available;
+- uses Garmin telemetry as enrichment rather than a second dose;
+- updates recommendations after late-arriving performed-training evidence.
+
+The first production target is the reported case:
+
+> A 77-minute `strength_training` activity on 2026-09-01, with richer app-side strength logging for the same physical session, must prevent the 2026-09-02 recommender from choosing another full-body strength session merely because weekly full-body coverage appears unfilled.
+
+---
+
+## Non-goals
+
+This work should **not**:
+
+- treat every Garmin `strength_training` activity as the exact catalog workout `strength_full_body_maintenance_01`;
+- infer reliable hard-set count or tonnage from sparse Garmin exercise-set timing;
+- reinterpret Garmin Training Effect or Garmin training load as resistance-training volume;
+- replace ADR-0034 with a new strength-specific matcher;
+- weaken source-link uniqueness or sticky manual reconciliation decisions;
+- require destructive bulk migration of all historical legacy strength documents;
+- redesign the structured-strength UI introduced by #321;
+- introduce a general ML exercise classifier as a prerequisite for fixing this incident.
+
+---
+
+# Target architecture
+
+## Current live path
+
+```text
+Garmin activities ---------------------> completedTraining.ts -----> recommendation facts
+                                                ^
+DailyRecommendation.adherence ----------|
+
+SessionExecution / legacy StrengthSession -----X
+PerformedTrainingOccurrence ------------------X
+```
+
+`reconcileCompletedTrainingEvents()` performs a second, recommendation-specific date/modality/duration reconciliation independent of ADR-0034.
+
+## Target path
+
+```text
+legacy StrengthSession --legacy adapter--\
+SessionExecution -------------------------> ADR-0034 source reconciliation
+Garmin/provider activity ----------------/             |
+                                                       v
+                                           PerformedTrainingOccurrence
+                                                       |
+                                  +--------------------+-------------------+
+                                  |                                        |
+                                  v                                        v
+                         exposure / spacing facts                  weekly role credit
+                                  |                                        |
+                                  +--------------------+-------------------+
+                                                       v
+                                                recommendation engine
+```
+
+The canonical occurrence answers **which source records describe the same physical workout**. A recommendation-specific fact builder then answers **what programming facts can safely be derived from that occurrence**.
+
+---
+
+# Core design decisions
+
+## D1. Separate recency from role fulfillment
+
+Create two independent derived concepts.
+
+### 1. `PerformedExposureFact`
+
+Broad fact used for spacing/recovery and recent-history reasoning.
+
+Suggested minimum type:
+
+```ts
+export interface PerformedExposureFact {
+  performedOccurrenceId: string;
+  localDate: string;
+  startedAt?: string;
+  endedAt?: string;
+  modality: SessionTemplate['modality'] | 'Unknown';
+  confidence: 'exact' | 'high' | 'inferred' | 'unknown';
+  sourceKinds: Array<'structured_execution' | 'provider_activity' | 'legacy_strength'>;
+  evidenceTier: EvidenceTier;
+}
+```
+
+For strength, a canonical occurrence whose trusted source says `strength_training`/Strength is enough to emit a recent strength exposure. Exact catalog identity is not required.
+
+### 2. `CoverageCreditFact`
+
+Narrow fact used by weekly role accounting.
+
+Suggested shape:
+
+```ts
+export interface CoverageCreditFact {
+  performedOccurrenceId: string;
+  coverageSetId: CoverageSetId;
+  coverageKey: PlanCoverageKey;
+  workoutId?: string;
+  creditKind: 'exact' | 'semantic_confident' | 'none';
+  confidence: number;
+  reasonCode:
+    | 'exact_workout_identity'
+    | 'semantic_classifier'
+    | 'generic_modality_only'
+    | 'insufficient_detail'
+    | 'conflicting_semantics';
+  sourceKinds: string[];
+}
+```
+
+Initial rollout should grant `primary_strength` only for exact known workout identities already declared in the relevant coverage set. `semantic_confident` can remain disabled until an explicit policy is authored.
+
+**Why:** an unclassified strength workout can be recent enough to make another full-body session undesirable while still not being semantically equivalent to the planner's exact full-body role.
+
+---
+
+## D2. Canonical occurrence is the only deduplication identity consumed downstream
+
+Recommendation code must not rematch Garmin to adherence/session execution using a separate heuristic after ADR-0034 has already linked sources.
+
+The legacy `reconcileCompletedTrainingEvents()` function can temporarily remain behind a dual-read/parity path, but the canonical side must never invoke its date/modality/duration matcher.
+
+This preserves:
+
+- one physical workout -> one occurrence;
+- Garmin re-sync idempotency;
+- multiple true same-day sessions;
+- manual link/unlink decisions;
+- merge audit history.
+
+---
+
+## D3. Reuse `legacyStrengthAdapter.ts`; do not invent another migration model
+
+For pre-#321 strength records, reuse:
+
+```ts
+adaptStrengthSessionToNormalizedExecution(session)
+```
+
+That adapter already preserves the historical app detail needed for strength semantics.
+
+Implementation must add/read legacy strength records through the occurrence/fact hydration path without destructively rewriting all history.
+
+Important limitation: the adapter emits a generic `legacy_strength` session source. Therefore it proves execution detail, but it does not automatically prove `strength_full_body_maintenance_01` identity.
+
+Exact role identity should be recovered only from durable evidence already present elsewhere, for example:
+
+- an explicit `SessionExecution.sessionSource` workout id;
+- a `sessionOccurrenceId` / prescription link;
+- recommendation/adherence metadata that names the exact workout;
+- another deterministic persisted relation defined by an ADR/test.
+
+If no such link exists, preserve `workoutId = undefined` and still emit recent-strength exposure.
+
+---
+
+## D4. Field-level source precedence
+
+Use this policy in recommendation hydration/fact derivation.
+
+| Domain field | Authority / precedence |
+|---|---|
+| physical occurrence identity | ADR-0034 canonical occurrence |
+| prescribed workout/template identity | structured execution / persisted recommendation link |
+| exercise identity | structured/app entry first |
+| sets/reps/load | structured/app entry first |
+| session/set RPE, rest events | structured/app first |
+| completion state | structured execution when available; otherwise trustworthy provider completion evidence |
+| canonical modality | structured execution first, provider fallback |
+| elapsed start/end/duration | structured timeline for session-of-record; provider telemetry available as enrichment |
+| HR/device/sensor metrics | Garmin/provider |
+| Garmin exercise sets | diagnostic fallback; never override structured app detail |
+| weekly exact role credit | semantic identity policy, not provider modality alone |
+| recent strength exposure | canonical occurrence + trustworthy modality |
+
+This matches the direction already encoded by `projectionBuilder.ts` and `activitiesReadModelService.ts`.
+
+---
+
+## D5. Sparse Garmin strength means “strength happened,” not “we know its full dose”
+
+For the production fixture:
+
+```text
+type = strength_training
+duration = 77 min
+TE aerobic = 0.2
+TE anaerobic = 0
+activityTrainingLoad ~= 2.9
+15 sparse exercise-set rows
+```
+
+Policy:
+
+- map modality to Strength;
+- emit recent-strength exposure with provider provenance;
+- retain elapsed duration as observed duration;
+- do not derive hard-set count from row count;
+- do not use Garmin TE/load to reduce the occurrence to “negligible strength”;
+- do not infer `primary_strength` solely from modality;
+- if matching app detail exists, use app detail for semantic/dose derivation.
+
+---
+
+## D6. Recommendation invalidation is part of correctness
+
+A canonical occurrence change inside the active recommendation history horizon must invalidate affected derived facts/recommendation snapshots.
+
+Events that require invalidation:
+
+- new occurrence created;
+- provider source attached;
+- structured source attached;
+- two occurrences merged;
+- manual unlink/keep-separate;
+- app execution materially edited/completed;
+- legacy strength record appears/changes;
+- source deletion/tombstone if supported;
+- occurrence local performed date/modality changes after reconciliation.
+
+Use the athlete-local performed date/time to determine the affected window, never `syncedAt`.
+
+A simple initial implementation can store/compare a `trainingHistoryRevision` or occurrence `updatedAt` watermark in the recommendation fact snapshot. If the latest relevant occurrence revision exceeds the snapshot watermark, recompute before returning a cached recommendation.
+
+---
+
+# Proposed implementation sequence
+
+The work is intentionally split so the lowest-risk correctness improvement lands first.
+
+## PR 1 — Canonical exposure facts + dual-read diagnostics
+
+### Purpose
+
+Make canonical occurrences consumable by recommendation code without yet changing weekly role credit.
+
+### Code targets
+
+Add a focused module, e.g.:
+
+- `app/src/engine/performedTrainingFacts.ts`
+- `app/src/engine/performedTrainingFacts.test.ts`
+
+It should depend on:
+
+- `app/src/training-occurrence/repository.ts` / canonical range query;
+- `app/src/training-occurrence/models.ts`;
+- `app/src/services/sessionExecutionService.ts` where structured hydration is needed;
+- existing Garmin/activity service only to hydrate provider metrics by **attached activity id**, not to rematch;
+- `app/src/sessions/legacyStrengthAdapter.ts` for historical app strength detail where the current storage path requires read-through.
+
+### API
+
+Prefer one range-oriented API so all recommendation consumers see one consistent snapshot:
+
+```ts
+getPerformedTrainingFactsInRange(userId, fromLocalDate, toLocalDateExclusive)
+  -> {
+       exposures: PerformedExposureFact[];
+       coverageCredits: CoverageCreditFact[];
+       revision: string;
+     }
+```
+
+### Behavior
+
+- one fact set per active canonical occurrence;
+- provider sources are hydrated by their explicit sourceRefs;
+- structured execution semantics win;
+- generic provider strength creates broad Strength exposure;
+- no change to production selection yet;
+- compare canonical exposure counts/modality/date/identity with the legacy completed-training output;
+- emit structured mismatch counters, not noisy per-session logs by default.
+
+### Required tests
+
+- Garmin-only strength -> one Strength exposure;
+- structured strength + Garmin -> one exposure, not two;
+- re-sync same Garmin id -> unchanged exposure count;
+- two same-day real sessions -> two exposures;
+- occurrence manual keep-separate -> remains two;
+- merged occurrence -> only survivor produces live facts;
+- local date / midnight boundary.
+
+---
+
+## PR 2 — Cut recent-load/spacing to canonical exposure facts
+
+### Purpose
+
+Fix the reported next-day duplicate-strength risk without changing exact weekly-role semantics.
+
+### Changes
+
+Find all recommendation eligibility/spacing logic that currently derives “recent strength” from legacy `CompletedTrainingEvent`/history. Route it to `PerformedExposureFact`.
+
+Add a named policy instead of embedding a one-off check in the full-body workout selector, for example:
+
+```ts
+strengthSpacingStatus(exposures, now, candidate)
+```
+
+The policy should consider:
+
+- most recent completed Strength exposure;
+- elapsed/local days since exposure;
+- candidate lower-body/systemic/neuromuscular cost;
+- existing readiness/tissue gates;
+- whether candidate is a recovery-safe/upper-only exception.
+
+Exact spacing thresholds should come from existing planner/recovery policy if already defined; this PR must not invent a new sports-science constant merely to pass the fixture. If no explicit threshold exists, author that policy separately and make it configurable/tested.
+
+### Production acceptance for the incident
+
+Given a 2026-09-01 canonical Strength occurrence, the 2026-09-02 engine must not choose `strength_full_body_maintenance_01` / reduced full-body strength **solely to close an unfulfilled weekly strength role** while ignoring the recent exposure.
+
+If another policy deliberately chooses strength despite the recent exposure, rationale must explicitly show that override; a weekly-target reason alone is insufficient.
+
+### Required regression tests
+
+- previous-day Garmin-only strength suppresses/down-ranks duplicate full-body candidate;
+- previous-day app-only structured strength does the same;
+- matching app + Garmin remains one exposure;
+- upper-body/trunk conditional alternative is not incorrectly treated as equivalent to full-body role;
+- cycling/running recent-exposure behavior remains unchanged.
+
+---
+
+## PR 3 — Cut weekly coverage credit to canonical semantic identity
+
+### Purpose
+
+Make `Weekly Stimulus Target (Full-body Strength)` derive from the same occurrence truth while preserving exact coverage semantics.
+
+### Algorithm
+
+For each active canonical occurrence:
+
+1. Resolve attached structured execution, if any.
+2. Resolve exact workout/prescription identity from `SessionExecution.sessionSource`, `sessionOccurrenceId`, prescription hash, or persisted recommendation link.
+3. Look up the active `CoverageSetDescriptor`.
+4. Grant each matching role once per occurrence.
+5. If only generic modality is known, emit `creditKind='none'` with `reasonCode='generic_modality_only'`.
+6. Never award the same role twice because both Garmin and app sources exist.
+
+For evergreen general training today:
+
+`primary_strength` maps to:
+
+- `strength_full_body_maintenance_01`
+- `strength_bodyweight_full_body_01`
+
+Do not broaden this mapping in the cutover PR.
+
+### Legacy app session handling
+
+For pre-#321 records:
+
+- normalize via `adaptStrengthSessionToNormalizedExecution()`;
+- recover exact workout identity only where a deterministic persisted link exists;
+- otherwise leave role credit unresolved while still preserving recent Strength exposure.
+
+If production data proves that `sourceRecommendationDate` can deterministically join one legacy strength session to one recommendation/workout on that date, implement that join with explicit collision handling and tests. Do not use “same date = same workout” when multiple candidate strength prescriptions/sessions are possible.
+
+### Required tests
+
+- exact `strength_full_body_maintenance_01` execution -> one `primary_strength` credit;
+- exact `strength_bodyweight_full_body_01` -> one `primary_strength` credit;
+- `strength_compact_power_01` -> no `primary_strength` credit;
+- generic Garmin Strength -> no exact `primary_strength` credit;
+- app+Garmin exact full-body -> one credit, not two;
+- exact catalog identity survives source arrival in either order;
+- unknown/legacy identity remains uncredited but observable.
+
+---
+
+## PR 4 — Late-sync invalidation + legacy history horizon
+
+### Purpose
+
+Ensure morning recommendations update when performed-training evidence arrives after the initial decision snapshot.
+
+### Changes
+
+- introduce/extend recommendation fact revision watermark;
+- update it when canonical occurrences or relevant source semantics change;
+- recompute current-day recommendation facts when a source affecting the lookback arrives;
+- ensure Garmin sync completion publishes/causes occurrence reconciliation before recommendation freshness is checked;
+- ensure legacy strength read-through covers at least the maximum recommendation lookback plus a small safety buffer;
+- do not use sync date as performed date.
+
+### Required tests
+
+Timeline fixture:
+
+1. recommendation computed at T0;
+2. Garmin activity for previous day syncs at T1;
+3. occurrence created/attached at T2;
+4. same current-day recommendation request at T3 sees a newer training-history revision and recomputes;
+5. returned recommendation includes the new recent Strength exposure.
+
+Also test:
+
+- week boundary Sunday/Monday;
+- DST / Warsaw-local calendar behavior;
+- provider source with adjacent provider-local date but canonical local date from structured execution;
+- repeated same sync run is idempotent.
+
+---
+
+## PR 5 — Remove recommendation-specific reconciliation
+
+### Entry gate
+
+Do this only after dual-read telemetry shows acceptable parity and all known differences are intentional.
+
+### Changes
+
+- remove/retire raw Garmin + `DailyRecommendation.adherence` matching from the live recommendation path;
+- keep pure cost/stimulus helpers from `completedTraining.ts` if still useful, but feed them canonical facts;
+- delete dead duration/date matching logic once no live consumer needs it;
+- remove obsolete shadow flags/diagnostics after a soak period.
+
+### Exit invariant
+
+There is one matcher for physical workout identity: ADR-0034.
+
+---
+
+# Data model and hydration details
+
+## Canonical source facts should remain minimal
+
+Do **not** inflate `PerformedTrainingOccurrence` into a giant mutable copy of every source field. ADR-0034 correctly keeps source records non-destructively linked.
+
+Recommendation fact hydration should fetch the attached sources and derive what it needs.
+
+This prevents stale duplicated exercise/HR fields and preserves auditability.
+
+## Legacy strength source representation
+
+Two implementation options are acceptable, in preference order:
+
+### Option A — expose legacy strength through the normalized execution repository/read layer
+
+If the repository already has a version-neutral execution query that can include legacy `StrengthSession` via adapter, use it. ADR-0034 then sees an execution source without any bespoke legacy occurrence type.
+
+### Option B — materialize a structured source on demand/rebuild
+
+If reconciliation currently only discovers persisted `SessionExecution`, extend rebuild/source discovery to feed an adapted legacy normalized execution as reconciliation input without destructive migration.
+
+Whichever option is selected, preserve stable source identity so repeated rebuilds do not create new occurrences.
+
+## App RPE/rest detail
+
+#321 adds richer structured rest/execution logging. Fact derivation should prefer that detail when available but remain backwards compatible:
+
+- missing rest events in old sessions are unknown, not zero;
+- missing RPE is unknown, not easy;
+- no attempt should be made to synthesize structured rest from Garmin set durations.
+
+---
+
+# Recommendation policy contract
+
+## Weekly target cannot override unresolved next-day strength exposure silently
+
+When:
+
+- `primary_strength` exact weekly credit is absent; **and**
+- a recent canonical Strength exposure exists;
+
+selection should not simply interpret the target as “schedule full-body strength now.”
+
+The selector needs an explicit state, conceptually:
+
+```ts
+{
+  weeklyRole: 'fulfilled' | 'unfulfilled' | 'uncertain',
+  recentExposure: 'none' | 'recent' | 'very_recent',
+}
+```
+
+The reported case is expected to be either:
+
+- `fulfilled + very_recent`, if exact legacy/app identity is recoverable; or
+- `unfulfilled/uncertain + very_recent`, if it is not.
+
+Neither state should produce an unqualified next-day full-body recommendation just because sleep/HRV are green.
+
+## Rationale requirements
+
+Replace opaque target-only reasoning with evidence-aware language/data.
+
+Internal reason payload should include:
+
+```ts
+{
+  reasonCode: 'weekly_strength_role' | 'recent_strength_spacing' | ...,
+  performedOccurrenceIds: string[],
+  roleCreditStatus?: 'fulfilled' | 'unfulfilled' | 'uncertain',
+  lastStrengthLocalDate?: string,
+  confidence?: string,
+  sourceKinds?: string[],
+}
+```
+
+UI wording can remain concise, but debugging must retain the structured evidence.
+
+---
+
+# Test fixture based on the production export
+
+Add an anonymized deterministic fixture reproducing the important shape of activity `24197884873` (the exact external ID may be replaced in tests):
+
+```ts
+{
+  date: '2026-09-01',
+  type: 'strength_training',
+  durationMin: 77,
+  trainingEffectAerobic: 0.2,
+  trainingEffectAnaerobic: 0,
+  averageHr: 85,
+  activityTrainingLoad: 2.9,
+  intensityTag: 'easy',
+  exerciseSets: [
+    { setType: 'active', repetitionCount: 2, exerciseCategory: 'SQUAT', durationSeconds: 120 },
+    { setType: 'active', repetitionCount: 5, exerciseCategory: 'DEADLIFT', exerciseName: 'BARBELL_DEADLIFT', durationSeconds: 327.627 },
+    { setType: 'active', repetitionCount: 5, durationSeconds: 1566.736 },
+    // plus sparse rows representative of the export
+  ]
+}
+```
+
+Pair it with:
+
+1. a legacy app `StrengthSession` containing richer exercise/set/RPE data;
+2. a structured #321 `SessionExecution` version of the same scenario;
+3. a Garmin-only variant.
+
+Assertions must verify behavior, not just parsing.
+
+---
+
+# Full acceptance matrix
+
+## Identity / deduplication
+
+- [ ] app execution + matching Garmin = one canonical occurrence
+- [ ] legacy app strength + matching Garmin = one canonical occurrence/read fact set
+- [ ] Garmin re-sync is idempotent
+- [ ] source arrival order does not change final semantics
+- [ ] two legitimate same-day strength workouts stay separate
+- [ ] manual keep-separate/unlink is respected by recommendation facts
+- [ ] merged loser occurrence never emits live duplicate facts
+
+## Strength semantics
+
+- [ ] app exercises/sets/reps/load/RPE survive hydration
+- [ ] Garmin set rows do not override app detail
+- [ ] Garmin-only strength emits recent Strength exposure
+- [ ] low Garmin TE/training load does not erase strength occurrence
+- [ ] sparse Garmin set rows do not become fabricated hard-set volume
+- [ ] missing old RPE/rest is represented as unknown
+
+## Weekly coverage
+
+- [ ] exact full-body maintenance workout earns `primary_strength` once
+- [ ] bodyweight full-body workout earns `primary_strength` once
+- [ ] compact strength does not silently satisfy `primary_strength`
+- [ ] upper-body/trunk does not satisfy `primary_strength`
+- [ ] generic Garmin strength does not automatically satisfy `primary_strength`
+- [ ] unresolved legacy identity produces explicit no/uncertain credit reason
+
+## Spacing / recommendation selection
+
+- [ ] previous-day Strength exposure influences full-body candidate eligibility/ranking
+- [ ] reported 2026-09-01 -> 2026-09-02 reproduction no longer yields duplicate full-body strength solely from weekly target
+- [ ] green HRV/sleep cannot bypass recent-strength spacing without explicit policy
+- [ ] if a deliberate override exists, rationale shows it
+- [ ] cycling/running recommendations are unchanged unless their own canonical facts differ intentionally
+
+## Time / freshness
+
+- [ ] local performed date drives history, not sync date
+- [ ] midnight boundary handled
+- [ ] week boundary handled
+- [ ] late Garmin sync invalidates/recomputes current recommendation facts
+- [ ] edited app session invalidates/recomputes facts
+- [ ] repeated sync with no semantic change does not cause recompute churn
+
+## Explainability / telemetry
+
+- [ ] reason can name contributing occurrence ids
+- [ ] role credit/no-credit reason is inspectable
+- [ ] source provenance/confidence recorded
+- [ ] dual-read mismatch counters exist during rollout
+- [ ] no PII/raw notes are added to telemetry payloads
+
+---
+
+# Rollout and safety gates
+
+## Phase A — shadow
+
+- build canonical facts in parallel;
+- compare occurrence count, modality, local date, exact workout identity, weekly role credits, and recent-exposure status;
+- categorize differences (`legacy_duplicate`, `canonical_linked`, `legacy_missing_execution`, `role_credit_changed`, `time_boundary`, etc.).
+
+## Phase B — recency cutover
+
+- canonical facts become authoritative only for recent-exposure/spacing;
+- weekly role remains old path temporarily;
+- monitor strength recommendation rate on day +1 after strength occurrences.
+
+## Phase C — role-credit cutover
+
+- canonical semantic identity becomes authoritative for weekly coverage;
+- compare role-credit deltas before serving.
+
+## Phase D — freshness/invalidation on
+
+- enforce occurrence revision watermark for current recommendations.
+
+## Phase E — legacy path removal
+
+- remove recommendation-specific matching after an agreed soak window and no unexplained high-severity deltas.
+
+### Rollback
+
+Maintain a temporary runtime flag around canonical recommendation facts until Phase E. Rollback should switch the **consumer** back, not delete canonical occurrence/source data.
+
+---
+
+# Metrics
+
+Recommended counters/gauges:
+
+- `training_occurrence.recommendation_fact_occurrences`
+- `training_occurrence.recommendation_fact_strength_exposures`
+- `training_occurrence.recommendation_fact_exact_role_credits`
+- `training_occurrence.recommendation_fact_unresolved_strength_role`
+- `training_occurrence.recommendation_dual_read_mismatch{reason}`
+- `training_occurrence.late_evidence_recommendation_invalidations`
+- `training_occurrence.duplicate_source_credit_prevented`
+
+Product-level guardrail:
+
+- rate of full-body strength recommendations within one local day after a completed Strength occurrence, segmented by explicit override reason.
+
+That should approach zero except where a deliberately authored policy permits it.
+
+---
+
+# Documentation updates required during implementation
+
+- update ADR-0034 when recommendation read authority is no longer shadow-only;
+- update ADR-0016 to make the distinction between broad exposure facts and exact weekly role credit explicit;
+- update the structured-strength/Garmin reconciliation analysis with the final source-precedence implementation;
+- document recommendation invalidation/revision semantics;
+- document legacy strength read-through behavior and retention horizon.
+
+---
+
+# Definition of done
+
+This initiative is complete when:
+
+1. the recommender no longer performs an independent raw Garmin/adherence identity match for live history;
+2. all performed-training recommendation facts come from active ADR-0034 occurrences;
+3. app + Garmin for one physical session are credited once;
+4. pre-#321 strength logs can contribute through the existing legacy adapter/read-through;
+5. generic strength reliably affects spacing without falsely satisfying exact full-body coverage;
+6. exact app/prescription identity satisfies `primary_strength` once when known;
+7. late-arriving provider/app evidence makes current recommendations fresh;
+8. the supplied 2026-09-01 production reproduction is covered by an automated regression test;
+9. rationale/debug output can explain both recent strength exposure and weekly role status;
+10. legacy recommendation-specific reconciliation has been removed after parity rollout.


### PR DESCRIPTION
## Summary

Documents a production strength-history/recommendation inconsistency observed on **2026-09-02** and proposes the staged implementation plan to fix it without weakening exact weekly-role semantics.

The motivating case is a **77-minute strength session performed on 2026-09-01** that:

- was recorded on Garmin as `strength_training`;
- was also started/logged in the app with richer sets/reps/RPE/rest detail;
- appears in History as strength training;
- nevertheless left the recommender proposing **Reduced Full-body Strength Maintenance** the next day with **Weekly Stimulus Target (Full-body Strength)** as a reason.

This PR is intentionally **analysis + implementation planning only**. It does not change recommendation behavior yet.

## Root cause

The repo now has two increasingly different completed-training read paths:

1. ADR-0034 / PR #324 canonical `PerformedTrainingOccurrence`, which can link structured execution and Garmin/provider evidence for one physical workout and already backs the evolving Activities read model; and
2. the live recommendation path in `app/src/engine/completedTraining.ts`, where `reconcileCompletedTrainingEvents()` still independently reconciles only raw Garmin activities with answered `DailyRecommendation.adherence` records using date + modality + a ±20-minute duration heuristic.

The live recommender path does **not** consume `SessionExecution`, pre-#321 legacy app strength detail normalized by `legacyStrengthAdapter.ts`, or the ADR-0034 canonical occurrence projection.

That creates the observed authority split: a workout can be visible in History and even recognized as generic Garmin Strength, but still lack the semantic evidence the weekly-coverage engine needs.

## Important distinction preserved by the proposal

The fix is **not** to map every Garmin `strength_training` activity to `primary_strength`.

`EVERGREEN_SESSION_COVERAGE.primary_strength` intentionally requires exact full-body workout identities (`strength_full_body_maintenance_01` / `strength_bodyweight_full_body_01`). Generic strength should not silently replace that role.

Instead, the plan separates two facts that the current behavior effectively conflates:

- **recent strength exposure / spacing** — broad occurrence-level evidence that strength happened recently;
- **exact weekly role credit** — narrow semantic evidence that the required full-body role was fulfilled.

A Garmin-only strength occurrence can safely answer the first question without fabricating the second.

## Why the supplied Garmin sets are not enough for exact credit

The production export has 15 active set rows, but only two carry exercise categories and only one carries a concrete exercise name. Several rows are missing reps and include implausibly long/repeated durations. Garmin TE/load are also very low despite a 77-minute strength workout.

The docs therefore propose:

- app/structured/legacy-app detail is authoritative for exercises, sets, reps, load, RPE/rest and known workout identity;
- Garmin enriches elapsed timing, HR, device/provider telemetry;
- sparse Garmin set rows remain diagnostic when better app detail exists;
- low Garmin cardio-oriented Training Effect/load never means “no meaningful strength exposure.”

## Relationship to recent PRs

### PR #321

#321 added structured strength execution/logging but explicitly did not cut stimulus credit or recommendation selection over to that model.

### PR #324

#324 added the canonical multi-source performed-training occurrence and Activities-side reconciliation/read-model work, but the recommendation engine remains intentionally outside that cutover/shadow boundary.

This incident is therefore the concrete production case motivating the next ADR-0034 consumer migration.

## Proposed implementation sequence

The implementation plan is split into five follow-up PRs:

1. **Canonical recommendation facts + dual-read diagnostics**
   - build occurrence-derived exposure/coverage facts;
   - no production selection change yet.

2. **Cut strength recency/spacing to canonical exposure facts**
   - lowest-risk behavioral fix for the reported next-day duplicate-strength issue;
   - previous-day generic Strength can suppress/down-rank another full-body exposure even when exact role identity is unresolved.

3. **Cut weekly role credit to canonical semantic identity**
   - exact known full-body workout identity earns `primary_strength` once;
   - generic Garmin Strength remains uncredited for the exact role.

4. **Late-sync invalidation + legacy-history support**
   - recompute current recommendations when previous-day performed-training evidence arrives after the first recommendation snapshot;
   - reuse the existing `adaptStrengthSessionToNormalizedExecution()` path for pre-#321 sessions.

5. **Remove recommendation-specific raw Garmin/adherence reconciliation**
   - after parity/soak gates, ADR-0034 becomes the single matcher for physical workout identity.

## Production acceptance case

For the reported scenario:

- the app log and Garmin activity must represent **one** physical occurrence;
- richer app semantics survive and Garmin telemetry enriches them;
- the occurrence creates a recent Strength exposure;
- if exact full-body/prescription identity is recoverable, `primary_strength` is credited exactly once;
- if identity is not recoverable, no fake exact role credit is granted, but the next-day engine still respects recent-strength spacing;
- a full-body strength recommendation on 2026-09-02 cannot be justified solely by “weekly full-body target is unfulfilled” while ignoring the 2026-09-01 strength occurrence;
- late Garmin arrival invalidates/recomputes stale recommendation facts.

## Test/rollout coverage in the plan

The plan includes regression cases for:

- legacy app strength + Garmin;
- #321 structured execution + Garmin;
- Garmin-only sparse strength;
- app-only strength;
- repeated Garmin resync;
- two legitimate same-day strength sessions;
- source arrival in either order;
- manual keep-separate/unlink;
- week/midnight/timezone boundaries;
- late provider sync after recommendation materialization;
- exact full-body vs compact/upper-body role credit;
- no double adaptation/recovery credit;
- rationale provenance and explicit credit/no-credit reasons.

## Files

- `docs/analysis/strength-recommendation-occurrence-credit-gap-2026-09-02.md`
  - production reproduction;
  - evidence-quality analysis;
  - current read-path trace;
  - root-cause chain;
  - failure matrix;
  - invariants and recommended domain facts.

- `docs/plans/strength-recommendation-canonical-occurrence-cutover-plan.md`
  - target architecture;
  - source precedence;
  - staged PR sequence;
  - legacy-strength handling;
  - late-sync invalidation;
  - test fixture and full acceptance matrix;
  - rollout/rollback/metrics;
  - definition of done.

## Key design invariant

> One physical workout should create one canonical occurrence and one recovery/adaptation dose. Exact weekly-role credit requires semantic evidence, while recent exposure/spacing requires only trustworthy evidence that the modality actually occurred.

This preserves planner precision while fixing the unsafe blind spot exposed by the production session.