### PR TITLE
🧹 Remove scanner-triggering action keyword from planner test comments

### DIFF
--- a/app/src/engine/planner.test.ts
+++ b/app/src/engine/planner.test.ts
@@ -553,7 +553,7 @@ describe('generateWeekAheadPlan weekly-architecture anchoring', () => {
         // seeded into the anchor day realistic-but-modest, so the anchor boost is being
         // tested on its own merits rather than fighting a hard day's residual fatigue (a
         // real hard/moderate day legitimately CAN outrank the anchor via the fatigue-tier
-        // gate -- that's correct, not a bug, so this test deliberately avoids that case).
+        // gate -- that's correct (expected behavior), so this test deliberately avoids that case).
         const readiness: DailyReadiness = { subjective: neutralSubjective({ soreness: 7 }), objective: quietObjective() };
         const event = cyclingEvent('2026-08-27'); // Specificity phase, no taper
         const todayRec = evaluateTraining(readiness, context, '2026-08-07');
@@ -927,7 +927,7 @@ describe('Phase 6.2b -- fixed activities as projected exposures', () => {
     });
 
     it('adds reserved same-day fixed-activity cost onto existing fatigue instead of masking it with max() when pre-existing fatigue is non-zero', () => {
-        // Regression for a real bug: combineMax(existingFatigue, reservedCost) discards the
+        // Regression test: combineMax(existingFatigue, reservedCost) previously discarded the
         // reservation whenever existing fatigue already exceeds it (max(0.3, 0.5) = 0.5 either
         // way looks like just the reservation, but max(0.6, 0.5) = 0.6 hides the reservation
         // entirely) -- reserved load must ADD to what is already there (clamped), the same way
@@ -1006,7 +1006,7 @@ describe('Phase 6.2b -- fixed activities as projected exposures', () => {
     });
 
     it('a booked fixed activity that already fully resolves an objective changes same-day ranking (stimulus credited before ranking, not after)', () => {
-        // Regression for a real ordering bug: applying fixed-activity stimulus credit AFTER
+        // Regression test for ordering: applying fixed-activity stimulus credit AFTER
         // that day's own pick meant `unresolvedObjectives` still listed strength_maintenance
         // as outstanding at ranking time, so a same-day Strength pick could still be chosen
         // for the SAME objective the booked activity had already covered. optimizer.ts's own


### PR DESCRIPTION
🎯 What
Removed developer action keyword (`bug`) from comments in `app/src/engine/planner.test.ts`.

💡 Why
Avoid triggering false positive alerts in the automated pending action item scanner.

✅ Verification
Ran `vitest run src/engine/planner.test.ts` (47/47 passed), `npm --prefix app run typecheck`, and `npm --prefix app run lint`. Verified no scanner keywords remain in `planner.test.ts`.

✨ Result
Cleaner comments in `app/src/engine/planner.test.ts` with no scanner false positive triggers.

---
*PR created automatically by Jules for task [1990358927188874826](https://jules.google.com/task/1990358927188874826) started by @Szczepanov*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Clarified regression-test comments covering fatigue-gate behavior, fixed-activity load handling, and stimulus-credit ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->