### PR TITLE
🧹 Remove unused future import in respiration script

### DIFF
--- a/scripts/respiration_baseline_evidence.py
+++ b/scripts/respiration_baseline_evidence.py
@@ -25,8 +25,6 @@ the fact that ``RespirationStrainPolicy`` defaults to ``'off'`` in production; t
 only produces measurement evidence for that future calibration decision.
 """
 
-from __future__ import annotations
-
 import argparse
 import json
 import random


### PR DESCRIPTION
🎯 **What:** Removed the unused `from __future__ import annotations` import from `scripts/respiration_baseline_evidence.py`.
💡 **Why:** This file explicitly targets Python 3.14 (as per `pyproject.toml` configuration) and standard type hint features like `|` unions are built-in, making this import completely redundant. Removing unused imports improves file readability and passes strict linter requirements cleanly.
✅ **Verification:** Verified by running `uv run ruff check .` and the full global `make check` suite. All validation, typing (mypy/tsc), and tests (pytest/vitest) successfully passed.
✨ **Result:** A cleaner script file without unnecessary legacy import statements, fully compliant with modern typing expectations.

---
*PR created automatically by Jules for task [12337615326046340876](https://jules.google.com/task/12337615326046340876) started by @Szczepanov*