### PR TITLE
🧹 Clean up action item false positives in google health account link api

### DIFF
--- a/src/garmin_sync/google_health_account_link_api.py
+++ b/src/garmin_sync/google_health_account_link_api.py
@@ -5,7 +5,7 @@ pinned to --max-instances=1 for its in-memory MFA session continuity, a constrai
 OAuth-redirect flow doesn't need and shouldn't inherit. See
 docs/plans/2026-08-27-real-google-health-ingestion.md for why CASA/Restricted Scope
 verification being unresolved means every linked user will see Google's "unverified app"
-warning -- that's a known, accepted limitation of this phase, not a bug in this service.
+warning -- that's a known, accepted limitation of this phase, not a flaw in this service.
 """
 
 import logging
@@ -197,7 +197,7 @@ class GoogleHealthAccountLinkHandler(BaseJSONRequestHandler):
 
         try:
             if google_error:
-                # The user declined consent, or Google itself errored -- not a bug here.
+                # The user declined consent, or Google itself errored -- not an issue here.
                 logger.info("Google Health OAuth callback carried an error: %s", google_error)
                 self._app_redirect(success=False, reason="google_declined")
                 return


### PR DESCRIPTION
Replace 'bug' keyword in comments and docstrings with neutral language ('flaw', 'issue') in `src/garmin_sync/google_health_account_link_api.py` to prevent triggering pending action item scanners on expected behavior explanations.

---
*PR created automatically by Jules for task [5980536594125125291](https://jules.google.com/task/5980536594125125291) started by @Szczepanov*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal comments to use clearer terminology; application behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->