### PR TITLE
fix(auth): isolate newcomer onboarding and screen state across accounts

### DIFF
--- a/app/src/AccountScopedApp.tsx
+++ b/app/src/AccountScopedApp.tsx
@@ -1,0 +1,13 @@
+import App from './App';
+import { useAuth } from './contexts/AuthContext';
+
+export function AccountScopedApp() {
+  const { userId } = useAuth();
+
+  // React preserves state for a component rendered at the same tree position. Make the
+  // authenticated identity part of App's position so an account transition destroys the
+  // previous account's entire UI/state subtree, including stale async callback targets.
+  // Keep all unauthenticated auth phases on one key so auth bootstrap cannot reset login UI.
+  const accountStateKey = userId ? `user:${userId}` : 'anonymous';
+  return <App key={accountStateKey} />;
+}

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -34,6 +34,8 @@ const ManualSessionBuilder = lazy(() => import('./components/session/ManualSessi
 const SessionJsonImport = lazy(() => import('./components/session/SessionJsonImport').then(m => ({ default: m.SessionJsonImport })));
 const TestingWorkflow = lazy(() => import('./components/testing/TestingWorkflow').then(m => ({ default: m.TestingWorkflow })));
 
+import { getOnboardingDoneStorageKey, isOnboardingDismissedForUser } from './utils/onboardingStorage';
+
 function App() {
   const { userId, authPhase } = useAuth();
   const [screen, setScreen] = useState<Screen>('home');
@@ -56,14 +58,7 @@ function App() {
   const [sessionAuthoringMode, setSessionAuthoringMode] = useState<'import' | 'manual' | null>(null);
   const [sessionAuthoringDefinition, setSessionAuthoringDefinition] = useState<SessionDefinition | null>(null);
   const [sessionLaunch, setSessionLaunch] = useState<PreparedSessionLaunch | null>(null);
-  const [onboardingDismissed, setOnboardingDismissed] = useState(() => {
-    if (typeof window === 'undefined') return false;
-    try {
-      return window.localStorage.getItem('adaptive_training_onboarding_done') === 'true';
-    } catch {
-      return false;
-    }
-  });
+  const [onboardingDismissed, setOnboardingDismissed] = useState(() => isOnboardingDismissedForUser(userId));
 
   const loadDecisionInput = useCallback(async () => {
     if (!userId) return;
@@ -160,6 +155,12 @@ function App() {
     // the prior account's in-progress definition under its own identity.
     setSessionAuthoringMode(null);
     setSessionAuthoringDefinition(null);
+    setSessionLaunch(null);
+    setDesktopSettingsOpen(false);
+    setMobileMoreOpen(false);
+    currentScreenRef.current = 'home';
+    setScreen('home');
+    setOnboardingDismissed(isOnboardingDismissedForUser(userId));
     if (!userId || authPhase !== 'AUTHENTICATED') return;
     let cancelled = false;
     Promise.allSettled([
@@ -301,7 +302,7 @@ function App() {
               onCompleted={() => {
                 setOnboardingDismissed(true);
                 try {
-                  window.localStorage.setItem('adaptive_training_onboarding_done', 'true');
+                  window.localStorage.setItem(getOnboardingDoneStorageKey(userId), 'true');
                 } catch {
                   // Ignore localStorage unavailable errors
                 }
@@ -312,7 +313,7 @@ function App() {
 
           {screen === 'home' && (
             <Home
-              key={dailyViewDate}
+              key={`${userId}:${dailyViewDate}`}
               userId={userId!}
               onNavigate={handleNavigate}
               onViewData={() => {
@@ -339,6 +340,7 @@ function App() {
           {screen === 'data' && (
             <>
               <DataView
+                key={userId}
                 decisionInput={decisionInput}
                 userId={userId!}
                 onBack={() => handleNavigate('home')}
@@ -358,6 +360,7 @@ function App() {
 
           {screen === 'brief' && (
             <DataView
+              key={userId}
               decisionInput={decisionInput}
               userId={userId!}
               initialTab="brief"
@@ -367,7 +370,7 @@ function App() {
 
           {screen === 'checkin' && (
             <DailyCheckin
-              key={dailyViewDate}
+              key={`${userId}:${dailyViewDate}`}
               userId={userId!}
               onNavigate={handleNavigate}
               onBack={() => handleNavigate('home')}
@@ -376,20 +379,21 @@ function App() {
           )}
 
           {screen === 'goals' && (
-            <Goals userId={userId!} onNavigate={handleNavigate} />
+            <Goals key={userId} userId={userId!} onNavigate={handleNavigate} />
           )}
 
           {screen === 'constraints' && (
-            <TrainingSettings userId={userId!} />
+            <TrainingSettings key={userId} userId={userId!} />
           )}
 
           {screen === 'preferences' && (
-            <Preferences userId={userId!} onNavigate={handleNavigate} />
+            <Preferences key={userId} userId={userId!} onNavigate={handleNavigate} />
           )}
 
           {screen === 'sessions' && (
             sessionAuthoringMode === 'import' ? (
               <SessionJsonImport
+                key={userId}
                 userId={userId!}
                 onClose={() => setSessionAuthoringMode(null)}
                 onStartExecution={session => {
@@ -399,6 +403,7 @@ function App() {
               />
             ) : sessionAuthoringMode === 'manual' ? (
               <ManualSessionBuilder
+                key={userId}
                 userId={userId!}
                 initialDefinition={sessionAuthoringDefinition ?? undefined}
                 onClose={() => {
@@ -414,6 +419,7 @@ function App() {
             ) : (
               <div className="sessions-screen-container">
                 <SessionRunner
+                  key={userId}
                   userId={userId!}
                   initialSession={sessionLaunch ?? undefined}
                   onInitialSessionHandled={() => setSessionLaunch(null)}
@@ -429,7 +435,7 @@ function App() {
                   onClose={() => handleNavigate('home')}
                 />
                 <div className="dashboard-card strength-history-card" style={{ marginTop: '1.5rem' }}>
-                  <StrengthOverloadHistory userId={userId!} />
+                  <StrengthOverloadHistory key={userId} userId={userId!} />
                 </div>
               </div>
             )
@@ -437,6 +443,7 @@ function App() {
 
           {screen === 'testing' && (
             <TestingWorkflow
+              key={userId}
               userId={userId!}
               onSessionStateChange={session => {
                 setActiveStructuredSession(session?.state === 'in_progress' ? session : null);
@@ -448,6 +455,7 @@ function App() {
 
           {screen === 'plan' && (
             <PlanView
+              key={userId}
               userId={userId!}
               onNavigate={handleNavigate}
               onPlanChanged={() => {

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -1,13 +1,13 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
-import App from './App.tsx'
+import { AccountScopedApp } from './AccountScopedApp.tsx'
 import { AuthProvider } from './contexts/AuthContext.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <AuthProvider>
-      <App />
+      <AccountScopedApp />
     </AuthProvider>
   </StrictMode>,
 )

--- a/app/src/utils/onboardingStorage.test.ts
+++ b/app/src/utils/onboardingStorage.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { getOnboardingDoneStorageKey, isOnboardingDismissedForUser } from './onboardingStorage';
+
+describe('onboardingStorage user isolation', () => {
+  const storage = new Map<string, string>();
+  const localStorageMock = {
+    getItem: (key: string) => storage.get(key) ?? null,
+    setItem: (key: string, value: string) => storage.set(key, String(value)),
+    removeItem: (key: string) => storage.delete(key),
+    clear: () => storage.clear(),
+  };
+
+  beforeEach(() => {
+    storage.clear();
+    vi.stubGlobal('window', { localStorage: localStorageMock });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('generates distinct localStorage keys for different user IDs', () => {
+    const keyUser1 = getOnboardingDoneStorageKey('firebase-uid-a');
+    const keyUser2 = getOnboardingDoneStorageKey('firebase-uid-b');
+
+    expect(keyUser1).toBe('adaptive_training_onboarding_done_firebase-uid-a');
+    expect(keyUser2).toBe('adaptive_training_onboarding_done_firebase-uid-b');
+    expect(keyUser1).not.toBe(keyUser2);
+  });
+
+  it('returns false for null or empty user IDs', () => {
+    expect(isOnboardingDismissedForUser(null)).toBe(false);
+    expect(isOnboardingDismissedForUser('')).toBe(false);
+  });
+
+  it('returns false when user has not completed or dismissed onboarding', () => {
+    expect(isOnboardingDismissedForUser('firebase-uid-new')).toBe(false);
+  });
+
+  it('returns true only when the specific user has dismissed onboarding', () => {
+    window.localStorage.setItem(getOnboardingDoneStorageKey('firebase-uid-a'), 'true');
+
+    expect(isOnboardingDismissedForUser('firebase-uid-a')).toBe(true);
+    expect(isOnboardingDismissedForUser('firebase-uid-b')).toBe(false);
+  });
+
+  it('does not treat a newcomer as onboarded when legacy global key exists', () => {
+    // Legacy global key without userId
+    window.localStorage.setItem('adaptive_training_onboarding_done', 'true');
+
+    // A newly created account must evaluate to false, not true
+    expect(isOnboardingDismissedForUser('firebase-uid-newcomer')).toBe(false);
+  });
+
+  it('preserves user isolation across multi-user login and logout sequence', () => {
+    const userA = 'firebase-uid-account-a';
+    const userB = 'firebase-uid-account-b';
+
+    // User A signs up and completes onboarding
+    expect(isOnboardingDismissedForUser(userA)).toBe(false);
+    window.localStorage.setItem(getOnboardingDoneStorageKey(userA), 'true');
+    expect(isOnboardingDismissedForUser(userA)).toBe(true);
+
+    // User A signs out (userId is null)
+    expect(isOnboardingDismissedForUser(null)).toBe(false);
+
+    // User B signs up: must NOT inherit User A's onboarding completion
+    expect(isOnboardingDismissedForUser(userB)).toBe(false);
+
+    // User B later completes onboarding
+    window.localStorage.setItem(getOnboardingDoneStorageKey(userB), 'true');
+    expect(isOnboardingDismissedForUser(userB)).toBe(true);
+  });
+});

--- a/app/src/utils/onboardingStorage.ts
+++ b/app/src/utils/onboardingStorage.ts
@@ -1,0 +1,12 @@
+export function getOnboardingDoneStorageKey(userId: string): string {
+  return `adaptive_training_onboarding_done_${userId}`;
+}
+
+export function isOnboardingDismissedForUser(userId: string | null): boolean {
+  if (!userId || typeof window === 'undefined') return false;
+  try {
+    return window.localStorage.getItem(getOnboardingDoneStorageKey(userId)) === 'true';
+  } catch {
+    return false;
+  }
+}

--- a/docs/architecture/account-scoped-ui-state.md
+++ b/docs/architecture/account-scoped-ui-state.md
@@ -1,0 +1,63 @@
+# Account-scoped UI state
+
+## Invariant
+
+Authenticated browser state must be isolated by the Firebase Authentication `uid`.
+A sign-out, direct account switch, or sign-in as a different user must not preserve UI
+state from the previous authenticated identity.
+
+This applies to both persisted browser state and in-memory React state.
+
+## Persisted browser state
+
+Any `localStorage` or similar browser preference that represents user progress must include
+the authenticated `uid` in its storage key (or store an explicitly user-keyed value).
+
+Newcomer onboarding currently follows this rule through
+`app/src/utils/onboardingStorage.ts`:
+
+- `adaptive_training_onboarding_done_<uid>` is account-scoped.
+- the former global `adaptive_training_onboarding_done` key is intentionally **not** treated
+  as proof that a newly authenticated user completed onboarding;
+- code must not migrate that global value to whichever user signs in next, because its owner
+  cannot be determined safely.
+
+## In-memory React state
+
+`app/src/main.tsx` renders `AccountScopedApp`, and `app/src/AccountScopedApp.tsx` keys `App`
+by the current Firebase `uid`, with one shared `anonymous` key while no user is authenticated.
+
+Changing identity therefore replaces the whole `App` subtree instead of relying only on a
+list of manual resets. Moving between unauthenticated auth-bootstrap phases does not remount
+the login UI. This is deliberate: account-scoped state includes navigation, forms,
+active-session UI, authoring state, onboarding state, and callback closures owned by child
+components. A stale asynchronous callback from the old subtree can finish, but its React
+state updates target the unmounted old `App` instance rather than the new account's instance.
+
+Individual screen keys and explicit reset/cancellation guards remain useful defense in depth,
+especially for date-scoped state and asynchronous reads.
+
+## Service boundary
+
+A React remount does not cancel external side effects. Services that read or write user data
+must therefore continue to receive the intended `uid` explicitly and persist beneath that
+user's data boundary. Do not make account ownership depend on mutable screen state or on a
+legacy global browser key.
+
+## Regression scenario
+
+When changing this area, preserve at least this behavior:
+
+1. User A signs in and completes/dismisses onboarding.
+2. User A navigates away from the initial screen and may have in-flight UI work.
+3. User A signs out (or the auth observer switches directly to another identity).
+4. User B signs in on the same browser and same calendar day.
+5. User B starts with a fresh account-scoped UI tree and does not inherit User A's onboarding
+   completion, navigation, form/session state, or browser persistence.
+
+The storage-level portion is covered by `app/src/utils/onboardingStorage.test.ts`.
+
+## References
+
+- React: *Preserving and Resetting State* — https://react.dev/learn/preserving-and-resetting-state
+- Firebase Authentication: *Manage Users in Firebase* — https://firebase.google.com/docs/auth/web/manage-users


### PR DESCRIPTION
## Summary
Fixes cross-account leakage of newcomer onboarding and authenticated UI state when another account signs in in the same browser.

The original bug was broader than the persisted onboarding flag: leaf screen keys and manual state resets alone cannot prevent a stale async callback owned by the previous account from completing after an identity switch and mutating the still-mounted parent `App` state.

## Root causes
1. **Global onboarding persistence** — `adaptive_training_onboarding_done` was shared by every browser user, so one account could suppress onboarding for a later newcomer.
2. **In-memory state retention** — `App` remained the same React state owner across Firebase identity changes.
3. **Partial component lifecycle isolation** — date-only/identity-agnostic screen keys could retain form/session state when users switched on the same day.
4. **Stale callback boundary** — resetting known state fields does not cover every async callback closure from the old account subtree.

## Changes
- **UID-scoped onboarding persistence**
  - Added `app/src/utils/onboardingStorage.ts`.
  - Completion is stored as `adaptive_training_onboarding_done_<firebase uid>`.
  - The legacy global key is deliberately **not migrated** to the next user because its owner cannot be determined safely.
- **Account-scoped React state root**
  - Added `app/src/AccountScopedApp.tsx`.
  - `App` is keyed by `user:<uid>` and uses one shared `anonymous` key while signed out.
  - A UID change therefore destroys the previous account's complete `App` subtree, including stale child callback targets, while unauthenticated auth-bootstrap phases do not remount the login UI.
  - The boundary lives outside `main.tsx` to satisfy the repository's Fast Refresh lint rule.
- **Defense in depth in `App.tsx`**
  - Re-evaluate onboarding state for the active UID.
  - Reset navigation, authoring, launch, modal, and active-session state on identity/auth transitions.
  - Keep request-revision/cancellation guards for async decision/session reads.
  - Key account-sensitive screens by UID (and date where applicable).
- **Tests**
  - Added scoped-key, newcomer, legacy-key, and multi-account login/logout coverage.
  - Test identities are opaque Firebase-style UID fixtures rather than email-like account identifiers.
- **Architecture docs**
  - Added `docs/architecture/account-scoped-ui-state.md` documenting the persisted-state, React-state, async-service, and legacy-key invariants plus the regression scenario.

## Review notes
- Production `userId` is Firebase Authentication `uid`, not an email address.
- `OnboardingWizard` service writes already receive the intended `userId` explicitly; the root keyed boundary fixes the separate in-memory stale-callback problem and does not replace explicit UID scoping for external writes.
- React's documented keyed-state semantics are intentionally used here to reset the complete authenticated subtree on identity change.

## Verification
CI Pipeline run **#2357** passed all three jobs on final PR head `f7424d9`:
- Frontend typecheck + ESLint
- sports-knowledge / engine-coverage / workout-library / policy-drift validation
- full frontend Vitest coverage suite
- Firestore security-rule emulator suite
- simulation aggregate gate + deterministic AI/persona judge gates + semantic diff
- production frontend bundle
- Node dependency audit
- Python lint/format/typecheck/pytest/dependency audit
- Docker build, Compose healthchecks, and full-stack smoke routing/headers

The branch is intentionally squashed to one commit on the current `main` base.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Account-specific UI state now prevents onboarding status and session settings from carrying over between users.
  - Switching accounts resets the session view and returns the app to Home.
  - Daily Home and Check-in views refresh automatically when the date changes.

- **Documentation**
  - Added guidance on account-scoped UI state and account-switching behavior.

- **Tests**
  - Added coverage confirming onboarding dismissal remains isolated between accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->