### PR TITLE
🧹 Rephrase comment in periodizationEventDemandKnowledge.test.ts

### DIFF
--- a/app/src/knowledge/periodizationEventDemandKnowledge.test.ts
+++ b/app/src/knowledge/periodizationEventDemandKnowledge.test.ts
@@ -119,7 +119,7 @@ describe('periodization and event-demand evidence pack (SKR3 W1)', () => {
         // Contributor tapers were de-duplicated onto the canonical taper policy (see
         // periodizationTaperAlignment.test.ts). The claim must describe that delegation, including
         // its real resolution order -- this pack's first draft asserted a duplicated 14/5-day
-        // contributor window table, written against pre-fix code. The legacy A/B defaults still
+        // contributor window table, written against earlier code. The legacy A/B defaults still
         // exist, but only as the canonical policy's own fallback.
         expect(multiEvent.statement).toContain('canonical taper-policy authority');
         expect(multiEvent.statement).toContain('athlete-authored start override first');


### PR DESCRIPTION
Rephrases 'pre-fix code' to 'earlier code' in app/src/knowledge/periodizationEventDemandKnowledge.test.ts comment to prevent false positive triggers in automated pending action item scanners.

---
*PR created automatically by Jules for task [1357227967266477718](https://jules.google.com/task/1357227967266477718) started by @Szczepanov*