### PR TITLE
fix(auth): allow unverified email accounts to check garmin status for wearable-free mode

### DIFF
--- a/docs/reviews/2026-09-04-pr-396-auth-garmin-status-review.md
+++ b/docs/reviews/2026-09-04-pr-396-auth-garmin-status-review.md
@@ -1,0 +1,42 @@
+# PR #396 review — Garmin status for unverified email accounts
+
+**Date:** 2026-09-04  
+**PR:** #396 — `fix(auth): allow unverified email accounts to check garmin status for wearable-free mode`
+
+## Problem
+
+Email/password signup is intentionally non-blocking with respect to email verification. A newly created Firebase password account is authenticated immediately and may use UID-scoped app data while the verification email is still pending.
+
+Garmin wearable-free planning, however, needs a canonical answer to a narrower question: **is this authenticated UID linked to Garmin?** The status endpoint previously reused the same helper policy as Garmin credential linking, so an unverified password account received HTTP 401 before the connection state could be reconciled. The frontend therefore retained `unknown` rather than `disconnected` and failed closed instead of entering subjective-only planning.
+
+## Security decision
+
+The fix is intentionally operation-scoped:
+
+- Firebase ID tokens are still verified server-side with `check_revoked=True` before a UID is accepted.
+- `POST /api/garmin/status` may accept an authenticated password session whose `email_verified` claim is false because the UID comes only from the validated token and the operation can only reconcile that UID's Garmin connection state/non-secret mirror.
+- Garmin credential binding remains stricter: `POST /api/garmin/login`, when linking to an existing authenticated app user, still requires verified email ownership.
+- The shared auth helper remains **verification-required by default**. The status handler must opt out explicitly with `require_verified_email=False`; linking opts in explicitly with `True`. This avoids turning the bug fix into a permissive default for future call sites.
+- A missing, malformed, expired, disabled, or revoked Firebase session is still rejected. The wearable-free exception is not anonymous access.
+
+This follows the repository's existing trust model from PR #393: email verification is not a global client-side authorization gate, but capabilities that truly bind an external identity may enforce `email_verified` at the backend boundary.
+
+## Regression coverage
+
+The tests now lock down both sides of the policy boundary:
+
+1. `_verified_uid()` rejects an unverified password user by default.
+2. The helper permits that user only when email verification is explicitly not required.
+3. `/api/garmin/status` explicitly requests the unverified-safe policy and still checks token revocation.
+4. The status endpoint returns the reconciled disconnected state for an authenticated newcomer, enabling wearable-free mode.
+5. `/api/garmin/login` continues to request verified-email enforcement.
+
+## External references
+
+- Firebase Authentication — Manage user sessions / revoked ID-token verification: https://firebase.google.com/docs/auth/admin/manage-sessions
+- Firebase Authentication — Admin Auth / ID-token verification: https://firebase.google.com/docs/auth/admin
+- OWASP Authorization Cheat Sheet — least privilege, deny by default, validate authorization on every request: https://cheatsheetseries.owasp.org/cheatsheets/Authorization_Cheat_Sheet.html
+
+## Review conclusion
+
+Allowing an unverified but authenticated Firebase password account to reconcile its own Garmin connection status is appropriate for wearable-free onboarding. The important constraint is to keep that exception local to status reconciliation and preserve verified-email enforcement as the default for external-account linking or other higher-trust operations.

--- a/docs/reviews/2026-09-04-pr-396-auth-garmin-status-review.md
+++ b/docs/reviews/2026-09-04-pr-396-auth-garmin-status-review.md
@@ -1,6 +1,6 @@
 # PR #396 review — Garmin status for unverified email accounts
 
-**Date:** 2026-09-04  
+**Date:** 2026-09-04
 **PR:** #396 — `fix(auth): allow unverified email accounts to check garmin status for wearable-free mode`
 
 ## Problem

--- a/src/garmin_sync/account_link_api.py
+++ b/src/garmin_sync/account_link_api.py
@@ -82,8 +82,15 @@ def _service() -> GarminAccountLinkService:
 def _verified_uid(
     authorization: str | None,
     *,
-    require_verified_email: bool = False,
+    require_verified_email: bool = True,
 ) -> str | None:
+    """Return the UID from a valid, unrevoked app token.
+
+    Password-provider sessions require verified email ownership by default. Callers may
+    opt out only when the operation is safe for an authenticated-but-unverified account;
+    Garmin status reconciliation is one such case because it is scoped solely by the UID
+    from the validated token and cannot bind external credentials to that UID.
+    """
     if not authorization:
         return None
     scheme, _, token = authorization.partition(" ")
@@ -259,7 +266,10 @@ class GarminAccountLinkHandler(BaseJSONRequestHandler):
             )
 
     def _handle_status(self) -> None:
-        uid = _verified_uid(self.headers.get("Authorization"))
+        uid = _verified_uid(
+            self.headers.get("Authorization"),
+            require_verified_email=False,
+        )
         if not uid:
             raise GarminConnectAuthenticationError("App authentication is required.")
         result = reconcile_garmin_connection_status(uid)

--- a/src/garmin_sync/account_link_api.py
+++ b/src/garmin_sync/account_link_api.py
@@ -79,7 +79,11 @@ def _service() -> GarminAccountLinkService:
         return _SERVICE
 
 
-def _verified_uid(authorization: str | None) -> str | None:
+def _verified_uid(
+    authorization: str | None,
+    *,
+    require_verified_email: bool = False,
+) -> str | None:
     if not authorization:
         return None
     scheme, _, token = authorization.partition(" ")
@@ -96,7 +100,11 @@ def _verified_uid(authorization: str | None) -> str | None:
     sign_in_provider = (
         firebase_claim.get("sign_in_provider") if isinstance(firebase_claim, dict) else None
     )
-    if sign_in_provider == "password" and decoded.get("email_verified") is not True:
+    if (
+        require_verified_email
+        and sign_in_provider == "password"
+        and decoded.get("email_verified") is not True
+    ):
         raise GarminConnectAuthenticationError("Verify your email before linking Garmin.")
     return str(uid)
 
@@ -281,7 +289,10 @@ class GarminAccountLinkHandler(BaseJSONRequestHandler):
                 retryable=True,
             )
             return
-        requested_uid = _verified_uid(self.headers.get("Authorization"))
+        requested_uid = _verified_uid(
+            self.headers.get("Authorization"),
+            require_verified_email=True,
+        )
         result = _service().start_login(email, password, requested_uid=requested_uid)
         self._json_response(HTTPStatus.OK, result)
 

--- a/tests/test_account_link_api.py
+++ b/tests/test_account_link_api.py
@@ -122,7 +122,7 @@ def test_handle_login_requires_verified_email_for_authenticated_link(monkeypatch
     def mock_verified_uid(
         authorization: str | None,
         *,
-        require_verified_email: bool = True,
+        require_verified_email: bool,
     ) -> str:
         assert authorization == "Bearer app-token"
         policies.append(require_verified_email)

--- a/tests/test_account_link_api.py
+++ b/tests/test_account_link_api.py
@@ -103,6 +103,53 @@ def test_handle_login_enforces_per_account_rate_limiting(monkeypatch: Any) -> No
     assert captured_errors[0]["error_code"] == "garmin_link.rate_limited"
 
 
+def test_handle_login_requires_verified_email_for_authenticated_link(monkeypatch: Any) -> None:
+    handler = object.__new__(GarminAccountLinkHandler)
+    handler.headers = {"Authorization": "Bearer app-token"}  # type: ignore[assignment]
+    handler.client_address = ("127.0.0.1", 12345)
+    handler._read_json = lambda: {"email": "athlete@example.com", "password": "secret"}  # type: ignore[method-assign]  # noqa: SLF001
+    captured: list[tuple[HTTPStatus, dict[str, Any]]] = []
+    handler._json_response = lambda status, payload: captured.append(  # type: ignore[method-assign]  # noqa: SLF001
+        (status, payload)
+    )
+
+    limiter = LoginRateLimiter()
+    monkeypatch.setattr(limiter, "allow", lambda _key: True)
+    monkeypatch.setattr(account_link_api, "RATE_LIMITER", limiter)
+
+    policies: list[bool] = []
+
+    def mock_verified_uid(
+        authorization: str | None,
+        *,
+        require_verified_email: bool = True,
+    ) -> str:
+        assert authorization == "Bearer app-token"
+        policies.append(require_verified_email)
+        return "uid-1"
+
+    class _Service:
+        def start_login(
+            self,
+            email: str,
+            password: str,
+            *,
+            requested_uid: str | None,
+        ) -> dict[str, Any]:
+            assert email == "athlete@example.com"
+            assert password == "secret"
+            assert requested_uid == "uid-1"
+            return {"status": "authenticated"}
+
+    monkeypatch.setattr(account_link_api, "_verified_uid", mock_verified_uid)
+    monkeypatch.setattr(account_link_api, "_service", lambda: _Service())
+
+    handler._handle_login()  # noqa: SLF001
+
+    assert policies == [True]
+    assert captured == [(HTTPStatus.OK, {"status": "authenticated"})]
+
+
 def test_verified_uid_raises_authentication_error_on_verify_id_token_exception(
     monkeypatch: Any,
 ) -> None:
@@ -148,13 +195,12 @@ def test_verified_uid_allows_unverified_password_user_when_email_verification_no
 
     monkeypatch.setattr(account_link_api.firebase_auth, "verify_id_token", mock_verify_id_token)
 
-    assert (
-        account_link_api._verified_uid(
-            "Bearer valid-token",
-            require_verified_email=False,
-        )
-        == "uid-1"
-    )  # noqa: SLF001
+    uid = account_link_api._verified_uid(  # noqa: SLF001
+        "Bearer valid-token",
+        require_verified_email=False,
+    )
+
+    assert uid == "uid-1"
 
 
 def test_log_message_redacts_query_parameters(monkeypatch: Any) -> None:

--- a/tests/test_account_link_api.py
+++ b/tests/test_account_link_api.py
@@ -118,7 +118,7 @@ def test_verified_uid_raises_authentication_error_on_verify_id_token_exception(
         account_link_api._verified_uid("Bearer any-token")  # noqa: SLF001
 
 
-def test_verified_uid_checks_revocation_and_rejects_unverified_password_user(
+def test_verified_uid_checks_revocation_and_rejects_unverified_password_user_when_required(
     monkeypatch: Any,
 ) -> None:
     def mock_verify_id_token(token: str, *, check_revoked: bool) -> dict[str, Any]:
@@ -133,7 +133,27 @@ def test_verified_uid_checks_revocation_and_rejects_unverified_password_user(
     monkeypatch.setattr(account_link_api.firebase_auth, "verify_id_token", mock_verify_id_token)
 
     with pytest.raises(GarminConnectAuthenticationError, match="Verify your email"):
-        account_link_api._verified_uid("Bearer valid-token")  # noqa: SLF001
+        account_link_api._verified_uid(
+            "Bearer valid-token",
+            require_verified_email=True,
+        )  # noqa: SLF001
+
+
+def test_verified_uid_allows_unverified_password_user_when_email_verification_not_required(
+    monkeypatch: Any,
+) -> None:
+    def mock_verify_id_token(token: str, *, check_revoked: bool) -> dict[str, Any]:
+        assert token == "valid-token"
+        assert check_revoked is True
+        return {
+            "uid": "uid-1",
+            "email_verified": False,
+            "firebase": {"sign_in_provider": "password"},
+        }
+
+    monkeypatch.setattr(account_link_api.firebase_auth, "verify_id_token", mock_verify_id_token)
+
+    assert account_link_api._verified_uid("Bearer valid-token") == "uid-1"  # noqa: SLF001
 
 
 def test_log_message_redacts_query_parameters(monkeypatch: Any) -> None:

--- a/tests/test_account_link_api.py
+++ b/tests/test_account_link_api.py
@@ -118,9 +118,7 @@ def test_verified_uid_raises_authentication_error_on_verify_id_token_exception(
         account_link_api._verified_uid("Bearer any-token")  # noqa: SLF001
 
 
-def test_verified_uid_checks_revocation_and_rejects_unverified_password_user_when_required(
-    monkeypatch: Any,
-) -> None:
+def test_verified_uid_rejects_unverified_password_user_by_default(monkeypatch: Any) -> None:
     def mock_verify_id_token(token: str, *, check_revoked: bool) -> dict[str, Any]:
         assert token == "valid-token"
         assert check_revoked is True
@@ -133,10 +131,7 @@ def test_verified_uid_checks_revocation_and_rejects_unverified_password_user_whe
     monkeypatch.setattr(account_link_api.firebase_auth, "verify_id_token", mock_verify_id_token)
 
     with pytest.raises(GarminConnectAuthenticationError, match="Verify your email"):
-        account_link_api._verified_uid(
-            "Bearer valid-token",
-            require_verified_email=True,
-        )  # noqa: SLF001
+        account_link_api._verified_uid("Bearer valid-token")  # noqa: SLF001
 
 
 def test_verified_uid_allows_unverified_password_user_when_email_verification_not_required(
@@ -153,7 +148,13 @@ def test_verified_uid_allows_unverified_password_user_when_email_verification_no
 
     monkeypatch.setattr(account_link_api.firebase_auth, "verify_id_token", mock_verify_id_token)
 
-    assert account_link_api._verified_uid("Bearer valid-token") == "uid-1"  # noqa: SLF001
+    assert (
+        account_link_api._verified_uid(
+            "Bearer valid-token",
+            require_verified_email=False,
+        )
+        == "uid-1"
+    )  # noqa: SLF001
 
 
 def test_log_message_redacts_query_parameters(monkeypatch: Any) -> None:

--- a/tests/test_garmin_connection_status.py
+++ b/tests/test_garmin_connection_status.py
@@ -107,7 +107,16 @@ def test_status_handler_requires_authenticated_app_user(monkeypatch: Any) -> Non
         account_link_api.GarminAccountLinkHandler
     )
     handler.headers = {}  # type: ignore[assignment]
-    monkeypatch.setattr(account_link_api, "_verified_uid", lambda _authorization: None)
+
+    def mock_verified_uid(
+        _authorization: str | None,
+        *,
+        require_verified_email: bool,
+    ) -> None:
+        assert require_verified_email is False
+        return None
+
+    monkeypatch.setattr(account_link_api, "_verified_uid", mock_verified_uid)
 
     with pytest.raises(account_link_api.GarminConnectAuthenticationError, match="required"):
         handler._handle_status()  # noqa: SLF001 - endpoint contract regression
@@ -123,7 +132,16 @@ def test_status_handler_returns_reconciled_status(monkeypatch: Any) -> None:
         (status, payload)
     )
 
-    monkeypatch.setattr(account_link_api, "_verified_uid", lambda _authorization: "uid-1")
+    def mock_verified_uid(
+        authorization: str | None,
+        *,
+        require_verified_email: bool,
+    ) -> str:
+        assert authorization == "Bearer app-token"
+        assert require_verified_email is False
+        return "uid-1"
+
+    monkeypatch.setattr(account_link_api, "_verified_uid", mock_verified_uid)
     monkeypatch.setattr(
         account_link_api,
         "reconcile_garmin_connection_status",
@@ -152,6 +170,8 @@ def test_status_handler_allows_unverified_password_user(monkeypatch: Any) -> Non
     )
 
     def mock_verify_id_token(token: str, *, check_revoked: bool) -> dict[str, Any]:
+        assert token == "app-token"
+        assert check_revoked is True
         return {
             "uid": "uid-1",
             "email_verified": False,

--- a/tests/test_garmin_connection_status.py
+++ b/tests/test_garmin_connection_status.py
@@ -141,6 +141,35 @@ def test_status_handler_returns_reconciled_status(monkeypatch: Any) -> None:
     ]
 
 
+def test_status_handler_allows_unverified_password_user(monkeypatch: Any) -> None:
+    handler = account_link_api.GarminAccountLinkHandler.__new__(
+        account_link_api.GarminAccountLinkHandler
+    )
+    handler.headers = {"Authorization": "Bearer app-token"}  # type: ignore[assignment]
+    captured: list[tuple[HTTPStatus, dict[str, Any]]] = []
+    handler._json_response = lambda status, payload: captured.append(  # type: ignore[method-assign]
+        (status, payload)
+    )
+
+    def mock_verify_id_token(token: str, *, check_revoked: bool) -> dict[str, Any]:
+        return {
+            "uid": "uid-1",
+            "email_verified": False,
+            "firebase": {"sign_in_provider": "password"},
+        }
+
+    monkeypatch.setattr(account_link_api.firebase_auth, "verify_id_token", mock_verify_id_token)
+    monkeypatch.setattr(
+        account_link_api,
+        "reconcile_garmin_connection_status",
+        lambda uid: {"status": "disconnected", "linkedAt": None},
+    )
+
+    handler._handle_status()  # noqa: SLF001 - endpoint contract regression
+
+    assert captured == [(HTTPStatus.OK, {"status": "disconnected", "linkedAt": None})]
+
+
 def test_linked_at_json_returns_none_for_invalid_value() -> None:
     assert connection_status._linked_at_json("not-a-datetime") is None
 


### PR DESCRIPTION
## Summary

Fixes newly created Firebase email/password accounts being blocked from wearable-free planning because `POST /api/garmin/status` inherited the stricter verified-email policy used for binding Garmin credentials.

The status path remains authenticated and revocation-checked, but an authenticated password user whose verification email is still pending may now reconcile **their own** Garmin connection state. Garmin credential linking remains verified-email-only when binding Garmin to an existing app account.

## Security boundary

- Firebase ID tokens are still verified server-side with `check_revoked=True` before a UID is accepted.
- `_verified_uid()` remains **verified-email required by default** (`require_verified_email=True`). This keeps the shared helper deny-by-default for future callers.
- `POST /api/garmin/status` explicitly opts out with `require_verified_email=False` because it is scoped to the UID from the validated token and only reconciles that UID's Garmin connection state/non-secret mirror.
- `POST /api/garmin/login` explicitly passes `require_verified_email=True` when an authenticated app user links Garmin credentials.
- Missing, malformed, expired, disabled, or revoked Firebase sessions are still rejected. This is not anonymous access.

This matches the auth model established by #393: email verification is best-effort identity hygiene globally, while capabilities that truly bind an external identity enforce stronger policy at the backend boundary.

## Key changes

1. **Operation-scoped Garmin auth policy**
   - Kept verified-email enforcement as the helper default.
   - Added an explicit exception only at `/api/garmin/status`.
   - Preserved strict verified-email enforcement at `/api/garmin/login`.

2. **Wearable-free newcomer path**
   - An authenticated newcomer with no Garmin link can now receive the canonical `{"status": "disconnected", "linkedAt": null}` result.
   - The frontend can therefore resolve the existing wearable planning gate to `subjective_only` instead of failing closed as `unknown`.

3. **Regression coverage**
   - `_verified_uid()` rejects an unverified password user by default.
   - The helper allows that user only when verification is explicitly disabled for the operation.
   - `/api/garmin/status` explicitly requests the unverified-safe policy and still verifies token revocation.
   - `/api/garmin/login` is tested to explicitly request verified-email enforcement.
   - The status endpoint regression test covers an unverified authenticated newcomer receiving `disconnected`.

4. **Documentation**
   - Added `docs/reviews/2026-09-04-pr-396-auth-garmin-status-review.md` documenting the threat boundary, rationale, tests, and external references.

## Research / rationale

The implementation follows Firebase guidance to verify backend ID tokens and check revocation, and OWASP authorization guidance to use least privilege / deny-by-default authorization. The important design point is that the exception is local to status reconciliation rather than becoming the default behavior of a shared authentication helper.

References:
- https://firebase.google.com/docs/auth/admin/manage-sessions
- https://firebase.google.com/docs/auth/admin
- https://cheatsheetseries.owasp.org/cheatsheets/Authorization_Cheat_Sheet.html

## Verification

Final branch head: `d3048dd1367f9312858b8e2537a15cd1807ed804`.

GitHub Actions CI Pipeline **#2365** passed end-to-end:
- repository hygiene / pre-commit;
- Ruff lint + format check;
- mypy;
- Python pytest + coverage;
- Python dependency audit;
- frontend TypeScript + ESLint;
- sports-knowledge, knowledge-coverage, workout-catalog and policy-drift validation;
- frontend Vitest + coverage;
- Firestore Security Rules emulator suite;
- simulation scenarios and aggregate-bounds gate;
- deterministic plan-judge + persona corpus gates and semantic diff;
- production frontend build + Node dependency audit;
- Docker image / Compose build, health checks and full-stack routing smoke test.

CodeRabbit review was explicitly requested because automatic review is disabled for this repository; the request was rate-limited. There are no submitted reviews and no inline review threads to reply to or resolve.