### PR TITLE
🧪 Add tests for workload_flags hr fidelity detector

### DIFF
--- a/tests/test_hr_fidelity_detectors.py
+++ b/tests/test_hr_fidelity_detectors.py
@@ -1,0 +1,73 @@
+from datetime import datetime, timedelta
+
+from garmin_sync._hr_fidelity_detectors import workload_flags
+from garmin_sync.fit_activity import FitRecordSample
+from garmin_sync.hr_fidelity import DEFAULT_HR_FIDELITY_POLICY
+
+_START = datetime(2026, 8, 29, 8, 0)
+
+
+def _records(
+    seconds: list[int],
+    *,
+    hr: float = 140,
+    cadence: float | None = None,
+    power: float | None = None,
+) -> list[FitRecordSample]:
+    return [
+        FitRecordSample(
+            timestamp=_START + timedelta(seconds=second),
+            heart_rate_bpm=hr,
+            cadence_rpm=cadence,
+            power_watts=power,
+        )
+        for second in seconds
+    ]
+
+
+def test_workload_flags_too_few_records() -> None:
+    assert workload_flags(_records([0]), DEFAULT_HR_FIDELITY_POLICY) == set()
+
+
+def test_workload_flags_short_duration() -> None:
+    assert workload_flags(_records([0, 179]), DEFAULT_HR_FIDELITY_POLICY) == set()
+
+
+def test_workload_flags_stale_plateau() -> None:
+    records = []
+    for i in range(181):
+        hr = 140.0
+        if i < 60:
+            power = 100.0
+        elif i < 120:
+            power = 100.0
+        else:
+            power = 250.0
+
+        records.append(
+            FitRecordSample(
+                timestamp=_START + timedelta(seconds=i),
+                heart_rate_bpm=hr,
+                power_watts=power,
+                cadence_rpm=None,
+            )
+        )
+
+    flags = workload_flags(records, DEFAULT_HR_FIDELITY_POLICY)
+    assert flags == {"STALE_PLATEAU", "WORKLOAD_DISCORDANCE"}
+
+
+def test_workload_flags_no_stale_plateau() -> None:
+    records = []
+    for i in range(181):
+        records.append(
+            FitRecordSample(
+                timestamp=_START + timedelta(seconds=i),
+                heart_rate_bpm=140.0,
+                power_watts=100.0,
+                cadence_rpm=None,
+            )
+        )
+
+    flags = workload_flags(records, DEFAULT_HR_FIDELITY_POLICY)
+    assert flags == set()


### PR DESCRIPTION
🎯 **What:** Tested the `workload_flags` function in `src/garmin_sync/_hr_fidelity_detectors.py` which was previously untested.

📊 **Coverage:** The tests cover the following scenarios for `workload_flags`:
- Early returns when there are fewer than 2 records.
- Early returns when the total duration of the records is shorter than `plateau_min_duration_seconds`.
- Returning no flags (empty set) when the duration is long enough but there is no stale plateau.
- Returning `{"STALE_PLATEAU", "WORKLOAD_DISCORDANCE"}` when a stale plateau is detected (i.e. heart rate remains flat while power varies significantly over time).

✨ **Result:** Test coverage improved for the core HR fidelity detectors module, specifically the logic around plateau detection, ensuring it will safely fail or flag anomalies exactly according to the artifact policy.

---
*PR created automatically by Jules for task [9212202684374545591](https://jules.google.com/task/9212202684374545591) started by @Szczepanov*