### PR TITLE
🧹 [fix false positive pending action] Resolve false positive "fix" keyword scanner in tests/test_identity_replay_export.py

### DIFF
--- a/tests/test_identity_replay_export.py
+++ b/tests/test_identity_replay_export.py
@@ -1,3 +1,4 @@
+from typing import Any
 from unittest.mock import MagicMock
 
 from garmin_sync.identity_replay_export import export_identity_replay_input
@@ -18,7 +19,7 @@ def _complete_garmin_snapshot(date: str) -> dict:
     }
 
 
-def _eight_sleep_bundle(date: str, **overrides) -> dict:
+def _eight_sleep_bundle(date: str, **overrides: Any) -> dict:
     bundle = {
         "logicalDate": date,
         "provider": "eight_sleep",
@@ -76,7 +77,7 @@ def test_export_paired_night_with_anchor_present() -> None:
     assert anchor_ref["lineageKey"] != shared_ref["lineageKey"]
 
     # This fixture's raw snapshot has no sleepSessionStart/sleepSessionEnd (e.g. a night
-    # synced before the sleep-timing plumbing fix) -- see
+    # synced before the sleep-timing plumbing update) -- see
     # test_export_garmin_session_populated_when_raw_has_sleep_timing for the positive case.
     assert night["garminSessions"] == []
     assert night["eightSleepSessions"] == [


### PR DESCRIPTION
🎯 What
Renamed "plumbing fix" to "plumbing update" in a comment inside `tests/test_identity_replay_export.py` to prevent automated scanners from flagging it as a pending action item (e.g. FIXME or TODO). Added correct typing to an untyped kwargs argument.

💡 Why
A repository scanner surfaced line 79 of `tests/test_identity_replay_export.py` as a pending action item because the comment contained the phrase "plumbing fix". Rewording this to "plumbing update" resolves the false positive while retaining the comment's meaning.

✅ Verification
Ran `uv run pytest tests/test_identity_replay_export.py` and it passed. Ran `uv run ruff check .` and `uv run ruff format .` and `uv run mypy src tests` to ensure no typing or linting regressions.

✨ Result
A cleaner codebase with one less false-positive pending action item flagged.

---
*PR created automatically by Jules for task [1176400324311343388](https://jules.google.com/task/1176400324311343388) started by @Szczepanov*