### PR TITLE
🧹 Remove unused `annotations` import in `fit_activity.py`

### DIFF
--- a/src/garmin_sync/fit_activity.py
+++ b/src/garmin_sync/fit_activity.py
@@ -6,8 +6,6 @@ or complete traces. A decoder error is all-or-nothing: callers must retain the b
 activity and treat fidelity as unassessed rather than using partial messages.
 """
 
-from __future__ import annotations
-
 from dataclasses import dataclass
 from datetime import datetime
 from io import BytesIO


### PR DESCRIPTION
🎯 **What:** Removed the unused `from __future__ import annotations` in `src/garmin_sync/fit_activity.py`.
💡 **Why:** `from __future__ import annotations` was flagged as unused by linters in this file. Removing unused imports helps maintain code health, readability, and clean boundaries.
✅ **Verification:** Verified by checking running type checking (`uv run mypy src tests`) and lint checks (`uv run ruff check .`). Additionally, ran full unit tests (`uv run pytest tests/`), ensuring everything continued to work effectively.
✨ **Result:** A cleaner codebase with the unused module properly cleaned up, maintaining the existing behavior.

---
*PR created automatically by Jules for task [7579230401699455130](https://jules.google.com/task/7579230401699455130) started by @Szczepanov*