### PR TITLE
🧹 [code health improvement] Remove unused `annotations` import from `_hr_fidelity_detectors.py`

### DIFF
--- a/src/garmin_sync/_hr_fidelity_detectors.py
+++ b/src/garmin_sync/_hr_fidelity_detectors.py
@@ -1,7 +1,5 @@
 """Deterministic artifact candidates for HRF3."""
 
-from __future__ import annotations
-
 from collections.abc import Iterator
 from datetime import datetime, timedelta
 from statistics import median


### PR DESCRIPTION
🎯 **What:** Removed the unused `from __future__ import annotations` import from `src/garmin_sync/_hr_fidelity_detectors.py`.
💡 **Why:** This file explicitly targets Python 3.14 (as per `pyproject.toml`), which has native support for modern typing syntax, making the forward-reference import redundant. Removing unused imports improves overall code maintainability and readability without impacting functionality.
✅ **Verification:** Verified by running `make check` which successfully completed `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy src`, `uv run pytest`, and frontend validations (`npm run typecheck` and `npm run validate:workouts`) without identifying any regressions. Code review also verified this was a safe and clean removal.
✨ **Result:** The codebase is cleaner and adheres to linting standards by eliminating dead code.

---
*PR created automatically by Jules for task [13218433741462493393](https://jules.google.com/task/13218433741462493393) started by @Szczepanov*