### PR TITLE
test(docs): harden SKR3 W3 recovery metadata audit

### DIFF
--- a/app/src/workouts/workoutRecoveryMetadata.test.ts
+++ b/app/src/workouts/workoutRecoveryMetadata.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { ENRICHED_TEMPLATES } from '../engine/templates';
 import { WORKOUTS } from './catalog';
 import { EXERCISES } from './exercises';
 import { validateWorkoutLibrary } from './validation';
@@ -52,6 +53,18 @@ describe('catalog workout recovery metadata audit (SKR3 W3)', () => {
     expect(byModality.strength.minDays2).toBe(0);
     expect(byModality.field.minDays1).toBe(1);
     expect(byModality.field.minDays2).toBe(2);
+  });
+
+  it('pins the safety-relevant one-day overrides whose associated engine template has lowerBodyCost >= 0.6', () => {
+    const templateById = new Map(ENRICHED_TEMPLATES.map(template => [template.id, template]));
+    const oneDayHighLowerBodyOverrides = WORKOUTS.filter(workout => {
+      if (workout.eligibility.minimumDaysAfterHardLowerBody !== 1) return false;
+      return (workout.engineTemplateIds ?? []).some(templateId =>
+        (templateById.get(templateId)?.costProfile?.lowerBody ?? 0) >= 0.6
+      );
+    });
+
+    expect(oneDayHighLowerBodyOverrides).toHaveLength(11);
   });
 
   it('rejects workouts with out-of-bounds recoveryHours or invalid minimumDaysAfterHardLowerBody', () => {

--- a/docs/analysis/2026-09-02-workout-catalog-recovery-metadata-audit.md
+++ b/docs/analysis/2026-09-02-workout-catalog-recovery-metadata-audit.md
@@ -12,7 +12,7 @@
 As part of completing the Sports Knowledge Registry migration (SKR3), Workstream W3 audited every active workout in `app/src/workouts/catalog/` for declared recovery metadata (`loadProfile.recoveryHours` and `eligibility.minimumDaysAfterHardLowerBody`).
 
 ### Key Findings
-1. **Universal Recovery Hours:** All 46 catalog workouts currently declare finite `recoveryHours` within the range $[0, 96]$; library validation rejects values outside the canonical numeric band $[0, 168]$ (7 days), while the catalog audit test separately asserts finiteness.
+1. **Universal Recovery Hours:** All 46 catalog workouts currently declare finite `recoveryHours` within the range $[0, 96]$; library validation rejects non-finite values and finite values outside the canonical numeric band $[0, 168]$ (7 days), while the catalog audit test separately pins the current authored range.
 2. **Spacing Overrides:** 21 of 46 workouts declare `eligibility.minimumDaysAfterHardLowerBody` (18 workouts declare 1 day; 3 workouts declare 2 days).
 3. **High Lower-Body Interaction:** 11 workouts whose associated engine template has `lowerBodyCost >= 0.6` declare `minimumDaysAfterHardLowerBody: 1`. This authored override permits next-day hard lower-body eligibility under `optimizer.ts:evaluateRecoveryConstraints` when no other recovery constraint blocks the candidate, diverging from the 2-day product fallback and the registered residual-fatigue boundary.
 4. **Protective Mitigation:** Most of those 11 workouts also declare recovery windows that reduce practical next-day placement risk, but the mechanisms are not equivalent: `RECOVERY_WINDOW_UNELAPSED` only blocks hard/anchor candidates and the exact declared `recoveryHours` vary by workout. The 1-day spacing override therefore remains behaviorally material and must not be described as universally neutralized by recovery-hours metadata.
@@ -110,17 +110,19 @@ Relevant external evidence can justify broad boundaries (for example, recovery i
 
 To prevent unvalidated drift in recovery metadata:
 1. **Schema Validation (`validateWorkoutLibrary` in `app/src/workouts/validation.ts`):**
-   - Rejects `recoveryHours < 0` and `recoveryHours > 168`.
+   - Rejects non-finite `recoveryHours` (`NaN`, `+Infinity`, `-Infinity`).
+   - Rejects finite `recoveryHours < 0` and `recoveryHours > 168`.
    - Enforces $1 \le \text{minimumDaysAfterHardLowerBody} \le 7$ (integer).
 2. **Automated Test Suite (`workoutRecoveryMetadata.test.ts`):**
    - Verifies that current catalog `recoveryHours` values are finite and remain within $[0, 168]$.
    - Audits modality distribution.
-   - Asserts reject behavior for out-of-range recovery hours and invalid minimum-day values.
+   - Pins the safety-relevant subset at 11 one-day overrides whose associated enriched engine template has lower-body cost `>= 0.6`.
+   - Asserts reject behavior for out-of-range and non-finite recovery hours plus invalid minimum-day values.
 3. **Execution Script:** `npm run validate:workouts` executes library validation during CI and pre-flight dev server start.
 
-### Validation gap retained as follow-up
+### Validator finiteness gap — closed
 
-`validateWorkoutLibrary` currently checks the numeric bounds but does not explicitly reject `NaN`; JavaScript comparisons with `NaN` are false. The catalog test proves current authored values are finite, so this is not an active catalog defect, but validator-level finiteness should be added in a follow-up (with a `NaN` mutation test) rather than claiming the validator already enforces it.
+The original audit identified a JavaScript `NaN` validation gap because ordinary numeric comparisons do not reject `NaN`. This PR closes that gap with an explicit `Number.isFinite` guard and mutation coverage for `NaN`, positive infinity, and negative infinity. The remaining P1 debt is calibration of the 11 authored one-day hard-lower-body overrides, not numeric validator hygiene.
 
 ---
 


### PR DESCRIPTION
## Summary

Post-merge follow-up to #334 from an independent final review pass.

#334 correctly added finite `recoveryHours` validation and documented 11 safety-relevant one-day hard-lower-body overrides, but one analysis document still described the earlier `NaN` validator gap as unresolved and the regression suite did not pin the documented 11-workout subset directly.

## Changes

- Synchronize `docs/analysis/2026-09-02-workout-catalog-recovery-metadata-audit.md` with the merged validator behavior:
  - explicitly records rejection of `NaN`, `+Infinity`, and `-Infinity`;
  - removes the stale claim that finiteness validation is future work;
  - clarifies that the remaining P1 debt is calibration of the authored one-day spacing overrides.
- Strengthen `workoutRecoveryMetadata.test.ts` by joining catalog `engineTemplateIds` to `ENRICHED_TEMPLATES` and asserting that exactly 11 workouts currently combine `minimumDaysAfterHardLowerBody: 1` with an associated engine-template lower-body cost `>= 0.6`.

## Scope / risk

- No optimizer behavior changes.
- No policy-constant changes.
- No UI changes.
- Test/documentation hardening only.
- The new assertion deliberately fails if the safety-relevant override population drifts without the audit/coverage rationale being reconsidered.

## Relationship to #334

#334 was merged while this final review pass was in progress, so rewriting its merged history was intentionally avoided. This PR carries only the two post-review hardening changes discovered after that merge.