### PR TITLE
🧹 [code health] Remove unused `annotations` import in `_hr_fidelity_timing.py`

### DIFF
--- a/src/garmin_sync/_hr_fidelity_timing.py
+++ b/src/garmin_sync/_hr_fidelity_timing.py
@@ -1,7 +1,5 @@
 """Timer-window, sampling, and coverage primitives for HRF3."""
 
-from __future__ import annotations
-
 from datetime import datetime
 from statistics import median
 from typing import TYPE_CHECKING


### PR DESCRIPTION
🎯 **What:** Removed the unused `from __future__ import annotations` import from `src/garmin_sync/_hr_fidelity_timing.py`.
💡 **Why:** It was an unused import. Removing it improves the codebase's readability and maintainability without affecting functionality.
✅ **Verification:** Verified by running `uv run mypy src/garmin_sync/_hr_fidelity_timing.py`, `uv run ruff check src/garmin_sync/_hr_fidelity_timing.py`, `uv run ruff format --check src/garmin_sync/_hr_fidelity_timing.py`, and the full test suite (`uv run pytest tests/`), ensuring no regressions were introduced.
✨ **Result:** A cleaner file with no unused imports.

---
*PR created automatically by Jules for task [50258006265892695](https://jules.google.com/task/50258006265892695) started by @Szczepanov*