### PR TITLE
🧹 [code health improvement] Remove unused register_provider method

### DIFF
--- a/src/garmin_sync/health_observation_service.py
+++ b/src/garmin_sync/health_observation_service.py
@@ -68,10 +68,6 @@ class HealthObservationService:
         # empty batch (see _reconcile_missing_sources).
         self._provider_transports: dict[str, set[str]] = {}
 
-    def register_provider(self, name: str, provider: RecoveryObservationProvider) -> None:
-        """Register a recovery observation provider."""
-        self.providers[name] = provider
-
     def _reconcile_missing_sources(
         self,
         logical_date_iso: str,


### PR DESCRIPTION
🎯 **What:**
Removed the unused `register_provider` method from `src/garmin_sync/health_observation_service.py`.

💡 **Why:**
The method was dead code (unused anywhere in `src/` or `tests/`), simplifying `HealthObservationService` and removing unnecessary state manipulation interfaces.

✅ **Verification:**
- Verified `register_provider` is not used via `grep` searches.
- Ran project linters and type checkers (`uv run ruff check .` and `uv run mypy src/garmin_sync/health_observation_service.py`), which all pass.
- Ran test suite (`uv run pytest tests/`), ensuring everything passes and functionality remains correct.

✨ **Result:**
Cleaned up the `HealthObservationService` component, making the codebase leaner and slightly more maintainable by getting rid of dead code.

---
*PR created automatically by Jules for task [10785597310221246397](https://jules.google.com/task/10785597310221246397) started by @Szczepanov*