### PR TITLE
feat(engine): cut weekly coverage credit over to canonical occurrence truth (PR 3)

### DIFF
--- a/app/src/engine/completedTraining.ts
+++ b/app/src/engine/completedTraining.ts
@@ -151,7 +151,7 @@ export function classifyGarminTier(signals: GarminEvidenceSignals): EvidenceTier
     const hasTrainingLoad = signals.activityTrainingLoad !== null && signals.activityTrainingLoad > 0;
     if (hasTrainingEffect && hasTrainingLoad) return 'measuredEffort';
     if (hasTrainingEffect) return 'garminTrainingEffect';
-    if (signals.intensityTag.trim() !== '') return 'durationIntensity';
+    if (signals.intensityTag && signals.intensityTag.trim() !== '') return 'durationIntensity';
     if (signals.modalityKnown) return 'athleteClassification';
     return 'genericModalityFallback';
 }

--- a/app/src/engine/coverage.ts
+++ b/app/src/engine/coverage.ts
@@ -5,6 +5,8 @@ import { workoutForTemplate } from '../workouts/prescription';
 import type { ObjectivePriority, SessionTemplate } from './models';
 import type { PlanDefinition } from './planSchedule';
 import { addDaysToLocalDateString } from '../utils/localDate';
+import type { PerformedTrainingFactsSnapshot } from './performedTrainingFacts';
+import type { CompletedExposure } from './trainingHistory';
 
 /**
  * Phase 6.2c / ADR-0016: physiological stimulus credit and programming-role coverage
@@ -70,6 +72,93 @@ export interface CoverageState {
 export interface CoverageHistoryEntry extends ExposureIdentity {
     date: string;
     source?: CoverageCreditSource;
+}
+
+export type CoverageHistoryInput =
+    | CompletedExposure
+    | CoverageHistoryEntry
+    | {
+        date?: string;
+        templateId?: string;
+        workoutId?: string;
+        durationMin?: number;
+        modality?: SessionTemplate['modality'] | string;
+        category?: SessionTemplate['category'] | string;
+        source?: CoverageCreditSource;
+        trainingRecordLike?: unknown;
+    };
+
+export interface CoverageExposureLike {
+    performedOccurrenceId?: string;
+    localDate?: string;
+    workoutId?: string;
+    templateId?: string;
+    durationMin?: number;
+    modality?: SessionTemplate['modality'] | string;
+    category?: SessionTemplate['category'] | string;
+}
+
+export type CoveragePerformedFacts =
+    | PerformedTrainingFactsSnapshot
+    | {
+        exposures: readonly CoverageExposureLike[];
+    };
+
+export function coverageHistoryFromFacts(facts: readonly CoverageExposureLike[]): CoverageHistoryEntry[] {
+    return facts.flatMap(fact => {
+        if (!fact.localDate) return [];
+        return [{
+            occurrenceKey: fact.performedOccurrenceId ?? `occ-${fact.localDate}-${fact.workoutId ?? fact.templateId ?? 'unknown'}`,
+            date: fact.localDate,
+            ...(fact.workoutId ? { workoutId: fact.workoutId } : {}),
+            ...(fact.templateId ? { templateId: fact.templateId } : {}),
+            ...(fact.durationMin !== undefined ? { durationMin: fact.durationMin } : {}),
+            ...(fact.modality && fact.modality !== 'Unknown' ? { modality: fact.modality as SessionTemplate['modality'] } : {}),
+            ...(fact.category ? { category: fact.category as SessionTemplate['category'] } : {}),
+            source: 'completed' as const,
+        }];
+    });
+}
+
+export function coverageHistoryFromCompletedExposures(history: readonly CoverageHistoryInput[]): CoverageHistoryEntry[] {
+    return history.flatMap(entry => {
+        if (!entry.date) return [];
+        const durationMin = ('durationMin' in entry && typeof entry.durationMin === 'number')
+            ? entry.durationMin
+            : ('trainingRecordLike' in entry && entry.trainingRecordLike && typeof entry.trainingRecordLike === 'object' && 'duration_min' in entry.trainingRecordLike && typeof (entry.trainingRecordLike as { duration_min?: unknown }).duration_min === 'number')
+                ? (entry.trainingRecordLike as { duration_min: number }).duration_min
+                : undefined;
+        return [{
+            date: entry.date,
+            ...(entry.templateId ? { templateId: entry.templateId } : {}),
+            ...(entry.workoutId ? { workoutId: entry.workoutId } : {}),
+            ...(durationMin !== undefined ? { durationMin } : {}),
+            ...(entry.modality && entry.modality !== 'Unknown' ? { modality: entry.modality as SessionTemplate['modality'] } : {}),
+            ...(entry.category ? { category: entry.category as SessionTemplate['category'] } : {}),
+            source: ('source' in entry && entry.source) ? entry.source : 'completed' as const,
+        }];
+    });
+}
+
+/**
+ * Resolves coverage history entries prioritizing ADR-0034 canonical performed facts over
+ * legacy reconstructed history.
+ *
+ * If canonical facts are supplied (even if empty, representing zero performed sessions),
+ * they are authoritative. Only when canonical facts are null/undefined does it fall back
+ * to legacy reconstructed history.
+ */
+export function resolveCoverageHistory(
+    performedFacts?: CoveragePerformedFacts | null,
+    legacyHistory?: readonly CoverageHistoryInput[],
+): CoverageHistoryEntry[] {
+    if (performedFacts && performedFacts.exposures) {
+        return coverageHistoryFromFacts(performedFacts.exposures);
+    }
+    if (legacyHistory) {
+        return coverageHistoryFromCompletedExposures(legacyHistory);
+    }
+    return [];
 }
 
 /** Descriptor-scoped lookup keeps the registry generic without reintroducing the old

--- a/app/src/engine/coverage.ts
+++ b/app/src/engine/coverage.ts
@@ -5,7 +5,7 @@ import { workoutForTemplate } from '../workouts/prescription';
 import type { ObjectivePriority, SessionTemplate } from './models';
 import type { PlanDefinition } from './planSchedule';
 import { addDaysToLocalDateString } from '../utils/localDate';
-import type { PerformedTrainingFactsSnapshot } from './performedTrainingFacts';
+import type { CoverageCreditFact, PerformedTrainingFactsSnapshot } from './performedTrainingFacts';
 import type { CompletedExposure } from './trainingHistory';
 
 /**
@@ -72,6 +72,13 @@ export interface CoverageState {
 export interface CoverageHistoryEntry extends ExposureIdentity {
     date: string;
     source?: CoverageCreditSource;
+    /**
+     * Canonical semantic role decisions emitted by performedTrainingFacts.ts. Presence is
+     * authoritative even when the array is empty: buildCoverageState must not re-infer a
+     * role from workout/template identity after the canonical fact layer declined credit.
+     * Legacy/projected entries leave this undefined and retain descriptor lookup below.
+     */
+    canonicalCoverageCredits?: readonly Pick<CoverageCreditFact, 'coverageSetId' | 'coverageKey' | 'creditKind'>[];
 }
 
 export type CoverageHistoryInput =
@@ -98,14 +105,40 @@ export interface CoverageExposureLike {
     category?: SessionTemplate['category'] | string;
 }
 
+export type CoverageCreditLike = Pick<CoverageCreditFact,
+    'performedOccurrenceId' | 'coverageSetId' | 'coverageKey' | 'creditKind'>;
+
 export type CoveragePerformedFacts =
     | PerformedTrainingFactsSnapshot
     | {
         exposures: readonly CoverageExposureLike[];
+        /** Transitional compatibility: older injected fixtures may omit the semantic
+         * ledger. Production PerformedTrainingFactsSnapshot always supplies it. */
+        coverageCredits?: readonly CoverageCreditLike[];
     };
 
-export function coverageHistoryFromFacts(facts: readonly CoverageExposureLike[]): CoverageHistoryEntry[] {
-    return facts.flatMap(fact => {
+export function coverageHistoryFromFacts(performedFacts: CoveragePerformedFacts): CoverageHistoryEntry[] {
+    const hasCanonicalCreditLedger = performedFacts.coverageCredits !== undefined;
+    const creditsByOccurrence = new Map<string, CoverageHistoryEntry['canonicalCoverageCredits']>();
+
+    if (hasCanonicalCreditLedger) {
+        for (const credit of performedFacts.coverageCredits ?? []) {
+            // PR 3 intentionally enables exact identity only. semantic_confident remains
+            // disabled until a separately authored policy defines its threshold/semantics;
+            // `none` is observability, never role fulfillment.
+            if (credit.creditKind !== 'exact') continue;
+            const current = creditsByOccurrence.get(credit.performedOccurrenceId) ?? [];
+            if (!current.some(item => item.coverageSetId === credit.coverageSetId && item.coverageKey === credit.coverageKey)) {
+                creditsByOccurrence.set(credit.performedOccurrenceId, [...current, {
+                    coverageSetId: credit.coverageSetId,
+                    coverageKey: credit.coverageKey,
+                    creditKind: credit.creditKind,
+                }]);
+            }
+        }
+    }
+
+    return performedFacts.exposures.flatMap(fact => {
         if (!fact.localDate) return [];
         return [{
             occurrenceKey: fact.performedOccurrenceId ?? `occ-${fact.localDate}-${fact.workoutId ?? fact.templateId ?? 'unknown'}`,
@@ -115,6 +148,11 @@ export function coverageHistoryFromFacts(facts: readonly CoverageExposureLike[])
             ...(fact.durationMin !== undefined ? { durationMin: fact.durationMin } : {}),
             ...(fact.modality && fact.modality !== 'Unknown' ? { modality: fact.modality as SessionTemplate['modality'] } : {}),
             ...(fact.category ? { category: fact.category as SessionTemplate['category'] } : {}),
+            ...(hasCanonicalCreditLedger ? {
+                canonicalCoverageCredits: fact.performedOccurrenceId
+                    ? (creditsByOccurrence.get(fact.performedOccurrenceId) ?? [])
+                    : [],
+            } : {}),
             source: 'completed' as const,
         }];
     });
@@ -153,7 +191,7 @@ export function resolveCoverageHistory(
     legacyHistory?: readonly CoverageHistoryInput[],
 ): CoverageHistoryEntry[] {
     if (performedFacts && performedFacts.exposures) {
-        return coverageHistoryFromFacts(performedFacts.exposures);
+        return coverageHistoryFromFacts(performedFacts);
     }
     if (legacyHistory) {
         return coverageHistoryFromCompletedExposures(legacyHistory);
@@ -202,6 +240,14 @@ export function workoutIdForTemplateId(templateId: string | undefined): string |
     return workoutForTemplate(templateId)?.id;
 }
 
+function hasRequiredAerobicDose(identity: ExposureIdentity, workoutId: string): boolean {
+    const minimumDuration = WORKOUTS_BY_ID.get(workoutId)?.duration.minimumMin;
+    return typeof minimumDuration === 'number'
+        && typeof identity.durationMin === 'number'
+        && Number.isFinite(identity.durationMin)
+        && identity.durationMin >= minimumDuration;
+}
+
 export function coverageKeysForExposure(
     identity: ExposureIdentity,
     phase: PlanPhase | null,
@@ -212,15 +258,33 @@ export function coverageKeysForExposure(
     if (!workoutId) return [];
     return descriptor.coverage
         .filter(item => item.phases.includes(phase) && item.workoutIds.includes(workoutId))
-        .filter(item => {
-            if (item.key !== 'aerobic_volume') return true;
-            const minimumDuration = WORKOUTS_BY_ID.get(workoutId)?.duration.minimumMin;
-            return typeof minimumDuration === 'number'
-                && typeof identity.durationMin === 'number'
-                && Number.isFinite(identity.durationMin)
-                && identity.durationMin >= minimumDuration;
-        })
+        .filter(item => item.key !== 'aerobic_volume' || hasRequiredAerobicDose(identity, workoutId))
         .map(item => item.key);
+}
+
+function canonicalCoverageKeysForExposure(
+    exposure: CoverageHistoryEntry,
+    phase: PlanPhase,
+    descriptor: CoverageSetDescriptor,
+    workoutId: string | undefined,
+): PlanCoverageKey[] | null {
+    if (exposure.canonicalCoverageCredits === undefined) return null;
+
+    const keys = exposure.canonicalCoverageCredits
+        .filter(credit => credit.creditKind === 'exact' && credit.coverageSetId === descriptor.id)
+        .map(credit => credit.coverageKey)
+        .filter((key, index, all) => all.indexOf(key) === index)
+        .filter(key => {
+            const definition = coverageFor(descriptor, key);
+            if (!definition || !definition.phases.includes(phase)) return false;
+            // Identity comes from the canonical semantic ledger; dose eligibility remains a
+            // coverage-state concern so a short exact Z2 execution cannot satisfy the
+            // authored aerobic-volume floor merely because its catalog id is known.
+            if (key !== 'aerobic_volume') return true;
+            return workoutId !== undefined && hasRequiredAerobicDose(exposure, workoutId);
+        });
+
+    return keys;
 }
 
 export function coverageKeysForTemplate(
@@ -359,7 +423,8 @@ export function buildCoverageState(
         if (seenOccurrences.has(occurrenceKey)) continue;
         seenOccurrences.add(occurrenceKey);
 
-        const keys = coverageKeysForExposure(exposure, block.phase, descriptor);
+        const canonicalKeys = canonicalCoverageKeysForExposure(exposure, block.phase, descriptor, workoutId);
+        const keys = canonicalKeys ?? coverageKeysForExposure(exposure, block.phase, descriptor);
         for (const key of keys) {
             const requirement = requirementsByKey.get(key);
             if (!requirement) continue;

--- a/app/src/engine/coverage.ts
+++ b/app/src/engine/coverage.ts
@@ -86,6 +86,7 @@ export type CoverageHistoryInput =
     | CoverageHistoryEntry
     | {
         date?: string;
+        occurrenceKey?: string;
         templateId?: string;
         workoutId?: string;
         durationMin?: number;
@@ -168,6 +169,7 @@ export function coverageHistoryFromCompletedExposures(history: readonly Coverage
                 : undefined;
         return [{
             date: entry.date,
+            ...('occurrenceKey' in entry && entry.occurrenceKey ? { occurrenceKey: entry.occurrenceKey } : {}),
             ...(entry.templateId ? { templateId: entry.templateId } : {}),
             ...(entry.workoutId ? { workoutId: entry.workoutId } : {}),
             ...(durationMin !== undefined ? { durationMin } : {}),

--- a/app/src/engine/externallyPlannedMode.test.ts
+++ b/app/src/engine/externallyPlannedMode.test.ts
@@ -25,6 +25,15 @@ const EMPTY_HISTORY: TrainingHistorySnapshot = {
     },
     generatedAt: '2026-08-18T05:00:00.000Z',
     revision: 'history-fixture-empty',
+    // Self-contained deterministic fixture: supplying the canonical fact ledger keeps
+    // resolveTrainingIntent from falling through to the Firestore occurrence read.
+    performedTrainingFacts: {
+        asOfDate: DATE,
+        windowDays: 7,
+        revision: 'performed-facts-fixture-empty',
+        exposures: [],
+        coverageCredits: [],
+    },
 };
 
 function readiness(s: Partial<SubjectiveInput> = {}, o: Partial<EngineObjectiveInput> = {}): DailyReadiness {

--- a/app/src/engine/optimizer.ts
+++ b/app/src/engine/optimizer.ts
@@ -22,7 +22,7 @@ import type { ResolvedAvailability } from './schedule';
 import { resolveAvailability } from './schedule';
 import { addDaysToLocalDateString, getDayDiff, getLocalDateString } from '../utils/localDate';
 import { qualifiesForObjective } from './microcycle';
-import { buildCoverageState, coverageNeedTierForTemplate, type CoverageState } from './coverage';
+import { buildCoverageState, coverageNeedTierForTemplate, resolveCoverageHistory, type CoverageState } from './coverage';
 import { resolvePlanDefinitionForEvent } from './planSchedule';
 import { resolveInjuryRestrictions } from './injuryPolicy';
 import { evaluateStrengthSpacingStatus, type StrengthExposureLike } from './strengthSpacingPolicy';
@@ -718,14 +718,11 @@ export function buildOptimizationContext(
     });
 
     const focusEvent = options.focusEvent ?? intent.periodization?.focusEvent ?? null;
+    const coverageHistory = resolveCoverageHistory(intent.performedTrainingFacts, intent.history);
     const coverageState = options.coverageState ?? buildCoverageState(
         resolvePlanDefinitionForEvent(focusEvent, options.authoredPlanBlocks),
         date,
-        rawHistory.flatMap(entry => entry.date && entry.templateId
-            ? [{ date: entry.date, templateId: entry.templateId, ...(typeof (entry as Record<string, unknown>).durationMin === 'number'
-                ? { durationMin: (entry as Record<string, number>).durationMin }
-                : {}) }]
-            : []),
+        coverageHistory,
     );
     const recentPerformedExposures = options.recentPerformedExposures ?? intent.performedTrainingFacts?.exposures;
 

--- a/app/src/engine/performedTrainingFacts.ts
+++ b/app/src/engine/performedTrainingFacts.ts
@@ -249,7 +249,7 @@ export function deriveFactsFromOccurrence(
         evidenceTier = classifyGarminTier({
             trainingEffectAerobic: hydrated.provider.garminActivity.trainingEffectAerobic,
             trainingEffectAnaerobic: hydrated.provider.garminActivity.trainingEffectAnaerobic,
-            intensityTag: hydrated.provider.garminActivity.intensityTag,
+            intensityTag: hydrated.provider.garminActivity.intensityTag ?? '',
             activityTrainingLoad: hydrated.provider.garminActivity.activityTrainingLoad,
             modalityKnown: modality !== 'Unknown',
         });

--- a/app/src/engine/planner.ts
+++ b/app/src/engine/planner.ts
@@ -65,7 +65,7 @@ import { resolveMinimumDaysAfterHardLowerBody, resolveRecoveryHoursForTemplate }
 import { resolvePlannedDoseForDate, resolveTrainingIntent } from './trainingIntent';
 import { resolvePlanDefinitionForEvent, type PlanDefinition } from './planSchedule';
 import { deriveObjectiveCreditFromProfile, type StimulusConfidence } from './stimulus';
-import { buildCoverageState, coverageNeedTierForTemplate, resolveCoverageHistory, workoutIdForTemplateId } from './coverage';
+import { buildCoverageState, coverageNeedTierForTemplate, resolveCoverageHistory, workoutIdForTemplateId, type CoverageHistoryEntry } from './coverage';
 import { resolveEvergreenPlan } from './evergreenPlanning';
 import { applyPlanningOverlays } from './planningOverlays';
 import {
@@ -145,6 +145,9 @@ export interface WeekAheadPlanSeed {
     microcycle: MicrocycleState;
     fatigue: FatigueState;
     trailingHistory?: (RecentHistoryEntry | SessionHistoryEntry)[];
+    /** Canonical completed-role history. Operational/projected history stays separate so
+     * future recommendations never reclassify completed occurrences through legacy lookup. */
+    completedCoverageHistory?: CoverageHistoryEntry[];
     droppedContributorObjectives?: DroppedContributorObjective[];
 }
 
@@ -456,6 +459,9 @@ export interface ProjectedDateState {
     microcycle: MicrocycleState;
     externalFatigue: FatigueState;
     projectedHistory: (RecentHistoryEntry | SessionHistoryEntry)[];
+    /** Coverage history is a separate semantic ledger: canonical completed facts plus
+     * hypothetical projected/fixed entries. */
+    coverageHistory?: CoverageHistoryEntry[];
 }
 
 export interface ProjectedDateEvaluation {
@@ -536,11 +542,11 @@ export function evaluateProjectedDate(
         {
             anchorRole, adjacentToAnchor, resolveMinimumDaysAfterHardLowerBody, resolveRecoveryHours: resolveRecoveryHoursForTemplate, fatigueTier,
             authoredPlanBlocks: shared.authoredPlanBlocks,
-            ...(shared.planDefinition ? {
+            ...(planDefinition ? {
                 coverageState: buildCoverageState(
                     planDefinition,
                     date,
-                    resolveCoverageHistory(undefined, state.projectedHistory),
+                    state.coverageHistory ?? resolveCoverageHistory(undefined, state.projectedHistory),
                 ),
             } : {}),
         },
@@ -1174,7 +1180,8 @@ export function generateWeekAheadPlan(
         planDefinition: suppliedPlanDefinition,
     };
 
-    const historyEntryFor = (date: string, template: SessionTemplate): RecentHistoryEntry => ({
+    type ProjectedHistoryEntry = RecentHistoryEntry & { source: 'projected' };
+    const historyEntryFor = (date: string, template: SessionTemplate): ProjectedHistoryEntry => ({
         date,
         templateId: template.id,
         category: template.category,
@@ -1185,12 +1192,23 @@ export function generateWeekAheadPlan(
         durationMin: template.durationMin,
         recoveryHours: resolveRecoveryHoursForTemplate(template.id),
         type: template.title,
+        source: 'projected',
     });
 
     const liveProjectedHistory = (): (RecentHistoryEntry | SessionHistoryEntry)[] => [
         ...(seed.trailingHistory ?? []),
         historyEntryFor(todayDate, todayRec.template),
         ...resultDays.map(day => historyEntryFor(day.date, day.template)),
+    ];
+
+    const completedCoverageHistory = seed.completedCoverageHistory
+        ?? resolveCoverageHistory(undefined, seed.trailingHistory ?? []);
+    const liveProjectedCoverageHistory = (): CoverageHistoryEntry[] => [
+        ...completedCoverageHistory,
+        ...resolveCoverageHistory(undefined, [
+            historyEntryFor(todayDate, todayRec.template),
+            ...resultDays.map(day => historyEntryFor(day.date, day.template)),
+        ]),
     ];
 
     const forecastDatesFrom = (startOffset: number): string[] => {
@@ -1225,6 +1243,7 @@ export function generateWeekAheadPlan(
         const cached = evaluationCache.get(cacheKey);
         if (cached) return cached;
         const history = liveProjectedHistory();
+        const coverageHistory = liveProjectedCoverageHistory();
         const loads: Array<{ date: string; cost: WorkoutCostProfile }> = [];
         fixedActivities
             .filter(activity => !activity.isCompleted && activity.expectedCost
@@ -1237,14 +1256,16 @@ export function generateWeekAheadPlan(
             const template = ENRICHED_TEMPLATES_BY_ID.get(item.templateId);
             if (!template) return;
             loads.push({ date: item.date, cost: enrichedCostProfile(item.templateId) });
-            history.push(historyEntryFor(item.date, template));
+            const projectedEntry = historyEntryFor(item.date, template);
+            history.push(projectedEntry);
+            coverageHistory.push(...resolveCoverageHistory(undefined, [projectedEntry]));
         });
         const fatigue = loads
             .sort((left, right) => left.date.localeCompare(right.date))
             .reduce((state, load) => applyCompletedSessionLoad(state, load.date, load.cost, fatigueFusionPolicy), externalFatigue);
         const evaluation = evaluateProjectedDate(
             date,
-            { microcycle, externalFatigue: fatigue, projectedHistory: history },
+            { microcycle, externalFatigue: fatigue, projectedHistory: history, coverageHistory },
             sharedProjection,
         );
         evaluationCache.set(cacheKey, evaluation);
@@ -1566,6 +1587,7 @@ export async function generateWeekAheadPlanWithIntent(
             microcycle: evergreen?.microcycle ?? intent.microcycle,
             fatigue: intent.fatigue,
             trailingHistory: trailingHistoryFromCompletedExposures(intent.history, todayDate),
+            completedCoverageHistory: resolveCoverageHistory(intent.performedTrainingFacts, intent.history),
             droppedContributorObjectives: intent.droppedContributorObjectives,
         },
         { ...options, fatigueFusionPolicy, events: intent.planningContext.mode === 'event_directed' ? events : [], ...(evergreen ? { planDefinition: evergreen.planDefinition } : {}) },

--- a/app/src/engine/planner.ts
+++ b/app/src/engine/planner.ts
@@ -65,7 +65,7 @@ import { resolveMinimumDaysAfterHardLowerBody, resolveRecoveryHoursForTemplate }
 import { resolvePlannedDoseForDate, resolveTrainingIntent } from './trainingIntent';
 import { resolvePlanDefinitionForEvent, type PlanDefinition } from './planSchedule';
 import { deriveObjectiveCreditFromProfile, type StimulusConfidence } from './stimulus';
-import { buildCoverageState, coverageNeedTierForTemplate, workoutIdForTemplateId } from './coverage';
+import { buildCoverageState, coverageNeedTierForTemplate, resolveCoverageHistory, workoutIdForTemplateId } from './coverage';
 import { resolveEvergreenPlan } from './evergreenPlanning';
 import { applyPlanningOverlays } from './planningOverlays';
 import {
@@ -536,7 +536,13 @@ export function evaluateProjectedDate(
         {
             anchorRole, adjacentToAnchor, resolveMinimumDaysAfterHardLowerBody, resolveRecoveryHours: resolveRecoveryHoursForTemplate, fatigueTier,
             authoredPlanBlocks: shared.authoredPlanBlocks,
-            ...(shared.planDefinition ? { coverageState: buildCoverageState(planDefinition, date) } : {}),
+            ...(shared.planDefinition ? {
+                coverageState: buildCoverageState(
+                    planDefinition,
+                    date,
+                    resolveCoverageHistory(undefined, state.projectedHistory),
+                ),
+            } : {}),
         },
         shared.fixedActivities,
     );

--- a/app/src/engine/policy.ts
+++ b/app/src/engine/policy.ts
@@ -1,11 +1,12 @@
 /** Increment whenever a change can alter a persisted recommendation decision. (Refactoring does not require a bump) */
 
-export const POLICY_VERSION = '2026-09-canonical-strength-spacing-v1';
+export const POLICY_VERSION = '2026-09-canonical-coverage-credit-v1';
 
 /** Historical versions are intentionally not re-executed by this build. Their compact
  * audits remain readable evidence, but replay is rejected explicitly because the old
  * decision function is not bundled alongside the current policy. */
 export const HISTORICAL_POLICY_VERSIONS = [
+    '2026-09-canonical-strength-spacing-v1',
     '2026-09-skr3-taper-resolution-v1',
     '2026-09-safety-policy-remediation-sep-c4',
     '2026-09-structured-strength-warmups-v1',

--- a/app/src/engine/rules.ts
+++ b/app/src/engine/rules.ts
@@ -42,7 +42,7 @@ import { SUBJECTIVE_BASELINE_METRICS, type SubjectiveBaseline, type SubjectiveBa
 import { resolveAvailability } from './schedule';
 import { workoutForTemplate } from '../workouts/prescription';
 import { resolveEvergreenPlan } from './evergreenPlanning';
-import { buildCoverageState } from './coverage';
+import { buildCoverageState, resolveCoverageHistory } from './coverage';
 import { applyPlanningOverlays } from './planningOverlays';
 import { mergeKnowledgeRefs, readinessKnowledgeRefs, trainingIntentKnowledgeRefs } from './knowledgeLineage';
 
@@ -711,7 +711,13 @@ export async function evaluateTrainingWithIntent(
         date,
         {
             resolveMinimumDaysAfterHardLowerBody, resolveRecoveryHours: resolveRecoveryHoursForTemplate, resolvedAvailability: availability, fatigueTier: mode, authoredPlanBlocks,
-            ...(evergreen ? { coverageState: buildCoverageState(evergreen.planDefinition, date) } : {}),
+            ...(evergreen ? {
+                coverageState: buildCoverageState(
+                    evergreen.planDefinition,
+                    date,
+                    resolveCoverageHistory(intent.performedTrainingFacts, intent.history),
+                ),
+            } : {}),
         },
         fixedActivities,
     );

--- a/app/src/engine/tests/canonicalCoverageCreditAuthority.test.ts
+++ b/app/src/engine/tests/canonicalCoverageCreditAuthority.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it } from 'vitest';
+import { buildCoverageState, resolveCoverageHistory } from '../coverage';
+import type { PerformedTrainingFactsSnapshot } from '../performedTrainingFacts';
+import type { PlanDefinition } from '../planSchedule';
+
+function plan(
+    coverageSetId: PlanDefinition['coverageSetId'],
+    phase: 'general' | 'build',
+    coverageKey: 'primary_strength' | 'aerobic_volume',
+): PlanDefinition {
+    return {
+        id: `plan-${coverageSetId}-${coverageKey}`,
+        eventId: 'event-1',
+        coverageSetId,
+        blocks: [{
+            id: 'block-1',
+            phase,
+            startDate: '2026-08-25',
+            endDate: '2026-09-10',
+            volumeScale: 1,
+            intensityScale: 1,
+        }],
+        objectives: [{
+            key: coverageKey === 'primary_strength' ? 'strength_maintenance' : 'zone2_aerobic',
+            coverageKey,
+            blockId: 'block-1',
+            requiredCredit: 1,
+            priority: 'must_have',
+            coverageMinimumSessions: 1,
+            coverageTargetSessions: 1,
+        }],
+        sequencingRules: [],
+    };
+}
+
+function snapshot(overrides: Partial<PerformedTrainingFactsSnapshot>): PerformedTrainingFactsSnapshot {
+    return {
+        asOfDate: '2026-09-03',
+        windowDays: 7,
+        revision: 'test-revision',
+        exposures: [],
+        coverageCredits: [],
+        ...overrides,
+    };
+}
+
+describe('canonical coverage semantic authority', () => {
+    it('does not reclassify an exact-looking exposure when canonical credit chose another role', () => {
+        const facts = snapshot({
+            exposures: [{
+                performedOccurrenceId: 'occ-1',
+                localDate: '2026-09-01',
+                modality: 'Strength',
+                confidence: 'exact',
+                sourceKinds: ['structured_execution'],
+                evidenceTier: 'completedStructuredWorkout',
+                workoutId: 'strength_full_body_maintenance_01',
+            }],
+            coverageCredits: [{
+                performedOccurrenceId: 'occ-1',
+                coverageSetId: 'september_cycling_event',
+                coverageKey: 'compact_strength',
+                workoutId: 'strength_full_body_maintenance_01',
+                creditKind: 'exact',
+                confidence: 1,
+                reasonCode: 'exact_workout_identity',
+                sourceKinds: ['structured_execution'],
+            }],
+        });
+
+        const state = buildCoverageState(
+            plan('september_cycling_event', 'build', 'primary_strength'),
+            '2026-09-03',
+            resolveCoverageHistory(facts),
+        );
+
+        expect(state.requirements.find(item => item.key === 'primary_strength')?.completedSessions).toBe(0);
+    });
+
+    it('fails closed when canonical credits belong to a different coverage set', () => {
+        const facts = snapshot({
+            exposures: [{
+                performedOccurrenceId: 'occ-2',
+                localDate: '2026-09-01',
+                modality: 'Strength',
+                confidence: 'exact',
+                sourceKinds: ['structured_execution'],
+                evidenceTier: 'completedStructuredWorkout',
+                workoutId: 'strength_full_body_maintenance_01',
+            }],
+            coverageCredits: [{
+                performedOccurrenceId: 'occ-2',
+                coverageSetId: 'evergreen_general',
+                coverageKey: 'primary_strength',
+                workoutId: 'strength_full_body_maintenance_01',
+                creditKind: 'exact',
+                confidence: 1,
+                reasonCode: 'exact_workout_identity',
+                sourceKinds: ['structured_execution'],
+            }],
+        });
+
+        const state = buildCoverageState(
+            plan('september_cycling_event', 'build', 'primary_strength'),
+            '2026-09-03',
+            resolveCoverageHistory(facts),
+        );
+
+        expect(state.requirements.find(item => item.key === 'primary_strength')?.completedSessions).toBe(0);
+    });
+
+    it('treats creditKind none as authoritative even if exposure carries a catalog workout id', () => {
+        const facts = snapshot({
+            exposures: [{
+                performedOccurrenceId: 'occ-3',
+                localDate: '2026-09-01',
+                modality: 'Strength',
+                confidence: 'inferred',
+                sourceKinds: ['provider_activity'],
+                evidenceTier: 'durationIntensity',
+                workoutId: 'strength_full_body_maintenance_01',
+            }],
+            coverageCredits: [{
+                performedOccurrenceId: 'occ-3',
+                coverageSetId: 'evergreen_general',
+                coverageKey: 'primary_strength',
+                workoutId: 'strength_full_body_maintenance_01',
+                creditKind: 'none',
+                confidence: 0,
+                reasonCode: 'generic_modality_only',
+                sourceKinds: ['provider_activity'],
+            }],
+        });
+
+        const state = buildCoverageState(
+            plan('evergreen_general', 'general', 'primary_strength'),
+            '2026-09-03',
+            resolveCoverageHistory(facts),
+        );
+
+        expect(state.requirements.find(item => item.key === 'primary_strength')?.completedSessions).toBe(0);
+    });
+
+    it('keeps semantic_confident disabled until a dedicated policy enables it', () => {
+        const facts = snapshot({
+            exposures: [{
+                performedOccurrenceId: 'occ-4',
+                localDate: '2026-09-01',
+                modality: 'Strength',
+                confidence: 'high',
+                sourceKinds: ['structured_execution'],
+                evidenceTier: 'completedStructuredWorkout',
+            }],
+            coverageCredits: [{
+                performedOccurrenceId: 'occ-4',
+                coverageSetId: 'evergreen_general',
+                coverageKey: 'primary_strength',
+                creditKind: 'semantic_confident',
+                confidence: 0.9,
+                reasonCode: 'semantic_classifier',
+                sourceKinds: ['structured_execution'],
+            }],
+        });
+
+        const state = buildCoverageState(
+            plan('evergreen_general', 'general', 'primary_strength'),
+            '2026-09-03',
+            resolveCoverageHistory(facts),
+        );
+
+        expect(state.requirements.find(item => item.key === 'primary_strength')?.completedSessions).toBe(0);
+    });
+
+    it('retains the aerobic minimum-duration guard after identity cuts over to canonical credits', () => {
+        const facts = snapshot({
+            exposures: [{
+                performedOccurrenceId: 'occ-5',
+                localDate: '2026-09-01',
+                modality: 'Cycling',
+                confidence: 'exact',
+                sourceKinds: ['structured_execution'],
+                evidenceTier: 'completedStructuredWorkout',
+                workoutId: 'cycling_zone2_standard_01',
+                durationMin: 1,
+            }],
+            coverageCredits: [{
+                performedOccurrenceId: 'occ-5',
+                coverageSetId: 'evergreen_general',
+                coverageKey: 'aerobic_volume',
+                workoutId: 'cycling_zone2_standard_01',
+                creditKind: 'exact',
+                confidence: 1,
+                reasonCode: 'exact_workout_identity',
+                sourceKinds: ['structured_execution'],
+            }],
+        });
+
+        const state = buildCoverageState(
+            plan('evergreen_general', 'general', 'aerobic_volume'),
+            '2026-09-03',
+            resolveCoverageHistory(facts),
+        );
+
+        expect(state.requirements.find(item => item.key === 'aerobic_volume')?.completedSessions).toBe(0);
+    });
+
+    it('keeps exposure-only injected fixtures on legacy descriptor lookup for projection compatibility', () => {
+        const history = resolveCoverageHistory({
+            exposures: [{
+                performedOccurrenceId: 'occ-legacy-fixture',
+                localDate: '2026-09-01',
+                modality: 'Strength',
+                workoutId: 'strength_full_body_maintenance_01',
+            }],
+        });
+
+        const state = buildCoverageState(
+            plan('evergreen_general', 'general', 'primary_strength'),
+            '2026-09-03',
+            history,
+        );
+
+        expect(state.requirements.find(item => item.key === 'primary_strength')?.completedSessions).toBe(1);
+    });
+});

--- a/app/src/engine/tests/canonicalCoverageCreditAuthority.test.ts
+++ b/app/src/engine/tests/canonicalCoverageCreditAuthority.test.ts
@@ -222,4 +222,24 @@ describe('canonical coverage semantic authority', () => {
 
         expect(state.requirements.find(item => item.key === 'primary_strength')?.completedSessions).toBe(1);
     });
+
+    it('records hypothetical planner entries as projected rather than completed coverage', () => {
+        const projectedHistory = resolveCoverageHistory(undefined, [{
+            date: '2026-09-02',
+            templateId: 'full_body_strength_01',
+            modality: 'Strength',
+            category: 'Full-body Strength',
+            source: 'projected',
+        }]);
+
+        const state = buildCoverageState(
+            plan('evergreen_general', 'general', 'primary_strength'),
+            '2026-09-03',
+            projectedHistory,
+        );
+        const requirement = state.requirements.find(item => item.key === 'primary_strength');
+
+        expect(requirement?.completedSessions).toBe(0);
+        expect(requirement?.projectedSessions).toBe(1);
+    });
 });

--- a/app/src/engine/tests/canonicalCoverageCreditAuthority.test.ts
+++ b/app/src/engine/tests/canonicalCoverageCreditAuthority.test.ts
@@ -226,7 +226,7 @@ describe('canonical coverage semantic authority', () => {
     it('records hypothetical planner entries as projected rather than completed coverage', () => {
         const projectedHistory = resolveCoverageHistory(undefined, [{
             date: '2026-09-02',
-            templateId: 'full_body_strength_01',
+            templateId: 'str_full_01',
             modality: 'Strength',
             category: 'Full-body Strength',
             source: 'projected',

--- a/app/src/engine/tests/canonicalCoverageCreditCutover.test.ts
+++ b/app/src/engine/tests/canonicalCoverageCreditCutover.test.ts
@@ -1,0 +1,395 @@
+import { describe, it, expect } from 'vitest';
+import {
+    deriveFactsFromOccurrence,
+    type HydratedOccurrenceContext,
+} from '../performedTrainingFacts';
+import {
+    buildCoverageState,
+    resolveCoverageHistory,
+    coverageNeedTierForTemplate,
+} from '../coverage';
+import { EVERGREEN_GENERAL_COVERAGE_SET } from '../../workouts/event-plan';
+import { TEMPLATES_BY_ID } from '../templates';
+import type { PerformedTrainingOccurrence } from '../../training-occurrence/models';
+import type { PlanDefinition } from '../planSchedule';
+
+const planDef: PlanDefinition = {
+    id: 'evergreen-general-plan',
+    eventId: 'event-1',
+    coverageSetId: 'evergreen_general',
+    blocks: [
+        {
+            id: 'block-general',
+            phase: 'general',
+            startDate: '2026-08-25',
+            endDate: '2026-09-10',
+            volumeScale: 1.0,
+            intensityScale: 1.0,
+        },
+    ],
+    objectives: [
+        {
+            key: 'strength_maintenance',
+            coverageKey: 'primary_strength',
+            blockId: 'block-general',
+            requiredCredit: 1,
+            priority: 'must_have',
+            role: 'primary_developmental',
+            coverageMinimumSessions: 1,
+            coverageTargetSessions: 1,
+        },
+    ],
+    sequencingRules: [],
+};
+
+function occurrence(
+    id: string,
+    date: string,
+    sourceRefs: PerformedTrainingOccurrence['sourceRefs'] = [],
+): PerformedTrainingOccurrence {
+    return {
+        schemaVersion: 1,
+        performedOccurrenceId: id,
+        userId: 'user-1',
+        status: 'active',
+        reconciliation: {
+            state: 'matched',
+        },
+        sourceRefs,
+        modality: 'Strength',
+        localDate: date,
+        startedAt: `${date}T10:00:00.000Z`,
+        createdAt: `${date}T11:00:00.000Z`,
+        updatedAt: `${date}T11:00:00.000Z`,
+    };
+}
+
+describe('PR 3 — Canonical weekly coverage credit cutover', () => {
+    const descriptor = EVERGREEN_GENERAL_COVERAGE_SET;
+    const fullBodyTemplate = TEMPLATES_BY_ID.get('str_full_01')!;
+
+    it('exact strength_full_body_maintenance_01 execution -> one primary_strength credit', () => {
+        const occ = occurrence('occ-fb-1', '2026-09-01', [
+            { kind: 'structured_execution', executionId: 'exec-fb-1' },
+        ]);
+        const hydrated: HydratedOccurrenceContext = {
+            structured: {
+                executionId: 'exec-fb-1',
+                workoutId: 'strength_full_body_maintenance_01',
+                templateId: 'str_full_01',
+                modality: 'Strength',
+                category: 'Full-body Strength',
+                startedAt: '2026-09-01T10:00:00.000Z',
+                durationMin: 60,
+                isLegacyStrength: false,
+            },
+        };
+
+        const facts = deriveFactsFromOccurrence(occ, hydrated, descriptor);
+        expect(facts.coverageCredits).toHaveLength(1);
+        expect(facts.coverageCredits[0]).toMatchObject({
+            coverageKey: 'primary_strength',
+            workoutId: 'strength_full_body_maintenance_01',
+            creditKind: 'exact',
+            confidence: 1.0,
+            reasonCode: 'exact_workout_identity',
+        });
+
+        // Test in buildCoverageState
+        const history = resolveCoverageHistory({
+            asOfDate: '2026-09-03',
+            windowDays: 7,
+            revision: 'rev-1',
+            exposures: [facts.exposure],
+            coverageCredits: facts.coverageCredits,
+        });
+
+        const state = buildCoverageState(planDef, '2026-09-03', history, descriptor);
+        const strengthReq = state.requirements.find(r => r.key === 'primary_strength');
+        expect(strengthReq).toBeDefined();
+        expect(strengthReq?.completedSessions).toBe(1);
+        expect(strengthReq?.credits).toHaveLength(1);
+        expect(strengthReq?.credits[0].workoutId).toBe('strength_full_body_maintenance_01');
+
+        // Need tier for full-body strength drops to 3 (already fulfilled)
+        const tier = coverageNeedTierForTemplate(state, fullBodyTemplate, null);
+        expect(tier).toBe(3);
+    });
+
+    it('exact strength_bodyweight_full_body_01 -> one primary_strength credit', () => {
+        const occ = occurrence('occ-bw-1', '2026-09-01', [
+            { kind: 'structured_execution', executionId: 'exec-bw-1' },
+        ]);
+        const hydrated: HydratedOccurrenceContext = {
+            structured: {
+                executionId: 'exec-bw-1',
+                workoutId: 'strength_bodyweight_full_body_01',
+                templateId: 'str_full_02',
+                modality: 'Strength',
+                category: 'Full-body Strength',
+                startedAt: '2026-09-01T10:00:00.000Z',
+                durationMin: 45,
+                isLegacyStrength: false,
+            },
+        };
+
+        const facts = deriveFactsFromOccurrence(occ, hydrated, descriptor);
+        expect(facts.coverageCredits).toHaveLength(1);
+        expect(facts.coverageCredits[0]).toMatchObject({
+            coverageKey: 'primary_strength',
+            workoutId: 'strength_bodyweight_full_body_01',
+            creditKind: 'exact',
+        });
+
+        const history = resolveCoverageHistory({
+            asOfDate: '2026-09-03',
+            windowDays: 7,
+            revision: 'rev-1',
+            exposures: [facts.exposure],
+            coverageCredits: facts.coverageCredits,
+        });
+
+        const state = buildCoverageState(planDef, '2026-09-03', history, descriptor);
+        const strengthReq = state.requirements.find(r => r.key === 'primary_strength');
+        expect(strengthReq?.completedSessions).toBe(1);
+    });
+
+    it('strength_compact_power_01 -> no primary_strength credit', () => {
+        const occ = occurrence('occ-cp-1', '2026-09-01', [
+            { kind: 'structured_execution', executionId: 'exec-cp-1' },
+        ]);
+        const hydrated: HydratedOccurrenceContext = {
+            structured: {
+                executionId: 'exec-cp-1',
+                workoutId: 'strength_compact_power_01',
+                modality: 'Strength',
+                startedAt: '2026-09-01T10:00:00.000Z',
+                durationMin: 30,
+                isLegacyStrength: false,
+            },
+        };
+
+        const facts = deriveFactsFromOccurrence(occ, hydrated, descriptor);
+        expect(facts.coverageCredits).toHaveLength(1);
+        expect(facts.coverageCredits[0].coverageKey).toBe('compact_strength');
+        expect(facts.coverageCredits.some(c => c.coverageKey === 'primary_strength')).toBe(false);
+
+        const history = resolveCoverageHistory({
+            asOfDate: '2026-09-03',
+            windowDays: 7,
+            revision: 'rev-1',
+            exposures: [facts.exposure],
+            coverageCredits: facts.coverageCredits,
+        });
+
+        const state = buildCoverageState(planDef, '2026-09-03', history, descriptor);
+        const strengthReq = state.requirements.find(r => r.key === 'primary_strength');
+        expect(strengthReq?.completedSessions).toBe(0);
+    });
+
+    it('generic Garmin Strength -> no exact primary_strength credit', () => {
+        const occ = occurrence('occ-garmin-1', '2026-09-01', [
+            { kind: 'provider_activity', provider: 'garmin', activityId: 'garmin-123' },
+        ]);
+        const hydrated: HydratedOccurrenceContext = {
+            provider: {
+                activityId: 'garmin-123',
+                provider: 'garmin',
+                modality: 'Strength',
+                startedAt: '2026-09-01T10:00:00.000Z',
+                durationMin: 60,
+                garminActivity: {
+                    activityId: 'garmin-123',
+                    date: '2026-09-01',
+                    durationMin: 60,
+                    type: 'strength_training',
+                    trainingEffectAerobic: 0.2,
+                    trainingEffectAnaerobic: 0,
+                    averageHr: null,
+                    activityTrainingLoad: 2.9,
+                    intensityTag: 'easy',
+                },
+            },
+        };
+
+        const facts = deriveFactsFromOccurrence(occ, hydrated, descriptor);
+        expect(facts.coverageCredits).toHaveLength(1);
+        expect(facts.coverageCredits[0]).toMatchObject({
+            coverageKey: 'primary_strength',
+            creditKind: 'none',
+            confidence: 0,
+            reasonCode: 'generic_modality_only',
+        });
+
+        const history = resolveCoverageHistory({
+            asOfDate: '2026-09-03',
+            windowDays: 7,
+            revision: 'rev-1',
+            exposures: [facts.exposure],
+            coverageCredits: facts.coverageCredits,
+        });
+
+        const state = buildCoverageState(planDef, '2026-09-03', history, descriptor);
+        const strengthReq = state.requirements.find(r => r.key === 'primary_strength');
+        expect(strengthReq?.completedSessions).toBe(0);
+        expect(strengthReq?.credits).toHaveLength(0);
+    });
+
+    it('app+Garmin exact full-body -> one credit, not two', () => {
+        const occ = occurrence('occ-merged-1', '2026-09-01', [
+            { kind: 'structured_execution', executionId: 'exec-fb-1' },
+            { kind: 'provider_activity', provider: 'garmin', activityId: 'garmin-123' },
+        ]);
+        const hydrated: HydratedOccurrenceContext = {
+            structured: {
+                executionId: 'exec-fb-1',
+                workoutId: 'strength_full_body_maintenance_01',
+                templateId: 'str_full_01',
+                modality: 'Strength',
+                category: 'Full-body Strength',
+                startedAt: '2026-09-01T10:00:00.000Z',
+                durationMin: 60,
+                isLegacyStrength: false,
+            },
+            provider: {
+                activityId: 'garmin-123',
+                provider: 'garmin',
+                modality: 'Strength',
+                startedAt: '2026-09-01T10:00:00.000Z',
+                durationMin: 60,
+                garminActivity: {
+                    activityId: 'garmin-123',
+                    date: '2026-09-01',
+                    durationMin: 60,
+                    type: 'strength_training',
+                    trainingEffectAerobic: 0.2,
+                    trainingEffectAnaerobic: 0,
+                    averageHr: null,
+                    activityTrainingLoad: 2.9,
+                    intensityTag: 'easy',
+                },
+            },
+        };
+
+        const facts = deriveFactsFromOccurrence(occ, hydrated, descriptor);
+        expect(facts.coverageCredits).toHaveLength(1);
+        expect(facts.coverageCredits[0].creditKind).toBe('exact');
+        expect(facts.coverageCredits[0].sourceKinds).toEqual(['structured_execution', 'provider_activity']);
+
+        const history = resolveCoverageHistory({
+            asOfDate: '2026-09-03',
+            windowDays: 7,
+            revision: 'rev-1',
+            exposures: [facts.exposure],
+            coverageCredits: facts.coverageCredits,
+        });
+
+        const state = buildCoverageState(planDef, '2026-09-03', history, descriptor);
+        const strengthReq = state.requirements.find(r => r.key === 'primary_strength');
+        expect(strengthReq?.completedSessions).toBe(1);
+        expect(strengthReq?.credits).toHaveLength(1);
+    });
+
+    it('exact catalog identity survives source arrival in either order', () => {
+        const occA = occurrence('occ-order-a', '2026-09-01', [
+            { kind: 'structured_execution', executionId: 'exec-1' },
+            { kind: 'provider_activity', provider: 'garmin', activityId: 'garmin-1' },
+        ]);
+        const occB = occurrence('occ-order-b', '2026-09-01', [
+            { kind: 'provider_activity', provider: 'garmin', activityId: 'garmin-1' },
+            { kind: 'structured_execution', executionId: 'exec-1' },
+        ]);
+
+        const hydrated: HydratedOccurrenceContext = {
+            structured: {
+                executionId: 'exec-1',
+                workoutId: 'strength_full_body_maintenance_01',
+                templateId: 'str_full_01',
+                modality: 'Strength',
+                category: 'Full-body Strength',
+                startedAt: '2026-09-01T10:00:00.000Z',
+                durationMin: 60,
+                isLegacyStrength: false,
+            },
+            provider: {
+                activityId: 'garmin-1',
+                provider: 'garmin',
+                modality: 'Strength',
+                startedAt: '2026-09-01T10:00:00.000Z',
+                durationMin: 60,
+            },
+        };
+
+        const factsA = deriveFactsFromOccurrence(occA, hydrated, descriptor);
+        const factsB = deriveFactsFromOccurrence(occB, hydrated, descriptor);
+
+        expect(factsA.exposure.workoutId).toBe('strength_full_body_maintenance_01');
+        expect(factsB.exposure.workoutId).toBe('strength_full_body_maintenance_01');
+        expect(factsA.coverageCredits[0].creditKind).toBe('exact');
+        expect(factsB.coverageCredits[0].creditKind).toBe('exact');
+    });
+
+    it('unknown/legacy identity remains uncredited but observable', () => {
+        const occ = occurrence('occ-legacy-1', '2026-09-01', [
+            { kind: 'structured_execution', executionId: 'exec-legacy-1' },
+        ]);
+        const hydrated: HydratedOccurrenceContext = {
+            structured: {
+                executionId: 'exec-legacy-1',
+                workoutId: undefined,
+                templateId: undefined,
+                modality: 'Strength',
+                startedAt: '2026-09-01T10:00:00.000Z',
+                durationMin: 50,
+                isLegacyStrength: true,
+            },
+        };
+
+        const facts = deriveFactsFromOccurrence(occ, hydrated, descriptor);
+        expect(facts.exposure.modality).toBe('Strength');
+        expect(facts.exposure.workoutId).toBeUndefined();
+        expect(facts.exposure.confidence).toBe('high');
+
+        expect(facts.coverageCredits).toHaveLength(1);
+        expect(facts.coverageCredits[0]).toMatchObject({
+            coverageKey: 'primary_strength',
+            creditKind: 'none',
+            reasonCode: 'generic_modality_only',
+        });
+
+        const history = resolveCoverageHistory({
+            asOfDate: '2026-09-03',
+            windowDays: 7,
+            revision: 'rev-1',
+            exposures: [facts.exposure],
+            coverageCredits: facts.coverageCredits,
+        });
+
+        const state = buildCoverageState(planDef, '2026-09-03', history, descriptor);
+        const strengthReq = state.requirements.find(r => r.key === 'primary_strength');
+        expect(strengthReq?.completedSessions).toBe(0);
+    });
+
+    it('resolveCoverageHistory treats canonical [] as authoritative over legacy fallback', () => {
+        const legacyExposures = [{
+            date: '2026-09-01',
+            modality: 'Strength' as const,
+            workoutId: 'strength_full_body_maintenance_01',
+            durationMin: 60,
+        }];
+
+        const historyFromEmpty = resolveCoverageHistory({
+            asOfDate: '2026-09-03',
+            windowDays: 7,
+            revision: 'rev-empty',
+            exposures: [],
+            coverageCredits: [],
+        }, legacyExposures);
+
+        expect(historyFromEmpty).toEqual([]);
+
+        const historyFromNull = resolveCoverageHistory(null, legacyExposures);
+        expect(historyFromNull).toHaveLength(1);
+        expect(historyFromNull[0].workoutId).toBe('strength_full_body_maintenance_01');
+    });
+});

--- a/app/src/engine/tests/legacyCoverageOccurrenceIdentity.test.ts
+++ b/app/src/engine/tests/legacyCoverageOccurrenceIdentity.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { buildCoverageState, resolveCoverageHistory } from '../coverage';
+import type { PlanDefinition } from '../planSchedule';
+
+const PLAN: PlanDefinition = {
+    id: 'legacy-occurrence-identity-plan',
+    eventId: 'event-1',
+    coverageSetId: 'evergreen_general',
+    blocks: [{
+        id: 'block-1',
+        phase: 'general',
+        startDate: '2026-08-25',
+        endDate: '2026-09-10',
+        volumeScale: 1,
+        intensityScale: 1,
+    }],
+    objectives: [{
+        key: 'strength_maintenance',
+        coverageKey: 'primary_strength',
+        blockId: 'block-1',
+        requiredCredit: 2,
+        priority: 'must_have',
+        coverageMinimumSessions: 1,
+        coverageTargetSessions: 2,
+    }],
+    sequencingRules: [],
+};
+
+describe('legacy coverage occurrence identity', () => {
+    it('keeps two distinct same-day executions of the same workout as two credits', () => {
+        const history = resolveCoverageHistory(undefined, [
+            {
+                occurrenceKey: 'legacy-occ-1',
+                date: '2026-09-01',
+                workoutId: 'strength_full_body_maintenance_01',
+            },
+            {
+                occurrenceKey: 'legacy-occ-2',
+                date: '2026-09-01',
+                workoutId: 'strength_full_body_maintenance_01',
+            },
+        ]);
+
+        const state = buildCoverageState(PLAN, '2026-09-03', history);
+        const requirement = state.requirements.find(item => item.key === 'primary_strength');
+
+        expect(requirement?.completedSessions).toBe(2);
+        expect(requirement?.credits.map(credit => credit.occurrenceKey)).toEqual([
+            'legacy-occ-1',
+            'legacy-occ-2',
+        ]);
+    });
+
+    it('deduplicates replay of the same legacy occurrence key', () => {
+        const history = resolveCoverageHistory(undefined, [
+            {
+                occurrenceKey: 'legacy-occ-replayed',
+                date: '2026-09-01',
+                workoutId: 'strength_full_body_maintenance_01',
+            },
+            {
+                occurrenceKey: 'legacy-occ-replayed',
+                date: '2026-09-01',
+                workoutId: 'strength_full_body_maintenance_01',
+            },
+        ]);
+
+        const state = buildCoverageState(PLAN, '2026-09-03', history);
+        const requirement = state.requirements.find(item => item.key === 'primary_strength');
+
+        expect(requirement?.completedSessions).toBe(1);
+        expect(requirement?.credits).toHaveLength(1);
+    });
+});

--- a/app/src/engine/tests/trainingIntentCanonicalFacts.test.ts
+++ b/app/src/engine/tests/trainingIntentCanonicalFacts.test.ts
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+    preparedPerformedFactsForCoverageSet,
+    resolveTrainingIntent,
+} from '../trainingIntent';
+import { getPerformedTrainingFactsInRange } from '../../training-occurrence/performedTrainingFactsService';
+import type { DailyReadiness } from '../models';
+import type { TrainingHistorySnapshot } from '../trainingHistorySnapshot';
+import type { PerformedTrainingFactsSnapshot } from '../performedTrainingFacts';
+
+vi.mock('../firestoreTrainingHistory', () => ({
+    firestoreTrainingHistoryProvider: {
+        reconstruct: vi.fn().mockResolvedValue([]),
+        getSnapshot: vi.fn().mockResolvedValue(null),
+    },
+}));
+
+vi.mock('../../training-occurrence/performedTrainingFactsService', () => ({
+    getPerformedTrainingFactsInRange: vi.fn(),
+}));
+
+function readiness(): DailyReadiness {
+    return {
+        subjective: {
+            readiness: 8,
+            sleepQuality: 8,
+            fatigue: 2,
+            soreness: 2,
+            stress: 3,
+            motivation: 8,
+            timeAvailable: 60,
+            painFlag: false,
+            alreadyTrainedToday: false,
+            preferredModalityToday: null,
+        },
+        objective: {
+            total_steps: 8000,
+            sleep_score: 85,
+            sleep_duration_min: 450,
+            rhr: 48,
+            rhr_7d_avg: 49,
+            rhr_delta: -1,
+            hrv_weekly_avg: 55,
+            hrv_last_night: 57,
+            hrv_delta: 2,
+            respiration: 13,
+            body_battery_wake: 85,
+            last_3_days_hard_sessions_count: 0,
+            yesterday_training: null,
+            today_training: null,
+            sleep_score_delta_7d: 0,
+            rhr_delta_28d: 0,
+            hrv_delta_28d: 0,
+            sleep_score_delta_28d: 0,
+            hrv_stdev_28d: 8,
+            rhr_stdev_28d: 3,
+            sleep_score_stdev_28d: 8,
+        },
+    };
+}
+
+function preparedHistory(): TrainingHistorySnapshot {
+    return {
+        throughDateExclusive: '2026-09-02',
+        windowDays: 7,
+        completedEvents: [],
+        exposures: [],
+        sourceStates: {
+            activities: { status: 'AVAILABLE' },
+            recommendations: { status: 'AVAILABLE' },
+            manualTraining: { status: 'MISSING' },
+        },
+        generatedAt: '2026-09-02T05:00:00Z',
+        revision: 'history-v1:test',
+    };
+}
+
+function canonicalFacts(revision: string): PerformedTrainingFactsSnapshot {
+    return {
+        asOfDate: '2026-09-02',
+        windowDays: 7,
+        revision,
+        exposures: [],
+        coverageCredits: [],
+    };
+}
+
+describe('training intent canonical facts + prepared history snapshot', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(getPerformedTrainingFactsInRange).mockResolvedValue(
+            canonicalFacts('canonical-facts-v1:evergreen_general:2026-08-26:2026-09-02:empty'),
+        );
+    });
+
+    it('accepts descriptor-scoped canonical revisions and rejects another coverage set', () => {
+        const evergreen = canonicalFacts('canonical-facts-v1:evergreen_general:2026-08-26:2026-09-02:empty');
+        const event = canonicalFacts('canonical-facts-v1:september_cycling_event:2026-08-26:2026-09-02:empty');
+
+        expect(preparedPerformedFactsForCoverageSet(evergreen, 'evergreen_general')).toBe(evergreen);
+        expect(preparedPerformedFactsForCoverageSet(event, 'evergreen_general')).toBeNull();
+    });
+
+    it('retains noncanonical revision strings for deterministic injected fixtures', () => {
+        const fixture = canonicalFacts('fixture-rev-1');
+        expect(preparedPerformedFactsForCoverageSet(fixture, 'evergreen_general')).toBe(fixture);
+    });
+
+    it('does not let a legacy prepared history snapshot suppress the live canonical occurrence read', async () => {
+        const snapshot = preparedHistory();
+
+        const intent = await resolveTrainingIntent(
+            'user-1',
+            [],
+            '2026-09-02',
+            readiness(),
+            7,
+            undefined,
+            snapshot,
+        );
+
+        expect(getPerformedTrainingFactsInRange).toHaveBeenCalledTimes(1);
+        expect(getPerformedTrainingFactsInRange).toHaveBeenCalledWith(
+            'user-1',
+            '2026-08-26',
+            '2026-09-02',
+            { coverageSetDescriptor: expect.objectContaining({ id: 'evergreen_general' }) },
+        );
+        expect(intent.performedTrainingFacts?.revision).toContain('canonical-facts-v1:evergreen_general:');
+    });
+
+    it('reuses a matching canonical snapshot without a duplicate live read', async () => {
+        const facts = canonicalFacts('canonical-facts-v1:evergreen_general:2026-08-26:2026-09-02:empty');
+        const snapshot = { ...preparedHistory(), performedTrainingFacts: facts };
+
+        const intent = await resolveTrainingIntent(
+            'user-1',
+            [],
+            '2026-09-02',
+            readiness(),
+            7,
+            undefined,
+            snapshot,
+        );
+
+        expect(getPerformedTrainingFactsInRange).not.toHaveBeenCalled();
+        expect(intent.performedTrainingFacts).toBe(facts);
+    });
+
+    it('refetches live facts when prepared canonical facts were derived for another coverage set', async () => {
+        const snapshot = {
+            ...preparedHistory(),
+            performedTrainingFacts: canonicalFacts(
+                'canonical-facts-v1:september_cycling_event:2026-08-26:2026-09-02:empty',
+            ),
+        };
+
+        const intent = await resolveTrainingIntent(
+            'user-1',
+            [],
+            '2026-09-02',
+            readiness(),
+            7,
+            undefined,
+            snapshot,
+        );
+
+        expect(getPerformedTrainingFactsInRange).toHaveBeenCalledTimes(1);
+        expect(intent.performedTrainingFacts?.revision).toContain('canonical-facts-v1:evergreen_general:');
+    });
+});

--- a/app/src/engine/tests/trainingIntentCanonicalFacts.test.ts
+++ b/app/src/engine/tests/trainingIntentCanonicalFacts.test.ts
@@ -66,8 +66,8 @@ function preparedHistory(): TrainingHistorySnapshot {
         completedEvents: [],
         exposures: [],
         sourceStates: {
-            activities: { status: 'AVAILABLE' },
-            recommendations: { status: 'AVAILABLE' },
+            activities: { status: 'AVAILABLE', revision: 'activities-rev' },
+            recommendations: { status: 'AVAILABLE', revision: 'recommendations-rev' },
             manualTraining: { status: 'MISSING' },
         },
         generatedAt: '2026-09-02T05:00:00Z',

--- a/app/src/engine/trainingIntent.ts
+++ b/app/src/engine/trainingIntent.ts
@@ -54,6 +54,7 @@ export interface TrainingIntent {
 const MAX_PLANNED_VOLUME = 1;
 const MAX_PLANNED_INTENSITY = 1.2;
 const ATHLETE_STATE_HISTORY_WINDOW_DAYS = 28;
+const CANONICAL_FACT_REVISION_PREFIX = 'canonical-facts-v1:';
 
 function boundedPlannedDose(volume: number, intensity: number): PlannedDose {
     return {
@@ -66,6 +67,23 @@ function needsEstablishedPerformanceEvidence(planningContext: PlanningContext): 
     if (planningContext.mode !== 'evergreen') return false;
     return planningContext.profile.priorities.some(priority =>
         priority === 'endurance' || priority === 'speed_power' || priority === 'sport_readiness');
+}
+
+/**
+ * A prepared history snapshot may carry canonical performed facts, but those semantic
+ * credits are valid only for the coverage set under which they were derived. Non-canonical
+ * revision strings are retained for deterministic injected fixtures; production canonical
+ * revisions must carry the descriptor id and fail closed on mismatch/legacy unscoped form.
+ */
+export function preparedPerformedFactsForCoverageSet(
+    facts: PerformedTrainingFactsSnapshot | null | undefined,
+    coverageSetId: string,
+): PerformedTrainingFactsSnapshot | null {
+    if (!facts) return null;
+    if (!facts.revision.startsWith(CANONICAL_FACT_REVISION_PREFIX)) return facts;
+    return facts.revision.startsWith(`${CANONICAL_FACT_REVISION_PREFIX}${coverageSetId}:`)
+        ? facts
+        : null;
 }
 
 /**
@@ -159,20 +177,24 @@ export async function resolveTrainingIntent(
     // operational history explicitly bounded so a 28-day state-evidence read cannot widen
     // fatigue or microcycle bookkeeping by accident.
     const history = operationalHistory.filter(exposure => exposure.date >= operationalWindowStart && exposure.date < date);
-    // The live/default path reads canonical occurrences for the narrow spacing/coverage cutovers.
-    // Injected history providers are also used by deterministic projections (including
-    // tomorrow's hypothetical "today was completed" history), so they deliberately keep
-    // their self-contained reconstructed history as the fallback.
-    const performedTrainingFacts = preparedHistorySnapshot
-        ? (preparedHistorySnapshot.performedTrainingFacts ?? null)
-        : historyProvider
-            ? null
-            : await (await import('../training-occurrence/performedTrainingFactsService')).getPerformedTrainingFactsInRange(
-                userId,
-                operationalWindowStart,
-                date,
-                { coverageSetDescriptor: performedFactsCoverageDescriptor },
-            );
+    // Reusing the legacy TrainingHistorySnapshot must not suppress the canonical occurrence
+    // read: Firestore history snapshots currently do not embed descriptor-scoped facts. If
+    // they do carry facts, accept them only when their canonical revision proves they were
+    // derived for this active coverage set. Injected history providers remain self-contained
+    // for deterministic projections and therefore fall back to reconstructed history when
+    // no matching canonical facts were explicitly provided.
+    let performedTrainingFacts = preparedPerformedFactsForCoverageSet(
+        preparedHistorySnapshot?.performedTrainingFacts,
+        performedFactsCoverageDescriptor.id,
+    );
+    if (!performedTrainingFacts && !historyProvider) {
+        performedTrainingFacts = await (await import('../training-occurrence/performedTrainingFactsService')).getPerformedTrainingFactsInRange(
+            userId,
+            operationalWindowStart,
+            date,
+            { coverageSetDescriptor: performedFactsCoverageDescriptor },
+        );
+    }
 
     let historySnapshot = operationalSnapshot;
     if (needsEstablishedPerformanceEvidence(planningContext) && operationalSnapshot) {

--- a/app/src/engine/trainingIntent.ts
+++ b/app/src/engine/trainingIntent.ts
@@ -9,6 +9,7 @@ import { addDaysToLocalDateString } from '../utils/localDate';
 import { resolvePlanningContext, type PlanningContext } from './planningMode';
 import { applyPlanningOverlays } from './planningOverlays';
 import type { PerformedTrainingFactsSnapshot } from './performedTrainingFacts';
+import { coverageSetFor, EVERGREEN_GENERAL_COVERAGE_SET } from '../workouts/event-plan';
 
 export type PlannedRecoveryReason =
   | 'scheduled_recovery'   // Prescribed microcycle rest day
@@ -141,6 +142,13 @@ export async function resolveTrainingIntent(
     const periodization = planningContext.mode === 'event_directed'
         ? eventPeriodization
         : evaluatePeriodizationPhase([], date);
+    const planDefinition = resolvePlanDefinitionForEvent(periodization.focusEvent, authoredPlanBlocks);
+    // CoverageCreditFact is descriptor-scoped. Derive canonical role facts against the same
+    // coverage set the live decision will consume; otherwise a workout whose role differs
+    // between evergreen and event plans can be silently reinterpreted at read time.
+    const performedFactsCoverageDescriptor = planDefinition
+        ? coverageSetFor(planDefinition.coverageSetId)
+        : EVERGREEN_GENERAL_COVERAGE_SET;
     const operationalSnapshot = preparedHistorySnapshot
         ?? await prepareTrainingHistorySnapshot(userId, date, windowDays, historyProvider);
     const provider = historyProvider ?? (await import('./firestoreTrainingHistory')).firestoreTrainingHistoryProvider;
@@ -151,15 +159,20 @@ export async function resolveTrainingIntent(
     // operational history explicitly bounded so a 28-day state-evidence read cannot widen
     // fatigue or microcycle bookkeeping by accident.
     const history = operationalHistory.filter(exposure => exposure.date >= operationalWindowStart && exposure.date < date);
-    // The live/default path reads canonical occurrences for the narrow spacing cutover.
+    // The live/default path reads canonical occurrences for the narrow spacing/coverage cutovers.
     // Injected history providers are also used by deterministic projections (including
     // tomorrow's hypothetical "today was completed" history), so they deliberately keep
-    // their self-contained reconstructed history as the spacing fallback.
+    // their self-contained reconstructed history as the fallback.
     const performedTrainingFacts = preparedHistorySnapshot
         ? (preparedHistorySnapshot.performedTrainingFacts ?? null)
         : historyProvider
             ? null
-            : await (await import('../training-occurrence/performedTrainingFactsService')).getPerformedTrainingFactsInRange(userId, operationalWindowStart, date);
+            : await (await import('../training-occurrence/performedTrainingFactsService')).getPerformedTrainingFactsInRange(
+                userId,
+                operationalWindowStart,
+                date,
+                { coverageSetDescriptor: performedFactsCoverageDescriptor },
+            );
 
     let historySnapshot = operationalSnapshot;
     if (needsEstablishedPerformanceEvidence(planningContext) && operationalSnapshot) {
@@ -183,7 +196,6 @@ export async function resolveTrainingIntent(
         };
     }
 
-    const planDefinition = resolvePlanDefinitionForEvent(periodization.focusEvent, authoredPlanBlocks);
     const builtMicrocycle = buildMicrocycleState(
         periodization.phase,
         addDaysToLocalDateString(date, -windowDays),

--- a/app/src/training-occurrence/performedTrainingFactsService.revision.test.ts
+++ b/app/src/training-occurrence/performedTrainingFactsService.revision.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+    EVERGREEN_GENERAL_COVERAGE_SET,
+    SEPTEMBER_CYCLING_EVENT_COVERAGE_SET,
+} from '../workouts/event-plan';
+import { getPerformedTrainingFactsInRange } from './performedTrainingFactsService';
+import { performedTrainingOccurrenceRepository as repository } from './repository';
+import type { PerformedTrainingOccurrence } from './models';
+import { activityService } from '../services/activityService';
+
+vi.mock('./repository', () => ({
+    performedTrainingOccurrenceRepository: {
+        queryActiveInDateWindow: vi.fn(),
+    },
+}));
+
+vi.mock('../services/sessionExecutionService', () => ({
+    sessionExecutionService: {
+        getExecution: vi.fn(),
+    },
+}));
+
+vi.mock('../services/activityService', () => ({
+    activityService: {
+        getActivitiesInRange: vi.fn(),
+    },
+}));
+
+vi.mock('../sessions/sessionDefinitionResolver', () => ({
+    resolveSessionDefinition: vi.fn().mockResolvedValue({ status: 'MISSING' }),
+}));
+
+function occurrence(): PerformedTrainingOccurrence {
+    return {
+        schemaVersion: 1,
+        performedOccurrenceId: 'pto-revision-1',
+        userId: 'user-1',
+        status: 'active',
+        localDate: '2026-09-01',
+        modality: 'Strength',
+        sourceRefs: [],
+        reconciliation: { state: 'single_source' },
+        createdAt: '2026-09-01T10:00:00Z',
+        updatedAt: '2026-09-01T11:00:00Z',
+    };
+}
+
+describe('performed training facts revision scope', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(activityService.getActivitiesInRange).mockResolvedValue({
+            status: 'AVAILABLE',
+            data: [],
+            revision: 'activities-rev',
+        });
+    });
+
+    it('scopes empty snapshot revisions by coverage set', async () => {
+        const evergreen = await getPerformedTrainingFactsInRange(
+            'user-1',
+            '2026-09-02',
+            '2026-09-02',
+            { coverageSetDescriptor: EVERGREEN_GENERAL_COVERAGE_SET },
+        );
+        const event = await getPerformedTrainingFactsInRange(
+            'user-1',
+            '2026-09-02',
+            '2026-09-02',
+            { coverageSetDescriptor: SEPTEMBER_CYCLING_EVENT_COVERAGE_SET },
+        );
+
+        expect(evergreen.revision).toContain(':evergreen_general:');
+        expect(event.revision).toContain(':september_cycling_event:');
+        expect(evergreen.revision).not.toBe(event.revision);
+    });
+
+    it('does not alias non-empty snapshots with identical occurrences but different role vocabularies', async () => {
+        vi.mocked(repository.queryActiveInDateWindow).mockResolvedValue([occurrence()]);
+
+        const evergreen = await getPerformedTrainingFactsInRange(
+            'user-1',
+            '2026-08-31',
+            '2026-09-02',
+            { coverageSetDescriptor: EVERGREEN_GENERAL_COVERAGE_SET },
+        );
+        const event = await getPerformedTrainingFactsInRange(
+            'user-1',
+            '2026-08-31',
+            '2026-09-02',
+            { coverageSetDescriptor: SEPTEMBER_CYCLING_EVENT_COVERAGE_SET },
+        );
+
+        expect(evergreen.exposures).toHaveLength(1);
+        expect(event.exposures).toHaveLength(1);
+        expect(evergreen.revision).not.toBe(event.revision);
+        expect(evergreen.revision).toContain('pto-revision-1:2026-09-01T11:00:00Z');
+        expect(event.revision).toContain('pto-revision-1:2026-09-01T11:00:00Z');
+    });
+});

--- a/app/src/training-occurrence/performedTrainingFactsService.ts
+++ b/app/src/training-occurrence/performedTrainingFactsService.ts
@@ -43,12 +43,13 @@ export async function getPerformedTrainingFactsInRange(
     toDateExclusive: string,
     options: GetPerformedTrainingFactsOptions = {},
 ): Promise<PerformedTrainingFactsSnapshot> {
+    const descriptor = options.coverageSetDescriptor ?? EVERGREEN_GENERAL_COVERAGE_SET;
     const toDateInclusive = getPreviousLocalDateString(toDateExclusive);
     if (toDateInclusive < fromDateInclusive) {
         return {
             asOfDate: toDateExclusive,
             windowDays: 0,
-            revision: `canonical-facts-v1:${fromDateInclusive}:${toDateExclusive}:empty`,
+            revision: `canonical-facts-v1:${descriptor.id}:${fromDateInclusive}:${toDateExclusive}:empty`,
             exposures: [],
             coverageCredits: [],
         };
@@ -65,7 +66,6 @@ export async function getPerformedTrainingFactsInRange(
         activitiesById = new Map(activities.map(a => [a.activityId, a]));
     }
 
-    const descriptor = options.coverageSetDescriptor ?? EVERGREEN_GENERAL_COVERAGE_SET;
     const exposures: PerformedExposureFact[] = [];
     const coverageCredits: CoverageCreditFact[] = [];
 
@@ -164,7 +164,10 @@ export async function getPerformedTrainingFactsInRange(
         .map(o => `${o.performedOccurrenceId}:${o.updatedAt}`)
         .sort()
         .join('|');
-    const revision = `canonical-facts-v1:${fromDateInclusive}:${toDateExclusive}:${occurrenceRevision}`;
+    // Coverage credits are descriptor-scoped semantic facts. Include that scope in the
+    // snapshot revision so evergreen/event interpretations of the same occurrences never
+    // alias as one immutable fact revision in cache/audit/replay consumers.
+    const revision = `canonical-facts-v1:${descriptor.id}:${fromDateInclusive}:${toDateExclusive}:${occurrenceRevision}`;
 
     return {
         asOfDate: toDateExclusive,

--- a/docs/architecture/canonical-coverage-credit.md
+++ b/docs/architecture/canonical-coverage-credit.md
@@ -1,0 +1,88 @@
+# Canonical weekly coverage credit authority
+
+**Status:** implemented by ADR-0034 PR 3 (`feat/canonical-coverage-credit`)
+
+## Purpose
+
+Weekly programming-role coverage must use the same canonical performed-training occurrence truth as recent-exposure spacing without collapsing the two concepts into one ledger.
+
+The architecture deliberately separates:
+
+1. **Occurrence identity** — `PerformedTrainingOccurrence` answers which provider/app records describe one physical session.
+2. **Broad performed exposure** — `PerformedExposureFact` answers what can safely be said about the performed session for recency/spacing.
+3. **Programming-role semantics** — `CoverageCreditFact` answers whether that occurrence satisfies an authored coverage role such as `primary_strength`.
+4. **Coverage-state eligibility** — `buildCoverageState()` applies the active plan phase, rolling window, required/target counts, and dose constraints such as the aerobic minimum duration.
+
+A downstream consumer must not use layer 2 to reconstruct a decision already made by layer 3.
+
+## Why the semantic ledger is authoritative
+
+A canonical exposure may carry an exact `workoutId`, but the programming role of that workout is coverage-set scoped. For example, `strength_bodyweight_full_body_01` is `primary_strength` in the evergreen general coverage set but `compact_strength` in the September cycling-event set.
+
+Therefore the live path derives `CoverageCreditFact` using the same `CoverageSetDescriptor` that the recommendation decision will consume. `buildCoverageState()` then accepts only canonical exact credits whose `coverageSetId` matches the active descriptor.
+
+This prevents a fact derived under one plan vocabulary from being silently reclassified under another.
+
+## Canonical no-credit is also authoritative
+
+`creditKind: 'none'` is an explicit semantic result, not missing data. A generic Garmin Strength activity can prove that strength happened for spacing while still failing to prove the exact full-body role.
+
+When the canonical credit ledger is present:
+
+- `exact` may satisfy the matching authored role;
+- `semantic_confident` remains disabled in PR 3 until a separate policy defines it;
+- `none` never satisfies a role;
+- a credit for another `coverageSetId` never satisfies the active set;
+- absence of a positive credit for an occurrence is authoritative and must not trigger a workout-id fallback.
+
+This fail-closed behavior is what preserves the cutover plan's D1 separation between recency and exact role fulfillment.
+
+## Legacy and projection compatibility
+
+Forecasts and deterministic tests can contain hypothetical future completions that do not exist yet as canonical occurrences. Legacy/projected `CoverageHistoryEntry` values therefore continue to use descriptor lookup from `workoutId` / `templateId` when no canonical semantic ledger is present.
+
+The distinction is structural:
+
+- canonical performed facts with a `coverageCredits` ledger -> semantic ledger is authoritative, including an empty positive-credit set;
+- legacy/projected history without that ledger -> existing descriptor lookup remains available.
+
+An explicitly empty canonical performed-facts snapshot remains authoritative over legacy completed history.
+
+## Dose and phase remain coverage-state concerns
+
+Canonical role identity does not bypass existing plan constraints.
+
+`buildCoverageState()` still verifies that a credited key exists in the active descriptor and phase. For `aerobic_volume`, it also preserves the catalog minimum-duration rule: knowing that an occurrence executed `cycling_zone2_standard_01` is not enough if the performed duration is below the authored minimum.
+
+This keeps the semantic boundary clean:
+
+- fact layer: *which role identity is proven?*
+- coverage layer: *is that proven role eligible in this plan window and was enough dose performed?*
+
+## Invariants
+
+1. One active canonical occurrence can award a given exact role at most once.
+2. App + Garmin sources attached to one occurrence cannot double-count coverage.
+3. Provider modality alone cannot invent exact role identity.
+4. Canonical `none` cannot be resurrected by downstream workout-id inference.
+5. Credits are valid only for the coverage set under which they were derived.
+6. `semantic_confident` is observational only until an explicit policy enables it.
+7. Phase and minimum-dose checks still apply after semantic cutover.
+8. Legacy/projected histories retain their existing fallback because projected sessions may not have canonical occurrence facts yet.
+
+## Regression coverage
+
+`canonicalCoverageCreditCutover.test.ts` covers the PR 3 acceptance matrix: exact full-body and bodyweight roles, compact-strength non-substitution, generic Garmin no-credit, app+Garmin deduplication, source-order independence, unknown/legacy observability, and authoritative empty canonical history.
+
+`canonicalCoverageCreditAuthority.test.ts` adds architectural regressions for:
+
+- canonical role differing from what a workout-id reclassification would infer;
+- cross-coverage-set credit leakage;
+- authoritative `creditKind: 'none'`;
+- disabled `semantic_confident` credit;
+- preservation of the aerobic minimum-duration gate;
+- exposure-only projection/test compatibility.
+
+## Rollout boundary
+
+This PR cuts weekly role accounting to canonical semantic identity, but it does not remove all legacy recommendation-history reconstruction. Late-sync invalidation/history revision remains PR 4, and retirement of recommendation-specific reconciliation remains PR 5 under the existing cutover plan.

--- a/docs/architecture/canonical-coverage-credit.md
+++ b/docs/architecture/canonical-coverage-credit.md
@@ -48,6 +48,23 @@ The distinction is structural:
 
 An explicitly empty canonical performed-facts snapshot remains authoritative over legacy completed history.
 
+### Prepared snapshots
+
+The legacy Firestore `TrainingHistorySnapshot` builder does not yet embed descriptor-scoped performed facts. Reusing such a prepared snapshot therefore must not suppress the canonical occurrence read. `resolveTrainingIntent()` reuses embedded canonical facts only when their revision proves they were derived for the active coverage set; otherwise the live path re-fetches canonical facts for that descriptor.
+
+Injected/custom history providers remain self-contained for deterministic tests and simulations and can continue to omit canonical facts.
+
+### Week-ahead projections
+
+The week-ahead planner keeps two histories on purpose:
+
+- operational/projected history for fatigue, spacing and objective simulation;
+- coverage history containing canonical completed role facts plus hypothetical projected entries.
+
+Completed canonical facts are never reconstructed from the rolling planner's legacy history. Today/tomorrow/forecast recommendations are added with `source: 'projected'`, so they contribute to `projectedSessions` rather than falsely appearing in `completedSessions`.
+
+This preserves canonical truth while still allowing hypothetical future sessions to participate in feasibility and weekly-role allocation.
+
 ## Dose and phase remain coverage-state concerns
 
 Canonical role identity does not bypass existing plan constraints.
@@ -76,6 +93,9 @@ Without coverage-set scope in the revision, two semantically different snapshots
 7. Phase and minimum-dose checks still apply after semantic cutover.
 8. Legacy/projected histories retain their existing fallback because projected sessions may not have canonical occurrence facts yet.
 9. Snapshot revisions cannot alias two coverage-set interpretations of the same occurrence set.
+10. Prepared legacy history snapshots cannot suppress the live canonical fact read.
+11. Rolling week-ahead projections cannot turn canonical completed facts back into legacy-derived role credit.
+12. Hypothetical recommendations count as projected coverage, not completed coverage.
 
 ## Regression coverage
 
@@ -88,7 +108,10 @@ Without coverage-set scope in the revision, two semantically different snapshots
 - authoritative `creditKind: 'none'`;
 - disabled `semantic_confident` credit;
 - preservation of the aerobic minimum-duration gate;
-- exposure-only projection/test compatibility.
+- exposure-only projection/test compatibility;
+- projected-vs-completed coverage accounting.
+
+`trainingIntentCanonicalFacts.test.ts` verifies that prepared legacy snapshots do not suppress canonical reads, matching scoped facts are reused, and mismatched coverage-set facts are re-fetched.
 
 `performedTrainingFactsService.revision.test.ts` verifies that empty and non-empty snapshots with identical physical-occurrence inputs receive different revisions when derived under different coverage sets.
 

--- a/docs/architecture/canonical-coverage-credit.md
+++ b/docs/architecture/canonical-coverage-credit.md
@@ -59,6 +59,12 @@ This keeps the semantic boundary clean:
 - fact layer: *which role identity is proven?*
 - coverage layer: *is that proven role eligible in this plan window and was enough dose performed?*
 
+## Revision identity
+
+`PerformedTrainingFactsSnapshot.revision` includes the active `coverageSetId` as well as the occurrence revision inputs. This is required because `coverageCredits` are descriptor-scoped semantic facts: the same physical occurrence can legitimately yield a different role set under `evergreen_general` and `september_cycling_event`.
+
+Without coverage-set scope in the revision, two semantically different snapshots could alias in cache, audit, or replay consumers even though their `coverageCredits` differ.
+
 ## Invariants
 
 1. One active canonical occurrence can award a given exact role at most once.
@@ -69,6 +75,7 @@ This keeps the semantic boundary clean:
 6. `semantic_confident` is observational only until an explicit policy enables it.
 7. Phase and minimum-dose checks still apply after semantic cutover.
 8. Legacy/projected histories retain their existing fallback because projected sessions may not have canonical occurrence facts yet.
+9. Snapshot revisions cannot alias two coverage-set interpretations of the same occurrence set.
 
 ## Regression coverage
 
@@ -82,6 +89,8 @@ This keeps the semantic boundary clean:
 - disabled `semantic_confident` credit;
 - preservation of the aerobic minimum-duration gate;
 - exposure-only projection/test compatibility.
+
+`performedTrainingFactsService.revision.test.ts` verifies that empty and non-empty snapshots with identical physical-occurrence inputs receive different revisions when derived under different coverage sets.
 
 ## Rollout boundary
 

--- a/docs/plans/strength-recommendation-canonical-occurrence-cutover-plan.md
+++ b/docs/plans/strength-recommendation-canonical-occurrence-cutover-plan.md
@@ -564,10 +564,10 @@ Assertions must verify behavior, not just parsing.
 
 ## Identity / deduplication
 
-- [ ] app execution + matching Garmin = one canonical occurrence
+- [x] app execution + matching Garmin = one canonical occurrence
 - [ ] legacy app strength + matching Garmin = one canonical occurrence/read fact set
 - [ ] Garmin re-sync is idempotent
-- [ ] source arrival order does not change final semantics
+- [x] source arrival order does not change final semantics
 - [ ] two legitimate same-day strength workouts stay separate
 - [ ] manual keep-separate/unlink is respected by recommendation facts
 - [ ] merged loser occurrence never emits live duplicate facts
@@ -576,27 +576,27 @@ Assertions must verify behavior, not just parsing.
 
 - [ ] app exercises/sets/reps/load/RPE survive hydration
 - [ ] Garmin set rows do not override app detail
-- [ ] Garmin-only strength emits recent Strength exposure
-- [ ] low Garmin TE/training load does not erase strength occurrence
+- [x] Garmin-only strength emits recent Strength exposure
+- [x] low Garmin TE/training load does not erase strength occurrence
 - [ ] sparse Garmin set rows do not become fabricated hard-set volume
-- [ ] missing old RPE/rest is represented as unknown
+- [x] missing old RPE/rest is represented as unknown
 
 ## Weekly coverage
 
-- [ ] exact full-body maintenance workout earns `primary_strength` once
-- [ ] bodyweight full-body workout earns `primary_strength` once
-- [ ] compact strength does not silently satisfy `primary_strength`
-- [ ] upper-body/trunk does not satisfy `primary_strength`
-- [ ] generic Garmin strength does not automatically satisfy `primary_strength`
-- [ ] unresolved legacy identity produces explicit no/uncertain credit reason
+- [x] exact full-body maintenance workout earns `primary_strength` once
+- [x] bodyweight full-body workout earns `primary_strength` once
+- [x] compact strength does not silently satisfy `primary_strength`
+- [x] upper-body/trunk does not satisfy `primary_strength`
+- [x] generic Garmin strength does not automatically satisfy `primary_strength`
+- [x] unresolved legacy identity produces explicit no/uncertain credit reason
 
 ## Spacing / recommendation selection
 
-- [ ] previous-day Strength exposure influences full-body candidate eligibility/ranking
-- [ ] reported 2026-09-01 -> 2026-09-02 reproduction no longer yields duplicate full-body strength solely from weekly target
-- [ ] green HRV/sleep cannot bypass recent-strength spacing without explicit policy
+- [x] previous-day Strength exposure influences full-body candidate eligibility/ranking
+- [x] reported 2026-09-01 -> 2026-09-02 reproduction no longer yields duplicate full-body strength solely from weekly target
+- [x] green HRV/sleep cannot bypass recent-strength spacing without explicit policy
 - [ ] if a deliberate override exists, rationale shows it
-- [ ] cycling/running recommendations are unchanged unless their own canonical facts differ intentionally
+- [x] cycling/running recommendations are unchanged unless their own canonical facts differ intentionally
 
 ## Time / freshness
 

--- a/docs/reviews/pr-331-canonical-coverage-credit-review.md
+++ b/docs/reviews/pr-331-canonical-coverage-credit-review.md
@@ -1,0 +1,63 @@
+# PR 331 Review Note: Canonical Weekly Coverage Credit Cutover (PR 3 / ADR-0016 / ADR-0034)
+
+**Date**: 2026-09-02
+**Author**: Antigravity
+**Branch**: `feat/canonical-coverage-credit`
+**Status**: Ready for Review / Merge
+
+---
+
+## 1. Context & Motivation
+
+Following the 2026-09-01 incident where an easy generic Garmin strength session was followed on 2026-09-02 by the recommender prioritizing `Reduced Full-body Strength Maintenance` (`str_full_03`) citing `Weekly Stimulus Target (Full-body Strength)`:
+- **PR 1 (PR #328)** introduced canonical occurrence facts (`PerformedExposureFact` and `CoverageCreditFact`).
+- **PR 2 (PR #329)** added resistance training spacing policy (`strengthSpacingPolicy.ts`) suppressing consecutive strength sessions.
+- **PR 3** cuts weekly coverage credit derivation over to canonical occurrence truth (`resolveCoverageHistory()`) so that weekly role coverage and stimulus targets faithfully reflect performed structured workouts while preventing generic wearable strength from masquerading as catalog strength workouts.
+
+---
+
+## 2. Key Architectural Decisions
+
+1. **Pure Functional History Resolution (`coverage.ts`)**:
+   - Implemented `` `coverage.ts` `resolveCoverageHistory()` ``, which accepts both canonical performed training facts (`PerformedTrainingFactsSnapshot` / `CoveragePerformedFacts`) and legacy history.
+   - When canonical facts are supplied (even if empty, representing zero sessions performed), they are strictly authoritative and do not fall back to legacy history.
+   - Polymorphic handling allows both typed `PerformedExposureFact` and legacy `CompletedExposure` / `RecentHistoryEntry` without loss of duration or modality fidelity.
+
+2. **Integration into Engine Entry Points**:
+   - In `` `optimizer.ts` `buildOptimizationContext()` ``, `coverageState` is constructed from canonical occurrence facts via `resolveCoverageHistory(intent.performedTrainingFacts, intent.history)`.
+   - In `` `rules.ts` `evaluateTrainingWithIntent()` ``, the evergreen coverage state builder now receives `resolveCoverageHistory(intent.performedTrainingFacts, intent.history)` rather than defaulting to empty history.
+   - In `` `planner.ts` `evaluateProjectedDate()` ``, coverage state incorporates `resolveCoverageHistory(undefined, state.projectedHistory)`.
+
+3. **Strict Coverage Identity Alignment**:
+   - `primary_strength` in `EVERGREEN_GENERAL_COVERAGE_SET` is only fulfilled by exact full-body workouts: `strength_full_body_maintenance_01` and `strength_bodyweight_full_body_01`.
+   - `strength_compact_power_01` awards `compact_strength` credit and never falsely satisfies `primary_strength`.
+   - Generic Garmin strength emits `creditKind: 'none'` with `reasonCode: 'generic_modality_only'`, ensuring no false `primary_strength` credit is awarded.
+   - Reconciled occurrences merging app execution and provider telemetry award exactly 1 credit, never 2.
+
+4. **Policy Version Bump**:
+   - Bumped `` `policy.ts` `POLICY_VERSION` `` to `'2026-09-canonical-coverage-credit-v1'`.
+   - Maintained immutable audit replay lineage by prepending `'2026-09-canonical-strength-spacing-v1'` to `HISTORICAL_POLICY_VERSIONS`.
+
+---
+
+## 3. Test Coverage
+
+- Added comprehensive test suite in `` `canonicalCoverageCreditCutover.test.ts` ``:
+  - Exact `strength_full_body_maintenance_01` structured execution awards one `primary_strength` credit and drops need tier to 3.
+  - Exact `strength_bodyweight_full_body_01` awards one `primary_strength` credit.
+  - `strength_compact_power_01` does not award `primary_strength` credit.
+  - Generic Garmin strength does not award `primary_strength` credit.
+  - App + Garmin merged occurrence awards exactly one credit, not two.
+  - Exact catalog identity survives source arrival in either order.
+  - Unknown/legacy identity remains uncredited for `primary_strength` but observable.
+  - `resolveCoverageHistory()` treats empty canonical array `[]` as authoritative over legacy history.
+
+---
+
+## 4. Verification
+
+- `tsc -b`: 0 errors.
+- `eslint .`: 0 warnings, 0 errors.
+- `vitest run`: 348 test files passed (3,242 unit tests passing).
+- `vite build`: Production client bundle built successfully.
+- Sports knowledge claims & workout catalog validations: passed.

--- a/docs/reviews/pr-331-canonical-coverage-credit-review.md
+++ b/docs/reviews/pr-331-canonical-coverage-credit-review.md
@@ -19,30 +19,36 @@ Following the 2026-09-01 incident where an easy generic Garmin strength session 
 ## 2. Key Architectural Decisions
 
 1. **Pure Functional History Resolution (`coverage.ts`)**:
-   - Implemented `` `coverage.ts` `resolveCoverageHistory()` ``, which accepts both canonical performed training facts (`PerformedTrainingFactsSnapshot` / `CoveragePerformedFacts`) and legacy history.
+   - Implemented `coverage.ts` `resolveCoverageHistory()`, which accepts both canonical performed training facts (`PerformedTrainingFactsSnapshot` / `CoveragePerformedFacts`) and legacy history.
    - When canonical facts are supplied (even if empty, representing zero sessions performed), they are strictly authoritative and do not fall back to legacy history.
-   - Polymorphic handling allows both typed `PerformedExposureFact` and legacy `CompletedExposure` / `RecentHistoryEntry` without loss of duration or modality fidelity.
+   - Polymorphic handling allows both typed `PerformedExposureFact` and legacy `CompletedExposure` / `RecentHistoryEntry` without loss of duration, modality, or stable occurrence identity.
 
 2. **Integration into Engine Entry Points**:
-   - In `` `optimizer.ts` `buildOptimizationContext()` ``, `coverageState` is constructed from canonical occurrence facts via `resolveCoverageHistory(intent.performedTrainingFacts, intent.history)`.
-   - In `` `rules.ts` `evaluateTrainingWithIntent()` ``, the evergreen coverage state builder now receives `resolveCoverageHistory(intent.performedTrainingFacts, intent.history)` rather than defaulting to empty history.
-   - In `` `planner.ts` `evaluateProjectedDate()` ``, coverage state incorporates `resolveCoverageHistory(undefined, state.projectedHistory)`.
+   - In `optimizer.ts` `buildOptimizationContext()`, `coverageState` is constructed from canonical occurrence facts via `resolveCoverageHistory(intent.performedTrainingFacts, intent.history)`.
+   - In `rules.ts` `evaluateTrainingWithIntent()`, the evergreen coverage state builder now receives `resolveCoverageHistory(intent.performedTrainingFacts, intent.history)` rather than defaulting to empty history.
+   - In `planner.ts` `evaluateProjectedDate()`, coverage state incorporates canonical completed coverage plus separately tagged projected history.
 
 3. **Strict Coverage Identity Alignment**:
    - `primary_strength` in `EVERGREEN_GENERAL_COVERAGE_SET` is only fulfilled by exact full-body workouts: `strength_full_body_maintenance_01` and `strength_bodyweight_full_body_01`.
    - `strength_compact_power_01` awards `compact_strength` credit and never falsely satisfies `primary_strength`.
    - Generic Garmin strength emits `creditKind: 'none'` with `reasonCode: 'generic_modality_only'`, ensuring no false `primary_strength` credit is awarded.
    - Reconciled occurrences merging app execution and provider telemetry award exactly 1 credit, never 2.
+   - Canonical credits are descriptor-scoped and only consumed for the active coverage set.
 
-4. **Policy Version Bump**:
-   - Bumped `` `policy.ts` `POLICY_VERSION` `` to `'2026-09-canonical-coverage-credit-v1'`.
+4. **Legacy occurrence identity remains idempotent**:
+   - `CompletedExposure.occurrenceKey` is now preserved by `coverageHistoryFromCompletedExposures()`.
+   - This is required because fallback coverage must distinguish two real executions of the same workout on the same day while still collapsing replay of the same occurrence.
+   - Regression tests cover both directions: distinct occurrence keys count separately; repeated use of the same key counts once.
+
+5. **Policy Version Bump**:
+   - Bumped `policy.ts` `POLICY_VERSION` to `'2026-09-canonical-coverage-credit-v1'`.
    - Maintained immutable audit replay lineage by prepending `'2026-09-canonical-strength-spacing-v1'` to `HISTORICAL_POLICY_VERSIONS`.
 
 ---
 
 ## 3. Test Coverage
 
-- Added comprehensive test suite in `` `canonicalCoverageCreditCutover.test.ts` ``:
+- Added comprehensive canonical cutover coverage in `canonicalCoverageCreditCutover.test.ts` and `canonicalCoverageCreditAuthority.test.ts`:
   - Exact `strength_full_body_maintenance_01` structured execution awards one `primary_strength` credit and drops need tier to 3.
   - Exact `strength_bodyweight_full_body_01` awards one `primary_strength` credit.
   - `strength_compact_power_01` does not award `primary_strength` credit.
@@ -51,13 +57,23 @@ Following the 2026-09-01 incident where an easy generic Garmin strength session 
   - Exact catalog identity survives source arrival in either order.
   - Unknown/legacy identity remains uncredited for `primary_strength` but observable.
   - `resolveCoverageHistory()` treats empty canonical array `[]` as authoritative over legacy history.
+  - Cross-coverage-set credits fail closed.
+  - `semantic_confident` remains disabled pending an explicit policy.
+  - Aerobic minimum-duration gating survives the semantic cutover.
+- Added `legacyCoverageOccurrenceIdentity.test.ts`:
+  - two distinct same-day executions of the same exact workout remain two coverage credits;
+  - replay of the same legacy occurrence key remains idempotent and counts once.
 
 ---
 
 ## 4. Verification
 
+Earlier branch verification before the final occurrence-identity follow-up reported:
+
 - `tsc -b`: 0 errors.
 - `eslint .`: 0 warnings, 0 errors.
 - `vitest run`: 348 test files passed (3,242 unit tests passing).
-- `vite build`: Production client bundle built successfully.
-- Sports knowledge claims & workout catalog validations: passed.
+- `vite build`: production client bundle built successfully.
+- sports knowledge claims & workout catalog validations: passed.
+
+The final follow-up commits were reviewed source-first and add focused regression tests, but no GitHub Actions workflow run was attached to the latest head at review time. Do not treat the earlier executable verification as proof for those final commits; rerun the repository check/build pipeline before merge if CI does not start automatically.


### PR DESCRIPTION
## Summary

Implements **PR 3** of `docs/plans/strength-recommendation-canonical-occurrence-cutover-plan.md`.

Weekly programming-role coverage now cuts over to canonical performed-training occurrence truth. Exact structured strength executions can satisfy authored weekly roles, while generic wearable strength remains observable but cannot masquerade as an exact catalog workout.

## What changed

- Added `resolveCoverageHistory()` in `app/src/engine/coverage.ts`.
  - Canonical performed facts are authoritative when present, including an explicitly empty snapshot.
  - Canonical `CoverageCreditFact` entries, rather than re-derived workout-role lookup, determine completed role identity.
  - Legacy/projected history remains supported as a compatibility path.
- Wired canonical coverage history into optimizer, rules, and week-ahead planning.
- Scoped performed-facts revisions to the active coverage-set descriptor so evergreen/event interpretations cannot alias.
- Preserved the aerobic minimum-duration guard after the identity cutover.
- Kept `semantic_confident` disabled pending an explicit policy.
- Preserved `CompletedExposure.occurrenceKey` through legacy coverage adaptation so two distinct same-day executions stay distinct while replay of the same occurrence remains idempotent.
- Hardened Garmin `intensityTag` handling against missing values.
- Bumped `POLICY_VERSION` to `2026-09-canonical-coverage-credit-v1` and retained historical replay lineage.

## Regression coverage

The PR now covers:

- exact `strength_full_body_maintenance_01` -> `primary_strength`;
- exact `strength_bodyweight_full_body_01` -> `primary_strength`;
- `strength_compact_power_01` -> `compact_strength`, not `primary_strength`;
- generic Garmin Strength -> no exact primary-strength credit;
- app + Garmin merged occurrence -> one credit, not two;
- source-arrival order invariance;
- authoritative empty canonical history;
- cross-coverage-set credits fail closed;
- `semantic_confident` remains disabled;
- aerobic minimum-duration preservation;
- two distinct legacy same-day occurrences count separately;
- replay of one legacy occurrence key counts once.

## Verification

Before the final occurrence-identity follow-up, the branch reported:

- `npm run check`: 348 test files / 3,242 tests passed, 0 lint warnings, 0 typecheck errors;
- `npm run build`: production bundle compiled successfully.

The final follow-up commits add the occurrence-key preservation fix, focused regression tests, and review documentation. At the time of this update there is no GitHub Actions run attached to the latest head, so the earlier executable results should not be misrepresented as verification of those final commits. Re-run the normal check/build pipeline before merge if CI does not start automatically.

See `docs/reviews/pr-331-canonical-coverage-credit-review.md` for the review record.