### PR TITLE
feat: prefill daily check-in available time from preferences & add 1-7 days exercise slider to onboarding

### DIFF
--- a/app/src/components/DailyCheckin.css
+++ b/app/src/components/DailyCheckin.css
@@ -227,6 +227,14 @@
   line-height: 1.4;
 }
 
+.availability-hint {
+  display: block;
+  margin-top: 0.35rem;
+  font-size: 0.75rem;
+  color: var(--text-secondary, #94a3b8);
+}
+
+
 /* Preset Quick-Fill Bar */
 .checkin-preset-bar {
   margin-bottom: 1rem;

--- a/app/src/components/DailyCheckin.tsx
+++ b/app/src/components/DailyCheckin.tsx
@@ -3,13 +3,15 @@ import { checkinService } from '../services/checkinService';
 import { recoverySnapshotService } from '../services/recoverySnapshotService';
 import { sessionExecutionService } from '../services/sessionExecutionService';
 import { sessionResponseService } from '../services/sessionResponseService';
+import { trainingSettingsService } from '../services/trainingSettingsService';
 import { relevantFollowupRegions } from '../responses/followupSchedule';
 import { EXERCISES_BY_ID } from '../workouts/exercises';
-import type { BodyRegion, DailySubjectiveCheckin, RedFlagCategory, RegionTissueResponse, TissueResponseLevel } from '../engine/models';
+import type { BodyRegion, DailySubjectiveCheckin, RedFlagCategory, RegionTissueResponse, TissueResponseLevel, TrainingSettings } from '../engine/models';
 import type { HealthContextCheckin } from '../engine/healthAnomalyModels';
 import { BODY_REGIONS, TISSUE_LEVELS } from '../engine/models';
 import { isCompletedSubjectiveCheckin } from '../engine/checkinCompletion';
-import { getLocalDateString, addDaysToLocalDateString } from '../utils/localDate';
+import { getLocalDateString, addDaysToLocalDateString, isWeekendLocalDateString } from '../utils/localDate';
+import { resolveDefaultTimeAvailableMin } from '../utils/checkinDefaults';
 import { getErrorMessage } from '../utils/errors';
 import type { Screen } from '../types/navigation';
 import { HealthContextSection } from './checkin/HealthContextSection';
@@ -138,6 +140,17 @@ export function DailyCheckin({ userId, onNavigate, onBack, onCheckinSaved }: Dai
       const today = getLocalDateString();
 
       try {
+        let trainingSettings: TrainingSettings | null = null;
+        try {
+          const settingsState = await trainingSettingsService.peekTrainingSettingsState(userId);
+          if (settingsState.status === 'AVAILABLE') {
+            trainingSettings = settingsState.data;
+          }
+        } catch {
+          // Fallback to standard preferences (45m weekday / 60m weekend) if settings can't be fetched
+        }
+
+        const defaultTimeAvailable = resolveDefaultTimeAvailableMin(trainingSettings, today);
         const existing = await checkinService.getCheckin(userId, today);
         const snapshot = await recoverySnapshotService.getRecoverySnapshotByDate(userId, today);
         setRecoverySnapshot(snapshot ?? null);
@@ -196,7 +209,22 @@ export function DailyCheckin({ userId, onNavigate, onBack, onCheckinSaved }: Dai
         setPendingFollowups(needed);
 
         if (existing) {
-          setCheckin(existing);
+          if (
+            (existing.availability?.timeAvailableMin === null || existing.availability?.timeAvailableMin === undefined) &&
+            !isCompletedSubjectiveCheckin(existing)
+          ) {
+            setCheckin({
+              ...existing,
+              availability: {
+                ...existing.availability,
+                timeAvailableMin: defaultTimeAvailable,
+                preferredModalityToday: existing.availability?.preferredModalityToday ?? null,
+                indoorOnly: existing.availability?.indoorOnly ?? false,
+              },
+            });
+          } else {
+            setCheckin(existing);
+          }
         } else {
           // Do not fabricate neutral subjective observations. Missing scores remain null so
           // they cannot contaminate the athlete's longitudinal subjective baseline; the
@@ -220,7 +248,7 @@ export function DailyCheckin({ userId, onNavigate, onBack, onCheckinSaved }: Dai
             unusuallyLimitedTime: false,
             alreadyTrainedToday: false,
             availability: {
-              timeAvailableMin: null,
+              timeAvailableMin: defaultTimeAvailable,
               preferredModalityToday: null,
               indoorOnly: false,
             },
@@ -851,6 +879,9 @@ export function DailyCheckin({ userId, onNavigate, onBack, onCheckinSaved }: Dai
                 onChange={(e) => handleAvailabilityChange('timeAvailableMin', e.target.value === '' ? null : Number(e.target.value))}
                 className="number-input"
               />
+              <span className="availability-hint">
+                Prefilled from your preferences ({isWeekendLocalDateString(checkin.date || getLocalDateString()) ? 'weekend' : 'weekday'}). You can adjust this for today.
+              </span>
             </div>
 
             <div className="form-group">

--- a/app/src/components/DailyCheckin.tsx
+++ b/app/src/components/DailyCheckin.tsx
@@ -3,15 +3,15 @@ import { checkinService } from '../services/checkinService';
 import { recoverySnapshotService } from '../services/recoverySnapshotService';
 import { sessionExecutionService } from '../services/sessionExecutionService';
 import { sessionResponseService } from '../services/sessionResponseService';
-import { trainingSettingsService } from '../services/trainingSettingsService';
+import { preferencesService } from '../services/preferencesService';
 import { relevantFollowupRegions } from '../responses/followupSchedule';
 import { EXERCISES_BY_ID } from '../workouts/exercises';
-import type { BodyRegion, DailySubjectiveCheckin, RedFlagCategory, RegionTissueResponse, TissueResponseLevel, TrainingSettings } from '../engine/models';
+import type { BodyRegion, DailySubjectiveCheckin, RedFlagCategory, RegionTissueResponse, TissueResponseLevel } from '../engine/models';
 import type { HealthContextCheckin } from '../engine/healthAnomalyModels';
 import { BODY_REGIONS, TISSUE_LEVELS } from '../engine/models';
 import { isCompletedSubjectiveCheckin } from '../engine/checkinCompletion';
-import { getLocalDateString, addDaysToLocalDateString, isWeekendLocalDateString } from '../utils/localDate';
-import { resolveDefaultTimeAvailableMin } from '../utils/checkinDefaults';
+import { getLocalDateString, addDaysToLocalDateString } from '../utils/localDate';
+import { resolveDefaultTimeAvailable, type CheckinAvailabilityDefault } from '../utils/checkinDefaults';
 import { getErrorMessage } from '../utils/errors';
 import type { Screen } from '../types/navigation';
 import { HealthContextSection } from './checkin/HealthContextSection';
@@ -127,6 +127,7 @@ export function DailyCheckin({ userId, onNavigate, onBack, onCheckinSaved }: Dai
   const [recoverySnapshot, setRecoverySnapshot] = useState<Awaited<ReturnType<typeof recoverySnapshotService.getRecoverySnapshotByDate>>>(null);
   const [pendingFollowups, setPendingFollowups] = useState<Array<{ region: BodyRegion; sessionRef?: RegionTissueResponse['sourceSessionRef'] }>>([]);
   const [pendingTissueRegion, setPendingTissueRegion] = useState<BodyRegion | ''>('');
+  const [availabilityDefault, setAvailabilityDefault] = useState<CheckinAvailabilityDefault | null>(null);
 
   const tissueSelectId = useId();
   const timeInputId = useId();
@@ -137,21 +138,23 @@ export function DailyCheckin({ userId, onNavigate, onBack, onCheckinSaved }: Dai
     try {
       setLoading(true);
       setError(null);
+      setAvailabilityDefault(null);
       const today = getLocalDateString();
 
       try {
-        let trainingSettings: TrainingSettings | null = null;
-        try {
-          const settingsState = await trainingSettingsService.peekTrainingSettingsState(userId);
-          if (settingsState.status === 'AVAILABLE') {
-            trainingSettings = settingsState.data;
-          }
-        } catch {
-          // Fallback to standard preferences (45m weekday / 60m weekend) if settings can't be fetched
+        // Persisted check-in state is authoritative. Only resolve a preference default when
+        // constructing a brand-new day, so a deliberate custom value or explicit blank is
+        // never silently replaced on reload after a partial/follow-up write.
+        const existing = await checkinService.getCheckin(userId, today);
+        let resolvedAvailabilityDefault: CheckinAvailabilityDefault | null = null;
+        if (!existing) {
+          const preferencesState = await preferencesService.getPreferencesState(userId);
+          resolvedAvailabilityDefault = resolveDefaultTimeAvailable(
+            preferencesState.status === 'AVAILABLE' ? preferencesState.data : null,
+            today,
+          );
         }
 
-        const defaultTimeAvailable = resolveDefaultTimeAvailableMin(trainingSettings, today);
-        const existing = await checkinService.getCheckin(userId, today);
         const snapshot = await recoverySnapshotService.getRecoverySnapshotByDate(userId, today);
         setRecoverySnapshot(snapshot ?? null);
 
@@ -209,23 +212,11 @@ export function DailyCheckin({ userId, onNavigate, onBack, onCheckinSaved }: Dai
         setPendingFollowups(needed);
 
         if (existing) {
-          if (
-            (existing.availability?.timeAvailableMin === null || existing.availability?.timeAvailableMin === undefined) &&
-            !isCompletedSubjectiveCheckin(existing)
-          ) {
-            setCheckin({
-              ...existing,
-              availability: {
-                ...existing.availability,
-                timeAvailableMin: defaultTimeAvailable,
-                preferredModalityToday: existing.availability?.preferredModalityToday ?? null,
-                indoorOnly: existing.availability?.indoorOnly ?? false,
-              },
-            });
-          } else {
-            setCheckin(existing);
-          }
+          setCheckin(existing);
         } else {
+          const defaultTimeAvailable = resolvedAvailabilityDefault
+            ?? resolveDefaultTimeAvailable(null, today);
+          setAvailabilityDefault(defaultTimeAvailable);
           // Do not fabricate neutral subjective observations. Missing scores remain null so
           // they cannot contaminate the athlete's longitudinal subjective baseline; the
           // engine already has a neutral fallback for a deliberately partial safety check-in.
@@ -248,7 +239,7 @@ export function DailyCheckin({ userId, onNavigate, onBack, onCheckinSaved }: Dai
             unusuallyLimitedTime: false,
             alreadyTrainedToday: false,
             availability: {
-              timeAvailableMin: defaultTimeAvailable,
+              timeAvailableMin: defaultTimeAvailable.minutes,
               preferredModalityToday: null,
               indoorOnly: false,
             },
@@ -879,9 +870,14 @@ export function DailyCheckin({ userId, onNavigate, onBack, onCheckinSaved }: Dai
                 onChange={(e) => handleAvailabilityChange('timeAvailableMin', e.target.value === '' ? null : Number(e.target.value))}
                 className="number-input"
               />
-              <span className="availability-hint">
-                Prefilled from your preferences ({isWeekendLocalDateString(checkin.date || getLocalDateString()) ? 'weekend' : 'weekday'}). You can adjust this for today.
-              </span>
+              {availabilityDefault && (
+                <span className="availability-hint">
+                  {availabilityDefault.source === 'preferences'
+                    ? `Prefilled from your ${availabilityDefault.dayType} Default Available Duration.`
+                    : `Using the standard ${availabilityDefault.dayType} default (${availabilityDefault.minutes} min).`}
+                  {' '}Adjust or clear it for today.
+                </span>
+              )}
             </div>
 
             <div className="form-group">

--- a/app/src/components/OnboardingWizard.css
+++ b/app/src/components/OnboardingWizard.css
@@ -158,36 +158,56 @@
     color: #38bdf8;
 }
 
-.days-selector-row {
-    display: flex;
-    gap: 0.5rem;
-    flex-wrap: wrap;
-}
-
-.days-pill {
-    flex: 1;
-    min-width: 100px;
+.days-slider-group {
     background: var(--bg-surface-elevated, #18181b);
     border: 1px solid var(--border-subtle, #27272a);
-    border-radius: 8px;
-    padding: 0.6rem 0.75rem;
-    font-size: 0.85rem;
-    font-weight: 600;
-    color: var(--text-main, #f4f4f5);
-    cursor: pointer;
-    text-align: center;
-    transition: all 0.15s ease;
+    border-radius: 12px;
+    padding: 1.15rem 1.25rem;
+    gap: 0.75rem;
 }
 
-.days-pill:hover {
-    border-color: var(--border-subtle, #3f3f46);
+.days-slider-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.75rem;
 }
 
-.days-pill.active {
-    background: var(--primary, #38bdf8);
-    color: #09090b;
-    border-color: var(--primary, #38bdf8);
+.days-slider-badge {
+    background: rgba(56, 189, 248, 0.15);
+    border: 1px solid rgba(56, 189, 248, 0.4);
+    color: #38bdf8;
+    padding: 0.25rem 0.75rem;
+    border-radius: 9999px;
+    font-size: 0.88rem;
     font-weight: 700;
+    letter-spacing: 0.01em;
+    white-space: nowrap;
+}
+
+.days-range-slider {
+    width: 100%;
+    height: 8px;
+    border-radius: 6px;
+    background: #27272a;
+    outline: none;
+    cursor: pointer;
+    accent-color: #38bdf8;
+    margin: 0.35rem 0 0.15rem;
+}
+
+.days-range-slider:focus-visible {
+    outline: 2px solid #38bdf8;
+    outline-offset: 2px;
+}
+
+.days-slider-labels {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: var(--text-muted, #a1a1aa);
+    padding: 0 2px;
 }
 
 .onboarding-action-row {

--- a/app/src/components/OnboardingWizard.test.tsx
+++ b/app/src/components/OnboardingWizard.test.tsx
@@ -1,10 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
-import {
-  ExerciseDaysSlider,
-  OnboardingWizard,
-  weeklyCommitmentFromExerciseDays,
-} from './OnboardingWizard';
+import { ExerciseDaysSlider, OnboardingWizard } from './OnboardingWizard';
+import { weeklyCommitmentFromExerciseDays } from './onboarding/weeklyCommitment';
 
 describe('OnboardingWizard', () => {
   it('renders Step 1 welcome screen by default', () => {

--- a/app/src/components/OnboardingWizard.test.tsx
+++ b/app/src/components/OnboardingWizard.test.tsx
@@ -1,6 +1,10 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { OnboardingWizard } from './OnboardingWizard';
+import {
+  ExerciseDaysSlider,
+  OnboardingWizard,
+  weeklyCommitmentFromExerciseDays,
+} from './OnboardingWizard';
 
 describe('OnboardingWizard', () => {
   it('renders Step 1 welcome screen by default', () => {
@@ -11,30 +15,60 @@ describe('OnboardingWizard', () => {
     expect(html).toContain('Welcome to Adaptive Training');
     expect(html).toContain('Let&#x27;s Set Up Your Profile →');
   });
+});
 
-  it('renders Step 3 with exercise days slider (min 1, max 7) instead of session pill buttons', () => {
+describe('ExerciseDaysSlider', () => {
+  it('renders a native 1-7 day range with an associated visible label', () => {
     const html = renderToStaticMarkup(
-      <OnboardingWizard userId="athlete-1" onCompleted={() => {}} initialStep={3} />
+      <ExerciseDaysSlider value={4} onChange={() => {}} />
     );
 
-    // Prompt & slider
     expect(html).toContain('How many days a week can you exercise?');
+    expect(html).toContain('for="onboarding-days-slider"');
     expect(html).toContain('id="onboarding-days-slider"');
     expect(html).toContain('type="range"');
     expect(html).toContain('min="1"');
     expect(html).toContain('max="7"');
     expect(html).toContain('step="1"');
-
-    // Default 4 days / week badge
     expect(html).toContain('4');
     expect(html).toContain('days / week');
-
-    // Min and max scale tick markers
-    expect(html).toContain('1 min');
-    expect(html).toContain('7 max');
-
-    // Old pill buttons are replaced
+    expect(html).toContain('1 day');
+    expect(html).toContain('7 days');
+    expect(html).not.toContain('aria-label="How many days a week can you exercise"');
     expect(html).not.toContain('days-pill');
     expect(html).not.toContain('10 / week');
+  });
+
+  it('uses singular day copy at the lower bound', () => {
+    const html = renderToStaticMarkup(
+      <ExerciseDaysSlider value={1} onChange={() => {}} />
+    );
+
+    expect(html).toContain('<strong>1</strong> day / week');
+  });
+});
+
+describe('weeklyCommitmentFromExerciseDays', () => {
+  it('maps available days onto the session-based planning contract with one-session flexibility', () => {
+    expect(weeklyCommitmentFromExerciseDays(1)).toEqual({
+      minSessions: 1,
+      targetSessions: 1,
+      maxSessions: 2,
+    });
+    expect(weeklyCommitmentFromExerciseDays(4)).toEqual({
+      minSessions: 3,
+      targetSessions: 4,
+      maxSessions: 5,
+    });
+    expect(weeklyCommitmentFromExerciseDays(7)).toEqual({
+      minSessions: 6,
+      targetSessions: 7,
+      maxSessions: 8,
+    });
+  });
+
+  it('defensively clamps non-slider inputs to the supported 1-7 day range', () => {
+    expect(weeklyCommitmentFromExerciseDays(0).targetSessions).toBe(1);
+    expect(weeklyCommitmentFromExerciseDays(9).targetSessions).toBe(7);
   });
 });

--- a/app/src/components/OnboardingWizard.test.tsx
+++ b/app/src/components/OnboardingWizard.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { OnboardingWizard } from './OnboardingWizard';
+
+describe('OnboardingWizard', () => {
+  it('renders Step 1 welcome screen by default', () => {
+    const html = renderToStaticMarkup(
+      <OnboardingWizard userId="athlete-1" onCompleted={() => {}} />
+    );
+
+    expect(html).toContain('Welcome to Adaptive Training');
+    expect(html).toContain('Let&#x27;s Set Up Your Profile →');
+  });
+
+  it('renders Step 3 with exercise days slider (min 1, max 7) instead of session pill buttons', () => {
+    const html = renderToStaticMarkup(
+      <OnboardingWizard userId="athlete-1" onCompleted={() => {}} initialStep={3} />
+    );
+
+    // Prompt & slider
+    expect(html).toContain('How many days a week can you exercise?');
+    expect(html).toContain('id="onboarding-days-slider"');
+    expect(html).toContain('type="range"');
+    expect(html).toContain('min="1"');
+    expect(html).toContain('max="7"');
+    expect(html).toContain('step="1"');
+
+    // Default 4 days / week badge
+    expect(html).toContain('4');
+    expect(html).toContain('days / week');
+
+    // Min and max scale tick markers
+    expect(html).toContain('1 min');
+    expect(html).toContain('7 max');
+
+    // Old pill buttons are replaced
+    expect(html).not.toContain('days-pill');
+    expect(html).not.toContain('10 / week');
+  });
+});

--- a/app/src/components/OnboardingWizard.tsx
+++ b/app/src/components/OnboardingWizard.tsx
@@ -7,17 +7,78 @@ import './OnboardingWizard.css';
 interface OnboardingWizardProps {
     userId: string;
     onCompleted: () => void;
-    initialStep?: 1 | 2 | 3;
 }
 
 type GoalFocus = 'general_fitness' | 'running' | 'cycling' | 'triathlon' | 'strength';
 type EquipmentTier = 'full_gym' | 'home_dumbbells' | 'minimal';
 
-export const OnboardingWizard = memo(function OnboardingWizard({ userId, onCompleted, initialStep = 1 }: OnboardingWizardProps) {
-    const [step, setStep] = useState<1 | 2 | 3>(initialStep);
+type WeeklyCommitment = {
+    minSessions: number;
+    targetSessions: number;
+    maxSessions: number;
+};
+
+/**
+ * The onboarding question is deliberately expressed as available exercise *days*, while
+ * the persisted training-intent contract is session-based. Treat one session per available
+ * day as the target and retain the existing ±1 planning flexibility. The +1 maximum may
+ * represent one double-session day; it does not invent an additional available day.
+ */
+export function weeklyCommitmentFromExerciseDays(exerciseDaysPerWeek: number): WeeklyCommitment {
+    const days = Math.min(7, Math.max(1, Math.round(exerciseDaysPerWeek)));
+    return {
+        minSessions: Math.max(1, days - 1),
+        targetSessions: days,
+        maxSessions: Math.min(14, days + 1),
+    };
+}
+
+interface ExerciseDaysSliderProps {
+    value: number;
+    onChange: (days: number) => void;
+    disabled?: boolean;
+}
+
+export function ExerciseDaysSlider({ value, onChange, disabled = false }: ExerciseDaysSliderProps) {
+    return (
+        <div className="choice-group days-slider-group">
+            <div className="days-slider-header">
+                <label htmlFor="onboarding-days-slider" className="group-heading">
+                    How many days a week can you exercise?
+                </label>
+                <span className="days-slider-badge">
+                    <strong>{value}</strong> {value === 1 ? 'day' : 'days'} / week
+                </span>
+            </div>
+            <input
+                id="onboarding-days-slider"
+                type="range"
+                min="1"
+                max="7"
+                step="1"
+                value={value}
+                onChange={(event) => onChange(Number(event.target.value))}
+                disabled={disabled}
+                className="days-range-slider"
+            />
+            <div className="days-slider-labels" aria-hidden="true">
+                <span>1 day</span>
+                <span>2</span>
+                <span>3</span>
+                <span>4</span>
+                <span>5</span>
+                <span>6</span>
+                <span>7 days</span>
+            </div>
+        </div>
+    );
+}
+
+export const OnboardingWizard = memo(function OnboardingWizard({ userId, onCompleted }: OnboardingWizardProps) {
+    const [step, setStep] = useState<1 | 2 | 3>(1);
     const [focus, setFocus] = useState<GoalFocus>('general_fitness');
     const [equipment, setEquipment] = useState<EquipmentTier>('full_gym');
-    const [sessionsPerWeek, setSessionsPerWeek] = useState<number>(4);
+    const [exerciseDaysPerWeek, setExerciseDaysPerWeek] = useState<number>(4);
     const [sportAccess, setSportAccess] = useState({ outdoor_bike: false, swim_access: false });
     const [saving, setSaving] = useState(false);
     const [saveError, setSaveError] = useState<string | null>(null);
@@ -57,7 +118,7 @@ export const OnboardingWizard = memo(function OnboardingWizard({ userId, onCompl
             await trainingSettingsService.updateTrainingSettings(userId, {
                 equipment: equipmentMap,
                 defaults: {
-                    weekdayMaxMinutes: sessionsPerWeek >= 5 ? 60 : 45,
+                    weekdayMaxMinutes: exerciseDaysPerWeek >= 5 ? 60 : 45,
                     weekendMaxMinutes: focus === 'running' || focus === 'cycling' || focus === 'triathlon' ? 180 : 90,
                     environment: 'either',
                 },
@@ -68,11 +129,7 @@ export const OnboardingWizard = memo(function OnboardingWizard({ userId, onCompl
                 priorities: [
                     domain === 'endurance' ? 'endurance' : domain === 'strength' ? 'strength_muscle' : 'health',
                 ],
-                weeklyCommitment: {
-                    minSessions: Math.max(1, sessionsPerWeek - 1),
-                    targetSessions: sessionsPerWeek,
-                    maxSessions: Math.min(14, sessionsPerWeek + 1),
-                },
+                weeklyCommitment: weeklyCommitmentFromExerciseDays(exerciseDaysPerWeek),
                 organizationPreference: 'auto',
                 schemaVersion: 1,
             });
@@ -190,37 +247,11 @@ export const OnboardingWizard = memo(function OnboardingWizard({ userId, onCompl
                             </div>
                         </div>
 
-                        <div className="choice-group days-slider-group">
-                            <div className="days-slider-header">
-                                <label htmlFor="onboarding-days-slider" className="group-heading">
-                                    How many days a week can you exercise?
-                                </label>
-                                <span className="days-slider-badge">
-                                    <strong>{sessionsPerWeek}</strong> {sessionsPerWeek === 1 ? 'day' : 'days'} / week
-                                </span>
-                            </div>
-                            <input
-                                id="onboarding-days-slider"
-                                type="range"
-                                min="1"
-                                max="7"
-                                step="1"
-                                value={sessionsPerWeek}
-                                onChange={(e) => setSessionsPerWeek(Number(e.target.value))}
-                                disabled={saving}
-                                className="days-range-slider"
-                                aria-label="How many days a week can you exercise"
-                            />
-                            <div className="days-slider-labels">
-                                <span>1 min</span>
-                                <span>2</span>
-                                <span>3</span>
-                                <span>4</span>
-                                <span>5</span>
-                                <span>6</span>
-                                <span>7 max</span>
-                            </div>
-                        </div>
+                        <ExerciseDaysSlider
+                            value={exerciseDaysPerWeek}
+                            onChange={setExerciseDaysPerWeek}
+                            disabled={saving}
+                        />
 
                         {saveError && <p className="form-error-msg" role="alert">{saveError}</p>}
 

--- a/app/src/components/OnboardingWizard.tsx
+++ b/app/src/components/OnboardingWizard.tsx
@@ -7,13 +7,14 @@ import './OnboardingWizard.css';
 interface OnboardingWizardProps {
     userId: string;
     onCompleted: () => void;
+    initialStep?: 1 | 2 | 3;
 }
 
 type GoalFocus = 'general_fitness' | 'running' | 'cycling' | 'triathlon' | 'strength';
 type EquipmentTier = 'full_gym' | 'home_dumbbells' | 'minimal';
 
-export const OnboardingWizard = memo(function OnboardingWizard({ userId, onCompleted }: OnboardingWizardProps) {
-    const [step, setStep] = useState<1 | 2 | 3>(1);
+export const OnboardingWizard = memo(function OnboardingWizard({ userId, onCompleted, initialStep = 1 }: OnboardingWizardProps) {
+    const [step, setStep] = useState<1 | 2 | 3>(initialStep);
     const [focus, setFocus] = useState<GoalFocus>('general_fitness');
     const [equipment, setEquipment] = useState<EquipmentTier>('full_gym');
     const [sessionsPerWeek, setSessionsPerWeek] = useState<number>(4);
@@ -189,14 +190,35 @@ export const OnboardingWizard = memo(function OnboardingWizard({ userId, onCompl
                             </div>
                         </div>
 
-                        <div className="choice-group">
-                            <label className="group-heading">Weekly Training Sessions:</label>
-                            <div className="days-selector-row">
-                                {[3, 4, 5, 6, 7, 8, 9, 10].map(sessions => (
-                                    <button key={sessions} type="button" className={`days-pill ${sessionsPerWeek === sessions ? 'active' : ''}`} onClick={() => setSessionsPerWeek(sessions)} disabled={saving}>
-                                        {sessions} / week
-                                    </button>
-                                ))}
+                        <div className="choice-group days-slider-group">
+                            <div className="days-slider-header">
+                                <label htmlFor="onboarding-days-slider" className="group-heading">
+                                    How many days a week can you exercise?
+                                </label>
+                                <span className="days-slider-badge">
+                                    <strong>{sessionsPerWeek}</strong> {sessionsPerWeek === 1 ? 'day' : 'days'} / week
+                                </span>
+                            </div>
+                            <input
+                                id="onboarding-days-slider"
+                                type="range"
+                                min="1"
+                                max="7"
+                                step="1"
+                                value={sessionsPerWeek}
+                                onChange={(e) => setSessionsPerWeek(Number(e.target.value))}
+                                disabled={saving}
+                                className="days-range-slider"
+                                aria-label="How many days a week can you exercise"
+                            />
+                            <div className="days-slider-labels">
+                                <span>1 min</span>
+                                <span>2</span>
+                                <span>3</span>
+                                <span>4</span>
+                                <span>5</span>
+                                <span>6</span>
+                                <span>7 max</span>
                             </div>
                         </div>
 

--- a/app/src/components/OnboardingWizard.tsx
+++ b/app/src/components/OnboardingWizard.tsx
@@ -2,6 +2,7 @@ import { useState, memo } from 'react';
 import { goalService } from '../services/goalService';
 import { trainingSettingsService } from '../services/trainingSettingsService';
 import { trainingIntentProfileService } from '../services/trainingIntentProfileService';
+import { weeklyCommitmentFromExerciseDays } from './onboarding/weeklyCommitment';
 import './OnboardingWizard.css';
 
 interface OnboardingWizardProps {
@@ -11,27 +12,6 @@ interface OnboardingWizardProps {
 
 type GoalFocus = 'general_fitness' | 'running' | 'cycling' | 'triathlon' | 'strength';
 type EquipmentTier = 'full_gym' | 'home_dumbbells' | 'minimal';
-
-type WeeklyCommitment = {
-    minSessions: number;
-    targetSessions: number;
-    maxSessions: number;
-};
-
-/**
- * The onboarding question is deliberately expressed as available exercise *days*, while
- * the persisted training-intent contract is session-based. Treat one session per available
- * day as the target and retain the existing ±1 planning flexibility. The +1 maximum may
- * represent one double-session day; it does not invent an additional available day.
- */
-export function weeklyCommitmentFromExerciseDays(exerciseDaysPerWeek: number): WeeklyCommitment {
-    const days = Math.min(7, Math.max(1, Math.round(exerciseDaysPerWeek)));
-    return {
-        minSessions: Math.max(1, days - 1),
-        targetSessions: days,
-        maxSessions: Math.min(14, days + 1),
-    };
-}
 
 interface ExerciseDaysSliderProps {
     value: number;

--- a/app/src/components/onboarding/weeklyCommitment.ts
+++ b/app/src/components/onboarding/weeklyCommitment.ts
@@ -1,0 +1,20 @@
+export type WeeklyCommitment = {
+  minSessions: number;
+  targetSessions: number;
+  maxSessions: number;
+};
+
+/**
+ * The onboarding question is deliberately expressed as available exercise *days*, while
+ * the persisted training-intent contract is session-based. Treat one session per available
+ * day as the target and retain the existing ±1 planning flexibility. The +1 maximum may
+ * represent one double-session day; it does not invent an additional available day.
+ */
+export function weeklyCommitmentFromExerciseDays(exerciseDaysPerWeek: number): WeeklyCommitment {
+  const days = Math.min(7, Math.max(1, Math.round(exerciseDaysPerWeek)));
+  return {
+    minSessions: Math.max(1, days - 1),
+    targetSessions: days,
+    maxSessions: Math.min(14, days + 1),
+  };
+}

--- a/app/src/utils/checkinDefaults.test.ts
+++ b/app/src/utils/checkinDefaults.test.ts
@@ -1,7 +1,6 @@
-﻿import { describe, it, expect } from 'vitest';
-import { resolveDefaultTimeAvailableMin } from './checkinDefaults';
+import { describe, expect, it } from 'vitest';
+import { resolveDefaultTimeAvailable, resolveDefaultTimeAvailableMin } from './checkinDefaults';
 import { isWeekendLocalDateString } from './localDate';
-import type { TrainingSettings } from '../engine/models';
 
 describe('isWeekendLocalDateString', () => {
   it('identifies Saturday and Sunday as weekends', () => {
@@ -18,60 +17,48 @@ describe('isWeekendLocalDateString', () => {
   });
 });
 
-describe('resolveDefaultTimeAvailableMin', () => {
+describe('resolveDefaultTimeAvailable', () => {
   const weekdayDate = '2026-09-04'; // Friday
   const weekendDate = '2026-09-05'; // Saturday
 
-  it('falls back to 45 min on weekdays and 60 min on weekends when settings are null or undefined', () => {
-    expect(resolveDefaultTimeAvailableMin(null, weekdayDate)).toBe(45);
-    expect(resolveDefaultTimeAvailableMin(null, weekendDate)).toBe(60);
-    expect(resolveDefaultTimeAvailableMin(undefined, weekdayDate)).toBe(45);
-    expect(resolveDefaultTimeAvailableMin(undefined, weekendDate)).toBe(60);
+  it('falls back to the standard 45/60 minute defaults when preferences are unavailable', () => {
+    expect(resolveDefaultTimeAvailable(null, weekdayDate)).toEqual({
+      minutes: 45,
+      dayType: 'weekday',
+      source: 'standard_default',
+    });
+    expect(resolveDefaultTimeAvailable(undefined, weekendDate)).toEqual({
+      minutes: 60,
+      dayType: 'weekend',
+      source: 'standard_default',
+    });
   });
 
-  it('falls back to 45 min on weekdays and 60 min on weekends when settings defaults are null', () => {
-    const emptySettings = {
-      defaults: {
-        weekdayMaxMinutes: null,
-        weekendMaxMinutes: null,
-      },
-    } as unknown as TrainingSettings;
+  it('uses the canonical Default Available Duration preference for the matching day type', () => {
+    const preferences = {
+      defaultWeekdayTimeMin: 35,
+      defaultWeekendTimeMin: 105,
+    };
 
-    expect(resolveDefaultTimeAvailableMin(emptySettings, weekdayDate)).toBe(45);
-    expect(resolveDefaultTimeAvailableMin(emptySettings, weekendDate)).toBe(60);
+    expect(resolveDefaultTimeAvailable(preferences, weekdayDate)).toEqual({
+      minutes: 35,
+      dayType: 'weekday',
+      source: 'preferences',
+    });
+    expect(resolveDefaultTimeAvailable(preferences, weekendDate)).toEqual({
+      minutes: 105,
+      dayType: 'weekend',
+      source: 'preferences',
+    });
   });
 
-  it('uses configured weekdayMaxMinutes on weekdays', () => {
-    const customSettings = {
-      defaults: {
-        weekdayMaxMinutes: 30,
-        weekendMaxMinutes: 90,
-      },
-    } as unknown as TrainingSettings;
+  it('defensively falls back when an unvalidated preference duration is outside the stored contract', () => {
+    const malformedPreferences = {
+      defaultWeekdayTimeMin: 0,
+      defaultWeekendTimeMin: 1441,
+    };
 
-    expect(resolveDefaultTimeAvailableMin(customSettings, weekdayDate)).toBe(30);
-  });
-
-  it('uses configured weekendMaxMinutes on weekends', () => {
-    const customSettings = {
-      defaults: {
-        weekdayMaxMinutes: 30,
-        weekendMaxMinutes: 90,
-      },
-    } as unknown as TrainingSettings;
-
-    expect(resolveDefaultTimeAvailableMin(customSettings, weekendDate)).toBe(90);
-  });
-
-  it('uses default when specific day preference is null but the other is set', () => {
-    const partialSettings = {
-      defaults: {
-        weekdayMaxMinutes: 75,
-        weekendMaxMinutes: null,
-      },
-    } as unknown as TrainingSettings;
-
-    expect(resolveDefaultTimeAvailableMin(partialSettings, weekdayDate)).toBe(75);
-    expect(resolveDefaultTimeAvailableMin(partialSettings, weekendDate)).toBe(60);
+    expect(resolveDefaultTimeAvailableMin(malformedPreferences, weekdayDate)).toBe(45);
+    expect(resolveDefaultTimeAvailableMin(malformedPreferences, weekendDate)).toBe(60);
   });
 });

--- a/app/src/utils/checkinDefaults.test.ts
+++ b/app/src/utils/checkinDefaults.test.ts
@@ -1,0 +1,77 @@
+﻿import { describe, it, expect } from 'vitest';
+import { resolveDefaultTimeAvailableMin } from './checkinDefaults';
+import { isWeekendLocalDateString } from './localDate';
+import type { TrainingSettings } from '../engine/models';
+
+describe('isWeekendLocalDateString', () => {
+  it('identifies Saturday and Sunday as weekends', () => {
+    expect(isWeekendLocalDateString('2026-09-05')).toBe(true); // Saturday
+    expect(isWeekendLocalDateString('2026-09-06')).toBe(true); // Sunday
+  });
+
+  it('identifies Monday through Friday as weekdays', () => {
+    expect(isWeekendLocalDateString('2026-09-01')).toBe(false); // Tuesday
+    expect(isWeekendLocalDateString('2026-09-02')).toBe(false); // Wednesday
+    expect(isWeekendLocalDateString('2026-09-03')).toBe(false); // Thursday
+    expect(isWeekendLocalDateString('2026-09-04')).toBe(false); // Friday
+    expect(isWeekendLocalDateString('2026-09-07')).toBe(false); // Monday
+  });
+});
+
+describe('resolveDefaultTimeAvailableMin', () => {
+  const weekdayDate = '2026-09-04'; // Friday
+  const weekendDate = '2026-09-05'; // Saturday
+
+  it('falls back to 45 min on weekdays and 60 min on weekends when settings are null or undefined', () => {
+    expect(resolveDefaultTimeAvailableMin(null, weekdayDate)).toBe(45);
+    expect(resolveDefaultTimeAvailableMin(null, weekendDate)).toBe(60);
+    expect(resolveDefaultTimeAvailableMin(undefined, weekdayDate)).toBe(45);
+    expect(resolveDefaultTimeAvailableMin(undefined, weekendDate)).toBe(60);
+  });
+
+  it('falls back to 45 min on weekdays and 60 min on weekends when settings defaults are null', () => {
+    const emptySettings = {
+      defaults: {
+        weekdayMaxMinutes: null,
+        weekendMaxMinutes: null,
+      },
+    } as unknown as TrainingSettings;
+
+    expect(resolveDefaultTimeAvailableMin(emptySettings, weekdayDate)).toBe(45);
+    expect(resolveDefaultTimeAvailableMin(emptySettings, weekendDate)).toBe(60);
+  });
+
+  it('uses configured weekdayMaxMinutes on weekdays', () => {
+    const customSettings = {
+      defaults: {
+        weekdayMaxMinutes: 30,
+        weekendMaxMinutes: 90,
+      },
+    } as unknown as TrainingSettings;
+
+    expect(resolveDefaultTimeAvailableMin(customSettings, weekdayDate)).toBe(30);
+  });
+
+  it('uses configured weekendMaxMinutes on weekends', () => {
+    const customSettings = {
+      defaults: {
+        weekdayMaxMinutes: 30,
+        weekendMaxMinutes: 90,
+      },
+    } as unknown as TrainingSettings;
+
+    expect(resolveDefaultTimeAvailableMin(customSettings, weekendDate)).toBe(90);
+  });
+
+  it('uses default when specific day preference is null but the other is set', () => {
+    const partialSettings = {
+      defaults: {
+        weekdayMaxMinutes: 75,
+        weekendMaxMinutes: null,
+      },
+    } as unknown as TrainingSettings;
+
+    expect(resolveDefaultTimeAvailableMin(partialSettings, weekdayDate)).toBe(75);
+    expect(resolveDefaultTimeAvailableMin(partialSettings, weekendDate)).toBe(60);
+  });
+});

--- a/app/src/utils/checkinDefaults.ts
+++ b/app/src/utils/checkinDefaults.ts
@@ -1,22 +1,59 @@
-﻿import type { TrainingSettings } from '../engine/models';
+import type { UserPreferences } from '../engine/models';
 import { isWeekendLocalDateString } from './localDate';
 
+export type TimeAvailabilityPreferences = Pick<
+  UserPreferences,
+  'defaultWeekdayTimeMin' | 'defaultWeekendTimeMin'
+>;
+
+export type CheckinAvailabilityDefault = {
+  minutes: number;
+  dayType: 'weekday' | 'weekend';
+  source: 'preferences' | 'standard_default';
+};
+
+const STANDARD_WEEKDAY_MINUTES = 45;
+const STANDARD_WEEKEND_MINUTES = 60;
+
+function isValidPreferenceDuration(value: unknown): value is number {
+  return Number.isInteger(value) && typeof value === 'number' && value >= 1 && value <= 1440;
+}
+
 /**
- * Resolves the initial prefilled timeAvailableMin for daily check-in.
- * Prefers the athlete's configured settings if present, otherwise defaults
- * to 45 minutes on weekdays and 60 minutes on weekends.
+ * Resolve the initial daily-check-in availability for a brand-new check-in.
+ *
+ * `UserPreferences.default*TimeMin` is the canonical user-facing "Default Available
+ * Duration" setting. TrainingSettings' weekday/weekend max-minute fields are hard
+ * session limits and are intentionally not substituted here: a feasibility cap is not
+ * the same concept as how much time the athlete says is available today.
+ *
+ * Persisted check-ins are authoritative and must not be passed back through this resolver;
+ * callers should only use this result when constructing a new daily check-in.
  */
-export function resolveDefaultTimeAvailableMin(
-  settings: TrainingSettings | null | undefined,
-  dateStr: string
-): number {
-  const isWeekend = isWeekendLocalDateString(dateStr);
-  if (isWeekend) {
-    return typeof settings?.defaults?.weekendMaxMinutes === 'number' && settings.defaults.weekendMaxMinutes > 0
-      ? settings.defaults.weekendMaxMinutes
-      : 60;
+export function resolveDefaultTimeAvailable(
+  preferences: TimeAvailabilityPreferences | null | undefined,
+  dateStr: string,
+): CheckinAvailabilityDefault {
+  const dayType = isWeekendLocalDateString(dateStr) ? 'weekend' : 'weekday';
+  const preferredMinutes = dayType === 'weekend'
+    ? preferences?.defaultWeekendTimeMin
+    : preferences?.defaultWeekdayTimeMin;
+
+  if (isValidPreferenceDuration(preferredMinutes)) {
+    return { minutes: preferredMinutes, dayType, source: 'preferences' };
   }
-  return typeof settings?.defaults?.weekdayMaxMinutes === 'number' && settings.defaults.weekdayMaxMinutes > 0
-    ? settings.defaults.weekdayMaxMinutes
-    : 45;
+
+  return {
+    minutes: dayType === 'weekend' ? STANDARD_WEEKEND_MINUTES : STANDARD_WEEKDAY_MINUTES,
+    dayType,
+    source: 'standard_default',
+  };
+}
+
+/** Numeric compatibility helper for callers/tests that only need the resolved minutes. */
+export function resolveDefaultTimeAvailableMin(
+  preferences: TimeAvailabilityPreferences | null | undefined,
+  dateStr: string,
+): number {
+  return resolveDefaultTimeAvailable(preferences, dateStr).minutes;
 }

--- a/app/src/utils/checkinDefaults.ts
+++ b/app/src/utils/checkinDefaults.ts
@@ -16,7 +16,10 @@ const STANDARD_WEEKDAY_MINUTES = 45;
 const STANDARD_WEEKEND_MINUTES = 60;
 
 function isValidPreferenceDuration(value: unknown): value is number {
-  return Number.isInteger(value) && typeof value === 'number' && value >= 1 && value <= 1440;
+  return typeof value === 'number'
+    && Number.isInteger(value)
+    && value >= 1
+    && value <= 1440;
 }
 
 /**

--- a/app/src/utils/checkinDefaults.ts
+++ b/app/src/utils/checkinDefaults.ts
@@ -1,0 +1,22 @@
+﻿import type { TrainingSettings } from '../engine/models';
+import { isWeekendLocalDateString } from './localDate';
+
+/**
+ * Resolves the initial prefilled timeAvailableMin for daily check-in.
+ * Prefers the athlete's configured settings if present, otherwise defaults
+ * to 45 minutes on weekdays and 60 minutes on weekends.
+ */
+export function resolveDefaultTimeAvailableMin(
+  settings: TrainingSettings | null | undefined,
+  dateStr: string
+): number {
+  const isWeekend = isWeekendLocalDateString(dateStr);
+  if (isWeekend) {
+    return typeof settings?.defaults?.weekendMaxMinutes === 'number' && settings.defaults.weekendMaxMinutes > 0
+      ? settings.defaults.weekendMaxMinutes
+      : 60;
+  }
+  return typeof settings?.defaults?.weekdayMaxMinutes === 'number' && settings.defaults.weekdayMaxMinutes > 0
+    ? settings.defaults.weekdayMaxMinutes
+    : 45;
+}

--- a/app/src/utils/localDate.ts
+++ b/app/src/utils/localDate.ts
@@ -65,3 +65,13 @@ export function getDayDiff(dateStrA: string, dateStrB: string): number {
     const utcB = toUtcMidnight(dateStrB);
     return Math.round((utcA - utcB) / (24 * 60 * 60 * 1000));
 }
+
+/**
+ * Determines whether a Warsaw-local YYYY-MM-DD calendar date is a weekend (Saturday or Sunday).
+ * Uses UTC date components so timezone transitions or local runtime offsets cannot shift the day.
+ */
+export function isWeekendLocalDateString(dateStr: string): boolean {
+    const [yearPart, monthPart, dayPart] = dateStr.split('-').map(Number);
+    const day = new Date(Date.UTC(yearPart, monthPart - 1, dayPart)).getUTCDay();
+    return day === 0 || day === 6;
+}


### PR DESCRIPTION
## Overview

This PR improves two athlete-facing setup/workflow paths:

1. **Daily Check-in available-time prefill** — a brand-new daily check-in now starts from the athlete's canonical **Preferences → Default Available Duration** (`defaultWeekdayTimeMin` / `defaultWeekendTimeMin`), with a defensive 45-minute weekday / 60-minute weekend fallback when preferences cannot be read.
2. **Onboarding exercise-days slider** — replaces the old 3–10 sessions/week pill buttons with a native 1–7 **days/week** range input and makes the translation from exercise days to the planner's session-based weekly commitment explicit.

## Review hardening applied

### Daily Check-in

- Uses `UserPreferences.defaultWeekdayTimeMin/defaultWeekendTimeMin` as the prefill authority. These are the fields the Preferences UI labels **Default Available Duration**.
- Does **not** substitute `TrainingSettings.defaults.weekdayMaxMinutes/weekendMaxMinutes`; those are session feasibility **limits**, not the same concept as an athlete's default daily availability.
- Applies the default **only when constructing a brand-new daily check-in**.
- Treats any persisted check-in as authoritative thereafter, including a deliberate custom value or an explicit `null`/cleared value. This prevents a partial tissue-follow-up write from causing a cleared time value to be silently repopulated on reload.
- Shows provenance text only when this render actually initialized a new check-in: either the matching weekday/weekend preference or the standard fallback.
- Keeps Warsaw-local weekday/weekend classification in the shared `localDate` utility.

### Onboarding

- Replaces the old session pills with a native `<input type="range" min="1" max="7" step="1">`.
- Uses the visible `<label>` as the slider's accessible name and marks visual tick labels as decorative.
- Makes endpoints unambiguous (`1 day` / `7 days`) instead of `1 min` / `7 max`.
- Renames internal state to `exerciseDaysPerWeek` so the code matches the user-facing question.
- Moves `weeklyCommitmentFromExerciseDays()` into a non-component onboarding module and documents the domain mapping:
  - target sessions = available exercise days;
  - minimum = target − 1 (floor 1);
  - maximum = target + 1 (schema permits up to 14), so the extra session can represent one double-session day rather than inventing an eighth available day.
- Removes the test-only `initialStep` prop from production `OnboardingWizard` and tests the focused slider component directly.

## Tests

- `checkinDefaults.test.ts`
  - Warsaw-local weekday/weekend classification;
  - canonical preference selection;
  - 45/60 fallback behavior;
  - defensive rejection of out-of-contract duration values.
- `OnboardingWizard.test.tsx`
  - normal onboarding entry screen;
  - native 1–7 slider bounds and visible label association;
  - singular/plural day copy and explicit endpoint wording;
  - days → weekly session commitment mapping and clamping.

## Validation

Latest head: `97cd4a80d023d3f127942d3332f505cb7f95f51a`.

**CI Pipeline #2339: PASS**

- Frontend typecheck + ESLint: pass
- Sports knowledge registry / engine knowledge coverage / workout validation / policy-drift checks: pass
- Frontend Vitest suite with coverage: pass
- Firestore security-rule emulator suite: pass
- Simulation aggregate-bounds gate + AI judge corpus + persona corpus: pass
- Frontend bundle + dependency audit: pass
- Python hygiene / ruff / mypy / pytest / dependency audit: pass
- Docker build + Compose smoke / routing / healthchecks: pass

## Scope note

This PR intentionally does **not** merge the Preferences default-duration model with Training Settings session limits. They represent different concepts in the current domain model; conflating them here would make a convenience prefill capable of changing feasibility semantics.