### PR TITLE
🧹 [code health] replace action keyword in subjectiveBaseline comment

### DIFF
--- a/app/src/engine/subjectiveBaseline.ts
+++ b/app/src/engine/subjectiveBaseline.ts
@@ -63,7 +63,7 @@ export const REFERENCE_SUBJECTIVE_BASELINE_POLICY: SubjectiveBaselinePolicy = {
     // it a dependency it has no other reason to carry -- the same reasoning `externalSession.ts`
     // gives for duplicating `EXTERNAL_MODIFY_MAX_SYSTEMIC_COST` instead of importing it from
     // `rules.ts`. If the reference numbers drift apart from contextBrief.ts's, that is a
-    // real finding for 9.6 to report, not a bug -- D-SUBJEST leaves both free to move.
+    // real finding for 9.6 to report, not an issue -- D-SUBJEST leaves both free to move.
     minRecentRecordedDays: 4,
     minLongRecordedDays: 10,
     variabilityFloor: 1.0,


### PR DESCRIPTION
This change replaces the phrase 'not a bug' with 'not an issue' in `app/src/engine/subjectiveBaseline.ts` to prevent false positive triggers in automated pending action item scanners.

---
*PR created automatically by Jules for task [13647666599474003382](https://jules.google.com/task/13647666599474003382) started by @Szczepanov*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified reference-policy documentation to describe a divergence as a finding rather than a bug.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->