### PR TITLE
✍️ Scribe: [documentation improvement] missing analysis docs in README index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -176,6 +176,8 @@ Point-in-time assessments of the system as built, including gaps between documen
 * [**2026-09-02 Workout Catalog Recovery Metadata Audit**](./analysis/2026-09-02-workout-catalog-recovery-metadata-audit.md) — SKR3 W3 audit focusing on session spacing heuristics and recovery defaults.
 * [**Strength recommendation occurrence-credit gap — 2026-09-02**](./analysis/strength-recommendation-occurrence-credit-gap-2026-09-02.md) — Production reproduction of strength occurrence-credit gap across ADR-0016, ADR-0023, and ADR-0034 boundaries.
 * [**Structured Strength and Garmin Activity Reconciliation Analysis**](./analysis/structured-strength-garmin-activity-reconciliation-analysis.md) — Architectural analysis for reconciling structured strength executions and Garmin activities into a canonical training occurrence.
+* [**2026-09-03 Persona AI Judge Safety & Modality Tuning Review**](./analysis/2026-09-03-persona-judge-safety-and-modality-tuning.md) — AI judge stability evaluation, candidate ranking modality deprioritization, and evergreen adverse recovery dose withholding.
+* [**2026-09-03 PR 388 auth and wearable-free review**](./analysis/2026-09-03-pr-388-auth-wearable-free-review.md) — Review of PR 388 covering authentication and provider-link boundaries, recommendation composition, and 7-day planning.
 
 ---
 


### PR DESCRIPTION
* **📄 What:** Appended `2026-09-03-persona-judge-safety-and-modality-tuning.md` and `2026-09-03-pr-388-auth-wearable-free-review.md` to the index of `### 🔍 Reviews & Analysis` in `docs/README.md`.
* **⚠️ Problem:** The two most recent `2026-09-03` analysis records were orphaned and not discoverable from the project's documentation hub, violating the index completeness rule discovered in previous audits.
* **📚 Source of truth:** The actual existence of these `.md` files in the `docs/analysis/` folder and the existing pattern of indexing all reviews in `docs/README.md`.
* **✅ Verification:** Confirmed the links are formatted properly and ran `make check` (including `npm run typecheck` and `pytest`) to ensure no side effects on the CI validation suite.
* **🎯 Impact:** Readers and subsequent agents can easily locate the Persona AI Judge Safety tuning details and the Wearable-Free PR 388 review from the root docs hub.
* **🔒 Governance:** No functionality or authority was modified. This was strictly an update to index existing internal analysis documentation.

---
*PR created automatically by Jules for task [1463697511486858676](https://jules.google.com/task/1463697511486858676) started by @Szczepanov*