### PR TITLE
🧹 Refactor comment in test_rebuild_and_audit.py

### DIFF
--- a/tests/test_rebuild_and_audit.py
+++ b/tests/test_rebuild_and_audit.py
@@ -247,7 +247,7 @@ def test_audit_reports_missing_snapshots_and_availability() -> None:
     assert report.snapshots_present == 4
     assert report.missing_snapshots == ["2026-08-04"]
     assert report.sleep_available == 4
-    # None of the fake snapshots set sleepTimingAvailable -- exercises the pre-fix
+    # None of the fake snapshots set sleepTimingAvailable -- exercises the earlier
     # (legacy) shape where the field is simply absent, same as real historical snapshots
     # synced before RawMetrics.sleepSessionStart/End existed.
     assert report.sleep_timing_available == 0


### PR DESCRIPTION
Reworded a comment in `tests/test_rebuild_and_audit.py` to replace 'pre-fix' with 'earlier', preventing false positives in automated action item scanners while maintaining explanatory clarity.

---
*PR created automatically by Jules for task [9442424464520546417](https://jules.google.com/task/9442424464520546417) started by @Szczepanov*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Clarified a test comment describing the legacy absent-field format.
  - No test behavior or assertions were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->