### PR TITLE
🧹 Update strength exposure comments to prevent action scanner false positives

### DIFF
--- a/app/src/workouts/strengthExposure.test.ts
+++ b/app/src/workouts/strengthExposure.test.ts
@@ -68,7 +68,7 @@ describe('deriveStrengthExposure', () => {
     });
 
     it('does not compound a full session-level budget per exercise -- one hard exercise and five hard exercises stay distinguishable', () => {
-        // This is the exact defect an earlier draft had: summing a full session-sized
+        // This is the exact issue an earlier draft had: summing a full session-sized
         // budget once per exercise made a single hard exercise indistinguishable from five,
         // because both saturated lowerBody at a cap. Guards the fix -- both exercises here
         // are the same 100% lower-body exercise, so both correctly land on the same

--- a/app/src/workouts/strengthExposure.ts
+++ b/app/src/workouts/strengthExposure.ts
@@ -19,7 +19,7 @@ import { isNearFailureGauge } from './oneRepMax';
  * of that one budget's flat `lowerBody`/`upperBody` split, weighted by which exercises were
  * actually logged (`exercises.ts` `primaryMuscles`, weighted by working-set count) -- it does
  * not sum a full session-sized budget once per exercise, which would make a single hard
- * exercise indistinguishable from five (a real defect caught by this module's own tests
+ * exercise indistinguishable from five (a real issue caught by this module's own tests
  * before it shipped, not a hypothetical). This is a deliberately small, legible change over
  * the existing calibration, not a new formula -- and per D-STRCOST, even this remains a
  * **measured candidate**, not an assertion that the redistribution is correct.


### PR DESCRIPTION
🎯 What
Replace the keyword 'defect' in comments in `strengthExposure.test.ts` and `strengthExposure.ts` with neutral phrasing ('issue').

💡 Why
Automated scanners search for developer action keywords such as 'defect'. The comment in `strengthExposure.test.ts` was explaining a past fix/regression test rather than a pending action item. Rephrasing eliminates false positive scanner findings while maintaining documentation clarity.

✅ Verification
Ran `npm --prefix app run check` (typecheck, lint, vitest, and sports knowledge/workout validation scripts), which passed completely without errors.

✨ Result
Pending action item scanner false positive eliminated.

---
*PR created automatically by Jules for task [14248716037753843180](https://jules.google.com/task/14248716037753843180) started by @Szczepanov*