### PR TITLE
🧹 [Extract shared HTTP response logic into BaseJSONRequestHandler]

### DIFF
--- a/src/garmin_sync/account_link_api.py
+++ b/src/garmin_sync/account_link_api.py
@@ -6,7 +6,7 @@ import threading
 import time
 from collections import defaultdict, deque
 from http import HTTPStatus
-from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from http.server import ThreadingHTTPServer
 from typing import Any
 
 from firebase_admin import auth as firebase_auth
@@ -19,8 +19,9 @@ from .account_link import (
     GarminLinkConfigurationError,
     GarminLinkConflictError,
 )
+from .base_api import BaseJSONRequestHandler
 from .connection_status import reconcile_garmin_connection_status
-from .error_reporting import log_exception, sanitize_text
+from .error_reporting import log_exception
 
 logging.basicConfig(
     level=logging.INFO,
@@ -94,9 +95,8 @@ def _verified_uid(authorization: str | None) -> str | None:
     return str(uid)
 
 
-class GarminAccountLinkHandler(BaseHTTPRequestHandler):
+class GarminAccountLinkHandler(BaseJSONRequestHandler):
     server_version = "GarminAccountLink/1"
-    request_id: str | None = None
 
     def log_message(self, format: str, *args: Any) -> None:
         # BaseHTTPRequestHandler includes the path but never request bodies. Keep logs
@@ -106,35 +106,6 @@ class GarminAccountLinkHandler(BaseHTTPRequestHandler):
             sanitized_path = self.path.split("?", 1)[0]
             message = message.replace(self.path, sanitized_path)
         logger.info("%s - %s", self.address_string(), message)
-
-    def _json_response(self, status: HTTPStatus, payload: dict[str, Any]) -> None:
-        body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
-        self.send_response(status.value)
-        self.send_header("Content-Type", "application/json; charset=utf-8")
-        self.send_header("Cache-Control", "no-store")
-        self.send_header("X-Content-Type-Options", "nosniff")
-        if self.request_id:
-            self.send_header("X-Request-ID", self.request_id)
-        self.send_header("Content-Length", str(len(body)))
-        self.end_headers()
-        self.wfile.write(body)
-
-    def _error_response(
-        self,
-        status: HTTPStatus,
-        *,
-        message: str,
-        error_code: str,
-        retryable: bool,
-    ) -> None:
-        payload: dict[str, Any] = {
-            "error": sanitize_text(message),
-            "errorCode": error_code,
-            "retryable": retryable,
-        }
-        if self.request_id:
-            payload["requestId"] = self.request_id
-        self._json_response(status, payload)
 
     def _read_json(self) -> dict[str, Any]:
         raw_length = self.headers.get("Content-Length", "0")

--- a/src/garmin_sync/base_api.py
+++ b/src/garmin_sync/base_api.py
@@ -1,0 +1,44 @@
+import json
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler
+from typing import Any
+
+from .error_reporting import sanitize_text
+
+
+class BaseJSONRequestHandler(BaseHTTPRequestHandler):
+    """Base class for HTTP handlers that respond with JSON.
+
+    Provides shared `_json_response` and `_error_response` utilities.
+    """
+
+    request_id: str | None = None
+
+    def _json_response(self, status: HTTPStatus, payload: dict[str, Any]) -> None:
+        body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        self.send_response(status.value)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("X-Content-Type-Options", "nosniff")
+        if self.request_id:
+            self.send_header("X-Request-ID", self.request_id)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _error_response(
+        self,
+        status: HTTPStatus,
+        *,
+        message: str,
+        error_code: str,
+        retryable: bool,
+    ) -> None:
+        payload: dict[str, Any] = {
+            "error": sanitize_text(message),
+            "errorCode": error_code,
+            "retryable": retryable,
+        }
+        if self.request_id:
+            payload["requestId"] = self.request_id
+        self._json_response(status, payload)

--- a/src/garmin_sync/google_health_account_link_api.py
+++ b/src/garmin_sync/google_health_account_link_api.py
@@ -8,18 +8,18 @@ verification being unresolved means every linked user will see Google's "unverif
 warning -- that's a known, accepted limitation of this phase, not a bug in this service.
 """
 
-import json
 import logging
 import os
 import secrets
 import urllib.parse
 from http import HTTPStatus
-from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from http.server import ThreadingHTTPServer
 from typing import Any
 
 from firebase_admin import auth as firebase_auth
 
-from .error_reporting import log_exception, sanitize_text
+from .base_api import BaseJSONRequestHandler
+from .error_reporting import log_exception
 from .firestore_repository import init_firestore_client
 from .google_health_account_link import (
     GoogleHealthConnectionRepository,
@@ -74,38 +74,13 @@ def _env(name: str) -> str:
     return value
 
 
-class GoogleHealthAccountLinkHandler(BaseHTTPRequestHandler):
+class GoogleHealthAccountLinkHandler(BaseJSONRequestHandler):
     server_version = "GoogleHealthAccountLink/1"
-    request_id: str | None = None
 
     def log_message(self, format: str, *args: Any) -> None:
         # Never log query strings here -- the callback URL carries `code`/`state`, both of
         # which are effectively bearer credentials for this flow.
         logger.info("%s - %s %s", self.address_string(), self.command, self.path.split("?")[0])
-
-    def _json_response(self, status: HTTPStatus, payload: dict[str, Any]) -> None:
-        body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
-        self.send_response(status.value)
-        self.send_header("Content-Type", "application/json; charset=utf-8")
-        self.send_header("Cache-Control", "no-store")
-        self.send_header("X-Content-Type-Options", "nosniff")
-        if self.request_id:
-            self.send_header("X-Request-ID", self.request_id)
-        self.send_header("Content-Length", str(len(body)))
-        self.end_headers()
-        self.wfile.write(body)
-
-    def _error_response(
-        self, status: HTTPStatus, *, message: str, error_code: str, retryable: bool
-    ) -> None:
-        payload: dict[str, Any] = {
-            "error": sanitize_text(message),
-            "errorCode": error_code,
-            "retryable": retryable,
-        }
-        if self.request_id:
-            payload["requestId"] = self.request_id
-        self._json_response(status, payload)
 
     def _redirect(self, location: str) -> None:
         self.send_response(HTTPStatus.FOUND.value)


### PR DESCRIPTION
🎯 **What:** Extracted duplicated `_json_response`, `_error_response`, and `request_id` logic from `GarminAccountLinkHandler` and `GoogleHealthAccountLinkHandler` into a new shared `BaseJSONRequestHandler` base class in `src/garmin_sync/base_api.py`.
💡 **Why:** Both the Garmin and Google Health API handlers previously duplicated the JSON HTTP response and error handling logic, creating a maintenance burden if changes to content-types, cache headers, or request IDs were needed. This refactoring DRYs up the codebase.
✅ **Verification:** Verified by checking the file contents, running `uv run ruff check --fix .` to ensure no unused imports remained, and running `uv run pytest` to confirm all 652 tests pass successfully with no behavioral regressions.
✨ **Result:** Improved maintainability and readability without altering the functionality of the APIs.

---
*PR created automatically by Jules for task [2533660448305606906](https://jules.google.com/task/2533660448305606906) started by @Szczepanov*