### PR TITLE
🧹 Fix false positive pending action keyword in multisource audit

### DIFF
--- a/src/garmin_sync/multisource_audit.py
+++ b/src/garmin_sync/multisource_audit.py
@@ -360,7 +360,7 @@ def run_multisource_audit(
 
         # Timing coverage per source, only over nights that source actually has sleep
         # data for -- a source with no sleep record that night is a coverage gap
-        # (garminOnlyDays/eightSleepOnlyDays/neitherDays above), not a missing-timestamp bug.
+        # (garminOnlyDays/eightSleepOnlyDays/neitherDays above), not a missing-timestamp defect.
         garmin_timing_ok = _garmin_sleep_timing_available(snap)
         if garmin_sleep is not None:
             if garmin_timing_ok:

--- a/tests/test_multisource_audit.py
+++ b/tests/test_multisource_audit.py
@@ -18,7 +18,8 @@ def test_audit_math_helpers() -> None:
 
     xs = [1.0, 2.0, 3.0, 4.0, 5.0]
     ys = [2.0, 4.0, 6.0, 8.0, 10.0]
-    assert round(_calc_correlation(xs, ys), 2) == 1.0
+    corr = _calc_correlation(xs, ys)
+    assert corr is not None and round(corr, 2) == 1.0
 
 
 def test_calc_percentile() -> None:


### PR DESCRIPTION
🎯 What
The comment `not a missing-timestamp bug.` in `src/garmin_sync/multisource_audit.py` was being flagged by a pending action scanner due to the word `bug`. The word has been changed to `defect` (`not a missing-timestamp defect.`) to resolve this false positive.

💡 Why
Linters and issue trackers frequently scan for keywords like `TODO`, `FIXME`, or `BUG`. Using these words in descriptive text causes false positives and clutters pending action trackers.

✅ Verification
- Updated the comment.
- Re-ran tests, mypy, and ruff to ensure the codebase remains clean.
- Also fixed a minor type assertion issue in `tests/test_multisource_audit.py` to ensure `mypy` continues passing.

✨ Result
No more false positives in the pending action scanner.

---
*PR created automatically by Jules for task [3358382660789688539](https://jules.google.com/task/3358382660789688539) started by @Szczepanov*