### PR TITLE
🧹 [remove unused import annotations in hr_fidelity.py]

### DIFF
--- a/src/garmin_sync/hr_fidelity.py
+++ b/src/garmin_sync/hr_fidelity.py
@@ -5,8 +5,6 @@ quality metadata. It deliberately has no persistence, provider, or recommendatio
 dependencies: a weak measurement reduces available HR evidence, never athlete state.
 """
 
-from __future__ import annotations
-
 from dataclasses import dataclass
 from typing import Literal
 


### PR DESCRIPTION
🎯 **What:** Removed unused `from __future__ import annotations` import from `src/garmin_sync/hr_fidelity.py`
💡 **Why:** It's an unused import, removing it cleans up the file and improves maintainability by removing unnecessary boilerplate.
✅ **Verification:** Verified via `uv run ruff check .`, `uv run mypy src tests`, and `uv run pytest`.
✨ **Result:** Codebase is cleaner and type hinting remains functional.

---
*PR created automatically by Jules for task [8329168009587744543](https://jules.google.com/task/8329168009587744543) started by @Szczepanov*