### PR TITLE
🧹 [Code Health] Remove unused annotations import from eight_sleep_mapper

### DIFF
--- a/src/garmin_sync/eight_sleep_mapper.py
+++ b/src/garmin_sync/eight_sleep_mapper.py
@@ -1,7 +1,5 @@
 """Map Eight Sleep trend payloads into ADR-0027 source-aware observations."""
 
-from __future__ import annotations
-
 import hashlib
 import json
 from datetime import datetime, timedelta


### PR DESCRIPTION
🎯 **What:** Removed the unused `from __future__ import annotations` import from `src/garmin_sync/eight_sleep_mapper.py`.
💡 **Why:** This improves the code health by ensuring unused imports are removed, increasing clarity and maintainability. Unused imports can clutter files.
✅ **Verification:** Ran `ruff`, `mypy`, and pytest to verify that no functional or semantic regressions occurred due to the change. All tests and linters passed successfully.
✨ **Result:** `src/garmin_sync/eight_sleep_mapper.py` is free of unused imports.

---
*PR created automatically by Jules for task [10948378140791361561](https://jules.google.com/task/10948378140791361561) started by @Szczepanov*