### PR TITLE
🧹 [code health] reword test comment in adapters.test.ts

### DIFF
--- a/app/src/engine/adapters.test.ts
+++ b/app/src/engine/adapters.test.ts
@@ -258,7 +258,7 @@ describe('mapContextFromGoalsAndTrainingSettings (Phase 5.4 tissue response wiri
         expect(context.constraints.impliedGuardrails).toContain('avoid_overhead_pressing');
     });
 
-    // Regression coverage for the Home.tsx forecast-leak bug: a today-only tissue-derived
+    // Regression coverage for the Home.tsx forecast-leak issue: a today-only tissue-derived
     // restriction (no standing InjuryConstraint at all) must restrict a decision built WITH
     // today's checkin, but must NOT restrict a decision built without one -- which is
     // exactly the distinction Home.tsx's `context` (today) vs `forecastContext`


### PR DESCRIPTION
Rewords comment in `app/src/engine/adapters.test.ts` from 'forecast-leak bug' to 'forecast-leak issue' to comply with project guidelines regarding developer action keywords.

---
*PR created automatically by Jules for task [6114928162902868548](https://jules.google.com/task/6114928162902868548) started by @Szczepanov*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Clarified a regression test comment describing a forecast-leak issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->