### PR TITLE
✍️ Scribe: [documentation improvement] docs/README.md analysis index update

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -5,3 +5,7 @@
 ## 2026-08-26 - README.md Index Missing Recent Analysis Documents
 **Learning:** The documentation hub (docs/README.md) acts as the routing table but can easily fall out of sync with newly added review/analysis files in docs/analysis/.
 **Action:** Always verify that newly added files in docs/analysis/ are indexed in the root docs/README.md.
+
+## 2026-09-02 - docs/README.md Index Missing Recent Analysis Documents
+**Learning:** The documentation hub (docs/README.md) acts as the routing table but can easily fall out of sync with newly added review/analysis files in docs/analysis/.
+**Action:** Always verify that newly added files in docs/analysis/ are indexed in the root docs/README.md.

--- a/docs/README.md
+++ b/docs/README.md
@@ -170,6 +170,11 @@ Point-in-time assessments of the system as built, including gaps between documen
 * [**2026-09-01 SEP-C2 — Subjective Mode Threshold & Neutral-Default Calibration**](./analysis/2026-09-01-sep-c2-subjective-mode-thresholds.md) — Recalibrates `readiness.subjective_mode_thresholds`, decoupling motivation and pain-flag semantics from the physical fatigue average and handling partial check-ins.
 * [**2026-09-01 SEP-C3 — Tissue Response Severity Latency & Lumbar Axial Guardrail Precision**](./analysis/2026-09-01-sep-c3-tissue-response-severity.md) — Remediation for tissue-response severity latency and lumbar axial-loading guardrail precision.
 * [**2026-09-01 SEP-C4 — Red-Flag & Clinical Escalation Protocol**](./analysis/2026-09-01-sep-c4-clinical-escalation-protocol.md) — Specification for a fail-closed clinical red-flag/escalation protocol.
+* [**2026-09-02 Evidence Pack — Periodization Objectives & Sport/Event Demand**](./analysis/2026-09-02-evidence-pack-periodization-event-demand.md) — SKR3 W1 periodization objectives and sport/event demand.
+* [**2026-09-02 Knowledge citation provenance audit**](./analysis/2026-09-02-knowledge-citation-provenance-audit.md) — Review of every `app/src/knowledge` module defining `KnowledgeSource` records.
+* [**2026-09-02 PR #335 Review Hardening — SKR4 Athlete Evidence Boundary**](./analysis/2026-09-02-pr335-review-hardening.md) — Review covering architecture, safety semantics, identity isolation, and stacked-branch consistency.
+* [**2026-09-02 Workout Catalog Recovery Metadata Audit**](./analysis/2026-09-02-workout-catalog-recovery-metadata-audit.md) — SKR3 W3 audit focusing on session spacing heuristics and recovery defaults.
+* [**Strength recommendation occurrence-credit gap — 2026-09-02**](./analysis/strength-recommendation-occurrence-credit-gap-2026-09-02.md) — Production reproduction of strength occurrence-credit gap across ADR-0016, ADR-0023, and ADR-0034 boundaries.
 * [**Structured Strength and Garmin Activity Reconciliation Analysis**](./analysis/structured-strength-garmin-activity-reconciliation-analysis.md) — Architectural analysis for reconciling structured strength executions and Garmin activities into a canonical training occurrence.
 
 ---


### PR DESCRIPTION
**📄 What:** 
Added missing links to the recent analysis documents from `docs/analysis/` dated `2026-09-02` to the index in `docs/README.md`. 
Specifically, the following documents were added:
- `2026-09-02-evidence-pack-periodization-event-demand.md`
- `2026-09-02-knowledge-citation-provenance-audit.md`
- `2026-09-02-pr335-review-hardening.md`
- `2026-09-02-workout-catalog-recovery-metadata-audit.md`
- `strength-recommendation-occurrence-credit-gap-2026-09-02.md`

**⚠️ Problem:** 
The documentation hub (`docs/README.md`) acts as a routing table but falls out of sync with newly added review/analysis files in `docs/analysis/`. These files need to be indexed so that they are discoverable by contributors.

**📚 Source of truth:** 
Code base `docs/analysis/` files.

**✅ Verification:** 
Ran `make check` from the repository root which applies formatting and runs linters (`ruff` and `eslint`) and tests (`pytest` and `vitest`). All tests and checks passed.

**🎯 Impact:** 
Improves discoverability of new documentation and architectural review insights for operators and contributors, lowering context barriers and preventing duplicated analysis.

**🔒 Governance:** 
No product scope was expanded, and no authority boundary, licensing rules, or operational limits were changed. This is purely a documentation update to the index.

---
*PR created automatically by Jules for task [13314269189627081137](https://jules.google.com/task/13314269189627081137) started by @Szczepanov*