### PR TITLE
🧹 fix timezone DST bug in addDaysToLocalDateString

### DIFF
--- a/app/src/utils/localDate.ts
+++ b/app/src/utils/localDate.ts
@@ -27,11 +27,12 @@ export function getLocalDateString(dateInput: Date = new Date(), timezone: strin
  * for a date that's already a correct local calendar date. `days` may be negative.
  */
 export function addDaysToLocalDateString(dateStr: string, days: number): string {
-    const d = new Date(dateStr + 'T00:00:00');
-    d.setDate(d.getDate() + days);
-    const year = d.getFullYear();
-    const month = String(d.getMonth() + 1).padStart(2, '0');
-    const day = String(d.getDate()).padStart(2, '0');
+    const [yearPart, monthPart, dayPart] = dateStr.split('-').map(Number);
+    const d = new Date(Date.UTC(yearPart, monthPart - 1, dayPart));
+    d.setUTCDate(d.getUTCDate() + days);
+    const year = d.getUTCFullYear();
+    const month = String(d.getUTCMonth() + 1).padStart(2, '0');
+    const day = String(d.getUTCDate()).padStart(2, '0');
     return `${year}-${month}-${day}`;
 }
 


### PR DESCRIPTION
🎯 What:
Refactored `addDaysToLocalDateString` to parse YYYY-MM-DD components directly and manipulate dates using `Date.UTC`, `.getUTCDate()`, and `.setUTCDate()`.

💡 Why:
The previous implementation, `new Date(dateStr + 'T00:00:00')`, parsed the date in the local timezone of the runtime. If the local timezone has a Daylight Saving Time transition precisely at midnight, the time can shift (e.g., 23:00 or 01:00), leading to off-by-one errors in calendar arithmetic when extracting `.getDate()` and `.getMonth()`. Using standard UTC ensures purely 24-hour jumps without timezone interferences, fulfilling the function's JSDoc mandate of "pure date-string arithmetic, no timezone instant involved".

✅ Verification:
- Unit tests (`timezoneDst.test.ts`) covering DST pass seamlessly.
- `make check` suite fully passes without regressions.

✨ Result:
Calendar arithmetic is now robust against any environment's local timezone rules and daylight saving time jumps.

---
*PR created automatically by Jules for task [4790681010854854995](https://jules.google.com/task/4790681010854854995) started by @Szczepanov*