### PR TITLE
🧹 [Code Health] Remove false-positive action item trigger in test comment

### DIFF
--- a/app/src/components/ExternalPlanImport.test.tsx
+++ b/app/src/components/ExternalPlanImport.test.tsx
@@ -156,7 +156,7 @@ describe('diffPlans — M3.7 fine-grained v2 content diff', () => {
  * the requirement -- the initial disabled/enabled state on first render -- via `PlanPreview`
  * directly (exported for exactly this). The other half (clicking the checkbox re-enables
  * Import) needs simulated interaction this repo's tooling can't do; the underlying state
- * (`acknowledged`) is a plain `useState` toggle with no logic of its own to hide a bug in.
+ * (`acknowledged`) is a plain `useState` toggle with no logic of its own to conceal defects.
  */
 describe('PlanPreview — M3.7 import acknowledgement gating', () => {
     function behaviorChangingDiff(): PlanDiffRow[] {


### PR DESCRIPTION
🎯 What: Rephrased a comment in `app/src/components/ExternalPlanImport.test.tsx` to avoid triggering an automated action-item scanner.
💡 Why: The previous phrasing ("hide a bug in") inadvertently flagged the file for review by matching a specific action keyword.
✅ Verification: Ran `make check` to ensure all tests pass and no functionality was modified.
✨ Result: The false positive has been addressed without altering the intent of the comment.

---
*PR created automatically by Jules for task [13381567171676510682](https://jules.google.com/task/13381567171676510682) started by @Szczepanov*