### PR TITLE
🧪 Add comprehensive tests for activity_motion_risk classifier

### DIFF
--- a/tests/test_hr_fidelity_detectors.py
+++ b/tests/test_hr_fidelity_detectors.py
@@ -9,15 +9,18 @@ def test_activity_motion_risk_moderate_for_cycling_and_running() -> None:
     assert activity_motion_risk("trail_running") == "moderate"
     assert activity_motion_risk("treadmill_run") == "moderate"
 
+
 def test_activity_motion_risk_high_for_erratic_movement_sports() -> None:
     assert activity_motion_risk("soccer") == "high"
     assert activity_motion_risk("strength_training") == "high"
     assert activity_motion_risk("rowing") == "high"
 
+
 def test_activity_motion_risk_unknown_for_other_sports() -> None:
     assert activity_motion_risk("yoga") == "unknown"
     assert activity_motion_risk("meditation") == "unknown"
     assert activity_motion_risk("walking") == "unknown"
+
 
 def test_activity_motion_risk_handles_formatting() -> None:
     assert activity_motion_risk("  cyCling  ") == "moderate"

--- a/tests/test_hr_fidelity_detectors.py
+++ b/tests/test_hr_fidelity_detectors.py
@@ -1,0 +1,26 @@
+from garmin_sync._hr_fidelity_detectors import activity_motion_risk
+
+
+def test_activity_motion_risk_moderate_for_cycling_and_running() -> None:
+    assert activity_motion_risk("cycling") == "moderate"
+    assert activity_motion_risk("gravel_cycling") == "moderate"
+    assert activity_motion_risk("run") == "moderate"
+    assert activity_motion_risk("running") == "moderate"
+    assert activity_motion_risk("trail_running") == "moderate"
+    assert activity_motion_risk("treadmill_run") == "moderate"
+
+def test_activity_motion_risk_high_for_erratic_movement_sports() -> None:
+    assert activity_motion_risk("soccer") == "high"
+    assert activity_motion_risk("strength_training") == "high"
+    assert activity_motion_risk("rowing") == "high"
+
+def test_activity_motion_risk_unknown_for_other_sports() -> None:
+    assert activity_motion_risk("yoga") == "unknown"
+    assert activity_motion_risk("meditation") == "unknown"
+    assert activity_motion_risk("walking") == "unknown"
+
+def test_activity_motion_risk_handles_formatting() -> None:
+    assert activity_motion_risk("  cyCling  ") == "moderate"
+    assert activity_motion_risk("RUNNING") == "moderate"
+    assert activity_motion_risk("  Trail_Running  ") == "moderate"
+    assert activity_motion_risk("SOCCER") == "high"


### PR DESCRIPTION
🎯 **What:** The `activity_motion_risk` function in `src/garmin_sync/_hr_fidelity_detectors.py` was completely untested, representing a gap in testing logic for classifying motion artifact risks based on activity type.

📊 **Coverage:** A new test file `tests/test_hr_fidelity_detectors.py` was created to comprehensively cover the `activity_motion_risk` function. The tests verify:
- Moderate motion risk assignment for cycling and running activities.
- High motion risk assignment for erratic movement sports like soccer and strength training.
- Unknown motion risk assignment for other unlisted sports.
- Formatting handling for inputs with surrounding whitespaces and mixed case formatting.

✨ **Result:** Increased testing coverage and confidence by adding direct unit tests for previously untested classification logic, preventing regressions if the activity classification groups change in the future.

---
*PR created automatically by Jules for task [9965281866426857859](https://jules.google.com/task/9965281866426857859) started by @Szczepanov*