### PR TITLE
🧹 [Remove unused annotations import in identity_replay_export.py]

### DIFF
--- a/src/garmin_sync/identity_replay_export.py
+++ b/src/garmin_sync/identity_replay_export.py
@@ -26,8 +26,6 @@ bespoke backfill script needed); `garminSessions` is `[]` for those exactly as b
 accurate for them, not a synthesized placeholder.
 """
 
-from __future__ import annotations
-
 import hashlib
 import json
 from dataclasses import dataclass, field


### PR DESCRIPTION
🎯 **What:** Removed the unused `from __future__ import annotations` import from `src/garmin_sync/identity_replay_export.py`.

💡 **Why:** This file uses native modern type hinting supported by Python 3.14 (the version targeted by this project, per the `pyproject.toml`), meaning the `from __future__ import annotations` line is redundant and flagging as unused. Cleaning it up reduces visual clutter, complies with linter recommendations, and improves overall code health.

✅ **Verification:** Verified by running:
- `uv run ruff format .` and `uv run ruff check .` for linting and formatting.
- `uv run mypy src/garmin_sync` to ensure typing rules hold.
- `make check` to ensure the full global test suite, including frontend validations, passes successfully without regression.

✨ **Result:** A slightly cleaner and lint-compliant codebase without changing existing functional behaviors or logic.

---
*PR created automatically by Jules for task [10457823170487793868](https://jules.google.com/task/10457823170487793868) started by @Szczepanov*