### PR TITLE
🧹 [remove unused annotations import]

### DIFF
--- a/scripts/export_garmin_zone_evidence.py
+++ b/scripts/export_garmin_zone_evidence.py
@@ -7,8 +7,6 @@ Pipe it directly to ``app/scripts/measure-garmin-zone-credit.mjs``; do not archi
 intermediate output.
 """
 
-from __future__ import annotations
-
 import argparse
 import json
 import sys


### PR DESCRIPTION
🎯 **What:** Removed the unused `from __future__ import annotations` import from `scripts/export_garmin_zone_evidence.py`.
💡 **Why:** This improves maintainability by removing unnecessary, unused code.
✅ **Verification:** Ran `make check` to ensure no functionality is broken and all linters pass.
✨ **Result:** A cleaner file without unneeded imports.

---
*PR created automatically by Jules for task [7537444897717428611](https://jules.google.com/task/7537444897717428611) started by @Szczepanov*