### PR TITLE
🧪 [testing improvement] Add tests for HealthObservationService.register_provider

### DIFF
--- a/tests/test_health_observation_service.py
+++ b/tests/test_health_observation_service.py
@@ -177,3 +177,28 @@ def test_health_observation_service_tombstones_bundles_on_empty_repeat_batch() -
         "2026-08-27", "garmin", "google_health"
     )
     assert res["google_health"]["reconciledStale"] == ["garmin_google_health"]
+
+
+def test_health_observation_service_register_provider() -> None:
+    mock_repo = MagicMock(spec=FirestoreRecoveryRepository)
+    service = HealthObservationService(
+        user_id="test_uid",
+        repository=mock_repo,
+        archive_store=NullArchiveStore(),
+    )
+
+    assert len(service.providers) == 0
+
+    mock_provider = MagicMock(spec=RecoveryObservationProvider)
+    service.register_provider("test_provider", mock_provider)
+
+    assert len(service.providers) == 1
+    assert "test_provider" in service.providers
+    assert service.providers["test_provider"] is mock_provider
+
+    # Test overwriting an existing provider
+    mock_provider2 = MagicMock(spec=RecoveryObservationProvider)
+    service.register_provider("test_provider", mock_provider2)
+
+    assert len(service.providers) == 1
+    assert service.providers["test_provider"] is mock_provider2


### PR DESCRIPTION
🎯 **What:** The `register_provider` method in `HealthObservationService` previously lacked test coverage, which could lead to uncaught bugs when refactoring.

📊 **Coverage:** A new test function, `test_health_observation_service_register_provider`, was added to verify that a provider is properly saved to the service's `providers` dictionary, and that replacing an existing provider with the same name correctly overwrites it.

✨ **Result:** Test coverage for `src/garmin_sync/health_observation_service.py` has improved, and we can now assert the state of providers inside `HealthObservationService` updates properly after calling `register_provider`.

---
*PR created automatically by Jules for task [5401320484308015097](https://jules.google.com/task/5401320484308015097) started by @Szczepanov*