### PR TITLE
🧹 [Remove unused __future__ annotations import]

### DIFF
--- a/src/garmin_sync/connection_status.py
+++ b/src/garmin_sync/connection_status.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any
 
 from google.cloud import firestore as google_firestore


### PR DESCRIPTION
🎯 **What:** Removed the unused `from __future__ import annotations` from `src/garmin_sync/connection_status.py`.

💡 **Why:** Unused imports clutter the codebase and slightly increase cognitive load. The project explicitly targets Python 3.14 (where PEP 604 type unions like `str | None` are natively supported without the need for `from __future__ import annotations`), making this import safe to remove. This improves overall maintainability and readability without side effects.

✅ **Verification:** Verified by running `uv run ruff check .` (linter checks passed), `uv run mypy src` (type checking passed successfully), and `uv run pytest` (all 652 tests passed). The change was also verified during code review, confirming no regressions.

✨ **Result:** A cleaner and more maintainable `connection_status.py` file with no unnecessary imports.

---
*PR created automatically by Jules for task [8873156997811941925](https://jules.google.com/task/8873156997811941925) started by @Szczepanov*