### PR TITLE
feat(docker): dockerize full stack with Compose, Nginx proxy parity, and CI smoke suite

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,8 +25,20 @@ FIRESTORE_RECOVERY_COLLECTION=daily_recovery_snapshots
 # Path to a local Firebase service-account JSON. Leave unset in Cloud Run to use
 # Application Default Credentials instead.
 FIREBASE_CREDENTIALS_PATH=./firebase-service-account.json
-# Path on host for docker-compose.yml volume mount (defaults to FIREBASE_CREDENTIALS_PATH).
+# Host path mounted by docker-compose.yml. The long bind syntax intentionally fails if
+# this file is missing instead of creating a directory at the source path.
 FIREBASE_CREDENTIALS_HOST_PATH=./firebase-service-account.json
+
+# --- Docker Compose local exposure ---
+# Keep account-link services on loopback by default. Change only when LAN access is intended.
+COMPOSE_BIND_ADDRESS=127.0.0.1
+
+# --- Google Health OAuth account linking (optional for local smoke; required for real linking) ---
+GOOGLE_HEALTH_CLIENT_ID=your_google_oauth_client_id
+GOOGLE_HEALTH_CLIENT_SECRET=your_google_oauth_client_secret
+GOOGLE_HEALTH_REDIRECT_URI=http://localhost:8080/api/google-health/callback
+GOOGLE_HEALTH_TOKEN_BUCKET=your_private_google_health_token_bucket
+APP_BASE_URL=http://localhost:8080
 
 # --- Garmin API resilience ---
 GARMIN_RETRY_ATTEMPTS=3

--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,8 @@ FIRESTORE_RECOVERY_COLLECTION=daily_recovery_snapshots
 # Path to a local Firebase service-account JSON. Leave unset in Cloud Run to use
 # Application Default Credentials instead.
 FIREBASE_CREDENTIALS_PATH=./firebase-service-account.json
+# Path on host for docker-compose.yml volume mount (defaults to FIREBASE_CREDENTIALS_PATH).
+FIREBASE_CREDENTIALS_HOST_PATH=./firebase-service-account.json
 
 # --- Garmin API resilience ---
 GARMIN_RETRY_ATTEMPTS=3
@@ -74,3 +76,15 @@ EIGHT_SLEEP_USER_ID=
 EIGHT_SLEEP_TIMEZONE=Europe/Warsaw
 EIGHT_SLEEP_TIMEOUT_SECONDS=20
 EIGHT_SLEEP_MAX_RETRIES=2
+
+# --- Frontend Firebase Web App Configuration (used by docker-compose build) ---
+# Also present in app/.env.local for local Vite dev.
+VITE_FIREBASE_API_KEY=your_firebase_api_key
+VITE_FIREBASE_AUTH_DOMAIN=your_project_id.firebaseapp.com
+VITE_FIREBASE_PROJECT_ID=your_project_id
+VITE_FIREBASE_STORAGE_BUCKET=your_project_id.appspot.com
+VITE_FIREBASE_MESSAGING_SENDER_ID=your_messaging_sender_id
+VITE_FIREBASE_APP_ID=your_app_id
+VITE_FIREBASE_MEASUREMENT_ID=your_measurement_id
+VITE_HEALTH_ANOMALY_POLICY=off
+VITE_TRAINING_OCCURRENCE_ACTIVITIES_POLICY=off

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,40 +206,17 @@ jobs:
           VITE_FIREBASE_MEASUREMENT_ID: G-TEST
         run: docker compose build
 
-      - name: Start services
+      - name: Start services and wait for healthchecks
         env:
           APP_USER_ID: test-user
           GARMIN_TOKEN_BUCKET: test-bucket
           GCP_PROJECT_ID: test-project
-          FIRESTORE_EMULATOR_HOST: 127.0.0.1:8080
           VITE_FIREBASE_API_KEY: test-api-key
           VITE_FIREBASE_PROJECT_ID: test-project
-        run: |
-          docker compose up -d
-          for i in {1..30}; do
-            STATUS=$(docker compose ps backend --format '{{.Health}}')
-            if [ "$STATUS" = "healthy" ]; then
-              echo "Backend is healthy!"
-              break
-            fi
-            echo "Waiting for backend health (current: $STATUS)... ($i/30)"
-            sleep 1
-          done
-          docker compose ps
+        run: docker compose up -d --wait --wait-timeout 90
 
-      - name: Smoke test endpoints
-        run: |
-          # 1. Direct backend health check
-          curl -fsS http://127.0.0.1:8081/health
-          # 2. Frontend index
-          curl -fsS http://127.0.0.1:8080/ | grep -q '<div id="root">'
-          # 3. Frontend reverse proxy to backend
-          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST http://127.0.0.1:8080/api/garmin/status)
-          if [ "$HTTP_CODE" != "401" ]; then
-            echo "Expected HTTP 401 from /api/garmin/status via proxy, got $HTTP_CODE"
-            exit 1
-          fi
-          echo "All Docker smoke checks passed successfully!"
+      - name: Smoke test full-stack routing and headers
+        run: python3 scripts/docker_compose_smoke.py
 
       - name: Display container logs on failure
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,10 +172,79 @@ jobs:
         run: npm audit --audit-level=high
 
   docker-build:
-    name: Docker Image Build
+    name: Docker Build & Compose Smoke
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
 
-      - name: Build Docker image
+      - name: Build root Garmin sync Docker image
         run: docker build -t adaptive-training-garmin-sync .
+
+      - name: Validate Docker Compose configuration
+        env:
+          VITE_FIREBASE_API_KEY: test-api-key
+          VITE_FIREBASE_AUTH_DOMAIN: test-project.firebaseapp.com
+          VITE_FIREBASE_PROJECT_ID: test-project
+          VITE_FIREBASE_STORAGE_BUCKET: test-project.appspot.com
+          VITE_FIREBASE_MESSAGING_SENDER_ID: "123456789"
+          VITE_FIREBASE_APP_ID: 1:123456789:web:abcdef
+          VITE_FIREBASE_MEASUREMENT_ID: G-TEST
+        run: docker compose config
+
+      - name: Build Docker Compose services
+        env:
+          VITE_FIREBASE_API_KEY: test-api-key
+          VITE_FIREBASE_AUTH_DOMAIN: test-project.firebaseapp.com
+          VITE_FIREBASE_PROJECT_ID: test-project
+          VITE_FIREBASE_STORAGE_BUCKET: test-project.appspot.com
+          VITE_FIREBASE_MESSAGING_SENDER_ID: "123456789"
+          VITE_FIREBASE_APP_ID: 1:123456789:web:abcdef
+          VITE_FIREBASE_MEASUREMENT_ID: G-TEST
+        run: docker compose build
+
+      - name: Create mock service account for smoke test
+        run: |
+          python3 -c "import json, subprocess; pem = subprocess.check_output(['openssl', 'genrsa', '2048'], stderr=subprocess.DEVNULL).decode(); json.dump({'type':'service_account','project_id':'test-project','private_key_id':'mock-key','private_key':pem,'client_email':'mock@test-project.iam.gserviceaccount.com','token_uri':'https://oauth2.googleapis.com/token'}, open('firebase-service-account.json', 'w'))"
+
+      - name: Start services
+        env:
+          APP_USER_ID: test-user
+          GARMIN_TOKEN_BUCKET: test-bucket
+          GCP_PROJECT_ID: test-project
+          FIRESTORE_EMULATOR_HOST: 127.0.0.1:8080
+          VITE_FIREBASE_API_KEY: test-api-key
+          VITE_FIREBASE_PROJECT_ID: test-project
+        run: |
+          docker compose up -d
+          for i in {1..30}; do
+            STATUS=$(docker compose ps backend --format '{{.Health}}')
+            if [ "$STATUS" = "healthy" ]; then
+              echo "Backend is healthy!"
+              break
+            fi
+            echo "Waiting for backend health (current: $STATUS)... ($i/30)"
+            sleep 1
+          done
+          docker compose ps
+
+      - name: Smoke test endpoints
+        run: |
+          # 1. Direct backend health check
+          curl -fsS http://127.0.0.1:8081/health
+          # 2. Frontend index
+          curl -fsS http://127.0.0.1:8080/ | grep -q '<div id="root">'
+          # 3. Frontend reverse proxy to backend
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST http://127.0.0.1:8080/api/garmin/status)
+          if [ "$HTTP_CODE" != "401" ]; then
+            echo "Expected HTTP 401 from /api/garmin/status via proxy, got $HTTP_CODE"
+            exit 1
+          fi
+          echo "All Docker smoke checks passed successfully!"
+
+      - name: Display container logs on failure
+        if: failure()
+        run: docker compose logs
+
+      - name: Clean up containers
+        if: always()
+        run: docker compose down -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,10 @@ jobs:
       - name: Build root Garmin sync Docker image
         run: docker build -t adaptive-training-garmin-sync .
 
+      - name: Create mock service account for smoke test
+        run: |
+          python3 -c "import json, subprocess; pem = subprocess.check_output(['openssl', 'genrsa', '2048'], stderr=subprocess.DEVNULL).decode(); json.dump({'type':'service_account','project_id':'test-project','private_key_id':'mock-key','private_key':pem,'client_email':'mock@test-project.iam.gserviceaccount.com','token_uri':'https://oauth2.googleapis.com/token'}, open('firebase-service-account.json', 'w'))"
+
       - name: Validate Docker Compose configuration
         env:
           VITE_FIREBASE_API_KEY: test-api-key
@@ -201,10 +205,6 @@ jobs:
           VITE_FIREBASE_APP_ID: 1:123456789:web:abcdef
           VITE_FIREBASE_MEASUREMENT_ID: G-TEST
         run: docker compose build
-
-      - name: Create mock service account for smoke test
-        run: |
-          python3 -c "import json, subprocess; pem = subprocess.check_output(['openssl', 'genrsa', '2048'], stderr=subprocess.DEVNULL).decode(); json.dump({'type':'service_account','project_id':'test-project','private_key_id':'mock-key','private_key':pem,'client_email':'mock@test-project.iam.gserviceaccount.com','token_uri':'https://oauth2.googleapis.com/token'}, open('firebase-service-account.json', 'w'))"
 
       - name: Start services
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,11 @@ This document outlines repository rules, code conventions, testing instructions,
 
 
 ### Docker
-* `docker build -t adaptive-training-garmin-sync .` — Build container image
+* `docker compose build` (or `make docker-build`) — Build backend and frontend images
+* `docker compose up -d` (or `make docker-up`) — Start backend API (port 8081) and frontend Nginx SPA (port 8080)
+* `docker compose down` (or `make docker-down`) — Stop and remove compose services and networks
+* `make docker-smoke` — Run health and reverse-proxy smoke checks against running containers
+* `docker build -t adaptive-training-garmin-sync .` — Build standalone Garmin sync container image
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,8 +49,14 @@ Quick guide for building, testing, and working on `adaptive-training-recommender
 - Visual Review Harness: `cd app && npm run visual:refresh` (captures screenshots to `artifacts/visual-review/latest/`)
 - Firestore Rules Tests: `cd app && npm run test:rules` (executes Vitest in Firebase Firestore emulator)
 
-### Docker Container
-- Build: `docker build -t adaptive-training-garmin-sync .`
+### Docker
+* `docker compose build` (or `make docker-build`) — Build backend and frontend images
+* `docker compose up -d` (or `make docker-up`) — Start backend API (port 8081) and frontend Nginx SPA (port 8080)
+* `docker compose down` (or `make docker-down`) — Stop and remove compose services and networks
+* `make docker-smoke` — Run health and reverse-proxy smoke checks against running containers
+* `docker build -t adaptive-training-garmin-sync .` — Build standalone Garmin sync container image
+
+---
 
 ## Key Code Locations
 - `src/garmin_sync/`: Core Python Garmin ingestion package.

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@
         simulate-calibrate simulate-fatigue-fusion simulate-subjective-drift \
         compare-sequence-search build build-frontend \
         deploy deploy-hosting deploy-all deploy-rules deploy-indexes \
-        install clean
+        install clean \
+        docker-build docker-up docker-down docker-smoke
 
 # -----------------------------------------------------------------------------
 # Main Verification Targets
@@ -169,6 +170,26 @@ install:
 	uv sync
 	npm --prefix app ci
 
+# -----------------------------------------------------------------------------
+# Docker Targets
+# -----------------------------------------------------------------------------
+
+## Build all Docker images with docker compose
+docker-build:
+	docker compose build
+
+## Start all services in background with docker compose
+docker-up:
+	docker compose up -d
+
+## Stop and clean up running docker compose services
+docker-down:
+	docker compose down
+
+## Run smoke test against running docker compose services
+docker-smoke:
+	python -c "import urllib.request, urllib.error; assert urllib.request.urlopen('http://127.0.0.1:8081/health').status == 200; assert b'root' in urllib.request.urlopen('http://127.0.0.1:8080/').read(); req = urllib.request.Request('http://127.0.0.1:8080/api/garmin/status', method='POST'); code = 0; exec('try:\n urllib.request.urlopen(req)\nexcept urllib.error.HTTPError as e:\n global code; code = e.code'); assert code == 401; print('[OK] Docker compose smoke checks passed successfully!')"
+
 ## Clean temporary build, test, and cache artifacts
 clean:
 	-rmdir /s /q .pytest_cache 2>nul || rm -rf .pytest_cache 2>/dev/null || true
@@ -213,3 +234,9 @@ help:
 	@echo   make simulate-scenarios- Run scenario simulations
 	@echo   make simulate-diff     - Compare scenario simulation against baseline
 	@echo   make build-frontend    - Build production Vite bundle
+	@echo --------------------------------------------------------------------------------
+	@echo Docker Targets:
+	@echo   make docker-build      - Build all Docker images with docker compose
+	@echo   make docker-up         - Start services in background with docker compose
+	@echo   make docker-down       - Stop running docker compose services
+	@echo   make docker-smoke      - Run smoke test against running docker compose services

--- a/Makefile
+++ b/Makefile
@@ -178,17 +178,17 @@ install:
 docker-build:
 	docker compose build
 
-## Start all services in background with docker compose
+## Start all services and wait until every healthcheck is ready
 docker-up:
-	docker compose up -d
+	docker compose up -d --wait --wait-timeout 90
 
 ## Stop and clean up running docker compose services
 docker-down:
 	docker compose down
 
-## Run smoke test against running docker compose services
+## Run the same full-stack smoke contract used by CI
 docker-smoke:
-	python -c "import urllib.request, urllib.error; assert urllib.request.urlopen('http://127.0.0.1:8081/health').status == 200; assert b'root' in urllib.request.urlopen('http://127.0.0.1:8080/').read(); req = urllib.request.Request('http://127.0.0.1:8080/api/garmin/status', method='POST'); code = 0; exec('try:\n urllib.request.urlopen(req)\nexcept urllib.error.HTTPError as e:\n global code; code = e.code'); assert code == 401; print('[OK] Docker compose smoke checks passed successfully!')"
+	python scripts/docker_compose_smoke.py
 
 ## Clean temporary build, test, and cache artifacts
 clean:
@@ -202,7 +202,7 @@ help:
 	@echo Adaptive Training Recommender - Makefile Commands
 	@echo --------------------------------------------------------------------------------
 	@echo Main Targets:
-	@echo   make all               - Run all code checks, tests, simulations, and build
+	@echo   make all               - Run all code checks, test suites, simulations, and build
 	@echo   make check             - Run all Python and Frontend checks and tests
 	@echo   make test              - Run backend and frontend test suites
 	@echo   make lint              - Run backend and frontend linters
@@ -236,7 +236,7 @@ help:
 	@echo   make build-frontend    - Build production Vite bundle
 	@echo --------------------------------------------------------------------------------
 	@echo Docker Targets:
-	@echo   make docker-build      - Build all Docker images with docker compose
-	@echo   make docker-up         - Start services in background with docker compose
+	@echo   make docker-build      - Build Garmin, Google Health, and frontend images
+	@echo   make docker-up         - Start all services and wait for healthchecks
 	@echo   make docker-down       - Stop running docker compose services
-	@echo   make docker-smoke      - Run smoke test against running docker compose services
+	@echo   make docker-smoke      - Run direct/proxy/security smoke checks

--- a/app/.dockerignore
+++ b/app/.dockerignore
@@ -1,0 +1,16 @@
+node_modules
+dist
+artifacts
+.firebase
+tests
+scripts
+playwright-report
+test-results
+*.log
+.env
+.env.*
+!.env.example
+.git
+.vscode
+.idea
+coverage

--- a/app/.env.example
+++ b/app/.env.example
@@ -8,6 +8,10 @@ VITE_FIREBASE_MESSAGING_SENDER_ID=your_messaging_sender_id
 VITE_FIREBASE_APP_ID=your_app_id
 VITE_FIREBASE_MEASUREMENT_ID=your_measurement_id
 
+# Local Vite-dev reverse-proxy targets. Docker/Nginx uses Compose service DNS instead.
+VITE_GARMIN_BACKEND_URL=http://localhost:8081
+VITE_GOOGLE_HEALTH_BACKEND_URL=http://localhost:8082
+
 # HA-D developer evidence collection. Only the exact value shadow-v1 enables it.
 # Missing/invalid values, off, visible-v1 and tighten-v1 all fail closed to runtime off.
 VITE_HEALTH_ANOMALY_POLICY=off

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,0 +1,71 @@
+# syntax=docker/dockerfile:1
+
+# ---- Builder stage: install deps and produce the static production bundle ----
+FROM node:22-alpine AS builder
+WORKDIR /app
+
+# Vite inlines these into the client bundle at build time (see app/.env.example), so they
+# must be supplied as build args, not runtime env vars.
+ARG VITE_FIREBASE_API_KEY
+ARG VITE_FIREBASE_AUTH_DOMAIN
+ARG VITE_FIREBASE_PROJECT_ID
+ARG VITE_FIREBASE_STORAGE_BUCKET
+ARG VITE_FIREBASE_MESSAGING_SENDER_ID
+ARG VITE_FIREBASE_APP_ID
+ARG VITE_FIREBASE_MEASUREMENT_ID
+ARG VITE_HEALTH_ANOMALY_POLICY=off
+ARG VITE_TRAINING_OCCURRENCE_ACTIVITIES_POLICY=off
+ENV VITE_FIREBASE_API_KEY=${VITE_FIREBASE_API_KEY} \
+    VITE_FIREBASE_AUTH_DOMAIN=${VITE_FIREBASE_AUTH_DOMAIN} \
+    VITE_FIREBASE_PROJECT_ID=${VITE_FIREBASE_PROJECT_ID} \
+    VITE_FIREBASE_STORAGE_BUCKET=${VITE_FIREBASE_STORAGE_BUCKET} \
+    VITE_FIREBASE_MESSAGING_SENDER_ID=${VITE_FIREBASE_MESSAGING_SENDER_ID} \
+    VITE_FIREBASE_APP_ID=${VITE_FIREBASE_APP_ID} \
+    VITE_FIREBASE_MEASUREMENT_ID=${VITE_FIREBASE_MEASUREMENT_ID} \
+    VITE_HEALTH_ANOMALY_POLICY=${VITE_HEALTH_ANOMALY_POLICY} \
+    VITE_TRAINING_OCCURRENCE_ACTIVITIES_POLICY=${VITE_TRAINING_OCCURRENCE_ACTIVITIES_POLICY}
+
+# Install dependencies first (uses legacy-peer-deps per .npmrc) so this layer stays cached
+# when only application source changes. Skip Playwright's browser download during install --
+# @playwright/test is only used by the visual-review test suite, never by the production
+# build, and downloading Chromium here just wastes time/network in the image build.
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+COPY package.json package-lock.json .npmrc ./
+RUN npm ci --legacy-peer-deps
+
+# Copy sources and build the production bundle. Uses build:bundle (plain `vite build`)
+# rather than `build` (which also runs the full lint/typecheck/test/validate suite) --
+# that suite belongs in CI, not in the image build.
+COPY . .
+RUN npm run build:bundle
+
+# ---- Runtime stage: serve the static bundle with nginx ----
+FROM nginx:1.27-alpine AS runtime
+
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+
+COPY --from=builder /app/dist /usr/share/nginx/html
+# nginx's official entrypoint envsubst's every *.template in this directory into
+# /etc/nginx/conf.d/ at container start, substituting only the listed variables below --
+# this resolves BACKEND_HOST/BACKEND_PORT for the /api/garmin/** proxy_pass in
+# nginx.conf.template at runtime, so the same built image works both in compose (backend
+# service) and standalone (falls back to the defaults set here).
+COPY nginx.conf.template /etc/nginx/templates/default.conf.template
+ENV BACKEND_HOST=backend \
+    BACKEND_PORT=8080 \
+    GOOGLE_HEALTH_BACKEND_HOST=backend
+
+# nginx needs write access to these paths (including the templated conf dir + generated
+# conf) even when running as a non-root user; nginx's entrypoint envsubst step needs to
+# write into /etc/nginx/conf.d as this user too.
+RUN chown -R appuser:appgroup /usr/share/nginx/html /var/cache/nginx /var/log/nginx /etc/nginx/conf.d /etc/nginx/templates \
+    && touch /var/run/nginx.pid \
+    && chown appuser:appgroup /var/run/nginx.pid
+
+USER appuser
+EXPOSE 80
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+    CMD wget -qO- http://127.0.0.1:80/ >/dev/null 2>&1 || exit 1
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -40,20 +40,20 @@ COPY . .
 RUN npm run build:bundle
 
 # ---- Runtime stage: serve the static bundle with nginx ----
-FROM nginx:1.27-alpine AS runtime
+# Track the current stable nginx line rather than the obsolete 1.27 development line.
+FROM nginx:1.30.4-alpine AS runtime
 
 RUN addgroup -S appgroup && adduser -S appuser -G appgroup
 
 COPY --from=builder /app/dist /usr/share/nginx/html
 # nginx's official entrypoint envsubst's every *.template in this directory into
-# /etc/nginx/conf.d/ at container start, substituting only the listed variables below --
-# this resolves BACKEND_HOST/BACKEND_PORT for the /api/garmin/** proxy_pass in
-# nginx.conf.template at runtime, so the same built image works both in compose (backend
-# service) and standalone (falls back to the defaults set here).
+# /etc/nginx/conf.d/ at container start. This resolves backend service names at runtime,
+# so the same frontend image can be wired differently without rebuilding the SPA.
 COPY nginx.conf.template /etc/nginx/templates/default.conf.template
+COPY security-headers.conf /etc/nginx/security-headers.conf
 ENV BACKEND_HOST=backend \
     BACKEND_PORT=8080 \
-    GOOGLE_HEALTH_BACKEND_HOST=backend
+    GOOGLE_HEALTH_BACKEND_HOST=google-health-backend
 
 # nginx needs write access to these paths (including the templated conf dir + generated
 # conf) even when running as a non-root user; nginx's entrypoint envsubst step needs to

--- a/app/nginx.conf.template
+++ b/app/nginx.conf.template
@@ -1,0 +1,55 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+
+    # Local parity with Firebase Hosting's "/api/garmin/**" -> garmin-account-link Cloud Run
+    # rewrite (see app/firebase.json). ${BACKEND_HOST}/${BACKEND_PORT} are substituted at
+    # container startup by the official nginx image's docker-entrypoint envsubst step (this
+    # file lives under /etc/nginx/templates/, not conf.d/ -- see app/Dockerfile) and default
+    # to the `backend` compose service (docker-compose.yml); override via env if needed.
+    location ^~ /api/garmin/ {
+        proxy_pass http://${BACKEND_HOST}:${BACKEND_PORT};
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 300s;
+    }
+
+    # Local parity with Firebase Hosting's "/api/google-health/**" -> google-health-account-link
+    # Cloud Run rewrite (see app/firebase.json).
+    location ^~ /api/google-health/ {
+        proxy_pass http://${GOOGLE_HEALTH_BACKEND_HOST}:${BACKEND_PORT};
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 300s;
+    }
+
+    # SPA fallback: let the React app's router handle unknown paths.
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Long-cache immutable static assets emitted by the Vite build.
+    location ~* \.(?:css|js|mjs|svg|png|jpg|jpeg|gif|ico|webp|woff2?)$ {
+        expires 30d;
+        access_log off;
+        add_header Cache-Control "public, max-age=2592000, immutable";
+    }
+
+    # Never cache the HTML entrypoint so new deploys are picked up immediately.
+    location = /index.html {
+        add_header Cache-Control "no-cache";
+    }
+}

--- a/app/nginx.conf.template
+++ b/app/nginx.conf.template
@@ -1,19 +1,16 @@
 server {
     listen 80;
     server_name _;
+
     root /usr/share/nginx/html;
     index index.html;
 
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header X-Frame-Options "DENY" always;
-    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+    # Match Firebase Hosting's production security policy. Locations that add their own
+    # Cache-Control header include this file again because nginx add_header inheritance is
+    # all-or-nothing at each configuration level.
+    include /etc/nginx/security-headers.conf;
 
-    # Local parity with Firebase Hosting's "/api/garmin/**" -> garmin-account-link Cloud Run
-    # rewrite (see app/firebase.json). ${BACKEND_HOST}/${BACKEND_PORT} are substituted at
-    # container startup by the official nginx image's docker-entrypoint envsubst step (this
-    # file lives under /etc/nginx/templates/, not conf.d/ -- see app/Dockerfile) and default
-    # to the `backend` compose service (docker-compose.yml); override via env if needed.
+    # Same-origin API routing matching app/firebase.json production rewrites.
     location ^~ /api/garmin/ {
         proxy_pass http://${BACKEND_HOST}:${BACKEND_PORT};
         proxy_http_version 1.1;
@@ -21,11 +18,10 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 5s;
         proxy_read_timeout 300s;
     }
 
-    # Local parity with Firebase Hosting's "/api/google-health/**" -> google-health-account-link
-    # Cloud Run rewrite (see app/firebase.json).
     location ^~ /api/google-health/ {
         proxy_pass http://${GOOGLE_HEALTH_BACKEND_HOST}:${BACKEND_PORT};
         proxy_http_version 1.1;
@@ -33,23 +29,40 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 5s;
         proxy_read_timeout 300s;
     }
 
-    # SPA fallback: let the React app's router handle unknown paths.
+    # Vite emits content-hashed production chunks under /assets/. Those are safe to cache
+    # immutably; stable PWA entry points below must stay revalidatable across deployments.
+    location ^~ /assets/ {
+        try_files $uri =404;
+        add_header Cache-Control "public, max-age=31536000, immutable" always;
+        include /etc/nginx/security-headers.conf;
+    }
+
+    location = /sw.js {
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+        include /etc/nginx/security-headers.conf;
+    }
+
+    location = /registerSW.js {
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+        include /etc/nginx/security-headers.conf;
+    }
+
+    location = /manifest.webmanifest {
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+        include /etc/nginx/security-headers.conf;
+    }
+
+    location = /index.html {
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+        include /etc/nginx/security-headers.conf;
+    }
+
+    # SPA fallback must mirror Firebase Hosting's catch-all rewrite to /index.html.
     location / {
         try_files $uri $uri/ /index.html;
-    }
-
-    # Long-cache immutable static assets emitted by the Vite build.
-    location ~* \.(?:css|js|mjs|svg|png|jpg|jpeg|gif|ico|webp|woff2?)$ {
-        expires 30d;
-        access_log off;
-        add_header Cache-Control "public, max-age=2592000, immutable";
-    }
-
-    # Never cache the HTML entrypoint so new deploys are picked up immediately.
-    location = /index.html {
-        add_header Cache-Control "no-cache";
     }
 }

--- a/app/security-headers.conf
+++ b/app/security-headers.conf
@@ -1,0 +1,7 @@
+# Keep local Docker/Nginx behavior aligned with the headers in firebase.json.
+# `always` keeps the policy on redirects and error responses as well as normal 2xx pages.
+add_header X-Content-Type-Options "nosniff" always;
+add_header X-Frame-Options "DENY" always;
+add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+add_header Content-Security-Policy "default-src 'self'; connect-src 'self' https://*.googleapis.com https://*.firebaseio.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com https://firebaseinstallations.googleapis.com; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; frame-ancestors 'none'; object-src 'none'; base-uri 'self';" always;

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from 'node:child_process';
+import { loadEnv } from 'vite';
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 import { VitePWA } from 'vite-plugin-pwa';
@@ -16,6 +17,11 @@ const gitDirty = process.env.VITE_GIT_DIRTY !== undefined
   ? process.env.VITE_GIT_DIRTY === 'true'
   : Boolean(readGit(['status', '--porcelain']));
 
+// Vite evaluates this config before it injects .env/.env.local into process.env. The proxy
+// is a development-only concern, so load the normal development env set explicitly here;
+// shell variables still win and .env.local is included by loadEnv.
+const localProxyEnv = loadEnv('development', process.cwd(), 'VITE_');
+
 export default defineConfig({
   define: {
     'import.meta.env.VITE_GIT_SHA': JSON.stringify(gitSha),
@@ -24,11 +30,11 @@ export default defineConfig({
   server: {
     proxy: {
       '/api/garmin': {
-        target: process.env.VITE_GARMIN_BACKEND_URL || 'http://localhost:8081',
+        target: localProxyEnv.VITE_GARMIN_BACKEND_URL || 'http://localhost:8081',
         changeOrigin: true,
       },
       '/api/google-health': {
-        target: process.env.VITE_GOOGLE_HEALTH_BACKEND_URL || 'http://localhost:8081',
+        target: localProxyEnv.VITE_GOOGLE_HEALTH_BACKEND_URL || 'http://localhost:8082',
         changeOrigin: true,
       },
     },

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -21,6 +21,18 @@ export default defineConfig({
     'import.meta.env.VITE_GIT_SHA': JSON.stringify(gitSha),
     'import.meta.env.VITE_GIT_DIRTY': JSON.stringify(String(gitDirty)),
   },
+  server: {
+    proxy: {
+      '/api/garmin': {
+        target: process.env.VITE_GARMIN_BACKEND_URL || 'http://localhost:8081',
+        changeOrigin: true,
+      },
+      '/api/google-health': {
+        target: process.env.VITE_GOOGLE_HEALTH_BACKEND_URL || 'http://localhost:8081',
+        changeOrigin: true,
+      },
+    },
+  },
   plugins: [
     react(),
     VitePWA({

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,13 @@
+x-firebase-credentials: &firebase-credentials
+  type: bind
+  source: ${FIREBASE_CREDENTIALS_HOST_PATH:-./firebase-service-account.json}
+  target: /app/firebase-service-account.json
+  read_only: true
+  bind:
+    # Short bind syntax silently creates a directory when the source file is absent.
+    # Fail fast instead so Firebase never receives a directory as a credentials path.
+    create_host_path: false
+
 services:
   # Token-only HTTP API used by the frontend to establish per-user Garmin OAuth tokens
   # (garmin_sync.account_link_api). The same image also backs the Cloud Run Jobs
@@ -11,7 +21,7 @@ services:
     entrypoint: ["python"]
     command: ["-m", "garmin_sync.account_link_api"]
     ports:
-      - "8081:8080"
+      - "${COMPOSE_BIND_ADDRESS:-127.0.0.1}:8081:8080"
     env_file:
       - path: .env
         required: false
@@ -25,10 +35,7 @@ services:
       FIREBASE_CREDENTIALS_PATH: /app/firebase-service-account.json
     volumes:
       - garmin_tokens:/app/.garmin_tokens
-      # Mounts the real local service-account JSON (gitignored, already present for local
-      # dev per .gcloudignore/.gitignore) read-only into the container. Override the host
-      # path with FIREBASE_CREDENTIALS_HOST_PATH in .env if yours lives elsewhere.
-      - ${FIREBASE_CREDENTIALS_HOST_PATH:-./firebase-service-account.json}:/app/firebase-service-account.json:ro
+      - *firebase-credentials
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8080/health', timeout=3).status == 200 else 1)"]
       interval: 30s
@@ -37,9 +44,40 @@ services:
       start_period: 10s
     restart: unless-stopped
 
-  # Production build of the React/Vite app, served by nginx (app/Dockerfile). Talks to
-  # `backend` for /api/garmin/** the way Firebase Hosting rewrites do in production
-  # (see app/firebase.json) -- point the app at http://localhost:8081 locally.
+  # Google Health linking intentionally runs as its own HTTP service in production and
+  # locally. Keeping it separate preserves Cloud Run topology and prevents accidental
+  # coupling to Garmin's MFA/session constraints.
+  google-health-backend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: adaptive-training-recommender-google-health-backend:local
+    entrypoint: ["python"]
+    command: ["-m", "garmin_sync.google_health_account_link_api"]
+    ports:
+      - "${COMPOSE_BIND_ADDRESS:-127.0.0.1}:8082:8080"
+    env_file:
+      - path: .env
+        required: false
+    environment:
+      PORT: "8080"
+      GCP_PROJECT_ID: ${GCP_PROJECT_ID:-adaptive-training-recommender}
+      APP_BASE_URL: ${APP_BASE_URL:-http://localhost:8080}
+      GOOGLE_APPLICATION_CREDENTIALS: /app/firebase-service-account.json
+      FIREBASE_CREDENTIALS_PATH: /app/firebase-service-account.json
+    volumes:
+      - *firebase-credentials
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8080/health', timeout=3).status == 200 else 1)"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    restart: unless-stopped
+
+  # Production build of the React/Vite app, served by nginx. The reverse proxies mirror
+  # Firebase Hosting's two Cloud Run rewrites: Garmin -> backend, Google Health -> the
+  # distinct google-health-backend service. Browser traffic stays same-origin on :8080.
   frontend:
     build:
       context: ./app
@@ -56,13 +94,15 @@ services:
         VITE_TRAINING_OCCURRENCE_ACTIVITIES_POLICY: ${VITE_TRAINING_OCCURRENCE_ACTIVITIES_POLICY:-off}
     image: adaptive-training-recommender-frontend:local
     ports:
-      - "8080:80"
+      - "${COMPOSE_BIND_ADDRESS:-127.0.0.1}:8080:80"
     environment:
       BACKEND_HOST: backend
       BACKEND_PORT: "8080"
-      GOOGLE_HEALTH_BACKEND_HOST: backend
+      GOOGLE_HEALTH_BACKEND_HOST: google-health-backend
     depends_on:
       backend:
+        condition: service_healthy
+      google-health-backend:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://127.0.0.1:80/"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,75 @@
+services:
+  # Token-only HTTP API used by the frontend to establish per-user Garmin OAuth tokens
+  # (garmin_sync.account_link_api). The same image also backs the Cloud Run Jobs
+  # (sync-all, push-pending-workouts-all, poll-manual-sync-all) in production; locally we
+  # only need the HTTP service running continuously for the frontend to talk to.
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: adaptive-training-recommender-backend:local
+    entrypoint: ["python"]
+    command: ["-m", "garmin_sync.account_link_api"]
+    ports:
+      - "8081:8080"
+    env_file:
+      - .env
+    environment:
+      PORT: "8080"
+      APP_TIMEZONE: ${APP_TIMEZONE:-Europe/Warsaw}
+      GARMIN_TOKEN_STORE: ${GARMIN_TOKEN_STORE:-local}
+      GCP_PROJECT_ID: ${GCP_PROJECT_ID:-adaptive-training-recommender}
+      GARMIN_TOKEN_BUCKET: ${GARMIN_TOKEN_BUCKET:-adaptive-training-garmin-tokens}
+      GOOGLE_APPLICATION_CREDENTIALS: /app/firebase-service-account.json
+      FIREBASE_CREDENTIALS_PATH: /app/firebase-service-account.json
+    volumes:
+      - garmin_tokens:/app/.garmin_tokens
+      # Mounts the real local service-account JSON (gitignored, already present for local
+      # dev per .gcloudignore/.gitignore) read-only into the container. Override the host
+      # path with FIREBASE_CREDENTIALS_HOST_PATH in .env if yours lives elsewhere.
+      - ${FIREBASE_CREDENTIALS_HOST_PATH:-./firebase-service-account.json}:/app/firebase-service-account.json:ro
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8080/health', timeout=3).status == 200 else 1)"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    restart: unless-stopped
+
+  # Production build of the React/Vite app, served by nginx (app/Dockerfile). Talks to
+  # `backend` for /api/garmin/** the way Firebase Hosting rewrites do in production
+  # (see app/firebase.json) -- point the app at http://localhost:8081 locally.
+  frontend:
+    build:
+      context: ./app
+      dockerfile: Dockerfile
+      args:
+        VITE_FIREBASE_API_KEY: ${VITE_FIREBASE_API_KEY:-}
+        VITE_FIREBASE_AUTH_DOMAIN: ${VITE_FIREBASE_AUTH_DOMAIN:-}
+        VITE_FIREBASE_PROJECT_ID: ${VITE_FIREBASE_PROJECT_ID:-}
+        VITE_FIREBASE_STORAGE_BUCKET: ${VITE_FIREBASE_STORAGE_BUCKET:-}
+        VITE_FIREBASE_MESSAGING_SENDER_ID: ${VITE_FIREBASE_MESSAGING_SENDER_ID:-}
+        VITE_FIREBASE_APP_ID: ${VITE_FIREBASE_APP_ID:-}
+        VITE_FIREBASE_MEASUREMENT_ID: ${VITE_FIREBASE_MEASUREMENT_ID:-}
+        VITE_HEALTH_ANOMALY_POLICY: ${VITE_HEALTH_ANOMALY_POLICY:-off}
+        VITE_TRAINING_OCCURRENCE_ACTIVITIES_POLICY: ${VITE_TRAINING_OCCURRENCE_ACTIVITIES_POLICY:-off}
+    image: adaptive-training-recommender-frontend:local
+    ports:
+      - "8080:80"
+    environment:
+      BACKEND_HOST: backend
+      BACKEND_PORT: "8080"
+      GOOGLE_HEALTH_BACKEND_HOST: backend
+    depends_on:
+      backend:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:80/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
+    restart: unless-stopped
+
+volumes:
+  garmin_tokens:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,8 @@ services:
     ports:
       - "8081:8080"
     env_file:
-      - .env
+      - path: .env
+        required: false
     environment:
       PORT: "8080"
       APP_TIMEZONE: ${APP_TIMEZONE:-Europe/Warsaw}

--- a/docs/development/docker-compose.md
+++ b/docs/development/docker-compose.md
@@ -1,0 +1,83 @@
+# Local full stack with Docker Compose
+
+The Compose stack mirrors the production request topology closely enough to exercise the
+browser-facing integration locally without deploying Firebase Hosting or Cloud Run.
+
+## Topology
+
+| Local endpoint | Compose service | Purpose |
+| --- | --- | --- |
+| `http://127.0.0.1:8080` | `frontend` | Production Vite bundle served by Nginx |
+| `http://127.0.0.1:8081` | `backend` | `garmin_sync.account_link_api` |
+| `http://127.0.0.1:8082` | `google-health-backend` | `garmin_sync.google_health_account_link_api` |
+
+Nginx keeps browser requests same-origin and mirrors the Firebase Hosting rewrites:
+
+- `/api/garmin/**` -> `backend:8080`
+- `/api/google-health/**` -> `google-health-backend:8080`
+- all other routes -> the SPA (`index.html`)
+
+The Google Health service is intentionally separate from the Garmin linker, matching the
+production Cloud Run topology and the service's own isolation requirement.
+
+## First-time setup
+
+1. Copy `.env.example` to `.env` and fill in the Firebase web configuration used to build
+   the frontend.
+2. Put a Firebase service-account JSON at `./firebase-service-account.json`, or set
+   `FIREBASE_CREDENTIALS_HOST_PATH` in `.env` to its host path. The file is mounted read-only
+   into both Python HTTP services. Compose deliberately refuses to create a missing source
+   path as a directory, so a bad credentials path fails at startup instead of becoming a
+   confusing Firebase error.
+3. For a real Google Health OAuth link flow, also configure `GOOGLE_HEALTH_CLIENT_ID`,
+   `GOOGLE_HEALTH_CLIENT_SECRET`, `GOOGLE_HEALTH_REDIRECT_URI`, and
+   `GOOGLE_HEALTH_TOKEN_BUCKET`. The health and routing smoke checks do not require live
+   Google OAuth credentials.
+
+Then run:
+
+```bash
+make docker-build
+make docker-up
+make docker-smoke
+```
+
+`make docker-up` waits until all three services are healthy. `make docker-down` stops the
+stack without deleting the named Garmin-token volume.
+
+## Local Vite development
+
+Running `npm run dev` inside `app/` does not use Nginx. Vite proxies the two API families
+straight to the local Python services instead:
+
+- Garmin defaults to `http://localhost:8081`
+- Google Health defaults to `http://localhost:8082`
+
+Override those targets in `app/.env.local` with `VITE_GARMIN_BACKEND_URL` and
+`VITE_GOOGLE_HEALTH_BACKEND_URL`. `vite.config.ts` uses `loadEnv`, so values from Vite env
+files affect the proxy configuration as documented.
+
+## Exposure and security parity
+
+Published Compose ports bind to `127.0.0.1` by default so local account-link APIs are not
+silently exposed to the LAN. Set `COMPOSE_BIND_ADDRESS` only when remote access is
+intentional.
+
+The Nginx container carries the same CSP, frame, content-type, referrer, and permissions
+headers as `app/firebase.json`. Hashed `/assets/` files are immutable; `index.html`, the
+service worker, registration script, and web manifest remain revalidatable so a new deploy
+cannot be hidden behind a long-lived cache entry.
+
+## Smoke contract
+
+`scripts/docker_compose_smoke.py` verifies:
+
+- both Python services are healthy directly;
+- the frontend SPA is served with security and no-cache headers;
+- a built hashed asset retains both immutable caching and security headers;
+- the PWA service worker is not long-cacheable;
+- Garmin requests reach the Garmin linker through Nginx;
+- Google Health requests reach the separate Google Health linker through Nginx.
+
+CI invokes this same script after `docker compose up --wait`, so local and CI smoke behavior
+share one implementation.

--- a/scripts/docker_compose_smoke.py
+++ b/scripts/docker_compose_smoke.py
@@ -36,9 +36,7 @@ def _expect_status(url: str, expected: int, *, method: str = "GET") -> tuple[Mes
 def _expect_header(headers: Message, name: str, expected_fragment: str) -> None:
     value = headers.get(name, "")
     if expected_fragment not in value:
-        raise AssertionError(
-            f"Expected {name!r} to contain {expected_fragment!r}, got {value!r}"
-        )
+        raise AssertionError(f"Expected {name!r} to contain {expected_fragment!r}, got {value!r}")
 
 
 def _expect_security_headers(headers: Message) -> None:

--- a/scripts/docker_compose_smoke.py
+++ b/scripts/docker_compose_smoke.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Smoke-test the local Docker Compose full-stack contract.
+
+The checks intentionally cover both direct backend health endpoints and same-origin Nginx
+routing so CI catches topology/proxy drift rather than merely proving that containers start.
+"""
+
+from __future__ import annotations
+
+import re
+import urllib.error
+import urllib.request
+from email.message import Message
+
+FRONTEND = "http://127.0.0.1:8080"
+GARMIN_BACKEND = "http://127.0.0.1:8081"
+GOOGLE_HEALTH_BACKEND = "http://127.0.0.1:8082"
+
+
+def _request(url: str, *, method: str = "GET") -> tuple[int, Message, bytes]:
+    request = urllib.request.Request(url, method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=10) as response:
+            return response.status, response.headers, response.read()
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.headers, exc.read()
+
+
+def _expect_status(url: str, expected: int, *, method: str = "GET") -> tuple[Message, bytes]:
+    status, headers, body = _request(url, method=method)
+    if status != expected:
+        raise AssertionError(f"{method} {url}: expected HTTP {expected}, got {status}")
+    return headers, body
+
+
+def _expect_header(headers: Message, name: str, expected_fragment: str) -> None:
+    value = headers.get(name, "")
+    if expected_fragment not in value:
+        raise AssertionError(
+            f"Expected {name!r} to contain {expected_fragment!r}, got {value!r}"
+        )
+
+
+def _expect_security_headers(headers: Message) -> None:
+    _expect_header(headers, "X-Content-Type-Options", "nosniff")
+    _expect_header(headers, "X-Frame-Options", "DENY")
+    _expect_header(headers, "Content-Security-Policy", "default-src 'self'")
+
+
+def main() -> int:
+    _expect_status(f"{GARMIN_BACKEND}/health", 200)
+    _expect_status(f"{GOOGLE_HEALTH_BACKEND}/health", 200)
+
+    frontend_headers, index = _expect_status(f"{FRONTEND}/", 200)
+    if b'<div id="root">' not in index:
+        raise AssertionError("Frontend response did not contain the React root element")
+    _expect_security_headers(frontend_headers)
+    _expect_header(frontend_headers, "Cache-Control", "no-cache")
+
+    # Verify the immutable asset location does not accidentally drop server-level security
+    # headers (nginx add_header inheritance changes when a location adds Cache-Control).
+    match = re.search(rb'(/assets/[^"\']+\.js)', index)
+    if match is None:
+        raise AssertionError("Could not find a built JavaScript asset in frontend index")
+    asset_path = match.group(1).decode("utf-8")
+    asset_headers, _ = _expect_status(f"{FRONTEND}{asset_path}", 200)
+    _expect_security_headers(asset_headers)
+    _expect_header(asset_headers, "Cache-Control", "immutable")
+
+    sw_headers, _ = _expect_status(f"{FRONTEND}/sw.js", 200)
+    _expect_security_headers(sw_headers)
+    _expect_header(sw_headers, "Cache-Control", "no-store")
+
+    # Authentication failures are deliberate here: the status codes prove that Nginx
+    # reached the correct service without requiring real user tokens or external APIs.
+    _expect_status(f"{FRONTEND}/api/garmin/status", 401, method="POST")
+    _expect_status(f"{FRONTEND}/api/google-health/start-link", 400, method="POST")
+
+    print("[OK] Docker Compose full-stack smoke checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/garmin_sync/firestore_repository.py
+++ b/src/garmin_sync/firestore_repository.py
@@ -26,11 +26,12 @@ logger = logging.getLogger(__name__)
 def init_firestore_client(credentials_path: str | None = None) -> Any:
     """Initialize Firebase Admin SDK and return Firestore client."""
     if not firebase_admin._apps:
-        if credentials_path and os.path.exists(credentials_path):
+        resolved_path = credentials_path or os.getenv("FIREBASE_CREDENTIALS_PATH")
+        if resolved_path and os.path.exists(resolved_path):
             logger.info(
-                f"Initializing Firebase Admin with service account from '{credentials_path}'..."
+                f"Initializing Firebase Admin with service account from '{resolved_path}'..."
             )
-            cred = credentials.Certificate(credentials_path)
+            cred = credentials.Certificate(resolved_path)
             firebase_admin.initialize_app(cred)
         else:
             logger.info("Initializing Firebase Admin with Application Default Credentials (ADC)...")

--- a/src/garmin_sync/firestore_repository.py
+++ b/src/garmin_sync/firestore_repository.py
@@ -27,12 +27,7 @@ def init_firestore_client(credentials_path: str | None = None) -> Any:
     """Initialize Firebase Admin SDK and return Firestore client."""
     if not firebase_admin._apps:
         resolved_path = credentials_path or os.getenv("FIREBASE_CREDENTIALS_PATH")
-        if resolved_path:
-            if not os.path.isfile(resolved_path):
-                raise FileNotFoundError(
-                    "Configured Firebase credentials path does not exist or is not a regular "
-                    f"file: {resolved_path}"
-                )
+        if resolved_path and os.path.exists(resolved_path):
             logger.info(
                 f"Initializing Firebase Admin with service account from '{resolved_path}'..."
             )
@@ -68,557 +63,850 @@ class FirestoreRecoveryRepository:
     def __init__(
         self,
         user_id: str,
-        collection_name: str | None = None,
-        db: Any | None = None,
-    ) -> None:
-        normalized_user_id = user_id.strip()
-        if not normalized_user_id or normalized_user_id == "default_user":
-            raise ValueError("FirestoreRecoveryRepository requires a valid non-default user_id")
-        self.user_id = user_id
-        self.collection_name = collection_name or os.getenv(
-            "FIRESTORE_RECOVERY_COLLECTION", "daily_recovery_snapshots"
-        )
-        self.db = db or init_firestore_client()
-
-    def _collection(self) -> Any:
-        return self.db.collection("users").document(self.user_id).collection(self.collection_name)
-
-    def upsert_snapshot(self, date: str, payload: dict[str, Any]) -> None:
-        """Upsert recovery snapshot with idempotent merge semantics."""
-        payload_user_id = payload.get("userId")
-        if payload_user_id != self.user_id:
+        collection_name: str = "daily_recovery_snapshots",
+        db: Any = None,
+        credentials_path: str | None = None,
+    ):
+        if not user_id or not user_id.strip() or user_id.strip() == "default_user":
             raise ValueError(
-                f"Snapshot userId '{payload_user_id}' does not match configured user_id '{self.user_id}'"
+                "FirestoreRecoveryRepository requires a valid non-default user_id (Firebase UID)."
             )
+        # Firebase Auth UIDs are identifiers, not free-form display text. Preserve the
+        # exact value supplied by Auth instead of normalizing it: stripping would make
+        # distinct legal UIDs share Firestore/token/archive scopes.
+        self.user_id = user_id
+        self.collection_name = collection_name
+        self._db = db
+        self.credentials_path = credentials_path
 
-        doc_ref = self._collection().document(date)
-        now = datetime.now(timezone.utc).isoformat()
+    @property
+    def db(self) -> Any:
+        return self._get_db()
 
-        doc = doc_ref.get()
-        data = dict(payload)
-        data["updatedAt"] = now
-        if not doc.exists:
-            data["createdAt"] = now
+    @db.setter
+    def db(self, value: Any) -> None:
+        self._db = value
 
-        doc_ref.set(data, merge=True)
+    def _get_db(self) -> Any:
+        if self._db is None:
+            self._db = init_firestore_client(self.credentials_path)
+        return self._db
 
-    def get_snapshot(self, date: str) -> dict[str, Any] | None:
-        """Return a recovery snapshot by date, or None if not found."""
-        doc = self._collection().document(date).get()
-        if not doc.exists:
+    def _get_doc_ref(self, date_iso: str) -> Any:
+        db = self._get_db()
+        return (
+            db.collection("users")
+            .document(self.user_id)
+            .collection(self.collection_name)
+            .document(date_iso)
+        )
+
+    def get_snapshot(self, date_iso: str) -> dict[str, Any] | None:
+        """Fetch recovery snapshot for target date."""
+        try:
+            doc_snap = self._get_doc_ref(date_iso).get()
+            if doc_snap.exists:
+                data = doc_snap.to_dict()
+                if data.get("userId") != self.user_id:
+                    raise ValueError(
+                        f"Document userId '{data.get('userId')}' does not match repository user_id '{self.user_id}'"
+                    )
+                return data
             return None
-        return cast(dict[str, Any], doc.to_dict())
+        except Exception as e:
+            logger.warning(
+                f"Error reading Firestore snapshot for user {self.user_id} date {date_iso}: {e}"
+            )
+            return None
+
+    def get_snapshots_batch(self, date_isos: list[str]) -> dict[str, dict[str, Any]]:
+        """Fetch multiple recovery snapshots efficiently in batches."""
+        db = self._get_db()
+        refs = [self._get_doc_ref(d) for d in date_isos]
+        snapshots = {}
+
+        chunk_size = 400
+        for i in range(0, len(refs), chunk_size):
+            chunk = refs[i : i + chunk_size]
+            try:
+                for doc_snap in db.get_all(chunk):
+                    if doc_snap.exists:
+                        data = doc_snap.to_dict()
+                        if data.get("userId") == self.user_id:
+                            snapshots[doc_snap.id] = data
+            except Exception as e:
+                logger.warning(
+                    f"Error reading batch of Firestore snapshots for user {self.user_id}: {e}"
+                )
+                raise
+        return snapshots
 
     def is_fresh(
         self,
-        date: str,
-        *,
-        staleness_minutes: int,
-        incomplete_staleness_minutes: int,
+        date_iso: str,
+        staleness_minutes: int = 60,
+        incomplete_staleness_minutes: int = 5,
+        require_complete: bool = True,
     ) -> bool:
-        """Return whether an existing snapshot is fresh enough to skip another sync.
+        """Check if date's snapshot was synced within staleness threshold.
 
-        Complete snapshots get the normal cooldown. Incomplete snapshots use a much shorter
-        cooldown so late-arriving Garmin metrics can be picked up quickly.
+        If require_complete is True and the snapshot is missing any core recovery metric
+        (sleep, resting HR, HRV, respiration, body battery wake, steps), it is considered
+        incomplete and only remains fresh for incomplete_staleness_minutes (a short rate-limit
+        cooldown). Once complete, it respects staleness_minutes.
         """
-        snapshot = self.get_snapshot(date)
+        snapshot = self.get_snapshot(date_iso)
         if not snapshot:
             return False
 
-        source = snapshot.get("source", {})
-        synced_at = source.get("garminSyncedAt") if isinstance(source, dict) else None
-        if not isinstance(synced_at, str):
+        synced_at_str = snapshot.get("source", {}).get("garminSyncedAt") or snapshot.get(
+            "updatedAt"
+        )
+        if not synced_at_str:
             return False
 
         try:
-            synced_dt = datetime.fromisoformat(synced_at.replace("Z", "+00:00"))
-        except ValueError:
-            return False
-        if synced_dt.tzinfo is None:
-            synced_dt = synced_dt.replace(tzinfo=timezone.utc)
+            synced_at = datetime.fromisoformat(synced_at_str)
+            if synced_at.tzinfo is None:
+                synced_at = synced_at.replace(tzinfo=timezone.utc)
+            now_utc = datetime.now(timezone.utc)
+            age_minutes = (now_utc - synced_at).total_seconds() / 60.0
 
-        age_minutes = (datetime.now(timezone.utc) - synced_dt).total_seconds() / 60.0
-        threshold = (
-            staleness_minutes
-            if is_snapshot_complete(snapshot)
-            else incomplete_staleness_minutes
-        )
-        return age_minutes < threshold
+            if require_complete and not is_snapshot_complete(snapshot):
+                return age_minutes < incomplete_staleness_minutes
 
-    def get_snapshots(self, dates: Iterable[str]) -> dict[str, dict[str, Any]]:
-        """Return existing snapshots keyed by date."""
-        snapshots: dict[str, dict[str, Any]] = {}
-        for date in dates:
-            snapshot = self.get_snapshot(date)
-            if snapshot:
-                snapshots[date] = snapshot
-        return snapshots
-
-    def iter_snapshots(self, *, start_date: str, end_date: str) -> Iterator[dict[str, Any]]:
-        """Yield snapshots in date order for the inclusive date range."""
-        query = (
-            self._collection()
-            .where(filter=FieldFilter("date", ">=", start_date))
-            .where(filter=FieldFilter("date", "<=", end_date))
-            .order_by("date")
-        )
-        for doc in query.stream():
-            data = doc.to_dict()
-            if isinstance(data, dict):
-                yield data
-
-    def delete_snapshot(self, date: str) -> None:
-        """Delete a snapshot by date."""
-        self._collection().document(date).delete()
-
-    def upsert_observation_bundle(
-        self,
-        bundle: "HealthObservationDayBundle",
-        *,
-        document_id: str | None = None,
-    ) -> bool:
-        """Persist a canonical observation bundle if source/version content changed.
-
-        Returns True when a write occurred, False when an existing row already has the
-        same `sourcePayloadHash` and `normalizerVersion`.
-        """
-        from .models import HealthObservationDayBundle
-
-        if not isinstance(bundle, HealthObservationDayBundle):
-            raise TypeError("bundle must be a HealthObservationDayBundle")
-        if bundle.userId != self.user_id:
-            raise ValueError(
-                f"Observation bundle userId '{bundle.userId}' does not match configured "
-                f"user_id '{self.user_id}'"
-            )
-
-        doc_id = document_id or f"{bundle.logicalDate}_{bundle.provider}_{bundle.transport}"
-        doc_ref = (
-            self.db.collection("users")
-            .document(self.user_id)
-            .collection("health_observations")
-            .document(doc_id)
-        )
-        payload = bundle.model_dump(mode="json")
-
-        transaction_factory = getattr(self.db, "transaction", None)
-        if callable(transaction_factory):
-            transaction = transaction_factory()
-
-            @firestore.transactional
-            def _upsert_in_transaction(txn: Any) -> bool:
-                existing = doc_ref.get(transaction=txn)
-                existing_data = existing.to_dict() if existing.exists else None
-                if isinstance(existing_data, dict) and (
-                    existing_data.get("sourcePayloadHash") == bundle.sourcePayloadHash
-                    and existing_data.get("normalizerVersion") == bundle.normalizerVersion
-                ):
-                    return False
-
-                previous_revision = 0
-                if isinstance(existing_data, dict):
-                    try:
-                        previous_revision = int(existing_data.get("revision") or 0)
-                    except (TypeError, ValueError):
-                        previous_revision = 0
-
-                write_payload = {
-                    **payload,
-                    "revision": max(1, previous_revision + 1),
-                    "updatedAt": firestore.SERVER_TIMESTAMP,
-                }
-                if not existing.exists:
-                    write_payload["createdAt"] = firestore.SERVER_TIMESTAMP
-                txn.set(doc_ref, write_payload, merge=True)
-                return True
-
-            return bool(_upsert_in_transaction(transaction))
-
-        # Fallback is primarily for deterministic tests/fakes that do not implement
-        # transactions. Production Firestore clients provide transaction().
-        existing = doc_ref.get()
-        existing_data = existing.to_dict() if existing.exists else None
-        if isinstance(existing_data, dict) and (
-            existing_data.get("sourcePayloadHash") == bundle.sourcePayloadHash
-            and existing_data.get("normalizerVersion") == bundle.normalizerVersion
-        ):
+            return age_minutes < staleness_minutes
+        except Exception as e:
+            logger.warning(f"Failed to parse synced_at timestamp '{synced_at_str}': {e}")
             return False
 
-        previous_revision = 0
-        if isinstance(existing_data, dict):
-            try:
-                previous_revision = int(existing_data.get("revision") or 0)
-            except (TypeError, ValueError):
-                previous_revision = 0
-        write_payload = {
-            **payload,
-            "revision": max(1, previous_revision + 1),
-            "updatedAt": firestore.SERVER_TIMESTAMP,
-        }
-        if not existing.exists:
-            write_payload["createdAt"] = firestore.SERVER_TIMESTAMP
-        doc_ref.set(write_payload, merge=True)
-        return True
-
-    def _identity_bundle_doc_ref(self, bundle_id: str) -> Any:
-        return (
-            self.db.collection("users")
-            .document(self.user_id)
-            .collection("health_identity_bundles")
-            .document(bundle_id)
-        )
-
-    def _identity_current_doc_ref(self) -> Any:
-        return (
-            self.db.collection("users")
-            .document(self.user_id)
-            .collection("identity_passports")
-            .document("current")
-        )
-
-    def save_identity_assessment(self, assessment: Mapping[str, Any]) -> None:
-        """Persist one immutable physiological identity assessment."""
-        validated = validate_automatic_identity_assessment(dict(assessment))
-        if validated.userId != self.user_id:
+    def upsert_snapshot(self, date_iso: str, payload: dict[str, Any]) -> None:
+        """Upsert user-scoped recovery snapshot document."""
+        if payload.get("userId") != self.user_id:
             raise ValueError(
-                "Identity assessment userId does not match configured Firestore repository user_id"
+                f"Payload userId '{payload.get('userId')}' does not match configured user_id '{self.user_id}'"
             )
-        doc_ref = self._identity_bundle_doc_ref(validated.bundleId)
-        payload = validated.model_dump(mode="json")
-        payload["updatedAt"] = firestore.SERVER_TIMESTAMP
-        try:
-            doc_ref.create(payload)
-        except Conflict as exc:
-            raise ValueError(
-                f"Identity assessment bundle '{validated.bundleId}' is immutable and already exists"
-            ) from exc
 
-    def get_identity_assessment(self, bundle_id: str) -> dict[str, Any] | None:
-        """Return one immutable physiological identity assessment."""
-        doc = self._identity_bundle_doc_ref(bundle_id).get()
-        if not doc.exists:
-            return None
-        data = doc.to_dict()
-        return dict(data) if isinstance(data, dict) else None
+        now_iso = datetime.now(timezone.utc).isoformat()
+        doc_ref = self._get_doc_ref(date_iso)
+        doc_snap = doc_ref.get()
 
-    def save_identity_passport_version(self, passport: Mapping[str, Any]) -> None:
-        """Persist one immutable Physiological Identity Passport version."""
-        validated = validate_identity_passport_version(dict(passport))
-        if validated.userId != self.user_id:
-            raise ValueError(
-                "Identity passport userId does not match configured Firestore repository user_id"
-            )
-        doc_ref = (
-            self.db.collection("users")
-            .document(self.user_id)
-            .collection("identity_passport_versions")
-            .document(validated.passportVersionId)
-        )
-        payload = validated.model_dump(mode="json")
-        payload["updatedAt"] = firestore.SERVER_TIMESTAMP
-        try:
-            doc_ref.create(payload)
-        except Conflict as exc:
-            raise ValueError(
-                f"Identity passport version '{validated.passportVersionId}' is immutable and already exists"
-            ) from exc
+        if not doc_snap.exists:
+            payload["createdAt"] = payload.get("createdAt") or now_iso
 
-    def get_identity_passport_version(self, passport_version_id: str) -> dict[str, Any] | None:
-        """Return one immutable Physiological Identity Passport version."""
-        doc = (
-            self.db.collection("users")
-            .document(self.user_id)
-            .collection("identity_passport_versions")
-            .document(passport_version_id)
-            .get()
-        )
-        if not doc.exists:
-            return None
-        data = doc.to_dict()
-        return dict(data) if isinstance(data, dict) else None
+        payload["updatedAt"] = now_iso
 
-    def save_identity_passport_current(self, current: Mapping[str, Any]) -> None:
-        """Persist the mutable pointer to the currently active passport version."""
-        validated = validate_identity_passport_current(dict(current))
-        if validated.userId != self.user_id:
-            raise ValueError(
-                "Identity passport current userId does not match configured Firestore repository user_id"
-            )
-        payload = validated.model_dump(mode="json")
-        payload["updatedAt"] = firestore.SERVER_TIMESTAMP
-        self._identity_current_doc_ref().set(payload, merge=False)
-
-    def get_identity_passport_current(self) -> dict[str, Any] | None:
-        """Return the mutable pointer to the currently active passport version."""
-        doc = self._identity_current_doc_ref().get()
-        if not doc.exists:
-            return None
-        data = doc.to_dict()
-        return dict(data) if isinstance(data, dict) else None
-
-    def save_identity_review_event(self, event: Mapping[str, Any]) -> None:
-        """Persist one immutable user review decision for a suspicious identity bundle."""
-        validated = validate_identity_review_event(dict(event))
-        if validated.userId != self.user_id:
-            raise ValueError(
-                "Identity review event userId does not match configured Firestore repository user_id"
-            )
-        doc_ref = (
-            self.db.collection("users")
-            .document(self.user_id)
-            .collection("health_identity_reviews")
-            .document(validated.reviewId)
-        )
-        payload = validated.model_dump(mode="json")
-        payload["updatedAt"] = firestore.SERVER_TIMESTAMP
-        try:
-            doc_ref.create(payload)
-        except Conflict as exc:
-            raise ValueError(
-                f"Identity review '{validated.reviewId}' is immutable and already exists"
-            ) from exc
-
-    def get_identity_review_event(self, review_id: str) -> dict[str, Any] | None:
-        """Return one immutable user review decision."""
-        doc = (
-            self.db.collection("users")
-            .document(self.user_id)
-            .collection("health_identity_reviews")
-            .document(review_id)
-            .get()
-        )
-        if not doc.exists:
-            return None
-        data = doc.to_dict()
-        return dict(data) if isinstance(data, dict) else None
-
-    def iter_identity_assessments(
-        self,
-        *,
-        start_date: str,
-        end_date: str,
-    ) -> Iterator[dict[str, Any]]:
-        """Yield physiological identity assessments in deterministic date/bundle order."""
-        query = (
-            self.db.collection("users")
-            .document(self.user_id)
-            .collection("health_identity_bundles")
-            .where(filter=FieldFilter("logicalDate", ">=", start_date))
-            .where(filter=FieldFilter("logicalDate", "<=", end_date))
-            .order_by("logicalDate")
-        )
-        rows: list[dict[str, Any]] = []
-        for doc in query.stream():
-            data = doc.to_dict()
-            if isinstance(data, dict):
-                rows.append(dict(data))
-        rows.sort(key=lambda row: (str(row.get("logicalDate", "")), str(row.get("bundleId", ""))))
-        yield from rows
-
-    def iter_identity_reviews(
-        self,
-        *,
-        start_date: str,
-        end_date: str,
-    ) -> Iterator[dict[str, Any]]:
-        """Yield immutable identity review events in deterministic date/review order."""
-        query = (
-            self.db.collection("users")
-            .document(self.user_id)
-            .collection("health_identity_reviews")
-            .where(filter=FieldFilter("logicalDate", ">=", start_date))
-            .where(filter=FieldFilter("logicalDate", "<=", end_date))
-            .order_by("logicalDate")
-        )
-        rows: list[dict[str, Any]] = []
-        for doc in query.stream():
-            data = doc.to_dict()
-            if isinstance(data, dict):
-                rows.append(dict(data))
-        rows.sort(key=lambda row: (str(row.get("logicalDate", "")), str(row.get("reviewId", ""))))
-        yield from rows
-
-    def build_effective_identity_decision_index(
-        self,
-        *,
-        start_date: str,
-        end_date: str,
-    ) -> dict[IdentityBundleKey, EffectiveIdentityDecisionProjection]:
-        """Build effective identity outcomes with immutable user reviews overriding automation."""
-        return build_effective_identity_decision_index(
-            self.iter_identity_assessments(start_date=start_date, end_date=end_date),
-            self.iter_identity_reviews(start_date=start_date, end_date=end_date),
+        doc_ref.set(payload, merge=True)
+        logger.info(
+            f"Successfully saved user-scoped snapshot users/{self.user_id}/{self.collection_name}/{date_iso}."
         )
 
-    def list_identity_training_observations(
-        self,
-        *,
-        limit: int | None = None,
-    ) -> list[dict[str, Any]]:
-        """Return identity-attributed historical observations newest-first.
-
-        This bounded read powers PI3 historical passport bootstrap. Observations are read
-        from the canonical `health_observations` collection and the persisted `identity`
-        attribution block is preserved for caller-side filtering.
-        """
-        query = self.db.collection("users").document(self.user_id).collection("health_observations")
-        if hasattr(query, "order_by"):
-            query = query.order_by("logicalDate", direction=firestore.Query.DESCENDING)
-        if limit is not None and hasattr(query, "limit"):
-            query = query.limit(limit)
-
-        rows: list[dict[str, Any]] = []
-        for doc in query.stream():
-            data = doc.to_dict()
-            if isinstance(data, dict):
-                rows.append(dict(data))
-        return rows
-
-    def list_identity_reviewed_reference_rows(
-        self,
-        *,
-        limit: int | None = None,
-    ) -> list[dict[str, Any]]:
-        """Return reviewed identity bundles as signed reference rows for passport bootstrap."""
-        reviews_query = (
-            self.db.collection("users")
-            .document(self.user_id)
-            .collection("health_identity_reviews")
-        )
-        if hasattr(reviews_query, "order_by"):
-            reviews_query = reviews_query.order_by(
-                "logicalDate", direction=firestore.Query.DESCENDING
-            )
-        if limit is not None and hasattr(reviews_query, "limit"):
-            reviews_query = reviews_query.limit(limit)
-
-        rows: list[dict[str, Any]] = []
-        for review_doc in reviews_query.stream():
-            review = review_doc.to_dict()
-            if not isinstance(review, dict):
-                continue
-            bundle_id = review.get("bundleId")
-            if not isinstance(bundle_id, str) or not bundle_id:
-                continue
-            bundle = self.get_identity_assessment(bundle_id)
-            if not bundle:
-                continue
-            rows.append(
-                {
-                    "review": dict(review),
-                    "bundle": bundle,
-                }
-            )
-        return rows
-
-    def list_identity_passport_versions(self, *, limit: int | None = None) -> list[dict[str, Any]]:
-        """Return immutable passport versions newest-first."""
-        query = (
-            self.db.collection("users")
-            .document(self.user_id)
-            .collection("identity_passport_versions")
-        )
-        if hasattr(query, "order_by"):
-            query = query.order_by("createdAt", direction=firestore.Query.DESCENDING)
-        if limit is not None and hasattr(query, "limit"):
-            query = query.limit(limit)
-
-        rows: list[dict[str, Any]] = []
-        for doc in query.stream():
-            data = doc.to_dict()
-            if isinstance(data, dict):
-                rows.append(dict(data))
-        return rows
-
-    def list_identity_review_events(self, *, limit: int | None = None) -> list[dict[str, Any]]:
-        """Return immutable identity review events newest-first."""
-        query = (
-            self.db.collection("users")
-            .document(self.user_id)
-            .collection("health_identity_reviews")
-        )
-        if hasattr(query, "order_by"):
-            query = query.order_by("createdAt", direction=firestore.Query.DESCENDING)
-        if limit is not None and hasattr(query, "limit"):
-            query = query.limit(limit)
-
-        rows: list[dict[str, Any]] = []
-        for doc in query.stream():
-            data = doc.to_dict()
-            if isinstance(data, dict):
-                rows.append(dict(data))
-        return rows
-
-    def get_identity_bundle_evidence_rows(
-        self,
-        *,
-        bundle_id: str,
-    ) -> list[dict[str, Any]]:
-        """Return the persisted observation rows referenced by one identity bundle."""
-        bundle = self.get_identity_assessment(bundle_id)
-        if not bundle:
-            return []
-
-        observation_ids = bundle.get("observationIds")
-        if not isinstance(observation_ids, list):
-            return []
-
-        collection = (
-            self.db.collection("users").document(self.user_id).collection("health_observations")
-        )
-        rows: list[dict[str, Any]] = []
-        for observation_id in observation_ids:
-            if not isinstance(observation_id, str) or not observation_id:
-                continue
-            doc = collection.document(observation_id).get()
-            if doc.exists:
-                data = doc.to_dict()
-                if isinstance(data, dict):
-                    rows.append(dict(data))
-        return rows
-
-    def batch_get_identity_assessments(self, bundle_ids: Iterable[str]) -> dict[str, dict[str, Any]]:
-        """Return existing physiological identity assessments keyed by bundle id."""
-        ids = list(dict.fromkeys(bundle_ids))
-        if not ids:
-            return {}
-        refs = [self._identity_bundle_doc_ref(bundle_id) for bundle_id in ids]
-        documents = self.db.get_all(refs)
-        result: dict[str, dict[str, Any]] = {}
-        for doc in documents:
-            if not doc.exists:
-                continue
-            data = doc.to_dict()
-            if isinstance(data, dict):
-                bundle_id = data.get("bundleId")
-                if isinstance(bundle_id, str):
-                    result[bundle_id] = dict(data)
-        return result
-
-    def batch_get_identity_reviews_by_bundle_id(
-        self, bundle_ids: Iterable[str]
+    def get_historical_snapshots(
+        self, start_date_iso: str, end_date_iso: str
     ) -> dict[str, dict[str, Any]]:
-        """Return latest review for each physiological identity bundle."""
-        ids = list(dict.fromkeys(bundle_ids))
-        if not ids:
-            return {}
+        """Fetch historical snapshots in range [start_date_iso, end_date_iso]."""
+        db = self._get_db()
+        docs = (
+            db.collection("users")
+            .document(self.user_id)
+            .collection(self.collection_name)
+            .where(filter=FieldFilter("date", ">=", start_date_iso))
+            .where(filter=FieldFilter("date", "<=", end_date_iso))
+            .stream()
+        )
 
         results: dict[str, dict[str, Any]] = {}
-        collection = (
-            self.db.collection("users").document(self.user_id).collection("health_identity_reviews")
-        )
-        for chunk in itertools.batched(ids, 30):
-            query = collection.where(filter=FieldFilter("bundleId", "in", list(chunk)))
-            for doc in query.stream():
-                data = doc.to_dict()
-                if not isinstance(data, dict):
-                    continue
-                bundle_id = data.get("bundleId")
-                if not isinstance(bundle_id, str):
-                    continue
-                previous = results.get(bundle_id)
-                if previous is None or str(data.get("createdAt", "")) > str(
-                    previous.get("createdAt", "")
-                ):
-                    results[bundle_id] = dict(data)
+        for doc in docs:
+            data = doc.to_dict()
+            date_key = data.get("date") or doc.id
+            results[date_key] = data
         return results
+
+    def upsert_activity(self, activity_id: str | int, payload: dict[str, Any]) -> None:
+        """Upsert a normalized activity record at users/{userId}/activities/{activityId}.
+        Doc ID = activityId, so re-fetching the same activity across overlapping sync
+        windows (e.g. daily 3-day lookback, backfill) naturally dedups instead of
+        creating duplicate records."""
+        db = self._get_db()
+        doc_ref = (
+            db.collection("users")
+            .document(self.user_id)
+            .collection("activities")
+            .document(str(activity_id))
+        )
+        doc_ref.set(payload, merge=True)
+
+    def upsert_activities(self, activities: list[tuple[str | int, dict[str, Any]]]) -> None:
+        """Batch upsert normalized activity records.
+        Handles Firestore's 500 document limit per batch automatically."""
+        if not activities:
+            return
+
+        db = self._get_db()
+        collection_ref = db.collection("users").document(self.user_id).collection("activities")
+
+        # Firestore batches are limited to 500 operations
+        batch_size = 500
+        for i in range(0, len(activities), batch_size):
+            chunk = activities[i : i + batch_size]
+            batch = db.batch()
+            for activity_id, payload in chunk:
+                doc_ref = collection_ref.document(str(activity_id))
+                batch.set(doc_ref, payload, merge=True)
+            batch.commit()
+
+    def get_activities_in_range(
+        self, start_date_iso: str, end_date_iso: str
+    ) -> list[dict[str, Any]]:
+        """Fetch normalized activities in range [start_date_iso, end_date_iso]."""
+        db = self._get_db()
+        docs = (
+            db.collection("users")
+            .document(self.user_id)
+            .collection("activities")
+            .where(filter=FieldFilter("date", ">=", start_date_iso))
+            .where(filter=FieldFilter("date", "<=", end_date_iso))
+            .order_by("date")
+            .stream()
+        )
+        return [doc.to_dict() for doc in docs]
+
+    def upsert_garmin_performance_targets(self, targets: Any) -> None:
+        """Merge Garmin's current targets into the user's preference profile.
+
+        Active targets are intentionally field-level owned: importing a new Garmin
+        value never replaces a target the coach/user marked ``manual``. Existing
+        target values without provenance predate this feature and are conservatively
+        treated as manual on their first import.
+        """
+        db = self._get_db()
+        doc_ref = (
+            db.collection("users")
+            .document(self.user_id)
+            .collection("preferences")
+            .document("profile")
+        )
+        now_iso = datetime.now(timezone.utc).isoformat()
+        incoming = {
+            "ftpWatts": targets.cycling_ftp_watts,
+            "thresholdPaceSecPerKm": targets.running_threshold_pace_sec_per_km,
+            "lthrBpm": targets.running_lthr_bpm,
+            "weightKg": targets.weight_kg,
+            "bodyFatPct": targets.body_fat_pct,
+        }
+        measured_at = {
+            "ftpMeasuredAt": targets.ftp_measured_at,
+            "thresholdMeasuredAt": targets.threshold_measured_at,
+            "lthrMeasuredAt": targets.lthr_measured_at,
+            "weightMeasuredAt": targets.weight_measured_at,
+        }
+
+        @firestore.transactional  # pyright: ignore[reportAttributeAccessIssue]
+        def merge_targets(transaction: Any) -> None:
+            snapshot = doc_ref.get(transaction=transaction)
+            existing: dict[str, Any] = cast(
+                dict[str, Any], snapshot.to_dict() if snapshot.exists else {}
+            )
+            raw_profile = existing.get("performanceProfile")
+            profile: dict[str, Any] = (
+                cast(dict[str, Any], raw_profile) if isinstance(raw_profile, dict) else {}
+            )
+            raw_sources = profile.get("targetSources")
+            sources: dict[str, Any] = (
+                cast(dict[str, Any], raw_sources) if isinstance(raw_sources, dict) else {}
+            )
+
+            raw_garmin = profile.get("garmin")
+            garmin: dict[str, Any] = (
+                cast(dict[str, Any], raw_garmin) if isinstance(raw_garmin, dict) else {}
+            )
+            # A partial Garmin response must not erase a previously successful import
+            # for another target (for example, cycling FTP can be available while
+            # running lactate threshold is not configured on the account).
+            garmin.update({key: value for key, value in incoming.items() if value is not None})
+            garmin.update({key: value for key, value in measured_at.items() if value is not None})
+            if targets.race_predictions is not None:
+                raw_race_predictions = garmin.get("racePredictions")
+                race_predictions: dict[str, Any] = (
+                    dict(raw_race_predictions) if isinstance(raw_race_predictions, dict) else {}
+                )
+                incoming_race_predictions = {
+                    "fiveKmSec": targets.race_predictions.five_km_sec,
+                    "tenKmSec": targets.race_predictions.ten_km_sec,
+                    "halfMarathonSec": targets.race_predictions.half_marathon_sec,
+                    "marathonSec": targets.race_predictions.marathon_sec,
+                }
+                race_predictions.update(
+                    {
+                        key: value
+                        for key, value in incoming_race_predictions.items()
+                        if value is not None
+                    }
+                )
+                race_predictions["fetchedAt"] = now_iso
+                garmin["racePredictions"] = race_predictions
+                profile["racePredictions"] = dict(race_predictions)
+            garmin["fetchedAt"] = now_iso
+            profile["garmin"] = garmin
+
+            for key, value in incoming.items():
+                if value is None:
+                    continue
+                source = sources.get(key)
+                existing_value = profile.get(key)
+                if source in {"manual", "coach"}:
+                    continue
+                if source == "garmin" or existing_value is None:
+                    profile[key] = value
+                    sources[key] = "garmin"
+                else:
+                    # Old documents have active values but no ownership metadata. The
+                    # safe migration is manual; an explicit UI action can adopt Garmin.
+                    sources[key] = "manual"
+
+            if sources:
+                profile["targetSources"] = sources
+
+            payload: dict[str, Any] = {
+                "userId": self.user_id,
+                "performanceProfile": profile,
+                "updatedAt": now_iso,
+            }
+            # A scheduled Garmin sync can run before the client has opened the app and
+            # created preferences. Do not leave that first-run document partial: the
+            # frontend treats an existing preferences record as complete.
+            if not snapshot.exists:
+                payload.update(
+                    {
+                        "preferredRecoveryStyle": "mixed",
+                        "defaultWeekdayTimeMin": 45,
+                        "defaultWeekendTimeMin": 60,
+                        "preferredTimeOfDay": "flexible",
+                        "preferredModalities": ["Running", "Cycling", "Strength"],
+                        "deprioritizedModalities": [],
+                        "avoidedModalities": [],
+                        "unavailableModalities": [],
+                        "explanationVerbosity": "detailed",
+                        "conservativeBias": False,
+                        "preferredUnits": {
+                            "distance": "km",
+                            "weight": "kg",
+                            "temperature": "celsius",
+                        },
+                        "schemaVersion": 1,
+                        "createdAt": now_iso,
+                    }
+                )
+            transaction.set(doc_ref, payload, merge=True)
+
+        merge_targets(db.transaction())
+        logger.info(
+            "Updated Garmin performance targets in user-scoped preferences for user=<UID-redacted>."
+        )
+
+    def upsert_garmin_gear(self, gear_items: list[Any]) -> None:
+        """Persist gear items to user collection and update preferences profile gearTracker."""
+        if not gear_items:
+            return
+        db = self._get_db()
+        now_iso = datetime.now(timezone.utc).isoformat()
+
+        profile_ref = (
+            db.collection("users")
+            .document(self.user_id)
+            .collection("preferences")
+            .document("profile")
+        )
+
+        gear_dicts = [
+            {
+                key: value
+                for key, value in {
+                    "gearPk": item.gear_pk,
+                    "uuid": item.uuid,
+                    "customMakeModel": item.custom_make_model,
+                    "displayName": item.display_name,
+                    "gearType": item.gear_type,
+                    "brand": item.brand,
+                    "model": item.model,
+                    "totalDistanceKm": item.total_distance_km,
+                    "maximumDistanceKm": item.maximum_distance_km,
+                    "dateBegin": item.date_begin,
+                    "dateEnd": item.date_end,
+                    "status": item.status,
+                }.items()
+                if value is not None
+            }
+            for item in gear_items
+        ]
+
+        batch = db.batch()
+        batch.set(
+            profile_ref,
+            {
+                "userId": self.user_id,
+                "gearTracker": {
+                    "items": gear_dicts,
+                    "syncedAt": now_iso,
+                },
+                "updatedAt": now_iso,
+            },
+            merge=True,
+        )
+
+        for item, g_dict in zip(gear_items, gear_dicts, strict=True):
+            gear_doc_ref = (
+                db.collection("users")
+                .document(self.user_id)
+                .collection("gear")
+                .document(item.gear_pk)
+            )
+            batch.set(
+                gear_doc_ref,
+                {
+                    "userId": self.user_id,
+                    **g_dict,
+                    "updatedAt": now_iso,
+                },
+                merge=True,
+            )
+
+        batch.commit()
+        logger.info(
+            "Updated Garmin gear items (%d) for user=<UID-redacted>.",
+            len(gear_items),
+        )
+
+    def count_activities_in_range(self, start_date_iso: str, end_date_iso: str) -> int:
+        """Count normalized activity records with date in [start_date_iso, end_date_iso]."""
+        db = self._get_db()
+        query = (
+            db.collection("users")
+            .document(self.user_id)
+            .collection("activities")
+            .where(filter=FieldFilter("date", ">=", start_date_iso))
+            .where(filter=FieldFilter("date", "<=", end_date_iso))
+        )
+        try:
+            agg = query.count()
+            result = agg.get()
+            return int(result[0][0].value)
+        except Exception:
+            # Firestore aggregation queries may be unavailable in older emulators/mocks --
+            # fall back to a client-side count. Use select([]) to project only document
+            # IDs, avoiding full document payload transfer.
+            return sum(1 for _ in query.select([]).stream())
+
+    def save_health_observation_day_bundle(
+        self,
+        bundle: Any,  # HealthObservationDayBundle
+    ) -> tuple[bool, int]:
+        """Save a day-source observation bundle to Firestore under
+        users/{userId}/health_observation_days/{YYYY-MM-DD}_{provider}_{transport}.
+
+        Returns (changed: bool, revision: int). If identical payload exists, returns (False, rev).
+        If payload updated, increments revision and saves.
+        """
+        db = self._get_db()
+        doc_id = f"{bundle.logicalDate}_{bundle.provider}_{bundle.transport}"
+        doc_ref = (
+            db.collection("users")
+            .document(self.user_id)
+            .collection("health_observation_days")
+            .document(doc_id)
+        )
+
+        now_iso = datetime.now(timezone.utc).isoformat()
+        transaction = getattr(db, "transaction", None)
+
+        if callable(transaction) and firestore is not None:
+
+            @firestore.transactional
+            def _update_in_txn(txn: Any) -> tuple[bool, int]:
+                existing_doc = doc_ref.get(transaction=txn)
+                current_rev = 1
+                if existing_doc.exists:
+                    data = existing_doc.to_dict() or {}
+                    existing_hash = data.get("sourcePayloadHash")
+                    existing_normalizer_version = data.get("normalizerVersion", 1)
+                    current_rev = data.get("revision", 1)
+                    if (
+                        existing_hash == bundle.sourcePayloadHash
+                        and existing_normalizer_version >= bundle.normalizerVersion
+                    ):
+                        return False, current_rev
+                    current_rev += 1
+
+                bundle.revision = current_rev
+                bundle.ingestedAt = now_iso
+                bundle.effectiveAt = now_iso
+                txn.set(doc_ref, bundle.to_dict())
+                return True, current_rev
+
+            txn = db.transaction()
+            changed, current_rev = _update_in_txn(txn)
+        else:
+            existing_doc = doc_ref.get()
+            current_rev = 1
+            if existing_doc.exists:
+                data = existing_doc.to_dict() or {}
+                existing_hash = data.get("sourcePayloadHash")
+                existing_normalizer_version = data.get("normalizerVersion", 1)
+                current_rev = data.get("revision", 1)
+                if (
+                    existing_hash == bundle.sourcePayloadHash
+                    and existing_normalizer_version >= bundle.normalizerVersion
+                ):
+                    logger.debug(
+                        "Health observation bundle %s already up to date at revision %d.",
+                        doc_id,
+                        current_rev,
+                    )
+                    return False, current_rev
+                current_rev += 1
+
+            bundle.revision = current_rev
+            bundle.ingestedAt = now_iso
+            bundle.effectiveAt = now_iso
+            doc_ref.set(bundle.to_dict())
+            changed = True
+
+        if changed:
+            logger.info(
+                "Saved health observation bundle %s for user=<UID-redacted> at revision %d (%d observations).",
+                doc_id,
+                current_rev,
+                len(bundle.observations),
+            )
+        else:
+            logger.debug(
+                "Health observation bundle %s already up to date at revision %d.",
+                doc_id,
+                current_rev,
+            )
+        return changed, current_rev
+
+    def get_health_observation_day_bundle(
+        self,
+        logical_date: str,
+        provider: str,
+        transport: str,
+    ) -> dict[str, Any] | None:
+        """Retrieve a specific day-source bundle from Firestore."""
+        db = self._get_db()
+        doc_id = f"{logical_date}_{provider}_{transport}"
+        doc_ref = (
+            db.collection("users")
+            .document(self.user_id)
+            .collection("health_observation_days")
+            .document(doc_id)
+        )
+        doc = doc_ref.get()
+        return doc.to_dict() if doc.exists else None
+
+    def delete_health_observation_day_bundle(
+        self,
+        logical_date: str,
+        provider: str,
+        transport: str,
+    ) -> bool:
+        """Delete a specific day-source bundle from Firestore, e.g. when a source that
+        was present in a prior sync is absent from the current authoritative batch and
+        must stop being queryable by fusion/audit code (D-MS reconciliation).
+
+        Returns True if a document existed and was deleted, False if there was nothing
+        to delete.
+        """
+        db = self._get_db()
+        doc_id = f"{logical_date}_{provider}_{transport}"
+        doc_ref = (
+            db.collection("users")
+            .document(self.user_id)
+            .collection("health_observation_days")
+            .document(doc_id)
+        )
+        existing_doc = doc_ref.get()
+        if not existing_doc.exists:
+            return False
+        doc_ref.delete()
+        return True
+
+    def delete_health_observation_day_bundles_batch(
+        self,
+        keys: list[tuple[str, str, str]],
+    ) -> int:
+        """Batch delete multiple day-source bundles from Firestore.
+
+        Keys should be a list of (logical_date, provider, transport) tuples.
+        Deletes are executed in batches of 500 to respect Firestore limits.
+
+        Returns the total number of deletion operations submitted to batches.
+        """
+        if not keys:
+            return 0
+
+        db = self._get_db()
+        collection_ref = (
+            db.collection("users").document(self.user_id).collection("health_observation_days")
+        )
+
+        def batched(
+            iterable: Iterable[tuple[str, str, str]], n: int
+        ) -> Iterator[list[tuple[str, str, str]]]:
+            it = iter(iterable)
+            while chunk := list(itertools.islice(it, n)):
+                yield chunk
+
+        deleted_count = 0
+        for chunk in batched(keys, 500):
+            batch = db.batch()
+            for logical_date, provider, transport in chunk:
+                doc_id = f"{logical_date}_{provider}_{transport}"
+                doc_ref = collection_ref.document(doc_id)
+                batch.delete(doc_ref)
+                deleted_count += 1
+            batch.commit()
+
+        return deleted_count
+
+    def get_health_observation_bundles_in_range(
+        self,
+        start_date: str,
+        end_date: str,
+        provider: str | None = None,
+        transport: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Retrieve all health observation day bundles within [start_date, end_date]."""
+        db = self._get_db()
+        query = (
+            db.collection("users")
+            .document(self.user_id)
+            .collection("health_observation_days")
+            .where(filter=FieldFilter("logicalDate", ">=", start_date))
+            .where(filter=FieldFilter("logicalDate", "<=", end_date))
+        )
+
+        docs: list[dict[str, Any]] = []
+        chunk_size = 500
+        paged_query = query.limit(chunk_size)
+
+        while True:
+            chunk_docs = list(paged_query.stream())
+            if not chunk_docs:
+                break
+
+            for doc in chunk_docs:
+                data = doc.to_dict()
+                if provider and data.get("provider") != provider:
+                    continue
+                if transport and data.get("transport") != transport:
+                    continue
+                docs.append(data)
+
+            if len(chunk_docs) < chunk_size:
+                break
+
+            last_doc = chunk_docs[-1]
+            paged_query = query.start_after(last_doc).limit(chunk_size)
+
+        docs.sort(key=lambda d: d.get("logicalDate", ""))
+        return docs
+
+    def save_connection_metadata(
+        self,
+        connection_name: str,
+        metadata: dict[str, Any],
+    ) -> None:
+        """Save non-secret connection metadata to users/{userId}/connections/{connection_name}."""
+        db = self._get_db()
+        doc_ref = (
+            db.collection("users")
+            .document(self.user_id)
+            .collection("connections")
+            .document(connection_name)
+        )
+        doc_ref.set(metadata, merge=True)
+
+    def get_connection_metadata(
+        self,
+        connection_name: str,
+    ) -> dict[str, Any] | None:
+        """Retrieve connection metadata from users/{userId}/connections/{connection_name}."""
+        db = self._get_db()
+        doc_ref = (
+            db.collection("users")
+            .document(self.user_id)
+            .collection("connections")
+            .document(connection_name)
+        )
+        doc = doc_ref.get()
+        return doc.to_dict() if doc.exists else None
+
+    def _identity_collection(self, collection_name: str) -> Any:
+        return self._get_db().collection("users").document(self.user_id).collection(collection_name)
+
+    def _save_immutable_identity_document(
+        self,
+        collection_name: str,
+        document_id: str,
+        payload: Mapping[str, Any],
+    ) -> bool:
+        """Create an immutable server-owned identity document atomically and idempotently.
+
+        Firestore ``create`` is a single create-only write. Replaying the exact bytes after a
+        conflict is a no-op; reusing an existing identity for different content is rejected so a
+        concurrent writer cannot overwrite evidence needed by historical replay.
+        """
+
+        if not document_id:
+            raise ValueError("Identity document id must be non-empty.")
+        stored = dict(payload)
+        doc_ref = self._identity_collection(collection_name).document(document_id)
+        try:
+            doc_ref.create(stored)
+            return True
+        except Conflict as error:
+            snapshot = doc_ref.get()
+            if snapshot.exists and snapshot.to_dict() == stored:
+                return False
+            raise ValueError(
+                f"Immutable identity document {collection_name}/{document_id} already exists "
+                "with different content."
+            ) from error
+
+    def save_identity_passport_version(self, passport: Mapping[str, Any]) -> bool:
+        """Persist one fully validated immutable/replayable passport version."""
+
+        if not validate_identity_passport_version(passport):
+            raise ValueError("Identity passport version does not match the persisted schema.")
+        version = cast(str, passport.get("passportVersion"))
+        return self._save_immutable_identity_document(
+            "physiological_identity_passport_versions", version, passport
+        )
+
+    def set_current_identity_passport(self, passport: Mapping[str, Any]) -> None:
+        """Replace the fully validated server-owned online passport materialization."""
+
+        if not validate_identity_passport_current(passport):
+            raise ValueError("Current identity passport does not match the persisted schema.")
+        self._identity_collection("physiological_identity_passports").document("current").set(
+            dict(passport)
+        )
+
+    def get_current_identity_passport(self) -> dict[str, Any] | None:
+        snapshot = (
+            self._identity_collection("physiological_identity_passports").document("current").get()
+        )
+        return snapshot.to_dict() if snapshot.exists else None
+
+    def get_identity_passport_version(self, version: str) -> dict[str, Any] | None:
+        snapshot = (
+            self._identity_collection("physiological_identity_passport_versions")
+            .document(version)
+            .get()
+        )
+        return snapshot.to_dict() if snapshot.exists else None
+
+    def save_automatic_identity_assessment(self, assessment: Mapping[str, Any]) -> bool:
+        """Persist fully validated immutable model output and every contributing bundle ref."""
+
+        if not validate_automatic_identity_assessment(assessment):
+            raise ValueError("Automatic identity assessment does not match the persisted schema.")
+        assessment_id = cast(str, assessment.get("id"))
+        return self._save_immutable_identity_document(
+            "health_identity_assessments", assessment_id, assessment
+        )
+
+    def get_automatic_identity_assessment(self, assessment_id: str) -> dict[str, Any] | None:
+        snapshot = (
+            self._identity_collection("health_identity_assessments").document(assessment_id).get()
+        )
+        return snapshot.to_dict() if snapshot.exists else None
+
+    def save_identity_review_event(self, event: Mapping[str, Any]) -> bool:
+        """Persist a fully validated append-only admin/user review event."""
+
+        if not validate_identity_review_event(event):
+            raise ValueError("Identity review event does not match the persisted schema.")
+        event_id = cast(str, event.get("id"))
+        stored_event = dict(event)
+        recorded_at = cast(str, stored_event["recordedAt"])
+        parsed = datetime.fromisoformat(recorded_at.replace("Z", "+00:00"))
+        stored_event["recordedAt"] = parsed
+        return self._save_immutable_identity_document(
+            "health_identity_review_events", event_id, stored_event
+        )
+
+    def get_identity_assessments_in_range(
+        self, start_night_key: str, end_night_key: str
+    ) -> list[dict[str, Any]]:
+        query = (
+            self._identity_collection("health_identity_assessments")
+            .where(filter=FieldFilter("sourceNightKey", ">=", start_night_key))
+            .where(filter=FieldFilter("sourceNightKey", "<=", end_night_key))
+        )
+        assessments = [doc.to_dict() for doc in query.stream()]
+        assessments.sort(key=lambda item: (item.get("sourceNightKey", ""), item.get("id", "")))
+        return assessments
+
+    def get_identity_review_events(self, assessment_id: str) -> list[dict[str, Any]]:
+        query = self._identity_collection("health_identity_review_events").where(
+            filter=FieldFilter("assessmentId", "==", assessment_id)
+        )
+        events = [doc.to_dict() for doc in query.stream()]
+        for event in events:
+            recorded_at = event.get("recordedAt")
+            if isinstance(recorded_at, datetime):
+                event["recordedAt"] = (
+                    recorded_at.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+                )
+        events.sort(key=lambda item: (item.get("recordedAt", ""), item.get("id", "")))
+        return events
+
+    def get_identity_review_events_for_assessments(
+        self, assessment_ids: list[str]
+    ) -> dict[str, list[dict[str, Any]]]:
+        if not assessment_ids:
+            return {}
+
+        reviews_by_assessment: dict[str, list[dict[str, Any]]] = {
+            assessment_id: [] for assessment_id in assessment_ids
+        }
+
+        chunk_size = 30
+        for i in range(0, len(assessment_ids), chunk_size):
+            chunk = assessment_ids[i : i + chunk_size]
+            query = self._identity_collection("health_identity_review_events").where(
+                filter=FieldFilter("assessmentId", "in", chunk)
+            )
+            events = [doc.to_dict() for doc in query.stream()]
+            for event in events:
+                recorded_at = event.get("recordedAt")
+                if isinstance(recorded_at, datetime):
+                    event["recordedAt"] = (
+                        recorded_at.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+                    )
+                assessment_id = event.get("assessmentId")
+                if isinstance(assessment_id, str) and assessment_id in reviews_by_assessment:
+                    reviews_by_assessment[assessment_id].append(event)
+
+        for events in reviews_by_assessment.values():
+            events.sort(key=lambda item: (item.get("recordedAt", ""), item.get("id", "")))
+
+        return reviews_by_assessment
+
+    def get_effective_identity_decision_projections_in_range(
+        self, start_night_key: str, end_night_key: str
+    ) -> dict[IdentityBundleKey, EffectiveIdentityDecisionProjection]:
+        """Derive baseline-authoritative decisions from immutable persisted evidence."""
+
+        assessments = self.get_identity_assessments_in_range(start_night_key, end_night_key)
+
+        assessment_ids = [
+            assessment_id
+            for assessment in assessments
+            if isinstance((assessment_id := assessment.get("id")), str)
+        ]
+
+        reviews = self.get_identity_review_events_for_assessments(assessment_ids)
+        return build_effective_identity_decision_index(assessments, reviews)

--- a/src/garmin_sync/firestore_repository.py
+++ b/src/garmin_sync/firestore_repository.py
@@ -27,7 +27,12 @@ def init_firestore_client(credentials_path: str | None = None) -> Any:
     """Initialize Firebase Admin SDK and return Firestore client."""
     if not firebase_admin._apps:
         resolved_path = credentials_path or os.getenv("FIREBASE_CREDENTIALS_PATH")
-        if resolved_path and os.path.exists(resolved_path):
+        if resolved_path:
+            if not os.path.isfile(resolved_path):
+                raise FileNotFoundError(
+                    "Configured Firebase credentials path does not exist or is not a regular "
+                    f"file: {resolved_path}"
+                )
             logger.info(
                 f"Initializing Firebase Admin with service account from '{resolved_path}'..."
             )
@@ -63,850 +68,557 @@ class FirestoreRecoveryRepository:
     def __init__(
         self,
         user_id: str,
-        collection_name: str = "daily_recovery_snapshots",
-        db: Any = None,
-        credentials_path: str | None = None,
-    ):
-        if not user_id or not user_id.strip() or user_id.strip() == "default_user":
-            raise ValueError(
-                "FirestoreRecoveryRepository requires a valid non-default user_id (Firebase UID)."
-            )
-        # Firebase Auth UIDs are identifiers, not free-form display text. Preserve the
-        # exact value supplied by Auth instead of normalizing it: stripping would make
-        # distinct legal UIDs share Firestore/token/archive scopes.
+        collection_name: str | None = None,
+        db: Any | None = None,
+    ) -> None:
+        normalized_user_id = user_id.strip()
+        if not normalized_user_id or normalized_user_id == "default_user":
+            raise ValueError("FirestoreRecoveryRepository requires a valid non-default user_id")
         self.user_id = user_id
-        self.collection_name = collection_name
-        self._db = db
-        self.credentials_path = credentials_path
-
-    @property
-    def db(self) -> Any:
-        return self._get_db()
-
-    @db.setter
-    def db(self, value: Any) -> None:
-        self._db = value
-
-    def _get_db(self) -> Any:
-        if self._db is None:
-            self._db = init_firestore_client(self.credentials_path)
-        return self._db
-
-    def _get_doc_ref(self, date_iso: str) -> Any:
-        db = self._get_db()
-        return (
-            db.collection("users")
-            .document(self.user_id)
-            .collection(self.collection_name)
-            .document(date_iso)
+        self.collection_name = collection_name or os.getenv(
+            "FIRESTORE_RECOVERY_COLLECTION", "daily_recovery_snapshots"
         )
+        self.db = db or init_firestore_client()
 
-    def get_snapshot(self, date_iso: str) -> dict[str, Any] | None:
-        """Fetch recovery snapshot for target date."""
-        try:
-            doc_snap = self._get_doc_ref(date_iso).get()
-            if doc_snap.exists:
-                data = doc_snap.to_dict()
-                if data.get("userId") != self.user_id:
-                    raise ValueError(
-                        f"Document userId '{data.get('userId')}' does not match repository user_id '{self.user_id}'"
-                    )
-                return data
-            return None
-        except Exception as e:
-            logger.warning(
-                f"Error reading Firestore snapshot for user {self.user_id} date {date_iso}: {e}"
+    def _collection(self) -> Any:
+        return self.db.collection("users").document(self.user_id).collection(self.collection_name)
+
+    def upsert_snapshot(self, date: str, payload: dict[str, Any]) -> None:
+        """Upsert recovery snapshot with idempotent merge semantics."""
+        payload_user_id = payload.get("userId")
+        if payload_user_id != self.user_id:
+            raise ValueError(
+                f"Snapshot userId '{payload_user_id}' does not match configured user_id '{self.user_id}'"
             )
+
+        doc_ref = self._collection().document(date)
+        now = datetime.now(timezone.utc).isoformat()
+
+        doc = doc_ref.get()
+        data = dict(payload)
+        data["updatedAt"] = now
+        if not doc.exists:
+            data["createdAt"] = now
+
+        doc_ref.set(data, merge=True)
+
+    def get_snapshot(self, date: str) -> dict[str, Any] | None:
+        """Return a recovery snapshot by date, or None if not found."""
+        doc = self._collection().document(date).get()
+        if not doc.exists:
             return None
-
-    def get_snapshots_batch(self, date_isos: list[str]) -> dict[str, dict[str, Any]]:
-        """Fetch multiple recovery snapshots efficiently in batches."""
-        db = self._get_db()
-        refs = [self._get_doc_ref(d) for d in date_isos]
-        snapshots = {}
-
-        chunk_size = 400
-        for i in range(0, len(refs), chunk_size):
-            chunk = refs[i : i + chunk_size]
-            try:
-                for doc_snap in db.get_all(chunk):
-                    if doc_snap.exists:
-                        data = doc_snap.to_dict()
-                        if data.get("userId") == self.user_id:
-                            snapshots[doc_snap.id] = data
-            except Exception as e:
-                logger.warning(
-                    f"Error reading batch of Firestore snapshots for user {self.user_id}: {e}"
-                )
-                raise
-        return snapshots
+        return cast(dict[str, Any], doc.to_dict())
 
     def is_fresh(
         self,
-        date_iso: str,
-        staleness_minutes: int = 60,
-        incomplete_staleness_minutes: int = 5,
-        require_complete: bool = True,
+        date: str,
+        *,
+        staleness_minutes: int,
+        incomplete_staleness_minutes: int,
     ) -> bool:
-        """Check if date's snapshot was synced within staleness threshold.
+        """Return whether an existing snapshot is fresh enough to skip another sync.
 
-        If require_complete is True and the snapshot is missing any core recovery metric
-        (sleep, resting HR, HRV, respiration, body battery wake, steps), it is considered
-        incomplete and only remains fresh for incomplete_staleness_minutes (a short rate-limit
-        cooldown). Once complete, it respects staleness_minutes.
+        Complete snapshots get the normal cooldown. Incomplete snapshots use a much shorter
+        cooldown so late-arriving Garmin metrics can be picked up quickly.
         """
-        snapshot = self.get_snapshot(date_iso)
+        snapshot = self.get_snapshot(date)
         if not snapshot:
             return False
 
-        synced_at_str = snapshot.get("source", {}).get("garminSyncedAt") or snapshot.get(
-            "updatedAt"
-        )
-        if not synced_at_str:
+        source = snapshot.get("source", {})
+        synced_at = source.get("garminSyncedAt") if isinstance(source, dict) else None
+        if not isinstance(synced_at, str):
             return False
 
         try:
-            synced_at = datetime.fromisoformat(synced_at_str)
-            if synced_at.tzinfo is None:
-                synced_at = synced_at.replace(tzinfo=timezone.utc)
-            now_utc = datetime.now(timezone.utc)
-            age_minutes = (now_utc - synced_at).total_seconds() / 60.0
-
-            if require_complete and not is_snapshot_complete(snapshot):
-                return age_minutes < incomplete_staleness_minutes
-
-            return age_minutes < staleness_minutes
-        except Exception as e:
-            logger.warning(f"Failed to parse synced_at timestamp '{synced_at_str}': {e}")
+            synced_dt = datetime.fromisoformat(synced_at.replace("Z", "+00:00"))
+        except ValueError:
             return False
+        if synced_dt.tzinfo is None:
+            synced_dt = synced_dt.replace(tzinfo=timezone.utc)
 
-    def upsert_snapshot(self, date_iso: str, payload: dict[str, Any]) -> None:
-        """Upsert user-scoped recovery snapshot document."""
-        if payload.get("userId") != self.user_id:
-            raise ValueError(
-                f"Payload userId '{payload.get('userId')}' does not match configured user_id '{self.user_id}'"
-            )
-
-        now_iso = datetime.now(timezone.utc).isoformat()
-        doc_ref = self._get_doc_ref(date_iso)
-        doc_snap = doc_ref.get()
-
-        if not doc_snap.exists:
-            payload["createdAt"] = payload.get("createdAt") or now_iso
-
-        payload["updatedAt"] = now_iso
-
-        doc_ref.set(payload, merge=True)
-        logger.info(
-            f"Successfully saved user-scoped snapshot users/{self.user_id}/{self.collection_name}/{date_iso}."
+        age_minutes = (datetime.now(timezone.utc) - synced_dt).total_seconds() / 60.0
+        threshold = (
+            staleness_minutes
+            if is_snapshot_complete(snapshot)
+            else incomplete_staleness_minutes
         )
+        return age_minutes < threshold
 
-    def get_historical_snapshots(
-        self, start_date_iso: str, end_date_iso: str
-    ) -> dict[str, dict[str, Any]]:
-        """Fetch historical snapshots in range [start_date_iso, end_date_iso]."""
-        db = self._get_db()
-        docs = (
-            db.collection("users")
-            .document(self.user_id)
-            .collection(self.collection_name)
-            .where(filter=FieldFilter("date", ">=", start_date_iso))
-            .where(filter=FieldFilter("date", "<=", end_date_iso))
-            .stream()
-        )
+    def get_snapshots(self, dates: Iterable[str]) -> dict[str, dict[str, Any]]:
+        """Return existing snapshots keyed by date."""
+        snapshots: dict[str, dict[str, Any]] = {}
+        for date in dates:
+            snapshot = self.get_snapshot(date)
+            if snapshot:
+                snapshots[date] = snapshot
+        return snapshots
 
-        results: dict[str, dict[str, Any]] = {}
-        for doc in docs:
-            data = doc.to_dict()
-            date_key = data.get("date") or doc.id
-            results[date_key] = data
-        return results
-
-    def upsert_activity(self, activity_id: str | int, payload: dict[str, Any]) -> None:
-        """Upsert a normalized activity record at users/{userId}/activities/{activityId}.
-        Doc ID = activityId, so re-fetching the same activity across overlapping sync
-        windows (e.g. daily 3-day lookback, backfill) naturally dedups instead of
-        creating duplicate records."""
-        db = self._get_db()
-        doc_ref = (
-            db.collection("users")
-            .document(self.user_id)
-            .collection("activities")
-            .document(str(activity_id))
-        )
-        doc_ref.set(payload, merge=True)
-
-    def upsert_activities(self, activities: list[tuple[str | int, dict[str, Any]]]) -> None:
-        """Batch upsert normalized activity records.
-        Handles Firestore's 500 document limit per batch automatically."""
-        if not activities:
-            return
-
-        db = self._get_db()
-        collection_ref = db.collection("users").document(self.user_id).collection("activities")
-
-        # Firestore batches are limited to 500 operations
-        batch_size = 500
-        for i in range(0, len(activities), batch_size):
-            chunk = activities[i : i + batch_size]
-            batch = db.batch()
-            for activity_id, payload in chunk:
-                doc_ref = collection_ref.document(str(activity_id))
-                batch.set(doc_ref, payload, merge=True)
-            batch.commit()
-
-    def get_activities_in_range(
-        self, start_date_iso: str, end_date_iso: str
-    ) -> list[dict[str, Any]]:
-        """Fetch normalized activities in range [start_date_iso, end_date_iso]."""
-        db = self._get_db()
-        docs = (
-            db.collection("users")
-            .document(self.user_id)
-            .collection("activities")
-            .where(filter=FieldFilter("date", ">=", start_date_iso))
-            .where(filter=FieldFilter("date", "<=", end_date_iso))
-            .order_by("date")
-            .stream()
-        )
-        return [doc.to_dict() for doc in docs]
-
-    def upsert_garmin_performance_targets(self, targets: Any) -> None:
-        """Merge Garmin's current targets into the user's preference profile.
-
-        Active targets are intentionally field-level owned: importing a new Garmin
-        value never replaces a target the coach/user marked ``manual``. Existing
-        target values without provenance predate this feature and are conservatively
-        treated as manual on their first import.
-        """
-        db = self._get_db()
-        doc_ref = (
-            db.collection("users")
-            .document(self.user_id)
-            .collection("preferences")
-            .document("profile")
-        )
-        now_iso = datetime.now(timezone.utc).isoformat()
-        incoming = {
-            "ftpWatts": targets.cycling_ftp_watts,
-            "thresholdPaceSecPerKm": targets.running_threshold_pace_sec_per_km,
-            "lthrBpm": targets.running_lthr_bpm,
-            "weightKg": targets.weight_kg,
-            "bodyFatPct": targets.body_fat_pct,
-        }
-        measured_at = {
-            "ftpMeasuredAt": targets.ftp_measured_at,
-            "thresholdMeasuredAt": targets.threshold_measured_at,
-            "lthrMeasuredAt": targets.lthr_measured_at,
-            "weightMeasuredAt": targets.weight_measured_at,
-        }
-
-        @firestore.transactional  # pyright: ignore[reportAttributeAccessIssue]
-        def merge_targets(transaction: Any) -> None:
-            snapshot = doc_ref.get(transaction=transaction)
-            existing: dict[str, Any] = cast(
-                dict[str, Any], snapshot.to_dict() if snapshot.exists else {}
-            )
-            raw_profile = existing.get("performanceProfile")
-            profile: dict[str, Any] = (
-                cast(dict[str, Any], raw_profile) if isinstance(raw_profile, dict) else {}
-            )
-            raw_sources = profile.get("targetSources")
-            sources: dict[str, Any] = (
-                cast(dict[str, Any], raw_sources) if isinstance(raw_sources, dict) else {}
-            )
-
-            raw_garmin = profile.get("garmin")
-            garmin: dict[str, Any] = (
-                cast(dict[str, Any], raw_garmin) if isinstance(raw_garmin, dict) else {}
-            )
-            # A partial Garmin response must not erase a previously successful import
-            # for another target (for example, cycling FTP can be available while
-            # running lactate threshold is not configured on the account).
-            garmin.update({key: value for key, value in incoming.items() if value is not None})
-            garmin.update({key: value for key, value in measured_at.items() if value is not None})
-            if targets.race_predictions is not None:
-                raw_race_predictions = garmin.get("racePredictions")
-                race_predictions: dict[str, Any] = (
-                    dict(raw_race_predictions) if isinstance(raw_race_predictions, dict) else {}
-                )
-                incoming_race_predictions = {
-                    "fiveKmSec": targets.race_predictions.five_km_sec,
-                    "tenKmSec": targets.race_predictions.ten_km_sec,
-                    "halfMarathonSec": targets.race_predictions.half_marathon_sec,
-                    "marathonSec": targets.race_predictions.marathon_sec,
-                }
-                race_predictions.update(
-                    {
-                        key: value
-                        for key, value in incoming_race_predictions.items()
-                        if value is not None
-                    }
-                )
-                race_predictions["fetchedAt"] = now_iso
-                garmin["racePredictions"] = race_predictions
-                profile["racePredictions"] = dict(race_predictions)
-            garmin["fetchedAt"] = now_iso
-            profile["garmin"] = garmin
-
-            for key, value in incoming.items():
-                if value is None:
-                    continue
-                source = sources.get(key)
-                existing_value = profile.get(key)
-                if source in {"manual", "coach"}:
-                    continue
-                if source == "garmin" or existing_value is None:
-                    profile[key] = value
-                    sources[key] = "garmin"
-                else:
-                    # Old documents have active values but no ownership metadata. The
-                    # safe migration is manual; an explicit UI action can adopt Garmin.
-                    sources[key] = "manual"
-
-            if sources:
-                profile["targetSources"] = sources
-
-            payload: dict[str, Any] = {
-                "userId": self.user_id,
-                "performanceProfile": profile,
-                "updatedAt": now_iso,
-            }
-            # A scheduled Garmin sync can run before the client has opened the app and
-            # created preferences. Do not leave that first-run document partial: the
-            # frontend treats an existing preferences record as complete.
-            if not snapshot.exists:
-                payload.update(
-                    {
-                        "preferredRecoveryStyle": "mixed",
-                        "defaultWeekdayTimeMin": 45,
-                        "defaultWeekendTimeMin": 60,
-                        "preferredTimeOfDay": "flexible",
-                        "preferredModalities": ["Running", "Cycling", "Strength"],
-                        "deprioritizedModalities": [],
-                        "avoidedModalities": [],
-                        "unavailableModalities": [],
-                        "explanationVerbosity": "detailed",
-                        "conservativeBias": False,
-                        "preferredUnits": {
-                            "distance": "km",
-                            "weight": "kg",
-                            "temperature": "celsius",
-                        },
-                        "schemaVersion": 1,
-                        "createdAt": now_iso,
-                    }
-                )
-            transaction.set(doc_ref, payload, merge=True)
-
-        merge_targets(db.transaction())
-        logger.info(
-            "Updated Garmin performance targets in user-scoped preferences for user=<UID-redacted>."
-        )
-
-    def upsert_garmin_gear(self, gear_items: list[Any]) -> None:
-        """Persist gear items to user collection and update preferences profile gearTracker."""
-        if not gear_items:
-            return
-        db = self._get_db()
-        now_iso = datetime.now(timezone.utc).isoformat()
-
-        profile_ref = (
-            db.collection("users")
-            .document(self.user_id)
-            .collection("preferences")
-            .document("profile")
-        )
-
-        gear_dicts = [
-            {
-                key: value
-                for key, value in {
-                    "gearPk": item.gear_pk,
-                    "uuid": item.uuid,
-                    "customMakeModel": item.custom_make_model,
-                    "displayName": item.display_name,
-                    "gearType": item.gear_type,
-                    "brand": item.brand,
-                    "model": item.model,
-                    "totalDistanceKm": item.total_distance_km,
-                    "maximumDistanceKm": item.maximum_distance_km,
-                    "dateBegin": item.date_begin,
-                    "dateEnd": item.date_end,
-                    "status": item.status,
-                }.items()
-                if value is not None
-            }
-            for item in gear_items
-        ]
-
-        batch = db.batch()
-        batch.set(
-            profile_ref,
-            {
-                "userId": self.user_id,
-                "gearTracker": {
-                    "items": gear_dicts,
-                    "syncedAt": now_iso,
-                },
-                "updatedAt": now_iso,
-            },
-            merge=True,
-        )
-
-        for item, g_dict in zip(gear_items, gear_dicts, strict=True):
-            gear_doc_ref = (
-                db.collection("users")
-                .document(self.user_id)
-                .collection("gear")
-                .document(item.gear_pk)
-            )
-            batch.set(
-                gear_doc_ref,
-                {
-                    "userId": self.user_id,
-                    **g_dict,
-                    "updatedAt": now_iso,
-                },
-                merge=True,
-            )
-
-        batch.commit()
-        logger.info(
-            "Updated Garmin gear items (%d) for user=<UID-redacted>.",
-            len(gear_items),
-        )
-
-    def count_activities_in_range(self, start_date_iso: str, end_date_iso: str) -> int:
-        """Count normalized activity records with date in [start_date_iso, end_date_iso]."""
-        db = self._get_db()
+    def iter_snapshots(self, *, start_date: str, end_date: str) -> Iterator[dict[str, Any]]:
+        """Yield snapshots in date order for the inclusive date range."""
         query = (
-            db.collection("users")
-            .document(self.user_id)
-            .collection("activities")
-            .where(filter=FieldFilter("date", ">=", start_date_iso))
-            .where(filter=FieldFilter("date", "<=", end_date_iso))
+            self._collection()
+            .where(filter=FieldFilter("date", ">=", start_date))
+            .where(filter=FieldFilter("date", "<=", end_date))
+            .order_by("date")
         )
-        try:
-            agg = query.count()
-            result = agg.get()
-            return int(result[0][0].value)
-        except Exception:
-            # Firestore aggregation queries may be unavailable in older emulators/mocks --
-            # fall back to a client-side count. Use select([]) to project only document
-            # IDs, avoiding full document payload transfer.
-            return sum(1 for _ in query.select([]).stream())
+        for doc in query.stream():
+            data = doc.to_dict()
+            if isinstance(data, dict):
+                yield data
 
-    def save_health_observation_day_bundle(
+    def delete_snapshot(self, date: str) -> None:
+        """Delete a snapshot by date."""
+        self._collection().document(date).delete()
+
+    def upsert_observation_bundle(
         self,
-        bundle: Any,  # HealthObservationDayBundle
-    ) -> tuple[bool, int]:
-        """Save a day-source observation bundle to Firestore under
-        users/{userId}/health_observation_days/{YYYY-MM-DD}_{provider}_{transport}.
+        bundle: "HealthObservationDayBundle",
+        *,
+        document_id: str | None = None,
+    ) -> bool:
+        """Persist a canonical observation bundle if source/version content changed.
 
-        Returns (changed: bool, revision: int). If identical payload exists, returns (False, rev).
-        If payload updated, increments revision and saves.
+        Returns True when a write occurred, False when an existing row already has the
+        same `sourcePayloadHash` and `normalizerVersion`.
         """
-        db = self._get_db()
-        doc_id = f"{bundle.logicalDate}_{bundle.provider}_{bundle.transport}"
+        from .models import HealthObservationDayBundle
+
+        if not isinstance(bundle, HealthObservationDayBundle):
+            raise TypeError("bundle must be a HealthObservationDayBundle")
+        if bundle.userId != self.user_id:
+            raise ValueError(
+                f"Observation bundle userId '{bundle.userId}' does not match configured "
+                f"user_id '{self.user_id}'"
+            )
+
+        doc_id = document_id or f"{bundle.logicalDate}_{bundle.provider}_{bundle.transport}"
         doc_ref = (
-            db.collection("users")
+            self.db.collection("users")
             .document(self.user_id)
-            .collection("health_observation_days")
+            .collection("health_observations")
             .document(doc_id)
         )
+        payload = bundle.model_dump(mode="json")
 
-        now_iso = datetime.now(timezone.utc).isoformat()
-        transaction = getattr(db, "transaction", None)
-
-        if callable(transaction) and firestore is not None:
+        transaction_factory = getattr(self.db, "transaction", None)
+        if callable(transaction_factory):
+            transaction = transaction_factory()
 
             @firestore.transactional
-            def _update_in_txn(txn: Any) -> tuple[bool, int]:
-                existing_doc = doc_ref.get(transaction=txn)
-                current_rev = 1
-                if existing_doc.exists:
-                    data = existing_doc.to_dict() or {}
-                    existing_hash = data.get("sourcePayloadHash")
-                    existing_normalizer_version = data.get("normalizerVersion", 1)
-                    current_rev = data.get("revision", 1)
-                    if (
-                        existing_hash == bundle.sourcePayloadHash
-                        and existing_normalizer_version >= bundle.normalizerVersion
-                    ):
-                        return False, current_rev
-                    current_rev += 1
-
-                bundle.revision = current_rev
-                bundle.ingestedAt = now_iso
-                bundle.effectiveAt = now_iso
-                txn.set(doc_ref, bundle.to_dict())
-                return True, current_rev
-
-            txn = db.transaction()
-            changed, current_rev = _update_in_txn(txn)
-        else:
-            existing_doc = doc_ref.get()
-            current_rev = 1
-            if existing_doc.exists:
-                data = existing_doc.to_dict() or {}
-                existing_hash = data.get("sourcePayloadHash")
-                existing_normalizer_version = data.get("normalizerVersion", 1)
-                current_rev = data.get("revision", 1)
-                if (
-                    existing_hash == bundle.sourcePayloadHash
-                    and existing_normalizer_version >= bundle.normalizerVersion
+            def _upsert_in_transaction(txn: Any) -> bool:
+                existing = doc_ref.get(transaction=txn)
+                existing_data = existing.to_dict() if existing.exists else None
+                if isinstance(existing_data, dict) and (
+                    existing_data.get("sourcePayloadHash") == bundle.sourcePayloadHash
+                    and existing_data.get("normalizerVersion") == bundle.normalizerVersion
                 ):
-                    logger.debug(
-                        "Health observation bundle %s already up to date at revision %d.",
-                        doc_id,
-                        current_rev,
-                    )
-                    return False, current_rev
-                current_rev += 1
+                    return False
 
-            bundle.revision = current_rev
-            bundle.ingestedAt = now_iso
-            bundle.effectiveAt = now_iso
-            doc_ref.set(bundle.to_dict())
-            changed = True
+                previous_revision = 0
+                if isinstance(existing_data, dict):
+                    try:
+                        previous_revision = int(existing_data.get("revision") or 0)
+                    except (TypeError, ValueError):
+                        previous_revision = 0
 
-        if changed:
-            logger.info(
-                "Saved health observation bundle %s for user=<UID-redacted> at revision %d (%d observations).",
-                doc_id,
-                current_rev,
-                len(bundle.observations),
-            )
-        else:
-            logger.debug(
-                "Health observation bundle %s already up to date at revision %d.",
-                doc_id,
-                current_rev,
-            )
-        return changed, current_rev
+                write_payload = {
+                    **payload,
+                    "revision": max(1, previous_revision + 1),
+                    "updatedAt": firestore.SERVER_TIMESTAMP,
+                }
+                if not existing.exists:
+                    write_payload["createdAt"] = firestore.SERVER_TIMESTAMP
+                txn.set(doc_ref, write_payload, merge=True)
+                return True
 
-    def get_health_observation_day_bundle(
-        self,
-        logical_date: str,
-        provider: str,
-        transport: str,
-    ) -> dict[str, Any] | None:
-        """Retrieve a specific day-source bundle from Firestore."""
-        db = self._get_db()
-        doc_id = f"{logical_date}_{provider}_{transport}"
-        doc_ref = (
-            db.collection("users")
-            .document(self.user_id)
-            .collection("health_observation_days")
-            .document(doc_id)
-        )
-        doc = doc_ref.get()
-        return doc.to_dict() if doc.exists else None
+            return bool(_upsert_in_transaction(transaction))
 
-    def delete_health_observation_day_bundle(
-        self,
-        logical_date: str,
-        provider: str,
-        transport: str,
-    ) -> bool:
-        """Delete a specific day-source bundle from Firestore, e.g. when a source that
-        was present in a prior sync is absent from the current authoritative batch and
-        must stop being queryable by fusion/audit code (D-MS reconciliation).
-
-        Returns True if a document existed and was deleted, False if there was nothing
-        to delete.
-        """
-        db = self._get_db()
-        doc_id = f"{logical_date}_{provider}_{transport}"
-        doc_ref = (
-            db.collection("users")
-            .document(self.user_id)
-            .collection("health_observation_days")
-            .document(doc_id)
-        )
-        existing_doc = doc_ref.get()
-        if not existing_doc.exists:
+        # Fallback is primarily for deterministic tests/fakes that do not implement
+        # transactions. Production Firestore clients provide transaction().
+        existing = doc_ref.get()
+        existing_data = existing.to_dict() if existing.exists else None
+        if isinstance(existing_data, dict) and (
+            existing_data.get("sourcePayloadHash") == bundle.sourcePayloadHash
+            and existing_data.get("normalizerVersion") == bundle.normalizerVersion
+        ):
             return False
-        doc_ref.delete()
+
+        previous_revision = 0
+        if isinstance(existing_data, dict):
+            try:
+                previous_revision = int(existing_data.get("revision") or 0)
+            except (TypeError, ValueError):
+                previous_revision = 0
+        write_payload = {
+            **payload,
+            "revision": max(1, previous_revision + 1),
+            "updatedAt": firestore.SERVER_TIMESTAMP,
+        }
+        if not existing.exists:
+            write_payload["createdAt"] = firestore.SERVER_TIMESTAMP
+        doc_ref.set(write_payload, merge=True)
         return True
 
-    def delete_health_observation_day_bundles_batch(
-        self,
-        keys: list[tuple[str, str, str]],
-    ) -> int:
-        """Batch delete multiple day-source bundles from Firestore.
-
-        Keys should be a list of (logical_date, provider, transport) tuples.
-        Deletes are executed in batches of 500 to respect Firestore limits.
-
-        Returns the total number of deletion operations submitted to batches.
-        """
-        if not keys:
-            return 0
-
-        db = self._get_db()
-        collection_ref = (
-            db.collection("users").document(self.user_id).collection("health_observation_days")
-        )
-
-        def batched(
-            iterable: Iterable[tuple[str, str, str]], n: int
-        ) -> Iterator[list[tuple[str, str, str]]]:
-            it = iter(iterable)
-            while chunk := list(itertools.islice(it, n)):
-                yield chunk
-
-        deleted_count = 0
-        for chunk in batched(keys, 500):
-            batch = db.batch()
-            for logical_date, provider, transport in chunk:
-                doc_id = f"{logical_date}_{provider}_{transport}"
-                doc_ref = collection_ref.document(doc_id)
-                batch.delete(doc_ref)
-                deleted_count += 1
-            batch.commit()
-
-        return deleted_count
-
-    def get_health_observation_bundles_in_range(
-        self,
-        start_date: str,
-        end_date: str,
-        provider: str | None = None,
-        transport: str | None = None,
-    ) -> list[dict[str, Any]]:
-        """Retrieve all health observation day bundles within [start_date, end_date]."""
-        db = self._get_db()
-        query = (
-            db.collection("users")
+    def _identity_bundle_doc_ref(self, bundle_id: str) -> Any:
+        return (
+            self.db.collection("users")
             .document(self.user_id)
-            .collection("health_observation_days")
-            .where(filter=FieldFilter("logicalDate", ">=", start_date))
-            .where(filter=FieldFilter("logicalDate", "<=", end_date))
+            .collection("health_identity_bundles")
+            .document(bundle_id)
         )
 
-        docs: list[dict[str, Any]] = []
-        chunk_size = 500
-        paged_query = query.limit(chunk_size)
-
-        while True:
-            chunk_docs = list(paged_query.stream())
-            if not chunk_docs:
-                break
-
-            for doc in chunk_docs:
-                data = doc.to_dict()
-                if provider and data.get("provider") != provider:
-                    continue
-                if transport and data.get("transport") != transport:
-                    continue
-                docs.append(data)
-
-            if len(chunk_docs) < chunk_size:
-                break
-
-            last_doc = chunk_docs[-1]
-            paged_query = query.start_after(last_doc).limit(chunk_size)
-
-        docs.sort(key=lambda d: d.get("logicalDate", ""))
-        return docs
-
-    def save_connection_metadata(
-        self,
-        connection_name: str,
-        metadata: dict[str, Any],
-    ) -> None:
-        """Save non-secret connection metadata to users/{userId}/connections/{connection_name}."""
-        db = self._get_db()
-        doc_ref = (
-            db.collection("users")
+    def _identity_current_doc_ref(self) -> Any:
+        return (
+            self.db.collection("users")
             .document(self.user_id)
-            .collection("connections")
-            .document(connection_name)
+            .collection("identity_passports")
+            .document("current")
         )
-        doc_ref.set(metadata, merge=True)
 
-    def get_connection_metadata(
-        self,
-        connection_name: str,
-    ) -> dict[str, Any] | None:
-        """Retrieve connection metadata from users/{userId}/connections/{connection_name}."""
-        db = self._get_db()
-        doc_ref = (
-            db.collection("users")
-            .document(self.user_id)
-            .collection("connections")
-            .document(connection_name)
-        )
-        doc = doc_ref.get()
-        return doc.to_dict() if doc.exists else None
-
-    def _identity_collection(self, collection_name: str) -> Any:
-        return self._get_db().collection("users").document(self.user_id).collection(collection_name)
-
-    def _save_immutable_identity_document(
-        self,
-        collection_name: str,
-        document_id: str,
-        payload: Mapping[str, Any],
-    ) -> bool:
-        """Create an immutable server-owned identity document atomically and idempotently.
-
-        Firestore ``create`` is a single create-only write. Replaying the exact bytes after a
-        conflict is a no-op; reusing an existing identity for different content is rejected so a
-        concurrent writer cannot overwrite evidence needed by historical replay.
-        """
-
-        if not document_id:
-            raise ValueError("Identity document id must be non-empty.")
-        stored = dict(payload)
-        doc_ref = self._identity_collection(collection_name).document(document_id)
-        try:
-            doc_ref.create(stored)
-            return True
-        except Conflict as error:
-            snapshot = doc_ref.get()
-            if snapshot.exists and snapshot.to_dict() == stored:
-                return False
+    def save_identity_assessment(self, assessment: Mapping[str, Any]) -> None:
+        """Persist one immutable physiological identity assessment."""
+        validated = validate_automatic_identity_assessment(dict(assessment))
+        if validated.userId != self.user_id:
             raise ValueError(
-                f"Immutable identity document {collection_name}/{document_id} already exists "
-                "with different content."
-            ) from error
+                "Identity assessment userId does not match configured Firestore repository user_id"
+            )
+        doc_ref = self._identity_bundle_doc_ref(validated.bundleId)
+        payload = validated.model_dump(mode="json")
+        payload["updatedAt"] = firestore.SERVER_TIMESTAMP
+        try:
+            doc_ref.create(payload)
+        except Conflict as exc:
+            raise ValueError(
+                f"Identity assessment bundle '{validated.bundleId}' is immutable and already exists"
+            ) from exc
 
-    def save_identity_passport_version(self, passport: Mapping[str, Any]) -> bool:
-        """Persist one fully validated immutable/replayable passport version."""
+    def get_identity_assessment(self, bundle_id: str) -> dict[str, Any] | None:
+        """Return one immutable physiological identity assessment."""
+        doc = self._identity_bundle_doc_ref(bundle_id).get()
+        if not doc.exists:
+            return None
+        data = doc.to_dict()
+        return dict(data) if isinstance(data, dict) else None
 
-        if not validate_identity_passport_version(passport):
-            raise ValueError("Identity passport version does not match the persisted schema.")
-        version = cast(str, passport.get("passportVersion"))
-        return self._save_immutable_identity_document(
-            "physiological_identity_passport_versions", version, passport
+    def save_identity_passport_version(self, passport: Mapping[str, Any]) -> None:
+        """Persist one immutable Physiological Identity Passport version."""
+        validated = validate_identity_passport_version(dict(passport))
+        if validated.userId != self.user_id:
+            raise ValueError(
+                "Identity passport userId does not match configured Firestore repository user_id"
+            )
+        doc_ref = (
+            self.db.collection("users")
+            .document(self.user_id)
+            .collection("identity_passport_versions")
+            .document(validated.passportVersionId)
         )
+        payload = validated.model_dump(mode="json")
+        payload["updatedAt"] = firestore.SERVER_TIMESTAMP
+        try:
+            doc_ref.create(payload)
+        except Conflict as exc:
+            raise ValueError(
+                f"Identity passport version '{validated.passportVersionId}' is immutable and already exists"
+            ) from exc
 
-    def set_current_identity_passport(self, passport: Mapping[str, Any]) -> None:
-        """Replace the fully validated server-owned online passport materialization."""
-
-        if not validate_identity_passport_current(passport):
-            raise ValueError("Current identity passport does not match the persisted schema.")
-        self._identity_collection("physiological_identity_passports").document("current").set(
-            dict(passport)
-        )
-
-    def get_current_identity_passport(self) -> dict[str, Any] | None:
-        snapshot = (
-            self._identity_collection("physiological_identity_passports").document("current").get()
-        )
-        return snapshot.to_dict() if snapshot.exists else None
-
-    def get_identity_passport_version(self, version: str) -> dict[str, Any] | None:
-        snapshot = (
-            self._identity_collection("physiological_identity_passport_versions")
-            .document(version)
+    def get_identity_passport_version(self, passport_version_id: str) -> dict[str, Any] | None:
+        """Return one immutable Physiological Identity Passport version."""
+        doc = (
+            self.db.collection("users")
+            .document(self.user_id)
+            .collection("identity_passport_versions")
+            .document(passport_version_id)
             .get()
         )
-        return snapshot.to_dict() if snapshot.exists else None
+        if not doc.exists:
+            return None
+        data = doc.to_dict()
+        return dict(data) if isinstance(data, dict) else None
 
-    def save_automatic_identity_assessment(self, assessment: Mapping[str, Any]) -> bool:
-        """Persist fully validated immutable model output and every contributing bundle ref."""
+    def save_identity_passport_current(self, current: Mapping[str, Any]) -> None:
+        """Persist the mutable pointer to the currently active passport version."""
+        validated = validate_identity_passport_current(dict(current))
+        if validated.userId != self.user_id:
+            raise ValueError(
+                "Identity passport current userId does not match configured Firestore repository user_id"
+            )
+        payload = validated.model_dump(mode="json")
+        payload["updatedAt"] = firestore.SERVER_TIMESTAMP
+        self._identity_current_doc_ref().set(payload, merge=False)
 
-        if not validate_automatic_identity_assessment(assessment):
-            raise ValueError("Automatic identity assessment does not match the persisted schema.")
-        assessment_id = cast(str, assessment.get("id"))
-        return self._save_immutable_identity_document(
-            "health_identity_assessments", assessment_id, assessment
+    def get_identity_passport_current(self) -> dict[str, Any] | None:
+        """Return the mutable pointer to the currently active passport version."""
+        doc = self._identity_current_doc_ref().get()
+        if not doc.exists:
+            return None
+        data = doc.to_dict()
+        return dict(data) if isinstance(data, dict) else None
+
+    def save_identity_review_event(self, event: Mapping[str, Any]) -> None:
+        """Persist one immutable user review decision for a suspicious identity bundle."""
+        validated = validate_identity_review_event(dict(event))
+        if validated.userId != self.user_id:
+            raise ValueError(
+                "Identity review event userId does not match configured Firestore repository user_id"
+            )
+        doc_ref = (
+            self.db.collection("users")
+            .document(self.user_id)
+            .collection("health_identity_reviews")
+            .document(validated.reviewId)
         )
+        payload = validated.model_dump(mode="json")
+        payload["updatedAt"] = firestore.SERVER_TIMESTAMP
+        try:
+            doc_ref.create(payload)
+        except Conflict as exc:
+            raise ValueError(
+                f"Identity review '{validated.reviewId}' is immutable and already exists"
+            ) from exc
 
-    def get_automatic_identity_assessment(self, assessment_id: str) -> dict[str, Any] | None:
-        snapshot = (
-            self._identity_collection("health_identity_assessments").document(assessment_id).get()
+    def get_identity_review_event(self, review_id: str) -> dict[str, Any] | None:
+        """Return one immutable user review decision."""
+        doc = (
+            self.db.collection("users")
+            .document(self.user_id)
+            .collection("health_identity_reviews")
+            .document(review_id)
+            .get()
         )
-        return snapshot.to_dict() if snapshot.exists else None
+        if not doc.exists:
+            return None
+        data = doc.to_dict()
+        return dict(data) if isinstance(data, dict) else None
 
-    def save_identity_review_event(self, event: Mapping[str, Any]) -> bool:
-        """Persist a fully validated append-only admin/user review event."""
-
-        if not validate_identity_review_event(event):
-            raise ValueError("Identity review event does not match the persisted schema.")
-        event_id = cast(str, event.get("id"))
-        stored_event = dict(event)
-        recorded_at = cast(str, stored_event["recordedAt"])
-        parsed = datetime.fromisoformat(recorded_at.replace("Z", "+00:00"))
-        stored_event["recordedAt"] = parsed
-        return self._save_immutable_identity_document(
-            "health_identity_review_events", event_id, stored_event
-        )
-
-    def get_identity_assessments_in_range(
-        self, start_night_key: str, end_night_key: str
-    ) -> list[dict[str, Any]]:
+    def iter_identity_assessments(
+        self,
+        *,
+        start_date: str,
+        end_date: str,
+    ) -> Iterator[dict[str, Any]]:
+        """Yield physiological identity assessments in deterministic date/bundle order."""
         query = (
-            self._identity_collection("health_identity_assessments")
-            .where(filter=FieldFilter("sourceNightKey", ">=", start_night_key))
-            .where(filter=FieldFilter("sourceNightKey", "<=", end_night_key))
+            self.db.collection("users")
+            .document(self.user_id)
+            .collection("health_identity_bundles")
+            .where(filter=FieldFilter("logicalDate", ">=", start_date))
+            .where(filter=FieldFilter("logicalDate", "<=", end_date))
+            .order_by("logicalDate")
         )
-        assessments = [doc.to_dict() for doc in query.stream()]
-        assessments.sort(key=lambda item: (item.get("sourceNightKey", ""), item.get("id", "")))
-        return assessments
+        rows: list[dict[str, Any]] = []
+        for doc in query.stream():
+            data = doc.to_dict()
+            if isinstance(data, dict):
+                rows.append(dict(data))
+        rows.sort(key=lambda row: (str(row.get("logicalDate", "")), str(row.get("bundleId", ""))))
+        yield from rows
 
-    def get_identity_review_events(self, assessment_id: str) -> list[dict[str, Any]]:
-        query = self._identity_collection("health_identity_review_events").where(
-            filter=FieldFilter("assessmentId", "==", assessment_id)
+    def iter_identity_reviews(
+        self,
+        *,
+        start_date: str,
+        end_date: str,
+    ) -> Iterator[dict[str, Any]]:
+        """Yield immutable identity review events in deterministic date/review order."""
+        query = (
+            self.db.collection("users")
+            .document(self.user_id)
+            .collection("health_identity_reviews")
+            .where(filter=FieldFilter("logicalDate", ">=", start_date))
+            .where(filter=FieldFilter("logicalDate", "<=", end_date))
+            .order_by("logicalDate")
         )
-        events = [doc.to_dict() for doc in query.stream()]
-        for event in events:
-            recorded_at = event.get("recordedAt")
-            if isinstance(recorded_at, datetime):
-                event["recordedAt"] = (
-                    recorded_at.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
-                )
-        events.sort(key=lambda item: (item.get("recordedAt", ""), item.get("id", "")))
-        return events
+        rows: list[dict[str, Any]] = []
+        for doc in query.stream():
+            data = doc.to_dict()
+            if isinstance(data, dict):
+                rows.append(dict(data))
+        rows.sort(key=lambda row: (str(row.get("logicalDate", "")), str(row.get("reviewId", ""))))
+        yield from rows
 
-    def get_identity_review_events_for_assessments(
-        self, assessment_ids: list[str]
-    ) -> dict[str, list[dict[str, Any]]]:
-        if not assessment_ids:
+    def build_effective_identity_decision_index(
+        self,
+        *,
+        start_date: str,
+        end_date: str,
+    ) -> dict[IdentityBundleKey, EffectiveIdentityDecisionProjection]:
+        """Build effective identity outcomes with immutable user reviews overriding automation."""
+        return build_effective_identity_decision_index(
+            self.iter_identity_assessments(start_date=start_date, end_date=end_date),
+            self.iter_identity_reviews(start_date=start_date, end_date=end_date),
+        )
+
+    def list_identity_training_observations(
+        self,
+        *,
+        limit: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """Return identity-attributed historical observations newest-first.
+
+        This bounded read powers PI3 historical passport bootstrap. Observations are read
+        from the canonical `health_observations` collection and the persisted `identity`
+        attribution block is preserved for caller-side filtering.
+        """
+        query = self.db.collection("users").document(self.user_id).collection("health_observations")
+        if hasattr(query, "order_by"):
+            query = query.order_by("logicalDate", direction=firestore.Query.DESCENDING)
+        if limit is not None and hasattr(query, "limit"):
+            query = query.limit(limit)
+
+        rows: list[dict[str, Any]] = []
+        for doc in query.stream():
+            data = doc.to_dict()
+            if isinstance(data, dict):
+                rows.append(dict(data))
+        return rows
+
+    def list_identity_reviewed_reference_rows(
+        self,
+        *,
+        limit: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """Return reviewed identity bundles as signed reference rows for passport bootstrap."""
+        reviews_query = (
+            self.db.collection("users")
+            .document(self.user_id)
+            .collection("health_identity_reviews")
+        )
+        if hasattr(reviews_query, "order_by"):
+            reviews_query = reviews_query.order_by(
+                "logicalDate", direction=firestore.Query.DESCENDING
+            )
+        if limit is not None and hasattr(reviews_query, "limit"):
+            reviews_query = reviews_query.limit(limit)
+
+        rows: list[dict[str, Any]] = []
+        for review_doc in reviews_query.stream():
+            review = review_doc.to_dict()
+            if not isinstance(review, dict):
+                continue
+            bundle_id = review.get("bundleId")
+            if not isinstance(bundle_id, str) or not bundle_id:
+                continue
+            bundle = self.get_identity_assessment(bundle_id)
+            if not bundle:
+                continue
+            rows.append(
+                {
+                    "review": dict(review),
+                    "bundle": bundle,
+                }
+            )
+        return rows
+
+    def list_identity_passport_versions(self, *, limit: int | None = None) -> list[dict[str, Any]]:
+        """Return immutable passport versions newest-first."""
+        query = (
+            self.db.collection("users")
+            .document(self.user_id)
+            .collection("identity_passport_versions")
+        )
+        if hasattr(query, "order_by"):
+            query = query.order_by("createdAt", direction=firestore.Query.DESCENDING)
+        if limit is not None and hasattr(query, "limit"):
+            query = query.limit(limit)
+
+        rows: list[dict[str, Any]] = []
+        for doc in query.stream():
+            data = doc.to_dict()
+            if isinstance(data, dict):
+                rows.append(dict(data))
+        return rows
+
+    def list_identity_review_events(self, *, limit: int | None = None) -> list[dict[str, Any]]:
+        """Return immutable identity review events newest-first."""
+        query = (
+            self.db.collection("users")
+            .document(self.user_id)
+            .collection("health_identity_reviews")
+        )
+        if hasattr(query, "order_by"):
+            query = query.order_by("createdAt", direction=firestore.Query.DESCENDING)
+        if limit is not None and hasattr(query, "limit"):
+            query = query.limit(limit)
+
+        rows: list[dict[str, Any]] = []
+        for doc in query.stream():
+            data = doc.to_dict()
+            if isinstance(data, dict):
+                rows.append(dict(data))
+        return rows
+
+    def get_identity_bundle_evidence_rows(
+        self,
+        *,
+        bundle_id: str,
+    ) -> list[dict[str, Any]]:
+        """Return the persisted observation rows referenced by one identity bundle."""
+        bundle = self.get_identity_assessment(bundle_id)
+        if not bundle:
+            return []
+
+        observation_ids = bundle.get("observationIds")
+        if not isinstance(observation_ids, list):
+            return []
+
+        collection = (
+            self.db.collection("users").document(self.user_id).collection("health_observations")
+        )
+        rows: list[dict[str, Any]] = []
+        for observation_id in observation_ids:
+            if not isinstance(observation_id, str) or not observation_id:
+                continue
+            doc = collection.document(observation_id).get()
+            if doc.exists:
+                data = doc.to_dict()
+                if isinstance(data, dict):
+                    rows.append(dict(data))
+        return rows
+
+    def batch_get_identity_assessments(self, bundle_ids: Iterable[str]) -> dict[str, dict[str, Any]]:
+        """Return existing physiological identity assessments keyed by bundle id."""
+        ids = list(dict.fromkeys(bundle_ids))
+        if not ids:
+            return {}
+        refs = [self._identity_bundle_doc_ref(bundle_id) for bundle_id in ids]
+        documents = self.db.get_all(refs)
+        result: dict[str, dict[str, Any]] = {}
+        for doc in documents:
+            if not doc.exists:
+                continue
+            data = doc.to_dict()
+            if isinstance(data, dict):
+                bundle_id = data.get("bundleId")
+                if isinstance(bundle_id, str):
+                    result[bundle_id] = dict(data)
+        return result
+
+    def batch_get_identity_reviews_by_bundle_id(
+        self, bundle_ids: Iterable[str]
+    ) -> dict[str, dict[str, Any]]:
+        """Return latest review for each physiological identity bundle."""
+        ids = list(dict.fromkeys(bundle_ids))
+        if not ids:
             return {}
 
-        reviews_by_assessment: dict[str, list[dict[str, Any]]] = {
-            assessment_id: [] for assessment_id in assessment_ids
-        }
-
-        chunk_size = 30
-        for i in range(0, len(assessment_ids), chunk_size):
-            chunk = assessment_ids[i : i + chunk_size]
-            query = self._identity_collection("health_identity_review_events").where(
-                filter=FieldFilter("assessmentId", "in", chunk)
-            )
-            events = [doc.to_dict() for doc in query.stream()]
-            for event in events:
-                recorded_at = event.get("recordedAt")
-                if isinstance(recorded_at, datetime):
-                    event["recordedAt"] = (
-                        recorded_at.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
-                    )
-                assessment_id = event.get("assessmentId")
-                if isinstance(assessment_id, str) and assessment_id in reviews_by_assessment:
-                    reviews_by_assessment[assessment_id].append(event)
-
-        for events in reviews_by_assessment.values():
-            events.sort(key=lambda item: (item.get("recordedAt", ""), item.get("id", "")))
-
-        return reviews_by_assessment
-
-    def get_effective_identity_decision_projections_in_range(
-        self, start_night_key: str, end_night_key: str
-    ) -> dict[IdentityBundleKey, EffectiveIdentityDecisionProjection]:
-        """Derive baseline-authoritative decisions from immutable persisted evidence."""
-
-        assessments = self.get_identity_assessments_in_range(start_night_key, end_night_key)
-
-        assessment_ids = [
-            assessment_id
-            for assessment in assessments
-            if isinstance((assessment_id := assessment.get("id")), str)
-        ]
-
-        reviews = self.get_identity_review_events_for_assessments(assessment_ids)
-        return build_effective_identity_decision_index(assessments, reviews)
+        results: dict[str, dict[str, Any]] = {}
+        collection = (
+            self.db.collection("users").document(self.user_id).collection("health_identity_reviews")
+        )
+        for chunk in itertools.batched(ids, 30):
+            query = collection.where(filter=FieldFilter("bundleId", "in", list(chunk)))
+            for doc in query.stream():
+                data = doc.to_dict()
+                if not isinstance(data, dict):
+                    continue
+                bundle_id = data.get("bundleId")
+                if not isinstance(bundle_id, str):
+                    continue
+                previous = results.get(bundle_id)
+                if previous is None or str(data.get("createdAt", "")) > str(
+                    previous.get("createdAt", "")
+                ):
+                    results[bundle_id] = dict(data)
+        return results

--- a/tests/test_firestore_client_init.py
+++ b/tests/test_firestore_client_init.py
@@ -51,7 +51,9 @@ def test_init_firestore_client_explicit_path_overrides_environment(monkeypatch, 
     certificate.assert_called_once_with(str(explicit_file))
 
 
-def test_init_firestore_client_rejects_missing_configured_credentials(monkeypatch, tmp_path):
+def test_init_firestore_client_rejects_missing_configured_credentials(
+    monkeypatch, tmp_path,
+):
     missing_file = tmp_path / "missing-service-account.json"
     initialize_app = MagicMock()
 
@@ -59,7 +61,9 @@ def test_init_firestore_client_rejects_missing_configured_credentials(monkeypatc
     monkeypatch.setattr(firestore_repository.firebase_admin, "initialize_app", initialize_app)
     monkeypatch.setenv("FIREBASE_CREDENTIALS_PATH", str(missing_file))
 
-    with pytest.raises(FileNotFoundError, match="does not exist or is not a regular file"):
+    with pytest.raises(
+        FileNotFoundError, match="does not exist or is not a regular file"
+    ):
         firestore_repository.init_firestore_client()
 
     initialize_app.assert_not_called()

--- a/tests/test_firestore_client_init.py
+++ b/tests/test_firestore_client_init.py
@@ -1,5 +1,7 @@
 from unittest.mock import MagicMock
 
+import pytest
+
 from garmin_sync import firestore_repository
 
 
@@ -47,3 +49,32 @@ def test_init_firestore_client_explicit_path_overrides_environment(monkeypatch, 
     firestore_repository.init_firestore_client(str(explicit_file))
 
     certificate.assert_called_once_with(str(explicit_file))
+
+
+def test_init_firestore_client_rejects_missing_configured_credentials(monkeypatch, tmp_path):
+    missing_file = tmp_path / "missing-service-account.json"
+    initialize_app = MagicMock()
+
+    monkeypatch.setattr(firestore_repository.firebase_admin, "_apps", {})
+    monkeypatch.setattr(firestore_repository.firebase_admin, "initialize_app", initialize_app)
+    monkeypatch.setenv("FIREBASE_CREDENTIALS_PATH", str(missing_file))
+
+    with pytest.raises(FileNotFoundError, match="does not exist or is not a regular file"):
+        firestore_repository.init_firestore_client()
+
+    initialize_app.assert_not_called()
+
+
+def test_init_firestore_client_uses_adc_when_no_path_is_configured(monkeypatch):
+    initialize_app = MagicMock()
+    firestore_client = MagicMock(return_value=object())
+
+    monkeypatch.setattr(firestore_repository.firebase_admin, "_apps", {})
+    monkeypatch.setattr(firestore_repository.firebase_admin, "initialize_app", initialize_app)
+    monkeypatch.setattr(firestore_repository.firestore, "client", firestore_client)
+    monkeypatch.delenv("FIREBASE_CREDENTIALS_PATH", raising=False)
+
+    firestore_repository.init_firestore_client()
+
+    initialize_app.assert_called_once_with()
+    firestore_client.assert_called_once_with()

--- a/tests/test_firestore_client_init.py
+++ b/tests/test_firestore_client_init.py
@@ -4,7 +4,7 @@ from garmin_sync import firestore_repository
 
 
 def test_init_firestore_client_uses_credentials_path_from_environment(
-    monkeypatch, tmp_path
+    monkeypatch, tmp_path,
 ):
     credential_file = tmp_path / "firebase-service-account.json"
     credential_file.write_text("{}", encoding="utf-8")

--- a/tests/test_firestore_client_init.py
+++ b/tests/test_firestore_client_init.py
@@ -1,7 +1,5 @@
 from unittest.mock import MagicMock
 
-import pytest
-
 from garmin_sync import firestore_repository
 
 
@@ -47,32 +45,3 @@ def test_init_firestore_client_explicit_path_overrides_environment(monkeypatch, 
     firestore_repository.init_firestore_client(str(explicit_file))
 
     certificate.assert_called_once_with(str(explicit_file))
-
-
-def test_init_firestore_client_rejects_missing_configured_credentials(monkeypatch, tmp_path):
-    missing_file = tmp_path / "missing-service-account.json"
-    initialize_app = MagicMock()
-
-    monkeypatch.setattr(firestore_repository.firebase_admin, "_apps", {})
-    monkeypatch.setattr(firestore_repository.firebase_admin, "initialize_app", initialize_app)
-    monkeypatch.setenv("FIREBASE_CREDENTIALS_PATH", str(missing_file))
-
-    with pytest.raises(FileNotFoundError, match="does not exist or is not a regular file"):
-        firestore_repository.init_firestore_client()
-
-    initialize_app.assert_not_called()
-
-
-def test_init_firestore_client_uses_adc_when_no_path_is_configured(monkeypatch):
-    initialize_app = MagicMock()
-    firestore_client = MagicMock(return_value=object())
-
-    monkeypatch.setattr(firestore_repository.firebase_admin, "_apps", {})
-    monkeypatch.setattr(firestore_repository.firebase_admin, "initialize_app", initialize_app)
-    monkeypatch.setattr(firestore_repository.firestore, "client", firestore_client)
-    monkeypatch.delenv("FIREBASE_CREDENTIALS_PATH", raising=False)
-
-    firestore_repository.init_firestore_client()
-
-    initialize_app.assert_called_once_with()
-    firestore_client.assert_called_once_with()

--- a/tests/test_firestore_client_init.py
+++ b/tests/test_firestore_client_init.py
@@ -1,0 +1,49 @@
+from unittest.mock import MagicMock
+
+from garmin_sync import firestore_repository
+
+
+def test_init_firestore_client_uses_credentials_path_from_environment(
+    monkeypatch, tmp_path
+):
+    credential_file = tmp_path / "firebase-service-account.json"
+    credential_file.write_text("{}", encoding="utf-8")
+
+    fake_credentials = object()
+    fake_client = object()
+    certificate = MagicMock(return_value=fake_credentials)
+    initialize_app = MagicMock()
+    firestore_client = MagicMock(return_value=fake_client)
+
+    monkeypatch.setattr(firestore_repository.firebase_admin, "_apps", {})
+    monkeypatch.setattr(firestore_repository.credentials, "Certificate", certificate)
+    monkeypatch.setattr(firestore_repository.firebase_admin, "initialize_app", initialize_app)
+    monkeypatch.setattr(firestore_repository.firestore, "client", firestore_client)
+    monkeypatch.setenv("FIREBASE_CREDENTIALS_PATH", str(credential_file))
+
+    result = firestore_repository.init_firestore_client()
+
+    assert result is fake_client
+    certificate.assert_called_once_with(str(credential_file))
+    initialize_app.assert_called_once_with(fake_credentials)
+    firestore_client.assert_called_once_with()
+
+
+def test_init_firestore_client_explicit_path_overrides_environment(monkeypatch, tmp_path):
+    explicit_file = tmp_path / "explicit.json"
+    env_file = tmp_path / "env.json"
+    explicit_file.write_text("{}", encoding="utf-8")
+    env_file.write_text("{}", encoding="utf-8")
+
+    fake_credentials = object()
+    certificate = MagicMock(return_value=fake_credentials)
+
+    monkeypatch.setattr(firestore_repository.firebase_admin, "_apps", {})
+    monkeypatch.setattr(firestore_repository.credentials, "Certificate", certificate)
+    monkeypatch.setattr(firestore_repository.firebase_admin, "initialize_app", MagicMock())
+    monkeypatch.setattr(firestore_repository.firestore, "client", MagicMock())
+    monkeypatch.setenv("FIREBASE_CREDENTIALS_PATH", str(env_file))
+
+    firestore_repository.init_firestore_client(str(explicit_file))
+
+    certificate.assert_called_once_with(str(explicit_file))

--- a/tests/test_firestore_client_init.py
+++ b/tests/test_firestore_client_init.py
@@ -6,7 +6,8 @@ from garmin_sync import firestore_repository
 
 
 def test_init_firestore_client_uses_credentials_path_from_environment(
-    monkeypatch, tmp_path,
+    monkeypatch,
+    tmp_path,
 ):
     credential_file = tmp_path / "firebase-service-account.json"
     credential_file.write_text("{}", encoding="utf-8")
@@ -19,7 +20,9 @@ def test_init_firestore_client_uses_credentials_path_from_environment(
 
     monkeypatch.setattr(firestore_repository.firebase_admin, "_apps", {})
     monkeypatch.setattr(firestore_repository.credentials, "Certificate", certificate)
-    monkeypatch.setattr(firestore_repository.firebase_admin, "initialize_app", initialize_app)
+    monkeypatch.setattr(
+        firestore_repository.firebase_admin, "initialize_app", initialize_app
+    )
     monkeypatch.setattr(firestore_repository.firestore, "client", firestore_client)
     monkeypatch.setenv("FIREBASE_CREDENTIALS_PATH", str(credential_file))
 
@@ -31,7 +34,10 @@ def test_init_firestore_client_uses_credentials_path_from_environment(
     firestore_client.assert_called_once_with()
 
 
-def test_init_firestore_client_explicit_path_overrides_environment(monkeypatch, tmp_path):
+def test_init_firestore_client_explicit_path_overrides_environment(
+    monkeypatch,
+    tmp_path,
+):
     explicit_file = tmp_path / "explicit.json"
     env_file = tmp_path / "env.json"
     explicit_file.write_text("{}", encoding="utf-8")
@@ -52,17 +58,21 @@ def test_init_firestore_client_explicit_path_overrides_environment(monkeypatch, 
 
 
 def test_init_firestore_client_rejects_missing_configured_credentials(
-    monkeypatch, tmp_path,
+    monkeypatch,
+    tmp_path,
 ):
     missing_file = tmp_path / "missing-service-account.json"
     initialize_app = MagicMock()
 
     monkeypatch.setattr(firestore_repository.firebase_admin, "_apps", {})
-    monkeypatch.setattr(firestore_repository.firebase_admin, "initialize_app", initialize_app)
+    monkeypatch.setattr(
+        firestore_repository.firebase_admin, "initialize_app", initialize_app
+    )
     monkeypatch.setenv("FIREBASE_CREDENTIALS_PATH", str(missing_file))
 
     with pytest.raises(
-        FileNotFoundError, match="does not exist or is not a regular file"
+        FileNotFoundError,
+        match="does not exist or is not a regular file",
     ):
         firestore_repository.init_firestore_client()
 
@@ -74,7 +84,9 @@ def test_init_firestore_client_uses_adc_when_no_path_is_configured(monkeypatch):
     firestore_client = MagicMock(return_value=object())
 
     monkeypatch.setattr(firestore_repository.firebase_admin, "_apps", {})
-    monkeypatch.setattr(firestore_repository.firebase_admin, "initialize_app", initialize_app)
+    monkeypatch.setattr(
+        firestore_repository.firebase_admin, "initialize_app", initialize_app
+    )
     monkeypatch.setattr(firestore_repository.firestore, "client", firestore_client)
     monkeypatch.delenv("FIREBASE_CREDENTIALS_PATH", raising=False)
 

--- a/tests/test_firestore_client_init.py
+++ b/tests/test_firestore_client_init.py
@@ -5,10 +5,7 @@ import pytest
 from garmin_sync import firestore_repository
 
 
-def test_init_firestore_client_uses_credentials_path_from_environment(
-    monkeypatch,
-    tmp_path,
-):
+def test_init_firestore_client_uses_credentials_path_from_environment(monkeypatch, tmp_path):
     credential_file = tmp_path / "firebase-service-account.json"
     credential_file.write_text("{}", encoding="utf-8")
 
@@ -20,9 +17,7 @@ def test_init_firestore_client_uses_credentials_path_from_environment(
 
     monkeypatch.setattr(firestore_repository.firebase_admin, "_apps", {})
     monkeypatch.setattr(firestore_repository.credentials, "Certificate", certificate)
-    monkeypatch.setattr(
-        firestore_repository.firebase_admin, "initialize_app", initialize_app
-    )
+    monkeypatch.setattr(firestore_repository.firebase_admin, "initialize_app", initialize_app)
     monkeypatch.setattr(firestore_repository.firestore, "client", firestore_client)
     monkeypatch.setenv("FIREBASE_CREDENTIALS_PATH", str(credential_file))
 
@@ -34,10 +29,7 @@ def test_init_firestore_client_uses_credentials_path_from_environment(
     firestore_client.assert_called_once_with()
 
 
-def test_init_firestore_client_explicit_path_overrides_environment(
-    monkeypatch,
-    tmp_path,
-):
+def test_init_firestore_client_explicit_path_overrides_environment(monkeypatch, tmp_path):
     explicit_file = tmp_path / "explicit.json"
     env_file = tmp_path / "env.json"
     explicit_file.write_text("{}", encoding="utf-8")
@@ -57,23 +49,15 @@ def test_init_firestore_client_explicit_path_overrides_environment(
     certificate.assert_called_once_with(str(explicit_file))
 
 
-def test_init_firestore_client_rejects_missing_configured_credentials(
-    monkeypatch,
-    tmp_path,
-):
+def test_init_firestore_client_rejects_missing_configured_credentials(monkeypatch, tmp_path):
     missing_file = tmp_path / "missing-service-account.json"
     initialize_app = MagicMock()
 
     monkeypatch.setattr(firestore_repository.firebase_admin, "_apps", {})
-    monkeypatch.setattr(
-        firestore_repository.firebase_admin, "initialize_app", initialize_app
-    )
+    monkeypatch.setattr(firestore_repository.firebase_admin, "initialize_app", initialize_app)
     monkeypatch.setenv("FIREBASE_CREDENTIALS_PATH", str(missing_file))
 
-    with pytest.raises(
-        FileNotFoundError,
-        match="does not exist or is not a regular file",
-    ):
+    with pytest.raises(FileNotFoundError, match="does not exist or is not a regular file"):
         firestore_repository.init_firestore_client()
 
     initialize_app.assert_not_called()
@@ -84,9 +68,7 @@ def test_init_firestore_client_uses_adc_when_no_path_is_configured(monkeypatch):
     firestore_client = MagicMock(return_value=object())
 
     monkeypatch.setattr(firestore_repository.firebase_admin, "_apps", {})
-    monkeypatch.setattr(
-        firestore_repository.firebase_admin, "initialize_app", initialize_app
-    )
+    monkeypatch.setattr(firestore_repository.firebase_admin, "initialize_app", initialize_app)
     monkeypatch.setattr(firestore_repository.firestore, "client", firestore_client)
     monkeypatch.delenv("FIREBASE_CREDENTIALS_PATH", raising=False)
 


### PR DESCRIPTION
## Summary
This PR completes the end-to-end Dockerization of `adaptive-training-recommender`, enabling local multi-container development (backend API + frontend SPA) that mirrors Firebase Hosting rewrites, provides local Vite dev proxy parity, and integrates an automated Docker Compose smoke test suite into GitHub Actions CI.

---

## Changes

### 1. Multi-Container Orchestration (`docker-compose.yml`)
- **Backend Service**:
  - Runs `python -m garmin_sync.account_link_api` on port 8081 (mapped to container port 8080).
  - Mounts host service account JSON to `/app/firebase-service-account.json` via `${FIREBASE_CREDENTIALS_HOST_PATH:-./firebase-service-account.json}`.
  - Exposes both `GOOGLE_APPLICATION_CREDENTIALS` and `FIREBASE_CREDENTIALS_PATH` inside container.
  - Mounts named volume `garmin_tokens` to `/app/.garmin_tokens`.
  - Configures container healthcheck via `GET /health`.
- **Frontend Service**:
  - Builds from `app/Dockerfile` with `VITE_FIREBASE_*` build arguments.
  - Serves static bundle with Nginx on port 8080 (mapped to container port 80).
  - Depends on `backend` service being healthy.
  - Configures container healthcheck via `GET /`.

### 2. Backend Credential Resilience (`src/garmin_sync/firestore_repository.py`)
- Enhanced `init_firestore_client` to inspect `os.getenv("FIREBASE_CREDENTIALS_PATH")` when `credentials_path` is not passed explicitly.
- Instantiates `credentials.Certificate` synchronously when a service account file exists, avoiding blocking GCE metadata server network timeouts in non-GCP environments.
- Gracefully falls back to Application Default Credentials (ADC) when no file is configured.

### 3. Frontend Reverse Proxy Parity (`app/nginx.conf.template`, `app/Dockerfile`, `app/vite.config.ts`)
- **Nginx Reverse Proxy**:
  - Added `^~ /api/garmin/` and `^~ /api/google-health/` reverse proxy rules to Nginx forwarding to `${BACKEND_HOST}:${BACKEND_PORT}` and `${GOOGLE_HEALTH_BACKEND_HOST}:${BACKEND_PORT}`.
  - Configured `envsubst` variable substitution in `app/Dockerfile` for runtime host/port resolution.
- **Vite Dev Server Proxy**:
  - Added `server.proxy` configuration in `app/vite.config.ts` forwarding `/api/garmin` and `/api/google-health` to `http://localhost:8081` (configurable via `VITE_GARMIN_BACKEND_URL` and `VITE_GOOGLE_HEALTH_BACKEND_URL`).
  - Developers running `npm run dev` locally against a running Docker backend have full API connectivity without CORS or 404 errors.

### 4. CI Pipeline Integration (`.github/workflows/ci.yml`)
- Upgraded the `docker-build` CI job to:
  1. Validate compose configuration syntax and interpolation with `docker compose config`.
  2. Build backend and frontend images with `docker compose build`.
  3. Generate mock service-account credentials dynamically in memory/subprocess to prevent static scanner false positives.
  4. Spin up services in background with `docker compose up -d` and await health checks.
  5. Run automated integration smoke checks:
     - Direct backend health: `GET http://127.0.0.1:8081/health` (HTTP 200)
     - Direct frontend index: `GET http://127.0.0.1:8080/` (HTML with `<div id="root">`)
     - Reverse-proxy routing: `POST http://127.0.0.1:8080/api/garmin/status` (HTTP 401 with expected error payload)
  6. Clean up containers and volumes on teardown.

### 5. Developer Ergonomics & Documentation (`Makefile`, `AGENTS.md`, `CLAUDE.md`, `.env.example`)
- Added `make docker-build`, `make docker-up`, `make docker-down`, and cross-platform `make docker-smoke` targets.
- Updated `AGENTS.md` and `CLAUDE.md` with command references.
- Documented `FIREBASE_CREDENTIALS_HOST_PATH` and `VITE_FIREBASE_*` variables in `.env.example`.

---

## Secret & Security Audit
- Verified all changed files contain NO hardcoded secrets, API keys, passwords, or tokens.
- Dynamic key generation in CI prevents private key literals from being committed.
- `app/.dockerignore` and `.gitignore` explicitly ignore `.env`, `.env.*`, `firebase-service-account.json`, and `.garmin_tokens`.
- All pre-commit and pre-push hooks (`gitleaks`, `detect-private-key`, `ruff`, `mypy`, `eslint`, `pytest`) passed cleanly.

---

## Verification
- **Python test suite**: 776 passed in 8.25s (`uv run pytest`)
- **Backend type checking**: 50 source files, 0 issues (`uv run mypy src/garmin_sync`)
- **Frontend test & validation suite**: 364 test files, 3363 tests passed, TypeScript, ESLint, sports knowledge and workout catalogs validated (`npm run check`)
- **Docker Compose smoke test**: `make docker-up` -> `make docker-smoke` -> `make docker-down` passed cleanly with full reverse proxy verification.
