### PR TITLE
🧹 Remove unused annotations import in fit_workout_identity

### DIFF
--- a/src/garmin_sync/fit_workout_identity.py
+++ b/src/garmin_sync/fit_workout_identity.py
@@ -13,8 +13,6 @@ additive evidence for a future correlation source and is intentionally not wired
 reconciliation scoring yet.
 """
 
-from __future__ import annotations
-
 import hashlib
 import json
 import math


### PR DESCRIPTION
🎯 **What:** Removed the unused `from __future__ import annotations` import from `src/garmin_sync/fit_workout_identity.py`.
💡 **Why:** The file requires Python >= 3.14, which supports native union operators (e.g. `|`) and generics, so the import is redundant and linting flags it as unused. This improves file readability and code health by keeping only necessary imports.
✅ **Verification:** Verified by checking file contents visually, running `uv run ruff check .` which passed cleanly, checking types on source with `uv run mypy src`, and running the test suite `uv run pytest tests/` which completed successfully (652/652 passed).
✨ **Result:** Cleaned up code file by removing unnecessary legacy type hint features, and all tests still pass safely.

---
*PR created automatically by Jules for task [15018908452847828924](https://jules.google.com/task/15018908452847828924) started by @Szczepanov*