### PR TITLE
fix(engine): isolate performed facts I/O service outside pure engine

### DIFF
--- a/app/src/engine/performedTrainingFacts.test.ts
+++ b/app/src/engine/performedTrainingFacts.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
     deriveFactsFromOccurrence,
-    getPerformedTrainingFactsInRange,
     compareCanonicalVsLegacyFacts,
     normalizeModality,
     templateIdForWorkoutId,
     type PerformedExposureFact,
     type HydratedOccurrenceContext,
 } from './performedTrainingFacts';
+import { getPerformedTrainingFactsInRange } from '../training-occurrence/performedTrainingFactsService';
 import type { PerformedTrainingOccurrence } from '../training-occurrence/models';
 import { performedTrainingOccurrenceRepository as repository } from '../training-occurrence/repository';
 import { activityService } from '../services/activityService';

--- a/app/src/engine/performedTrainingFacts.ts
+++ b/app/src/engine/performedTrainingFacts.ts
@@ -13,19 +13,10 @@
 import type { SessionTemplate, EvidenceTier, NormalizedGarminActivity, CompletedTrainingEvent } from './models';
 import type { CoverageSetId, PlanCoverageKey, CoverageSetDescriptor } from '../workouts/event-plan';
 import { EVERGREEN_GENERAL_COVERAGE_SET } from '../workouts/event-plan';
-import { WORKOUTS_BY_ID } from '../workouts/catalog';
 import { workoutForTemplate } from '../workouts/prescription';
 import { ENRICHED_TEMPLATES } from './templates';
-import {
-    isProviderActivityRef,
-    isStructuredExecutionRef,
-    type PerformedTrainingOccurrence,
-} from '../training-occurrence/models';
-import { performedTrainingOccurrenceRepository as repository } from '../training-occurrence/repository';
-import { sessionExecutionService } from '../services/sessionExecutionService';
-import { activityService } from '../services/activityService';
-import { resolveSessionDefinition } from '../sessions/sessionDefinitionResolver';
-import { getLocalDateString, getPreviousLocalDateString } from '../utils/localDate';
+import type { PerformedTrainingOccurrence } from '../training-occurrence/models';
+import { getLocalDateString } from '../utils/localDate';
 import { classifyGarminTier } from './completedTraining';
 
 export type FactConfidence = 'exact' | 'high' | 'inferred' | 'unknown';
@@ -95,7 +86,7 @@ export function templateIdForWorkoutId(workoutId: string): string | undefined {
     return matches.length === 1 ? matches[0].id : undefined;
 }
 
-function categoryForWorkoutId(workoutId: string): SessionTemplate['category'] | undefined {
+export function categoryForWorkoutId(workoutId: string): SessionTemplate['category'] | undefined {
     const matches = templatesForWorkoutId(workoutId);
     if (matches.length === 0) return undefined;
     const categories = new Set(matches.map(template => template.category));
@@ -312,152 +303,7 @@ export function deriveFactsFromOccurrence(
     return { exposure, coverageCredits };
 }
 
-export interface GetPerformedTrainingFactsOptions {
-    preloadedActivities?: NormalizedGarminActivity[];
-    coverageSetDescriptor?: CoverageSetDescriptor;
-}
 
-/**
- * Range query returning canonical recommendation facts.
- * Range convention: `fromDateInclusive` <= localDate < `toDateExclusive`.
- */
-export async function getPerformedTrainingFactsInRange(
-    userId: string,
-    fromDateInclusive: string,
-    toDateExclusive: string,
-    options: GetPerformedTrainingFactsOptions = {},
-): Promise<PerformedTrainingFactsSnapshot> {
-    const toDateInclusive = getPreviousLocalDateString(toDateExclusive);
-    if (toDateInclusive < fromDateInclusive) {
-        return {
-            asOfDate: toDateExclusive,
-            windowDays: 0,
-            revision: `canonical-facts-v1:${fromDateInclusive}:${toDateExclusive}:empty`,
-            exposures: [],
-            coverageCredits: [],
-        };
-    }
-
-    const activeOccurrences = await repository.queryActiveInDateWindow(userId, fromDateInclusive, toDateInclusive);
-
-    let activitiesById: Map<string, NormalizedGarminActivity>;
-    if (options.preloadedActivities) {
-        activitiesById = new Map(options.preloadedActivities.map(a => [a.activityId, a]));
-    } else {
-        const activitiesState = await activityService.getActivitiesInRange(userId, fromDateInclusive, toDateExclusive);
-        const activities = activitiesState.status === 'AVAILABLE' ? activitiesState.data : [];
-        activitiesById = new Map(activities.map(a => [a.activityId, a]));
-    }
-
-    const descriptor = options.coverageSetDescriptor ?? EVERGREEN_GENERAL_COVERAGE_SET;
-    const exposures: PerformedExposureFact[] = [];
-    const coverageCredits: CoverageCreditFact[] = [];
-
-    for (const occurrence of activeOccurrences) {
-        const structuredRef = occurrence.sourceRefs.find(isStructuredExecutionRef);
-        const garminRef = occurrence.sourceRefs
-            .filter(isProviderActivityRef)
-            .find(ref => ref.provider.toLowerCase() === 'garmin');
-
-        const hydrated: HydratedOccurrenceContext = {};
-
-        if (structuredRef) {
-            const execState = await sessionExecutionService.getExecution(userId, structuredRef.executionId);
-            if (execState.status === 'AVAILABLE') {
-                const execution = execState.data;
-                let workoutId: string | undefined;
-                let templateId: string | undefined;
-                let category: SessionTemplate['category'] | undefined;
-                let isLegacyStrength = false;
-
-                if (execution.sessionSource.kind === 'catalog') {
-                    if (execution.sessionSource.workoutId === 'legacy_strength') {
-                        isLegacyStrength = true;
-                    } else {
-                        workoutId = execution.sessionSource.workoutId;
-                        templateId = templateIdForWorkoutId(workoutId);
-                        category = categoryForWorkoutId(workoutId);
-                    }
-                } else if (execution.sessionSource.kind === 'manual' && execution.sessionSource.definitionId === 'legacy_strength') {
-                    isLegacyStrength = true;
-                }
-
-                let executionModality: SessionTemplate['modality'] | undefined;
-                if (workoutId) {
-                    const workout = WORKOUTS_BY_ID.get(workoutId);
-                    if (workout?.modality) {
-                        const m = normalizeModality(workout.modality);
-                        if (m !== 'Unknown') executionModality = m;
-                    }
-                }
-
-                const defState = await resolveSessionDefinition(userId, execution.sessionSource, execution.prescriptionHash);
-                if (defState.status === 'AVAILABLE') {
-                    const def = defState.data;
-                    if (!executionModality && def.dominantModality) {
-                        const m = normalizeModality(def.dominantModality);
-                        if (m !== 'Unknown') executionModality = m;
-                    }
-                }
-
-                if (!executionModality && isLegacyStrength) {
-                    executionModality = 'Strength';
-                }
-
-                const durationMin = execution.completedAt && execution.startedAt
-                    ? Math.max(0, Math.round((Date.parse(execution.completedAt) - Date.parse(execution.startedAt)) / 60000))
-                    : undefined;
-
-                hydrated.structured = {
-                    executionId: execution.executionId,
-                    ...(workoutId ? { workoutId } : {}),
-                    ...(templateId ? { templateId } : {}),
-                    ...(executionModality ? { modality: executionModality } : {}),
-                    ...(category ? { category } : {}),
-                    startedAt: execution.startedAt,
-                    ...(execution.completedAt ? { endedAt: execution.completedAt } : {}),
-                    ...(durationMin !== undefined ? { durationMin } : {}),
-                    isLegacyStrength,
-                };
-            }
-        }
-
-        if (garminRef) {
-            const garminActivity = activitiesById.get(garminRef.activityId);
-            const providerModality = garminActivity ? normalizeModality(garminActivity.type) : undefined;
-            const duration = garminActivity?.durationMin;
-            hydrated.provider = {
-                activityId: garminRef.activityId,
-                provider: garminRef.provider,
-                ...(providerModality ? { modality: providerModality } : {}),
-                ...(garminActivity?.startedAt ? { startedAt: garminActivity.startedAt } : {}),
-                ...(garminActivity?.endedAt ? { endedAt: garminActivity.endedAt } : {}),
-                ...(duration !== null && duration !== undefined ? { durationMin: duration } : {}),
-                ...(garminActivity ? { garminActivity } : {}),
-            };
-        }
-
-        const facts = deriveFactsFromOccurrence(occurrence, hydrated, descriptor);
-        exposures.push(facts.exposure);
-        coverageCredits.push(...facts.coverageCredits);
-    }
-
-    exposures.sort((a, b) => a.localDate.localeCompare(b.localDate));
-
-    const occurrenceRevision = activeOccurrences
-        .map(o => `${o.performedOccurrenceId}:${o.updatedAt}`)
-        .sort()
-        .join('|');
-    const revision = `canonical-facts-v1:${fromDateInclusive}:${toDateExclusive}:${occurrenceRevision}`;
-
-    return {
-        asOfDate: toDateExclusive,
-        windowDays: Math.max(1, Math.round((Date.parse(toDateExclusive) - Date.parse(fromDateInclusive)) / 86400000)),
-        revision,
-        exposures,
-        coverageCredits,
-    };
-}
 
 interface ComparableExposure {
     date: string;

--- a/app/src/engine/trainingHistorySnapshot.ts
+++ b/app/src/engine/trainingHistorySnapshot.ts
@@ -3,6 +3,7 @@ import type { DataState, DataStateSummary } from './dataState';
 import { summarizeDataState } from './dataState';
 import { completedEventToExposure, reconcileCompletedTrainingEvents } from './completedTraining';
 import type { CompletedExposure } from './trainingHistory';
+import type { PerformedTrainingFactsSnapshot } from './performedTrainingFacts';
 import { workoutForTemplate } from '../workouts/prescription';
 import { deriveStrengthExposure } from '../workouts/strengthExposure';
 
@@ -25,6 +26,8 @@ export interface TrainingHistorySnapshot {
     /** Optional wider evidence window for evergreen athlete-state inference. It is never
      * replayed into fatigue, microcycle objectives, or delivered-dose accounting. */
     athleteStateEvidence?: AthleteStateHistoryEvidence;
+    /** Optional canonical performed training facts for narrow recency/spacing cutover. */
+    performedTrainingFacts?: PerformedTrainingFactsSnapshot | null;
 }
 
 export type ManualTrainingPolicy = 'off' | 'included';

--- a/app/src/engine/trainingIntent.ts
+++ b/app/src/engine/trainingIntent.ts
@@ -8,7 +8,7 @@ import { resolvePlanDefinitionForEvent, type PlanDefinition } from './planSchedu
 import { addDaysToLocalDateString } from '../utils/localDate';
 import { resolvePlanningContext, type PlanningContext } from './planningMode';
 import { applyPlanningOverlays } from './planningOverlays';
-import { getPerformedTrainingFactsInRange, type PerformedTrainingFactsSnapshot } from './performedTrainingFacts';
+import type { PerformedTrainingFactsSnapshot } from './performedTrainingFacts';
 
 export type PlannedRecoveryReason =
   | 'scheduled_recovery'   // Prescribed microcycle rest day
@@ -155,9 +155,11 @@ export async function resolveTrainingIntent(
     // Injected history providers are also used by deterministic projections (including
     // tomorrow's hypothetical "today was completed" history), so they deliberately keep
     // their self-contained reconstructed history as the spacing fallback.
-    const performedTrainingFacts = historyProvider
-        ? null
-        : await getPerformedTrainingFactsInRange(userId, operationalWindowStart, date);
+    const performedTrainingFacts = preparedHistorySnapshot
+        ? (preparedHistorySnapshot.performedTrainingFacts ?? null)
+        : historyProvider
+            ? null
+            : await (await import('../training-occurrence/performedTrainingFactsService')).getPerformedTrainingFactsInRange(userId, operationalWindowStart, date);
 
     let historySnapshot = operationalSnapshot;
     if (needsEstablishedPerformanceEvidence(planningContext) && operationalSnapshot) {

--- a/app/src/training-occurrence/performedTrainingFactsService.ts
+++ b/app/src/training-occurrence/performedTrainingFactsService.ts
@@ -1,0 +1,176 @@
+/**
+ * Boundary service for reading and hydrating canonical performed training facts from Firestore.
+ *
+ * Isolated outside app/src/engine so the recommendation engine and adjudication layer
+ * remain strictly free of static I/O and Firebase imports.
+ */
+import type { SessionTemplate, NormalizedGarminActivity } from '../engine/models';
+import type { CoverageSetDescriptor } from '../workouts/event-plan';
+import { EVERGREEN_GENERAL_COVERAGE_SET } from '../workouts/event-plan';
+import { WORKOUTS_BY_ID } from '../workouts/catalog';
+import {
+    isProviderActivityRef,
+    isStructuredExecutionRef,
+} from './models';
+import { performedTrainingOccurrenceRepository as repository } from './repository';
+import { sessionExecutionService } from '../services/sessionExecutionService';
+import { activityService } from '../services/activityService';
+import { resolveSessionDefinition } from '../sessions/sessionDefinitionResolver';
+import { getPreviousLocalDateString } from '../utils/localDate';
+import {
+    deriveFactsFromOccurrence,
+    categoryForWorkoutId,
+    templateIdForWorkoutId,
+    normalizeModality,
+    type PerformedExposureFact,
+    type CoverageCreditFact,
+    type PerformedTrainingFactsSnapshot,
+    type HydratedOccurrenceContext,
+} from '../engine/performedTrainingFacts';
+
+export interface GetPerformedTrainingFactsOptions {
+    coverageSetDescriptor?: CoverageSetDescriptor;
+    preloadedActivities?: readonly NormalizedGarminActivity[];
+}
+
+/**
+ * Range query returning canonical recommendation facts.
+ * Range convention: `fromDateInclusive` <= localDate < `toDateExclusive`.
+ */
+export async function getPerformedTrainingFactsInRange(
+    userId: string,
+    fromDateInclusive: string,
+    toDateExclusive: string,
+    options: GetPerformedTrainingFactsOptions = {},
+): Promise<PerformedTrainingFactsSnapshot> {
+    const toDateInclusive = getPreviousLocalDateString(toDateExclusive);
+    if (toDateInclusive < fromDateInclusive) {
+        return {
+            asOfDate: toDateExclusive,
+            windowDays: 0,
+            revision: `canonical-facts-v1:${fromDateInclusive}:${toDateExclusive}:empty`,
+            exposures: [],
+            coverageCredits: [],
+        };
+    }
+
+    const activeOccurrences = await repository.queryActiveInDateWindow(userId, fromDateInclusive, toDateInclusive);
+
+    let activitiesById: Map<string, NormalizedGarminActivity>;
+    if (options.preloadedActivities) {
+        activitiesById = new Map(options.preloadedActivities.map(a => [a.activityId, a]));
+    } else {
+        const activitiesState = await activityService.getActivitiesInRange(userId, fromDateInclusive, toDateExclusive);
+        const activities = activitiesState.status === 'AVAILABLE' ? activitiesState.data : [];
+        activitiesById = new Map(activities.map(a => [a.activityId, a]));
+    }
+
+    const descriptor = options.coverageSetDescriptor ?? EVERGREEN_GENERAL_COVERAGE_SET;
+    const exposures: PerformedExposureFact[] = [];
+    const coverageCredits: CoverageCreditFact[] = [];
+
+    for (const occurrence of activeOccurrences) {
+        const structuredRef = occurrence.sourceRefs.find(isStructuredExecutionRef);
+        const garminRef = occurrence.sourceRefs
+            .filter(isProviderActivityRef)
+            .find(ref => ref.provider.toLowerCase() === 'garmin');
+
+        const hydrated: HydratedOccurrenceContext = {};
+
+        if (structuredRef) {
+            const execState = await sessionExecutionService.getExecution(userId, structuredRef.executionId);
+            if (execState.status === 'AVAILABLE') {
+                const execution = execState.data;
+                let workoutId: string | undefined;
+                let templateId: string | undefined;
+                let category: SessionTemplate['category'] | undefined;
+                let isLegacyStrength = false;
+
+                if (execution.sessionSource.kind === 'catalog') {
+                    if (execution.sessionSource.workoutId === 'legacy_strength') {
+                        isLegacyStrength = true;
+                    } else {
+                        workoutId = execution.sessionSource.workoutId;
+                        templateId = templateIdForWorkoutId(workoutId);
+                        category = categoryForWorkoutId(workoutId);
+                    }
+                } else if (execution.sessionSource.kind === 'manual' && execution.sessionSource.definitionId === 'legacy_strength') {
+                    isLegacyStrength = true;
+                }
+
+                let executionModality: SessionTemplate['modality'] | undefined;
+                if (workoutId) {
+                    const workout = WORKOUTS_BY_ID.get(workoutId);
+                    if (workout?.modality) {
+                        const m = normalizeModality(workout.modality);
+                        if (m !== 'Unknown') executionModality = m;
+                    }
+                }
+
+                const defState = await resolveSessionDefinition(userId, execution.sessionSource, execution.prescriptionHash);
+                if (defState.status === 'AVAILABLE') {
+                    const def = defState.data;
+                    if (!executionModality && def.dominantModality) {
+                        const m = normalizeModality(def.dominantModality);
+                        if (m !== 'Unknown') executionModality = m;
+                    }
+                }
+
+                if (!executionModality && isLegacyStrength) {
+                    executionModality = 'Strength';
+                }
+
+                const durationMin = execution.completedAt && execution.startedAt
+                    ? Math.max(0, Math.round((Date.parse(execution.completedAt) - Date.parse(execution.startedAt)) / 60000))
+                    : undefined;
+
+                hydrated.structured = {
+                    executionId: execution.executionId,
+                    ...(workoutId ? { workoutId } : {}),
+                    ...(templateId ? { templateId } : {}),
+                    ...(executionModality ? { modality: executionModality } : {}),
+                    ...(category ? { category } : {}),
+                    startedAt: execution.startedAt,
+                    ...(execution.completedAt ? { endedAt: execution.completedAt } : {}),
+                    ...(durationMin !== undefined ? { durationMin } : {}),
+                    isLegacyStrength,
+                };
+            }
+        }
+
+        if (garminRef) {
+            const garminActivity = activitiesById.get(garminRef.activityId);
+            const providerModality = garminActivity ? normalizeModality(garminActivity.type) : undefined;
+            const duration = garminActivity?.durationMin;
+            hydrated.provider = {
+                activityId: garminRef.activityId,
+                provider: garminRef.provider,
+                ...(providerModality ? { modality: providerModality } : {}),
+                ...(garminActivity?.startedAt ? { startedAt: garminActivity.startedAt } : {}),
+                ...(garminActivity?.endedAt ? { endedAt: garminActivity.endedAt } : {}),
+                ...(duration !== null && duration !== undefined ? { durationMin: duration } : {}),
+                ...(garminActivity ? { garminActivity } : {}),
+            };
+        }
+
+        const facts = deriveFactsFromOccurrence(occurrence, hydrated, descriptor);
+        exposures.push(facts.exposure);
+        coverageCredits.push(...facts.coverageCredits);
+    }
+
+    exposures.sort((a, b) => a.localDate.localeCompare(b.localDate));
+
+    const occurrenceRevision = activeOccurrences
+        .map(o => `${o.performedOccurrenceId}:${o.updatedAt}`)
+        .sort()
+        .join('|');
+    const revision = `canonical-facts-v1:${fromDateInclusive}:${toDateExclusive}:${occurrenceRevision}`;
+
+    return {
+        asOfDate: toDateExclusive,
+        windowDays: Math.max(1, Math.round((Date.parse(toDateExclusive) - Date.parse(fromDateInclusive)) / 86400000)),
+        revision,
+        exposures,
+        coverageCredits,
+    };
+}


### PR DESCRIPTION
## Summary
Restores the architectural boundary between pure engine logic and Firestore I/O after PR #328/#329 merge.

## Problem
In commit \51d6f732\, \getPerformedTrainingFactsInRange()\ was located in \pp/src/engine/performedTrainingFacts.ts\ with static imports reaching \epository.ts\ and \irebase.ts\. This:
1. Broke \src/engine/externalArchitecture.test.ts\ (\djudication stays free of I/O, so it can be replayed from persisted inputs alone\).
2. Broke \src/engine/externallyPlannedMode.test.ts\ with \FirebaseError: Missing or insufficient permissions\ in offline unit test environments because \	rainingIntent.ts\ invoked live I/O when \historyProvider\ was omitted even if \preparedHistorySnapshot\ was passed.

## Solution
1. Moved \getPerformedTrainingFactsInRange()\ to \pp/src/training-occurrence/performedTrainingFactsService.ts\.
2. Kept \pp/src/engine/performedTrainingFacts.ts\ strictly pure (no Firestore, repository, or service imports).
3. In \	rainingIntent.ts\:
   - Imported \	ype { PerformedTrainingFactsSnapshot }\ only.
   - When \preparedHistorySnapshot\ is provided, read \preparedHistorySnapshot.performedTrainingFacts ?? null\ without any I/O.
   - In un-injected live paths, dynamically load \performedTrainingFactsService.ts\.
4. Extended \TrainingHistorySnapshot\ to carry optional \performedTrainingFacts?: PerformedTrainingFactsSnapshot | null\.

## Verification
- \
pm test -- src/engine/externalArchitecture.test.ts src/engine/externallyPlannedMode.test.ts src/engine/performedTrainingFacts.test.ts\: 3/3 passed.
- \
pm run check\: Full suite passed (3,234 tests, typecheck, lint, knowledge & workout validation).