### PR TITLE
feat(engine): implement H5 Phase 1 -- block intent, canonical replay, and pure progression review

### DIFF
--- a/app/src/engine/blockIntent.test.ts
+++ b/app/src/engine/blockIntent.test.ts
@@ -1,4 +1,4 @@
-﻿import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import {
     validateIntentBlock,
     validatePlanIntentBlocks,
@@ -11,10 +11,7 @@ describe('blockIntent validation (ADR-0037 D-INTENT)', () => {
         revision: 1,
         sourcePlanId: 'plan_cycling_advanced_01',
         sourcePlanRevision: 1,
-        dateRange: {
-            startDate: '2026-09-07',
-            endDate: '2026-10-04',
-        },
+        dateRange: { startDate: '2026-09-07', endDate: '2026-10-04' },
         objectives: [
             {
                 id: 'obj_threshold_dev',
@@ -23,14 +20,26 @@ describe('blockIntent validation (ADR-0037 D-INTENT)', () => {
                 coverageKey: 'sustained_quality',
                 intent: 'develop',
                 priority: 'must_have',
-                doseEnvelope: {
-                    min: 60,
-                    target: 90,
-                    max: 120,
-                    unit: 'minutes',
-                    floorSemantics: 'hard_floor',
-                },
+                doseEnvelope: { min: 60, target: 90, max: 120, unit: 'minutes', floorSemantics: 'hard_floor' },
                 knowledgeLineage: ['claim_threshold_interval_adaptation_v1'],
+                protectedRoles: ['sustained_quality'],
+                allowedSubstitutions: [{
+                    targetCoverageKey: 'sustained_quality',
+                    allowedCoverageKeys: ['outdoor_event_specific'],
+                    minDoseFraction: 0.9,
+                    rationale: 'Equivalent authored quality role when exact coverage qualifies.',
+                }],
+                successCriteria: {
+                    evaluationRef: { id: 'eval_threshold', revision: 1, metricId: 'cycling_ftp' },
+                    minCompletedExposures: 3,
+                    targetTrend: 'improving',
+                },
+                entryPrerequisites: {
+                    requiredPriorExposures: 2,
+                    minBaselineDays: 7,
+                    prohibitedTissueSeverities: ['limit', 'exclude'],
+                },
+                exitCriteria: { maxWeeksInBlock: 4, stagnationReviewAfterWeeks: 3 },
             },
             {
                 id: 'obj_strength_maint',
@@ -39,165 +48,216 @@ describe('blockIntent validation (ADR-0037 D-INTENT)', () => {
                 coverageKey: 'primary_strength',
                 intent: 'maintain',
                 priority: 'should_have',
-                doseEnvelope: {
-                    min: 1,
-                    target: 2,
-                    max: 2,
-                    unit: 'sessions',
-                    floorSemantics: 'soft_floor',
+                doseEnvelope: { min: 1, target: 2, max: 2, unit: 'sessions', floorSemantics: 'soft_floor' },
+                successCriteria: {
+                    evaluationRef: { id: 'eval_strength', revision: 1, metricId: 'strength_maintenance' },
+                    targetTrend: 'stable',
+                    acceptableDeclineTolerancePct: 3,
                 },
-                knowledgeLineage: ['claim_resistance_maintenance_dose_v1'],
             },
         ],
-        reviewSchedule: {
-            reviewCadenceDays: 14,
-            nextReviewDate: '2026-09-21',
-        },
+        reviewSchedule: { reviewCadenceDays: 14, nextReviewDate: '2026-09-21' },
         progressionContract: {
-            targetBinding: {
-                objectiveId: 'obj_threshold_dev',
-            },
+            targetBinding: { objectiveId: 'obj_threshold_dev' },
             variable: 'duration_min',
             unit: 'minutes',
             currentValue: 90,
-            permittedRange: {
-                min: 60,
-                max: 120,
-            },
+            permittedRange: { min: 60, max: 120 },
             increment: 10,
             observationWindowDays: 14,
             minCompletedExposures: 3,
             requiredFollowUpCoveragePct: 66,
             reviewCadenceDays: 14,
-            reductionAlternative: {
-                decrement: 10,
-                trigger: 'adverse_response',
-            },
+            reductionAlternative: { decrement: 10, trigger: 'adverse_response' },
         },
         title: 'Cycling Build & Strength Maintenance',
     };
 
-    it('accepts a fully valid intent block with develop and maintain objectives', () => {
-        const result = validateIntentBlock(validBlock);
-        expect(result.valid).toBe(true);
-        expect(result.issues).toHaveLength(0);
+    it('accepts a fully valid develop + maintain block', () => {
+        expect(validateIntentBlock(validBlock)).toEqual({ valid: true, issues: [] });
     });
 
-    it('rejects an empty objective list', () => {
-        const invalid: IntentBlock = {
+    it('rejects missing source identity and invalid calendar/review dates', () => {
+        const invalid = {
             ...validBlock,
-            objectives: [],
-        };
-        const result = validateIntentBlock(invalid);
-        expect(result.valid).toBe(false);
-        expect(result.issues.some(i => i.code === 'NO_OBJECTIVES')).toBe(true);
+            sourcePlanId: '',
+            sourcePlanRevision: 0,
+            dateRange: { startDate: '2026-02-30', endDate: '2026-10-04' },
+            reviewSchedule: { reviewCadenceDays: 0, nextReviewDate: '2026-99-01' },
+        } as IntentBlock;
+        const codes = validateIntentBlock(invalid).issues.map(issue => issue.code);
+        expect(codes).toContain('MISSING_SOURCE_PLAN_ID');
+        expect(codes).toContain('INVALID_SOURCE_PLAN_REVISION');
+        expect(codes).toContain('INVALID_DATE_RANGE');
+        expect(codes).toContain('INVALID_BLOCK_REVIEW_CADENCE');
+        expect(codes).toContain('INVALID_NEXT_REVIEW_DATE');
     });
 
-    it('rejects duplicate objective IDs within the same block', () => {
+    it('rejects empty/duplicate objective ids and unsupported objective vocabulary', () => {
         const invalid: IntentBlock = {
             ...validBlock,
             objectives: [
-                validBlock.objectives[0],
-                { ...validBlock.objectives[0], sport: 'running' },
+                { ...validBlock.objectives[0], sport: 'rowing' as never },
+                { ...validBlock.objectives[0], coverageKey: 'anything' as never },
             ],
         };
-        const result = validateIntentBlock(invalid);
-        expect(result.valid).toBe(false);
-        expect(result.issues.some(i => i.code === 'DUPLICATE_OBJECTIVE_ID')).toBe(true);
+        const codes = validateIntentBlock(invalid).issues.map(issue => issue.code);
+        expect(codes).toContain('DUPLICATE_OBJECTIVE_ID');
+        expect(codes).toContain('INVALID_OBJECTIVE_SPORT');
+        expect(codes).toContain('INVALID_OBJECTIVE_COVERAGE_KEY');
     });
 
-    it('rejects unsupported dose units', () => {
+    it('rejects unsupported dose units and non-finite/inverted envelopes', () => {
         const invalid: IntentBlock = {
             ...validBlock,
-            objectives: [
-                {
-                    ...validBlock.objectives[0],
-                    doseEnvelope: {
-                        ...validBlock.objectives[0].doseEnvelope,
-                        unit: 'gallons' as unknown as import('./blockIntent').DoseUnit,
-                    },
+            objectives: [{
+                ...validBlock.objectives[0],
+                doseEnvelope: {
+                    ...validBlock.objectives[0].doseEnvelope,
+                    min: Number.NaN,
+                    target: 130,
+                    max: 120,
+                    unit: 'gallons' as never,
                 },
-            ],
+            }],
         };
-        const result = validateIntentBlock(invalid);
-        expect(result.valid).toBe(false);
-        expect(result.issues.some(i => i.code === 'UNSUPPORTED_DOSE_UNIT')).toBe(true);
+        const codes = validateIntentBlock(invalid).issues.map(issue => issue.code);
+        expect(codes).toContain('UNSUPPORTED_DOSE_UNIT');
+        expect(codes).toContain('INVALID_DOSE_MIN');
+        expect(codes).toContain('INVERTED_DOSE_BOUNDS_TARGET_MAX');
     });
 
-    it('rejects inverted dose envelopes (min > target or target > max)', () => {
-        const invertedMinTarget: IntentBlock = {
+    it('validates substitutions, prerequisites and prospective outcome criteria', () => {
+        const invalid: IntentBlock = {
             ...validBlock,
-            objectives: [
-                {
-                    ...validBlock.objectives[0],
-                    doseEnvelope: {
-                        ...validBlock.objectives[0].doseEnvelope,
-                        min: 100,
-                        target: 80,
-                    },
-                },
-            ],
+            objectives: [{
+                ...validBlock.objectives[0],
+                allowedSubstitutions: [{
+                    targetCoverageKey: 'aerobic_volume',
+                    allowedCoverageKeys: [],
+                    minDoseFraction: 1.2,
+                }],
+                entryPrerequisites: { requiredPriorExposures: 1.5 },
+                successCriteria: { targetTrend: 'improving' },
+            }],
         };
-        const result = validateIntentBlock(invertedMinTarget);
-        expect(result.valid).toBe(false);
-        expect(result.issues.some(i => i.code === 'INVERTED_DOSE_BOUNDS_MIN_TARGET')).toBe(true);
+        const codes = validateIntentBlock(invalid).issues.map(issue => issue.code);
+        expect(codes).toContain('SUBSTITUTION_TARGET_MISMATCH');
+        expect(codes).toContain('EMPTY_SUBSTITUTION_CANDIDATES');
+        expect(codes).toContain('INVALID_SUBSTITUTION_MIN_DOSE_FRACTION');
+        expect(codes).toContain('INVALID_REQUIRED_PRIOR_EXPOSURES');
+        expect(codes).toContain('OUTCOME_CRITERIA_REQUIRE_EVALUATION_REF');
     });
 
-    it('rejects progression contract targeting a non-existent objective ID', () => {
+    it('requires measured maintenance to declare an explicit decline tolerance', () => {
+        const invalid: IntentBlock = {
+            ...validBlock,
+            objectives: [{
+                ...validBlock.objectives[1],
+                successCriteria: {
+                    evaluationRef: { id: 'eval_strength', revision: 1, metricId: 'strength_maintenance' },
+                    targetTrend: 'stable',
+                },
+            }],
+        };
+        expect(validateIntentBlock(invalid).issues.some(issue =>
+            issue.code === 'MAINTENANCE_OUTCOME_REQUIRES_TOLERANCE',
+        )).toBe(true);
+    });
+
+    it('rejects dangling targets, arbitrary progression paths/units and non-finite current values', () => {
         const invalid: IntentBlock = {
             ...validBlock,
             progressionContract: {
                 ...validBlock.progressionContract!,
-                targetBinding: {
-                    objectiveId: 'non_existent_objective_id',
-                },
+                targetBinding: { objectiveId: 'missing' },
+                variable: 'watts.anywhere' as never,
+                unit: 'joules',
+                currentValue: Number.NaN,
             },
         };
-        const result = validateIntentBlock(invalid);
-        expect(result.valid).toBe(false);
-        expect(result.issues.some(i => i.code === 'DANGLING_PROGRESSION_TARGET_OBJECTIVE')).toBe(true);
+        const codes = validateIntentBlock(invalid).issues.map(issue => issue.code);
+        expect(codes).toContain('DANGLING_PROGRESSION_TARGET_OBJECTIVE');
+        expect(codes).toContain('UNSUPPORTED_PROGRESSION_VARIABLE');
+        expect(codes).toContain('INVALID_CURRENT_VALUE');
     });
 
-    it('rejects progression contract with current value outside permitted range', () => {
+    it('requires positive integer evidence windows/cadence and non-zero follow-up coverage', () => {
         const invalid: IntentBlock = {
             ...validBlock,
             progressionContract: {
                 ...validBlock.progressionContract!,
-                currentValue: 150, // max is 120
+                observationWindowDays: 14.5,
+                minCompletedExposures: 2.5,
+                requiredFollowUpCoveragePct: 0,
+                reviewCadenceDays: 7,
             },
         };
-        const result = validateIntentBlock(invalid);
-        expect(result.valid).toBe(false);
-        expect(result.issues.some(i => i.code === 'CURRENT_VALUE_OUT_OF_RANGE')).toBe(true);
+        const codes = validateIntentBlock(invalid).issues.map(issue => issue.code);
+        expect(codes).toContain('INVALID_OBSERVATION_WINDOW');
+        expect(codes).toContain('INVALID_MIN_COMPLETED_EXPOSURES');
+        expect(codes).toContain('INVALID_FOLLOW_UP_COVERAGE_PCT');
+        expect(codes).toContain('PROGRESSION_REVIEW_CADENCE_MISMATCH');
     });
 
-    it('rejects non-positive progression increment', () => {
+    it('rejects ambiguous adverse actions and reductions that need hidden range clamping', () => {
+        const ambiguous: IntentBlock = {
+            ...validBlock,
+            progressionContract: {
+                ...validBlock.progressionContract!,
+                redirectCriteria: { triggers: ['adverse_response'] },
+            },
+        };
+        expect(validateIntentBlock(ambiguous).issues.some(issue =>
+            issue.code === 'AMBIGUOUS_ADVERSE_RESPONSE_ACTION',
+        )).toBe(true);
+
+        const overReduction: IntentBlock = {
+            ...validBlock,
+            progressionContract: {
+                ...validBlock.progressionContract!,
+                currentValue: 65,
+                reductionAlternative: { decrement: 10, trigger: 'adverse_response' },
+            },
+        };
+        expect(validateIntentBlock(overReduction).issues.some(issue =>
+            issue.code === 'REDUCTION_DECREMENT_EXCEEDS_RANGE',
+        )).toBe(true);
+    });
+
+    it('rejects progression ranges outside the authored objective envelope', () => {
         const invalid: IntentBlock = {
             ...validBlock,
             progressionContract: {
                 ...validBlock.progressionContract!,
-                increment: 0,
+                permittedRange: { min: 50, max: 130 },
             },
         };
-        const result = validateIntentBlock(invalid);
-        expect(result.valid).toBe(false);
-        expect(result.issues.some(i => i.code === 'INVALID_PROGRESSION_INCREMENT')).toBe(true);
+        expect(validateIntentBlock(invalid).issues.some(issue =>
+            issue.code === 'PROGRESSION_RANGE_EXCEEDS_OBJECTIVE_ENVELOPE',
+        )).toBe(true);
     });
 
-    it('validates plan-level blocks and rejects overlapping active intervals', () => {
-        const blockA: IntentBlock = {
-            ...validBlock,
-            id: 'block_a',
-            dateRange: { startDate: '2026-09-01', endDate: '2026-09-15' },
-        };
-        const blockBOverlapping: IntentBlock = {
-            ...validBlock,
-            id: 'block_b',
-            dateRange: { startDate: '2026-09-10', endDate: '2026-09-25' },
-        };
+    it('rejects overlapping blocks only within the same source plan', () => {
+        const blockA: IntentBlock = { ...validBlock, id: 'block_a', dateRange: { startDate: '2026-09-01', endDate: '2026-09-15' }, reviewSchedule: { reviewCadenceDays: 7, nextReviewDate: '2026-09-08' }, progressionContract: undefined };
+        const blockB: IntentBlock = { ...validBlock, id: 'block_b', dateRange: { startDate: '2026-09-10', endDate: '2026-09-25' }, reviewSchedule: { reviewCadenceDays: 7, nextReviewDate: '2026-09-17' }, progressionContract: undefined };
+        const otherPlan: IntentBlock = { ...blockB, id: 'block_other', sourcePlanId: 'plan_other' };
 
-        const result = validatePlanIntentBlocks([blockA, blockBOverlapping]);
-        expect(result.valid).toBe(false);
-        expect(result.issues.some(i => i.code === 'OVERLAPPING_INTENT_BLOCKS')).toBe(true);
+        expect(validatePlanIntentBlocks([blockA, blockB]).issues.some(issue =>
+            issue.code === 'OVERLAPPING_INTENT_BLOCKS',
+        )).toBe(true);
+        expect(validatePlanIntentBlocks([blockA, otherPlan]).issues.some(issue =>
+            issue.code === 'OVERLAPPING_INTENT_BLOCKS',
+        )).toBe(false);
+    });
+
+    it('does not throw during plan overlap validation when a block has a malformed date', () => {
+        const malformed = {
+            ...validBlock,
+            id: 'bad_date',
+            dateRange: { startDate: '', endDate: '' },
+        } as IntentBlock;
+        expect(() => validatePlanIntentBlocks([validBlock, malformed])).not.toThrow();
+        expect(validatePlanIntentBlocks([validBlock, malformed]).valid).toBe(false);
     });
 });

--- a/app/src/engine/blockIntent.test.ts
+++ b/app/src/engine/blockIntent.test.ts
@@ -1,0 +1,203 @@
+﻿import { describe, it, expect } from 'vitest';
+import {
+    validateIntentBlock,
+    validatePlanIntentBlocks,
+    type IntentBlock,
+} from './blockIntent';
+
+describe('blockIntent validation (ADR-0037 D-INTENT)', () => {
+    const validBlock: IntentBlock = {
+        id: 'block_2026_09_cycling_build',
+        revision: 1,
+        sourcePlanId: 'plan_cycling_advanced_01',
+        sourcePlanRevision: 1,
+        dateRange: {
+            startDate: '2026-09-07',
+            endDate: '2026-10-04',
+        },
+        objectives: [
+            {
+                id: 'obj_threshold_dev',
+                sport: 'cycling',
+                adaptationScope: 'aerobic_power',
+                coverageKey: 'sustained_quality',
+                intent: 'develop',
+                priority: 'must_have',
+                doseEnvelope: {
+                    min: 60,
+                    target: 90,
+                    max: 120,
+                    unit: 'minutes',
+                    floorSemantics: 'hard_floor',
+                },
+                knowledgeLineage: ['claim_threshold_interval_adaptation_v1'],
+            },
+            {
+                id: 'obj_strength_maint',
+                sport: 'strength',
+                adaptationScope: 'muscle_retention',
+                coverageKey: 'primary_strength',
+                intent: 'maintain',
+                priority: 'should_have',
+                doseEnvelope: {
+                    min: 1,
+                    target: 2,
+                    max: 2,
+                    unit: 'sessions',
+                    floorSemantics: 'soft_floor',
+                },
+                knowledgeLineage: ['claim_resistance_maintenance_dose_v1'],
+            },
+        ],
+        reviewSchedule: {
+            reviewCadenceDays: 14,
+            nextReviewDate: '2026-09-21',
+        },
+        progressionContract: {
+            targetBinding: {
+                objectiveId: 'obj_threshold_dev',
+            },
+            variable: 'duration_min',
+            unit: 'minutes',
+            currentValue: 90,
+            permittedRange: {
+                min: 60,
+                max: 120,
+            },
+            increment: 10,
+            observationWindowDays: 14,
+            minCompletedExposures: 3,
+            requiredFollowUpCoveragePct: 66,
+            reviewCadenceDays: 14,
+            reductionAlternative: {
+                decrement: 10,
+                trigger: 'adverse_response',
+            },
+        },
+        title: 'Cycling Build & Strength Maintenance',
+    };
+
+    it('accepts a fully valid intent block with develop and maintain objectives', () => {
+        const result = validateIntentBlock(validBlock);
+        expect(result.valid).toBe(true);
+        expect(result.issues).toHaveLength(0);
+    });
+
+    it('rejects an empty objective list', () => {
+        const invalid: IntentBlock = {
+            ...validBlock,
+            objectives: [],
+        };
+        const result = validateIntentBlock(invalid);
+        expect(result.valid).toBe(false);
+        expect(result.issues.some(i => i.code === 'NO_OBJECTIVES')).toBe(true);
+    });
+
+    it('rejects duplicate objective IDs within the same block', () => {
+        const invalid: IntentBlock = {
+            ...validBlock,
+            objectives: [
+                validBlock.objectives[0],
+                { ...validBlock.objectives[0], sport: 'running' },
+            ],
+        };
+        const result = validateIntentBlock(invalid);
+        expect(result.valid).toBe(false);
+        expect(result.issues.some(i => i.code === 'DUPLICATE_OBJECTIVE_ID')).toBe(true);
+    });
+
+    it('rejects unsupported dose units', () => {
+        const invalid: IntentBlock = {
+            ...validBlock,
+            objectives: [
+                {
+                    ...validBlock.objectives[0],
+                    doseEnvelope: {
+                        ...validBlock.objectives[0].doseEnvelope,
+                        unit: 'gallons' as unknown as import('./blockIntent').DoseUnit,
+                    },
+                },
+            ],
+        };
+        const result = validateIntentBlock(invalid);
+        expect(result.valid).toBe(false);
+        expect(result.issues.some(i => i.code === 'UNSUPPORTED_DOSE_UNIT')).toBe(true);
+    });
+
+    it('rejects inverted dose envelopes (min > target or target > max)', () => {
+        const invertedMinTarget: IntentBlock = {
+            ...validBlock,
+            objectives: [
+                {
+                    ...validBlock.objectives[0],
+                    doseEnvelope: {
+                        ...validBlock.objectives[0].doseEnvelope,
+                        min: 100,
+                        target: 80,
+                    },
+                },
+            ],
+        };
+        const result = validateIntentBlock(invertedMinTarget);
+        expect(result.valid).toBe(false);
+        expect(result.issues.some(i => i.code === 'INVERTED_DOSE_BOUNDS_MIN_TARGET')).toBe(true);
+    });
+
+    it('rejects progression contract targeting a non-existent objective ID', () => {
+        const invalid: IntentBlock = {
+            ...validBlock,
+            progressionContract: {
+                ...validBlock.progressionContract!,
+                targetBinding: {
+                    objectiveId: 'non_existent_objective_id',
+                },
+            },
+        };
+        const result = validateIntentBlock(invalid);
+        expect(result.valid).toBe(false);
+        expect(result.issues.some(i => i.code === 'DANGLING_PROGRESSION_TARGET_OBJECTIVE')).toBe(true);
+    });
+
+    it('rejects progression contract with current value outside permitted range', () => {
+        const invalid: IntentBlock = {
+            ...validBlock,
+            progressionContract: {
+                ...validBlock.progressionContract!,
+                currentValue: 150, // max is 120
+            },
+        };
+        const result = validateIntentBlock(invalid);
+        expect(result.valid).toBe(false);
+        expect(result.issues.some(i => i.code === 'CURRENT_VALUE_OUT_OF_RANGE')).toBe(true);
+    });
+
+    it('rejects non-positive progression increment', () => {
+        const invalid: IntentBlock = {
+            ...validBlock,
+            progressionContract: {
+                ...validBlock.progressionContract!,
+                increment: 0,
+            },
+        };
+        const result = validateIntentBlock(invalid);
+        expect(result.valid).toBe(false);
+        expect(result.issues.some(i => i.code === 'INVALID_PROGRESSION_INCREMENT')).toBe(true);
+    });
+
+    it('validates plan-level blocks and rejects overlapping active intervals', () => {
+        const blockA: IntentBlock = {
+            ...validBlock,
+            id: 'block_a',
+            dateRange: { startDate: '2026-09-01', endDate: '2026-09-15' },
+        };
+        const blockBOverlapping: IntentBlock = {
+            ...validBlock,
+            id: 'block_b',
+            dateRange: { startDate: '2026-09-10', endDate: '2026-09-25' },
+        };
+
+        const result = validatePlanIntentBlocks([blockA, blockBOverlapping]);
+        expect(result.valid).toBe(false);
+        expect(result.issues.some(i => i.code === 'OVERLAPPING_INTENT_BLOCKS')).toBe(true);
+    });
+});

--- a/app/src/engine/blockIntent.test.ts
+++ b/app/src/engine/blockIntent.test.ts
@@ -16,13 +16,16 @@ describe('blockIntent validation (ADR-0037 D-INTENT)', () => {
             {
                 id: 'obj_threshold_dev',
                 sport: 'cycling',
-                adaptationScope: 'aerobic_power',
+                adaptationScope: 'threshold_quality',
                 coverageKey: 'sustained_quality',
                 intent: 'develop',
                 priority: 'must_have',
                 doseEnvelope: { min: 60, target: 90, max: 120, unit: 'minutes', floorSemantics: 'hard_floor' },
                 knowledgeLineage: ['claim_threshold_interval_adaptation_v1'],
-                protectedRoles: ['sustained_quality'],
+                protectedRoles: [
+                    { kind: 'coverage_role', coverageKey: 'sustained_quality' },
+                    { kind: 'session', sessionId: 'session_threshold_anchor' },
+                ],
                 allowedSubstitutions: [{
                     targetCoverageKey: 'sustained_quality',
                     allowedCoverageKeys: ['outdoor_event_specific'],
@@ -44,11 +47,12 @@ describe('blockIntent validation (ADR-0037 D-INTENT)', () => {
             {
                 id: 'obj_strength_maint',
                 sport: 'strength',
-                adaptationScope: 'muscle_retention',
+                adaptationScope: 'strength_maintenance',
                 coverageKey: 'primary_strength',
                 intent: 'maintain',
                 priority: 'should_have',
                 doseEnvelope: { min: 1, target: 2, max: 2, unit: 'sessions', floorSemantics: 'soft_floor' },
+                knowledgeLineage: ['claim_strength_maintenance_v1'],
                 successCriteria: {
                     evaluationRef: { id: 'eval_strength', revision: 1, metricId: 'strength_maintenance' },
                     targetTrend: 'stable',
@@ -64,6 +68,7 @@ describe('blockIntent validation (ADR-0037 D-INTENT)', () => {
             currentValue: 90,
             permittedRange: { min: 60, max: 120 },
             increment: 10,
+            knowledgeLineage: ['policy_progression_duration_v1'],
             observationWindowDays: 14,
             minCompletedExposures: 3,
             requiredFollowUpCoveragePct: 66,
@@ -93,18 +98,56 @@ describe('blockIntent validation (ADR-0037 D-INTENT)', () => {
         expect(codes).toContain('INVALID_NEXT_REVIEW_DATE');
     });
 
-    it('rejects empty/duplicate objective ids and unsupported objective vocabulary', () => {
+    it('rejects unsupported typed objective vocabulary and duplicate objective ids', () => {
         const invalid: IntentBlock = {
             ...validBlock,
             objectives: [
-                { ...validBlock.objectives[0], sport: 'rowing' as never },
+                { ...validBlock.objectives[0], sport: 'rowing' as never, adaptationScope: 'free_text_scope' as never },
                 { ...validBlock.objectives[0], coverageKey: 'anything' as never },
             ],
         };
         const codes = validateIntentBlock(invalid).issues.map(issue => issue.code);
         expect(codes).toContain('DUPLICATE_OBJECTIVE_ID');
         expect(codes).toContain('INVALID_OBJECTIVE_SPORT');
+        expect(codes).toContain('INVALID_ADAPTATION_SCOPE');
         expect(codes).toContain('INVALID_OBJECTIVE_COVERAGE_KEY');
+    });
+
+    it('rejects free-form/invalid protected references instead of treating labels as exact roles', () => {
+        const invalid: IntentBlock = {
+            ...validBlock,
+            objectives: [{
+                ...validBlock.objectives[0],
+                protectedRoles: [
+                    { kind: 'coverage_role', coverageKey: 'made_up_role' as never },
+                    { kind: 'session', sessionId: '' },
+                    { kind: 'session', sessionId: '' },
+                ],
+            }],
+        };
+        const codes = validateIntentBlock(invalid).issues.map(issue => issue.code);
+        expect(codes).toContain('INVALID_PROTECTED_COVERAGE_ROLE');
+        expect(codes).toContain('INVALID_PROTECTED_SESSION_ID');
+        expect(codes).toContain('DUPLICATE_PROTECTED_ROLE');
+    });
+
+    it('requires objective and progression knowledge lineage plus non-empty success criteria', () => {
+        const invalid: IntentBlock = {
+            ...validBlock,
+            objectives: [{
+                ...validBlock.objectives[0],
+                knowledgeLineage: [],
+                successCriteria: {},
+            }],
+            progressionContract: {
+                ...validBlock.progressionContract!,
+                targetBinding: { objectiveId: 'obj_threshold_dev' },
+                knowledgeLineage: [],
+            },
+        };
+        const codes = validateIntentBlock(invalid).issues.map(issue => issue.code);
+        expect(codes.filter(code => code === 'MISSING_KNOWLEDGE_LINEAGE').length).toBeGreaterThanOrEqual(2);
+        expect(codes).toContain('EMPTY_SUCCESS_CRITERIA');
     });
 
     it('rejects unsupported dose units and non-finite/inverted envelopes', () => {
@@ -132,11 +175,7 @@ describe('blockIntent validation (ADR-0037 D-INTENT)', () => {
             ...validBlock,
             objectives: [{
                 ...validBlock.objectives[0],
-                allowedSubstitutions: [{
-                    targetCoverageKey: 'aerobic_volume',
-                    allowedCoverageKeys: [],
-                    minDoseFraction: 1.2,
-                }],
+                allowedSubstitutions: [{ targetCoverageKey: 'aerobic_volume', allowedCoverageKeys: [], minDoseFraction: 1.2 }],
                 entryPrerequisites: { requiredPriorExposures: 1.5 },
                 successCriteria: { targetTrend: 'improving' },
             }],
@@ -160,9 +199,7 @@ describe('blockIntent validation (ADR-0037 D-INTENT)', () => {
                 },
             }],
         };
-        expect(validateIntentBlock(invalid).issues.some(issue =>
-            issue.code === 'MAINTENANCE_OUTCOME_REQUIRES_TOLERANCE',
-        )).toBe(true);
+        expect(validateIntentBlock(invalid).issues.some(issue => issue.code === 'MAINTENANCE_OUTCOME_REQUIRES_TOLERANCE')).toBe(true);
     });
 
     it('rejects dangling targets, arbitrary progression paths/units and non-finite current values', () => {
@@ -200,7 +237,17 @@ describe('blockIntent validation (ADR-0037 D-INTENT)', () => {
         expect(codes).toContain('PROGRESSION_REVIEW_CADENCE_MISMATCH');
     });
 
-    it('rejects ambiguous adverse actions and reductions that need hidden range clamping', () => {
+    it('requires an authored reduction or redirect fallback and rejects ambiguous adverse actions', () => {
+        const missingFallback: IntentBlock = {
+            ...validBlock,
+            progressionContract: {
+                ...validBlock.progressionContract!,
+                reductionAlternative: undefined,
+                redirectCriteria: undefined,
+            },
+        };
+        expect(validateIntentBlock(missingFallback).issues.some(issue => issue.code === 'MISSING_PROGRESSION_FALLBACK')).toBe(true);
+
         const ambiguous: IntentBlock = {
             ...validBlock,
             progressionContract: {
@@ -208,11 +255,11 @@ describe('blockIntent validation (ADR-0037 D-INTENT)', () => {
                 redirectCriteria: { triggers: ['adverse_response'] },
             },
         };
-        expect(validateIntentBlock(ambiguous).issues.some(issue =>
-            issue.code === 'AMBIGUOUS_ADVERSE_RESPONSE_ACTION',
-        )).toBe(true);
+        expect(validateIntentBlock(ambiguous).issues.some(issue => issue.code === 'AMBIGUOUS_ADVERSE_RESPONSE_ACTION')).toBe(true);
+    });
 
-        const overReduction: IntentBlock = {
+    it('rejects reductions that need hidden range clamping', () => {
+        const invalid: IntentBlock = {
             ...validBlock,
             progressionContract: {
                 ...validBlock.progressionContract!,
@@ -220,22 +267,15 @@ describe('blockIntent validation (ADR-0037 D-INTENT)', () => {
                 reductionAlternative: { decrement: 10, trigger: 'adverse_response' },
             },
         };
-        expect(validateIntentBlock(overReduction).issues.some(issue =>
-            issue.code === 'REDUCTION_DECREMENT_EXCEEDS_RANGE',
-        )).toBe(true);
+        expect(validateIntentBlock(invalid).issues.some(issue => issue.code === 'REDUCTION_DECREMENT_EXCEEDS_RANGE')).toBe(true);
     });
 
     it('rejects progression ranges outside the authored objective envelope', () => {
         const invalid: IntentBlock = {
             ...validBlock,
-            progressionContract: {
-                ...validBlock.progressionContract!,
-                permittedRange: { min: 50, max: 130 },
-            },
+            progressionContract: { ...validBlock.progressionContract!, permittedRange: { min: 50, max: 130 } },
         };
-        expect(validateIntentBlock(invalid).issues.some(issue =>
-            issue.code === 'PROGRESSION_RANGE_EXCEEDS_OBJECTIVE_ENVELOPE',
-        )).toBe(true);
+        expect(validateIntentBlock(invalid).issues.some(issue => issue.code === 'PROGRESSION_RANGE_EXCEEDS_OBJECTIVE_ENVELOPE')).toBe(true);
     });
 
     it('rejects overlapping blocks only within the same source plan', () => {
@@ -243,20 +283,12 @@ describe('blockIntent validation (ADR-0037 D-INTENT)', () => {
         const blockB: IntentBlock = { ...validBlock, id: 'block_b', dateRange: { startDate: '2026-09-10', endDate: '2026-09-25' }, reviewSchedule: { reviewCadenceDays: 7, nextReviewDate: '2026-09-17' }, progressionContract: undefined };
         const otherPlan: IntentBlock = { ...blockB, id: 'block_other', sourcePlanId: 'plan_other' };
 
-        expect(validatePlanIntentBlocks([blockA, blockB]).issues.some(issue =>
-            issue.code === 'OVERLAPPING_INTENT_BLOCKS',
-        )).toBe(true);
-        expect(validatePlanIntentBlocks([blockA, otherPlan]).issues.some(issue =>
-            issue.code === 'OVERLAPPING_INTENT_BLOCKS',
-        )).toBe(false);
+        expect(validatePlanIntentBlocks([blockA, blockB]).issues.some(issue => issue.code === 'OVERLAPPING_INTENT_BLOCKS')).toBe(true);
+        expect(validatePlanIntentBlocks([blockA, otherPlan]).issues.some(issue => issue.code === 'OVERLAPPING_INTENT_BLOCKS')).toBe(false);
     });
 
     it('does not throw during plan overlap validation when a block has a malformed date', () => {
-        const malformed = {
-            ...validBlock,
-            id: 'bad_date',
-            dateRange: { startDate: '', endDate: '' },
-        } as IntentBlock;
+        const malformed = { ...validBlock, id: 'bad_date', dateRange: { startDate: '', endDate: '' } } as IntentBlock;
         expect(() => validatePlanIntentBlocks([validBlock, malformed])).not.toThrow();
         expect(validatePlanIntentBlocks([validBlock, malformed]).valid).toBe(false);
     });

--- a/app/src/engine/blockIntent.test.ts
+++ b/app/src/engine/blockIntent.test.ts
@@ -256,6 +256,20 @@ describe('blockIntent validation (ADR-0037 D-INTENT)', () => {
             },
         };
         expect(validateIntentBlock(ambiguous).issues.some(issue => issue.code === 'AMBIGUOUS_ADVERSE_RESPONSE_ACTION')).toBe(true);
+
+        const withoutTriggers = {
+            ...validBlock,
+            progressionContract: {
+                ...validBlock.progressionContract!,
+                reductionAlternative: undefined,
+                redirectCriteria: {} as never,
+            },
+        };
+        const withoutTriggersValidation = validateIntentBlock(withoutTriggers);
+        expect(withoutTriggersValidation.valid).toBe(false);
+        const codes = withoutTriggersValidation.issues.map(issue => issue.code);
+        expect(codes).toContain('EMPTY_REDIRECT_TRIGGERS');
+        expect(codes).toContain('MISSING_PROGRESSION_FALLBACK');
     });
 
     it('rejects reductions that need hidden range clamping', () => {

--- a/app/src/engine/blockIntent.ts
+++ b/app/src/engine/blockIntent.ts
@@ -7,7 +7,7 @@
  */
 
 import type { PlanCoverageKey } from '../workouts/event-plan';
-import type { ObjectivePriority } from './models';
+import type { ObjectiveKey, ObjectivePriority } from './models';
 
 export type BlockIntent = 'develop' | 'maintain';
 export type BlockSport = 'cycling' | 'strength' | 'running' | 'swimming' | 'multisport' | 'cross_training';
@@ -38,6 +38,16 @@ export const SUPPORTED_BLOCK_SPORTS: readonly BlockSport[] = [
     'swimming',
     'multisport',
     'cross_training',
+] as const;
+
+export const SUPPORTED_ADAPTATION_SCOPES: readonly ObjectiveKey[] = [
+    'threshold_quality',
+    'surge_repeatability',
+    'zone2_aerobic',
+    'strength_maintenance',
+    'strength_development',
+    'race_specific_endurance',
+    'vo2_max',
 ] as const;
 
 export const SUPPORTED_OBJECTIVE_PRIORITIES: readonly ObjectivePriority[] = [
@@ -78,6 +88,10 @@ export interface DoseEnvelope {
     floorSemantics: FloorSemantics;
 }
 
+export type BlockProtectedRole =
+    | { kind: 'coverage_role'; coverageKey: PlanCoverageKey }
+    | { kind: 'session'; sessionId: string };
+
 export interface BlockSubstitutionRule {
     targetCoverageKey: PlanCoverageKey;
     allowedCoverageKeys: readonly PlanCoverageKey[];
@@ -111,15 +125,17 @@ export interface BlockExitCriteria {
 export interface BlockObjectiveDefinition {
     id: string;
     sport: BlockSport;
-    adaptationScope: string;
+    /** Phase 1 reuses the repository's typed objective vocabulary rather than accepting a
+     * new free-text physiological namespace. */
+    adaptationScope: ObjectiveKey;
     coverageKey: PlanCoverageKey;
     intent: BlockIntent;
     priority: ObjectivePriority;
     doseEnvelope: DoseEnvelope;
-    knowledgeLineage?: readonly string[];
-    protectedRoles?: readonly string[];
+    knowledgeLineage: readonly string[];
+    protectedRoles?: readonly BlockProtectedRole[];
     allowedSubstitutions?: readonly BlockSubstitutionRule[];
-    successCriteria?: BlockSuccessCriteria;
+    successCriteria: BlockSuccessCriteria;
     entryPrerequisites?: BlockPrerequisites;
     exitCriteria?: BlockExitCriteria;
 }
@@ -151,7 +167,7 @@ export interface BlockProgressionContract {
         max: number;
     };
     increment: number;
-    knowledgeLineage?: readonly string[];
+    knowledgeLineage: readonly string[];
     observationWindowDays: number;
     minCompletedExposures: number;
     requiredFollowUpCoveragePct: number;
@@ -222,9 +238,18 @@ function isNonNegativeInteger(value: unknown): value is number {
     return Number.isInteger(value) && (value as number) >= 0;
 }
 
-function validateOptionalStringSet(values: readonly string[] | undefined, path: string): ValidationIssue[] {
-    if (values === undefined) return [];
+function validateStringSet(values: readonly string[] | undefined, path: string, required: boolean): ValidationIssue[] {
     const issues: ValidationIssue[] = [];
+    if (!values || values.length === 0) {
+        if (required) {
+            issues.push({
+                code: 'MISSING_KNOWLEDGE_LINEAGE',
+                message: 'At least one pinned knowledge/product-policy lineage reference is required',
+                path,
+            });
+        }
+        return issues;
+    }
     const seen = new Set<string>();
     values.forEach((value, index) => {
         if (!isNonEmptyString(value)) {
@@ -267,58 +292,69 @@ export function validateDoseEnvelope(envelope: DoseEnvelope, path: string): Vali
     }
 
     if (!Number.isFinite(envelope.min) || envelope.min < 0) {
-        issues.push({
-            code: 'INVALID_DOSE_MIN',
-            message: `Dose min must be a finite non-negative number: ${envelope.min}`,
-            path: `${path}.min`,
-        });
+        issues.push({ code: 'INVALID_DOSE_MIN', message: `Dose min must be a finite non-negative number: ${envelope.min}`, path: `${path}.min` });
     }
     if (!Number.isFinite(envelope.target) || envelope.target < 0) {
-        issues.push({
-            code: 'INVALID_DOSE_TARGET',
-            message: `Dose target must be a finite non-negative number: ${envelope.target}`,
-            path: `${path}.target`,
-        });
+        issues.push({ code: 'INVALID_DOSE_TARGET', message: `Dose target must be a finite non-negative number: ${envelope.target}`, path: `${path}.target` });
     }
     if (!Number.isFinite(envelope.max) || envelope.max < 0) {
-        issues.push({
-            code: 'INVALID_DOSE_MAX',
-            message: `Dose max must be a finite non-negative number: ${envelope.max}`,
-            path: `${path}.max`,
-        });
+        issues.push({ code: 'INVALID_DOSE_MAX', message: `Dose max must be a finite non-negative number: ${envelope.max}`, path: `${path}.max` });
     }
     if (Number.isFinite(envelope.min) && Number.isFinite(envelope.target) && envelope.min > envelope.target) {
-        issues.push({
-            code: 'INVERTED_DOSE_BOUNDS_MIN_TARGET',
-            message: `Dose min (${envelope.min}) cannot exceed target (${envelope.target})`,
-            path: `${path}.min`,
-        });
+        issues.push({ code: 'INVERTED_DOSE_BOUNDS_MIN_TARGET', message: `Dose min (${envelope.min}) cannot exceed target (${envelope.target})`, path: `${path}.min` });
     }
     if (Number.isFinite(envelope.target) && Number.isFinite(envelope.max) && envelope.target > envelope.max) {
-        issues.push({
-            code: 'INVERTED_DOSE_BOUNDS_TARGET_MAX',
-            message: `Dose target (${envelope.target}) cannot exceed max (${envelope.max})`,
-            path: `${path}.max`,
-        });
+        issues.push({ code: 'INVERTED_DOSE_BOUNDS_TARGET_MAX', message: `Dose target (${envelope.target}) cannot exceed max (${envelope.max})`, path: `${path}.max` });
     }
     if (envelope.floorSemantics !== 'hard_floor' && envelope.floorSemantics !== 'soft_floor') {
-        issues.push({
-            code: 'INVALID_FLOOR_SEMANTICS',
-            message: `Invalid floor semantics: ${envelope.floorSemantics}`,
-            path: `${path}.floorSemantics`,
-        });
+        issues.push({ code: 'INVALID_FLOOR_SEMANTICS', message: `Invalid floor semantics: ${envelope.floorSemantics}`, path: `${path}.floorSemantics` });
     }
 
     return issues;
 }
 
+function validateProtectedRoles(roles: readonly BlockProtectedRole[] | undefined, path: string): ValidationIssue[] {
+    if (!roles) return [];
+    const issues: ValidationIssue[] = [];
+    const seen = new Set<string>();
+    roles.forEach((role, index) => {
+        const rolePath = `${path}[${index}]`;
+        let identity = '';
+        if (role.kind === 'coverage_role') {
+            if (!isSupportedCoverageKey(role.coverageKey)) {
+                issues.push({ code: 'INVALID_PROTECTED_COVERAGE_ROLE', message: `Unsupported protected coverage role: ${role.coverageKey}`, path: `${rolePath}.coverageKey` });
+            }
+            identity = `coverage_role:${role.coverageKey}`;
+        } else if (role.kind === 'session') {
+            if (!isNonEmptyString(role.sessionId)) {
+                issues.push({ code: 'INVALID_PROTECTED_SESSION_ID', message: 'Protected session id must be non-empty', path: `${rolePath}.sessionId` });
+            }
+            identity = `session:${role.sessionId}`;
+        } else {
+            issues.push({ code: 'INVALID_PROTECTED_ROLE_KIND', message: `Unsupported protected role kind: ${String((role as { kind?: unknown }).kind)}`, path: `${rolePath}.kind` });
+            return;
+        }
+        if (seen.has(identity)) {
+            issues.push({ code: 'DUPLICATE_PROTECTED_ROLE', message: `Duplicate protected reference: ${identity}`, path: rolePath });
+        }
+        seen.add(identity);
+    });
+    return issues;
+}
+
 function validateSuccessCriteria(
-    criteria: BlockSuccessCriteria | undefined,
+    criteria: BlockSuccessCriteria,
     intent: BlockIntent,
     path: string,
 ): ValidationIssue[] {
-    if (!criteria) return [];
     const issues: ValidationIssue[] = [];
+    if (!criteria.evaluationRef && criteria.minCompletedExposures === undefined) {
+        issues.push({
+            code: 'EMPTY_SUCCESS_CRITERIA',
+            message: 'Success criteria must declare a process exposure threshold and/or a pinned evaluationRef',
+            path,
+        });
+    }
     if (criteria.evaluationRef) {
         if (!isNonEmptyString(criteria.evaluationRef.id)) {
             issues.push({ code: 'INVALID_EVALUATION_REF_ID', message: 'Evaluation id must be non-empty', path: `${path}.evaluationRef.id` });
@@ -331,11 +367,7 @@ function validateSuccessCriteria(
         }
     }
     if (criteria.minCompletedExposures !== undefined && !isPositiveInteger(criteria.minCompletedExposures)) {
-        issues.push({
-            code: 'INVALID_SUCCESS_MIN_EXPOSURES',
-            message: 'Success minCompletedExposures must be a positive integer',
-            path: `${path}.minCompletedExposures`,
-        });
+        issues.push({ code: 'INVALID_SUCCESS_MIN_EXPOSURES', message: 'Success minCompletedExposures must be a positive integer', path: `${path}.minCompletedExposures` });
     }
     if (criteria.targetTrend !== undefined && criteria.targetTrend !== 'stable' && criteria.targetTrend !== 'improving') {
         issues.push({ code: 'INVALID_TARGET_TREND', message: `Unsupported target trend: ${criteria.targetTrend}`, path: `${path}.targetTrend` });
@@ -345,32 +377,16 @@ function validateSuccessCriteria(
         || criteria.acceptableDeclineTolerancePct < 0
         || criteria.acceptableDeclineTolerancePct > 100
     )) {
-        issues.push({
-            code: 'INVALID_DECLINE_TOLERANCE',
-            message: 'acceptableDeclineTolerancePct must be finite and between 0 and 100',
-            path: `${path}.acceptableDeclineTolerancePct`,
-        });
+        issues.push({ code: 'INVALID_DECLINE_TOLERANCE', message: 'acceptableDeclineTolerancePct must be finite and between 0 and 100', path: `${path}.acceptableDeclineTolerancePct` });
     }
     if ((criteria.targetTrend !== undefined || criteria.acceptableDeclineTolerancePct !== undefined) && !criteria.evaluationRef) {
-        issues.push({
-            code: 'OUTCOME_CRITERIA_REQUIRE_EVALUATION_REF',
-            message: 'Outcome trend/tolerance criteria require a pinned evaluationRef',
-            path,
-        });
+        issues.push({ code: 'OUTCOME_CRITERIA_REQUIRE_EVALUATION_REF', message: 'Outcome trend/tolerance criteria require a pinned evaluationRef', path });
     }
     if (intent === 'develop' && criteria.evaluationRef && criteria.targetTrend === undefined) {
-        issues.push({
-            code: 'DEVELOPMENT_OUTCOME_REQUIRES_TARGET_TREND',
-            message: 'A measured development objective must declare its prospective targetTrend',
-            path: `${path}.targetTrend`,
-        });
+        issues.push({ code: 'DEVELOPMENT_OUTCOME_REQUIRES_TARGET_TREND', message: 'A measured development objective must declare its prospective targetTrend', path: `${path}.targetTrend` });
     }
     if (intent === 'maintain' && criteria.evaluationRef && criteria.acceptableDeclineTolerancePct === undefined) {
-        issues.push({
-            code: 'MAINTENANCE_OUTCOME_REQUIRES_TOLERANCE',
-            message: 'A measured maintenance objective must declare an acceptable decline tolerance',
-            path: `${path}.acceptableDeclineTolerancePct`,
-        });
+        issues.push({ code: 'MAINTENANCE_OUTCOME_REQUIRES_TOLERANCE', message: 'A measured maintenance objective must declare an acceptable decline tolerance', path: `${path}.acceptableDeclineTolerancePct` });
     }
     return issues;
 }
@@ -407,24 +423,15 @@ function validateExitCriteria(criteria: BlockExitCriteria | undefined, path: str
     if (criteria.stagnationReviewAfterWeeks !== undefined && !isPositiveInteger(criteria.stagnationReviewAfterWeeks)) {
         issues.push({ code: 'INVALID_STAGNATION_REVIEW_WEEKS', message: 'stagnationReviewAfterWeeks must be a positive integer', path: `${path}.stagnationReviewAfterWeeks` });
     }
-    if (
-        criteria.maxWeeksInBlock !== undefined
+    if (criteria.maxWeeksInBlock !== undefined
         && criteria.stagnationReviewAfterWeeks !== undefined
-        && criteria.stagnationReviewAfterWeeks > criteria.maxWeeksInBlock
-    ) {
-        issues.push({
-            code: 'STAGNATION_REVIEW_AFTER_BLOCK_EXIT',
-            message: 'stagnationReviewAfterWeeks cannot exceed maxWeeksInBlock',
-            path: `${path}.stagnationReviewAfterWeeks`,
-        });
+        && criteria.stagnationReviewAfterWeeks > criteria.maxWeeksInBlock) {
+        issues.push({ code: 'STAGNATION_REVIEW_AFTER_BLOCK_EXIT', message: 'stagnationReviewAfterWeeks cannot exceed maxWeeksInBlock', path: `${path}.stagnationReviewAfterWeeks` });
     }
     return issues;
 }
 
-function validateSubstitutions(
-    objective: BlockObjectiveDefinition,
-    path: string,
-): ValidationIssue[] {
+function validateSubstitutions(objective: BlockObjectiveDefinition, path: string): ValidationIssue[] {
     if (!objective.allowedSubstitutions) return [];
     const issues: ValidationIssue[] = [];
     const targets = new Set<PlanCoverageKey>();
@@ -434,11 +441,7 @@ function validateSubstitutions(
             issues.push({ code: 'INVALID_SUBSTITUTION_TARGET', message: `Unsupported target coverage key: ${rule.targetCoverageKey}`, path: `${rulePath}.targetCoverageKey` });
         } else {
             if (rule.targetCoverageKey !== objective.coverageKey) {
-                issues.push({
-                    code: 'SUBSTITUTION_TARGET_MISMATCH',
-                    message: `Substitution target ${rule.targetCoverageKey} does not match objective coverage ${objective.coverageKey}`,
-                    path: `${rulePath}.targetCoverageKey`,
-                });
+                issues.push({ code: 'SUBSTITUTION_TARGET_MISMATCH', message: `Substitution target ${rule.targetCoverageKey} does not match objective coverage ${objective.coverageKey}`, path: `${rulePath}.targetCoverageKey` });
             }
             if (targets.has(rule.targetCoverageKey)) {
                 issues.push({ code: 'DUPLICATE_SUBSTITUTION_TARGET', message: `Duplicate substitution rule for ${rule.targetCoverageKey}`, path: `${rulePath}.targetCoverageKey` });
@@ -463,11 +466,7 @@ function validateSubstitutions(
             || rule.minDoseFraction <= 0
             || rule.minDoseFraction > 1
         )) {
-            issues.push({
-                code: 'INVALID_SUBSTITUTION_MIN_DOSE_FRACTION',
-                message: 'minDoseFraction must be finite and in (0, 1]',
-                path: `${rulePath}.minDoseFraction`,
-            });
+            issues.push({ code: 'INVALID_SUBSTITUTION_MIN_DOSE_FRACTION', message: 'minDoseFraction must be finite and in (0, 1]', path: `${rulePath}.minDoseFraction` });
         }
     });
     return issues;
@@ -500,17 +499,9 @@ export function validateProgressionContract(
 
     const expectedUnit = PROGRESSION_VARIABLE_UNITS[contract.variable];
     if (!expectedUnit) {
-        issues.push({
-            code: 'UNSUPPORTED_PROGRESSION_VARIABLE',
-            message: `Unsupported progression variable: ${String(contract.variable)}`,
-            path: `${path}.variable`,
-        });
+        issues.push({ code: 'UNSUPPORTED_PROGRESSION_VARIABLE', message: `Unsupported progression variable: ${String(contract.variable)}`, path: `${path}.variable` });
     } else if (contract.unit !== expectedUnit) {
-        issues.push({
-            code: 'PROGRESSION_VARIABLE_UNIT_MISMATCH',
-            message: `Progression variable ${contract.variable} requires unit ${expectedUnit}, got ${contract.unit}`,
-            path: `${path}.unit`,
-        });
+        issues.push({ code: 'PROGRESSION_VARIABLE_UNIT_MISMATCH', message: `Progression variable ${contract.variable} requires unit ${expectedUnit}, got ${contract.unit}`, path: `${path}.unit` });
     }
 
     if (!Number.isFinite(contract.currentValue) || contract.currentValue < 0) {
@@ -531,14 +522,9 @@ export function validateProgressionContract(
             issues.push({ code: 'CURRENT_VALUE_OUT_OF_RANGE', message: `Current value (${contract.currentValue}) is outside permitted range [${range.min}, ${range.max}]`, path: `${path}.currentValue` });
         }
         if (targetObjective && contract.unit === targetObjective.doseEnvelope.unit && (
-            range.min < targetObjective.doseEnvelope.min
-            || range.max > targetObjective.doseEnvelope.max
+            range.min < targetObjective.doseEnvelope.min || range.max > targetObjective.doseEnvelope.max
         )) {
-            issues.push({
-                code: 'PROGRESSION_RANGE_EXCEEDS_OBJECTIVE_ENVELOPE',
-                message: `Progression range [${range.min}, ${range.max}] must stay within objective envelope [${targetObjective.doseEnvelope.min}, ${targetObjective.doseEnvelope.max}]`,
-                path: `${path}.permittedRange`,
-            });
+            issues.push({ code: 'PROGRESSION_RANGE_EXCEEDS_OBJECTIVE_ENVELOPE', message: `Progression range [${range.min}, ${range.max}] must stay within objective envelope [${targetObjective.doseEnvelope.min}, ${targetObjective.doseEnvelope.max}]`, path: `${path}.permittedRange` });
         }
     }
 
@@ -555,7 +541,7 @@ export function validateProgressionContract(
         issues.push({ code: 'INVALID_REVIEW_CADENCE', message: `Review cadence days must be a positive integer: ${contract.reviewCadenceDays}`, path: `${path}.reviewCadenceDays` });
     }
 
-    issues.push(...validateOptionalStringSet(contract.knowledgeLineage, `${path}.knowledgeLineage`));
+    issues.push(...validateStringSet(contract.knowledgeLineage, `${path}.knowledgeLineage`, true));
 
     if (contract.reductionAlternative) {
         if (contract.reductionAlternative.trigger !== 'adverse_response') {
@@ -565,11 +551,7 @@ export function validateProgressionContract(
             issues.push({ code: 'INVALID_REDUCTION_DECREMENT', message: `Reduction decrement must be a positive finite number: ${contract.reductionAlternative.decrement}`, path: `${path}.reductionAlternative.decrement` });
         } else if (range && Number.isFinite(range.min) && Number.isFinite(contract.currentValue)
             && contract.currentValue - contract.reductionAlternative.decrement < range.min) {
-            issues.push({
-                code: 'REDUCTION_DECREMENT_EXCEEDS_RANGE',
-                message: 'Reduction alternative must produce a value inside the permitted range without hidden clamping',
-                path: `${path}.reductionAlternative.decrement`,
-            });
+            issues.push({ code: 'REDUCTION_DECREMENT_EXCEEDS_RANGE', message: 'Reduction alternative must produce a value inside the permitted range without hidden clamping', path: `${path}.reductionAlternative.decrement` });
         }
     }
 
@@ -589,15 +571,17 @@ export function validateProgressionContract(
         }
     }
 
-    if (
-        contract.reductionAlternative?.trigger === 'adverse_response'
-        && contract.redirectCriteria?.triggers.includes('adverse_response')
-    ) {
+    if (!contract.reductionAlternative && (!contract.redirectCriteria || contract.redirectCriteria.triggers.length === 0)) {
         issues.push({
-            code: 'AMBIGUOUS_ADVERSE_RESPONSE_ACTION',
-            message: 'The same adverse_response trigger cannot request both reduction and redirect',
+            code: 'MISSING_PROGRESSION_FALLBACK',
+            message: 'An enabled progression contract requires a bounded reduction alternative or explicit redirect-to-review trigger',
             path,
         });
+    }
+
+    if (contract.reductionAlternative?.trigger === 'adverse_response'
+        && contract.redirectCriteria?.triggers.includes('adverse_response')) {
+        issues.push({ code: 'AMBIGUOUS_ADVERSE_RESPONSE_ACTION', message: 'The same adverse_response trigger cannot request both reduction and redirect', path });
     }
 
     return issues;
@@ -611,8 +595,8 @@ function validateObjective(objective: BlockObjectiveDefinition, path: string): V
     if (!(SUPPORTED_BLOCK_SPORTS as readonly string[]).includes(objective.sport)) {
         issues.push({ code: 'INVALID_OBJECTIVE_SPORT', message: `Unsupported objective sport: ${objective.sport}`, path: `${path}.sport` });
     }
-    if (!isNonEmptyString(objective.adaptationScope)) {
-        issues.push({ code: 'INVALID_ADAPTATION_SCOPE', message: 'adaptationScope must be a non-empty string', path: `${path}.adaptationScope` });
+    if (!(SUPPORTED_ADAPTATION_SCOPES as readonly string[]).includes(objective.adaptationScope)) {
+        issues.push({ code: 'INVALID_ADAPTATION_SCOPE', message: `Unsupported adaptation scope: ${objective.adaptationScope}`, path: `${path}.adaptationScope` });
     }
     if (!isSupportedCoverageKey(objective.coverageKey)) {
         issues.push({ code: 'INVALID_OBJECTIVE_COVERAGE_KEY', message: `Unsupported coverage key: ${objective.coverageKey}`, path: `${path}.coverageKey` });
@@ -628,10 +612,14 @@ function validateObjective(objective: BlockObjectiveDefinition, path: string): V
     } else {
         issues.push({ code: 'MISSING_DOSE_ENVELOPE', message: 'Objective must specify a doseEnvelope', path: `${path}.doseEnvelope` });
     }
-    issues.push(...validateOptionalStringSet(objective.knowledgeLineage, `${path}.knowledgeLineage`));
-    issues.push(...validateOptionalStringSet(objective.protectedRoles, `${path}.protectedRoles`));
+    issues.push(...validateStringSet(objective.knowledgeLineage, `${path}.knowledgeLineage`, true));
+    issues.push(...validateProtectedRoles(objective.protectedRoles, `${path}.protectedRoles`));
     issues.push(...validateSubstitutions(objective, `${path}.allowedSubstitutions`));
-    issues.push(...validateSuccessCriteria(objective.successCriteria, objective.intent, `${path}.successCriteria`));
+    if (!objective.successCriteria) {
+        issues.push({ code: 'MISSING_SUCCESS_CRITERIA', message: 'Objective must declare prospective process and/or outcome success criteria', path: `${path}.successCriteria` });
+    } else {
+        issues.push(...validateSuccessCriteria(objective.successCriteria, objective.intent, `${path}.successCriteria`));
+    }
     issues.push(...validatePrerequisites(objective.entryPrerequisites, `${path}.entryPrerequisites`));
     issues.push(...validateExitCriteria(objective.exitCriteria, `${path}.exitCriteria`));
     return issues;
@@ -671,11 +659,7 @@ export function validateIntentBlock(block: IntentBlock): IntentBlockValidationRe
         block.reviewSchedule.nextReviewDate < block.dateRange.startDate
         || block.reviewSchedule.nextReviewDate > block.dateRange.endDate
     )) {
-        issues.push({
-            code: 'NEXT_REVIEW_OUTSIDE_BLOCK',
-            message: 'nextReviewDate must fall inside the active block interval',
-            path: `${rootPath}.reviewSchedule.nextReviewDate`,
-        });
+        issues.push({ code: 'NEXT_REVIEW_OUTSIDE_BLOCK', message: 'nextReviewDate must fall inside the active block interval', path: `${rootPath}.reviewSchedule.nextReviewDate` });
     }
 
     const objectivesById = new Map<string, BlockObjectiveDefinition>();
@@ -697,17 +681,11 @@ export function validateIntentBlock(block: IntentBlock): IntentBlockValidationRe
 
     if (block.progressionContract) {
         issues.push(...validateProgressionContract(block.progressionContract, objectivesById, `${rootPath}.progressionContract`));
-        if (
-            block.reviewSchedule
+        if (block.reviewSchedule
             && isPositiveInteger(block.reviewSchedule.reviewCadenceDays)
             && isPositiveInteger(block.progressionContract.reviewCadenceDays)
-            && block.reviewSchedule.reviewCadenceDays !== block.progressionContract.reviewCadenceDays
-        ) {
-            issues.push({
-                code: 'PROGRESSION_REVIEW_CADENCE_MISMATCH',
-                message: 'Block review cadence and progression contract cadence must agree',
-                path: `${rootPath}.progressionContract.reviewCadenceDays`,
-            });
+            && block.reviewSchedule.reviewCadenceDays !== block.progressionContract.reviewCadenceDays) {
+            issues.push({ code: 'PROGRESSION_REVIEW_CADENCE_MISMATCH', message: 'Block review cadence and progression contract cadence must agree', path: `${rootPath}.progressionContract.reviewCadenceDays` });
         }
     }
 
@@ -726,22 +704,16 @@ export function validatePlanIntentBlocks(blocks: readonly IntentBlock[]): Intent
         if (isNonEmptyString(block.sourcePlanId) && isNonEmptyString(block.id)) {
             const ids = blockIdsByPlan.get(block.sourcePlanId) ?? new Set<string>();
             if (ids.has(block.id)) {
-                issues.push({
-                    code: 'DUPLICATE_BLOCK_ID',
-                    message: `Duplicate block ID across plan ${block.sourcePlanId}: ${block.id}`,
-                    path: `blocks[${index}].id`,
-                });
+                issues.push({ code: 'DUPLICATE_BLOCK_ID', message: `Duplicate block ID across plan ${block.sourcePlanId}: ${block.id}`, path: `blocks[${index}].id` });
             }
             ids.add(block.id);
             blockIdsByPlan.set(block.sourcePlanId, ids);
         }
 
-        if (
-            isNonEmptyString(block.sourcePlanId)
+        if (isNonEmptyString(block.sourcePlanId)
             && isValidLocalDateString(block.dateRange?.startDate)
             && isValidLocalDateString(block.dateRange?.endDate)
-            && block.dateRange.startDate <= block.dateRange.endDate
-        ) {
+            && block.dateRange.startDate <= block.dateRange.endDate) {
             const intervals = validIntervalsByPlan.get(block.sourcePlanId) ?? [];
             intervals.push(block);
             validIntervalsByPlan.set(block.sourcePlanId, intervals);
@@ -752,11 +724,7 @@ export function validatePlanIntentBlocks(blocks: readonly IntentBlock[]): Intent
         const sorted = [...planBlocks].sort((a, b) => a.dateRange.startDate.localeCompare(b.dateRange.startDate));
         for (let i = 0; i < sorted.length - 1; i++) {
             if (sorted[i].dateRange.endDate >= sorted[i + 1].dateRange.startDate) {
-                issues.push({
-                    code: 'OVERLAPPING_INTENT_BLOCKS',
-                    message: `Intent blocks ${sorted[i].id} and ${sorted[i + 1].id} overlap in plan ${planId}: ${sorted[i].dateRange.endDate} >= ${sorted[i + 1].dateRange.startDate}`,
-                    path: `blocks[${sorted[i].id}]`,
-                });
+                issues.push({ code: 'OVERLAPPING_INTENT_BLOCKS', message: `Intent blocks ${sorted[i].id} and ${sorted[i + 1].id} overlap in plan ${planId}: ${sorted[i].dateRange.endDate} >= ${sorted[i + 1].dateRange.startDate}`, path: `blocks[${sorted[i].id}]` });
             }
         }
     }

--- a/app/src/engine/blockIntent.ts
+++ b/app/src/engine/blockIntent.ts
@@ -1,9 +1,9 @@
 /**
  * ADR-0037: Block Intent and Controlled Progression (H5a).
  *
- * Defines domain models and fail-closed validators for explicit per-objective intent
- * (`develop` | `maintain`), dose envelopes, protected roles/substitutions, prospective
- * review criteria, and one bounded progression experiment.
+ * Defines domain models and fail-closed validators for explicit per-objective intent,
+ * dose envelopes, protected roles/substitutions, prospective review criteria, and one
+ * bounded progression experiment.
  */
 
 import type { PlanCoverageKey } from '../workouts/event-plan';
@@ -11,74 +11,33 @@ import type { ObjectiveKey, ObjectivePriority } from './models';
 
 export type BlockIntent = 'develop' | 'maintain';
 export type BlockSport = 'cycling' | 'strength' | 'running' | 'swimming' | 'multisport' | 'cross_training';
-
-export type DoseUnit =
-    | 'minutes'
-    | 'sessions'
-    | 'repetitions'
-    | 'kilometers'
-    | 'tss'
-    | 'joules'
-    | 'rpe_load';
+export type DoseUnit = 'minutes' | 'sessions' | 'repetitions' | 'kilometers' | 'tss' | 'joules' | 'rpe_load';
+export type FloorSemantics = 'hard_floor' | 'soft_floor';
+export type TissueSeverity = 'monitor' | 'limit' | 'exclude';
 
 export const SUPPORTED_DOSE_UNITS: readonly DoseUnit[] = [
-    'minutes',
-    'sessions',
-    'repetitions',
-    'kilometers',
-    'tss',
-    'joules',
-    'rpe_load',
+    'minutes', 'sessions', 'repetitions', 'kilometers', 'tss', 'joules', 'rpe_load',
 ] as const;
 
 export const SUPPORTED_BLOCK_SPORTS: readonly BlockSport[] = [
-    'cycling',
-    'strength',
-    'running',
-    'swimming',
-    'multisport',
-    'cross_training',
+    'cycling', 'strength', 'running', 'swimming', 'multisport', 'cross_training',
 ] as const;
 
 export const SUPPORTED_ADAPTATION_SCOPES: readonly ObjectiveKey[] = [
-    'threshold_quality',
-    'surge_repeatability',
-    'zone2_aerobic',
-    'strength_maintenance',
-    'strength_development',
-    'race_specific_endurance',
-    'vo2_max',
+    'threshold_quality', 'surge_repeatability', 'zone2_aerobic', 'strength_maintenance',
+    'strength_development', 'race_specific_endurance', 'vo2_max',
 ] as const;
 
 export const SUPPORTED_OBJECTIVE_PRIORITIES: readonly ObjectivePriority[] = [
-    'must_have',
-    'should_have',
-    'nice_to_have',
+    'must_have', 'should_have', 'nice_to_have',
 ] as const;
 
 export const SUPPORTED_PLAN_COVERAGE_KEYS: readonly PlanCoverageKey[] = [
-    'aerobic_volume',
-    'recovery_spin',
-    'sustained_quality',
-    'short_surges',
-    'gap_closing',
-    'outdoor_event_specific',
-    'primary_strength',
-    'compact_strength',
-    'upper_body_trunk',
-    'field_maintenance',
-    'walk_run',
-    'recovery_or_rest',
-    'travel_aerobic',
-    'travel_strength',
-    'taper_sharpening',
-    'pre_race_openers',
-    'race_week_strength',
-    'race_day',
+    'aerobic_volume', 'recovery_spin', 'sustained_quality', 'short_surges', 'gap_closing',
+    'outdoor_event_specific', 'primary_strength', 'compact_strength', 'upper_body_trunk',
+    'field_maintenance', 'walk_run', 'recovery_or_rest', 'travel_aerobic', 'travel_strength',
+    'taper_sharpening', 'pre_race_openers', 'race_week_strength', 'race_day',
 ] as const;
-
-export type FloorSemantics = 'hard_floor' | 'soft_floor';
-export type TissueSeverity = 'monitor' | 'limit' | 'exclude';
 
 export interface DoseEnvelope {
     min: number;
@@ -101,11 +60,7 @@ export interface BlockSubstitutionRule {
 }
 
 export interface BlockSuccessCriteria {
-    evaluationRef?: {
-        id: string;
-        revision: number;
-        metricId: string;
-    };
+    evaluationRef?: { id: string; revision: number; metricId: string };
     minCompletedExposures?: number;
     targetTrend?: 'stable' | 'improving';
     acceptableDeclineTolerancePct?: number;
@@ -125,8 +80,7 @@ export interface BlockExitCriteria {
 export interface BlockObjectiveDefinition {
     id: string;
     sport: BlockSport;
-    /** Phase 1 reuses the repository's typed objective vocabulary rather than accepting a
-     * new free-text physiological namespace. */
+    /** Phase 1 reuses the repository's typed objective vocabulary. */
     adaptationScope: ObjectiveKey;
     coverageKey: PlanCoverageKey;
     intent: BlockIntent;
@@ -140,11 +94,7 @@ export interface BlockObjectiveDefinition {
     exitCriteria?: BlockExitCriteria;
 }
 
-/**
- * Phase-1 progression deliberately supports only a registered duration variable. Additional
- * prescription variables must be added here with an explicit unit mapping and tests rather
- * than accepted as arbitrary executable/free-text field paths (ADR-0037 D-CHANGE).
- */
+/** Phase 1 intentionally supports only one registered prescription variable. */
 export type ProgressionVariable = 'duration_min';
 export const PROGRESSION_VARIABLE_UNITS: Readonly<Record<ProgressionVariable, DoseUnit>> = {
     duration_min: 'minutes',
@@ -154,32 +104,20 @@ export type ProgressionReductionTrigger = 'adverse_response';
 export type ProgressionRedirectTrigger = 'adverse_response' | 'active_restriction';
 
 export interface BlockProgressionContract {
-    targetBinding: {
-        objectiveId: string;
-        sessionId?: string;
-        stepId?: string;
-    };
+    targetBinding: { objectiveId: string; sessionId?: string; stepId?: string };
     variable: ProgressionVariable;
     unit: DoseUnit;
     currentValue: number;
-    permittedRange: {
-        min: number;
-        max: number;
-    };
+    permittedRange: { min: number; max: number };
     increment: number;
     knowledgeLineage: readonly string[];
     observationWindowDays: number;
     minCompletedExposures: number;
     requiredFollowUpCoveragePct: number;
     reviewCadenceDays: number;
-    reductionAlternative?: {
-        decrement: number;
-        trigger: ProgressionReductionTrigger;
-    };
-    /** Explicit stop-and-review triggers. No hidden adverse-count threshold exists. */
-    redirectCriteria?: {
-        triggers: readonly ProgressionRedirectTrigger[];
-    };
+    reductionAlternative?: { decrement: number; trigger: ProgressionReductionTrigger };
+    /** Explicit stop-and-review triggers; no hidden adverse-count threshold exists. */
+    redirectCriteria?: { triggers: readonly ProgressionRedirectTrigger[] };
 }
 
 export interface IntentBlock {
@@ -187,17 +125,11 @@ export interface IntentBlock {
     revision: number;
     sourcePlanId: string;
     sourcePlanRevision: number;
-    dateRange: {
-        startDate: string;
-        endDate: string;
-    };
+    dateRange: { startDate: string; endDate: string };
     objectives: readonly BlockObjectiveDefinition[];
-    reviewSchedule: {
-        reviewCadenceDays: number;
-        nextReviewDate: string;
-    };
+    reviewSchedule: { reviewCadenceDays: number; nextReviewDate: string };
     progressionContract?: BlockProgressionContract;
-    /** Presentation / descriptive labels only; excluded from canonical replay digest. */
+    /** Presentation-only labels; excluded from canonical replay digest. */
     title?: string;
     notes?: string;
 }
@@ -238,7 +170,11 @@ function isNonNegativeInteger(value: unknown): value is number {
     return Number.isInteger(value) && (value as number) >= 0;
 }
 
-function validateStringSet(values: readonly string[] | undefined, path: string, required: boolean): ValidationIssue[] {
+function validateStringSet(
+    values: readonly string[] | undefined,
+    path: string,
+    required: boolean,
+): ValidationIssue[] {
     const issues: ValidationIssue[] = [];
     if (!values || values.length === 0) {
         if (required) {
@@ -250,6 +186,7 @@ function validateStringSet(values: readonly string[] | undefined, path: string, 
         }
         return issues;
     }
+
     const seen = new Set<string>();
     values.forEach((value, index) => {
         if (!isNonEmptyString(value)) {
@@ -282,23 +219,17 @@ function isSupportedCoverageKey(key: string): key is PlanCoverageKey {
 
 export function validateDoseEnvelope(envelope: DoseEnvelope, path: string): ValidationIssue[] {
     const issues: ValidationIssue[] = [];
-
     if (!isSupportedDoseUnit(envelope.unit)) {
-        issues.push({
-            code: 'UNSUPPORTED_DOSE_UNIT',
-            message: `Unsupported dose unit: ${envelope.unit}`,
-            path: `${path}.unit`,
-        });
+        issues.push({ code: 'UNSUPPORTED_DOSE_UNIT', message: `Unsupported dose unit: ${envelope.unit}`, path: `${path}.unit` });
     }
-
     if (!Number.isFinite(envelope.min) || envelope.min < 0) {
-        issues.push({ code: 'INVALID_DOSE_MIN', message: `Dose min must be a finite non-negative number: ${envelope.min}`, path: `${path}.min` });
+        issues.push({ code: 'INVALID_DOSE_MIN', message: `Dose min must be finite and non-negative: ${envelope.min}`, path: `${path}.min` });
     }
     if (!Number.isFinite(envelope.target) || envelope.target < 0) {
-        issues.push({ code: 'INVALID_DOSE_TARGET', message: `Dose target must be a finite non-negative number: ${envelope.target}`, path: `${path}.target` });
+        issues.push({ code: 'INVALID_DOSE_TARGET', message: `Dose target must be finite and non-negative: ${envelope.target}`, path: `${path}.target` });
     }
     if (!Number.isFinite(envelope.max) || envelope.max < 0) {
-        issues.push({ code: 'INVALID_DOSE_MAX', message: `Dose max must be a finite non-negative number: ${envelope.max}`, path: `${path}.max` });
+        issues.push({ code: 'INVALID_DOSE_MAX', message: `Dose max must be finite and non-negative: ${envelope.max}`, path: `${path}.max` });
     }
     if (Number.isFinite(envelope.min) && Number.isFinite(envelope.target) && envelope.min > envelope.target) {
         issues.push({ code: 'INVERTED_DOSE_BOUNDS_MIN_TARGET', message: `Dose min (${envelope.min}) cannot exceed target (${envelope.target})`, path: `${path}.min` });
@@ -309,33 +240,53 @@ export function validateDoseEnvelope(envelope: DoseEnvelope, path: string): Vali
     if (envelope.floorSemantics !== 'hard_floor' && envelope.floorSemantics !== 'soft_floor') {
         issues.push({ code: 'INVALID_FLOOR_SEMANTICS', message: `Invalid floor semantics: ${envelope.floorSemantics}`, path: `${path}.floorSemantics` });
     }
-
     return issues;
 }
 
-function validateProtectedRoles(roles: readonly BlockProtectedRole[] | undefined, path: string): ValidationIssue[] {
+function validateProtectedRoles(
+    roles: readonly BlockProtectedRole[] | undefined,
+    path: string,
+): ValidationIssue[] {
     if (!roles) return [];
     const issues: ValidationIssue[] = [];
     const seen = new Set<string>();
+
     roles.forEach((role, index) => {
         const rolePath = `${path}[${index}]`;
-        let identity = '';
+        let identity: string;
         if (role.kind === 'coverage_role') {
             if (!isSupportedCoverageKey(role.coverageKey)) {
-                issues.push({ code: 'INVALID_PROTECTED_COVERAGE_ROLE', message: `Unsupported protected coverage role: ${role.coverageKey}`, path: `${rolePath}.coverageKey` });
+                issues.push({
+                    code: 'INVALID_PROTECTED_COVERAGE_ROLE',
+                    message: `Unsupported protected coverage role: ${role.coverageKey}`,
+                    path: `${rolePath}.coverageKey`,
+                });
             }
             identity = `coverage_role:${role.coverageKey}`;
         } else if (role.kind === 'session') {
             if (!isNonEmptyString(role.sessionId)) {
-                issues.push({ code: 'INVALID_PROTECTED_SESSION_ID', message: 'Protected session id must be non-empty', path: `${rolePath}.sessionId` });
+                issues.push({
+                    code: 'INVALID_PROTECTED_SESSION_ID',
+                    message: 'Protected session id must be non-empty',
+                    path: `${rolePath}.sessionId`,
+                });
             }
             identity = `session:${role.sessionId}`;
         } else {
-            issues.push({ code: 'INVALID_PROTECTED_ROLE_KIND', message: `Unsupported protected role kind: ${String((role as { kind?: unknown }).kind)}`, path: `${rolePath}.kind` });
+            issues.push({
+                code: 'INVALID_PROTECTED_ROLE_KIND',
+                message: `Unsupported protected role kind: ${String((role as { kind?: unknown }).kind)}`,
+                path: `${rolePath}.kind`,
+            });
             return;
         }
+
         if (seen.has(identity)) {
-            issues.push({ code: 'DUPLICATE_PROTECTED_ROLE', message: `Duplicate protected reference: ${identity}`, path: rolePath });
+            issues.push({
+                code: 'DUPLICATE_PROTECTED_ROLE',
+                message: `Duplicate protected reference: ${identity}`,
+                path: rolePath,
+            });
         }
         seen.add(identity);
     });
@@ -351,7 +302,7 @@ function validateSuccessCriteria(
     if (!criteria.evaluationRef && criteria.minCompletedExposures === undefined) {
         issues.push({
             code: 'EMPTY_SUCCESS_CRITERIA',
-            message: 'Success criteria must declare a process exposure threshold and/or a pinned evaluationRef',
+            message: 'Success criteria must declare a process exposure threshold and/or pinned evaluationRef',
             path,
         });
     }
@@ -377,21 +328,24 @@ function validateSuccessCriteria(
         || criteria.acceptableDeclineTolerancePct < 0
         || criteria.acceptableDeclineTolerancePct > 100
     )) {
-        issues.push({ code: 'INVALID_DECLINE_TOLERANCE', message: 'acceptableDeclineTolerancePct must be finite and between 0 and 100', path: `${path}.acceptableDeclineTolerancePct` });
+        issues.push({ code: 'INVALID_DECLINE_TOLERANCE', message: 'acceptableDeclineTolerancePct must be finite and in [0, 100]', path: `${path}.acceptableDeclineTolerancePct` });
     }
     if ((criteria.targetTrend !== undefined || criteria.acceptableDeclineTolerancePct !== undefined) && !criteria.evaluationRef) {
         issues.push({ code: 'OUTCOME_CRITERIA_REQUIRE_EVALUATION_REF', message: 'Outcome trend/tolerance criteria require a pinned evaluationRef', path });
     }
     if (intent === 'develop' && criteria.evaluationRef && criteria.targetTrend === undefined) {
-        issues.push({ code: 'DEVELOPMENT_OUTCOME_REQUIRES_TARGET_TREND', message: 'A measured development objective must declare its prospective targetTrend', path: `${path}.targetTrend` });
+        issues.push({ code: 'DEVELOPMENT_OUTCOME_REQUIRES_TARGET_TREND', message: 'Measured development requires a prospective targetTrend', path: `${path}.targetTrend` });
     }
     if (intent === 'maintain' && criteria.evaluationRef && criteria.acceptableDeclineTolerancePct === undefined) {
-        issues.push({ code: 'MAINTENANCE_OUTCOME_REQUIRES_TOLERANCE', message: 'A measured maintenance objective must declare an acceptable decline tolerance', path: `${path}.acceptableDeclineTolerancePct` });
+        issues.push({ code: 'MAINTENANCE_OUTCOME_REQUIRES_TOLERANCE', message: 'Measured maintenance requires an acceptable decline tolerance', path: `${path}.acceptableDeclineTolerancePct` });
     }
     return issues;
 }
 
-function validatePrerequisites(prerequisites: BlockPrerequisites | undefined, path: string): ValidationIssue[] {
+function validatePrerequisites(
+    prerequisites: BlockPrerequisites | undefined,
+    path: string,
+): ValidationIssue[] {
     if (!prerequisites) return [];
     const issues: ValidationIssue[] = [];
     if (prerequisites.requiredPriorExposures !== undefined && !isNonNegativeInteger(prerequisites.requiredPriorExposures)) {
@@ -414,7 +368,10 @@ function validatePrerequisites(prerequisites: BlockPrerequisites | undefined, pa
     return issues;
 }
 
-function validateExitCriteria(criteria: BlockExitCriteria | undefined, path: string): ValidationIssue[] {
+function validateExitCriteria(
+    criteria: BlockExitCriteria | undefined,
+    path: string,
+): ValidationIssue[] {
     if (!criteria) return [];
     const issues: ValidationIssue[] = [];
     if (criteria.maxWeeksInBlock !== undefined && !isPositiveInteger(criteria.maxWeeksInBlock)) {
@@ -431,10 +388,14 @@ function validateExitCriteria(criteria: BlockExitCriteria | undefined, path: str
     return issues;
 }
 
-function validateSubstitutions(objective: BlockObjectiveDefinition, path: string): ValidationIssue[] {
+function validateSubstitutions(
+    objective: BlockObjectiveDefinition,
+    path: string,
+): ValidationIssue[] {
     if (!objective.allowedSubstitutions) return [];
     const issues: ValidationIssue[] = [];
     const targets = new Set<PlanCoverageKey>();
+
     objective.allowedSubstitutions.forEach((rule, index) => {
         const rulePath = `${path}[${index}]`;
         if (!isSupportedCoverageKey(rule.targetCoverageKey)) {
@@ -448,6 +409,7 @@ function validateSubstitutions(objective: BlockObjectiveDefinition, path: string
             }
             targets.add(rule.targetCoverageKey);
         }
+
         if (!Array.isArray(rule.allowedCoverageKeys) || rule.allowedCoverageKeys.length === 0) {
             issues.push({ code: 'EMPTY_SUBSTITUTION_CANDIDATES', message: 'allowedCoverageKeys must contain at least one typed coverage key', path: `${rulePath}.allowedCoverageKeys` });
         } else {
@@ -461,6 +423,7 @@ function validateSubstitutions(objective: BlockObjectiveDefinition, path: string
                 allowed.add(key);
             });
         }
+
         if (rule.minDoseFraction !== undefined && (
             !Number.isFinite(rule.minDoseFraction)
             || rule.minDoseFraction <= 0
@@ -508,7 +471,7 @@ export function validateProgressionContract(
         issues.push({ code: 'INVALID_CURRENT_VALUE', message: `Current value must be finite and non-negative: ${contract.currentValue}`, path: `${path}.currentValue` });
     }
     if (!Number.isFinite(contract.increment) || contract.increment <= 0) {
-        issues.push({ code: 'INVALID_PROGRESSION_INCREMENT', message: `Progression increment must be a positive finite number: ${contract.increment}`, path: `${path}.increment` });
+        issues.push({ code: 'INVALID_PROGRESSION_INCREMENT', message: `Progression increment must be positive and finite: ${contract.increment}`, path: `${path}.increment` });
     }
 
     const range = contract.permittedRange;
@@ -518,8 +481,9 @@ export function validateProgressionContract(
         if (range.min >= range.max) {
             issues.push({ code: 'INVERTED_PERMITTED_RANGE', message: `Permitted range min (${range.min}) must be less than max (${range.max})`, path: `${path}.permittedRange` });
         }
-        if (Number.isFinite(contract.currentValue) && (contract.currentValue < range.min || contract.currentValue > range.max)) {
-            issues.push({ code: 'CURRENT_VALUE_OUT_OF_RANGE', message: `Current value (${contract.currentValue}) is outside permitted range [${range.min}, ${range.max}]`, path: `${path}.currentValue` });
+        if (Number.isFinite(contract.currentValue)
+            && (contract.currentValue < range.min || contract.currentValue > range.max)) {
+            issues.push({ code: 'CURRENT_VALUE_OUT_OF_RANGE', message: `Current value (${contract.currentValue}) is outside [${range.min}, ${range.max}]`, path: `${path}.currentValue` });
         }
         if (targetObjective && contract.unit === targetObjective.doseEnvelope.unit && (
             range.min < targetObjective.doseEnvelope.min || range.max > targetObjective.doseEnvelope.max
@@ -529,12 +493,14 @@ export function validateProgressionContract(
     }
 
     if (!isPositiveInteger(contract.observationWindowDays)) {
-        issues.push({ code: 'INVALID_OBSERVATION_WINDOW', message: `Observation window must be a positive integer days: ${contract.observationWindowDays}`, path: `${path}.observationWindowDays` });
+        issues.push({ code: 'INVALID_OBSERVATION_WINDOW', message: `Observation window must be positive integer days: ${contract.observationWindowDays}`, path: `${path}.observationWindowDays` });
     }
     if (!isPositiveInteger(contract.minCompletedExposures)) {
         issues.push({ code: 'INVALID_MIN_COMPLETED_EXPOSURES', message: `Min completed exposures must be a positive integer: ${contract.minCompletedExposures}`, path: `${path}.minCompletedExposures` });
     }
-    if (!Number.isFinite(contract.requiredFollowUpCoveragePct) || contract.requiredFollowUpCoveragePct <= 0 || contract.requiredFollowUpCoveragePct > 100) {
+    if (!Number.isFinite(contract.requiredFollowUpCoveragePct)
+        || contract.requiredFollowUpCoveragePct <= 0
+        || contract.requiredFollowUpCoveragePct > 100) {
         issues.push({ code: 'INVALID_FOLLOW_UP_COVERAGE_PCT', message: `Required follow-up coverage percent must be in (0, 100]: ${contract.requiredFollowUpCoveragePct}`, path: `${path}.requiredFollowUpCoveragePct` });
     }
     if (!isPositiveInteger(contract.reviewCadenceDays)) {
@@ -547,11 +513,14 @@ export function validateProgressionContract(
         if (contract.reductionAlternative.trigger !== 'adverse_response') {
             issues.push({ code: 'UNSUPPORTED_REDUCTION_TRIGGER', message: `Unsupported reduction trigger: ${contract.reductionAlternative.trigger}`, path: `${path}.reductionAlternative.trigger` });
         }
-        if (!Number.isFinite(contract.reductionAlternative.decrement) || contract.reductionAlternative.decrement <= 0) {
-            issues.push({ code: 'INVALID_REDUCTION_DECREMENT', message: `Reduction decrement must be a positive finite number: ${contract.reductionAlternative.decrement}`, path: `${path}.reductionAlternative.decrement` });
-        } else if (range && Number.isFinite(range.min) && Number.isFinite(contract.currentValue)
+        if (!Number.isFinite(contract.reductionAlternative.decrement)
+            || contract.reductionAlternative.decrement <= 0) {
+            issues.push({ code: 'INVALID_REDUCTION_DECREMENT', message: `Reduction decrement must be positive and finite: ${contract.reductionAlternative.decrement}`, path: `${path}.reductionAlternative.decrement` });
+        } else if (range
+            && Number.isFinite(range.min)
+            && Number.isFinite(contract.currentValue)
             && contract.currentValue - contract.reductionAlternative.decrement < range.min) {
-            issues.push({ code: 'REDUCTION_DECREMENT_EXCEEDS_RANGE', message: 'Reduction alternative must produce a value inside the permitted range without hidden clamping', path: `${path}.reductionAlternative.decrement` });
+            issues.push({ code: 'REDUCTION_DECREMENT_EXCEEDS_RANGE', message: 'Reduction alternative must remain inside the permitted range without hidden clamping', path: `${path}.reductionAlternative.decrement` });
         }
     }
 
@@ -571,26 +540,30 @@ export function validateProgressionContract(
         }
     }
 
-    if (!contract.reductionAlternative && (!contract.redirectCriteria || contract.redirectCriteria.triggers.length === 0)) {
+    if (!contract.reductionAlternative
+        && (!contract.redirectCriteria || contract.redirectCriteria.triggers.length === 0)) {
         issues.push({
             code: 'MISSING_PROGRESSION_FALLBACK',
-            message: 'An enabled progression contract requires a bounded reduction alternative or explicit redirect-to-review trigger',
+            message: 'Enabled progression requires a bounded reduction alternative or explicit redirect-to-review trigger',
             path,
         });
     }
 
     if (contract.reductionAlternative?.trigger === 'adverse_response'
         && contract.redirectCriteria?.triggers.includes('adverse_response')) {
-        issues.push({ code: 'AMBIGUOUS_ADVERSE_RESPONSE_ACTION', message: 'The same adverse_response trigger cannot request both reduction and redirect', path });
+        issues.push({
+            code: 'AMBIGUOUS_ADVERSE_RESPONSE_ACTION',
+            message: 'The same adverse_response trigger cannot request both reduction and redirect',
+            path,
+        });
     }
-
     return issues;
 }
 
 function validateObjective(objective: BlockObjectiveDefinition, path: string): ValidationIssue[] {
     const issues: ValidationIssue[] = [];
     if (!isNonEmptyString(objective.id)) {
-        issues.push({ code: 'MISSING_OBJECTIVE_ID', message: 'Objective ID must be a non-empty string', path: `${path}.id` });
+        issues.push({ code: 'MISSING_OBJECTIVE_ID', message: 'Objective ID must be non-empty', path: `${path}.id` });
     }
     if (!(SUPPORTED_BLOCK_SPORTS as readonly string[]).includes(objective.sport)) {
         issues.push({ code: 'INVALID_OBJECTIVE_SPORT', message: `Unsupported objective sport: ${objective.sport}`, path: `${path}.sport` });
@@ -602,7 +575,7 @@ function validateObjective(objective: BlockObjectiveDefinition, path: string): V
         issues.push({ code: 'INVALID_OBJECTIVE_COVERAGE_KEY', message: `Unsupported coverage key: ${objective.coverageKey}`, path: `${path}.coverageKey` });
     }
     if (objective.intent !== 'develop' && objective.intent !== 'maintain') {
-        issues.push({ code: 'INVALID_OBJECTIVE_INTENT', message: `Objective intent must be 'develop' or 'maintain', got: ${objective.intent}`, path: `${path}.intent` });
+        issues.push({ code: 'INVALID_OBJECTIVE_INTENT', message: `Objective intent must be develop or maintain, got: ${objective.intent}`, path: `${path}.intent` });
     }
     if (!(SUPPORTED_OBJECTIVE_PRIORITIES as readonly string[]).includes(objective.priority)) {
         issues.push({ code: 'INVALID_OBJECTIVE_PRIORITY', message: `Unsupported objective priority: ${objective.priority}`, path: `${path}.priority` });
@@ -630,13 +603,13 @@ export function validateIntentBlock(block: IntentBlock): IntentBlockValidationRe
     const rootPath = `intentBlock[${block.id || 'unknown'}]`;
 
     if (!isNonEmptyString(block.id)) {
-        issues.push({ code: 'MISSING_BLOCK_ID', message: 'Block ID must be a non-empty string', path: `${rootPath}.id` });
+        issues.push({ code: 'MISSING_BLOCK_ID', message: 'Block ID must be non-empty', path: `${rootPath}.id` });
     }
     if (!isPositiveInteger(block.revision)) {
         issues.push({ code: 'INVALID_BLOCK_REVISION', message: `Block revision must be a positive integer: ${block.revision}`, path: `${rootPath}.revision` });
     }
     if (!isNonEmptyString(block.sourcePlanId)) {
-        issues.push({ code: 'MISSING_SOURCE_PLAN_ID', message: 'sourcePlanId must be a non-empty string', path: `${rootPath}.sourcePlanId` });
+        issues.push({ code: 'MISSING_SOURCE_PLAN_ID', message: 'sourcePlanId must be non-empty', path: `${rootPath}.sourcePlanId` });
     }
     if (!isPositiveInteger(block.sourcePlanRevision)) {
         issues.push({ code: 'INVALID_SOURCE_PLAN_REVISION', message: `sourcePlanRevision must be a positive integer: ${block.sourcePlanRevision}`, path: `${rootPath}.sourcePlanRevision` });
@@ -651,10 +624,10 @@ export function validateIntentBlock(block: IntentBlock): IntentBlockValidationRe
     }
 
     if (!block.reviewSchedule || !isPositiveInteger(block.reviewSchedule.reviewCadenceDays)) {
-        issues.push({ code: 'INVALID_BLOCK_REVIEW_CADENCE', message: 'Block reviewSchedule.reviewCadenceDays must be a positive integer', path: `${rootPath}.reviewSchedule.reviewCadenceDays` });
+        issues.push({ code: 'INVALID_BLOCK_REVIEW_CADENCE', message: 'reviewSchedule.reviewCadenceDays must be positive', path: `${rootPath}.reviewSchedule.reviewCadenceDays` });
     }
     if (!block.reviewSchedule || !isValidLocalDateString(block.reviewSchedule.nextReviewDate)) {
-        issues.push({ code: 'INVALID_NEXT_REVIEW_DATE', message: 'Block reviewSchedule.nextReviewDate must be a valid YYYY-MM-DD date', path: `${rootPath}.reviewSchedule.nextReviewDate` });
+        issues.push({ code: 'INVALID_NEXT_REVIEW_DATE', message: 'nextReviewDate must be a valid YYYY-MM-DD date', path: `${rootPath}.reviewSchedule.nextReviewDate` });
     } else if (startValid && endValid && (
         block.reviewSchedule.nextReviewDate < block.dateRange.startDate
         || block.reviewSchedule.nextReviewDate > block.dateRange.endDate
@@ -685,10 +658,9 @@ export function validateIntentBlock(block: IntentBlock): IntentBlockValidationRe
             && isPositiveInteger(block.reviewSchedule.reviewCadenceDays)
             && isPositiveInteger(block.progressionContract.reviewCadenceDays)
             && block.reviewSchedule.reviewCadenceDays !== block.progressionContract.reviewCadenceDays) {
-            issues.push({ code: 'PROGRESSION_REVIEW_CADENCE_MISMATCH', message: 'Block review cadence and progression contract cadence must agree', path: `${rootPath}.progressionContract.reviewCadenceDays` });
+            issues.push({ code: 'PROGRESSION_REVIEW_CADENCE_MISMATCH', message: 'Block and progression review cadence must agree', path: `${rootPath}.progressionContract.reviewCadenceDays` });
         }
     }
-
     return { valid: issues.length === 0, issues };
 }
 
@@ -698,8 +670,7 @@ export function validatePlanIntentBlocks(blocks: readonly IntentBlock[]): Intent
     const validIntervalsByPlan = new Map<string, IntentBlock[]>();
 
     blocks.forEach((block, index) => {
-        const singleResult = validateIntentBlock(block);
-        issues.push(...singleResult.issues);
+        issues.push(...validateIntentBlock(block).issues);
 
         if (isNonEmptyString(block.sourcePlanId) && isNonEmptyString(block.id)) {
             const ids = blockIdsByPlan.get(block.sourcePlanId) ?? new Set<string>();
@@ -724,10 +695,13 @@ export function validatePlanIntentBlocks(blocks: readonly IntentBlock[]): Intent
         const sorted = [...planBlocks].sort((a, b) => a.dateRange.startDate.localeCompare(b.dateRange.startDate));
         for (let i = 0; i < sorted.length - 1; i++) {
             if (sorted[i].dateRange.endDate >= sorted[i + 1].dateRange.startDate) {
-                issues.push({ code: 'OVERLAPPING_INTENT_BLOCKS', message: `Intent blocks ${sorted[i].id} and ${sorted[i + 1].id} overlap in plan ${planId}: ${sorted[i].dateRange.endDate} >= ${sorted[i + 1].dateRange.startDate}`, path: `blocks[${sorted[i].id}]` });
+                issues.push({
+                    code: 'OVERLAPPING_INTENT_BLOCKS',
+                    message: `Intent blocks ${sorted[i].id} and ${sorted[i + 1].id} overlap in plan ${planId}: ${sorted[i].dateRange.endDate} >= ${sorted[i + 1].dateRange.startDate}`,
+                    path: `blocks[${sorted[i].id}]`,
+                });
             }
         }
     }
-
     return { valid: issues.length === 0, issues };
 }

--- a/app/src/engine/blockIntent.ts
+++ b/app/src/engine/blockIntent.ts
@@ -524,12 +524,16 @@ export function validateProgressionContract(
         }
     }
 
+    const redirectTriggers = Array.isArray(contract.redirectCriteria?.triggers)
+        ? contract.redirectCriteria.triggers
+        : undefined;
+
     if (contract.redirectCriteria) {
-        if (!Array.isArray(contract.redirectCriteria.triggers) || contract.redirectCriteria.triggers.length === 0) {
+        if (!redirectTriggers || redirectTriggers.length === 0) {
             issues.push({ code: 'EMPTY_REDIRECT_TRIGGERS', message: 'redirectCriteria.triggers must not be empty', path: `${path}.redirectCriteria.triggers` });
         } else {
             const seen = new Set<ProgressionRedirectTrigger>();
-            contract.redirectCriteria.triggers.forEach((trigger, index) => {
+            redirectTriggers.forEach((trigger, index) => {
                 if (trigger !== 'adverse_response' && trigger !== 'active_restriction') {
                     issues.push({ code: 'UNSUPPORTED_REDIRECT_TRIGGER', message: `Unsupported redirect trigger: ${trigger}`, path: `${path}.redirectCriteria.triggers[${index}]` });
                 } else if (seen.has(trigger)) {
@@ -541,7 +545,7 @@ export function validateProgressionContract(
     }
 
     if (!contract.reductionAlternative
-        && (!contract.redirectCriteria || contract.redirectCriteria.triggers.length === 0)) {
+        && (!contract.redirectCriteria || !redirectTriggers || redirectTriggers.length === 0)) {
         issues.push({
             code: 'MISSING_PROGRESSION_FALLBACK',
             message: 'Enabled progression requires a bounded reduction alternative or explicit redirect-to-review trigger',
@@ -550,7 +554,7 @@ export function validateProgressionContract(
     }
 
     if (contract.reductionAlternative?.trigger === 'adverse_response'
-        && contract.redirectCriteria?.triggers.includes('adverse_response')) {
+        && redirectTriggers?.includes('adverse_response')) {
         issues.push({
             code: 'AMBIGUOUS_ADVERSE_RESPONSE_ACTION',
             message: 'The same adverse_response trigger cannot request both reduction and redirect',

--- a/app/src/engine/blockIntent.ts
+++ b/app/src/engine/blockIntent.ts
@@ -1,15 +1,16 @@
-﻿/**
+/**
  * ADR-0037: Block Intent and Controlled Progression (H5a).
  *
- * Defines domain models and validators for explicit per-objective intent
- * (`develop` | `maintain`), dose envelopes, protected roles, substitution rules,
- * and bounded progression contracts.
+ * Defines domain models and fail-closed validators for explicit per-objective intent
+ * (`develop` | `maintain`), dose envelopes, protected roles/substitutions, prospective
+ * review criteria, and one bounded progression experiment.
  */
 
 import type { PlanCoverageKey } from '../workouts/event-plan';
 import type { ObjectivePriority } from './models';
 
 export type BlockIntent = 'develop' | 'maintain';
+export type BlockSport = 'cycling' | 'strength' | 'running' | 'swimming' | 'multisport' | 'cross_training';
 
 export type DoseUnit =
     | 'minutes'
@@ -30,7 +31,44 @@ export const SUPPORTED_DOSE_UNITS: readonly DoseUnit[] = [
     'rpe_load',
 ] as const;
 
+export const SUPPORTED_BLOCK_SPORTS: readonly BlockSport[] = [
+    'cycling',
+    'strength',
+    'running',
+    'swimming',
+    'multisport',
+    'cross_training',
+] as const;
+
+export const SUPPORTED_OBJECTIVE_PRIORITIES: readonly ObjectivePriority[] = [
+    'must_have',
+    'should_have',
+    'nice_to_have',
+] as const;
+
+export const SUPPORTED_PLAN_COVERAGE_KEYS: readonly PlanCoverageKey[] = [
+    'aerobic_volume',
+    'recovery_spin',
+    'sustained_quality',
+    'short_surges',
+    'gap_closing',
+    'outdoor_event_specific',
+    'primary_strength',
+    'compact_strength',
+    'upper_body_trunk',
+    'field_maintenance',
+    'walk_run',
+    'recovery_or_rest',
+    'travel_aerobic',
+    'travel_strength',
+    'taper_sharpening',
+    'pre_race_openers',
+    'race_week_strength',
+    'race_day',
+] as const;
+
 export type FloorSemantics = 'hard_floor' | 'soft_floor';
+export type TissueSeverity = 'monitor' | 'limit' | 'exclude';
 
 export interface DoseEnvelope {
     min: number;
@@ -44,6 +82,7 @@ export interface BlockSubstitutionRule {
     targetCoverageKey: PlanCoverageKey;
     allowedCoverageKeys: readonly PlanCoverageKey[];
     minDoseFraction?: number;
+    /** Human-facing explanation only; never semantic replay identity. */
     rationale?: string;
 }
 
@@ -61,7 +100,7 @@ export interface BlockSuccessCriteria {
 export interface BlockPrerequisites {
     requiredPriorExposures?: number;
     minBaselineDays?: number;
-    prohibitedTissueSeverities?: readonly ('monitor' | 'limit' | 'exclude')[];
+    prohibitedTissueSeverities?: readonly TissueSeverity[];
 }
 
 export interface BlockExitCriteria {
@@ -71,7 +110,7 @@ export interface BlockExitCriteria {
 
 export interface BlockObjectiveDefinition {
     id: string;
-    sport: 'cycling' | 'strength' | 'running' | 'swimming' | 'multisport' | 'cross_training';
+    sport: BlockSport;
     adaptationScope: string;
     coverageKey: PlanCoverageKey;
     intent: BlockIntent;
@@ -85,14 +124,27 @@ export interface BlockObjectiveDefinition {
     exitCriteria?: BlockExitCriteria;
 }
 
+/**
+ * Phase-1 progression deliberately supports only a registered duration variable. Additional
+ * prescription variables must be added here with an explicit unit mapping and tests rather
+ * than accepted as arbitrary executable/free-text field paths (ADR-0037 D-CHANGE).
+ */
+export type ProgressionVariable = 'duration_min';
+export const PROGRESSION_VARIABLE_UNITS: Readonly<Record<ProgressionVariable, DoseUnit>> = {
+    duration_min: 'minutes',
+};
+
+export type ProgressionReductionTrigger = 'adverse_response';
+export type ProgressionRedirectTrigger = 'adverse_response' | 'active_restriction';
+
 export interface BlockProgressionContract {
     targetBinding: {
         objectiveId: string;
         sessionId?: string;
         stepId?: string;
     };
-    variable: string;
-    unit: string;
+    variable: ProgressionVariable;
+    unit: DoseUnit;
     currentValue: number;
     permittedRange: {
         min: number;
@@ -106,7 +158,11 @@ export interface BlockProgressionContract {
     reviewCadenceDays: number;
     reductionAlternative?: {
         decrement: number;
-        trigger: 'adverse_response' | 'stagnation';
+        trigger: ProgressionReductionTrigger;
+    };
+    /** Explicit stop-and-review triggers. No hidden adverse-count threshold exists. */
+    redirectCriteria?: {
+        triggers: readonly ProgressionRedirectTrigger[];
     };
 }
 
@@ -125,7 +181,7 @@ export interface IntentBlock {
         nextReviewDate: string;
     };
     progressionContract?: BlockProgressionContract;
-    /** Presentation / descriptive labels only; excluded from canonical replay digest */
+    /** Presentation / descriptive labels only; excluded from canonical replay digest. */
     title?: string;
     notes?: string;
 }
@@ -141,8 +197,62 @@ export interface IntentBlockValidationResult {
     issues: ValidationIssue[];
 }
 
+function isNonEmptyString(value: unknown): value is string {
+    return typeof value === 'string' && value.trim().length > 0;
+}
+
+export function isValidLocalDateString(value: unknown): value is string {
+    if (typeof value !== 'string') return false;
+    const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+    if (!match) return false;
+    const year = Number(match[1]);
+    const month = Number(match[2]);
+    const day = Number(match[3]);
+    const candidate = new Date(Date.UTC(year, month - 1, day));
+    return candidate.getUTCFullYear() === year
+        && candidate.getUTCMonth() === month - 1
+        && candidate.getUTCDate() === day;
+}
+
+function isPositiveInteger(value: unknown): value is number {
+    return Number.isInteger(value) && (value as number) > 0;
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+    return Number.isInteger(value) && (value as number) >= 0;
+}
+
+function validateOptionalStringSet(values: readonly string[] | undefined, path: string): ValidationIssue[] {
+    if (values === undefined) return [];
+    const issues: ValidationIssue[] = [];
+    const seen = new Set<string>();
+    values.forEach((value, index) => {
+        if (!isNonEmptyString(value)) {
+            issues.push({
+                code: 'INVALID_STRING_SET_MEMBER',
+                message: 'Set members must be non-empty strings',
+                path: `${path}[${index}]`,
+            });
+            return;
+        }
+        if (seen.has(value)) {
+            issues.push({
+                code: 'DUPLICATE_STRING_SET_MEMBER',
+                message: `Duplicate value: ${value}`,
+                path: `${path}[${index}]`,
+            });
+        }
+        seen.add(value);
+    });
+    return issues;
+}
+
 export function isSupportedDoseUnit(unit: string): unit is DoseUnit {
     return (SUPPORTED_DOSE_UNITS as readonly string[]).includes(unit);
+}
+
+function isSupportedCoverageKey(key: string): key is PlanCoverageKey {
+    return (SUPPORTED_PLAN_COVERAGE_KEYS as readonly string[]).includes(key);
 }
 
 export function validateDoseEnvelope(envelope: DoseEnvelope, path: string): ValidationIssue[] {
@@ -163,7 +273,6 @@ export function validateDoseEnvelope(envelope: DoseEnvelope, path: string): Vali
             path: `${path}.min`,
         });
     }
-
     if (!Number.isFinite(envelope.target) || envelope.target < 0) {
         issues.push({
             code: 'INVALID_DOSE_TARGET',
@@ -171,7 +280,6 @@ export function validateDoseEnvelope(envelope: DoseEnvelope, path: string): Vali
             path: `${path}.target`,
         });
     }
-
     if (!Number.isFinite(envelope.max) || envelope.max < 0) {
         issues.push({
             code: 'INVALID_DOSE_MAX',
@@ -179,23 +287,20 @@ export function validateDoseEnvelope(envelope: DoseEnvelope, path: string): Vali
             path: `${path}.max`,
         });
     }
-
-    if (envelope.min > envelope.target) {
+    if (Number.isFinite(envelope.min) && Number.isFinite(envelope.target) && envelope.min > envelope.target) {
         issues.push({
             code: 'INVERTED_DOSE_BOUNDS_MIN_TARGET',
             message: `Dose min (${envelope.min}) cannot exceed target (${envelope.target})`,
             path: `${path}.min`,
         });
     }
-
-    if (envelope.target > envelope.max) {
+    if (Number.isFinite(envelope.target) && Number.isFinite(envelope.max) && envelope.target > envelope.max) {
         issues.push({
             code: 'INVERTED_DOSE_BOUNDS_TARGET_MAX',
             message: `Dose target (${envelope.target}) cannot exceed max (${envelope.max})`,
             path: `${path}.max`,
         });
     }
-
     if (envelope.floorSemantics !== 'hard_floor' && envelope.floorSemantics !== 'soft_floor') {
         issues.push({
             code: 'INVALID_FLOOR_SEMANTICS',
@@ -207,120 +312,328 @@ export function validateDoseEnvelope(envelope: DoseEnvelope, path: string): Vali
     return issues;
 }
 
+function validateSuccessCriteria(
+    criteria: BlockSuccessCriteria | undefined,
+    intent: BlockIntent,
+    path: string,
+): ValidationIssue[] {
+    if (!criteria) return [];
+    const issues: ValidationIssue[] = [];
+    if (criteria.evaluationRef) {
+        if (!isNonEmptyString(criteria.evaluationRef.id)) {
+            issues.push({ code: 'INVALID_EVALUATION_REF_ID', message: 'Evaluation id must be non-empty', path: `${path}.evaluationRef.id` });
+        }
+        if (!isPositiveInteger(criteria.evaluationRef.revision)) {
+            issues.push({ code: 'INVALID_EVALUATION_REF_REVISION', message: 'Evaluation revision must be a positive integer', path: `${path}.evaluationRef.revision` });
+        }
+        if (!isNonEmptyString(criteria.evaluationRef.metricId)) {
+            issues.push({ code: 'INVALID_EVALUATION_METRIC_ID', message: 'Evaluation metricId must be non-empty', path: `${path}.evaluationRef.metricId` });
+        }
+    }
+    if (criteria.minCompletedExposures !== undefined && !isPositiveInteger(criteria.minCompletedExposures)) {
+        issues.push({
+            code: 'INVALID_SUCCESS_MIN_EXPOSURES',
+            message: 'Success minCompletedExposures must be a positive integer',
+            path: `${path}.minCompletedExposures`,
+        });
+    }
+    if (criteria.targetTrend !== undefined && criteria.targetTrend !== 'stable' && criteria.targetTrend !== 'improving') {
+        issues.push({ code: 'INVALID_TARGET_TREND', message: `Unsupported target trend: ${criteria.targetTrend}`, path: `${path}.targetTrend` });
+    }
+    if (criteria.acceptableDeclineTolerancePct !== undefined && (
+        !Number.isFinite(criteria.acceptableDeclineTolerancePct)
+        || criteria.acceptableDeclineTolerancePct < 0
+        || criteria.acceptableDeclineTolerancePct > 100
+    )) {
+        issues.push({
+            code: 'INVALID_DECLINE_TOLERANCE',
+            message: 'acceptableDeclineTolerancePct must be finite and between 0 and 100',
+            path: `${path}.acceptableDeclineTolerancePct`,
+        });
+    }
+    if ((criteria.targetTrend !== undefined || criteria.acceptableDeclineTolerancePct !== undefined) && !criteria.evaluationRef) {
+        issues.push({
+            code: 'OUTCOME_CRITERIA_REQUIRE_EVALUATION_REF',
+            message: 'Outcome trend/tolerance criteria require a pinned evaluationRef',
+            path,
+        });
+    }
+    if (intent === 'develop' && criteria.evaluationRef && criteria.targetTrend === undefined) {
+        issues.push({
+            code: 'DEVELOPMENT_OUTCOME_REQUIRES_TARGET_TREND',
+            message: 'A measured development objective must declare its prospective targetTrend',
+            path: `${path}.targetTrend`,
+        });
+    }
+    if (intent === 'maintain' && criteria.evaluationRef && criteria.acceptableDeclineTolerancePct === undefined) {
+        issues.push({
+            code: 'MAINTENANCE_OUTCOME_REQUIRES_TOLERANCE',
+            message: 'A measured maintenance objective must declare an acceptable decline tolerance',
+            path: `${path}.acceptableDeclineTolerancePct`,
+        });
+    }
+    return issues;
+}
+
+function validatePrerequisites(prerequisites: BlockPrerequisites | undefined, path: string): ValidationIssue[] {
+    if (!prerequisites) return [];
+    const issues: ValidationIssue[] = [];
+    if (prerequisites.requiredPriorExposures !== undefined && !isNonNegativeInteger(prerequisites.requiredPriorExposures)) {
+        issues.push({ code: 'INVALID_REQUIRED_PRIOR_EXPOSURES', message: 'requiredPriorExposures must be a non-negative integer', path: `${path}.requiredPriorExposures` });
+    }
+    if (prerequisites.minBaselineDays !== undefined && !isNonNegativeInteger(prerequisites.minBaselineDays)) {
+        issues.push({ code: 'INVALID_MIN_BASELINE_DAYS', message: 'minBaselineDays must be a non-negative integer', path: `${path}.minBaselineDays` });
+    }
+    if (prerequisites.prohibitedTissueSeverities) {
+        const seen = new Set<TissueSeverity>();
+        prerequisites.prohibitedTissueSeverities.forEach((severity, index) => {
+            if (severity !== 'monitor' && severity !== 'limit' && severity !== 'exclude') {
+                issues.push({ code: 'INVALID_PROHIBITED_TISSUE_SEVERITY', message: `Unsupported tissue severity: ${severity}`, path: `${path}.prohibitedTissueSeverities[${index}]` });
+            } else if (seen.has(severity)) {
+                issues.push({ code: 'DUPLICATE_PROHIBITED_TISSUE_SEVERITY', message: `Duplicate tissue severity: ${severity}`, path: `${path}.prohibitedTissueSeverities[${index}]` });
+            }
+            seen.add(severity);
+        });
+    }
+    return issues;
+}
+
+function validateExitCriteria(criteria: BlockExitCriteria | undefined, path: string): ValidationIssue[] {
+    if (!criteria) return [];
+    const issues: ValidationIssue[] = [];
+    if (criteria.maxWeeksInBlock !== undefined && !isPositiveInteger(criteria.maxWeeksInBlock)) {
+        issues.push({ code: 'INVALID_MAX_WEEKS_IN_BLOCK', message: 'maxWeeksInBlock must be a positive integer', path: `${path}.maxWeeksInBlock` });
+    }
+    if (criteria.stagnationReviewAfterWeeks !== undefined && !isPositiveInteger(criteria.stagnationReviewAfterWeeks)) {
+        issues.push({ code: 'INVALID_STAGNATION_REVIEW_WEEKS', message: 'stagnationReviewAfterWeeks must be a positive integer', path: `${path}.stagnationReviewAfterWeeks` });
+    }
+    if (
+        criteria.maxWeeksInBlock !== undefined
+        && criteria.stagnationReviewAfterWeeks !== undefined
+        && criteria.stagnationReviewAfterWeeks > criteria.maxWeeksInBlock
+    ) {
+        issues.push({
+            code: 'STAGNATION_REVIEW_AFTER_BLOCK_EXIT',
+            message: 'stagnationReviewAfterWeeks cannot exceed maxWeeksInBlock',
+            path: `${path}.stagnationReviewAfterWeeks`,
+        });
+    }
+    return issues;
+}
+
+function validateSubstitutions(
+    objective: BlockObjectiveDefinition,
+    path: string,
+): ValidationIssue[] {
+    if (!objective.allowedSubstitutions) return [];
+    const issues: ValidationIssue[] = [];
+    const targets = new Set<PlanCoverageKey>();
+    objective.allowedSubstitutions.forEach((rule, index) => {
+        const rulePath = `${path}[${index}]`;
+        if (!isSupportedCoverageKey(rule.targetCoverageKey)) {
+            issues.push({ code: 'INVALID_SUBSTITUTION_TARGET', message: `Unsupported target coverage key: ${rule.targetCoverageKey}`, path: `${rulePath}.targetCoverageKey` });
+        } else {
+            if (rule.targetCoverageKey !== objective.coverageKey) {
+                issues.push({
+                    code: 'SUBSTITUTION_TARGET_MISMATCH',
+                    message: `Substitution target ${rule.targetCoverageKey} does not match objective coverage ${objective.coverageKey}`,
+                    path: `${rulePath}.targetCoverageKey`,
+                });
+            }
+            if (targets.has(rule.targetCoverageKey)) {
+                issues.push({ code: 'DUPLICATE_SUBSTITUTION_TARGET', message: `Duplicate substitution rule for ${rule.targetCoverageKey}`, path: `${rulePath}.targetCoverageKey` });
+            }
+            targets.add(rule.targetCoverageKey);
+        }
+        if (!Array.isArray(rule.allowedCoverageKeys) || rule.allowedCoverageKeys.length === 0) {
+            issues.push({ code: 'EMPTY_SUBSTITUTION_CANDIDATES', message: 'allowedCoverageKeys must contain at least one typed coverage key', path: `${rulePath}.allowedCoverageKeys` });
+        } else {
+            const allowed = new Set<PlanCoverageKey>();
+            rule.allowedCoverageKeys.forEach((key, allowedIndex) => {
+                if (!isSupportedCoverageKey(key)) {
+                    issues.push({ code: 'INVALID_SUBSTITUTION_CANDIDATE', message: `Unsupported coverage key: ${key}`, path: `${rulePath}.allowedCoverageKeys[${allowedIndex}]` });
+                } else if (allowed.has(key)) {
+                    issues.push({ code: 'DUPLICATE_SUBSTITUTION_CANDIDATE', message: `Duplicate allowed coverage key: ${key}`, path: `${rulePath}.allowedCoverageKeys[${allowedIndex}]` });
+                }
+                allowed.add(key);
+            });
+        }
+        if (rule.minDoseFraction !== undefined && (
+            !Number.isFinite(rule.minDoseFraction)
+            || rule.minDoseFraction <= 0
+            || rule.minDoseFraction > 1
+        )) {
+            issues.push({
+                code: 'INVALID_SUBSTITUTION_MIN_DOSE_FRACTION',
+                message: 'minDoseFraction must be finite and in (0, 1]',
+                path: `${rulePath}.minDoseFraction`,
+            });
+        }
+    });
+    return issues;
+}
+
 export function validateProgressionContract(
     contract: BlockProgressionContract,
-    validObjectiveIds: Set<string>,
+    objectivesById: ReadonlyMap<string, BlockObjectiveDefinition>,
     path: string,
 ): ValidationIssue[] {
     const issues: ValidationIssue[] = [];
+    const binding = contract.targetBinding;
+    const objectiveId = binding?.objectiveId;
+    const targetObjective = objectiveId ? objectivesById.get(objectiveId) : undefined;
 
-    if (!contract.targetBinding || !contract.targetBinding.objectiveId) {
-        issues.push({
-            code: 'MISSING_TARGET_OBJECTIVE_ID',
-            message: 'Progression contract must bind to an objectiveId',
-            path: `${path}.targetBinding.objectiveId`,
-        });
-    } else if (!validObjectiveIds.has(contract.targetBinding.objectiveId)) {
-        issues.push({
-            code: 'DANGLING_PROGRESSION_TARGET_OBJECTIVE',
-            message: `Progression target objectiveId ${contract.targetBinding.objectiveId} is not in block objectives`,
-            path: `${path}.targetBinding.objectiveId`,
-        });
+    if (!binding || !isNonEmptyString(objectiveId)) {
+        issues.push({ code: 'MISSING_TARGET_OBJECTIVE_ID', message: 'Progression contract must bind to an objectiveId', path: `${path}.targetBinding.objectiveId` });
+    } else if (!targetObjective) {
+        issues.push({ code: 'DANGLING_PROGRESSION_TARGET_OBJECTIVE', message: `Progression target objectiveId ${objectiveId} is not in block objectives`, path: `${path}.targetBinding.objectiveId` });
+    }
+    if (binding?.sessionId !== undefined && !isNonEmptyString(binding.sessionId)) {
+        issues.push({ code: 'INVALID_TARGET_SESSION_ID', message: 'targetBinding.sessionId must be non-empty when present', path: `${path}.targetBinding.sessionId` });
+    }
+    if (binding?.stepId !== undefined && !isNonEmptyString(binding.stepId)) {
+        issues.push({ code: 'INVALID_TARGET_STEP_ID', message: 'targetBinding.stepId must be non-empty when present', path: `${path}.targetBinding.stepId` });
+    }
+    if (binding?.stepId !== undefined && binding.sessionId === undefined) {
+        issues.push({ code: 'STEP_BINDING_REQUIRES_SESSION', message: 'targetBinding.stepId requires targetBinding.sessionId', path: `${path}.targetBinding.stepId` });
     }
 
-    if (!contract.variable || typeof contract.variable !== 'string' || contract.variable.trim() === '') {
+    const expectedUnit = PROGRESSION_VARIABLE_UNITS[contract.variable];
+    if (!expectedUnit) {
         issues.push({
-            code: 'INVALID_PROGRESSION_VARIABLE',
-            message: 'Progression variable must be a non-empty string',
+            code: 'UNSUPPORTED_PROGRESSION_VARIABLE',
+            message: `Unsupported progression variable: ${String(contract.variable)}`,
             path: `${path}.variable`,
         });
-    }
-
-    if (!contract.unit || typeof contract.unit !== 'string' || contract.unit.trim() === '') {
+    } else if (contract.unit !== expectedUnit) {
         issues.push({
-            code: 'INVALID_PROGRESSION_UNIT',
-            message: 'Progression unit must be a non-empty string',
+            code: 'PROGRESSION_VARIABLE_UNIT_MISMATCH',
+            message: `Progression variable ${contract.variable} requires unit ${expectedUnit}, got ${contract.unit}`,
             path: `${path}.unit`,
         });
     }
 
+    if (!Number.isFinite(contract.currentValue) || contract.currentValue < 0) {
+        issues.push({ code: 'INVALID_CURRENT_VALUE', message: `Current value must be finite and non-negative: ${contract.currentValue}`, path: `${path}.currentValue` });
+    }
     if (!Number.isFinite(contract.increment) || contract.increment <= 0) {
-        issues.push({
-            code: 'INVALID_PROGRESSION_INCREMENT',
-            message: `Progression increment must be a positive finite number: ${contract.increment}`,
-            path: `${path}.increment`,
-        });
+        issues.push({ code: 'INVALID_PROGRESSION_INCREMENT', message: `Progression increment must be a positive finite number: ${contract.increment}`, path: `${path}.increment` });
     }
 
-    if (!contract.permittedRange || !Number.isFinite(contract.permittedRange.min) || !Number.isFinite(contract.permittedRange.max)) {
-        issues.push({
-            code: 'INVALID_PERMITTED_RANGE',
-            message: 'Permitted range min and max must be finite numbers',
-            path: `${path}.permittedRange`,
-        });
+    const range = contract.permittedRange;
+    if (!range || !Number.isFinite(range.min) || !Number.isFinite(range.max) || range.min < 0 || range.max < 0) {
+        issues.push({ code: 'INVALID_PERMITTED_RANGE', message: 'Permitted range min/max must be finite non-negative numbers', path: `${path}.permittedRange` });
     } else {
-        if (contract.permittedRange.min >= contract.permittedRange.max) {
+        if (range.min >= range.max) {
+            issues.push({ code: 'INVERTED_PERMITTED_RANGE', message: `Permitted range min (${range.min}) must be less than max (${range.max})`, path: `${path}.permittedRange` });
+        }
+        if (Number.isFinite(contract.currentValue) && (contract.currentValue < range.min || contract.currentValue > range.max)) {
+            issues.push({ code: 'CURRENT_VALUE_OUT_OF_RANGE', message: `Current value (${contract.currentValue}) is outside permitted range [${range.min}, ${range.max}]`, path: `${path}.currentValue` });
+        }
+        if (targetObjective && contract.unit === targetObjective.doseEnvelope.unit && (
+            range.min < targetObjective.doseEnvelope.min
+            || range.max > targetObjective.doseEnvelope.max
+        )) {
             issues.push({
-                code: 'INVERTED_PERMITTED_RANGE',
-                message: `Permitted range min (${contract.permittedRange.min}) must be less than max (${contract.permittedRange.max})`,
+                code: 'PROGRESSION_RANGE_EXCEEDS_OBJECTIVE_ENVELOPE',
+                message: `Progression range [${range.min}, ${range.max}] must stay within objective envelope [${targetObjective.doseEnvelope.min}, ${targetObjective.doseEnvelope.max}]`,
                 path: `${path}.permittedRange`,
             });
         }
-        if (contract.currentValue < contract.permittedRange.min || contract.currentValue > contract.permittedRange.max) {
-            issues.push({
-                code: 'CURRENT_VALUE_OUT_OF_RANGE',
-                message: `Current value (${contract.currentValue}) is outside permitted range [${contract.permittedRange.min}, ${contract.permittedRange.max}]`,
-                path: `${path}.currentValue`,
-            });
-        }
     }
 
-    if (!Number.isFinite(contract.observationWindowDays) || contract.observationWindowDays <= 0) {
-        issues.push({
-            code: 'INVALID_OBSERVATION_WINDOW',
-            message: `Observation window must be a positive integer days: ${contract.observationWindowDays}`,
-            path: `${path}.observationWindowDays`,
-        });
+    if (!isPositiveInteger(contract.observationWindowDays)) {
+        issues.push({ code: 'INVALID_OBSERVATION_WINDOW', message: `Observation window must be a positive integer days: ${contract.observationWindowDays}`, path: `${path}.observationWindowDays` });
+    }
+    if (!isPositiveInteger(contract.minCompletedExposures)) {
+        issues.push({ code: 'INVALID_MIN_COMPLETED_EXPOSURES', message: `Min completed exposures must be a positive integer: ${contract.minCompletedExposures}`, path: `${path}.minCompletedExposures` });
+    }
+    if (!Number.isFinite(contract.requiredFollowUpCoveragePct) || contract.requiredFollowUpCoveragePct <= 0 || contract.requiredFollowUpCoveragePct > 100) {
+        issues.push({ code: 'INVALID_FOLLOW_UP_COVERAGE_PCT', message: `Required follow-up coverage percent must be in (0, 100]: ${contract.requiredFollowUpCoveragePct}`, path: `${path}.requiredFollowUpCoveragePct` });
+    }
+    if (!isPositiveInteger(contract.reviewCadenceDays)) {
+        issues.push({ code: 'INVALID_REVIEW_CADENCE', message: `Review cadence days must be a positive integer: ${contract.reviewCadenceDays}`, path: `${path}.reviewCadenceDays` });
     }
 
-    if (!Number.isFinite(contract.minCompletedExposures) || contract.minCompletedExposures < 1) {
-        issues.push({
-            code: 'INVALID_MIN_COMPLETED_EXPOSURES',
-            message: `Min completed exposures must be at least 1: ${contract.minCompletedExposures}`,
-            path: `${path}.minCompletedExposures`,
-        });
-    }
-
-    if (
-        !Number.isFinite(contract.requiredFollowUpCoveragePct) ||
-        contract.requiredFollowUpCoveragePct < 0 ||
-        contract.requiredFollowUpCoveragePct > 100
-    ) {
-        issues.push({
-            code: 'INVALID_FOLLOW_UP_COVERAGE_PCT',
-            message: `Required follow-up coverage percent must be between 0 and 100: ${contract.requiredFollowUpCoveragePct}`,
-            path: `${path}.requiredFollowUpCoveragePct`,
-        });
-    }
-
-    if (!Number.isFinite(contract.reviewCadenceDays) || contract.reviewCadenceDays <= 0) {
-        issues.push({
-            code: 'INVALID_REVIEW_CADENCE',
-            message: `Review cadence days must be a positive integer: ${contract.reviewCadenceDays}`,
-            path: `${path}.reviewCadenceDays`,
-        });
-    }
+    issues.push(...validateOptionalStringSet(contract.knowledgeLineage, `${path}.knowledgeLineage`));
 
     if (contract.reductionAlternative) {
+        if (contract.reductionAlternative.trigger !== 'adverse_response') {
+            issues.push({ code: 'UNSUPPORTED_REDUCTION_TRIGGER', message: `Unsupported reduction trigger: ${contract.reductionAlternative.trigger}`, path: `${path}.reductionAlternative.trigger` });
+        }
         if (!Number.isFinite(contract.reductionAlternative.decrement) || contract.reductionAlternative.decrement <= 0) {
+            issues.push({ code: 'INVALID_REDUCTION_DECREMENT', message: `Reduction decrement must be a positive finite number: ${contract.reductionAlternative.decrement}`, path: `${path}.reductionAlternative.decrement` });
+        } else if (range && Number.isFinite(range.min) && Number.isFinite(contract.currentValue)
+            && contract.currentValue - contract.reductionAlternative.decrement < range.min) {
             issues.push({
-                code: 'INVALID_REDUCTION_DECREMENT',
-                message: `Reduction decrement must be a positive finite number: ${contract.reductionAlternative.decrement}`,
+                code: 'REDUCTION_DECREMENT_EXCEEDS_RANGE',
+                message: 'Reduction alternative must produce a value inside the permitted range without hidden clamping',
                 path: `${path}.reductionAlternative.decrement`,
             });
         }
     }
 
+    if (contract.redirectCriteria) {
+        if (!Array.isArray(contract.redirectCriteria.triggers) || contract.redirectCriteria.triggers.length === 0) {
+            issues.push({ code: 'EMPTY_REDIRECT_TRIGGERS', message: 'redirectCriteria.triggers must not be empty', path: `${path}.redirectCriteria.triggers` });
+        } else {
+            const seen = new Set<ProgressionRedirectTrigger>();
+            contract.redirectCriteria.triggers.forEach((trigger, index) => {
+                if (trigger !== 'adverse_response' && trigger !== 'active_restriction') {
+                    issues.push({ code: 'UNSUPPORTED_REDIRECT_TRIGGER', message: `Unsupported redirect trigger: ${trigger}`, path: `${path}.redirectCriteria.triggers[${index}]` });
+                } else if (seen.has(trigger)) {
+                    issues.push({ code: 'DUPLICATE_REDIRECT_TRIGGER', message: `Duplicate redirect trigger: ${trigger}`, path: `${path}.redirectCriteria.triggers[${index}]` });
+                }
+                seen.add(trigger);
+            });
+        }
+    }
+
+    if (
+        contract.reductionAlternative?.trigger === 'adverse_response'
+        && contract.redirectCriteria?.triggers.includes('adverse_response')
+    ) {
+        issues.push({
+            code: 'AMBIGUOUS_ADVERSE_RESPONSE_ACTION',
+            message: 'The same adverse_response trigger cannot request both reduction and redirect',
+            path,
+        });
+    }
+
+    return issues;
+}
+
+function validateObjective(objective: BlockObjectiveDefinition, path: string): ValidationIssue[] {
+    const issues: ValidationIssue[] = [];
+    if (!isNonEmptyString(objective.id)) {
+        issues.push({ code: 'MISSING_OBJECTIVE_ID', message: 'Objective ID must be a non-empty string', path: `${path}.id` });
+    }
+    if (!(SUPPORTED_BLOCK_SPORTS as readonly string[]).includes(objective.sport)) {
+        issues.push({ code: 'INVALID_OBJECTIVE_SPORT', message: `Unsupported objective sport: ${objective.sport}`, path: `${path}.sport` });
+    }
+    if (!isNonEmptyString(objective.adaptationScope)) {
+        issues.push({ code: 'INVALID_ADAPTATION_SCOPE', message: 'adaptationScope must be a non-empty string', path: `${path}.adaptationScope` });
+    }
+    if (!isSupportedCoverageKey(objective.coverageKey)) {
+        issues.push({ code: 'INVALID_OBJECTIVE_COVERAGE_KEY', message: `Unsupported coverage key: ${objective.coverageKey}`, path: `${path}.coverageKey` });
+    }
+    if (objective.intent !== 'develop' && objective.intent !== 'maintain') {
+        issues.push({ code: 'INVALID_OBJECTIVE_INTENT', message: `Objective intent must be 'develop' or 'maintain', got: ${objective.intent}`, path: `${path}.intent` });
+    }
+    if (!(SUPPORTED_OBJECTIVE_PRIORITIES as readonly string[]).includes(objective.priority)) {
+        issues.push({ code: 'INVALID_OBJECTIVE_PRIORITY', message: `Unsupported objective priority: ${objective.priority}`, path: `${path}.priority` });
+    }
+    if (objective.doseEnvelope) {
+        issues.push(...validateDoseEnvelope(objective.doseEnvelope, `${path}.doseEnvelope`));
+    } else {
+        issues.push({ code: 'MISSING_DOSE_ENVELOPE', message: 'Objective must specify a doseEnvelope', path: `${path}.doseEnvelope` });
+    }
+    issues.push(...validateOptionalStringSet(objective.knowledgeLineage, `${path}.knowledgeLineage`));
+    issues.push(...validateOptionalStringSet(objective.protectedRoles, `${path}.protectedRoles`));
+    issues.push(...validateSubstitutions(objective, `${path}.allowedSubstitutions`));
+    issues.push(...validateSuccessCriteria(objective.successCriteria, objective.intent, `${path}.successCriteria`));
+    issues.push(...validatePrerequisites(objective.entryPrerequisites, `${path}.entryPrerequisites`));
+    issues.push(...validateExitCriteria(objective.exitCriteria, `${path}.exitCriteria`));
     return issues;
 }
 
@@ -328,127 +641,125 @@ export function validateIntentBlock(block: IntentBlock): IntentBlockValidationRe
     const issues: ValidationIssue[] = [];
     const rootPath = `intentBlock[${block.id || 'unknown'}]`;
 
-    if (!block.id || typeof block.id !== 'string' || block.id.trim() === '') {
-        issues.push({
-            code: 'MISSING_BLOCK_ID',
-            message: 'Block ID must be a non-empty string',
-            path: `${rootPath}.id`,
-        });
+    if (!isNonEmptyString(block.id)) {
+        issues.push({ code: 'MISSING_BLOCK_ID', message: 'Block ID must be a non-empty string', path: `${rootPath}.id` });
+    }
+    if (!isPositiveInteger(block.revision)) {
+        issues.push({ code: 'INVALID_BLOCK_REVISION', message: `Block revision must be a positive integer: ${block.revision}`, path: `${rootPath}.revision` });
+    }
+    if (!isNonEmptyString(block.sourcePlanId)) {
+        issues.push({ code: 'MISSING_SOURCE_PLAN_ID', message: 'sourcePlanId must be a non-empty string', path: `${rootPath}.sourcePlanId` });
+    }
+    if (!isPositiveInteger(block.sourcePlanRevision)) {
+        issues.push({ code: 'INVALID_SOURCE_PLAN_REVISION', message: `sourcePlanRevision must be a positive integer: ${block.sourcePlanRevision}`, path: `${rootPath}.sourcePlanRevision` });
     }
 
-    if (!Number.isInteger(block.revision) || block.revision < 1) {
-        issues.push({
-            code: 'INVALID_BLOCK_REVISION',
-            message: `Block revision must be a positive integer: ${block.revision}`,
-            path: `${rootPath}.revision`,
-        });
-    }
-
-    if (!block.dateRange || !block.dateRange.startDate || !block.dateRange.endDate) {
-        issues.push({
-            code: 'MISSING_DATE_RANGE',
-            message: 'Block date range must specify startDate and endDate',
-            path: `${rootPath}.dateRange`,
-        });
+    const startValid = isValidLocalDateString(block.dateRange?.startDate);
+    const endValid = isValidLocalDateString(block.dateRange?.endDate);
+    if (!startValid || !endValid) {
+        issues.push({ code: 'INVALID_DATE_RANGE', message: 'Block dateRange must contain valid YYYY-MM-DD calendar dates', path: `${rootPath}.dateRange` });
     } else if (block.dateRange.startDate > block.dateRange.endDate) {
+        issues.push({ code: 'INVERTED_DATE_RANGE', message: `Block startDate (${block.dateRange.startDate}) cannot be after endDate (${block.dateRange.endDate})`, path: `${rootPath}.dateRange` });
+    }
+
+    if (!block.reviewSchedule || !isPositiveInteger(block.reviewSchedule.reviewCadenceDays)) {
+        issues.push({ code: 'INVALID_BLOCK_REVIEW_CADENCE', message: 'Block reviewSchedule.reviewCadenceDays must be a positive integer', path: `${rootPath}.reviewSchedule.reviewCadenceDays` });
+    }
+    if (!block.reviewSchedule || !isValidLocalDateString(block.reviewSchedule.nextReviewDate)) {
+        issues.push({ code: 'INVALID_NEXT_REVIEW_DATE', message: 'Block reviewSchedule.nextReviewDate must be a valid YYYY-MM-DD date', path: `${rootPath}.reviewSchedule.nextReviewDate` });
+    } else if (startValid && endValid && (
+        block.reviewSchedule.nextReviewDate < block.dateRange.startDate
+        || block.reviewSchedule.nextReviewDate > block.dateRange.endDate
+    )) {
         issues.push({
-            code: 'INVERTED_DATE_RANGE',
-            message: `Block startDate (${block.dateRange.startDate}) cannot be after endDate (${block.dateRange.endDate})`,
-            path: `${rootPath}.dateRange`,
+            code: 'NEXT_REVIEW_OUTSIDE_BLOCK',
+            message: 'nextReviewDate must fall inside the active block interval',
+            path: `${rootPath}.reviewSchedule.nextReviewDate`,
         });
     }
 
+    const objectivesById = new Map<string, BlockObjectiveDefinition>();
     if (!Array.isArray(block.objectives) || block.objectives.length === 0) {
-        issues.push({
-            code: 'NO_OBJECTIVES',
-            message: 'Block must contain at least one objective',
-            path: `${rootPath}.objectives`,
-        });
+        issues.push({ code: 'NO_OBJECTIVES', message: 'Block must contain at least one objective', path: `${rootPath}.objectives` });
     } else {
-        const objectiveIds = new Set<string>();
-        for (let i = 0; i < block.objectives.length; i++) {
-            const obj = block.objectives[i];
-            const objPath = `${rootPath}.objectives[${i}]`;
-
-            if (!obj.id || typeof obj.id !== 'string' || obj.id.trim() === '') {
-                issues.push({
-                    code: 'MISSING_OBJECTIVE_ID',
-                    message: 'Objective ID must be a non-empty string',
-                    path: `${objPath}.id`,
-                });
-            } else if (objectiveIds.has(obj.id)) {
-                issues.push({
-                    code: 'DUPLICATE_OBJECTIVE_ID',
-                    message: `Duplicate objective ID: ${obj.id}`,
-                    path: `${objPath}.id`,
-                });
-            } else {
-                objectiveIds.add(obj.id);
+        block.objectives.forEach((objective, index) => {
+            const objectivePath = `${rootPath}.objectives[${index}]`;
+            issues.push(...validateObjective(objective, objectivePath));
+            if (isNonEmptyString(objective.id)) {
+                if (objectivesById.has(objective.id)) {
+                    issues.push({ code: 'DUPLICATE_OBJECTIVE_ID', message: `Duplicate objective ID: ${objective.id}`, path: `${objectivePath}.id` });
+                } else {
+                    objectivesById.set(objective.id, objective);
+                }
             }
+        });
+    }
 
-            if (obj.intent !== 'develop' && obj.intent !== 'maintain') {
-                issues.push({
-                    code: 'INVALID_OBJECTIVE_INTENT',
-                    message: `Objective intent must be 'develop' or 'maintain', got: ${obj.intent}`,
-                    path: `${objPath}.intent`,
-                });
-            }
-
-            if (obj.doseEnvelope) {
-                issues.push(...validateDoseEnvelope(obj.doseEnvelope, `${objPath}.doseEnvelope`));
-            } else {
-                issues.push({
-                    code: 'MISSING_DOSE_ENVELOPE',
-                    message: 'Objective must specify a doseEnvelope',
-                    path: `${objPath}.doseEnvelope`,
-                });
-            }
-        }
-
-        if (block.progressionContract) {
-            issues.push(...validateProgressionContract(block.progressionContract, objectiveIds, `${rootPath}.progressionContract`));
+    if (block.progressionContract) {
+        issues.push(...validateProgressionContract(block.progressionContract, objectivesById, `${rootPath}.progressionContract`));
+        if (
+            block.reviewSchedule
+            && isPositiveInteger(block.reviewSchedule.reviewCadenceDays)
+            && isPositiveInteger(block.progressionContract.reviewCadenceDays)
+            && block.reviewSchedule.reviewCadenceDays !== block.progressionContract.reviewCadenceDays
+        ) {
+            issues.push({
+                code: 'PROGRESSION_REVIEW_CADENCE_MISMATCH',
+                message: 'Block review cadence and progression contract cadence must agree',
+                path: `${rootPath}.progressionContract.reviewCadenceDays`,
+            });
         }
     }
 
-    return {
-        valid: issues.length === 0,
-        issues,
-    };
+    return { valid: issues.length === 0, issues };
 }
 
 export function validatePlanIntentBlocks(blocks: readonly IntentBlock[]): IntentBlockValidationResult {
     const issues: ValidationIssue[] = [];
-    const blockIds = new Set<string>();
+    const blockIdsByPlan = new Map<string, Set<string>>();
+    const validIntervalsByPlan = new Map<string, IntentBlock[]>();
 
-    for (let i = 0; i < blocks.length; i++) {
-        const block = blocks[i];
+    blocks.forEach((block, index) => {
         const singleResult = validateIntentBlock(block);
         issues.push(...singleResult.issues);
 
-        if (blockIds.has(block.id)) {
-            issues.push({
-                code: 'DUPLICATE_BLOCK_ID',
-                message: `Duplicate block ID across plan: ${block.id}`,
-                path: `blocks[${i}].id`,
-            });
+        if (isNonEmptyString(block.sourcePlanId) && isNonEmptyString(block.id)) {
+            const ids = blockIdsByPlan.get(block.sourcePlanId) ?? new Set<string>();
+            if (ids.has(block.id)) {
+                issues.push({
+                    code: 'DUPLICATE_BLOCK_ID',
+                    message: `Duplicate block ID across plan ${block.sourcePlanId}: ${block.id}`,
+                    path: `blocks[${index}].id`,
+                });
+            }
+            ids.add(block.id);
+            blockIdsByPlan.set(block.sourcePlanId, ids);
         }
-        blockIds.add(block.id);
+
+        if (
+            isNonEmptyString(block.sourcePlanId)
+            && isValidLocalDateString(block.dateRange?.startDate)
+            && isValidLocalDateString(block.dateRange?.endDate)
+            && block.dateRange.startDate <= block.dateRange.endDate
+        ) {
+            const intervals = validIntervalsByPlan.get(block.sourcePlanId) ?? [];
+            intervals.push(block);
+            validIntervalsByPlan.set(block.sourcePlanId, intervals);
+        }
+    });
+
+    for (const [planId, planBlocks] of validIntervalsByPlan) {
+        const sorted = [...planBlocks].sort((a, b) => a.dateRange.startDate.localeCompare(b.dateRange.startDate));
+        for (let i = 0; i < sorted.length - 1; i++) {
+            if (sorted[i].dateRange.endDate >= sorted[i + 1].dateRange.startDate) {
+                issues.push({
+                    code: 'OVERLAPPING_INTENT_BLOCKS',
+                    message: `Intent blocks ${sorted[i].id} and ${sorted[i + 1].id} overlap in plan ${planId}: ${sorted[i].dateRange.endDate} >= ${sorted[i + 1].dateRange.startDate}`,
+                    path: `blocks[${sorted[i].id}]`,
+                });
+            }
+        }
     }
 
-    // Check for overlapping active intervals
-    const sorted = [...blocks].sort((a, b) => a.dateRange.startDate.localeCompare(b.dateRange.startDate));
-    for (let i = 0; i < sorted.length - 1; i++) {
-        if (sorted[i].dateRange.endDate >= sorted[i + 1].dateRange.startDate) {
-            issues.push({
-                code: 'OVERLAPPING_INTENT_BLOCKS',
-                message: `Intent blocks ${sorted[i].id} and ${sorted[i + 1].id} overlap: ${sorted[i].dateRange.endDate} >= ${sorted[i + 1].dateRange.startDate}`,
-                path: `blocks[${sorted[i].id}]`,
-            });
-        }
-    }
-
-    return {
-        valid: issues.length === 0,
-        issues,
-    };
+    return { valid: issues.length === 0, issues };
 }

--- a/app/src/engine/blockIntent.ts
+++ b/app/src/engine/blockIntent.ts
@@ -1,0 +1,454 @@
+﻿/**
+ * ADR-0037: Block Intent and Controlled Progression (H5a).
+ *
+ * Defines domain models and validators for explicit per-objective intent
+ * (`develop` | `maintain`), dose envelopes, protected roles, substitution rules,
+ * and bounded progression contracts.
+ */
+
+import type { PlanCoverageKey } from '../workouts/event-plan';
+import type { ObjectivePriority } from './models';
+
+export type BlockIntent = 'develop' | 'maintain';
+
+export type DoseUnit =
+    | 'minutes'
+    | 'sessions'
+    | 'repetitions'
+    | 'kilometers'
+    | 'tss'
+    | 'joules'
+    | 'rpe_load';
+
+export const SUPPORTED_DOSE_UNITS: readonly DoseUnit[] = [
+    'minutes',
+    'sessions',
+    'repetitions',
+    'kilometers',
+    'tss',
+    'joules',
+    'rpe_load',
+] as const;
+
+export type FloorSemantics = 'hard_floor' | 'soft_floor';
+
+export interface DoseEnvelope {
+    min: number;
+    target: number;
+    max: number;
+    unit: DoseUnit;
+    floorSemantics: FloorSemantics;
+}
+
+export interface BlockSubstitutionRule {
+    targetCoverageKey: PlanCoverageKey;
+    allowedCoverageKeys: readonly PlanCoverageKey[];
+    minDoseFraction?: number;
+    rationale?: string;
+}
+
+export interface BlockSuccessCriteria {
+    evaluationRef?: {
+        id: string;
+        revision: number;
+        metricId: string;
+    };
+    minCompletedExposures?: number;
+    targetTrend?: 'stable' | 'improving';
+    acceptableDeclineTolerancePct?: number;
+}
+
+export interface BlockPrerequisites {
+    requiredPriorExposures?: number;
+    minBaselineDays?: number;
+    prohibitedTissueSeverities?: readonly ('monitor' | 'limit' | 'exclude')[];
+}
+
+export interface BlockExitCriteria {
+    maxWeeksInBlock?: number;
+    stagnationReviewAfterWeeks?: number;
+}
+
+export interface BlockObjectiveDefinition {
+    id: string;
+    sport: 'cycling' | 'strength' | 'running' | 'swimming' | 'multisport' | 'cross_training';
+    adaptationScope: string;
+    coverageKey: PlanCoverageKey;
+    intent: BlockIntent;
+    priority: ObjectivePriority;
+    doseEnvelope: DoseEnvelope;
+    knowledgeLineage?: readonly string[];
+    protectedRoles?: readonly string[];
+    allowedSubstitutions?: readonly BlockSubstitutionRule[];
+    successCriteria?: BlockSuccessCriteria;
+    entryPrerequisites?: BlockPrerequisites;
+    exitCriteria?: BlockExitCriteria;
+}
+
+export interface BlockProgressionContract {
+    targetBinding: {
+        objectiveId: string;
+        sessionId?: string;
+        stepId?: string;
+    };
+    variable: string;
+    unit: string;
+    currentValue: number;
+    permittedRange: {
+        min: number;
+        max: number;
+    };
+    increment: number;
+    knowledgeLineage?: readonly string[];
+    observationWindowDays: number;
+    minCompletedExposures: number;
+    requiredFollowUpCoveragePct: number;
+    reviewCadenceDays: number;
+    reductionAlternative?: {
+        decrement: number;
+        trigger: 'adverse_response' | 'stagnation';
+    };
+}
+
+export interface IntentBlock {
+    id: string;
+    revision: number;
+    sourcePlanId: string;
+    sourcePlanRevision: number;
+    dateRange: {
+        startDate: string;
+        endDate: string;
+    };
+    objectives: readonly BlockObjectiveDefinition[];
+    reviewSchedule: {
+        reviewCadenceDays: number;
+        nextReviewDate: string;
+    };
+    progressionContract?: BlockProgressionContract;
+    /** Presentation / descriptive labels only; excluded from canonical replay digest */
+    title?: string;
+    notes?: string;
+}
+
+export interface ValidationIssue {
+    code: string;
+    message: string;
+    path: string;
+}
+
+export interface IntentBlockValidationResult {
+    valid: boolean;
+    issues: ValidationIssue[];
+}
+
+export function isSupportedDoseUnit(unit: string): unit is DoseUnit {
+    return (SUPPORTED_DOSE_UNITS as readonly string[]).includes(unit);
+}
+
+export function validateDoseEnvelope(envelope: DoseEnvelope, path: string): ValidationIssue[] {
+    const issues: ValidationIssue[] = [];
+
+    if (!isSupportedDoseUnit(envelope.unit)) {
+        issues.push({
+            code: 'UNSUPPORTED_DOSE_UNIT',
+            message: `Unsupported dose unit: ${envelope.unit}`,
+            path: `${path}.unit`,
+        });
+    }
+
+    if (!Number.isFinite(envelope.min) || envelope.min < 0) {
+        issues.push({
+            code: 'INVALID_DOSE_MIN',
+            message: `Dose min must be a finite non-negative number: ${envelope.min}`,
+            path: `${path}.min`,
+        });
+    }
+
+    if (!Number.isFinite(envelope.target) || envelope.target < 0) {
+        issues.push({
+            code: 'INVALID_DOSE_TARGET',
+            message: `Dose target must be a finite non-negative number: ${envelope.target}`,
+            path: `${path}.target`,
+        });
+    }
+
+    if (!Number.isFinite(envelope.max) || envelope.max < 0) {
+        issues.push({
+            code: 'INVALID_DOSE_MAX',
+            message: `Dose max must be a finite non-negative number: ${envelope.max}`,
+            path: `${path}.max`,
+        });
+    }
+
+    if (envelope.min > envelope.target) {
+        issues.push({
+            code: 'INVERTED_DOSE_BOUNDS_MIN_TARGET',
+            message: `Dose min (${envelope.min}) cannot exceed target (${envelope.target})`,
+            path: `${path}.min`,
+        });
+    }
+
+    if (envelope.target > envelope.max) {
+        issues.push({
+            code: 'INVERTED_DOSE_BOUNDS_TARGET_MAX',
+            message: `Dose target (${envelope.target}) cannot exceed max (${envelope.max})`,
+            path: `${path}.max`,
+        });
+    }
+
+    if (envelope.floorSemantics !== 'hard_floor' && envelope.floorSemantics !== 'soft_floor') {
+        issues.push({
+            code: 'INVALID_FLOOR_SEMANTICS',
+            message: `Invalid floor semantics: ${envelope.floorSemantics}`,
+            path: `${path}.floorSemantics`,
+        });
+    }
+
+    return issues;
+}
+
+export function validateProgressionContract(
+    contract: BlockProgressionContract,
+    validObjectiveIds: Set<string>,
+    path: string,
+): ValidationIssue[] {
+    const issues: ValidationIssue[] = [];
+
+    if (!contract.targetBinding || !contract.targetBinding.objectiveId) {
+        issues.push({
+            code: 'MISSING_TARGET_OBJECTIVE_ID',
+            message: 'Progression contract must bind to an objectiveId',
+            path: `${path}.targetBinding.objectiveId`,
+        });
+    } else if (!validObjectiveIds.has(contract.targetBinding.objectiveId)) {
+        issues.push({
+            code: 'DANGLING_PROGRESSION_TARGET_OBJECTIVE',
+            message: `Progression target objectiveId ${contract.targetBinding.objectiveId} is not in block objectives`,
+            path: `${path}.targetBinding.objectiveId`,
+        });
+    }
+
+    if (!contract.variable || typeof contract.variable !== 'string' || contract.variable.trim() === '') {
+        issues.push({
+            code: 'INVALID_PROGRESSION_VARIABLE',
+            message: 'Progression variable must be a non-empty string',
+            path: `${path}.variable`,
+        });
+    }
+
+    if (!contract.unit || typeof contract.unit !== 'string' || contract.unit.trim() === '') {
+        issues.push({
+            code: 'INVALID_PROGRESSION_UNIT',
+            message: 'Progression unit must be a non-empty string',
+            path: `${path}.unit`,
+        });
+    }
+
+    if (!Number.isFinite(contract.increment) || contract.increment <= 0) {
+        issues.push({
+            code: 'INVALID_PROGRESSION_INCREMENT',
+            message: `Progression increment must be a positive finite number: ${contract.increment}`,
+            path: `${path}.increment`,
+        });
+    }
+
+    if (!contract.permittedRange || !Number.isFinite(contract.permittedRange.min) || !Number.isFinite(contract.permittedRange.max)) {
+        issues.push({
+            code: 'INVALID_PERMITTED_RANGE',
+            message: 'Permitted range min and max must be finite numbers',
+            path: `${path}.permittedRange`,
+        });
+    } else {
+        if (contract.permittedRange.min >= contract.permittedRange.max) {
+            issues.push({
+                code: 'INVERTED_PERMITTED_RANGE',
+                message: `Permitted range min (${contract.permittedRange.min}) must be less than max (${contract.permittedRange.max})`,
+                path: `${path}.permittedRange`,
+            });
+        }
+        if (contract.currentValue < contract.permittedRange.min || contract.currentValue > contract.permittedRange.max) {
+            issues.push({
+                code: 'CURRENT_VALUE_OUT_OF_RANGE',
+                message: `Current value (${contract.currentValue}) is outside permitted range [${contract.permittedRange.min}, ${contract.permittedRange.max}]`,
+                path: `${path}.currentValue`,
+            });
+        }
+    }
+
+    if (!Number.isFinite(contract.observationWindowDays) || contract.observationWindowDays <= 0) {
+        issues.push({
+            code: 'INVALID_OBSERVATION_WINDOW',
+            message: `Observation window must be a positive integer days: ${contract.observationWindowDays}`,
+            path: `${path}.observationWindowDays`,
+        });
+    }
+
+    if (!Number.isFinite(contract.minCompletedExposures) || contract.minCompletedExposures < 1) {
+        issues.push({
+            code: 'INVALID_MIN_COMPLETED_EXPOSURES',
+            message: `Min completed exposures must be at least 1: ${contract.minCompletedExposures}`,
+            path: `${path}.minCompletedExposures`,
+        });
+    }
+
+    if (
+        !Number.isFinite(contract.requiredFollowUpCoveragePct) ||
+        contract.requiredFollowUpCoveragePct < 0 ||
+        contract.requiredFollowUpCoveragePct > 100
+    ) {
+        issues.push({
+            code: 'INVALID_FOLLOW_UP_COVERAGE_PCT',
+            message: `Required follow-up coverage percent must be between 0 and 100: ${contract.requiredFollowUpCoveragePct}`,
+            path: `${path}.requiredFollowUpCoveragePct`,
+        });
+    }
+
+    if (!Number.isFinite(contract.reviewCadenceDays) || contract.reviewCadenceDays <= 0) {
+        issues.push({
+            code: 'INVALID_REVIEW_CADENCE',
+            message: `Review cadence days must be a positive integer: ${contract.reviewCadenceDays}`,
+            path: `${path}.reviewCadenceDays`,
+        });
+    }
+
+    if (contract.reductionAlternative) {
+        if (!Number.isFinite(contract.reductionAlternative.decrement) || contract.reductionAlternative.decrement <= 0) {
+            issues.push({
+                code: 'INVALID_REDUCTION_DECREMENT',
+                message: `Reduction decrement must be a positive finite number: ${contract.reductionAlternative.decrement}`,
+                path: `${path}.reductionAlternative.decrement`,
+            });
+        }
+    }
+
+    return issues;
+}
+
+export function validateIntentBlock(block: IntentBlock): IntentBlockValidationResult {
+    const issues: ValidationIssue[] = [];
+    const rootPath = `intentBlock[${block.id || 'unknown'}]`;
+
+    if (!block.id || typeof block.id !== 'string' || block.id.trim() === '') {
+        issues.push({
+            code: 'MISSING_BLOCK_ID',
+            message: 'Block ID must be a non-empty string',
+            path: `${rootPath}.id`,
+        });
+    }
+
+    if (!Number.isInteger(block.revision) || block.revision < 1) {
+        issues.push({
+            code: 'INVALID_BLOCK_REVISION',
+            message: `Block revision must be a positive integer: ${block.revision}`,
+            path: `${rootPath}.revision`,
+        });
+    }
+
+    if (!block.dateRange || !block.dateRange.startDate || !block.dateRange.endDate) {
+        issues.push({
+            code: 'MISSING_DATE_RANGE',
+            message: 'Block date range must specify startDate and endDate',
+            path: `${rootPath}.dateRange`,
+        });
+    } else if (block.dateRange.startDate > block.dateRange.endDate) {
+        issues.push({
+            code: 'INVERTED_DATE_RANGE',
+            message: `Block startDate (${block.dateRange.startDate}) cannot be after endDate (${block.dateRange.endDate})`,
+            path: `${rootPath}.dateRange`,
+        });
+    }
+
+    if (!Array.isArray(block.objectives) || block.objectives.length === 0) {
+        issues.push({
+            code: 'NO_OBJECTIVES',
+            message: 'Block must contain at least one objective',
+            path: `${rootPath}.objectives`,
+        });
+    } else {
+        const objectiveIds = new Set<string>();
+        for (let i = 0; i < block.objectives.length; i++) {
+            const obj = block.objectives[i];
+            const objPath = `${rootPath}.objectives[${i}]`;
+
+            if (!obj.id || typeof obj.id !== 'string' || obj.id.trim() === '') {
+                issues.push({
+                    code: 'MISSING_OBJECTIVE_ID',
+                    message: 'Objective ID must be a non-empty string',
+                    path: `${objPath}.id`,
+                });
+            } else if (objectiveIds.has(obj.id)) {
+                issues.push({
+                    code: 'DUPLICATE_OBJECTIVE_ID',
+                    message: `Duplicate objective ID: ${obj.id}`,
+                    path: `${objPath}.id`,
+                });
+            } else {
+                objectiveIds.add(obj.id);
+            }
+
+            if (obj.intent !== 'develop' && obj.intent !== 'maintain') {
+                issues.push({
+                    code: 'INVALID_OBJECTIVE_INTENT',
+                    message: `Objective intent must be 'develop' or 'maintain', got: ${obj.intent}`,
+                    path: `${objPath}.intent`,
+                });
+            }
+
+            if (obj.doseEnvelope) {
+                issues.push(...validateDoseEnvelope(obj.doseEnvelope, `${objPath}.doseEnvelope`));
+            } else {
+                issues.push({
+                    code: 'MISSING_DOSE_ENVELOPE',
+                    message: 'Objective must specify a doseEnvelope',
+                    path: `${objPath}.doseEnvelope`,
+                });
+            }
+        }
+
+        if (block.progressionContract) {
+            issues.push(...validateProgressionContract(block.progressionContract, objectiveIds, `${rootPath}.progressionContract`));
+        }
+    }
+
+    return {
+        valid: issues.length === 0,
+        issues,
+    };
+}
+
+export function validatePlanIntentBlocks(blocks: readonly IntentBlock[]): IntentBlockValidationResult {
+    const issues: ValidationIssue[] = [];
+    const blockIds = new Set<string>();
+
+    for (let i = 0; i < blocks.length; i++) {
+        const block = blocks[i];
+        const singleResult = validateIntentBlock(block);
+        issues.push(...singleResult.issues);
+
+        if (blockIds.has(block.id)) {
+            issues.push({
+                code: 'DUPLICATE_BLOCK_ID',
+                message: `Duplicate block ID across plan: ${block.id}`,
+                path: `blocks[${i}].id`,
+            });
+        }
+        blockIds.add(block.id);
+    }
+
+    // Check for overlapping active intervals
+    const sorted = [...blocks].sort((a, b) => a.dateRange.startDate.localeCompare(b.dateRange.startDate));
+    for (let i = 0; i < sorted.length - 1; i++) {
+        if (sorted[i].dateRange.endDate >= sorted[i + 1].dateRange.startDate) {
+            issues.push({
+                code: 'OVERLAPPING_INTENT_BLOCKS',
+                message: `Intent blocks ${sorted[i].id} and ${sorted[i + 1].id} overlap: ${sorted[i].dateRange.endDate} >= ${sorted[i + 1].dateRange.startDate}`,
+                path: `blocks[${sorted[i].id}]`,
+            });
+        }
+    }
+
+    return {
+        valid: issues.length === 0,
+        issues,
+    };
+}

--- a/app/src/engine/blockIntentReplay.test.ts
+++ b/app/src/engine/blockIntentReplay.test.ts
@@ -1,0 +1,254 @@
+﻿import { describe, it, expect } from 'vitest';
+import type { IntentBlock } from './blockIntent';
+import type { TrainingIntentProfile, TrainingPriority } from './models';
+import {
+    buildTreatmentIntentReplayPayloadV1,
+    hashTreatmentIntentReplayPayload,
+    verifyTreatmentIntentReplayDigest,
+    canonicalizeTreatmentIntentJson,
+    type TreatmentIntentReplayPayloadV1,
+} from './blockIntentReplay';
+
+describe('blockIntentReplay (ADR-0037 D-REPLAY)', () => {
+    const baseBlock: IntentBlock = {
+        id: 'block_cycling_phase_01',
+        revision: 2,
+        sourcePlanId: 'plan_external_road_2026',
+        sourcePlanRevision: 3,
+        dateRange: {
+            startDate: '2026-09-07',
+            endDate: '2026-10-04',
+        },
+        objectives: [
+            {
+                id: 'obj_cycling_tempo',
+                sport: 'cycling',
+                adaptationScope: 'tempo_endurance',
+                coverageKey: 'sustained_quality',
+                intent: 'develop',
+                priority: 'must_have',
+                doseEnvelope: {
+                    min: 60,
+                    target: 90,
+                    max: 120,
+                    unit: 'minutes',
+                    floorSemantics: 'hard_floor',
+                },
+                knowledgeLineage: ['claim_tempo_durability_v1'],
+                protectedRoles: ['sustained_quality'],
+                allowedSubstitutions: [
+                    {
+                        targetCoverageKey: 'sustained_quality',
+                        allowedCoverageKeys: ['outdoor_event_specific'],
+                        minDoseFraction: 0.9,
+                    },
+                ],
+                entryPrerequisites: {
+                    requiredPriorExposures: 4,
+                    minBaselineDays: 14,
+                    prohibitedTissueSeverities: ['limit', 'exclude'],
+                },
+                exitCriteria: {
+                    maxWeeksInBlock: 4,
+                },
+            },
+            {
+                id: 'obj_strength_retention',
+                sport: 'strength',
+                adaptationScope: 'force_preservation',
+                coverageKey: 'primary_strength',
+                intent: 'maintain',
+                priority: 'should_have',
+                doseEnvelope: {
+                    min: 1,
+                    target: 2,
+                    max: 2,
+                    unit: 'sessions',
+                    floorSemantics: 'soft_floor',
+                },
+            },
+        ],
+        reviewSchedule: {
+            reviewCadenceDays: 14,
+            nextReviewDate: '2026-09-21',
+        },
+        progressionContract: {
+            targetBinding: {
+                objectiveId: 'obj_cycling_tempo',
+            },
+            variable: 'duration_min',
+            unit: 'minutes',
+            currentValue: 90,
+            permittedRange: {
+                min: 60,
+                max: 120,
+            },
+            increment: 10,
+            observationWindowDays: 14,
+            minCompletedExposures: 3,
+            requiredFollowUpCoveragePct: 75,
+            reviewCadenceDays: 14,
+            reductionAlternative: {
+                decrement: 10,
+                trigger: 'adverse_response',
+            },
+        },
+        title: 'Initial Build Phase Block',
+        notes: 'Coaching note for athlete view',
+    };
+
+    const baseProfile: Pick<TrainingIntentProfile, 'priorities' | 'weeklyCommitment'> = {
+        priorities: ['endurance', 'strength_muscle'],
+        weeklyCommitment: {
+            minSessions: 4,
+            targetSessions: 6,
+            maxSessions: 7,
+        },
+    };
+
+    it('produces a deterministic SHA-256 hash regardless of object key order', async () => {
+        const payload1 = buildTreatmentIntentReplayPayloadV1(baseBlock, baseProfile, 'external-plan@4');
+        const hash1 = await hashTreatmentIntentReplayPayload(payload1);
+
+        // Check canonical json serialization
+        const json1 = canonicalizeTreatmentIntentJson(payload1);
+        expect(json1).toContain('treatment_intent_replay_v1');
+
+        // Reconstruct payload with scrambled top-level key insertion order
+        const scrambledPayload: TreatmentIntentReplayPayloadV1 = {
+            block: payload1.block,
+            schemaVersion: payload1.schemaVersion,
+            trainingIntentProfile: payload1.trainingIntentProfile,
+            sourcePlanIdentity: payload1.sourcePlanIdentity,
+        };
+        const hash2 = await hashTreatmentIntentReplayPayload(scrambledPayload);
+
+        expect(hash1).toHaveLength(64);
+        expect(hash1).toBe(hash2);
+        expect(await verifyTreatmentIntentReplayDigest(payload1, hash1)).toBe(true);
+    });
+
+    it('excludes display-only fields (title, notes) from replay digest', async () => {
+        const payload1 = buildTreatmentIntentReplayPayloadV1(baseBlock, baseProfile, 'external-plan@4');
+        const hash1 = await hashTreatmentIntentReplayPayload(payload1);
+
+        const modifiedBlock: IntentBlock = {
+            ...baseBlock,
+            title: 'Changed Title completely for UI',
+            notes: 'Completely altered coach notes that should not affect decision semantics',
+        };
+        const payload2 = buildTreatmentIntentReplayPayloadV1(modifiedBlock, baseProfile, 'external-plan@4');
+        const hash2 = await hashTreatmentIntentReplayPayload(payload2);
+
+        expect(hash1).toBe(hash2);
+    });
+
+    it('fails digest verification when TrainingIntentProfile priorities are mutated', async () => {
+        const payload = buildTreatmentIntentReplayPayloadV1(baseBlock, baseProfile, 'external-plan@4');
+        const baseHash = await hashTreatmentIntentReplayPayload(payload);
+
+        const mutatedProfile = {
+            ...baseProfile,
+            priorities: ['health', 'endurance'] as TrainingPriority[],
+        };
+        const mutatedPayload = buildTreatmentIntentReplayPayloadV1(baseBlock, mutatedProfile, 'external-plan@4');
+        const mutatedHash = await hashTreatmentIntentReplayPayload(mutatedPayload);
+
+        expect(mutatedHash).not.toBe(baseHash);
+        expect(await verifyTreatmentIntentReplayDigest(mutatedPayload, baseHash)).toBe(false);
+    });
+
+    it('fails digest verification when weeklyCommitment fields are mutated independently', async () => {
+        const payload = buildTreatmentIntentReplayPayloadV1(baseBlock, baseProfile, 'external-plan@4');
+        const baseHash = await hashTreatmentIntentReplayPayload(payload);
+
+        // Mutate minSessions
+        const mutMin = buildTreatmentIntentReplayPayloadV1(
+            baseBlock,
+            { ...baseProfile, weeklyCommitment: { ...baseProfile.weeklyCommitment, minSessions: 5 } },
+            'external-plan@4',
+        );
+        expect(await hashTreatmentIntentReplayPayload(mutMin)).not.toBe(baseHash);
+
+        // Mutate targetSessions
+        const mutTarget = buildTreatmentIntentReplayPayloadV1(
+            baseBlock,
+            { ...baseProfile, weeklyCommitment: { ...baseProfile.weeklyCommitment, targetSessions: 5 } },
+            'external-plan@4',
+        );
+        expect(await hashTreatmentIntentReplayPayload(mutTarget)).not.toBe(baseHash);
+
+        // Mutate maxSessions
+        const mutMax = buildTreatmentIntentReplayPayloadV1(
+            baseBlock,
+            { ...baseProfile, weeklyCommitment: { ...baseProfile.weeklyCommitment, maxSessions: 8 } },
+            'external-plan@4',
+        );
+        expect(await hashTreatmentIntentReplayPayload(mutMax)).not.toBe(baseHash);
+    });
+
+    it('fails digest verification when objective intent (develop vs maintain) is mutated', async () => {
+        const payload = buildTreatmentIntentReplayPayloadV1(baseBlock, baseProfile, 'external-plan@4');
+        const baseHash = await hashTreatmentIntentReplayPayload(payload);
+
+        const mutatedBlock: IntentBlock = {
+            ...baseBlock,
+            objectives: [
+                { ...baseBlock.objectives[0], intent: 'maintain' },
+                baseBlock.objectives[1],
+            ],
+        };
+        const mutatedPayload = buildTreatmentIntentReplayPayloadV1(mutatedBlock, baseProfile, 'external-plan@4');
+        expect(await hashTreatmentIntentReplayPayload(mutatedPayload)).not.toBe(baseHash);
+    });
+
+    it('fails digest verification when dose bounds or floor semantics are mutated', async () => {
+        const payload = buildTreatmentIntentReplayPayloadV1(baseBlock, baseProfile, 'external-plan@4');
+        const baseHash = await hashTreatmentIntentReplayPayload(payload);
+
+        const mutatedBlock: IntentBlock = {
+            ...baseBlock,
+            objectives: [
+                {
+                    ...baseBlock.objectives[0],
+                    doseEnvelope: { ...baseBlock.objectives[0].doseEnvelope, min: 75 },
+                },
+                baseBlock.objectives[1],
+            ],
+        };
+        const mutatedPayload = buildTreatmentIntentReplayPayloadV1(mutatedBlock, baseProfile, 'external-plan@4');
+        expect(await hashTreatmentIntentReplayPayload(mutatedPayload)).not.toBe(baseHash);
+    });
+
+    it('fails digest verification when progression contract fields are mutated', async () => {
+        const payload = buildTreatmentIntentReplayPayloadV1(baseBlock, baseProfile, 'external-plan@4');
+        const baseHash = await hashTreatmentIntentReplayPayload(payload);
+
+        // Mutate increment
+        const mutatedIncrement: IntentBlock = {
+            ...baseBlock,
+            progressionContract: { ...baseBlock.progressionContract!, increment: 15 },
+        };
+        expect(await hashTreatmentIntentReplayPayload(
+            buildTreatmentIntentReplayPayloadV1(mutatedIncrement, baseProfile, 'external-plan@4'),
+        )).not.toBe(baseHash);
+
+        // Mutate currentValue
+        const mutatedCurrentVal: IntentBlock = {
+            ...baseBlock,
+            progressionContract: { ...baseBlock.progressionContract!, currentValue: 100 },
+        };
+        expect(await hashTreatmentIntentReplayPayload(
+            buildTreatmentIntentReplayPayloadV1(mutatedCurrentVal, baseProfile, 'external-plan@4'),
+        )).not.toBe(baseHash);
+
+        // Mutate permitted range
+        const mutatedRange: IntentBlock = {
+            ...baseBlock,
+            progressionContract: { ...baseBlock.progressionContract!, permittedRange: { min: 60, max: 130 } },
+        };
+        expect(await hashTreatmentIntentReplayPayload(
+            buildTreatmentIntentReplayPayloadV1(mutatedRange, baseProfile, 'external-plan@4'),
+        )).not.toBe(baseHash);
+    });
+});

--- a/app/src/engine/blockIntentReplay.test.ts
+++ b/app/src/engine/blockIntentReplay.test.ts
@@ -20,13 +20,16 @@ describe('blockIntentReplay (ADR-0037 D-REPLAY)', () => {
             {
                 id: 'obj_cycling_tempo',
                 sport: 'cycling',
-                adaptationScope: 'tempo_endurance',
+                adaptationScope: 'threshold_quality',
                 coverageKey: 'sustained_quality',
                 intent: 'develop',
                 priority: 'must_have',
                 doseEnvelope: { min: 60, target: 90, max: 120, unit: 'minutes', floorSemantics: 'hard_floor' },
                 knowledgeLineage: ['claim_tempo_durability_v1', 'claim_threshold_v1'],
-                protectedRoles: ['sustained_quality', 'anchor_quality'],
+                protectedRoles: [
+                    { kind: 'coverage_role', coverageKey: 'sustained_quality' },
+                    { kind: 'session', sessionId: 'threshold_anchor' },
+                ],
                 allowedSubstitutions: [{
                     targetCoverageKey: 'sustained_quality',
                     allowedCoverageKeys: ['outdoor_event_specific', 'gap_closing'],
@@ -38,21 +41,19 @@ describe('blockIntentReplay (ADR-0037 D-REPLAY)', () => {
                     minCompletedExposures: 3,
                     targetTrend: 'improving',
                 },
-                entryPrerequisites: {
-                    requiredPriorExposures: 4,
-                    minBaselineDays: 14,
-                    prohibitedTissueSeverities: ['limit', 'exclude'],
-                },
+                entryPrerequisites: { requiredPriorExposures: 4, minBaselineDays: 14, prohibitedTissueSeverities: ['limit', 'exclude'] },
                 exitCriteria: { maxWeeksInBlock: 4, stagnationReviewAfterWeeks: 3 },
             },
             {
                 id: 'obj_strength_retention',
                 sport: 'strength',
-                adaptationScope: 'force_preservation',
+                adaptationScope: 'strength_maintenance',
                 coverageKey: 'primary_strength',
                 intent: 'maintain',
                 priority: 'should_have',
                 doseEnvelope: { min: 1, target: 2, max: 2, unit: 'sessions', floorSemantics: 'soft_floor' },
+                knowledgeLineage: ['claim_strength_maintenance_v1'],
+                successCriteria: { minCompletedExposures: 1 },
             },
         ],
         reviewSchedule: { reviewCadenceDays: 14, nextReviewDate: '2026-09-21' },
@@ -80,9 +81,7 @@ describe('blockIntentReplay (ADR-0037 D-REPLAY)', () => {
     };
 
     async function digest(block = baseBlock, profile = baseProfile, schema = 'external-plan@4', sourceRef?: string) {
-        return hashTreatmentIntentReplayPayload(
-            buildTreatmentIntentReplayPayloadV1(block, profile, schema, sourceRef),
-        );
+        return hashTreatmentIntentReplayPayload(buildTreatmentIntentReplayPayloadV1(block, profile, schema, sourceRef));
     }
 
     it('produces deterministic canonical JSON regardless of object key insertion order', async () => {
@@ -106,7 +105,7 @@ describe('blockIntentReplay (ADR-0037 D-REPLAY)', () => {
                 baseBlock.objectives[1],
                 {
                     ...baseBlock.objectives[0],
-                    knowledgeLineage: [...baseBlock.objectives[0].knowledgeLineage!].reverse(),
+                    knowledgeLineage: [...baseBlock.objectives[0].knowledgeLineage].reverse(),
                     protectedRoles: [...baseBlock.objectives[0].protectedRoles!].reverse(),
                     allowedSubstitutions: [{
                         ...baseBlock.objectives[0].allowedSubstitutions![0],
@@ -120,28 +119,22 @@ describe('blockIntentReplay (ADR-0037 D-REPLAY)', () => {
             ],
             progressionContract: {
                 ...baseBlock.progressionContract!,
-                knowledgeLineage: [...baseBlock.progressionContract!.knowledgeLineage!].reverse(),
+                knowledgeLineage: [...baseBlock.progressionContract!.knowledgeLineage].reverse(),
             },
         };
         expect(await digest(reordered)).toBe(await digest());
     });
 
-    it('normalizes empty optional sets to the same identity as omission', async () => {
-        const withoutOptionalSets: IntentBlock = {
+    it('normalizes empty optional protected/substitution sets to omission', async () => {
+        const without: IntentBlock = {
             ...baseBlock,
-            objectives: [
-                { ...baseBlock.objectives[0], protectedRoles: undefined },
-                baseBlock.objectives[1],
-            ],
+            objectives: [{ ...baseBlock.objectives[0], protectedRoles: undefined, allowedSubstitutions: undefined }, baseBlock.objectives[1]],
         };
-        const withEmptySets: IntentBlock = {
-            ...withoutOptionalSets,
-            objectives: [
-                { ...withoutOptionalSets.objectives[0], protectedRoles: [] },
-                withoutOptionalSets.objectives[1],
-            ],
+        const empty: IntentBlock = {
+            ...without,
+            objectives: [{ ...without.objectives[0], protectedRoles: [], allowedSubstitutions: [] }, without.objectives[1]],
         };
-        expect(await digest(withoutOptionalSets)).toBe(await digest(withEmptySets));
+        expect(await digest(without)).toBe(await digest(empty));
     });
 
     it('excludes display-only title/notes and substitution rationale from digest', async () => {
@@ -151,60 +144,75 @@ describe('blockIntentReplay (ADR-0037 D-REPLAY)', () => {
             notes: 'Changed coaching note',
             objectives: [{
                 ...baseBlock.objectives[0],
-                allowedSubstitutions: [{
-                    ...baseBlock.objectives[0].allowedSubstitutions![0],
-                    rationale: 'Completely different explanation',
-                }],
+                allowedSubstitutions: [{ ...baseBlock.objectives[0].allowedSubstitutions![0], rationale: 'Completely different explanation' }],
             }, baseBlock.objectives[1]],
         };
         expect(await digest(modified)).toBe(await digest());
     });
 
-    it('changes identity for source plan schema/revision/provenance and effective bounds', async () => {
-        expect(await digest(baseBlock, baseProfile, 'external-plan@3')).not.toBe(await digest());
-        expect(await digest({ ...baseBlock, sourcePlanRevision: 4 })).not.toBe(await digest());
-        expect(await digest(baseBlock, baseProfile, 'external-plan@4', 'manual:abc')).not.toBe(await digest());
-        expect(await digest({ ...baseBlock, dateRange: { ...baseBlock.dateRange, endDate: '2026-10-03' } })).not.toBe(await digest());
+    it('changes identity for source and block identity/effective bounds', async () => {
+        const baseHash = await digest();
+        const mutations: Array<Promise<string>> = [
+            digest(baseBlock, baseProfile, 'external-plan@3'),
+            digest({ ...baseBlock, sourcePlanId: 'different_plan' }),
+            digest({ ...baseBlock, sourcePlanRevision: 4 }),
+            digest(baseBlock, baseProfile, 'external-plan@4', 'manual:abc'),
+            digest({ ...baseBlock, id: 'different_block' }),
+            digest({ ...baseBlock, revision: 3 }),
+            digest({ ...baseBlock, dateRange: { ...baseBlock.dateRange, endDate: '2026-10-03' } }),
+        ];
+        for (const mutation of mutations) expect(await mutation).not.toBe(baseHash);
     });
 
-    it('changes identity for pinned profile priorities and each weekly commitment field', async () => {
+    it('changes identity for pinned profile priorities and every weekly commitment field', async () => {
         const baseHash = await digest();
         const mutatedPriorities = { ...baseProfile, priorities: ['health', 'endurance'] as TrainingPriority[] };
         expect(await digest(baseBlock, mutatedPriorities)).not.toBe(baseHash);
         for (const [field, value] of [['minSessions', 5], ['targetSessions', 5], ['maxSessions', 8]] as const) {
-            expect(await digest(baseBlock, {
-                ...baseProfile,
-                weeklyCommitment: { ...baseProfile.weeklyCommitment, [field]: value },
-            })).not.toBe(baseHash);
+            expect(await digest(baseBlock, { ...baseProfile, weeklyCommitment: { ...baseProfile.weeklyCommitment, [field]: value } })).not.toBe(baseHash);
         }
     });
 
-    it('changes identity for objective intent/dose/protected roles/substitutions/success/prerequisites/exit rules', async () => {
+    it('changes identity for every objective semantic family', async () => {
         const baseHash = await digest();
+        const obj = baseBlock.objectives[0];
         const mutations: IntentBlock[] = [
-            { ...baseBlock, objectives: [{ ...baseBlock.objectives[0], intent: 'maintain' }, baseBlock.objectives[1]] },
-            { ...baseBlock, objectives: [{ ...baseBlock.objectives[0], doseEnvelope: { ...baseBlock.objectives[0].doseEnvelope, min: 75 } }, baseBlock.objectives[1]] },
-            { ...baseBlock, objectives: [{ ...baseBlock.objectives[0], protectedRoles: ['different_role'] }, baseBlock.objectives[1]] },
-            { ...baseBlock, objectives: [{ ...baseBlock.objectives[0], allowedSubstitutions: [{ ...baseBlock.objectives[0].allowedSubstitutions![0], minDoseFraction: 0.8 }] }, baseBlock.objectives[1]] },
-            { ...baseBlock, objectives: [{ ...baseBlock.objectives[0], successCriteria: { ...baseBlock.objectives[0].successCriteria!, minCompletedExposures: 4 } }, baseBlock.objectives[1]] },
-            { ...baseBlock, objectives: [{ ...baseBlock.objectives[0], entryPrerequisites: { ...baseBlock.objectives[0].entryPrerequisites!, minBaselineDays: 21 } }, baseBlock.objectives[1]] },
-            { ...baseBlock, objectives: [{ ...baseBlock.objectives[0], exitCriteria: { ...baseBlock.objectives[0].exitCriteria!, maxWeeksInBlock: 5 } }, baseBlock.objectives[1]] },
+            { ...baseBlock, objectives: [{ ...obj, sport: 'running' }, baseBlock.objectives[1]] },
+            { ...baseBlock, objectives: [{ ...obj, adaptationScope: 'vo2_max' }, baseBlock.objectives[1]] },
+            { ...baseBlock, objectives: [{ ...obj, coverageKey: 'gap_closing' }, baseBlock.objectives[1]] },
+            { ...baseBlock, objectives: [{ ...obj, intent: 'maintain' }, baseBlock.objectives[1]] },
+            { ...baseBlock, objectives: [{ ...obj, priority: 'nice_to_have' }, baseBlock.objectives[1]] },
+            { ...baseBlock, objectives: [{ ...obj, doseEnvelope: { ...obj.doseEnvelope, min: 75 } }, baseBlock.objectives[1]] },
+            { ...baseBlock, objectives: [{ ...obj, doseEnvelope: { ...obj.doseEnvelope, target: 95 } }, baseBlock.objectives[1]] },
+            { ...baseBlock, objectives: [{ ...obj, doseEnvelope: { ...obj.doseEnvelope, max: 115 } }, baseBlock.objectives[1]] },
+            { ...baseBlock, objectives: [{ ...obj, doseEnvelope: { ...obj.doseEnvelope, floorSemantics: 'soft_floor' } }, baseBlock.objectives[1]] },
+            { ...baseBlock, objectives: [{ ...obj, knowledgeLineage: [...obj.knowledgeLineage, 'new_claim'] }, baseBlock.objectives[1]] },
+            { ...baseBlock, objectives: [{ ...obj, protectedRoles: [{ kind: 'session', sessionId: 'different' }] }, baseBlock.objectives[1]] },
+            { ...baseBlock, objectives: [{ ...obj, allowedSubstitutions: [{ ...obj.allowedSubstitutions![0], minDoseFraction: 0.8 }] }, baseBlock.objectives[1]] },
+            { ...baseBlock, objectives: [{ ...obj, successCriteria: { ...obj.successCriteria, minCompletedExposures: 4 } }, baseBlock.objectives[1]] },
+            { ...baseBlock, objectives: [{ ...obj, entryPrerequisites: { ...obj.entryPrerequisites!, minBaselineDays: 21 } }, baseBlock.objectives[1]] },
+            { ...baseBlock, objectives: [{ ...obj, exitCriteria: { ...obj.exitCriteria!, maxWeeksInBlock: 5 } }, baseBlock.objectives[1]] },
         ];
         for (const mutation of mutations) expect(await digest(mutation)).not.toBe(baseHash);
     });
 
-    it('changes identity for review timing and every progression-rule family', async () => {
+    it('changes identity for review timing and every progression semantic family', async () => {
         const baseHash = await digest();
+        const pc = baseBlock.progressionContract!;
         const mutations: IntentBlock[] = [
             { ...baseBlock, reviewSchedule: { ...baseBlock.reviewSchedule, nextReviewDate: '2026-09-22' } },
-            { ...baseBlock, progressionContract: { ...baseBlock.progressionContract!, currentValue: 100 } },
-            { ...baseBlock, progressionContract: { ...baseBlock.progressionContract!, increment: 15 } },
-            { ...baseBlock, progressionContract: { ...baseBlock.progressionContract!, permittedRange: { min: 60, max: 115 } } },
-            { ...baseBlock, progressionContract: { ...baseBlock.progressionContract!, observationWindowDays: 10 } },
-            { ...baseBlock, progressionContract: { ...baseBlock.progressionContract!, minCompletedExposures: 4 } },
-            { ...baseBlock, progressionContract: { ...baseBlock.progressionContract!, requiredFollowUpCoveragePct: 90 } },
-            { ...baseBlock, progressionContract: { ...baseBlock.progressionContract!, reductionAlternative: { decrement: 5, trigger: 'adverse_response' } } },
-            { ...baseBlock, progressionContract: { ...baseBlock.progressionContract!, redirectCriteria: { triggers: ['active_restriction'] } } },
+            { ...baseBlock, progressionContract: { ...pc, targetBinding: { objectiveId: pc.targetBinding.objectiveId, sessionId: 'session_a' } } },
+            { ...baseBlock, progressionContract: { ...pc, currentValue: 100 } },
+            { ...baseBlock, progressionContract: { ...pc, increment: 15 } },
+            { ...baseBlock, progressionContract: { ...pc, permittedRange: { min: 65, max: 120 } } },
+            { ...baseBlock, progressionContract: { ...pc, permittedRange: { min: 60, max: 115 } } },
+            { ...baseBlock, progressionContract: { ...pc, knowledgeLineage: [...pc.knowledgeLineage, 'new_policy'] } },
+            { ...baseBlock, progressionContract: { ...pc, observationWindowDays: 10 } },
+            { ...baseBlock, progressionContract: { ...pc, minCompletedExposures: 4 } },
+            { ...baseBlock, progressionContract: { ...pc, requiredFollowUpCoveragePct: 90 } },
+            { ...baseBlock, progressionContract: { ...pc, reviewCadenceDays: 7 } },
+            { ...baseBlock, progressionContract: { ...pc, reductionAlternative: { decrement: 5, trigger: 'adverse_response' } } },
+            { ...baseBlock, progressionContract: { ...pc, reductionAlternative: undefined, redirectCriteria: { triggers: ['active_restriction'] } } },
         ];
         for (const mutation of mutations) expect(await digest(mutation)).not.toBe(baseHash);
     });

--- a/app/src/engine/blockIntentReplay.test.ts
+++ b/app/src/engine/blockIntentReplay.test.ts
@@ -1,11 +1,11 @@
-﻿import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import type { IntentBlock } from './blockIntent';
 import type { TrainingIntentProfile, TrainingPriority } from './models';
 import {
     buildTreatmentIntentReplayPayloadV1,
+    canonicalizeTreatmentIntentJson,
     hashTreatmentIntentReplayPayload,
     verifyTreatmentIntentReplayDigest,
-    canonicalizeTreatmentIntentJson,
     type TreatmentIntentReplayPayloadV1,
 } from './blockIntentReplay';
 
@@ -15,10 +15,7 @@ describe('blockIntentReplay (ADR-0037 D-REPLAY)', () => {
         revision: 2,
         sourcePlanId: 'plan_external_road_2026',
         sourcePlanRevision: 3,
-        dateRange: {
-            startDate: '2026-09-07',
-            endDate: '2026-10-04',
-        },
+        dateRange: { startDate: '2026-09-07', endDate: '2026-10-04' },
         objectives: [
             {
                 id: 'obj_cycling_tempo',
@@ -27,30 +24,26 @@ describe('blockIntentReplay (ADR-0037 D-REPLAY)', () => {
                 coverageKey: 'sustained_quality',
                 intent: 'develop',
                 priority: 'must_have',
-                doseEnvelope: {
-                    min: 60,
-                    target: 90,
-                    max: 120,
-                    unit: 'minutes',
-                    floorSemantics: 'hard_floor',
+                doseEnvelope: { min: 60, target: 90, max: 120, unit: 'minutes', floorSemantics: 'hard_floor' },
+                knowledgeLineage: ['claim_tempo_durability_v1', 'claim_threshold_v1'],
+                protectedRoles: ['sustained_quality', 'anchor_quality'],
+                allowedSubstitutions: [{
+                    targetCoverageKey: 'sustained_quality',
+                    allowedCoverageKeys: ['outdoor_event_specific', 'gap_closing'],
+                    minDoseFraction: 0.9,
+                    rationale: 'Human-facing substitution explanation',
+                }],
+                successCriteria: {
+                    evaluationRef: { id: 'eval_spec_01', revision: 1, metricId: 'cycling_ftp' },
+                    minCompletedExposures: 3,
+                    targetTrend: 'improving',
                 },
-                knowledgeLineage: ['claim_tempo_durability_v1'],
-                protectedRoles: ['sustained_quality'],
-                allowedSubstitutions: [
-                    {
-                        targetCoverageKey: 'sustained_quality',
-                        allowedCoverageKeys: ['outdoor_event_specific'],
-                        minDoseFraction: 0.9,
-                    },
-                ],
                 entryPrerequisites: {
                     requiredPriorExposures: 4,
                     minBaselineDays: 14,
                     prohibitedTissueSeverities: ['limit', 'exclude'],
                 },
-                exitCriteria: {
-                    maxWeeksInBlock: 4,
-                },
+                exitCriteria: { maxWeeksInBlock: 4, stagnationReviewAfterWeeks: 3 },
             },
             {
                 id: 'obj_strength_retention',
@@ -59,39 +52,23 @@ describe('blockIntentReplay (ADR-0037 D-REPLAY)', () => {
                 coverageKey: 'primary_strength',
                 intent: 'maintain',
                 priority: 'should_have',
-                doseEnvelope: {
-                    min: 1,
-                    target: 2,
-                    max: 2,
-                    unit: 'sessions',
-                    floorSemantics: 'soft_floor',
-                },
+                doseEnvelope: { min: 1, target: 2, max: 2, unit: 'sessions', floorSemantics: 'soft_floor' },
             },
         ],
-        reviewSchedule: {
-            reviewCadenceDays: 14,
-            nextReviewDate: '2026-09-21',
-        },
+        reviewSchedule: { reviewCadenceDays: 14, nextReviewDate: '2026-09-21' },
         progressionContract: {
-            targetBinding: {
-                objectiveId: 'obj_cycling_tempo',
-            },
+            targetBinding: { objectiveId: 'obj_cycling_tempo' },
             variable: 'duration_min',
             unit: 'minutes',
             currentValue: 90,
-            permittedRange: {
-                min: 60,
-                max: 120,
-            },
+            permittedRange: { min: 60, max: 120 },
             increment: 10,
+            knowledgeLineage: ['policy_progression_review_v1'],
             observationWindowDays: 14,
             minCompletedExposures: 3,
             requiredFollowUpCoveragePct: 75,
             reviewCadenceDays: 14,
-            reductionAlternative: {
-                decrement: 10,
-                trigger: 'adverse_response',
-            },
+            reductionAlternative: { decrement: 10, trigger: 'adverse_response' },
         },
         title: 'Initial Build Phase Block',
         notes: 'Coaching note for athlete view',
@@ -99,156 +76,144 @@ describe('blockIntentReplay (ADR-0037 D-REPLAY)', () => {
 
     const baseProfile: Pick<TrainingIntentProfile, 'priorities' | 'weeklyCommitment'> = {
         priorities: ['endurance', 'strength_muscle'],
-        weeklyCommitment: {
-            minSessions: 4,
-            targetSessions: 6,
-            maxSessions: 7,
-        },
+        weeklyCommitment: { minSessions: 4, targetSessions: 6, maxSessions: 7 },
     };
 
-    it('produces a deterministic SHA-256 hash regardless of object key order', async () => {
-        const payload1 = buildTreatmentIntentReplayPayloadV1(baseBlock, baseProfile, 'external-plan@4');
-        const hash1 = await hashTreatmentIntentReplayPayload(payload1);
-
-        // Check canonical json serialization
-        const json1 = canonicalizeTreatmentIntentJson(payload1);
-        expect(json1).toContain('treatment_intent_replay_v1');
-
-        // Reconstruct payload with scrambled top-level key insertion order
-        const scrambledPayload: TreatmentIntentReplayPayloadV1 = {
-            block: payload1.block,
-            schemaVersion: payload1.schemaVersion,
-            trainingIntentProfile: payload1.trainingIntentProfile,
-            sourcePlanIdentity: payload1.sourcePlanIdentity,
-        };
-        const hash2 = await hashTreatmentIntentReplayPayload(scrambledPayload);
-
-        expect(hash1).toHaveLength(64);
-        expect(hash1).toBe(hash2);
-        expect(await verifyTreatmentIntentReplayDigest(payload1, hash1)).toBe(true);
-    });
-
-    it('excludes display-only fields (title, notes) from replay digest', async () => {
-        const payload1 = buildTreatmentIntentReplayPayloadV1(baseBlock, baseProfile, 'external-plan@4');
-        const hash1 = await hashTreatmentIntentReplayPayload(payload1);
-
-        const modifiedBlock: IntentBlock = {
-            ...baseBlock,
-            title: 'Changed Title completely for UI',
-            notes: 'Completely altered coach notes that should not affect decision semantics',
-        };
-        const payload2 = buildTreatmentIntentReplayPayloadV1(modifiedBlock, baseProfile, 'external-plan@4');
-        const hash2 = await hashTreatmentIntentReplayPayload(payload2);
-
-        expect(hash1).toBe(hash2);
-    });
-
-    it('fails digest verification when TrainingIntentProfile priorities are mutated', async () => {
-        const payload = buildTreatmentIntentReplayPayloadV1(baseBlock, baseProfile, 'external-plan@4');
-        const baseHash = await hashTreatmentIntentReplayPayload(payload);
-
-        const mutatedProfile = {
-            ...baseProfile,
-            priorities: ['health', 'endurance'] as TrainingPriority[],
-        };
-        const mutatedPayload = buildTreatmentIntentReplayPayloadV1(baseBlock, mutatedProfile, 'external-plan@4');
-        const mutatedHash = await hashTreatmentIntentReplayPayload(mutatedPayload);
-
-        expect(mutatedHash).not.toBe(baseHash);
-        expect(await verifyTreatmentIntentReplayDigest(mutatedPayload, baseHash)).toBe(false);
-    });
-
-    it('fails digest verification when weeklyCommitment fields are mutated independently', async () => {
-        const payload = buildTreatmentIntentReplayPayloadV1(baseBlock, baseProfile, 'external-plan@4');
-        const baseHash = await hashTreatmentIntentReplayPayload(payload);
-
-        // Mutate minSessions
-        const mutMin = buildTreatmentIntentReplayPayloadV1(
-            baseBlock,
-            { ...baseProfile, weeklyCommitment: { ...baseProfile.weeklyCommitment, minSessions: 5 } },
-            'external-plan@4',
+    async function digest(block = baseBlock, profile = baseProfile, schema = 'external-plan@4', sourceRef?: string) {
+        return hashTreatmentIntentReplayPayload(
+            buildTreatmentIntentReplayPayloadV1(block, profile, schema, sourceRef),
         );
-        expect(await hashTreatmentIntentReplayPayload(mutMin)).not.toBe(baseHash);
+    }
 
-        // Mutate targetSessions
-        const mutTarget = buildTreatmentIntentReplayPayloadV1(
-            baseBlock,
-            { ...baseProfile, weeklyCommitment: { ...baseProfile.weeklyCommitment, targetSessions: 5 } },
-            'external-plan@4',
-        );
-        expect(await hashTreatmentIntentReplayPayload(mutTarget)).not.toBe(baseHash);
-
-        // Mutate maxSessions
-        const mutMax = buildTreatmentIntentReplayPayloadV1(
-            baseBlock,
-            { ...baseProfile, weeklyCommitment: { ...baseProfile.weeklyCommitment, maxSessions: 8 } },
-            'external-plan@4',
-        );
-        expect(await hashTreatmentIntentReplayPayload(mutMax)).not.toBe(baseHash);
+    it('produces deterministic canonical JSON regardless of object key insertion order', async () => {
+        const payload = buildTreatmentIntentReplayPayloadV1(baseBlock, baseProfile, 'external-plan@4');
+        const hash = await hashTreatmentIntentReplayPayload(payload);
+        const scrambled: TreatmentIntentReplayPayloadV1 = {
+            block: payload.block,
+            schemaVersion: payload.schemaVersion,
+            trainingIntentProfile: payload.trainingIntentProfile,
+            sourcePlanIdentity: payload.sourcePlanIdentity,
+        };
+        expect(canonicalizeTreatmentIntentJson(payload)).toContain('treatment_intent_replay_v1');
+        expect(await hashTreatmentIntentReplayPayload(scrambled)).toBe(hash);
+        expect(await verifyTreatmentIntentReplayDigest(payload, hash)).toBe(true);
     });
 
-    it('fails digest verification when objective intent (develop vs maintain) is mutated', async () => {
-        const payload = buildTreatmentIntentReplayPayloadV1(baseBlock, baseProfile, 'external-plan@4');
-        const baseHash = await hashTreatmentIntentReplayPayload(payload);
-
-        const mutatedBlock: IntentBlock = {
+    it('canonicalizes semantically unordered objective/set collections', async () => {
+        const reordered: IntentBlock = {
             ...baseBlock,
             objectives: [
-                { ...baseBlock.objectives[0], intent: 'maintain' },
                 baseBlock.objectives[1],
-            ],
-        };
-        const mutatedPayload = buildTreatmentIntentReplayPayloadV1(mutatedBlock, baseProfile, 'external-plan@4');
-        expect(await hashTreatmentIntentReplayPayload(mutatedPayload)).not.toBe(baseHash);
-    });
-
-    it('fails digest verification when dose bounds or floor semantics are mutated', async () => {
-        const payload = buildTreatmentIntentReplayPayloadV1(baseBlock, baseProfile, 'external-plan@4');
-        const baseHash = await hashTreatmentIntentReplayPayload(payload);
-
-        const mutatedBlock: IntentBlock = {
-            ...baseBlock,
-            objectives: [
                 {
                     ...baseBlock.objectives[0],
-                    doseEnvelope: { ...baseBlock.objectives[0].doseEnvelope, min: 75 },
+                    knowledgeLineage: [...baseBlock.objectives[0].knowledgeLineage!].reverse(),
+                    protectedRoles: [...baseBlock.objectives[0].protectedRoles!].reverse(),
+                    allowedSubstitutions: [{
+                        ...baseBlock.objectives[0].allowedSubstitutions![0],
+                        allowedCoverageKeys: [...baseBlock.objectives[0].allowedSubstitutions![0].allowedCoverageKeys].reverse(),
+                    }],
+                    entryPrerequisites: {
+                        ...baseBlock.objectives[0].entryPrerequisites!,
+                        prohibitedTissueSeverities: [...baseBlock.objectives[0].entryPrerequisites!.prohibitedTissueSeverities!].reverse(),
+                    },
                 },
+            ],
+            progressionContract: {
+                ...baseBlock.progressionContract!,
+                knowledgeLineage: [...baseBlock.progressionContract!.knowledgeLineage!].reverse(),
+            },
+        };
+        expect(await digest(reordered)).toBe(await digest());
+    });
+
+    it('normalizes empty optional sets to the same identity as omission', async () => {
+        const withoutOptionalSets: IntentBlock = {
+            ...baseBlock,
+            objectives: [
+                { ...baseBlock.objectives[0], protectedRoles: undefined },
                 baseBlock.objectives[1],
             ],
         };
-        const mutatedPayload = buildTreatmentIntentReplayPayloadV1(mutatedBlock, baseProfile, 'external-plan@4');
-        expect(await hashTreatmentIntentReplayPayload(mutatedPayload)).not.toBe(baseHash);
+        const withEmptySets: IntentBlock = {
+            ...withoutOptionalSets,
+            objectives: [
+                { ...withoutOptionalSets.objectives[0], protectedRoles: [] },
+                withoutOptionalSets.objectives[1],
+            ],
+        };
+        expect(await digest(withoutOptionalSets)).toBe(await digest(withEmptySets));
     });
 
-    it('fails digest verification when progression contract fields are mutated', async () => {
-        const payload = buildTreatmentIntentReplayPayloadV1(baseBlock, baseProfile, 'external-plan@4');
-        const baseHash = await hashTreatmentIntentReplayPayload(payload);
-
-        // Mutate increment
-        const mutatedIncrement: IntentBlock = {
+    it('excludes display-only title/notes and substitution rationale from digest', async () => {
+        const modified: IntentBlock = {
             ...baseBlock,
-            progressionContract: { ...baseBlock.progressionContract!, increment: 15 },
+            title: 'Changed title',
+            notes: 'Changed coaching note',
+            objectives: [{
+                ...baseBlock.objectives[0],
+                allowedSubstitutions: [{
+                    ...baseBlock.objectives[0].allowedSubstitutions![0],
+                    rationale: 'Completely different explanation',
+                }],
+            }, baseBlock.objectives[1]],
         };
-        expect(await hashTreatmentIntentReplayPayload(
-            buildTreatmentIntentReplayPayloadV1(mutatedIncrement, baseProfile, 'external-plan@4'),
-        )).not.toBe(baseHash);
+        expect(await digest(modified)).toBe(await digest());
+    });
 
-        // Mutate currentValue
-        const mutatedCurrentVal: IntentBlock = {
-            ...baseBlock,
-            progressionContract: { ...baseBlock.progressionContract!, currentValue: 100 },
-        };
-        expect(await hashTreatmentIntentReplayPayload(
-            buildTreatmentIntentReplayPayloadV1(mutatedCurrentVal, baseProfile, 'external-plan@4'),
-        )).not.toBe(baseHash);
+    it('changes identity for source plan schema/revision/provenance and effective bounds', async () => {
+        expect(await digest(baseBlock, baseProfile, 'external-plan@3')).not.toBe(await digest());
+        expect(await digest({ ...baseBlock, sourcePlanRevision: 4 })).not.toBe(await digest());
+        expect(await digest(baseBlock, baseProfile, 'external-plan@4', 'manual:abc')).not.toBe(await digest());
+        expect(await digest({ ...baseBlock, dateRange: { ...baseBlock.dateRange, endDate: '2026-10-03' } })).not.toBe(await digest());
+    });
 
-        // Mutate permitted range
-        const mutatedRange: IntentBlock = {
+    it('changes identity for pinned profile priorities and each weekly commitment field', async () => {
+        const baseHash = await digest();
+        const mutatedPriorities = { ...baseProfile, priorities: ['health', 'endurance'] as TrainingPriority[] };
+        expect(await digest(baseBlock, mutatedPriorities)).not.toBe(baseHash);
+        for (const [field, value] of [['minSessions', 5], ['targetSessions', 5], ['maxSessions', 8]] as const) {
+            expect(await digest(baseBlock, {
+                ...baseProfile,
+                weeklyCommitment: { ...baseProfile.weeklyCommitment, [field]: value },
+            })).not.toBe(baseHash);
+        }
+    });
+
+    it('changes identity for objective intent/dose/protected roles/substitutions/success/prerequisites/exit rules', async () => {
+        const baseHash = await digest();
+        const mutations: IntentBlock[] = [
+            { ...baseBlock, objectives: [{ ...baseBlock.objectives[0], intent: 'maintain' }, baseBlock.objectives[1]] },
+            { ...baseBlock, objectives: [{ ...baseBlock.objectives[0], doseEnvelope: { ...baseBlock.objectives[0].doseEnvelope, min: 75 } }, baseBlock.objectives[1]] },
+            { ...baseBlock, objectives: [{ ...baseBlock.objectives[0], protectedRoles: ['different_role'] }, baseBlock.objectives[1]] },
+            { ...baseBlock, objectives: [{ ...baseBlock.objectives[0], allowedSubstitutions: [{ ...baseBlock.objectives[0].allowedSubstitutions![0], minDoseFraction: 0.8 }] }, baseBlock.objectives[1]] },
+            { ...baseBlock, objectives: [{ ...baseBlock.objectives[0], successCriteria: { ...baseBlock.objectives[0].successCriteria!, minCompletedExposures: 4 } }, baseBlock.objectives[1]] },
+            { ...baseBlock, objectives: [{ ...baseBlock.objectives[0], entryPrerequisites: { ...baseBlock.objectives[0].entryPrerequisites!, minBaselineDays: 21 } }, baseBlock.objectives[1]] },
+            { ...baseBlock, objectives: [{ ...baseBlock.objectives[0], exitCriteria: { ...baseBlock.objectives[0].exitCriteria!, maxWeeksInBlock: 5 } }, baseBlock.objectives[1]] },
+        ];
+        for (const mutation of mutations) expect(await digest(mutation)).not.toBe(baseHash);
+    });
+
+    it('changes identity for review timing and every progression-rule family', async () => {
+        const baseHash = await digest();
+        const mutations: IntentBlock[] = [
+            { ...baseBlock, reviewSchedule: { ...baseBlock.reviewSchedule, nextReviewDate: '2026-09-22' } },
+            { ...baseBlock, progressionContract: { ...baseBlock.progressionContract!, currentValue: 100 } },
+            { ...baseBlock, progressionContract: { ...baseBlock.progressionContract!, increment: 15 } },
+            { ...baseBlock, progressionContract: { ...baseBlock.progressionContract!, permittedRange: { min: 60, max: 115 } } },
+            { ...baseBlock, progressionContract: { ...baseBlock.progressionContract!, observationWindowDays: 10 } },
+            { ...baseBlock, progressionContract: { ...baseBlock.progressionContract!, minCompletedExposures: 4 } },
+            { ...baseBlock, progressionContract: { ...baseBlock.progressionContract!, requiredFollowUpCoveragePct: 90 } },
+            { ...baseBlock, progressionContract: { ...baseBlock.progressionContract!, reductionAlternative: { decrement: 5, trigger: 'adverse_response' } } },
+            { ...baseBlock, progressionContract: { ...baseBlock.progressionContract!, redirectCriteria: { triggers: ['active_restriction'] } } },
+        ];
+        for (const mutation of mutations) expect(await digest(mutation)).not.toBe(baseHash);
+    });
+
+    it('rejects non-finite numbers instead of hashing them as JSON null', async () => {
+        const payload = buildTreatmentIntentReplayPayloadV1({
             ...baseBlock,
-            progressionContract: { ...baseBlock.progressionContract!, permittedRange: { min: 60, max: 130 } },
-        };
-        expect(await hashTreatmentIntentReplayPayload(
-            buildTreatmentIntentReplayPayloadV1(mutatedRange, baseProfile, 'external-plan@4'),
-        )).not.toBe(baseHash);
+            progressionContract: { ...baseBlock.progressionContract!, currentValue: Number.NaN },
+        }, baseProfile, 'external-plan@4');
+        await expect(hashTreatmentIntentReplayPayload(payload)).rejects.toThrow('non-finite number');
     });
 });

--- a/app/src/engine/blockIntentReplay.ts
+++ b/app/src/engine/blockIntentReplay.ts
@@ -1,0 +1,316 @@
+﻿/**
+ * ADR-0037: Block Intent and Controlled Progression (H5a).
+ *
+ * D-REPLAY: Canonical semantic replay projection and deterministic SHA-256 hashing.
+ * Exhaustively projects every behavior-affecting field, pins a canonical snapshot of
+ * the TrainingIntentProfile (priorities and weeklyCommitment), and excludes display-only fields.
+ */
+
+import type { TrainingIntentProfile, TrainingPriority } from './models';
+import type {
+    BlockObjectiveDefinition,
+    BlockProgressionContract,
+    BlockSubstitutionRule,
+    IntentBlock,
+} from './blockIntent';
+
+export const TREATMENT_INTENT_REPLAY_SCHEMA_VERSION = 'treatment_intent_replay_v1' as const;
+
+export interface PinnedTrainingIntentProfileSnapshot {
+    priorities: readonly TrainingPriority[];
+    weeklyCommitment: {
+        minSessions: number;
+        targetSessions: number;
+        maxSessions: number;
+    };
+    schemaVersion?: number;
+}
+
+export interface SourcePlanIdentity {
+    planId: string;
+    schemaVersion: string;
+    revision: number;
+    sourceRef?: string;
+}
+
+export interface CanonicalReplayObjective {
+    id: string;
+    sport: string;
+    adaptationScope: string;
+    coverageKey: string;
+    intent: 'develop' | 'maintain';
+    priority: string;
+    doseEnvelope: {
+        min: number;
+        target: number;
+        max: number;
+        unit: string;
+        floorSemantics: 'hard_floor' | 'soft_floor';
+    };
+    knowledgeLineage?: readonly string[];
+    protectedRoles?: readonly string[];
+    allowedSubstitutions?: readonly {
+        targetCoverageKey: string;
+        allowedCoverageKeys: readonly string[];
+        minDoseFraction?: number;
+        rationale?: string;
+    }[];
+    successCriteria?: {
+        evaluationRef?: {
+            id: string;
+            revision: number;
+            metricId: string;
+        };
+        minCompletedExposures?: number;
+        targetTrend?: 'stable' | 'improving';
+        acceptableDeclineTolerancePct?: number;
+    };
+    entryPrerequisites?: {
+        requiredPriorExposures?: number;
+        minBaselineDays?: number;
+        prohibitedTissueSeverities?: readonly string[];
+    };
+    exitCriteria?: {
+        maxWeeksInBlock?: number;
+        stagnationReviewAfterWeeks?: number;
+    };
+}
+
+export interface CanonicalReplayProgressionContract {
+    targetBinding: {
+        objectiveId: string;
+        sessionId?: string;
+        stepId?: string;
+    };
+    variable: string;
+    unit: string;
+    currentValue: number;
+    permittedRange: {
+        min: number;
+        max: number;
+    };
+    increment: number;
+    knowledgeLineage?: readonly string[];
+    observationWindowDays: number;
+    minCompletedExposures: number;
+    requiredFollowUpCoveragePct: number;
+    reviewCadenceDays: number;
+    reductionAlternative?: {
+        decrement: number;
+        trigger: 'adverse_response' | 'stagnation';
+    };
+}
+
+export interface TreatmentIntentReplayPayloadV1 {
+    schemaVersion: typeof TREATMENT_INTENT_REPLAY_SCHEMA_VERSION;
+    sourcePlanIdentity: SourcePlanIdentity;
+    trainingIntentProfile: PinnedTrainingIntentProfileSnapshot;
+    block: {
+        id: string;
+        revision: number;
+        dateRange: {
+            startDate: string;
+            endDate: string;
+        };
+        objectives: readonly CanonicalReplayObjective[];
+        reviewSchedule: {
+            reviewCadenceDays: number;
+            nextReviewDate: string;
+        };
+        progressionContract?: CanonicalReplayProgressionContract;
+    };
+}
+
+/**
+ * Sorts and canonicalizes substitutions by targetCoverageKey.
+ */
+function canonicalizeSubstitutions(
+    substitutions?: readonly BlockSubstitutionRule[],
+): CanonicalReplayObjective['allowedSubstitutions'] {
+    if (!substitutions || substitutions.length === 0) return undefined;
+    return [...substitutions]
+        .sort((a, b) => a.targetCoverageKey.localeCompare(b.targetCoverageKey))
+        .map(sub => ({
+            targetCoverageKey: sub.targetCoverageKey,
+            allowedCoverageKeys: [...sub.allowedCoverageKeys].sort(),
+            minDoseFraction: sub.minDoseFraction,
+            rationale: sub.rationale,
+        }));
+}
+
+/**
+ * Transforms an objective into its canonical replay shape.
+ */
+function canonicalizeObjective(obj: BlockObjectiveDefinition): CanonicalReplayObjective {
+    return {
+        id: obj.id,
+        sport: obj.sport,
+        adaptationScope: obj.adaptationScope,
+        coverageKey: obj.coverageKey,
+        intent: obj.intent,
+        priority: obj.priority,
+        doseEnvelope: {
+            min: obj.doseEnvelope.min,
+            target: obj.doseEnvelope.target,
+            max: obj.doseEnvelope.max,
+            unit: obj.doseEnvelope.unit,
+            floorSemantics: obj.doseEnvelope.floorSemantics,
+        },
+        knowledgeLineage: obj.knowledgeLineage ? [...obj.knowledgeLineage].sort() : undefined,
+        protectedRoles: obj.protectedRoles ? [...obj.protectedRoles].sort() : undefined,
+        allowedSubstitutions: canonicalizeSubstitutions(obj.allowedSubstitutions),
+        successCriteria: obj.successCriteria ? {
+            evaluationRef: obj.successCriteria.evaluationRef ? {
+                id: obj.successCriteria.evaluationRef.id,
+                revision: obj.successCriteria.evaluationRef.revision,
+                metricId: obj.successCriteria.evaluationRef.metricId,
+            } : undefined,
+            minCompletedExposures: obj.successCriteria.minCompletedExposures,
+            targetTrend: obj.successCriteria.targetTrend,
+            acceptableDeclineTolerancePct: obj.successCriteria.acceptableDeclineTolerancePct,
+        } : undefined,
+        entryPrerequisites: obj.entryPrerequisites ? {
+            requiredPriorExposures: obj.entryPrerequisites.requiredPriorExposures,
+            minBaselineDays: obj.entryPrerequisites.minBaselineDays,
+            prohibitedTissueSeverities: obj.entryPrerequisites.prohibitedTissueSeverities
+                ? [...obj.entryPrerequisites.prohibitedTissueSeverities].sort()
+                : undefined,
+        } : undefined,
+        exitCriteria: obj.exitCriteria ? {
+            maxWeeksInBlock: obj.exitCriteria.maxWeeksInBlock,
+            stagnationReviewAfterWeeks: obj.exitCriteria.stagnationReviewAfterWeeks,
+        } : undefined,
+    };
+}
+
+/**
+ * Canonicalizes the progression contract.
+ */
+function canonicalizeProgressionContract(
+    contract?: BlockProgressionContract,
+): CanonicalReplayProgressionContract | undefined {
+    if (!contract) return undefined;
+    return {
+        targetBinding: {
+            objectiveId: contract.targetBinding.objectiveId,
+            sessionId: contract.targetBinding.sessionId,
+            stepId: contract.targetBinding.stepId,
+        },
+        variable: contract.variable,
+        unit: contract.unit,
+        currentValue: contract.currentValue,
+        permittedRange: {
+            min: contract.permittedRange.min,
+            max: contract.permittedRange.max,
+        },
+        increment: contract.increment,
+        knowledgeLineage: contract.knowledgeLineage ? [...contract.knowledgeLineage].sort() : undefined,
+        observationWindowDays: contract.observationWindowDays,
+        minCompletedExposures: contract.minCompletedExposures,
+        requiredFollowUpCoveragePct: contract.requiredFollowUpCoveragePct,
+        reviewCadenceDays: contract.reviewCadenceDays,
+        reductionAlternative: contract.reductionAlternative ? {
+            decrement: contract.reductionAlternative.decrement,
+            trigger: contract.reductionAlternative.trigger,
+        } : undefined,
+    };
+}
+
+/**
+ * Builds the canonical replay projection. Pins TrainingIntentProfile priorities
+ * and weeklyCommitment, canonicalizes all semantic fields, and omits display-only fields (title, notes).
+ */
+export function buildTreatmentIntentReplayPayloadV1(
+    block: IntentBlock,
+    profile: Pick<TrainingIntentProfile, 'priorities' | 'weeklyCommitment'> & { schemaVersion?: number },
+    sourceSchemaVersion: string,
+    sourceRef?: string,
+): TreatmentIntentReplayPayloadV1 {
+    const sortedObjectives = [...block.objectives]
+        .sort((a, b) => a.id.localeCompare(b.id))
+        .map(canonicalizeObjective);
+
+    return {
+        schemaVersion: TREATMENT_INTENT_REPLAY_SCHEMA_VERSION,
+        sourcePlanIdentity: {
+            planId: block.sourcePlanId,
+            schemaVersion: sourceSchemaVersion,
+            revision: block.sourcePlanRevision,
+            sourceRef,
+        },
+        trainingIntentProfile: {
+            priorities: [...profile.priorities],
+            weeklyCommitment: {
+                minSessions: profile.weeklyCommitment.minSessions,
+                targetSessions: profile.weeklyCommitment.targetSessions,
+                maxSessions: profile.weeklyCommitment.maxSessions,
+            },
+            schemaVersion: profile.schemaVersion,
+        },
+        block: {
+            id: block.id,
+            revision: block.revision,
+            dateRange: {
+                startDate: block.dateRange.startDate,
+                endDate: block.dateRange.endDate,
+            },
+            objectives: sortedObjectives,
+            reviewSchedule: {
+                reviewCadenceDays: block.reviewSchedule.reviewCadenceDays,
+                nextReviewDate: block.reviewSchedule.nextReviewDate,
+            },
+            progressionContract: canonicalizeProgressionContract(block.progressionContract),
+        },
+    };
+}
+
+/**
+ * Deterministically sorts all object keys recursively and omits undefined values.
+ */
+export function canonicalizeReplayJson(value: unknown): unknown {
+    if (Array.isArray(value)) {
+        return value.map(canonicalizeReplayJson);
+    }
+    if (value !== null && typeof value === 'object') {
+        const obj = value as Record<string, unknown>;
+        return Object.fromEntries(
+            Object.keys(obj)
+                .sort()
+                .filter(k => obj[k] !== undefined)
+                .map(key => [key, canonicalizeReplayJson(obj[key])]),
+        );
+    }
+    return value;
+}
+
+/**
+ * Serializes the canonical replay payload to a deterministic JSON string.
+ */
+export function canonicalizeTreatmentIntentJson(payload: TreatmentIntentReplayPayloadV1): string {
+    return JSON.stringify(canonicalizeReplayJson(payload));
+}
+
+/**
+ * Computes the SHA-256 hex digest of the canonical replay payload.
+ */
+export async function hashTreatmentIntentReplayPayload(
+    payload: TreatmentIntentReplayPayloadV1,
+): Promise<string> {
+    const canonicalJson = canonicalizeTreatmentIntentJson(payload);
+    const bytes = new TextEncoder().encode(canonicalJson);
+    const digestBuffer = await crypto.subtle.digest('SHA-256', bytes);
+    return Array.from(new Uint8Array(digestBuffer))
+        .map(b => b.toString(16).padStart(2, '0'))
+        .join('');
+}
+
+/**
+ * Verifies that the digest of a replay payload matches an expected SHA-256 digest.
+ */
+export async function verifyTreatmentIntentReplayDigest(
+    payload: TreatmentIntentReplayPayloadV1,
+    expectedDigest: string,
+): Promise<boolean> {
+    const actualDigest = await hashTreatmentIntentReplayPayload(payload);
+    return actualDigest === expectedDigest;
+}

--- a/app/src/engine/blockIntentReplay.ts
+++ b/app/src/engine/blockIntentReplay.ts
@@ -23,6 +23,10 @@ export interface PinnedTrainingIntentProfileSnapshot {
     schemaVersion?: number;
 }
 
+function compareCodeUnits(a: string, b: string): number {
+    return a < b ? -1 : a > b ? 1 : 0;
+}
+
 export interface SourcePlanIdentity {
     planId: string;
     schemaVersion: string;
@@ -100,7 +104,7 @@ export interface TreatmentIntentReplayPayloadV1 {
 
 function canonicalizeStringSet(values?: readonly string[]): readonly string[] | undefined {
     if (!values || values.length === 0) return undefined;
-    return [...values].sort();
+    return [...values].sort(compareCodeUnits);
 }
 
 function canonicalizeProtectedRoles(roles?: readonly BlockProtectedRole[]): CanonicalReplayObjective['protectedRoles'] {
@@ -112,7 +116,7 @@ function canonicalizeProtectedRoles(roles?: readonly BlockProtectedRole[]): Cano
         .sort((a, b) => {
             const aKey = a.kind === 'coverage_role' ? `${a.kind}:${a.coverageKey}` : `${a.kind}:${a.sessionId}`;
             const bKey = b.kind === 'coverage_role' ? `${b.kind}:${b.coverageKey}` : `${b.kind}:${b.sessionId}`;
-            return aKey.localeCompare(bKey);
+            return compareCodeUnits(aKey, bKey);
         });
 }
 
@@ -122,13 +126,13 @@ function canonicalizeSubstitutions(substitutions?: readonly BlockSubstitutionRul
     return [...substitutions]
         .map(sub => ({
             targetCoverageKey: sub.targetCoverageKey,
-            allowedCoverageKeys: [...sub.allowedCoverageKeys].sort(),
+            allowedCoverageKeys: [...sub.allowedCoverageKeys].sort(compareCodeUnits),
             minDoseFraction: sub.minDoseFraction,
         }))
         .sort((a, b) => {
-            const targetOrder = a.targetCoverageKey.localeCompare(b.targetCoverageKey);
+            const targetOrder = compareCodeUnits(a.targetCoverageKey, b.targetCoverageKey);
             if (targetOrder !== 0) return targetOrder;
-            return a.allowedCoverageKeys.join('\u0000').localeCompare(b.allowedCoverageKeys.join('\u0000'));
+            return compareCodeUnits(a.allowedCoverageKeys.join('\u0000'), b.allowedCoverageKeys.join('\u0000'));
         });
 }
 
@@ -171,7 +175,7 @@ function canonicalizeObjective(obj: BlockObjectiveDefinition): CanonicalReplayOb
             unit: obj.doseEnvelope.unit,
             floorSemantics: obj.doseEnvelope.floorSemantics,
         },
-        knowledgeLineage: [...obj.knowledgeLineage].sort(),
+        knowledgeLineage: [...obj.knowledgeLineage].sort(compareCodeUnits),
         protectedRoles: canonicalizeProtectedRoles(obj.protectedRoles),
         allowedSubstitutions: canonicalizeSubstitutions(obj.allowedSubstitutions),
         successCriteria: canonicalizeSuccessCriteria(obj),
@@ -193,7 +197,7 @@ function canonicalizeProgressionContract(contract?: BlockProgressionContract): C
         currentValue: contract.currentValue,
         permittedRange: { min: contract.permittedRange.min, max: contract.permittedRange.max },
         increment: contract.increment,
-        knowledgeLineage: [...contract.knowledgeLineage].sort(),
+        knowledgeLineage: [...contract.knowledgeLineage].sort(compareCodeUnits),
         observationWindowDays: contract.observationWindowDays,
         minCompletedExposures: contract.minCompletedExposures,
         requiredFollowUpCoveragePct: contract.requiredFollowUpCoveragePct,
@@ -220,7 +224,7 @@ export function buildTreatmentIntentReplayPayloadV1(
     sourceSchemaVersion: string,
     sourceRef?: string,
 ): TreatmentIntentReplayPayloadV1 {
-    const sortedObjectives = [...block.objectives].sort((a, b) => a.id.localeCompare(b.id)).map(canonicalizeObjective);
+    const sortedObjectives = [...block.objectives].sort((a, b) => compareCodeUnits(a.id, b.id)).map(canonicalizeObjective);
     return {
         schemaVersion: TREATMENT_INTENT_REPLAY_SCHEMA_VERSION,
         sourcePlanIdentity: {
@@ -265,7 +269,7 @@ export function canonicalizeReplayJson(value: unknown): unknown {
     }
     if (value !== null && typeof value === 'object') {
         const obj = value as Record<string, unknown>;
-        return Object.fromEntries(Object.keys(obj).sort().filter(key => obj[key] !== undefined).map(key => [key, canonicalizeReplayJson(obj[key])]));
+        return Object.fromEntries(Object.keys(obj).sort(compareCodeUnits).filter(key => obj[key] !== undefined).map(key => [key, canonicalizeReplayJson(obj[key])]));
     }
     return value;
 }

--- a/app/src/engine/blockIntentReplay.ts
+++ b/app/src/engine/blockIntentReplay.ts
@@ -1,9 +1,9 @@
-﻿/**
+/**
  * ADR-0037: Block Intent and Controlled Progression (H5a).
  *
- * D-REPLAY: Canonical semantic replay projection and deterministic SHA-256 hashing.
- * Exhaustively projects every behavior-affecting field, pins a canonical snapshot of
- * the TrainingIntentProfile (priorities and weeklyCommitment), and excludes display-only fields.
+ * D-REPLAY: canonical semantic replay projection and deterministic SHA-256 hashing.
+ * Every behavior-affecting authored field in the Phase-1 contract is projected explicitly;
+ * proven presentation-only fields are deliberately excluded and regression-tested.
  */
 
 import type { TrainingIntentProfile, TrainingPriority } from './models';
@@ -53,7 +53,6 @@ export interface CanonicalReplayObjective {
         targetCoverageKey: string;
         allowedCoverageKeys: readonly string[];
         minDoseFraction?: number;
-        rationale?: string;
     }[];
     successCriteria?: {
         evaluationRef?: {
@@ -97,7 +96,10 @@ export interface CanonicalReplayProgressionContract {
     reviewCadenceDays: number;
     reductionAlternative?: {
         decrement: number;
-        trigger: 'adverse_response' | 'stagnation';
+        trigger: string;
+    };
+    redirectCriteria?: {
+        triggers: readonly string[];
     };
 }
 
@@ -121,27 +123,58 @@ export interface TreatmentIntentReplayPayloadV1 {
     };
 }
 
-/**
- * Sorts and canonicalizes substitutions by targetCoverageKey.
- */
+function canonicalizeStringSet(values?: readonly string[]): readonly string[] | undefined {
+    if (!values || values.length === 0) return undefined;
+    return [...values].sort();
+}
+
+/** Human-facing substitution rationale is intentionally excluded from semantic identity. */
 function canonicalizeSubstitutions(
     substitutions?: readonly BlockSubstitutionRule[],
 ): CanonicalReplayObjective['allowedSubstitutions'] {
     if (!substitutions || substitutions.length === 0) return undefined;
     return [...substitutions]
-        .sort((a, b) => a.targetCoverageKey.localeCompare(b.targetCoverageKey))
         .map(sub => ({
             targetCoverageKey: sub.targetCoverageKey,
             allowedCoverageKeys: [...sub.allowedCoverageKeys].sort(),
             minDoseFraction: sub.minDoseFraction,
-            rationale: sub.rationale,
-        }));
+        }))
+        .sort((a, b) => {
+            const targetOrder = a.targetCoverageKey.localeCompare(b.targetCoverageKey);
+            if (targetOrder !== 0) return targetOrder;
+            return a.allowedCoverageKeys.join('\u0000').localeCompare(b.allowedCoverageKeys.join('\u0000'));
+        });
 }
 
-/**
- * Transforms an objective into its canonical replay shape.
- */
+function canonicalizeSuccessCriteria(
+    objective: BlockObjectiveDefinition,
+): CanonicalReplayObjective['successCriteria'] {
+    const criteria = objective.successCriteria;
+    if (!criteria) return undefined;
+    const projected = {
+        evaluationRef: criteria.evaluationRef ? {
+            id: criteria.evaluationRef.id,
+            revision: criteria.evaluationRef.revision,
+            metricId: criteria.evaluationRef.metricId,
+        } : undefined,
+        minCompletedExposures: criteria.minCompletedExposures,
+        targetTrend: criteria.targetTrend,
+        acceptableDeclineTolerancePct: criteria.acceptableDeclineTolerancePct,
+    };
+    return Object.values(projected).every(value => value === undefined) ? undefined : projected;
+}
+
 function canonicalizeObjective(obj: BlockObjectiveDefinition): CanonicalReplayObjective {
+    const entryPrerequisites = obj.entryPrerequisites ? {
+        requiredPriorExposures: obj.entryPrerequisites.requiredPriorExposures,
+        minBaselineDays: obj.entryPrerequisites.minBaselineDays,
+        prohibitedTissueSeverities: canonicalizeStringSet(obj.entryPrerequisites.prohibitedTissueSeverities),
+    } : undefined;
+    const exitCriteria = obj.exitCriteria ? {
+        maxWeeksInBlock: obj.exitCriteria.maxWeeksInBlock,
+        stagnationReviewAfterWeeks: obj.exitCriteria.stagnationReviewAfterWeeks,
+    } : undefined;
+
     return {
         id: obj.id,
         sport: obj.sport,
@@ -156,36 +189,19 @@ function canonicalizeObjective(obj: BlockObjectiveDefinition): CanonicalReplayOb
             unit: obj.doseEnvelope.unit,
             floorSemantics: obj.doseEnvelope.floorSemantics,
         },
-        knowledgeLineage: obj.knowledgeLineage ? [...obj.knowledgeLineage].sort() : undefined,
-        protectedRoles: obj.protectedRoles ? [...obj.protectedRoles].sort() : undefined,
+        knowledgeLineage: canonicalizeStringSet(obj.knowledgeLineage),
+        protectedRoles: canonicalizeStringSet(obj.protectedRoles),
         allowedSubstitutions: canonicalizeSubstitutions(obj.allowedSubstitutions),
-        successCriteria: obj.successCriteria ? {
-            evaluationRef: obj.successCriteria.evaluationRef ? {
-                id: obj.successCriteria.evaluationRef.id,
-                revision: obj.successCriteria.evaluationRef.revision,
-                metricId: obj.successCriteria.evaluationRef.metricId,
-            } : undefined,
-            minCompletedExposures: obj.successCriteria.minCompletedExposures,
-            targetTrend: obj.successCriteria.targetTrend,
-            acceptableDeclineTolerancePct: obj.successCriteria.acceptableDeclineTolerancePct,
-        } : undefined,
-        entryPrerequisites: obj.entryPrerequisites ? {
-            requiredPriorExposures: obj.entryPrerequisites.requiredPriorExposures,
-            minBaselineDays: obj.entryPrerequisites.minBaselineDays,
-            prohibitedTissueSeverities: obj.entryPrerequisites.prohibitedTissueSeverities
-                ? [...obj.entryPrerequisites.prohibitedTissueSeverities].sort()
-                : undefined,
-        } : undefined,
-        exitCriteria: obj.exitCriteria ? {
-            maxWeeksInBlock: obj.exitCriteria.maxWeeksInBlock,
-            stagnationReviewAfterWeeks: obj.exitCriteria.stagnationReviewAfterWeeks,
-        } : undefined,
+        successCriteria: canonicalizeSuccessCriteria(obj),
+        entryPrerequisites: entryPrerequisites && Object.values(entryPrerequisites).some(value => value !== undefined)
+            ? entryPrerequisites
+            : undefined,
+        exitCriteria: exitCriteria && Object.values(exitCriteria).some(value => value !== undefined)
+            ? exitCriteria
+            : undefined,
     };
 }
 
-/**
- * Canonicalizes the progression contract.
- */
 function canonicalizeProgressionContract(
     contract?: BlockProgressionContract,
 ): CanonicalReplayProgressionContract | undefined {
@@ -204,7 +220,7 @@ function canonicalizeProgressionContract(
             max: contract.permittedRange.max,
         },
         increment: contract.increment,
-        knowledgeLineage: contract.knowledgeLineage ? [...contract.knowledgeLineage].sort() : undefined,
+        knowledgeLineage: canonicalizeStringSet(contract.knowledgeLineage),
         observationWindowDays: contract.observationWindowDays,
         minCompletedExposures: contract.minCompletedExposures,
         requiredFollowUpCoveragePct: contract.requiredFollowUpCoveragePct,
@@ -213,12 +229,17 @@ function canonicalizeProgressionContract(
             decrement: contract.reductionAlternative.decrement,
             trigger: contract.reductionAlternative.trigger,
         } : undefined,
+        redirectCriteria: contract.redirectCriteria ? {
+            triggers: canonicalizeStringSet(contract.redirectCriteria.triggers) ?? [],
+        } : undefined,
     };
 }
 
 /**
- * Builds the canonical replay projection. Pins TrainingIntentProfile priorities
- * and weeklyCommitment, canonicalizes all semantic fields, and omits display-only fields (title, notes).
+ * Builds the versioned semantic projection. `title`, `notes`, and substitution `rationale`
+ * are display-only and therefore excluded. Objective/set ordering is canonicalized where
+ * order has no behavior, while `TrainingIntentProfile.priorities` order is preserved because
+ * the persisted profile may use order as authored preference precedence.
  */
 export function buildTreatmentIntentReplayPayloadV1(
     block: IntentBlock,
@@ -265,10 +286,18 @@ export function buildTreatmentIntentReplayPayloadV1(
 }
 
 /**
- * Deterministically sorts all object keys recursively and omits undefined values.
+ * Deterministically sorts object keys recursively and omits undefined object members.
+ * Non-finite numbers are rejected rather than silently serialized as `null`, which would
+ * create an ambiguous cryptographic identity for invalid semantic inputs.
  */
 export function canonicalizeReplayJson(value: unknown): unknown {
+    if (typeof value === 'number' && !Number.isFinite(value)) {
+        throw new Error('Replay payload contains a non-finite number');
+    }
     if (Array.isArray(value)) {
+        if (value.some(item => item === undefined)) {
+            throw new Error('Replay payload arrays cannot contain undefined members');
+        }
         return value.map(canonicalizeReplayJson);
     }
     if (value !== null && typeof value === 'object') {
@@ -276,23 +305,17 @@ export function canonicalizeReplayJson(value: unknown): unknown {
         return Object.fromEntries(
             Object.keys(obj)
                 .sort()
-                .filter(k => obj[k] !== undefined)
+                .filter(key => obj[key] !== undefined)
                 .map(key => [key, canonicalizeReplayJson(obj[key])]),
         );
     }
     return value;
 }
 
-/**
- * Serializes the canonical replay payload to a deterministic JSON string.
- */
 export function canonicalizeTreatmentIntentJson(payload: TreatmentIntentReplayPayloadV1): string {
     return JSON.stringify(canonicalizeReplayJson(payload));
 }
 
-/**
- * Computes the SHA-256 hex digest of the canonical replay payload.
- */
 export async function hashTreatmentIntentReplayPayload(
     payload: TreatmentIntentReplayPayloadV1,
 ): Promise<string> {
@@ -300,13 +323,10 @@ export async function hashTreatmentIntentReplayPayload(
     const bytes = new TextEncoder().encode(canonicalJson);
     const digestBuffer = await crypto.subtle.digest('SHA-256', bytes);
     return Array.from(new Uint8Array(digestBuffer))
-        .map(b => b.toString(16).padStart(2, '0'))
+        .map(byte => byte.toString(16).padStart(2, '0'))
         .join('');
 }
 
-/**
- * Verifies that the digest of a replay payload matches an expected SHA-256 digest.
- */
 export async function verifyTreatmentIntentReplayDigest(
     payload: TreatmentIntentReplayPayloadV1,
     expectedDigest: string,

--- a/app/src/engine/blockIntentReplay.ts
+++ b/app/src/engine/blockIntentReplay.ts
@@ -10,6 +10,7 @@ import type { TrainingIntentProfile, TrainingPriority } from './models';
 import type {
     BlockObjectiveDefinition,
     BlockProgressionContract,
+    BlockProtectedRole,
     BlockSubstitutionRule,
     IntentBlock,
 } from './blockIntent';
@@ -18,11 +19,7 @@ export const TREATMENT_INTENT_REPLAY_SCHEMA_VERSION = 'treatment_intent_replay_v
 
 export interface PinnedTrainingIntentProfileSnapshot {
     priorities: readonly TrainingPriority[];
-    weeklyCommitment: {
-        minSessions: number;
-        targetSessions: number;
-        maxSessions: number;
-    };
+    weeklyCommitment: { minSessions: number; targetSessions: number; maxSessions: number };
     schemaVersion?: number;
 }
 
@@ -47,19 +44,18 @@ export interface CanonicalReplayObjective {
         unit: string;
         floorSemantics: 'hard_floor' | 'soft_floor';
     };
-    knowledgeLineage?: readonly string[];
-    protectedRoles?: readonly string[];
+    knowledgeLineage: readonly string[];
+    protectedRoles?: readonly (
+        | { kind: 'coverage_role'; coverageKey: string }
+        | { kind: 'session'; sessionId: string }
+    )[];
     allowedSubstitutions?: readonly {
         targetCoverageKey: string;
         allowedCoverageKeys: readonly string[];
         minDoseFraction?: number;
     }[];
-    successCriteria?: {
-        evaluationRef?: {
-            id: string;
-            revision: number;
-            metricId: string;
-        };
+    successCriteria: {
+        evaluationRef?: { id: string; revision: number; metricId: string };
         minCompletedExposures?: number;
         targetTrend?: 'stable' | 'improving';
         acceptableDeclineTolerancePct?: number;
@@ -69,38 +65,23 @@ export interface CanonicalReplayObjective {
         minBaselineDays?: number;
         prohibitedTissueSeverities?: readonly string[];
     };
-    exitCriteria?: {
-        maxWeeksInBlock?: number;
-        stagnationReviewAfterWeeks?: number;
-    };
+    exitCriteria?: { maxWeeksInBlock?: number; stagnationReviewAfterWeeks?: number };
 }
 
 export interface CanonicalReplayProgressionContract {
-    targetBinding: {
-        objectiveId: string;
-        sessionId?: string;
-        stepId?: string;
-    };
+    targetBinding: { objectiveId: string; sessionId?: string; stepId?: string };
     variable: string;
     unit: string;
     currentValue: number;
-    permittedRange: {
-        min: number;
-        max: number;
-    };
+    permittedRange: { min: number; max: number };
     increment: number;
-    knowledgeLineage?: readonly string[];
+    knowledgeLineage: readonly string[];
     observationWindowDays: number;
     minCompletedExposures: number;
     requiredFollowUpCoveragePct: number;
     reviewCadenceDays: number;
-    reductionAlternative?: {
-        decrement: number;
-        trigger: string;
-    };
-    redirectCriteria?: {
-        triggers: readonly string[];
-    };
+    reductionAlternative?: { decrement: number; trigger: string };
+    redirectCriteria?: { triggers: readonly string[] };
 }
 
 export interface TreatmentIntentReplayPayloadV1 {
@@ -110,15 +91,9 @@ export interface TreatmentIntentReplayPayloadV1 {
     block: {
         id: string;
         revision: number;
-        dateRange: {
-            startDate: string;
-            endDate: string;
-        };
+        dateRange: { startDate: string; endDate: string };
         objectives: readonly CanonicalReplayObjective[];
-        reviewSchedule: {
-            reviewCadenceDays: number;
-            nextReviewDate: string;
-        };
+        reviewSchedule: { reviewCadenceDays: number; nextReviewDate: string };
         progressionContract?: CanonicalReplayProgressionContract;
     };
 }
@@ -128,10 +103,21 @@ function canonicalizeStringSet(values?: readonly string[]): readonly string[] | 
     return [...values].sort();
 }
 
+function canonicalizeProtectedRoles(roles?: readonly BlockProtectedRole[]): CanonicalReplayObjective['protectedRoles'] {
+    if (!roles || roles.length === 0) return undefined;
+    return [...roles]
+        .map(role => role.kind === 'coverage_role'
+            ? { kind: 'coverage_role' as const, coverageKey: role.coverageKey }
+            : { kind: 'session' as const, sessionId: role.sessionId })
+        .sort((a, b) => {
+            const aKey = a.kind === 'coverage_role' ? `${a.kind}:${a.coverageKey}` : `${a.kind}:${a.sessionId}`;
+            const bKey = b.kind === 'coverage_role' ? `${b.kind}:${b.coverageKey}` : `${b.kind}:${b.sessionId}`;
+            return aKey.localeCompare(bKey);
+        });
+}
+
 /** Human-facing substitution rationale is intentionally excluded from semantic identity. */
-function canonicalizeSubstitutions(
-    substitutions?: readonly BlockSubstitutionRule[],
-): CanonicalReplayObjective['allowedSubstitutions'] {
+function canonicalizeSubstitutions(substitutions?: readonly BlockSubstitutionRule[]): CanonicalReplayObjective['allowedSubstitutions'] {
     if (!substitutions || substitutions.length === 0) return undefined;
     return [...substitutions]
         .map(sub => ({
@@ -146,12 +132,9 @@ function canonicalizeSubstitutions(
         });
 }
 
-function canonicalizeSuccessCriteria(
-    objective: BlockObjectiveDefinition,
-): CanonicalReplayObjective['successCriteria'] {
+function canonicalizeSuccessCriteria(objective: BlockObjectiveDefinition): CanonicalReplayObjective['successCriteria'] {
     const criteria = objective.successCriteria;
-    if (!criteria) return undefined;
-    const projected = {
+    return {
         evaluationRef: criteria.evaluationRef ? {
             id: criteria.evaluationRef.id,
             revision: criteria.evaluationRef.revision,
@@ -161,7 +144,6 @@ function canonicalizeSuccessCriteria(
         targetTrend: criteria.targetTrend,
         acceptableDeclineTolerancePct: criteria.acceptableDeclineTolerancePct,
     };
-    return Object.values(projected).every(value => value === undefined) ? undefined : projected;
 }
 
 function canonicalizeObjective(obj: BlockObjectiveDefinition): CanonicalReplayObjective {
@@ -189,22 +171,16 @@ function canonicalizeObjective(obj: BlockObjectiveDefinition): CanonicalReplayOb
             unit: obj.doseEnvelope.unit,
             floorSemantics: obj.doseEnvelope.floorSemantics,
         },
-        knowledgeLineage: canonicalizeStringSet(obj.knowledgeLineage),
-        protectedRoles: canonicalizeStringSet(obj.protectedRoles),
+        knowledgeLineage: [...obj.knowledgeLineage].sort(),
+        protectedRoles: canonicalizeProtectedRoles(obj.protectedRoles),
         allowedSubstitutions: canonicalizeSubstitutions(obj.allowedSubstitutions),
         successCriteria: canonicalizeSuccessCriteria(obj),
-        entryPrerequisites: entryPrerequisites && Object.values(entryPrerequisites).some(value => value !== undefined)
-            ? entryPrerequisites
-            : undefined,
-        exitCriteria: exitCriteria && Object.values(exitCriteria).some(value => value !== undefined)
-            ? exitCriteria
-            : undefined,
+        entryPrerequisites: entryPrerequisites && Object.values(entryPrerequisites).some(value => value !== undefined) ? entryPrerequisites : undefined,
+        exitCriteria: exitCriteria && Object.values(exitCriteria).some(value => value !== undefined) ? exitCriteria : undefined,
     };
 }
 
-function canonicalizeProgressionContract(
-    contract?: BlockProgressionContract,
-): CanonicalReplayProgressionContract | undefined {
+function canonicalizeProgressionContract(contract?: BlockProgressionContract): CanonicalReplayProgressionContract | undefined {
     if (!contract) return undefined;
     return {
         targetBinding: {
@@ -215,12 +191,9 @@ function canonicalizeProgressionContract(
         variable: contract.variable,
         unit: contract.unit,
         currentValue: contract.currentValue,
-        permittedRange: {
-            min: contract.permittedRange.min,
-            max: contract.permittedRange.max,
-        },
+        permittedRange: { min: contract.permittedRange.min, max: contract.permittedRange.max },
         increment: contract.increment,
-        knowledgeLineage: canonicalizeStringSet(contract.knowledgeLineage),
+        knowledgeLineage: [...contract.knowledgeLineage].sort(),
         observationWindowDays: contract.observationWindowDays,
         minCompletedExposures: contract.minCompletedExposures,
         requiredFollowUpCoveragePct: contract.requiredFollowUpCoveragePct,
@@ -239,7 +212,7 @@ function canonicalizeProgressionContract(
  * Builds the versioned semantic projection. `title`, `notes`, and substitution `rationale`
  * are display-only and therefore excluded. Objective/set ordering is canonicalized where
  * order has no behavior, while `TrainingIntentProfile.priorities` order is preserved because
- * the persisted profile may use order as authored preference precedence.
+ * profile priority order may be authored preference precedence in allocation.
  */
 export function buildTreatmentIntentReplayPayloadV1(
     block: IntentBlock,
@@ -247,10 +220,7 @@ export function buildTreatmentIntentReplayPayloadV1(
     sourceSchemaVersion: string,
     sourceRef?: string,
 ): TreatmentIntentReplayPayloadV1 {
-    const sortedObjectives = [...block.objectives]
-        .sort((a, b) => a.id.localeCompare(b.id))
-        .map(canonicalizeObjective);
-
+    const sortedObjectives = [...block.objectives].sort((a, b) => a.id.localeCompare(b.id)).map(canonicalizeObjective);
     return {
         schemaVersion: TREATMENT_INTENT_REPLAY_SCHEMA_VERSION,
         sourcePlanIdentity: {
@@ -271,10 +241,7 @@ export function buildTreatmentIntentReplayPayloadV1(
         block: {
             id: block.id,
             revision: block.revision,
-            dateRange: {
-                startDate: block.dateRange.startDate,
-                endDate: block.dateRange.endDate,
-            },
+            dateRange: { startDate: block.dateRange.startDate, endDate: block.dateRange.endDate },
             objectives: sortedObjectives,
             reviewSchedule: {
                 reviewCadenceDays: block.reviewSchedule.reviewCadenceDays,
@@ -291,23 +258,14 @@ export function buildTreatmentIntentReplayPayloadV1(
  * create an ambiguous cryptographic identity for invalid semantic inputs.
  */
 export function canonicalizeReplayJson(value: unknown): unknown {
-    if (typeof value === 'number' && !Number.isFinite(value)) {
-        throw new Error('Replay payload contains a non-finite number');
-    }
+    if (typeof value === 'number' && !Number.isFinite(value)) throw new Error('Replay payload contains a non-finite number');
     if (Array.isArray(value)) {
-        if (value.some(item => item === undefined)) {
-            throw new Error('Replay payload arrays cannot contain undefined members');
-        }
+        if (value.some(item => item === undefined)) throw new Error('Replay payload arrays cannot contain undefined members');
         return value.map(canonicalizeReplayJson);
     }
     if (value !== null && typeof value === 'object') {
         const obj = value as Record<string, unknown>;
-        return Object.fromEntries(
-            Object.keys(obj)
-                .sort()
-                .filter(key => obj[key] !== undefined)
-                .map(key => [key, canonicalizeReplayJson(obj[key])]),
-        );
+        return Object.fromEntries(Object.keys(obj).sort().filter(key => obj[key] !== undefined).map(key => [key, canonicalizeReplayJson(obj[key])]));
     }
     return value;
 }
@@ -316,21 +274,13 @@ export function canonicalizeTreatmentIntentJson(payload: TreatmentIntentReplayPa
     return JSON.stringify(canonicalizeReplayJson(payload));
 }
 
-export async function hashTreatmentIntentReplayPayload(
-    payload: TreatmentIntentReplayPayloadV1,
-): Promise<string> {
+export async function hashTreatmentIntentReplayPayload(payload: TreatmentIntentReplayPayloadV1): Promise<string> {
     const canonicalJson = canonicalizeTreatmentIntentJson(payload);
     const bytes = new TextEncoder().encode(canonicalJson);
     const digestBuffer = await crypto.subtle.digest('SHA-256', bytes);
-    return Array.from(new Uint8Array(digestBuffer))
-        .map(byte => byte.toString(16).padStart(2, '0'))
-        .join('');
+    return Array.from(new Uint8Array(digestBuffer)).map(byte => byte.toString(16).padStart(2, '0')).join('');
 }
 
-export async function verifyTreatmentIntentReplayDigest(
-    payload: TreatmentIntentReplayPayloadV1,
-    expectedDigest: string,
-): Promise<boolean> {
-    const actualDigest = await hashTreatmentIntentReplayPayload(payload);
-    return actualDigest === expectedDigest;
+export async function verifyTreatmentIntentReplayDigest(payload: TreatmentIntentReplayPayloadV1, expectedDigest: string): Promise<boolean> {
+    return (await hashTreatmentIntentReplayPayload(payload)) === expectedDigest;
 }

--- a/app/src/engine/progressionReview.test.ts
+++ b/app/src/engine/progressionReview.test.ts
@@ -1,10 +1,13 @@
-﻿import { describe, it, expect } from 'vitest';
-import type { IntentBlock } from './blockIntent';
-import type { TrainingIntentProfile } from './models';
-import type { PerformedExposureFact } from './performedTrainingFacts';
-import type { SessionOutcome } from '../responses/outcome';
+import { describe, expect, it } from 'vitest';
 import type { ProgressResult } from '../observations/progress';
-import { evaluateProgressionReview } from './progressionReview';
+import type { SessionOutcome } from '../responses/outcome';
+import type { CoverageCreditFact, PerformedExposureFact } from './performedTrainingFacts';
+import type { IntentBlock } from './blockIntent';
+import {
+    evaluateProgressionReview,
+    type BoundProgressEvidence,
+    type LinkedProgressionExposureEvidence,
+} from './progressionReview';
 
 describe('progressionReview evaluator (ADR-0037 D-CHANGE / D-AUTHORITY)', () => {
     const validBlock: IntentBlock = {
@@ -13,29 +16,22 @@ describe('progressionReview evaluator (ADR-0037 D-CHANGE / D-AUTHORITY)', () => 
         sourcePlanId: 'plan_01',
         sourcePlanRevision: 1,
         dateRange: { startDate: '2026-09-01', endDate: '2026-09-28' },
-        objectives: [
-            {
-                id: 'obj_cycling_tempo',
-                sport: 'cycling',
-                adaptationScope: 'tempo_endurance',
-                coverageKey: 'sustained_quality',
-                intent: 'develop',
-                priority: 'must_have',
-                doseEnvelope: { min: 60, target: 90, max: 120, unit: 'minutes', floorSemantics: 'hard_floor' },
-                successCriteria: {
-                    evaluationRef: { id: 'eval_spec_01', revision: 1, metricId: 'cycling_ftp' },
-                    targetTrend: 'improving',
-                },
+        objectives: [{
+            id: 'obj_cycling_tempo',
+            sport: 'cycling',
+            adaptationScope: 'tempo_endurance',
+            coverageKey: 'sustained_quality',
+            intent: 'develop',
+            priority: 'must_have',
+            doseEnvelope: { min: 60, target: 90, max: 120, unit: 'minutes', floorSemantics: 'hard_floor' },
+            successCriteria: {
+                evaluationRef: { id: 'eval_spec_01', revision: 1, metricId: 'cycling_ftp' },
+                targetTrend: 'improving',
             },
-        ],
-        reviewSchedule: {
-            reviewCadenceDays: 14,
-            nextReviewDate: '2026-09-14',
-        },
+        }],
+        reviewSchedule: { reviewCadenceDays: 14, nextReviewDate: '2026-09-14' },
         progressionContract: {
-            targetBinding: {
-                objectiveId: 'obj_cycling_tempo',
-            },
+            targetBinding: { objectiveId: 'obj_cycling_tempo' },
             variable: 'duration_min',
             unit: 'minutes',
             currentValue: 90,
@@ -45,261 +41,349 @@ describe('progressionReview evaluator (ADR-0037 D-CHANGE / D-AUTHORITY)', () => 
             minCompletedExposures: 3,
             requiredFollowUpCoveragePct: 66,
             reviewCadenceDays: 14,
-            reductionAlternative: {
-                decrement: 10,
-                trigger: 'adverse_response',
-            },
+            reductionAlternative: { decrement: 10, trigger: 'adverse_response' },
         },
     };
 
-    const baseProfile: Pick<TrainingIntentProfile, 'priorities' | 'weeklyCommitment'> = {
-        priorities: ['endurance'],
-        weeklyCommitment: { minSessions: 3, targetSessions: 5, maxSessions: 6 },
+    const exposures: PerformedExposureFact[] = [
+        { performedOccurrenceId: 'occ_01', localDate: '2026-09-05', modality: 'Cycling', confidence: 'exact', sourceKinds: ['structured_execution'], evidenceTier: 'completedStructuredWorkout' },
+        { performedOccurrenceId: 'occ_02', localDate: '2026-09-08', modality: 'Cycling', confidence: 'exact', sourceKinds: ['structured_execution'], evidenceTier: 'completedStructuredWorkout' },
+        { performedOccurrenceId: 'occ_03', localDate: '2026-09-12', modality: 'Cycling', confidence: 'exact', sourceKinds: ['structured_execution'], evidenceTier: 'completedStructuredWorkout' },
+    ];
+
+    const outcomes: SessionOutcome[] = exposures.map((exposure, index) => ({
+        policyVersion: 'm5.3-outcome-v1',
+        sourceSession: { kind: 'execution', id: `s${index + 1}`, date: exposure.localDate },
+        status: 'passed',
+        hasFollowUpData: true,
+        sourceFacts: { responseIds: [`r${index + 1}`], tissueRegions: [] },
+        override: {},
+    }));
+
+    const improving: ProgressResult = {
+        metricId: 'cycling_ftp',
+        comparable: true,
+        status: 'meaningful_improvement',
+        reasons: ['cleared noise floor'],
+        progressPolicyVersion: 'ov-progress-v1',
+        absoluteChange: 10,
+        percentChange: 3.5,
     };
 
-    const mockExposures: PerformedExposureFact[] = [
-        {
-            performedOccurrenceId: 'occ_01',
-            localDate: '2026-09-05',
-            modality: 'Cycling',
-            confidence: 'exact',
+    const boundImproving: BoundProgressEvidence[] = [{
+        evaluationRef: { id: 'eval_spec_01', revision: 1, metricId: 'cycling_ftp' },
+        result: improving,
+    }];
+
+    function coverage(exposure: PerformedExposureFact, key: CoverageCreditFact['coverageKey'] = 'sustained_quality'): CoverageCreditFact[] {
+        return [{
+            performedOccurrenceId: exposure.performedOccurrenceId,
+            coverageSetId: 'evergreen_general',
+            coverageKey: key,
+            workoutId: 'cycling_controlled_threshold_4x8_01',
+            creditKind: 'exact',
+            confidence: 1,
+            reasonCode: 'exact_workout_identity',
             sourceKinds: ['structured_execution'],
-            evidenceTier: 'completedStructuredWorkout',
-        },
-        {
-            performedOccurrenceId: 'occ_02',
-            localDate: '2026-09-08',
-            modality: 'Cycling',
-            confidence: 'exact',
-            sourceKinds: ['structured_execution'],
-            evidenceTier: 'completedStructuredWorkout',
-        },
-        {
-            performedOccurrenceId: 'occ_03',
-            localDate: '2026-09-12',
-            modality: 'Cycling',
-            confidence: 'exact',
-            sourceKinds: ['structured_execution'],
-            evidenceTier: 'completedStructuredWorkout',
-        },
-    ];
+        }];
+    }
 
-    const mockPassedOutcomes: SessionOutcome[] = [
-        {
-            policyVersion: 'm5.3-outcome-v1',
-            sourceSession: { kind: 'execution', id: 's1', date: '2026-09-05' },
-            status: 'passed',
-            hasFollowUpData: true,
-            sourceFacts: { responseIds: ['r1'], tissueRegions: [] },
-            override: {},
-        },
-        {
-            policyVersion: 'm5.3-outcome-v1',
-            sourceSession: { kind: 'execution', id: 's2', date: '2026-09-08' },
-            status: 'passed',
-            hasFollowUpData: true,
-            sourceFacts: { responseIds: ['r2'], tissueRegions: [] },
-            override: {},
-        },
-        {
-            policyVersion: 'm5.3-outcome-v1',
-            sourceSession: { kind: 'execution', id: 's3', date: '2026-09-12' },
-            status: 'passed',
-            hasFollowUpData: true,
-            sourceFacts: { responseIds: ['r3'], tissueRegions: [] },
-            override: {},
-        },
-    ];
-
-    const mockImprovingProgress: ProgressResult[] = [
-        {
-            metricId: 'cycling_ftp',
-            comparable: true,
-            status: 'meaningful_improvement',
-            reasons: ['cleared noise floor'],
-            progressPolicyVersion: 'ov-progress-v1',
-            absoluteChange: 10,
-            percentChange: 3.5,
-        },
-    ];
-
-    it('returns advance_proposal when all prerequisites, exposure count, follow-up, and outcome metrics are satisfied', () => {
-        const result = evaluateProgressionReview({
-            intentBlock: validBlock,
-            trainingIntentProfile: baseProfile,
-            asOfDate: '2026-09-14',
-            completedExposures: mockExposures,
-            sessionOutcomes: mockPassedOutcomes,
-            progressResults: mockImprovingProgress,
-        });
-
-        expect(result.action).toBe('advance_proposal');
-        expect(result.proposedChange).toBeDefined();
-        expect(result.proposedChange?.variable).toBe('duration_min');
-        expect(result.proposedChange?.previousValue).toBe(90);
-        expect(result.proposedChange?.proposedValue).toBe(100); // 90 + 10 increment
-        expect(result.evidenceAudit.exposuresObserved).toBe(3);
-        expect(result.evidenceAudit.followUpCoveragePct).toBe(100);
-        expect(result.evidenceAudit.adverseResponseCount).toBe(0);
-    });
-
-    it('returns hold if block has no progression contract defined', () => {
-        const blockWithoutContract: IntentBlock = {
-            ...validBlock,
-            progressionContract: undefined,
+    function linked(
+        exposure: PerformedExposureFact,
+        outcome: SessionOutcome | undefined,
+        options: {
+            coverageKey?: CoverageCreditFact['coverageKey'];
+            prescriptionStatus?: LinkedProgressionExposureEvidence['prescription']['status'];
+        } = {},
+    ): LinkedProgressionExposureEvidence {
+        return {
+            exposure,
+            coverageCredits: coverage(exposure, options.coverageKey),
+            prescription: { status: options.prescriptionStatus ?? 'matched_current_target' },
+            ...(outcome ? { outcome } : {}),
         };
-        const result = evaluateProgressionReview({
-            intentBlock: blockWithoutContract,
-            trainingIntentProfile: baseProfile,
-            asOfDate: '2026-09-14',
-            completedExposures: mockExposures,
-            sessionOutcomes: mockPassedOutcomes,
-        });
+    }
 
-        expect(result.action).toBe('hold');
-        expect(result.reasons).toContain('no_progression_contract_defined');
-        expect(result.proposedChange).toBeUndefined();
-    });
+    const cleanLinked = exposures.map((exposure, index) => linked(exposure, outcomes[index]));
 
-    it('returns hold if review cadence date has not yet arrived', () => {
-        const result = evaluateProgressionReview({
+    it('advances only when linked canonical role/prescription/follow-up/outcome evidence all pass', () => {
+        const review = evaluateProgressionReview({
             intentBlock: validBlock,
-            trainingIntentProfile: baseProfile,
-            asOfDate: '2026-09-10', // nextReviewDate is 2026-09-14
-            completedExposures: mockExposures,
-            sessionOutcomes: mockPassedOutcomes,
+            asOfDate: '2026-09-14',
+            linkedExposures: cleanLinked,
+            boundProgressResults: boundImproving,
         });
-
-        expect(result.action).toBe('hold');
-        expect(result.reasons.some(r => r.includes('review_cadence_not_reached'))).toBe(true);
+        expect(review.action).toBe('advance_proposal');
+        expect(review.proposedChange).toMatchObject({ previousValue: 90, proposedValue: 100 });
+        expect(review.proposedChange?.derivedDoseEffects.delta).toBe(10);
+        expect(review.evidenceAudit).toMatchObject({
+            windowStartDate: '2026-09-01',
+            windowEndDate: '2026-09-14',
+            exposuresObserved: 3,
+            followUpCoveragePct: 100,
+        });
     });
 
-    it('returns hold if observed completed exposures are fewer than required', () => {
-        const result = evaluateProgressionReview({
+    it('holds when there is no progression contract', () => {
+        const review = evaluateProgressionReview({
+            intentBlock: { ...validBlock, progressionContract: undefined },
+            asOfDate: '2026-09-14',
+            linkedExposures: cleanLinked,
+        });
+        expect(review.action).toBe('hold');
+        expect(review.reasons).toContain('no_progression_contract_defined');
+    });
+
+    it('holds until the authored review date', () => {
+        const review = evaluateProgressionReview({
             intentBlock: validBlock,
-            trainingIntentProfile: baseProfile,
-            asOfDate: '2026-09-14',
-            completedExposures: [mockExposures[0]], // only 1 exposure, 3 required
-            sessionOutcomes: [mockPassedOutcomes[0]],
-            progressResults: mockImprovingProgress,
+            asOfDate: '2026-09-10',
+            linkedExposures: cleanLinked,
         });
-
-        expect(result.action).toBe('hold');
-        expect(result.reasons.some(r => r.includes('insufficient_completed_exposures'))).toBe(true);
-        expect(result.proposedChange).toBeUndefined();
+        expect(review.action).toBe('hold');
+        expect(review.reasons.some(reason => reason.includes('review_cadence_not_reached'))).toBe(true);
     });
 
-    it('returns hold if follow-up coverage is below required percentage', () => {
-        const outcomesWithoutFollowup: SessionOutcome[] = [
-            { ...mockPassedOutcomes[0], hasFollowUpData: false },
-            { ...mockPassedOutcomes[1], hasFollowUpData: false },
-            { ...mockPassedOutcomes[2], hasFollowUpData: true },
-        ]; // 1 of 3 = 33% < 66% required
-
-        const result = evaluateProgressionReview({
+    it('applies the observation-window lower bound instead of counting arbitrarily old work', () => {
+        const old = { ...exposures[0], performedOccurrenceId: 'old', localDate: '2026-08-15' };
+        const review = evaluateProgressionReview({
             intentBlock: validBlock,
-            trainingIntentProfile: baseProfile,
             asOfDate: '2026-09-14',
-            completedExposures: mockExposures,
-            sessionOutcomes: outcomesWithoutFollowup,
-            progressResults: mockImprovingProgress,
+            linkedExposures: [linked(old, outcomes[0]), cleanLinked[1], cleanLinked[2]],
+            boundProgressResults: boundImproving,
         });
-
-        expect(result.action).toBe('hold');
-        expect(result.reasons.some(r => r.includes('insufficient_followup_evidence'))).toBe(true);
+        expect(review.action).toBe('hold');
+        expect(review.evidenceAudit.exposuresObserved).toBe(2);
+        expect(review.reasons.some(reason => reason.includes('insufficient_completed_exposures'))).toBe(true);
     });
 
-    it('triggers reduce_proposal when adverse tissue response is observed and reductionAlternative is present', () => {
-        const reactiveOutcomes: SessionOutcome[] = [
-            mockPassedOutcomes[0],
-            mockPassedOutcomes[1],
-            {
-                ...mockPassedOutcomes[2],
-                status: 'reactive',
-                hasFollowUpData: true,
-            },
-        ];
-
-        const result = evaluateProgressionReview({
+    it('does not count same-modality work without exact target coverage', () => {
+        const unrelated = linked(exposures[0], outcomes[0], { coverageKey: 'aerobic_volume' });
+        const review = evaluateProgressionReview({
             intentBlock: validBlock,
-            trainingIntentProfile: baseProfile,
             asOfDate: '2026-09-14',
-            completedExposures: mockExposures,
-            sessionOutcomes: reactiveOutcomes,
-            progressResults: mockImprovingProgress,
+            linkedExposures: [unrelated, cleanLinked[1], cleanLinked[2]],
+            boundProgressResults: boundImproving,
         });
-
-        expect(result.action).toBe('reduce_proposal');
-        expect(result.proposedChange?.previousValue).toBe(90);
-        expect(result.proposedChange?.proposedValue).toBe(80); // 90 - 10 decrement
+        expect(review.evidenceAudit.candidateExposureCount).toBe(3);
+        expect(review.evidenceAudit.exposuresObserved).toBe(2);
+        expect(review.evidenceAudit.excludedExposureCount).toBe(1);
+        expect(review.action).toBe('hold');
     });
 
-    it('triggers redirect when multiple adverse responses or active restrictions are present', () => {
-        const multipleReactive: SessionOutcome[] = [
-            mockPassedOutcomes[0],
-            { ...mockPassedOutcomes[1], status: 'reactive' },
-            { ...mockPassedOutcomes[2], status: 'reactive' },
-        ];
-
-        const result = evaluateProgressionReview({
+    it('does not count prescription-mismatched or partial work as completed current-target exposure', () => {
+        const partial = linked(exposures[0], outcomes[0], { prescriptionStatus: 'partial' });
+        const review = evaluateProgressionReview({
             intentBlock: validBlock,
-            trainingIntentProfile: baseProfile,
             asOfDate: '2026-09-14',
-            completedExposures: mockExposures,
-            sessionOutcomes: multipleReactive,
+            linkedExposures: [partial, cleanLinked[1], cleanLinked[2]],
+            boundProgressResults: boundImproving,
         });
-
-        expect(result.action).toBe('redirect');
-        expect(result.reasons.some(r => r.includes('adverse_safety_response_detected'))).toBe(true);
+        expect(review.evidenceAudit.exposuresObserved).toBe(2);
+        expect(review.action).toBe('hold');
     });
 
-    it('returns hold when current value is already at permitted maximum', () => {
-        const maxedBlock: IntentBlock = {
-            ...validBlock,
-            progressionContract: {
-                ...validBlock.progressionContract!,
-                currentValue: 120, // max is 120
-            },
-        };
-
-        const result = evaluateProgressionReview({
-            intentBlock: maxedBlock,
-            trainingIntentProfile: baseProfile,
+    it('deduplicates repeated canonical occurrence ids', () => {
+        const review = evaluateProgressionReview({
+            intentBlock: validBlock,
             asOfDate: '2026-09-14',
-            completedExposures: mockExposures,
-            sessionOutcomes: mockPassedOutcomes,
-            progressResults: mockImprovingProgress,
+            linkedExposures: [cleanLinked[0], cleanLinked[0], cleanLinked[1], cleanLinked[2]],
+            boundProgressResults: boundImproving,
         });
-
-        expect(result.action).toBe('hold');
-        expect(result.reasons.some(r => r.includes('max_permitted_value_reached'))).toBe(true);
+        expect(review.evidenceAudit.candidateExposureCount).toBe(3);
+        expect(review.evidenceAudit.exposuresObserved).toBe(3);
+        expect(review.action).toBe('advance_proposal');
     });
 
-    it('adverse safety response strictly blocks advance even if outcome metric is improving (Safety Monotonicity)', () => {
-        const reactiveOutcomesNoAlternative: SessionOutcome[] = [
-            mockPassedOutcomes[0],
-            { ...mockPassedOutcomes[1], status: 'reactive' },
-            mockPassedOutcomes[2],
-        ];
-        const blockWithoutReduction: IntentBlock = {
+    it('uses only outcomes explicitly linked to qualifying occurrences', () => {
+        const unrelatedReactive = linked(
+            { ...exposures[0], performedOccurrenceId: 'unrelated', localDate: '2026-09-11' },
+            { ...outcomes[0], status: 'reactive' },
+            { coverageKey: 'aerobic_volume' },
+        );
+        const review = evaluateProgressionReview({
+            intentBlock: validBlock,
+            asOfDate: '2026-09-14',
+            linkedExposures: [...cleanLinked, unrelatedReactive],
+            boundProgressResults: boundImproving,
+        });
+        expect(review.evidenceAudit.adverseResponseCount).toBe(0);
+        expect(review.action).toBe('advance_proposal');
+    });
+
+    it('holds when linked follow-up coverage is below the authored threshold', () => {
+        const lowFollowUp = cleanLinked.map((evidence, index) => index === 0
+            ? evidence
+            : { ...evidence, outcome: { ...evidence.outcome!, hasFollowUpData: false, status: 'unknown' as const } });
+        const review = evaluateProgressionReview({
+            intentBlock: validBlock,
+            asOfDate: '2026-09-14',
+            linkedExposures: lowFollowUp,
+            boundProgressResults: boundImproving,
+        });
+        expect(review.evidenceAudit.followUpCoveragePct).toBe(33);
+        expect(review.action).toBe('hold');
+        expect(review.reasons.some(reason => reason.includes('insufficient_followup_evidence'))).toBe(true);
+    });
+
+    it('reduces on authored adverse_response reduction without a hidden adverse-count redirect threshold', () => {
+        const twoReactive = cleanLinked.map((evidence, index) => index === 0
+            ? evidence
+            : { ...evidence, outcome: { ...evidence.outcome!, status: 'reactive' as const } });
+        const review = evaluateProgressionReview({
+            intentBlock: validBlock,
+            asOfDate: '2026-09-14',
+            linkedExposures: twoReactive,
+            boundProgressResults: boundImproving,
+        });
+        expect(review.evidenceAudit.adverseResponseCount).toBe(2);
+        expect(review.action).toBe('reduce_proposal');
+        expect(review.proposedChange?.proposedValue).toBe(80);
+    });
+
+    it('redirects only when an explicit redirect trigger is authored', () => {
+        const redirectBlock: IntentBlock = {
             ...validBlock,
             progressionContract: {
                 ...validBlock.progressionContract!,
                 reductionAlternative: undefined,
+                redirectCriteria: { triggers: ['adverse_response'] },
             },
         };
-
-        const result = evaluateProgressionReview({
-            intentBlock: blockWithoutReduction,
-            trainingIntentProfile: baseProfile,
+        const reactive = cleanLinked.map((evidence, index) => index === 2
+            ? { ...evidence, outcome: { ...evidence.outcome!, status: 'reactive' as const } }
+            : evidence);
+        const review = evaluateProgressionReview({
+            intentBlock: redirectBlock,
             asOfDate: '2026-09-14',
-            completedExposures: mockExposures,
-            sessionOutcomes: reactiveOutcomesNoAlternative,
-            progressResults: mockImprovingProgress, // outcome says improving!
+            linkedExposures: reactive,
         });
+        expect(review.action).toBe('redirect');
+        expect(review.reasons[0]).toContain('adverse_response_triggers_redirect');
+    });
 
-        expect(result.action).toBe('hold');
-        expect(result.action).not.toBe('advance_proposal');
-        expect(result.reasons.some(r => r.includes('adverse_safety_response_blocks_advancement'))).toBe(true);
+    it('active restrictions block advancement and redirect only when explicitly authored', () => {
+        const held = evaluateProgressionReview({
+            intentBlock: validBlock,
+            asOfDate: '2026-09-14',
+            linkedExposures: cleanLinked,
+            activeRestrictions: { hasAdverseTissue: true },
+        });
+        expect(held.action).toBe('hold');
+
+        const redirectBlock: IntentBlock = {
+            ...validBlock,
+            progressionContract: {
+                ...validBlock.progressionContract!,
+                redirectCriteria: { triggers: ['active_restriction'] },
+            },
+        };
+        const redirected = evaluateProgressionReview({
+            intentBlock: redirectBlock,
+            asOfDate: '2026-09-14',
+            linkedExposures: cleanLinked,
+            activeRestrictions: { hasAdverseTissue: true },
+        });
+        expect(redirected.action).toBe('redirect');
+    });
+
+    it('holds at the maximum permitted value', () => {
+        const review = evaluateProgressionReview({
+            intentBlock: {
+                ...validBlock,
+                progressionContract: { ...validBlock.progressionContract!, currentValue: 120 },
+            },
+            asOfDate: '2026-09-14',
+            linkedExposures: cleanLinked,
+            boundProgressResults: boundImproving,
+        });
+        expect(review.action).toBe('hold');
+        expect(review.reasons[0]).toContain('max_permitted_value_reached');
+    });
+
+    it('matches the full evaluation reference, not metric id alone', () => {
+        const wrongRevision: BoundProgressEvidence[] = [{
+            evaluationRef: { id: 'eval_spec_01', revision: 2, metricId: 'cycling_ftp' },
+            result: improving,
+        }];
+        const review = evaluateProgressionReview({
+            intentBlock: validBlock,
+            asOfDate: '2026-09-14',
+            linkedExposures: cleanLinked,
+            boundProgressResults: wrongRevision,
+        });
+        expect(review.action).toBe('hold');
+        expect(review.reasons[0]).toContain('bound_outcome_metric_missing');
+    });
+
+    it('enforces the authored improving target instead of treating merely non-declining as success', () => {
+        const flat: BoundProgressEvidence[] = [{
+            evaluationRef: { id: 'eval_spec_01', revision: 1, metricId: 'cycling_ftp' },
+            result: { ...improving, status: 'unclear_within_noise', percentChange: 0.2 },
+        }];
+        const review = evaluateProgressionReview({
+            intentBlock: validBlock,
+            asOfDate: '2026-09-14',
+            linkedExposures: cleanLinked,
+            boundProgressResults: flat,
+        });
+        expect(review.action).toBe('hold');
+        expect(review.reasons[0]).toContain('bound_outcome_not_improving');
+    });
+
+    it('requires explicit prerequisite evidence when the objective authored prerequisites', () => {
+        const block: IntentBlock = {
+            ...validBlock,
+            objectives: [{
+                ...validBlock.objectives[0],
+                entryPrerequisites: { requiredPriorExposures: 2, minBaselineDays: 7 },
+            }],
+        };
+        const review = evaluateProgressionReview({
+            intentBlock: block,
+            asOfDate: '2026-09-14',
+            linkedExposures: cleanLinked,
+            boundProgressResults: boundImproving,
+        });
+        expect(review.action).toBe('hold');
+        expect(review.reasons).toContain('required_prior_exposure_evidence_missing');
+        expect(review.reasons).toContain('required_baseline_duration_evidence_missing');
+    });
+
+    it('redirects when an authored maximum block duration has expired', () => {
+        const block: IntentBlock = {
+            ...validBlock,
+            dateRange: { startDate: '2026-08-01', endDate: '2026-09-28' },
+            objectives: [{
+                ...validBlock.objectives[0],
+                exitCriteria: { maxWeeksInBlock: 4 },
+            }],
+        };
+        const review = evaluateProgressionReview({
+            intentBlock: block,
+            asOfDate: '2026-09-14',
+            linkedExposures: cleanLinked,
+        });
+        expect(review.action).toBe('redirect');
+        expect(review.reasons[0]).toContain('max_block_duration_exit_reached');
+    });
+
+    it('adverse safety evidence blocks advance even when the outcome metric is improving', () => {
+        const block: IntentBlock = {
+            ...validBlock,
+            progressionContract: { ...validBlock.progressionContract!, reductionAlternative: undefined },
+        };
+        const reactive = cleanLinked.map((evidence, index) => index === 1
+            ? { ...evidence, outcome: { ...evidence.outcome!, status: 'reactive' as const } }
+            : evidence);
+        const review = evaluateProgressionReview({
+            intentBlock: block,
+            asOfDate: '2026-09-14',
+            linkedExposures: reactive,
+            boundProgressResults: boundImproving,
+        });
+        expect(review.action).toBe('hold');
+        expect(review.action).not.toBe('advance_proposal');
+        expect(review.reasons[0]).toContain('adverse_safety_response_blocks_advancement');
     });
 });

--- a/app/src/engine/progressionReview.test.ts
+++ b/app/src/engine/progressionReview.test.ts
@@ -1,0 +1,305 @@
+﻿import { describe, it, expect } from 'vitest';
+import type { IntentBlock } from './blockIntent';
+import type { TrainingIntentProfile } from './models';
+import type { PerformedExposureFact } from './performedTrainingFacts';
+import type { SessionOutcome } from '../responses/outcome';
+import type { ProgressResult } from '../observations/progress';
+import { evaluateProgressionReview } from './progressionReview';
+
+describe('progressionReview evaluator (ADR-0037 D-CHANGE / D-AUTHORITY)', () => {
+    const validBlock: IntentBlock = {
+        id: 'block_build_01',
+        revision: 1,
+        sourcePlanId: 'plan_01',
+        sourcePlanRevision: 1,
+        dateRange: { startDate: '2026-09-01', endDate: '2026-09-28' },
+        objectives: [
+            {
+                id: 'obj_cycling_tempo',
+                sport: 'cycling',
+                adaptationScope: 'tempo_endurance',
+                coverageKey: 'sustained_quality',
+                intent: 'develop',
+                priority: 'must_have',
+                doseEnvelope: { min: 60, target: 90, max: 120, unit: 'minutes', floorSemantics: 'hard_floor' },
+                successCriteria: {
+                    evaluationRef: { id: 'eval_spec_01', revision: 1, metricId: 'cycling_ftp' },
+                    targetTrend: 'improving',
+                },
+            },
+        ],
+        reviewSchedule: {
+            reviewCadenceDays: 14,
+            nextReviewDate: '2026-09-14',
+        },
+        progressionContract: {
+            targetBinding: {
+                objectiveId: 'obj_cycling_tempo',
+            },
+            variable: 'duration_min',
+            unit: 'minutes',
+            currentValue: 90,
+            permittedRange: { min: 60, max: 120 },
+            increment: 10,
+            observationWindowDays: 14,
+            minCompletedExposures: 3,
+            requiredFollowUpCoveragePct: 66,
+            reviewCadenceDays: 14,
+            reductionAlternative: {
+                decrement: 10,
+                trigger: 'adverse_response',
+            },
+        },
+    };
+
+    const baseProfile: Pick<TrainingIntentProfile, 'priorities' | 'weeklyCommitment'> = {
+        priorities: ['endurance'],
+        weeklyCommitment: { minSessions: 3, targetSessions: 5, maxSessions: 6 },
+    };
+
+    const mockExposures: PerformedExposureFact[] = [
+        {
+            performedOccurrenceId: 'occ_01',
+            localDate: '2026-09-05',
+            modality: 'Cycling',
+            confidence: 'exact',
+            sourceKinds: ['structured_execution'],
+            evidenceTier: 'completedStructuredWorkout',
+        },
+        {
+            performedOccurrenceId: 'occ_02',
+            localDate: '2026-09-08',
+            modality: 'Cycling',
+            confidence: 'exact',
+            sourceKinds: ['structured_execution'],
+            evidenceTier: 'completedStructuredWorkout',
+        },
+        {
+            performedOccurrenceId: 'occ_03',
+            localDate: '2026-09-12',
+            modality: 'Cycling',
+            confidence: 'exact',
+            sourceKinds: ['structured_execution'],
+            evidenceTier: 'completedStructuredWorkout',
+        },
+    ];
+
+    const mockPassedOutcomes: SessionOutcome[] = [
+        {
+            policyVersion: 'm5.3-outcome-v1',
+            sourceSession: { kind: 'execution', id: 's1', date: '2026-09-05' },
+            status: 'passed',
+            hasFollowUpData: true,
+            sourceFacts: { responseIds: ['r1'], tissueRegions: [] },
+            override: {},
+        },
+        {
+            policyVersion: 'm5.3-outcome-v1',
+            sourceSession: { kind: 'execution', id: 's2', date: '2026-09-08' },
+            status: 'passed',
+            hasFollowUpData: true,
+            sourceFacts: { responseIds: ['r2'], tissueRegions: [] },
+            override: {},
+        },
+        {
+            policyVersion: 'm5.3-outcome-v1',
+            sourceSession: { kind: 'execution', id: 's3', date: '2026-09-12' },
+            status: 'passed',
+            hasFollowUpData: true,
+            sourceFacts: { responseIds: ['r3'], tissueRegions: [] },
+            override: {},
+        },
+    ];
+
+    const mockImprovingProgress: ProgressResult[] = [
+        {
+            metricId: 'cycling_ftp',
+            comparable: true,
+            status: 'meaningful_improvement',
+            reasons: ['cleared noise floor'],
+            progressPolicyVersion: 'ov-progress-v1',
+            absoluteChange: 10,
+            percentChange: 3.5,
+        },
+    ];
+
+    it('returns advance_proposal when all prerequisites, exposure count, follow-up, and outcome metrics are satisfied', () => {
+        const result = evaluateProgressionReview({
+            intentBlock: validBlock,
+            trainingIntentProfile: baseProfile,
+            asOfDate: '2026-09-14',
+            completedExposures: mockExposures,
+            sessionOutcomes: mockPassedOutcomes,
+            progressResults: mockImprovingProgress,
+        });
+
+        expect(result.action).toBe('advance_proposal');
+        expect(result.proposedChange).toBeDefined();
+        expect(result.proposedChange?.variable).toBe('duration_min');
+        expect(result.proposedChange?.previousValue).toBe(90);
+        expect(result.proposedChange?.proposedValue).toBe(100); // 90 + 10 increment
+        expect(result.evidenceAudit.exposuresObserved).toBe(3);
+        expect(result.evidenceAudit.followUpCoveragePct).toBe(100);
+        expect(result.evidenceAudit.adverseResponseCount).toBe(0);
+    });
+
+    it('returns hold if block has no progression contract defined', () => {
+        const blockWithoutContract: IntentBlock = {
+            ...validBlock,
+            progressionContract: undefined,
+        };
+        const result = evaluateProgressionReview({
+            intentBlock: blockWithoutContract,
+            trainingIntentProfile: baseProfile,
+            asOfDate: '2026-09-14',
+            completedExposures: mockExposures,
+            sessionOutcomes: mockPassedOutcomes,
+        });
+
+        expect(result.action).toBe('hold');
+        expect(result.reasons).toContain('no_progression_contract_defined');
+        expect(result.proposedChange).toBeUndefined();
+    });
+
+    it('returns hold if review cadence date has not yet arrived', () => {
+        const result = evaluateProgressionReview({
+            intentBlock: validBlock,
+            trainingIntentProfile: baseProfile,
+            asOfDate: '2026-09-10', // nextReviewDate is 2026-09-14
+            completedExposures: mockExposures,
+            sessionOutcomes: mockPassedOutcomes,
+        });
+
+        expect(result.action).toBe('hold');
+        expect(result.reasons.some(r => r.includes('review_cadence_not_reached'))).toBe(true);
+    });
+
+    it('returns hold if observed completed exposures are fewer than required', () => {
+        const result = evaluateProgressionReview({
+            intentBlock: validBlock,
+            trainingIntentProfile: baseProfile,
+            asOfDate: '2026-09-14',
+            completedExposures: [mockExposures[0]], // only 1 exposure, 3 required
+            sessionOutcomes: [mockPassedOutcomes[0]],
+            progressResults: mockImprovingProgress,
+        });
+
+        expect(result.action).toBe('hold');
+        expect(result.reasons.some(r => r.includes('insufficient_completed_exposures'))).toBe(true);
+        expect(result.proposedChange).toBeUndefined();
+    });
+
+    it('returns hold if follow-up coverage is below required percentage', () => {
+        const outcomesWithoutFollowup: SessionOutcome[] = [
+            { ...mockPassedOutcomes[0], hasFollowUpData: false },
+            { ...mockPassedOutcomes[1], hasFollowUpData: false },
+            { ...mockPassedOutcomes[2], hasFollowUpData: true },
+        ]; // 1 of 3 = 33% < 66% required
+
+        const result = evaluateProgressionReview({
+            intentBlock: validBlock,
+            trainingIntentProfile: baseProfile,
+            asOfDate: '2026-09-14',
+            completedExposures: mockExposures,
+            sessionOutcomes: outcomesWithoutFollowup,
+            progressResults: mockImprovingProgress,
+        });
+
+        expect(result.action).toBe('hold');
+        expect(result.reasons.some(r => r.includes('insufficient_followup_evidence'))).toBe(true);
+    });
+
+    it('triggers reduce_proposal when adverse tissue response is observed and reductionAlternative is present', () => {
+        const reactiveOutcomes: SessionOutcome[] = [
+            mockPassedOutcomes[0],
+            mockPassedOutcomes[1],
+            {
+                ...mockPassedOutcomes[2],
+                status: 'reactive',
+                hasFollowUpData: true,
+            },
+        ];
+
+        const result = evaluateProgressionReview({
+            intentBlock: validBlock,
+            trainingIntentProfile: baseProfile,
+            asOfDate: '2026-09-14',
+            completedExposures: mockExposures,
+            sessionOutcomes: reactiveOutcomes,
+            progressResults: mockImprovingProgress,
+        });
+
+        expect(result.action).toBe('reduce_proposal');
+        expect(result.proposedChange?.previousValue).toBe(90);
+        expect(result.proposedChange?.proposedValue).toBe(80); // 90 - 10 decrement
+    });
+
+    it('triggers redirect when multiple adverse responses or active restrictions are present', () => {
+        const multipleReactive: SessionOutcome[] = [
+            mockPassedOutcomes[0],
+            { ...mockPassedOutcomes[1], status: 'reactive' },
+            { ...mockPassedOutcomes[2], status: 'reactive' },
+        ];
+
+        const result = evaluateProgressionReview({
+            intentBlock: validBlock,
+            trainingIntentProfile: baseProfile,
+            asOfDate: '2026-09-14',
+            completedExposures: mockExposures,
+            sessionOutcomes: multipleReactive,
+        });
+
+        expect(result.action).toBe('redirect');
+        expect(result.reasons.some(r => r.includes('adverse_safety_response_detected'))).toBe(true);
+    });
+
+    it('returns hold when current value is already at permitted maximum', () => {
+        const maxedBlock: IntentBlock = {
+            ...validBlock,
+            progressionContract: {
+                ...validBlock.progressionContract!,
+                currentValue: 120, // max is 120
+            },
+        };
+
+        const result = evaluateProgressionReview({
+            intentBlock: maxedBlock,
+            trainingIntentProfile: baseProfile,
+            asOfDate: '2026-09-14',
+            completedExposures: mockExposures,
+            sessionOutcomes: mockPassedOutcomes,
+            progressResults: mockImprovingProgress,
+        });
+
+        expect(result.action).toBe('hold');
+        expect(result.reasons.some(r => r.includes('max_permitted_value_reached'))).toBe(true);
+    });
+
+    it('adverse safety response strictly blocks advance even if outcome metric is improving (Safety Monotonicity)', () => {
+        const reactiveOutcomesNoAlternative: SessionOutcome[] = [
+            mockPassedOutcomes[0],
+            { ...mockPassedOutcomes[1], status: 'reactive' },
+            mockPassedOutcomes[2],
+        ];
+        const blockWithoutReduction: IntentBlock = {
+            ...validBlock,
+            progressionContract: {
+                ...validBlock.progressionContract!,
+                reductionAlternative: undefined,
+            },
+        };
+
+        const result = evaluateProgressionReview({
+            intentBlock: blockWithoutReduction,
+            trainingIntentProfile: baseProfile,
+            asOfDate: '2026-09-14',
+            completedExposures: mockExposures,
+            sessionOutcomes: reactiveOutcomesNoAlternative,
+            progressResults: mockImprovingProgress, // outcome says improving!
+        });
+
+        expect(result.action).toBe('hold');
+        expect(result.action).not.toBe('advance_proposal');
+        expect(result.reasons.some(r => r.includes('adverse_safety_response_blocks_advancement'))).toBe(true);
+    });
+});

--- a/app/src/engine/progressionReview.test.ts
+++ b/app/src/engine/progressionReview.test.ts
@@ -94,19 +94,28 @@ describe('progressionReview evaluator (ADR-0037 D-CHANGE / D-AUTHORITY)', () => 
         options: {
             coverageKey?: CoverageCreditFact['coverageKey'];
             prescriptionStatus?: LinkedProgressionExposureEvidence['prescription']['status'];
+            prescriptionValue?: number;
+            deliveredDoseFraction?: number;
         } = {},
     ): LinkedProgressionExposureEvidence {
         return {
             exposure,
             coverageCredits: coverage(exposure, options.coverageKey),
-            prescription: { status: options.prescriptionStatus ?? 'matched_current_target' },
+            ...(options.deliveredDoseFraction === undefined ? {} : { deliveredDoseFraction: options.deliveredDoseFraction }),
+            prescription: {
+                status: options.prescriptionStatus ?? 'matched_current_target',
+                sourceRevision: 1,
+                variable: 'duration_min',
+                unit: 'minutes',
+                value: options.prescriptionValue ?? 90,
+            },
             ...(outcome ? { outcome } : {}),
         };
     }
 
     const cleanLinked = exposures.map((exposure, index) => linked(exposure, outcomes[index]));
 
-    it('advances only when linked canonical role/prescription/follow-up/outcome evidence all pass', () => {
+    it('advances only when linked canonical role/current-dose/follow-up/outcome evidence all pass', () => {
         const review = evaluateProgressionReview({
             intentBlock: validBlock,
             asOfDate: '2026-09-14',
@@ -144,6 +153,16 @@ describe('progressionReview evaluator (ADR-0037 D-CHANGE / D-AUTHORITY)', () => 
         expect(review.reasons.some(reason => reason.includes('review_cadence_not_reached'))).toBe(true);
     });
 
+    it('redirects rather than proposing a new dose when the authored block interval has ended', () => {
+        const review = evaluateProgressionReview({
+            intentBlock: validBlock,
+            asOfDate: '2026-09-28',
+            linkedExposures: cleanLinked,
+        });
+        expect(review.action).toBe('redirect');
+        expect(review.reasons).toContain('block_interval_ended_requires_review');
+    });
+
     it('applies the observation-window lower bound instead of counting arbitrarily old work', () => {
         const old = { ...exposures[0], performedOccurrenceId: 'old', localDate: '2026-08-15' };
         const review = evaluateProgressionReview({
@@ -171,6 +190,59 @@ describe('progressionReview evaluator (ADR-0037 D-CHANGE / D-AUTHORITY)', () => 
         expect(review.action).toBe('hold');
     });
 
+    it('accepts an explicitly allowed exact substitution only when its dose qualification is proven', () => {
+        const block: IntentBlock = {
+            ...validBlock,
+            objectives: [{
+                ...validBlock.objectives[0],
+                allowedSubstitutions: [{
+                    targetCoverageKey: 'sustained_quality',
+                    allowedCoverageKeys: ['outdoor_event_specific'],
+                    minDoseFraction: 0.9,
+                }],
+            }],
+        };
+        const substitution = linked(exposures[0], outcomes[0], {
+            coverageKey: 'outdoor_event_specific',
+            deliveredDoseFraction: 0.9,
+        });
+        const review = evaluateProgressionReview({
+            intentBlock: block,
+            asOfDate: '2026-09-14',
+            linkedExposures: [substitution, cleanLinked[1], cleanLinked[2]],
+            boundProgressResults: boundImproving,
+        });
+        expect(review.evidenceAudit.roleRelevantExposureCount).toBe(3);
+        expect(review.evidenceAudit.exposuresObserved).toBe(3);
+        expect(review.action).toBe('advance_proposal');
+
+        const underDose = evaluateProgressionReview({
+            intentBlock: block,
+            asOfDate: '2026-09-14',
+            linkedExposures: [
+                linked(exposures[0], outcomes[0], { coverageKey: 'outdoor_event_specific', deliveredDoseFraction: 0.8 }),
+                cleanLinked[1],
+                cleanLinked[2],
+            ],
+            boundProgressResults: boundImproving,
+        });
+        expect(underDose.evidenceAudit.exposuresObserved).toBe(2);
+        expect(underDose.action).toBe('hold');
+    });
+
+    it('does not count a stale/different prescription value as current-target exposure', () => {
+        const stale = linked(exposures[0], outcomes[0], { prescriptionValue: 80 });
+        const review = evaluateProgressionReview({
+            intentBlock: validBlock,
+            asOfDate: '2026-09-14',
+            linkedExposures: [stale, cleanLinked[1], cleanLinked[2]],
+            boundProgressResults: boundImproving,
+        });
+        expect(review.evidenceAudit.roleRelevantExposureCount).toBe(3);
+        expect(review.evidenceAudit.exposuresObserved).toBe(2);
+        expect(review.action).toBe('hold');
+    });
+
     it('does not count prescription-mismatched or partial work as completed current-target exposure', () => {
         const partial = linked(exposures[0], outcomes[0], { prescriptionStatus: 'partial' });
         const review = evaluateProgressionReview({
@@ -181,6 +253,23 @@ describe('progressionReview evaluator (ADR-0037 D-CHANGE / D-AUTHORITY)', () => 
         });
         expect(review.evidenceAudit.exposuresObserved).toBe(2);
         expect(review.action).toBe('hold');
+    });
+
+    it('still applies adverse safety evidence from a partial target exposure', () => {
+        const partialReactive = linked(
+            exposures[0],
+            { ...outcomes[0], status: 'reactive' },
+            { prescriptionStatus: 'partial' },
+        );
+        const review = evaluateProgressionReview({
+            intentBlock: validBlock,
+            asOfDate: '2026-09-14',
+            linkedExposures: [partialReactive, ...cleanLinked],
+            boundProgressResults: boundImproving,
+        });
+        expect(review.evidenceAudit.exposuresObserved).toBe(3);
+        expect(review.evidenceAudit.adverseResponseCount).toBe(1);
+        expect(review.action).toBe('reduce_proposal');
     });
 
     it('deduplicates repeated canonical occurrence ids', () => {
@@ -195,7 +284,7 @@ describe('progressionReview evaluator (ADR-0037 D-CHANGE / D-AUTHORITY)', () => 
         expect(review.action).toBe('advance_proposal');
     });
 
-    it('uses only outcomes explicitly linked to qualifying occurrences', () => {
+    it('uses only outcomes bundled with role-relevant canonical occurrences', () => {
         const unrelatedReactive = linked(
             { ...exposures[0], performedOccurrenceId: 'unrelated', localDate: '2026-09-11' },
             { ...outcomes[0], status: 'reactive' },
@@ -224,6 +313,21 @@ describe('progressionReview evaluator (ADR-0037 D-CHANGE / D-AUTHORITY)', () => 
         expect(review.evidenceAudit.followUpCoveragePct).toBe(33);
         expect(review.action).toBe('hold');
         expect(review.reasons.some(reason => reason.includes('insufficient_followup_evidence'))).toBe(true);
+    });
+
+    it('holds on unknown outcome evidence even if the caller marks follow-up as present', () => {
+        const unknown = cleanLinked.map((evidence, index) => index === 0
+            ? { ...evidence, outcome: { ...evidence.outcome!, status: 'unknown' as const, hasFollowUpData: true } }
+            : evidence);
+        const review = evaluateProgressionReview({
+            intentBlock: validBlock,
+            asOfDate: '2026-09-14',
+            linkedExposures: unknown,
+            boundProgressResults: boundImproving,
+        });
+        expect(review.evidenceAudit.unknownResponseCount).toBe(1);
+        expect(review.action).toBe('hold');
+        expect(review.reasons[0]).toContain('unknown_response_evidence_blocks_advancement');
     });
 
     it('reduces on authored adverse_response reduction without a hidden adverse-count redirect threshold', () => {
@@ -294,7 +398,10 @@ describe('progressionReview evaluator (ADR-0037 D-CHANGE / D-AUTHORITY)', () => 
                 progressionContract: { ...validBlock.progressionContract!, currentValue: 120 },
             },
             asOfDate: '2026-09-14',
-            linkedExposures: cleanLinked,
+            linkedExposures: cleanLinked.map(evidence => ({
+                ...evidence,
+                prescription: { ...evidence.prescription, value: 120 },
+            })),
             boundProgressResults: boundImproving,
         });
         expect(review.action).toBe('hold');
@@ -329,6 +436,33 @@ describe('progressionReview evaluator (ADR-0037 D-CHANGE / D-AUTHORITY)', () => 
         });
         expect(review.action).toBe('hold');
         expect(review.reasons[0]).toContain('bound_outcome_not_improving');
+    });
+
+    it('does not treat unclear-within-noise as proof of maintenance', () => {
+        const maintenanceBlock: IntentBlock = {
+            ...validBlock,
+            objectives: [{
+                ...validBlock.objectives[0],
+                intent: 'maintain',
+                successCriteria: {
+                    evaluationRef: { id: 'eval_spec_01', revision: 1, metricId: 'cycling_ftp' },
+                    targetTrend: 'stable',
+                    acceptableDeclineTolerancePct: 3,
+                },
+            }],
+        };
+        const unclear: BoundProgressEvidence[] = [{
+            evaluationRef: { id: 'eval_spec_01', revision: 1, metricId: 'cycling_ftp' },
+            result: { ...improving, status: 'unclear_within_noise', percentChange: 0.2 },
+        }];
+        const review = evaluateProgressionReview({
+            intentBlock: maintenanceBlock,
+            asOfDate: '2026-09-14',
+            linkedExposures: cleanLinked,
+            boundProgressResults: unclear,
+        });
+        expect(review.action).toBe('hold');
+        expect(review.reasons[0]).toBe('stable_target_unclear_within_noise');
     });
 
     it('requires explicit prerequisite evidence when the objective authored prerequisites', () => {

--- a/app/src/engine/progressionReview.test.ts
+++ b/app/src/engine/progressionReview.test.ts
@@ -95,6 +95,7 @@ describe('progressionReview evaluator (ADR-0037 D-CHANGE / D-AUTHORITY)', () => 
             coverageKey?: CoverageCreditFact['coverageKey'];
             prescriptionStatus?: LinkedProgressionExposureEvidence['prescription']['status'];
             prescriptionValue?: number;
+            sourcePlanRevision?: number;
             deliveredDoseFraction?: number;
         } = {},
     ): LinkedProgressionExposureEvidence {
@@ -104,7 +105,7 @@ describe('progressionReview evaluator (ADR-0037 D-CHANGE / D-AUTHORITY)', () => 
             ...(options.deliveredDoseFraction === undefined ? {} : { deliveredDoseFraction: options.deliveredDoseFraction }),
             prescription: {
                 status: options.prescriptionStatus ?? 'matched_current_target',
-                sourceRevision: 1,
+                sourcePlanRevision: options.sourcePlanRevision ?? 1,
                 variable: 'duration_min',
                 unit: 'minutes',
                 value: options.prescriptionValue ?? 90,
@@ -130,6 +131,7 @@ describe('progressionReview evaluator (ADR-0037 D-CHANGE / D-AUTHORITY)', () => 
             windowEndDate: '2026-09-14',
             exposuresObserved: 3,
             followUpCoveragePct: 100,
+            ambiguousOccurrenceCount: 0,
         });
     });
 
@@ -185,8 +187,8 @@ describe('progressionReview evaluator (ADR-0037 D-CHANGE / D-AUTHORITY)', () => 
             boundProgressResults: boundImproving,
         });
         expect(review.evidenceAudit.candidateExposureCount).toBe(3);
+        expect(review.evidenceAudit.roleRelevantExposureCount).toBe(2);
         expect(review.evidenceAudit.exposuresObserved).toBe(2);
-        expect(review.evidenceAudit.excludedExposureCount).toBe(1);
         expect(review.action).toBe('hold');
     });
 
@@ -226,20 +228,22 @@ describe('progressionReview evaluator (ADR-0037 D-CHANGE / D-AUTHORITY)', () => 
             ],
             boundProgressResults: boundImproving,
         });
+        expect(underDose.evidenceAudit.roleRelevantExposureCount).toBe(3);
         expect(underDose.evidenceAudit.exposuresObserved).toBe(2);
         expect(underDose.action).toBe('hold');
     });
 
-    it('does not count a stale/different prescription value as current-target exposure', () => {
-        const stale = linked(exposures[0], outcomes[0], { prescriptionValue: 80 });
+    it('does not count a stale value or stale source-plan revision as current-target exposure', () => {
+        const staleValue = linked(exposures[0], outcomes[0], { prescriptionValue: 80 });
+        const staleRevision = linked(exposures[1], outcomes[1], { sourcePlanRevision: 2 });
         const review = evaluateProgressionReview({
             intentBlock: validBlock,
             asOfDate: '2026-09-14',
-            linkedExposures: [stale, cleanLinked[1], cleanLinked[2]],
+            linkedExposures: [staleValue, staleRevision, cleanLinked[2]],
             boundProgressResults: boundImproving,
         });
         expect(review.evidenceAudit.roleRelevantExposureCount).toBe(3);
-        expect(review.evidenceAudit.exposuresObserved).toBe(2);
+        expect(review.evidenceAudit.exposuresObserved).toBe(1);
         expect(review.action).toBe('hold');
     });
 
@@ -255,10 +259,15 @@ describe('progressionReview evaluator (ADR-0037 D-CHANGE / D-AUTHORITY)', () => 
         expect(review.action).toBe('hold');
     });
 
-    it('still applies adverse safety evidence from a partial target exposure', () => {
+    it('still applies adverse safety evidence from an extra partial target attempt', () => {
+        const partialExposure: PerformedExposureFact = {
+            ...exposures[0],
+            performedOccurrenceId: 'occ_partial',
+            localDate: '2026-09-11',
+        };
         const partialReactive = linked(
-            exposures[0],
-            { ...outcomes[0], status: 'reactive' },
+            partialExposure,
+            { ...outcomes[0], sourceSession: { ...outcomes[0].sourceSession, id: 'partial-session', date: '2026-09-11' }, status: 'reactive' },
             { prescriptionStatus: 'partial' },
         );
         const review = evaluateProgressionReview({
@@ -267,12 +276,33 @@ describe('progressionReview evaluator (ADR-0037 D-CHANGE / D-AUTHORITY)', () => 
             linkedExposures: [partialReactive, ...cleanLinked],
             boundProgressResults: boundImproving,
         });
+        expect(review.evidenceAudit.roleRelevantExposureCount).toBe(4);
         expect(review.evidenceAudit.exposuresObserved).toBe(3);
         expect(review.evidenceAudit.adverseResponseCount).toBe(1);
         expect(review.action).toBe('reduce_proposal');
     });
 
-    it('deduplicates repeated canonical occurrence ids', () => {
+    it('requires follow-up evidence for partial/under-dose target attempts too', () => {
+        const partialExposure: PerformedExposureFact = {
+            ...exposures[0],
+            performedOccurrenceId: 'occ_partial_missing',
+            localDate: '2026-09-11',
+        };
+        const partialUnknown = linked(partialExposure, undefined, { prescriptionStatus: 'partial' });
+        const review = evaluateProgressionReview({
+            intentBlock: validBlock,
+            asOfDate: '2026-09-14',
+            linkedExposures: [partialUnknown, ...cleanLinked],
+            boundProgressResults: boundImproving,
+        });
+        expect(review.evidenceAudit.exposuresObserved).toBe(3);
+        expect(review.evidenceAudit.followUpCoveragePct).toBe(75);
+        expect(review.evidenceAudit.unknownResponseCount).toBe(1);
+        expect(review.action).toBe('hold');
+        expect(review.reasons[0]).toContain('unknown_response_evidence_blocks_advancement');
+    });
+
+    it('deduplicates identical repeated canonical occurrence evidence', () => {
         const review = evaluateProgressionReview({
             intentBlock: validBlock,
             asOfDate: '2026-09-14',
@@ -280,14 +310,35 @@ describe('progressionReview evaluator (ADR-0037 D-CHANGE / D-AUTHORITY)', () => 
             boundProgressResults: boundImproving,
         });
         expect(review.evidenceAudit.candidateExposureCount).toBe(3);
+        expect(review.evidenceAudit.ambiguousOccurrenceCount).toBe(0);
         expect(review.evidenceAudit.exposuresObserved).toBe(3);
         expect(review.action).toBe('advance_proposal');
     });
 
-    it('uses only outcomes bundled with role-relevant canonical occurrences', () => {
+    it('fails closed on conflicting duplicate evidence for the same canonical occurrence', () => {
+        const conflicting = linked(exposures[0], outcomes[0], { prescriptionValue: 80 });
+        const review = evaluateProgressionReview({
+            intentBlock: validBlock,
+            asOfDate: '2026-09-14',
+            linkedExposures: [cleanLinked[0], conflicting, cleanLinked[1], cleanLinked[2]],
+            boundProgressResults: boundImproving,
+        });
+        expect(review.evidenceAudit.candidateExposureCount).toBe(3);
+        expect(review.evidenceAudit.ambiguousOccurrenceCount).toBe(1);
+        expect(review.evidenceAudit.exposuresObserved).toBe(2);
+        expect(review.action).toBe('hold');
+        expect(review.reasons[0]).toContain('conflicting_duplicate_occurrence_evidence');
+    });
+
+    it('uses only outcomes bundled with target/allowed-role canonical occurrences', () => {
+        const unrelatedExposure: PerformedExposureFact = {
+            ...exposures[0],
+            performedOccurrenceId: 'unrelated',
+            localDate: '2026-09-11',
+        };
         const unrelatedReactive = linked(
-            { ...exposures[0], performedOccurrenceId: 'unrelated', localDate: '2026-09-11' },
-            { ...outcomes[0], status: 'reactive' },
+            unrelatedExposure,
+            { ...outcomes[0], sourceSession: { ...outcomes[0].sourceSession, id: 'unrelated-session', date: '2026-09-11' }, status: 'reactive' },
             { coverageKey: 'aerobic_volume' },
         );
         const review = evaluateProgressionReview({
@@ -300,7 +351,7 @@ describe('progressionReview evaluator (ADR-0037 D-CHANGE / D-AUTHORITY)', () => 
         expect(review.action).toBe('advance_proposal');
     });
 
-    it('holds when linked follow-up coverage is below the authored threshold', () => {
+    it('holds when role-relevant follow-up coverage is below the authored threshold', () => {
         const lowFollowUp = cleanLinked.map((evidence, index) => index === 0
             ? evidence
             : { ...evidence, outcome: { ...evidence.outcome!, hasFollowUpData: false, status: 'unknown' as const } });

--- a/app/src/engine/progressionReview.test.ts
+++ b/app/src/engine/progressionReview.test.ts
@@ -11,36 +11,22 @@ import {
 
 describe('progressionReview evaluator (ADR-0037 D-CHANGE / D-AUTHORITY)', () => {
     const validBlock: IntentBlock = {
-        id: 'block_build_01',
-        revision: 1,
-        sourcePlanId: 'plan_01',
-        sourcePlanRevision: 1,
+        id: 'block_build_01', revision: 1, sourcePlanId: 'plan_01', sourcePlanRevision: 1,
         dateRange: { startDate: '2026-09-01', endDate: '2026-09-28' },
         objectives: [{
-            id: 'obj_cycling_tempo',
-            sport: 'cycling',
-            adaptationScope: 'tempo_endurance',
-            coverageKey: 'sustained_quality',
-            intent: 'develop',
-            priority: 'must_have',
+            id: 'obj_cycling_tempo', sport: 'cycling', adaptationScope: 'threshold_quality', coverageKey: 'sustained_quality',
+            intent: 'develop', priority: 'must_have',
             doseEnvelope: { min: 60, target: 90, max: 120, unit: 'minutes', floorSemantics: 'hard_floor' },
-            successCriteria: {
-                evaluationRef: { id: 'eval_spec_01', revision: 1, metricId: 'cycling_ftp' },
-                targetTrend: 'improving',
-            },
+            knowledgeLineage: ['claim_threshold_progression_v1'],
+            successCriteria: { evaluationRef: { id: 'eval_spec_01', revision: 1, metricId: 'cycling_ftp' }, targetTrend: 'improving' },
+            exitCriteria: { maxWeeksInBlock: 4, stagnationReviewAfterWeeks: 3 },
         }],
         reviewSchedule: { reviewCadenceDays: 14, nextReviewDate: '2026-09-14' },
         progressionContract: {
-            targetBinding: { objectiveId: 'obj_cycling_tempo' },
-            variable: 'duration_min',
-            unit: 'minutes',
-            currentValue: 90,
-            permittedRange: { min: 60, max: 120 },
-            increment: 10,
-            observationWindowDays: 14,
-            minCompletedExposures: 3,
-            requiredFollowUpCoveragePct: 66,
-            reviewCadenceDays: 14,
+            targetBinding: { objectiveId: 'obj_cycling_tempo' }, variable: 'duration_min', unit: 'minutes', currentValue: 90,
+            permittedRange: { min: 60, max: 120 }, increment: 10,
+            knowledgeLineage: ['policy_duration_progression_v1'],
+            observationWindowDays: 14, minCompletedExposures: 3, requiredFollowUpCoveragePct: 66, reviewCadenceDays: 14,
             reductionAlternative: { decrement: 10, trigger: 'adverse_response' },
         },
     };
@@ -52,53 +38,29 @@ describe('progressionReview evaluator (ADR-0037 D-CHANGE / D-AUTHORITY)', () => 
     ];
 
     const outcomes: SessionOutcome[] = exposures.map((exposure, index) => ({
-        policyVersion: 'm5.3-outcome-v1',
-        sourceSession: { kind: 'execution', id: `s${index + 1}`, date: exposure.localDate },
-        status: 'passed',
-        hasFollowUpData: true,
-        sourceFacts: { responseIds: [`r${index + 1}`], tissueRegions: [] },
-        override: {},
+        policyVersion: 'm5.3-outcome-v1', sourceSession: { kind: 'execution', id: `s${index + 1}`, date: exposure.localDate },
+        status: 'passed', hasFollowUpData: true, sourceFacts: { responseIds: [`r${index + 1}`], tissueRegions: [] }, override: {},
     }));
 
     const improving: ProgressResult = {
-        metricId: 'cycling_ftp',
-        comparable: true,
-        status: 'meaningful_improvement',
-        reasons: ['cleared noise floor'],
-        progressPolicyVersion: 'ov-progress-v1',
-        absoluteChange: 10,
-        percentChange: 3.5,
+        metricId: 'cycling_ftp', comparable: true, status: 'meaningful_improvement', reasons: ['cleared noise floor'],
+        progressPolicyVersion: 'ov-progress-v1', absoluteChange: 10, percentChange: 3.5,
     };
-
-    const boundImproving: BoundProgressEvidence[] = [{
-        evaluationRef: { id: 'eval_spec_01', revision: 1, metricId: 'cycling_ftp' },
-        result: improving,
-    }];
+    const boundImproving: BoundProgressEvidence[] = [{ evaluationRef: { id: 'eval_spec_01', revision: 1, metricId: 'cycling_ftp' }, result: improving }];
 
     function coverage(exposure: PerformedExposureFact, key: CoverageCreditFact['coverageKey'] = 'sustained_quality'): CoverageCreditFact[] {
-        return [{
-            performedOccurrenceId: exposure.performedOccurrenceId,
-            coverageSetId: 'evergreen_general',
-            coverageKey: key,
-            workoutId: 'cycling_controlled_threshold_4x8_01',
-            creditKind: 'exact',
-            confidence: 1,
-            reasonCode: 'exact_workout_identity',
-            sourceKinds: ['structured_execution'],
-        }];
+        return [{ performedOccurrenceId: exposure.performedOccurrenceId, coverageSetId: 'evergreen_general', coverageKey: key,
+            workoutId: 'cycling_controlled_threshold_4x8_01', creditKind: 'exact', confidence: 1,
+            reasonCode: 'exact_workout_identity', sourceKinds: ['structured_execution'] }];
     }
 
-    function linked(
-        exposure: PerformedExposureFact,
-        outcome: SessionOutcome | undefined,
-        options: {
-            coverageKey?: CoverageCreditFact['coverageKey'];
-            prescriptionStatus?: LinkedProgressionExposureEvidence['prescription']['status'];
-            prescriptionValue?: number;
-            sourcePlanRevision?: number;
-            deliveredDoseFraction?: number;
-        } = {},
-    ): LinkedProgressionExposureEvidence {
+    function linked(exposure: PerformedExposureFact, outcome: SessionOutcome | undefined, options: {
+        coverageKey?: CoverageCreditFact['coverageKey'];
+        prescriptionStatus?: LinkedProgressionExposureEvidence['prescription']['status'];
+        prescriptionValue?: number;
+        sourcePlanRevision?: number;
+        deliveredDoseFraction?: number;
+    } = {}): LinkedProgressionExposureEvidence {
         return {
             exposure,
             coverageCredits: coverage(exposure, options.coverageKey),
@@ -106,469 +68,156 @@ describe('progressionReview evaluator (ADR-0037 D-CHANGE / D-AUTHORITY)', () => 
             prescription: {
                 status: options.prescriptionStatus ?? 'matched_current_target',
                 sourcePlanRevision: options.sourcePlanRevision ?? 1,
-                variable: 'duration_min',
-                unit: 'minutes',
-                value: options.prescriptionValue ?? 90,
+                variable: 'duration_min', unit: 'minutes', value: options.prescriptionValue ?? 90,
             },
             ...(outcome ? { outcome } : {}),
         };
     }
-
     const cleanLinked = exposures.map((exposure, index) => linked(exposure, outcomes[index]));
 
     it('advances only when linked canonical role/current-dose/follow-up/outcome evidence all pass', () => {
-        const review = evaluateProgressionReview({
-            intentBlock: validBlock,
-            asOfDate: '2026-09-14',
-            linkedExposures: cleanLinked,
-            boundProgressResults: boundImproving,
-        });
+        const review = evaluateProgressionReview({ intentBlock: validBlock, asOfDate: '2026-09-14', linkedExposures: cleanLinked, boundProgressResults: boundImproving });
         expect(review.action).toBe('advance_proposal');
         expect(review.proposedChange).toMatchObject({ previousValue: 90, proposedValue: 100 });
-        expect(review.proposedChange?.derivedDoseEffects.delta).toBe(10);
-        expect(review.evidenceAudit).toMatchObject({
-            windowStartDate: '2026-09-01',
-            windowEndDate: '2026-09-14',
-            exposuresObserved: 3,
-            followUpCoveragePct: 100,
-            ambiguousOccurrenceCount: 0,
-        });
+        expect(review.evidenceAudit).toMatchObject({ windowStartDate: '2026-09-01', windowEndDate: '2026-09-14', exposuresObserved: 3, followUpCoveragePct: 100, ambiguousOccurrenceCount: 0 });
     });
 
     it('holds when there is no progression contract', () => {
-        const review = evaluateProgressionReview({
-            intentBlock: { ...validBlock, progressionContract: undefined },
-            asOfDate: '2026-09-14',
-            linkedExposures: cleanLinked,
-        });
+        const review = evaluateProgressionReview({ intentBlock: { ...validBlock, progressionContract: undefined }, asOfDate: '2026-09-14', linkedExposures: cleanLinked });
         expect(review.action).toBe('hold');
         expect(review.reasons).toContain('no_progression_contract_defined');
     });
 
-    it('holds until the authored review date', () => {
-        const review = evaluateProgressionReview({
-            intentBlock: validBlock,
-            asOfDate: '2026-09-10',
-            linkedExposures: cleanLinked,
-        });
-        expect(review.action).toBe('hold');
-        expect(review.reasons.some(reason => reason.includes('review_cadence_not_reached'))).toBe(true);
-    });
-
-    it('redirects rather than proposing a new dose when the authored block interval has ended', () => {
-        const review = evaluateProgressionReview({
-            intentBlock: validBlock,
-            asOfDate: '2026-09-28',
-            linkedExposures: cleanLinked,
-        });
-        expect(review.action).toBe('redirect');
-        expect(review.reasons).toContain('block_interval_ended_requires_review');
+    it('holds until review date and redirects at the authored block boundary', () => {
+        expect(evaluateProgressionReview({ intentBlock: validBlock, asOfDate: '2026-09-10', linkedExposures: cleanLinked }).action).toBe('hold');
+        const ended = evaluateProgressionReview({ intentBlock: validBlock, asOfDate: '2026-09-28', linkedExposures: cleanLinked });
+        expect(ended.action).toBe('redirect');
+        expect(ended.reasons).toContain('block_interval_ended_requires_review');
     });
 
     it('applies the observation-window lower bound instead of counting arbitrarily old work', () => {
         const old = { ...exposures[0], performedOccurrenceId: 'old', localDate: '2026-08-15' };
-        const review = evaluateProgressionReview({
-            intentBlock: validBlock,
-            asOfDate: '2026-09-14',
-            linkedExposures: [linked(old, outcomes[0]), cleanLinked[1], cleanLinked[2]],
-            boundProgressResults: boundImproving,
-        });
-        expect(review.action).toBe('hold');
+        const review = evaluateProgressionReview({ intentBlock: validBlock, asOfDate: '2026-09-14', linkedExposures: [linked(old, outcomes[0]), cleanLinked[1], cleanLinked[2]], boundProgressResults: boundImproving });
         expect(review.evidenceAudit.exposuresObserved).toBe(2);
-        expect(review.reasons.some(reason => reason.includes('insufficient_completed_exposures'))).toBe(true);
+        expect(review.action).toBe('hold');
     });
 
     it('does not count same-modality work without exact target coverage', () => {
         const unrelated = linked(exposures[0], outcomes[0], { coverageKey: 'aerobic_volume' });
-        const review = evaluateProgressionReview({
-            intentBlock: validBlock,
-            asOfDate: '2026-09-14',
-            linkedExposures: [unrelated, cleanLinked[1], cleanLinked[2]],
-            boundProgressResults: boundImproving,
-        });
-        expect(review.evidenceAudit.candidateExposureCount).toBe(3);
+        const review = evaluateProgressionReview({ intentBlock: validBlock, asOfDate: '2026-09-14', linkedExposures: [unrelated, cleanLinked[1], cleanLinked[2]], boundProgressResults: boundImproving });
         expect(review.evidenceAudit.roleRelevantExposureCount).toBe(2);
         expect(review.evidenceAudit.exposuresObserved).toBe(2);
         expect(review.action).toBe('hold');
     });
 
-    it('accepts an explicitly allowed exact substitution only when its dose qualification is proven', () => {
-        const block: IntentBlock = {
-            ...validBlock,
-            objectives: [{
-                ...validBlock.objectives[0],
-                allowedSubstitutions: [{
-                    targetCoverageKey: 'sustained_quality',
-                    allowedCoverageKeys: ['outdoor_event_specific'],
-                    minDoseFraction: 0.9,
-                }],
-            }],
-        };
-        const substitution = linked(exposures[0], outcomes[0], {
-            coverageKey: 'outdoor_event_specific',
-            deliveredDoseFraction: 0.9,
-        });
-        const review = evaluateProgressionReview({
-            intentBlock: block,
-            asOfDate: '2026-09-14',
-            linkedExposures: [substitution, cleanLinked[1], cleanLinked[2]],
-            boundProgressResults: boundImproving,
-        });
-        expect(review.evidenceAudit.roleRelevantExposureCount).toBe(3);
-        expect(review.evidenceAudit.exposuresObserved).toBe(3);
+    it('accepts an explicitly allowed substitution only when its dose qualification is proven', () => {
+        const block: IntentBlock = { ...validBlock, objectives: [{ ...validBlock.objectives[0], allowedSubstitutions: [{ targetCoverageKey: 'sustained_quality', allowedCoverageKeys: ['outdoor_event_specific'], minDoseFraction: 0.9 }] }] };
+        const review = evaluateProgressionReview({ intentBlock: block, asOfDate: '2026-09-14', linkedExposures: [linked(exposures[0], outcomes[0], { coverageKey: 'outdoor_event_specific', deliveredDoseFraction: 0.9 }), cleanLinked[1], cleanLinked[2]], boundProgressResults: boundImproving });
         expect(review.action).toBe('advance_proposal');
-
-        const underDose = evaluateProgressionReview({
-            intentBlock: block,
-            asOfDate: '2026-09-14',
-            linkedExposures: [
-                linked(exposures[0], outcomes[0], { coverageKey: 'outdoor_event_specific', deliveredDoseFraction: 0.8 }),
-                cleanLinked[1],
-                cleanLinked[2],
-            ],
-            boundProgressResults: boundImproving,
-        });
+        const underDose = evaluateProgressionReview({ intentBlock: block, asOfDate: '2026-09-14', linkedExposures: [linked(exposures[0], outcomes[0], { coverageKey: 'outdoor_event_specific', deliveredDoseFraction: 0.8 }), cleanLinked[1], cleanLinked[2]], boundProgressResults: boundImproving });
         expect(underDose.evidenceAudit.roleRelevantExposureCount).toBe(3);
         expect(underDose.evidenceAudit.exposuresObserved).toBe(2);
         expect(underDose.action).toBe('hold');
     });
 
-    it('does not count a stale value or stale source-plan revision as current-target exposure', () => {
-        const staleValue = linked(exposures[0], outcomes[0], { prescriptionValue: 80 });
-        const staleRevision = linked(exposures[1], outcomes[1], { sourcePlanRevision: 2 });
-        const review = evaluateProgressionReview({
-            intentBlock: validBlock,
-            asOfDate: '2026-09-14',
-            linkedExposures: [staleValue, staleRevision, cleanLinked[2]],
-            boundProgressResults: boundImproving,
-        });
-        expect(review.evidenceAudit.roleRelevantExposureCount).toBe(3);
+    it('does not count stale dose or source-plan revision as current-target evidence', () => {
+        const review = evaluateProgressionReview({ intentBlock: validBlock, asOfDate: '2026-09-14', linkedExposures: [linked(exposures[0], outcomes[0], { prescriptionValue: 80 }), linked(exposures[1], outcomes[1], { sourcePlanRevision: 2 }), cleanLinked[2]], boundProgressResults: boundImproving });
         expect(review.evidenceAudit.exposuresObserved).toBe(1);
         expect(review.action).toBe('hold');
     });
 
-    it('does not count prescription-mismatched or partial work as completed current-target exposure', () => {
-        const partial = linked(exposures[0], outcomes[0], { prescriptionStatus: 'partial' });
-        const review = evaluateProgressionReview({
-            intentBlock: validBlock,
-            asOfDate: '2026-09-14',
-            linkedExposures: [partial, cleanLinked[1], cleanLinked[2]],
-            boundProgressResults: boundImproving,
-        });
-        expect(review.evidenceAudit.exposuresObserved).toBe(2);
-        expect(review.action).toBe('hold');
-    });
-
-    it('still applies adverse safety evidence from an extra partial target attempt', () => {
-        const partialExposure: PerformedExposureFact = {
-            ...exposures[0],
-            performedOccurrenceId: 'occ_partial',
-            localDate: '2026-09-11',
-        };
-        const partialReactive = linked(
-            partialExposure,
-            { ...outcomes[0], sourceSession: { ...outcomes[0].sourceSession, id: 'partial-session', date: '2026-09-11' }, status: 'reactive' },
-            { prescriptionStatus: 'partial' },
-        );
-        const review = evaluateProgressionReview({
-            intentBlock: validBlock,
-            asOfDate: '2026-09-14',
-            linkedExposures: [partialReactive, ...cleanLinked],
-            boundProgressResults: boundImproving,
-        });
-        expect(review.evidenceAudit.roleRelevantExposureCount).toBe(4);
+    it('retains partial target attempts for safety but not completed-dose credit', () => {
+        const partialExposure: PerformedExposureFact = { ...exposures[0], performedOccurrenceId: 'occ_partial', localDate: '2026-09-11' };
+        const partialReactive = linked(partialExposure, { ...outcomes[0], sourceSession: { ...outcomes[0].sourceSession, id: 'partial', date: '2026-09-11' }, status: 'reactive' }, { prescriptionStatus: 'partial' });
+        const review = evaluateProgressionReview({ intentBlock: validBlock, asOfDate: '2026-09-14', linkedExposures: [partialReactive, ...cleanLinked], boundProgressResults: boundImproving });
         expect(review.evidenceAudit.exposuresObserved).toBe(3);
         expect(review.evidenceAudit.adverseResponseCount).toBe(1);
         expect(review.action).toBe('reduce_proposal');
     });
 
-    it('requires follow-up evidence for partial/under-dose target attempts too', () => {
-        const partialExposure: PerformedExposureFact = {
-            ...exposures[0],
-            performedOccurrenceId: 'occ_partial_missing',
-            localDate: '2026-09-11',
-        };
-        const partialUnknown = linked(partialExposure, undefined, { prescriptionStatus: 'partial' });
-        const review = evaluateProgressionReview({
-            intentBlock: validBlock,
-            asOfDate: '2026-09-14',
-            linkedExposures: [partialUnknown, ...cleanLinked],
-            boundProgressResults: boundImproving,
-        });
-        expect(review.evidenceAudit.exposuresObserved).toBe(3);
+    it('requires follow-up evidence for partial target attempts too', () => {
+        const partialExposure: PerformedExposureFact = { ...exposures[0], performedOccurrenceId: 'occ_partial_missing', localDate: '2026-09-11' };
+        const review = evaluateProgressionReview({ intentBlock: validBlock, asOfDate: '2026-09-14', linkedExposures: [linked(partialExposure, undefined, { prescriptionStatus: 'partial' }), ...cleanLinked], boundProgressResults: boundImproving });
         expect(review.evidenceAudit.followUpCoveragePct).toBe(75);
         expect(review.evidenceAudit.unknownResponseCount).toBe(1);
         expect(review.action).toBe('hold');
-        expect(review.reasons[0]).toContain('unknown_response_evidence_blocks_advancement');
     });
 
-    it('deduplicates identical repeated canonical occurrence evidence', () => {
-        const review = evaluateProgressionReview({
-            intentBlock: validBlock,
-            asOfDate: '2026-09-14',
-            linkedExposures: [cleanLinked[0], cleanLinked[0], cleanLinked[1], cleanLinked[2]],
-            boundProgressResults: boundImproving,
-        });
-        expect(review.evidenceAudit.candidateExposureCount).toBe(3);
-        expect(review.evidenceAudit.ambiguousOccurrenceCount).toBe(0);
-        expect(review.evidenceAudit.exposuresObserved).toBe(3);
-        expect(review.action).toBe('advance_proposal');
+    it('deduplicates identical evidence and fails closed on conflicting duplicate evidence', () => {
+        const duplicate = evaluateProgressionReview({ intentBlock: validBlock, asOfDate: '2026-09-14', linkedExposures: [cleanLinked[0], cleanLinked[0], cleanLinked[1], cleanLinked[2]], boundProgressResults: boundImproving });
+        expect(duplicate.evidenceAudit.ambiguousOccurrenceCount).toBe(0);
+        expect(duplicate.action).toBe('advance_proposal');
+        const conflict = evaluateProgressionReview({ intentBlock: validBlock, asOfDate: '2026-09-14', linkedExposures: [cleanLinked[0], linked(exposures[0], outcomes[0], { prescriptionValue: 80 }), cleanLinked[1], cleanLinked[2]], boundProgressResults: boundImproving });
+        expect(conflict.evidenceAudit.ambiguousOccurrenceCount).toBe(1);
+        expect(conflict.action).toBe('hold');
+        expect(conflict.reasons[0]).toContain('conflicting_duplicate_occurrence_evidence');
     });
 
-    it('fails closed on conflicting duplicate evidence for the same canonical occurrence', () => {
-        const conflicting = linked(exposures[0], outcomes[0], { prescriptionValue: 80 });
-        const review = evaluateProgressionReview({
-            intentBlock: validBlock,
-            asOfDate: '2026-09-14',
-            linkedExposures: [cleanLinked[0], conflicting, cleanLinked[1], cleanLinked[2]],
-            boundProgressResults: boundImproving,
-        });
-        expect(review.evidenceAudit.candidateExposureCount).toBe(3);
-        expect(review.evidenceAudit.ambiguousOccurrenceCount).toBe(1);
-        expect(review.evidenceAudit.exposuresObserved).toBe(2);
-        expect(review.action).toBe('hold');
-        expect(review.reasons[0]).toContain('conflicting_duplicate_occurrence_evidence');
-    });
-
-    it('uses only outcomes bundled with target/allowed-role canonical occurrences', () => {
-        const unrelatedExposure: PerformedExposureFact = {
-            ...exposures[0],
-            performedOccurrenceId: 'unrelated',
-            localDate: '2026-09-11',
-        };
-        const unrelatedReactive = linked(
-            unrelatedExposure,
-            { ...outcomes[0], sourceSession: { ...outcomes[0].sourceSession, id: 'unrelated-session', date: '2026-09-11' }, status: 'reactive' },
-            { coverageKey: 'aerobic_volume' },
-        );
-        const review = evaluateProgressionReview({
-            intentBlock: validBlock,
-            asOfDate: '2026-09-14',
-            linkedExposures: [...cleanLinked, unrelatedReactive],
-            boundProgressResults: boundImproving,
-        });
+    it('unrelated outcomes do not influence target safety', () => {
+        const unrelatedExposure: PerformedExposureFact = { ...exposures[0], performedOccurrenceId: 'unrelated', localDate: '2026-09-11' };
+        const unrelatedReactive = linked(unrelatedExposure, { ...outcomes[0], sourceSession: { ...outcomes[0].sourceSession, id: 'unrelated', date: '2026-09-11' }, status: 'reactive' }, { coverageKey: 'aerobic_volume' });
+        const review = evaluateProgressionReview({ intentBlock: validBlock, asOfDate: '2026-09-14', linkedExposures: [...cleanLinked, unrelatedReactive], boundProgressResults: boundImproving });
         expect(review.evidenceAudit.adverseResponseCount).toBe(0);
         expect(review.action).toBe('advance_proposal');
     });
 
-    it('holds when role-relevant follow-up coverage is below the authored threshold', () => {
-        const lowFollowUp = cleanLinked.map((evidence, index) => index === 0
-            ? evidence
-            : { ...evidence, outcome: { ...evidence.outcome!, hasFollowUpData: false, status: 'unknown' as const } });
-        const review = evaluateProgressionReview({
-            intentBlock: validBlock,
-            asOfDate: '2026-09-14',
-            linkedExposures: lowFollowUp,
-            boundProgressResults: boundImproving,
-        });
-        expect(review.evidenceAudit.followUpCoveragePct).toBe(33);
-        expect(review.action).toBe('hold');
-        expect(review.reasons.some(reason => reason.includes('insufficient_followup_evidence'))).toBe(true);
+    it('holds on insufficient/unknown follow-up evidence', () => {
+        const lowFollowUp = cleanLinked.map((evidence, index) => index === 0 ? evidence : { ...evidence, outcome: { ...evidence.outcome!, hasFollowUpData: false, status: 'unknown' as const } });
+        const low = evaluateProgressionReview({ intentBlock: validBlock, asOfDate: '2026-09-14', linkedExposures: lowFollowUp, boundProgressResults: boundImproving });
+        expect(low.evidenceAudit.followUpCoveragePct).toBe(33);
+        expect(low.action).toBe('hold');
+        const unknown = cleanLinked.map((evidence, index) => index === 0 ? { ...evidence, outcome: { ...evidence.outcome!, status: 'unknown' as const, hasFollowUpData: true } } : evidence);
+        const unknownReview = evaluateProgressionReview({ intentBlock: validBlock, asOfDate: '2026-09-14', linkedExposures: unknown, boundProgressResults: boundImproving });
+        expect(unknownReview.evidenceAudit.unknownResponseCount).toBe(1);
+        expect(unknownReview.action).toBe('hold');
     });
 
-    it('holds on unknown outcome evidence even if the caller marks follow-up as present', () => {
-        const unknown = cleanLinked.map((evidence, index) => index === 0
-            ? { ...evidence, outcome: { ...evidence.outcome!, status: 'unknown' as const, hasFollowUpData: true } }
-            : evidence);
-        const review = evaluateProgressionReview({
-            intentBlock: validBlock,
-            asOfDate: '2026-09-14',
-            linkedExposures: unknown,
-            boundProgressResults: boundImproving,
-        });
-        expect(review.evidenceAudit.unknownResponseCount).toBe(1);
-        expect(review.action).toBe('hold');
-        expect(review.reasons[0]).toContain('unknown_response_evidence_blocks_advancement');
-    });
-
-    it('reduces on authored adverse_response reduction without a hidden adverse-count redirect threshold', () => {
-        const twoReactive = cleanLinked.map((evidence, index) => index === 0
-            ? evidence
-            : { ...evidence, outcome: { ...evidence.outcome!, status: 'reactive' as const } });
-        const review = evaluateProgressionReview({
-            intentBlock: validBlock,
-            asOfDate: '2026-09-14',
-            linkedExposures: twoReactive,
-            boundProgressResults: boundImproving,
-        });
-        expect(review.evidenceAudit.adverseResponseCount).toBe(2);
-        expect(review.action).toBe('reduce_proposal');
-        expect(review.proposedChange?.proposedValue).toBe(80);
-    });
-
-    it('redirects only when an explicit redirect trigger is authored', () => {
-        const redirectBlock: IntentBlock = {
-            ...validBlock,
-            progressionContract: {
-                ...validBlock.progressionContract!,
-                reductionAlternative: undefined,
-                redirectCriteria: { triggers: ['adverse_response'] },
-            },
-        };
-        const reactive = cleanLinked.map((evidence, index) => index === 2
-            ? { ...evidence, outcome: { ...evidence.outcome!, status: 'reactive' as const } }
-            : evidence);
-        const review = evaluateProgressionReview({
-            intentBlock: redirectBlock,
-            asOfDate: '2026-09-14',
-            linkedExposures: reactive,
-        });
-        expect(review.action).toBe('redirect');
-        expect(review.reasons[0]).toContain('adverse_response_triggers_redirect');
+    it('uses authored adverse fallback without hidden response-count thresholds', () => {
+        const reactive = cleanLinked.map((evidence, index) => index === 0 ? evidence : { ...evidence, outcome: { ...evidence.outcome!, status: 'reactive' as const } });
+        const reduced = evaluateProgressionReview({ intentBlock: validBlock, asOfDate: '2026-09-14', linkedExposures: reactive, boundProgressResults: boundImproving });
+        expect(reduced.action).toBe('reduce_proposal');
+        expect(reduced.proposedChange?.proposedValue).toBe(80);
+        const redirectBlock: IntentBlock = { ...validBlock, progressionContract: { ...validBlock.progressionContract!, reductionAlternative: undefined, redirectCriteria: { triggers: ['adverse_response'] } } };
+        expect(evaluateProgressionReview({ intentBlock: redirectBlock, asOfDate: '2026-09-14', linkedExposures: reactive }).action).toBe('redirect');
     });
 
     it('active restrictions block advancement and redirect only when explicitly authored', () => {
-        const held = evaluateProgressionReview({
-            intentBlock: validBlock,
-            asOfDate: '2026-09-14',
-            linkedExposures: cleanLinked,
-            activeRestrictions: { hasAdverseTissue: true },
-        });
-        expect(held.action).toBe('hold');
-
-        const redirectBlock: IntentBlock = {
-            ...validBlock,
-            progressionContract: {
-                ...validBlock.progressionContract!,
-                redirectCriteria: { triggers: ['active_restriction'] },
-            },
-        };
-        const redirected = evaluateProgressionReview({
-            intentBlock: redirectBlock,
-            asOfDate: '2026-09-14',
-            linkedExposures: cleanLinked,
-            activeRestrictions: { hasAdverseTissue: true },
-        });
-        expect(redirected.action).toBe('redirect');
+        expect(evaluateProgressionReview({ intentBlock: validBlock, asOfDate: '2026-09-14', linkedExposures: cleanLinked, activeRestrictions: { hasAdverseTissue: true } }).action).toBe('hold');
+        const redirectBlock: IntentBlock = { ...validBlock, progressionContract: { ...validBlock.progressionContract!, reductionAlternative: undefined, redirectCriteria: { triggers: ['active_restriction'] } } };
+        expect(evaluateProgressionReview({ intentBlock: redirectBlock, asOfDate: '2026-09-14', linkedExposures: cleanLinked, activeRestrictions: { hasAdverseTissue: true } }).action).toBe('redirect');
     });
 
-    it('holds at the maximum permitted value', () => {
-        const review = evaluateProgressionReview({
-            intentBlock: {
-                ...validBlock,
-                progressionContract: { ...validBlock.progressionContract!, currentValue: 120 },
-            },
-            asOfDate: '2026-09-14',
-            linkedExposures: cleanLinked.map(evidence => ({
-                ...evidence,
-                prescription: { ...evidence.prescription, value: 120 },
-            })),
-            boundProgressResults: boundImproving,
-        });
-        expect(review.action).toBe('hold');
-        expect(review.reasons[0]).toContain('max_permitted_value_reached');
+    it('holds at max and matches the full evaluation reference', () => {
+        const atMax = evaluateProgressionReview({ intentBlock: { ...validBlock, progressionContract: { ...validBlock.progressionContract!, currentValue: 120 } }, asOfDate: '2026-09-14', linkedExposures: cleanLinked.map(evidence => ({ ...evidence, prescription: { ...evidence.prescription, value: 120 } })), boundProgressResults: boundImproving });
+        expect(atMax.action).toBe('hold');
+        const wrongRevision: BoundProgressEvidence[] = [{ evaluationRef: { id: 'eval_spec_01', revision: 2, metricId: 'cycling_ftp' }, result: improving }];
+        const wrong = evaluateProgressionReview({ intentBlock: validBlock, asOfDate: '2026-09-14', linkedExposures: cleanLinked, boundProgressResults: wrongRevision });
+        expect(wrong.action).toBe('hold');
+        expect(wrong.reasons[0]).toContain('bound_outcome_metric_missing');
     });
 
-    it('matches the full evaluation reference, not metric id alone', () => {
-        const wrongRevision: BoundProgressEvidence[] = [{
-            evaluationRef: { id: 'eval_spec_01', revision: 2, metricId: 'cycling_ftp' },
-            result: improving,
-        }];
-        const review = evaluateProgressionReview({
-            intentBlock: validBlock,
-            asOfDate: '2026-09-14',
-            linkedExposures: cleanLinked,
-            boundProgressResults: wrongRevision,
-        });
-        expect(review.action).toBe('hold');
-        expect(review.reasons[0]).toContain('bound_outcome_metric_missing');
+    it('enforces improving outcome and does not treat unclear-within-noise as maintenance proof', () => {
+        const flat: BoundProgressEvidence[] = [{ evaluationRef: { id: 'eval_spec_01', revision: 1, metricId: 'cycling_ftp' }, result: { ...improving, status: 'unclear_within_noise', percentChange: 0.2 } }];
+        expect(evaluateProgressionReview({ intentBlock: validBlock, asOfDate: '2026-09-14', linkedExposures: cleanLinked, boundProgressResults: flat }).action).toBe('hold');
+        const maintenanceBlock: IntentBlock = { ...validBlock, objectives: [{ ...validBlock.objectives[0], intent: 'maintain', successCriteria: { evaluationRef: { id: 'eval_spec_01', revision: 1, metricId: 'cycling_ftp' }, targetTrend: 'stable', acceptableDeclineTolerancePct: 3 } }] };
+        const maintenance = evaluateProgressionReview({ intentBlock: maintenanceBlock, asOfDate: '2026-09-14', linkedExposures: cleanLinked, boundProgressResults: flat });
+        expect(maintenance.action).toBe('hold');
+        expect(maintenance.reasons[0]).toBe('stable_target_unclear_within_noise');
     });
 
-    it('enforces the authored improving target instead of treating merely non-declining as success', () => {
-        const flat: BoundProgressEvidence[] = [{
-            evaluationRef: { id: 'eval_spec_01', revision: 1, metricId: 'cycling_ftp' },
-            result: { ...improving, status: 'unclear_within_noise', percentChange: 0.2 },
-        }];
-        const review = evaluateProgressionReview({
-            intentBlock: validBlock,
-            asOfDate: '2026-09-14',
-            linkedExposures: cleanLinked,
-            boundProgressResults: flat,
-        });
-        expect(review.action).toBe('hold');
-        expect(review.reasons[0]).toContain('bound_outcome_not_improving');
+    it('requires explicit prerequisite evidence and respects max block duration', () => {
+        const prereqBlock: IntentBlock = { ...validBlock, objectives: [{ ...validBlock.objectives[0], entryPrerequisites: { requiredPriorExposures: 2, minBaselineDays: 7 } }] };
+        const prereq = evaluateProgressionReview({ intentBlock: prereqBlock, asOfDate: '2026-09-14', linkedExposures: cleanLinked, boundProgressResults: boundImproving });
+        expect(prereq.reasons).toContain('required_prior_exposure_evidence_missing');
+        const expired: IntentBlock = { ...validBlock, dateRange: { startDate: '2026-08-01', endDate: '2026-09-28' }, objectives: [{ ...validBlock.objectives[0], exitCriteria: { maxWeeksInBlock: 4 } }] };
+        expect(evaluateProgressionReview({ intentBlock: expired, asOfDate: '2026-09-14', linkedExposures: cleanLinked }).action).toBe('redirect');
     });
 
-    it('does not treat unclear-within-noise as proof of maintenance', () => {
-        const maintenanceBlock: IntentBlock = {
-            ...validBlock,
-            objectives: [{
-                ...validBlock.objectives[0],
-                intent: 'maintain',
-                successCriteria: {
-                    evaluationRef: { id: 'eval_spec_01', revision: 1, metricId: 'cycling_ftp' },
-                    targetTrend: 'stable',
-                    acceptableDeclineTolerancePct: 3,
-                },
-            }],
-        };
-        const unclear: BoundProgressEvidence[] = [{
-            evaluationRef: { id: 'eval_spec_01', revision: 1, metricId: 'cycling_ftp' },
-            result: { ...improving, status: 'unclear_within_noise', percentChange: 0.2 },
-        }];
-        const review = evaluateProgressionReview({
-            intentBlock: maintenanceBlock,
-            asOfDate: '2026-09-14',
-            linkedExposures: cleanLinked,
-            boundProgressResults: unclear,
-        });
-        expect(review.action).toBe('hold');
-        expect(review.reasons[0]).toBe('stable_target_unclear_within_noise');
-    });
-
-    it('requires explicit prerequisite evidence when the objective authored prerequisites', () => {
-        const block: IntentBlock = {
-            ...validBlock,
-            objectives: [{
-                ...validBlock.objectives[0],
-                entryPrerequisites: { requiredPriorExposures: 2, minBaselineDays: 7 },
-            }],
-        };
-        const review = evaluateProgressionReview({
-            intentBlock: block,
-            asOfDate: '2026-09-14',
-            linkedExposures: cleanLinked,
-            boundProgressResults: boundImproving,
-        });
-        expect(review.action).toBe('hold');
-        expect(review.reasons).toContain('required_prior_exposure_evidence_missing');
-        expect(review.reasons).toContain('required_baseline_duration_evidence_missing');
-    });
-
-    it('redirects when an authored maximum block duration has expired', () => {
-        const block: IntentBlock = {
-            ...validBlock,
-            dateRange: { startDate: '2026-08-01', endDate: '2026-09-28' },
-            objectives: [{
-                ...validBlock.objectives[0],
-                exitCriteria: { maxWeeksInBlock: 4 },
-            }],
-        };
-        const review = evaluateProgressionReview({
-            intentBlock: block,
-            asOfDate: '2026-09-14',
-            linkedExposures: cleanLinked,
-        });
-        expect(review.action).toBe('redirect');
-        expect(review.reasons[0]).toContain('max_block_duration_exit_reached');
-    });
-
-    it('adverse safety evidence blocks advance even when the outcome metric is improving', () => {
-        const block: IntentBlock = {
-            ...validBlock,
-            progressionContract: { ...validBlock.progressionContract!, reductionAlternative: undefined },
-        };
-        const reactive = cleanLinked.map((evidence, index) => index === 1
-            ? { ...evidence, outcome: { ...evidence.outcome!, status: 'reactive' as const } }
-            : evidence);
-        const review = evaluateProgressionReview({
-            intentBlock: block,
-            asOfDate: '2026-09-14',
-            linkedExposures: reactive,
-            boundProgressResults: boundImproving,
-        });
+    it('adverse safety evidence blocks advance even with an improving outcome', () => {
+        const block: IntentBlock = { ...validBlock, progressionContract: { ...validBlock.progressionContract!, reductionAlternative: undefined, redirectCriteria: { triggers: ['active_restriction'] } } };
+        const reactive = cleanLinked.map((evidence, index) => index === 1 ? { ...evidence, outcome: { ...evidence.outcome!, status: 'reactive' as const } } : evidence);
+        const review = evaluateProgressionReview({ intentBlock: block, asOfDate: '2026-09-14', linkedExposures: reactive, boundProgressResults: boundImproving });
         expect(review.action).toBe('hold');
         expect(review.action).not.toBe('advance_proposal');
-        expect(review.reasons[0]).toContain('adverse_safety_response_blocks_advancement');
     });
 });

--- a/app/src/engine/progressionReview.ts
+++ b/app/src/engine/progressionReview.ts
@@ -10,6 +10,7 @@ import type { ProgressResult } from '../observations/progress';
 import type { SessionOutcome } from '../responses/outcome';
 import type { CoverageCreditFact, PerformedExposureFact } from './performedTrainingFacts';
 import type {
+    BlockObjectiveDefinition,
     BlockProgressionContract,
     IntentBlock,
     TissueSeverity,
@@ -37,6 +38,7 @@ export interface ProgressionEvidenceAudit {
     windowStartDate?: string;
     windowEndDate?: string;
     candidateExposureCount: number;
+    roleRelevantExposureCount: number;
     exposuresObserved: number;
     excludedExposureCount: number;
     exposuresRequired: number;
@@ -45,6 +47,7 @@ export interface ProgressionEvidenceAudit {
     missingFollowUpCount: number;
     adverseResponseCount: number;
     cautionResponseCount: number;
+    unknownResponseCount: number;
     outcomeMetricEvaluated?: string;
     outcomeTrend?: string;
 }
@@ -62,18 +65,25 @@ export interface ProgressionReviewResult {
 export type ProgressionPrescriptionMatch = 'matched_current_target' | 'partial' | 'mismatch' | 'unknown';
 
 /**
- * One canonical occurrence with all evidence already linked to that occurrence. The caller
- * owns construction of this join from canonical stores; the evaluator verifies occurrence
- * ids/coverage and refuses to infer identity from dates or modality.
+ * One canonical occurrence with all evidence already joined to that occurrence by the caller.
+ * `coverageCredits` still carry the canonical occurrence id and are verified here. Prescription
+ * evidence pins the exact variable/value under review so a stale or different dose cannot be
+ * counted merely because it used the same modality or role.
  */
 export interface LinkedProgressionExposureEvidence {
     exposure: PerformedExposureFact;
     coverageCredits: readonly CoverageCreditFact[];
+    /** Fraction of the target dose delivered, required when an authored substitution has a
+     * `minDoseFraction` qualification. */
+    deliveredDoseFraction?: number;
     prescription: {
         status: ProgressionPrescriptionMatch;
-        definitionId?: string;
-        revision?: number;
+        sourceRevision: number;
+        sessionId?: string;
         stepId?: string;
+        variable: BlockProgressionContract['variable'];
+        unit: BlockProgressionContract['unit'];
+        value: number;
     };
     outcome?: SessionOutcome;
 }
@@ -123,6 +133,7 @@ function calendarDaysInclusive(startDate: string, endDate: string): number {
 function emptyAudit(contract?: BlockProgressionContract): ProgressionEvidenceAudit {
     return {
         candidateExposureCount: 0,
+        roleRelevantExposureCount: 0,
         exposuresObserved: 0,
         excludedExposureCount: 0,
         exposuresRequired: contract?.minCompletedExposures ?? 0,
@@ -131,6 +142,7 @@ function emptyAudit(contract?: BlockProgressionContract): ProgressionEvidenceAud
         missingFollowUpCount: 0,
         adverseResponseCount: 0,
         cautionResponseCount: 0,
+        unknownResponseCount: 0,
     };
 }
 
@@ -154,7 +166,7 @@ function result(
     };
 }
 
-function exactCoverageMatches(
+function hasExactCoverage(
     evidence: LinkedProgressionExposureEvidence,
     coverageKey: string,
 ): boolean {
@@ -165,15 +177,42 @@ function exactCoverageMatches(
     );
 }
 
+function coverageMatchesObjective(
+    evidence: LinkedProgressionExposureEvidence,
+    objective: BlockObjectiveDefinition,
+): boolean {
+    if (hasExactCoverage(evidence, objective.coverageKey)) return true;
+
+    for (const substitution of objective.allowedSubstitutions ?? []) {
+        if (substitution.targetCoverageKey !== objective.coverageKey) continue;
+        const allowedExactCoverage = substitution.allowedCoverageKeys.some(key =>
+            hasExactCoverage(evidence, key),
+        );
+        if (!allowedExactCoverage) continue;
+        if (substitution.minDoseFraction === undefined) return true;
+        if (evidence.deliveredDoseFraction !== undefined
+            && Number.isFinite(evidence.deliveredDoseFraction)
+            && evidence.deliveredDoseFraction >= substitution.minDoseFraction) {
+            return true;
+        }
+    }
+    return false;
+}
+
 function prescriptionMatchesTarget(
     evidence: LinkedProgressionExposureEvidence,
     contract: BlockProgressionContract,
 ): boolean {
-    if (evidence.prescription.status !== 'matched_current_target') return false;
+    const prescription = evidence.prescription;
+    if (prescription.status !== 'matched_current_target') return false;
+    if (!Number.isInteger(prescription.sourceRevision) || prescription.sourceRevision < 1) return false;
+    if (prescription.variable !== contract.variable) return false;
+    if (prescription.unit !== contract.unit) return false;
+    if (!Number.isFinite(prescription.value) || prescription.value !== contract.currentValue) return false;
     if (contract.targetBinding.sessionId !== undefined
-        && evidence.prescription.definitionId !== contract.targetBinding.sessionId) return false;
+        && prescription.sessionId !== contract.targetBinding.sessionId) return false;
     if (contract.targetBinding.stepId !== undefined
-        && evidence.prescription.stepId !== contract.targetBinding.stepId) return false;
+        && prescription.stepId !== contract.targetBinding.stepId) return false;
     return true;
 }
 
@@ -195,7 +234,7 @@ function redirectTrigger(contract: BlockProgressionContract, trigger: 'adverse_r
 
 function evaluatePrerequisites(
     input: ProgressionReviewInput,
-    targetObjective: IntentBlock['objectives'][number],
+    targetObjective: BlockObjectiveDefinition,
 ): string[] {
     const prerequisites = targetObjective.entryPrerequisites;
     if (!prerequisites) return [];
@@ -244,6 +283,10 @@ function outcomeSatisfiesTargetTrend(
     if (progress.status === 'meaningful_improvement' || progress.status === 'possible_improvement') {
         return { passes: true };
     }
+    // ADR-0037 explicitly says `unclear_within_noise` alone does not prove maintenance.
+    if (progress.status === 'unclear_within_noise') {
+        return { passes: false, reason: 'stable_target_unclear_within_noise' };
+    }
     if (acceptableDeclineTolerancePct === undefined || progress.percentChange === undefined) {
         return { passes: false, reason: 'stable_target_missing_comparable_decline_tolerance_evidence' };
     }
@@ -289,6 +332,9 @@ export function evaluateProgressionReview(input: ProgressionReviewInput): Progre
     if (input.asOfDate < input.intentBlock.dateRange.startDate) {
         return result('hold', ['review_before_block_start'], input, initialAudit);
     }
+    if (input.asOfDate >= input.intentBlock.dateRange.endDate) {
+        return result('redirect', ['block_interval_ended_requires_review'], input, initialAudit);
+    }
     if (input.asOfDate < input.intentBlock.reviewSchedule.nextReviewDate) {
         return result(
             'hold',
@@ -326,9 +372,7 @@ export function evaluateProgressionReview(input: ProgressionReviewInput): Progre
     const windowStartDate = rawWindowStart > input.intentBlock.dateRange.startDate
         ? rawWindowStart
         : input.intentBlock.dateRange.startDate;
-    const windowEndDate = input.asOfDate < input.intentBlock.dateRange.endDate
-        ? input.asOfDate
-        : input.intentBlock.dateRange.endDate;
+    const windowEndDate = input.asOfDate;
 
     const canonicalByOccurrence = new Map<string, LinkedProgressionExposureEvidence>();
     for (const evidence of input.linkedExposures) {
@@ -339,9 +383,11 @@ export function evaluateProgressionReview(input: ProgressionReviewInput): Progre
     }
 
     const candidates = [...canonicalByOccurrence.values()];
-    const matchingExposures = candidates.filter(evidence =>
-        exactCoverageMatches(evidence, targetObjective.coverageKey)
-        && prescriptionMatchesTarget(evidence, contract),
+    const roleRelevantExposures = candidates.filter(evidence =>
+        coverageMatchesObjective(evidence, targetObjective),
+    );
+    const matchingExposures = roleRelevantExposures.filter(evidence =>
+        prescriptionMatchesTarget(evidence, contract),
     );
 
     const exposuresRequired = Math.max(
@@ -352,10 +398,18 @@ export function evaluateProgressionReview(input: ProgressionReviewInput): Progre
     let completedWithFollowUp = 0;
     let adverseCount = 0;
     let cautionCount = 0;
+    let unknownCount = 0;
+
+    // Safety evidence from any role-relevant exposure in the observation window matters,
+    // including partial or mismatched dose attempts. Those attempts still do not count as
+    // completed current-target exposures below.
+    for (const evidence of roleRelevantExposures) {
+        if (evidence.outcome?.status === 'reactive') adverseCount++;
+        else if (evidence.outcome?.status === 'caution') cautionCount++;
+    }
     for (const evidence of matchingExposures) {
         if (evidence.outcome?.hasFollowUpData) completedWithFollowUp++;
-        if (evidence.outcome?.status === 'reactive') adverseCount++;
-        if (evidence.outcome?.status === 'caution') cautionCount++;
+        if (!evidence.outcome || evidence.outcome.status === 'unknown') unknownCount++;
     }
 
     const followUpCoveragePct = matchingExposures.length > 0
@@ -365,6 +419,7 @@ export function evaluateProgressionReview(input: ProgressionReviewInput): Progre
         windowStartDate,
         windowEndDate,
         candidateExposureCount: candidates.length,
+        roleRelevantExposureCount: roleRelevantExposures.length,
         exposuresObserved: matchingExposures.length,
         excludedExposureCount: candidates.length - matchingExposures.length,
         exposuresRequired,
@@ -373,6 +428,7 @@ export function evaluateProgressionReview(input: ProgressionReviewInput): Progre
         missingFollowUpCount: matchingExposures.length - completedWithFollowUp,
         adverseResponseCount: adverseCount,
         cautionResponseCount: cautionCount,
+        unknownResponseCount: unknownCount,
     };
 
     const evaluationRef = targetObjective.successCriteria?.evaluationRef;
@@ -441,6 +497,15 @@ export function evaluateProgressionReview(input: ProgressionReviewInput): Progre
         return result(
             'hold',
             [`insufficient_followup_evidence: coverage ${followUpCoveragePct}% < required ${contract.requiredFollowUpCoveragePct}%`],
+            input,
+            evidenceAudit,
+        );
+    }
+
+    if (unknownCount > 0) {
+        return result(
+            'hold',
+            [`unknown_response_evidence_blocks_advancement: ${unknownCount} target exposure(s)`],
             input,
             evidenceAudit,
         );

--- a/app/src/engine/progressionReview.ts
+++ b/app/src/engine/progressionReview.ts
@@ -1,29 +1,22 @@
-﻿/**
+/**
  * ADR-0037: Block Intent and Controlled Progression (H5b).
  *
- * D-CHANGE / D-AUTHORITY: Pure report-only progression review evaluator.
- * Evaluates canonical completed work, follow-up responses, and outcome evidence
- * against explicit progression contracts, deriving one of:
- * - advance_proposal
- * - hold
- * - reduce_proposal
- * - redirect
- *
- * Enforces safety monotonicity: adverse or missing follow-up evidence strictly
- * blocks advancement, regardless of favorable outcome metrics.
+ * Pure, report-only progression review. This module has no selection authority. It consumes
+ * already-linked canonical occurrence/coverage/prescription/response evidence and returns a
+ * frozen proposal/hold/reduce/redirect result. It never infers linkage from modality alone.
  */
 
-import type { SessionOutcome } from '../responses/outcome';
-import type { PerformedExposureFact } from './performedTrainingFacts';
 import type { ProgressResult } from '../observations/progress';
-import type { TrainingIntentProfile } from './models';
-import type { BlockProgressionContract, IntentBlock } from './blockIntent';
+import type { SessionOutcome } from '../responses/outcome';
+import type { CoverageCreditFact, PerformedExposureFact } from './performedTrainingFacts';
+import type {
+    BlockProgressionContract,
+    IntentBlock,
+    TissueSeverity,
+} from './blockIntent';
+import { isValidLocalDateString, validateIntentBlock } from './blockIntent';
 
-export type ProgressionReviewAction =
-    | 'advance_proposal'
-    | 'hold'
-    | 'reduce_proposal'
-    | 'redirect';
+export type ProgressionReviewAction = 'advance_proposal' | 'hold' | 'reduce_proposal' | 'redirect';
 
 export interface ProposedProgressionChange {
     targetBinding: {
@@ -35,14 +28,21 @@ export interface ProposedProgressionChange {
     unit: string;
     previousValue: number;
     proposedValue: number;
-    derivedDoseEffects?: Record<string, number>;
+    derivedDoseEffects: {
+        delta: number;
+    };
 }
 
 export interface ProgressionEvidenceAudit {
+    windowStartDate?: string;
+    windowEndDate?: string;
+    candidateExposureCount: number;
     exposuresObserved: number;
+    excludedExposureCount: number;
     exposuresRequired: number;
     followUpCoveragePct: number;
     requiredFollowUpCoveragePct: number;
+    missingFollowUpCount: number;
     adverseResponseCount: number;
     cautionResponseCount: number;
     outcomeMetricEvaluated?: string;
@@ -59,284 +59,456 @@ export interface ProgressionReviewResult {
     contractVariable?: string;
 }
 
+export type ProgressionPrescriptionMatch = 'matched_current_target' | 'partial' | 'mismatch' | 'unknown';
+
+/**
+ * One canonical occurrence with all evidence already linked to that occurrence. The caller
+ * owns construction of this join from canonical stores; the evaluator verifies occurrence
+ * ids/coverage and refuses to infer identity from dates or modality.
+ */
+export interface LinkedProgressionExposureEvidence {
+    exposure: PerformedExposureFact;
+    coverageCredits: readonly CoverageCreditFact[];
+    prescription: {
+        status: ProgressionPrescriptionMatch;
+        definitionId?: string;
+        revision?: number;
+        stepId?: string;
+    };
+    outcome?: SessionOutcome;
+}
+
+/** Progress output frozen against the exact authored evaluation reference. */
+export interface BoundProgressEvidence {
+    evaluationRef: {
+        id: string;
+        revision: number;
+        metricId: string;
+    };
+    result: ProgressResult;
+}
+
+export interface ProgressionPrerequisiteEvidence {
+    priorComparableExposures?: number;
+    baselineDays?: number;
+    observedTissueSeverities?: readonly TissueSeverity[];
+}
+
 export interface ProgressionReviewInput {
     intentBlock: IntentBlock;
-    trainingIntentProfile: Pick<TrainingIntentProfile, 'priorities' | 'weeklyCommitment'>;
     asOfDate: string;
-    /** Completed exposure facts in the relevant historical window */
-    completedExposures: readonly PerformedExposureFact[];
-    /** Linked session outcomes for completed work */
-    sessionOutcomes: readonly SessionOutcome[];
-    /** Bound metric progress results from performance testing/observations, if any */
-    progressResults?: readonly ProgressResult[];
-    /** Current active restrictions or adverse tissue signals */
+    linkedExposures: readonly LinkedProgressionExposureEvidence[];
+    boundProgressResults?: readonly BoundProgressEvidence[];
+    prerequisiteEvidence?: ProgressionPrerequisiteEvidence;
     activeRestrictions?: {
         hasAdverseTissue: boolean;
         prohibitedRegions?: readonly string[];
     };
 }
 
-/**
- * Derives a pure progression review decision from input evidence.
- */
-export function evaluateProgressionReview(input: ProgressionReviewInput): ProgressionReviewResult {
-    const {
-        intentBlock,
-        asOfDate,
-        completedExposures,
-        sessionOutcomes,
-        progressResults = [],
-        activeRestrictions,
-    } = input;
+function addCalendarDays(date: string, days: number): string {
+    const [year, month, day] = date.split('-').map(Number);
+    const instant = new Date(Date.UTC(year, month - 1, day + days));
+    return `${instant.getUTCFullYear()}-${String(instant.getUTCMonth() + 1).padStart(2, '0')}-${String(instant.getUTCDate()).padStart(2, '0')}`;
+}
 
-    const contract: BlockProgressionContract | undefined = intentBlock.progressionContract;
+function calendarDaysInclusive(startDate: string, endDate: string): number {
+    const [startYear, startMonth, startDay] = startDate.split('-').map(Number);
+    const [endYear, endMonth, endDay] = endDate.split('-').map(Number);
+    const start = Date.UTC(startYear, startMonth - 1, startDay);
+    const end = Date.UTC(endYear, endMonth - 1, endDay);
+    return Math.floor((end - start) / 86_400_000) + 1;
+}
 
-    // Default empty evidence audit
-    const emptyAudit: ProgressionEvidenceAudit = {
+function emptyAudit(contract?: BlockProgressionContract): ProgressionEvidenceAudit {
+    return {
+        candidateExposureCount: 0,
         exposuresObserved: 0,
-        exposuresRequired: contract ? contract.minCompletedExposures : 0,
+        excludedExposureCount: 0,
+        exposuresRequired: contract?.minCompletedExposures ?? 0,
         followUpCoveragePct: 0,
-        requiredFollowUpCoveragePct: contract ? contract.requiredFollowUpCoveragePct : 0,
+        requiredFollowUpCoveragePct: contract?.requiredFollowUpCoveragePct ?? 0,
+        missingFollowUpCount: 0,
         adverseResponseCount: 0,
         cautionResponseCount: 0,
     };
+}
 
-    // 1. Contract existence gate
+function result(
+    action: ProgressionReviewAction,
+    reasons: readonly string[],
+    input: ProgressionReviewInput,
+    evidenceAudit: ProgressionEvidenceAudit,
+    proposedChange?: ProposedProgressionChange,
+): ProgressionReviewResult {
+    return {
+        action,
+        reasons,
+        ...(proposedChange ? { proposedChange } : {}),
+        evidenceAudit,
+        asOfDate: input.asOfDate,
+        blockId: input.intentBlock.id,
+        ...(input.intentBlock.progressionContract
+            ? { contractVariable: input.intentBlock.progressionContract.variable }
+            : {}),
+    };
+}
+
+function exactCoverageMatches(
+    evidence: LinkedProgressionExposureEvidence,
+    coverageKey: string,
+): boolean {
+    return evidence.coverageCredits.some(credit =>
+        credit.performedOccurrenceId === evidence.exposure.performedOccurrenceId
+        && credit.coverageKey === coverageKey
+        && credit.creditKind === 'exact',
+    );
+}
+
+function prescriptionMatchesTarget(
+    evidence: LinkedProgressionExposureEvidence,
+    contract: BlockProgressionContract,
+): boolean {
+    if (evidence.prescription.status !== 'matched_current_target') return false;
+    if (contract.targetBinding.sessionId !== undefined
+        && evidence.prescription.definitionId !== contract.targetBinding.sessionId) return false;
+    if (contract.targetBinding.stepId !== undefined
+        && evidence.prescription.stepId !== contract.targetBinding.stepId) return false;
+    return true;
+}
+
+function boundProgressFor(
+    evidence: readonly BoundProgressEvidence[],
+    evaluationRef: { id: string; revision: number; metricId: string },
+): ProgressResult | undefined {
+    return evidence.find(item =>
+        item.evaluationRef.id === evaluationRef.id
+        && item.evaluationRef.revision === evaluationRef.revision
+        && item.evaluationRef.metricId === evaluationRef.metricId
+        && item.result.metricId === evaluationRef.metricId,
+    )?.result;
+}
+
+function redirectTrigger(contract: BlockProgressionContract, trigger: 'adverse_response' | 'active_restriction'): boolean {
+    return contract.redirectCriteria?.triggers.includes(trigger) === true;
+}
+
+function evaluatePrerequisites(
+    input: ProgressionReviewInput,
+    targetObjective: IntentBlock['objectives'][number],
+): string[] {
+    const prerequisites = targetObjective.entryPrerequisites;
+    if (!prerequisites) return [];
+    const evidence = input.prerequisiteEvidence;
+    const reasons: string[] = [];
+
+    if (prerequisites.requiredPriorExposures !== undefined) {
+        if (evidence?.priorComparableExposures === undefined) {
+            reasons.push('required_prior_exposure_evidence_missing');
+        } else if (evidence.priorComparableExposures < prerequisites.requiredPriorExposures) {
+            reasons.push(`insufficient_prior_exposures: observed ${evidence.priorComparableExposures} < required ${prerequisites.requiredPriorExposures}`);
+        }
+    }
+    if (prerequisites.minBaselineDays !== undefined) {
+        if (evidence?.baselineDays === undefined) {
+            reasons.push('required_baseline_duration_evidence_missing');
+        } else if (evidence.baselineDays < prerequisites.minBaselineDays) {
+            reasons.push(`insufficient_baseline_days: observed ${evidence.baselineDays} < required ${prerequisites.minBaselineDays}`);
+        }
+    }
+    if (prerequisites.prohibitedTissueSeverities?.length) {
+        if (!evidence?.observedTissueSeverities) {
+            reasons.push('required_tissue_prerequisite_evidence_missing');
+        } else {
+            const prohibited = evidence.observedTissueSeverities.find(severity =>
+                prerequisites.prohibitedTissueSeverities?.includes(severity),
+            );
+            if (prohibited) reasons.push(`prohibited_tissue_severity_present: ${prohibited}`);
+        }
+    }
+    return reasons;
+}
+
+function outcomeSatisfiesTargetTrend(
+    progress: ProgressResult,
+    targetTrend: 'stable' | 'improving' | undefined,
+    acceptableDeclineTolerancePct: number | undefined,
+): { passes: boolean; reason?: string } {
+    if (targetTrend === undefined) return { passes: true };
+    if (targetTrend === 'improving') {
+        return progress.status === 'meaningful_improvement' || progress.status === 'possible_improvement'
+            ? { passes: true }
+            : { passes: false, reason: `bound_outcome_not_improving: status ${progress.status}` };
+    }
+
+    if (progress.status === 'meaningful_improvement' || progress.status === 'possible_improvement') {
+        return { passes: true };
+    }
+    if (acceptableDeclineTolerancePct === undefined || progress.percentChange === undefined) {
+        return { passes: false, reason: 'stable_target_missing_comparable_decline_tolerance_evidence' };
+    }
+    if (Math.abs(progress.percentChange) <= acceptableDeclineTolerancePct) {
+        return { passes: true };
+    }
+    return {
+        passes: false,
+        reason: `stable_target_outside_tolerance: |${progress.percentChange}%| > ${acceptableDeclineTolerancePct}%`,
+    };
+}
+
+/** Derives a pure report-only review from frozen linked evidence. */
+export function evaluateProgressionReview(input: ProgressionReviewInput): ProgressionReviewResult {
+    const contract = input.intentBlock.progressionContract;
+    const initialAudit = emptyAudit(contract);
+
+    if (!isValidLocalDateString(input.asOfDate)) {
+        return result('hold', ['invalid_review_as_of_date'], input, initialAudit);
+    }
+
+    const validation = validateIntentBlock(input.intentBlock);
+    if (!validation.valid) {
+        return result(
+            'hold',
+            ['invalid_intent_block', ...validation.issues.map(issue => `validation:${issue.code}`)],
+            input,
+            initialAudit,
+        );
+    }
+
     if (!contract) {
-        return {
-            action: 'hold',
-            reasons: ['no_progression_contract_defined'],
-            evidenceAudit: emptyAudit,
-            asOfDate,
-            blockId: intentBlock.id,
-        };
+        return result('hold', ['no_progression_contract_defined'], input, initialAudit);
     }
 
-    // 2. Find matching target objective
-    const targetObj = intentBlock.objectives.find(o => o.id === contract.targetBinding.objectiveId);
-    if (!targetObj) {
-        return {
-            action: 'hold',
-            reasons: ['target_objective_not_found'],
-            evidenceAudit: emptyAudit,
-            asOfDate,
-            blockId: intentBlock.id,
-            contractVariable: contract.variable,
-        };
+    const targetObjective = input.intentBlock.objectives.find(objective =>
+        objective.id === contract.targetBinding.objectiveId,
+    );
+    if (!targetObjective) {
+        return result('hold', ['target_objective_not_found'], input, initialAudit);
     }
 
-    // 3. Cadence timing check
-    if (intentBlock.reviewSchedule && asOfDate < intentBlock.reviewSchedule.nextReviewDate) {
-        return {
-            action: 'hold',
-            reasons: [`review_cadence_not_reached: asOfDate ${asOfDate} < nextReviewDate ${intentBlock.reviewSchedule.nextReviewDate}`],
-            evidenceAudit: emptyAudit,
-            asOfDate,
-            blockId: intentBlock.id,
-            contractVariable: contract.variable,
-        };
+    if (input.asOfDate < input.intentBlock.dateRange.startDate) {
+        return result('hold', ['review_before_block_start'], input, initialAudit);
+    }
+    if (input.asOfDate < input.intentBlock.reviewSchedule.nextReviewDate) {
+        return result(
+            'hold',
+            [`review_cadence_not_reached: asOfDate ${input.asOfDate} < nextReviewDate ${input.intentBlock.reviewSchedule.nextReviewDate}`],
+            input,
+            initialAudit,
+        );
     }
 
-    // 4. Filter completed exposures relevant to this target within the observation window
-    const windowExposures = completedExposures.filter(exp => {
-        if (exp.localDate > asOfDate) return false;
-        if (targetObj.sport === 'cycling' && exp.modality !== 'Cycling') return false;
-        if (targetObj.sport === 'strength' && exp.modality !== 'Strength') return false;
-        if (targetObj.sport === 'running' && exp.modality !== 'Running') return false;
-        return true;
-    });
+    const prerequisiteReasons = evaluatePrerequisites(input, targetObjective);
+    if (prerequisiteReasons.length > 0) {
+        return result('hold', prerequisiteReasons, input, initialAudit);
+    }
 
-    const exposuresObserved = windowExposures.length;
+    const elapsedDays = calendarDaysInclusive(input.intentBlock.dateRange.startDate, input.asOfDate);
+    if (targetObjective.exitCriteria?.maxWeeksInBlock !== undefined
+        && elapsedDays > targetObjective.exitCriteria.maxWeeksInBlock * 7) {
+        return result(
+            'redirect',
+            [`max_block_duration_exit_reached: ${elapsedDays} days > ${targetObjective.exitCriteria.maxWeeksInBlock * 7}`],
+            input,
+            initialAudit,
+        );
+    }
 
-    // 5. Match session outcomes for window exposures
+    if (input.activeRestrictions?.hasAdverseTissue) {
+        const audit = { ...initialAudit, adverseResponseCount: 1 };
+        if (redirectTrigger(contract, 'active_restriction')) {
+            return result('redirect', ['active_restriction_triggers_redirect'], input, audit);
+        }
+        return result('hold', ['active_restriction_blocks_advancement'], input, audit);
+    }
+
+    const rawWindowStart = addCalendarDays(input.asOfDate, -(contract.observationWindowDays - 1));
+    const windowStartDate = rawWindowStart > input.intentBlock.dateRange.startDate
+        ? rawWindowStart
+        : input.intentBlock.dateRange.startDate;
+    const windowEndDate = input.asOfDate < input.intentBlock.dateRange.endDate
+        ? input.asOfDate
+        : input.intentBlock.dateRange.endDate;
+
+    const canonicalByOccurrence = new Map<string, LinkedProgressionExposureEvidence>();
+    for (const evidence of input.linkedExposures) {
+        const occurrenceId = evidence.exposure.performedOccurrenceId;
+        if (!occurrenceId) continue;
+        if (evidence.exposure.localDate < windowStartDate || evidence.exposure.localDate > windowEndDate) continue;
+        if (!canonicalByOccurrence.has(occurrenceId)) canonicalByOccurrence.set(occurrenceId, evidence);
+    }
+
+    const candidates = [...canonicalByOccurrence.values()];
+    const matchingExposures = candidates.filter(evidence =>
+        exactCoverageMatches(evidence, targetObjective.coverageKey)
+        && prescriptionMatchesTarget(evidence, contract),
+    );
+
+    const exposuresRequired = Math.max(
+        contract.minCompletedExposures,
+        targetObjective.successCriteria?.minCompletedExposures ?? 0,
+    );
+
     let completedWithFollowUp = 0;
     let adverseCount = 0;
     let cautionCount = 0;
-
-    for (const outcome of sessionOutcomes) {
-        if (outcome.hasFollowUpData) {
-            completedWithFollowUp++;
-        }
-        if (outcome.status === 'reactive') {
-            adverseCount++;
-        } else if (outcome.status === 'caution') {
-            cautionCount++;
-        }
+    for (const evidence of matchingExposures) {
+        if (evidence.outcome?.hasFollowUpData) completedWithFollowUp++;
+        if (evidence.outcome?.status === 'reactive') adverseCount++;
+        if (evidence.outcome?.status === 'caution') cautionCount++;
     }
 
-    // Also consider active restrictions as adverse tissue signal
-    if (activeRestrictions?.hasAdverseTissue) {
-        adverseCount++;
-    }
-
-    const followUpCoveragePct = exposuresObserved > 0
-        ? Math.min(100, Math.round((completedWithFollowUp / exposuresObserved) * 100))
+    const followUpCoveragePct = matchingExposures.length > 0
+        ? Math.min(100, Math.round((completedWithFollowUp / matchingExposures.length) * 100))
         : 0;
-
     const evidenceAudit: ProgressionEvidenceAudit = {
-        exposuresObserved,
-        exposuresRequired: contract.minCompletedExposures,
+        windowStartDate,
+        windowEndDate,
+        candidateExposureCount: candidates.length,
+        exposuresObserved: matchingExposures.length,
+        excludedExposureCount: candidates.length - matchingExposures.length,
+        exposuresRequired,
         followUpCoveragePct,
         requiredFollowUpCoveragePct: contract.requiredFollowUpCoveragePct,
+        missingFollowUpCount: matchingExposures.length - completedWithFollowUp,
         adverseResponseCount: adverseCount,
         cautionResponseCount: cautionCount,
     };
 
-    // Check outcome evaluation progress if specified in objective success criteria
-    if (targetObj.successCriteria?.evaluationRef) {
-        const matchingProgress = progressResults.find(
-            p => p.metricId === targetObj.successCriteria?.evaluationRef?.metricId,
-        );
-        if (matchingProgress) {
-            evidenceAudit.outcomeMetricEvaluated = matchingProgress.metricId;
-            evidenceAudit.outcomeTrend = matchingProgress.status;
-        }
+    const evaluationRef = targetObjective.successCriteria?.evaluationRef;
+    const boundProgress = evaluationRef
+        ? boundProgressFor(input.boundProgressResults ?? [], evaluationRef)
+        : undefined;
+    if (evaluationRef && boundProgress) {
+        evidenceAudit.outcomeMetricEvaluated = boundProgress.metricId;
+        evidenceAudit.outcomeTrend = boundProgress.status;
     }
 
-    // 6. Hard safety & adverse response check (Takes strict precedence over advancement!)
+    // Safety-monotonic evidence always wins over favorable outcomes.
     if (adverseCount > 0) {
-        if (adverseCount >= 2 || (activeRestrictions && activeRestrictions.hasAdverseTissue)) {
-            return {
-                action: 'redirect',
-                reasons: [`adverse_safety_response_detected: ${adverseCount} adverse signals`],
+        if (redirectTrigger(contract, 'adverse_response')) {
+            return result(
+                'redirect',
+                [`adverse_response_triggers_redirect: ${adverseCount} reactive outcome(s)`],
+                input,
                 evidenceAudit,
-                asOfDate,
-                blockId: intentBlock.id,
-                contractVariable: contract.variable,
-            };
-        }
-
-        if (contract.reductionAlternative) {
-            const reducedVal = Math.max(
-                contract.permittedRange.min,
-                contract.currentValue - contract.reductionAlternative.decrement,
             );
-            return {
-                action: 'reduce_proposal',
-                reasons: [`adverse_response_triggers_reduction: ${adverseCount} adverse signal(s)`],
-                proposedChange: {
+        }
+        if (contract.reductionAlternative?.trigger === 'adverse_response') {
+            const proposedValue = contract.currentValue - contract.reductionAlternative.decrement;
+            return result(
+                'reduce_proposal',
+                [`adverse_response_triggers_reduction: ${adverseCount} reactive outcome(s)`],
+                input,
+                evidenceAudit,
+                {
                     targetBinding: contract.targetBinding,
                     variable: contract.variable,
                     unit: contract.unit,
                     previousValue: contract.currentValue,
-                    proposedValue: reducedVal,
+                    proposedValue,
+                    derivedDoseEffects: { delta: proposedValue - contract.currentValue },
                 },
-                evidenceAudit,
-                asOfDate,
-                blockId: intentBlock.id,
-                contractVariable: contract.variable,
-            };
+            );
         }
-
-        return {
-            action: 'hold',
-            reasons: [`adverse_safety_response_blocks_advancement: ${adverseCount} reactive outcome(s)`],
+        return result(
+            'hold',
+            [`adverse_safety_response_blocks_advancement: ${adverseCount} reactive outcome(s)`],
+            input,
             evidenceAudit,
-            asOfDate,
-            blockId: intentBlock.id,
-            contractVariable: contract.variable,
-        };
+        );
     }
 
     if (cautionCount > 0) {
-        return {
-            action: 'hold',
-            reasons: [`cautionary_tissue_response_blocks_advancement: ${cautionCount} caution outcome(s)`],
+        return result(
+            'hold',
+            [`cautionary_tissue_response_blocks_advancement: ${cautionCount} caution outcome(s)`],
+            input,
             evidenceAudit,
-            asOfDate,
-            blockId: intentBlock.id,
-            contractVariable: contract.variable,
-        };
+        );
     }
 
-    // 7. Exposure quantity check
-    if (exposuresObserved < contract.minCompletedExposures) {
-        return {
-            action: 'hold',
-            reasons: [`insufficient_completed_exposures: observed ${exposuresObserved} < required ${contract.minCompletedExposures}`],
+    if (matchingExposures.length < exposuresRequired) {
+        return result(
+            'hold',
+            [`insufficient_completed_exposures: observed ${matchingExposures.length} < required ${exposuresRequired}`],
+            input,
             evidenceAudit,
-            asOfDate,
-            blockId: intentBlock.id,
-            contractVariable: contract.variable,
-        };
+        );
     }
 
-    // 8. Follow-up coverage check
     if (followUpCoveragePct < contract.requiredFollowUpCoveragePct) {
-        return {
-            action: 'hold',
-            reasons: [`insufficient_followup_evidence: coverage ${followUpCoveragePct}% < required ${contract.requiredFollowUpCoveragePct}%`],
+        return result(
+            'hold',
+            [`insufficient_followup_evidence: coverage ${followUpCoveragePct}% < required ${contract.requiredFollowUpCoveragePct}%`],
+            input,
             evidenceAudit,
-            asOfDate,
-            blockId: intentBlock.id,
-            contractVariable: contract.variable,
-        };
+        );
     }
 
-    // 9. Boundary-at-maximum check
     if (contract.currentValue >= contract.permittedRange.max) {
-        return {
-            action: 'hold',
-            reasons: [`max_permitted_value_reached: currentValue ${contract.currentValue} >= max ${contract.permittedRange.max}`],
+        return result(
+            'hold',
+            [`max_permitted_value_reached: currentValue ${contract.currentValue} >= max ${contract.permittedRange.max}`],
+            input,
             evidenceAudit,
-            asOfDate,
-            blockId: intentBlock.id,
-            contractVariable: contract.variable,
-        };
+        );
     }
 
-    // 10. Outcome metric check (if specified)
-    if (targetObj.successCriteria?.evaluationRef) {
-        const metricId = targetObj.successCriteria.evaluationRef.metricId;
-        const matchingProgress = progressResults.find(p => p.metricId === metricId);
-        if (!matchingProgress) {
-            return {
-                action: 'hold',
-                reasons: [`bound_outcome_metric_missing: no progress result for ${metricId}`],
+    if (evaluationRef) {
+        if (!boundProgress) {
+            return result(
+                'hold',
+                [`bound_outcome_metric_missing: no frozen progress result for ${evaluationRef.id}@${evaluationRef.revision}/${evaluationRef.metricId}`],
+                input,
                 evidenceAudit,
-                asOfDate,
-                blockId: intentBlock.id,
-                contractVariable: contract.variable,
-            };
+            );
         }
-        if (!matchingProgress.comparable || matchingProgress.status === 'non_comparable') {
-            return {
-                action: 'hold',
-                reasons: [`bound_outcome_metric_non_comparable: ${metricId} is non-comparable`],
+        if (!boundProgress.comparable || boundProgress.status === 'non_comparable' || boundProgress.status === 'insufficient_evidence') {
+            return result(
+                'hold',
+                [`bound_outcome_metric_non_comparable: ${evaluationRef.metricId} has status ${boundProgress.status}`],
+                input,
                 evidenceAudit,
-                asOfDate,
-                blockId: intentBlock.id,
-                contractVariable: contract.variable,
-            };
+            );
         }
-        if (matchingProgress.status === 'meaningful_decline' || matchingProgress.status === 'possible_decline') {
-            return {
-                action: 'hold',
-                reasons: [`bound_outcome_metric_declining: ${metricId} has status ${matchingProgress.status}`],
-                evidenceAudit,
-                asOfDate,
-                blockId: intentBlock.id,
-                contractVariable: contract.variable,
-            };
+
+        const trend = outcomeSatisfiesTargetTrend(
+            boundProgress,
+            targetObjective.successCriteria?.targetTrend,
+            targetObjective.successCriteria?.acceptableDeclineTolerancePct,
+        );
+        if (!trend.passes) {
+            const stagnationWeeks = targetObjective.exitCriteria?.stagnationReviewAfterWeeks;
+            if (
+                targetObjective.intent === 'develop'
+                && stagnationWeeks !== undefined
+                && elapsedDays > stagnationWeeks * 7
+            ) {
+                return result(
+                    'redirect',
+                    [`stagnation_review_due_after_${stagnationWeeks}_weeks`, ...(trend.reason ? [trend.reason] : [])],
+                    input,
+                    evidenceAudit,
+                );
+            }
+            return result('hold', [trend.reason ?? 'bound_outcome_target_not_satisfied'], input, evidenceAudit);
         }
     }
 
-    // 11. All criteria met: advance proposal with bounded increment
     const proposedValue = Math.min(contract.permittedRange.max, contract.currentValue + contract.increment);
-
-    return {
-        action: 'advance_proposal',
-        reasons: ['all_progression_prerequisites_and_evidence_criteria_satisfied'],
-        proposedChange: {
+    return result(
+        'advance_proposal',
+        ['all_progression_prerequisites_and_evidence_criteria_satisfied'],
+        input,
+        evidenceAudit,
+        {
             targetBinding: contract.targetBinding,
             variable: contract.variable,
             unit: contract.unit,
             previousValue: contract.currentValue,
             proposedValue,
+            derivedDoseEffects: { delta: proposedValue - contract.currentValue },
         },
-        evidenceAudit,
-        asOfDate,
-        blockId: intentBlock.id,
-        contractVariable: contract.variable,
-    };
+    );
 }

--- a/app/src/engine/progressionReview.ts
+++ b/app/src/engine/progressionReview.ts
@@ -1,0 +1,342 @@
+﻿/**
+ * ADR-0037: Block Intent and Controlled Progression (H5b).
+ *
+ * D-CHANGE / D-AUTHORITY: Pure report-only progression review evaluator.
+ * Evaluates canonical completed work, follow-up responses, and outcome evidence
+ * against explicit progression contracts, deriving one of:
+ * - advance_proposal
+ * - hold
+ * - reduce_proposal
+ * - redirect
+ *
+ * Enforces safety monotonicity: adverse or missing follow-up evidence strictly
+ * blocks advancement, regardless of favorable outcome metrics.
+ */
+
+import type { SessionOutcome } from '../responses/outcome';
+import type { PerformedExposureFact } from './performedTrainingFacts';
+import type { ProgressResult } from '../observations/progress';
+import type { TrainingIntentProfile } from './models';
+import type { BlockProgressionContract, IntentBlock } from './blockIntent';
+
+export type ProgressionReviewAction =
+    | 'advance_proposal'
+    | 'hold'
+    | 'reduce_proposal'
+    | 'redirect';
+
+export interface ProposedProgressionChange {
+    targetBinding: {
+        objectiveId: string;
+        sessionId?: string;
+        stepId?: string;
+    };
+    variable: string;
+    unit: string;
+    previousValue: number;
+    proposedValue: number;
+    derivedDoseEffects?: Record<string, number>;
+}
+
+export interface ProgressionEvidenceAudit {
+    exposuresObserved: number;
+    exposuresRequired: number;
+    followUpCoveragePct: number;
+    requiredFollowUpCoveragePct: number;
+    adverseResponseCount: number;
+    cautionResponseCount: number;
+    outcomeMetricEvaluated?: string;
+    outcomeTrend?: string;
+}
+
+export interface ProgressionReviewResult {
+    action: ProgressionReviewAction;
+    reasons: readonly string[];
+    proposedChange?: ProposedProgressionChange;
+    evidenceAudit: ProgressionEvidenceAudit;
+    asOfDate: string;
+    blockId: string;
+    contractVariable?: string;
+}
+
+export interface ProgressionReviewInput {
+    intentBlock: IntentBlock;
+    trainingIntentProfile: Pick<TrainingIntentProfile, 'priorities' | 'weeklyCommitment'>;
+    asOfDate: string;
+    /** Completed exposure facts in the relevant historical window */
+    completedExposures: readonly PerformedExposureFact[];
+    /** Linked session outcomes for completed work */
+    sessionOutcomes: readonly SessionOutcome[];
+    /** Bound metric progress results from performance testing/observations, if any */
+    progressResults?: readonly ProgressResult[];
+    /** Current active restrictions or adverse tissue signals */
+    activeRestrictions?: {
+        hasAdverseTissue: boolean;
+        prohibitedRegions?: readonly string[];
+    };
+}
+
+/**
+ * Derives a pure progression review decision from input evidence.
+ */
+export function evaluateProgressionReview(input: ProgressionReviewInput): ProgressionReviewResult {
+    const {
+        intentBlock,
+        asOfDate,
+        completedExposures,
+        sessionOutcomes,
+        progressResults = [],
+        activeRestrictions,
+    } = input;
+
+    const contract: BlockProgressionContract | undefined = intentBlock.progressionContract;
+
+    // Default empty evidence audit
+    const emptyAudit: ProgressionEvidenceAudit = {
+        exposuresObserved: 0,
+        exposuresRequired: contract ? contract.minCompletedExposures : 0,
+        followUpCoveragePct: 0,
+        requiredFollowUpCoveragePct: contract ? contract.requiredFollowUpCoveragePct : 0,
+        adverseResponseCount: 0,
+        cautionResponseCount: 0,
+    };
+
+    // 1. Contract existence gate
+    if (!contract) {
+        return {
+            action: 'hold',
+            reasons: ['no_progression_contract_defined'],
+            evidenceAudit: emptyAudit,
+            asOfDate,
+            blockId: intentBlock.id,
+        };
+    }
+
+    // 2. Find matching target objective
+    const targetObj = intentBlock.objectives.find(o => o.id === contract.targetBinding.objectiveId);
+    if (!targetObj) {
+        return {
+            action: 'hold',
+            reasons: ['target_objective_not_found'],
+            evidenceAudit: emptyAudit,
+            asOfDate,
+            blockId: intentBlock.id,
+            contractVariable: contract.variable,
+        };
+    }
+
+    // 3. Cadence timing check
+    if (intentBlock.reviewSchedule && asOfDate < intentBlock.reviewSchedule.nextReviewDate) {
+        return {
+            action: 'hold',
+            reasons: [`review_cadence_not_reached: asOfDate ${asOfDate} < nextReviewDate ${intentBlock.reviewSchedule.nextReviewDate}`],
+            evidenceAudit: emptyAudit,
+            asOfDate,
+            blockId: intentBlock.id,
+            contractVariable: contract.variable,
+        };
+    }
+
+    // 4. Filter completed exposures relevant to this target within the observation window
+    const windowExposures = completedExposures.filter(exp => {
+        if (exp.localDate > asOfDate) return false;
+        if (targetObj.sport === 'cycling' && exp.modality !== 'Cycling') return false;
+        if (targetObj.sport === 'strength' && exp.modality !== 'Strength') return false;
+        if (targetObj.sport === 'running' && exp.modality !== 'Running') return false;
+        return true;
+    });
+
+    const exposuresObserved = windowExposures.length;
+
+    // 5. Match session outcomes for window exposures
+    let completedWithFollowUp = 0;
+    let adverseCount = 0;
+    let cautionCount = 0;
+
+    for (const outcome of sessionOutcomes) {
+        if (outcome.hasFollowUpData) {
+            completedWithFollowUp++;
+        }
+        if (outcome.status === 'reactive') {
+            adverseCount++;
+        } else if (outcome.status === 'caution') {
+            cautionCount++;
+        }
+    }
+
+    // Also consider active restrictions as adverse tissue signal
+    if (activeRestrictions?.hasAdverseTissue) {
+        adverseCount++;
+    }
+
+    const followUpCoveragePct = exposuresObserved > 0
+        ? Math.min(100, Math.round((completedWithFollowUp / exposuresObserved) * 100))
+        : 0;
+
+    const evidenceAudit: ProgressionEvidenceAudit = {
+        exposuresObserved,
+        exposuresRequired: contract.minCompletedExposures,
+        followUpCoveragePct,
+        requiredFollowUpCoveragePct: contract.requiredFollowUpCoveragePct,
+        adverseResponseCount: adverseCount,
+        cautionResponseCount: cautionCount,
+    };
+
+    // Check outcome evaluation progress if specified in objective success criteria
+    if (targetObj.successCriteria?.evaluationRef) {
+        const matchingProgress = progressResults.find(
+            p => p.metricId === targetObj.successCriteria?.evaluationRef?.metricId,
+        );
+        if (matchingProgress) {
+            evidenceAudit.outcomeMetricEvaluated = matchingProgress.metricId;
+            evidenceAudit.outcomeTrend = matchingProgress.status;
+        }
+    }
+
+    // 6. Hard safety & adverse response check (Takes strict precedence over advancement!)
+    if (adverseCount > 0) {
+        if (adverseCount >= 2 || (activeRestrictions && activeRestrictions.hasAdverseTissue)) {
+            return {
+                action: 'redirect',
+                reasons: [`adverse_safety_response_detected: ${adverseCount} adverse signals`],
+                evidenceAudit,
+                asOfDate,
+                blockId: intentBlock.id,
+                contractVariable: contract.variable,
+            };
+        }
+
+        if (contract.reductionAlternative) {
+            const reducedVal = Math.max(
+                contract.permittedRange.min,
+                contract.currentValue - contract.reductionAlternative.decrement,
+            );
+            return {
+                action: 'reduce_proposal',
+                reasons: [`adverse_response_triggers_reduction: ${adverseCount} adverse signal(s)`],
+                proposedChange: {
+                    targetBinding: contract.targetBinding,
+                    variable: contract.variable,
+                    unit: contract.unit,
+                    previousValue: contract.currentValue,
+                    proposedValue: reducedVal,
+                },
+                evidenceAudit,
+                asOfDate,
+                blockId: intentBlock.id,
+                contractVariable: contract.variable,
+            };
+        }
+
+        return {
+            action: 'hold',
+            reasons: [`adverse_safety_response_blocks_advancement: ${adverseCount} reactive outcome(s)`],
+            evidenceAudit,
+            asOfDate,
+            blockId: intentBlock.id,
+            contractVariable: contract.variable,
+        };
+    }
+
+    if (cautionCount > 0) {
+        return {
+            action: 'hold',
+            reasons: [`cautionary_tissue_response_blocks_advancement: ${cautionCount} caution outcome(s)`],
+            evidenceAudit,
+            asOfDate,
+            blockId: intentBlock.id,
+            contractVariable: contract.variable,
+        };
+    }
+
+    // 7. Exposure quantity check
+    if (exposuresObserved < contract.minCompletedExposures) {
+        return {
+            action: 'hold',
+            reasons: [`insufficient_completed_exposures: observed ${exposuresObserved} < required ${contract.minCompletedExposures}`],
+            evidenceAudit,
+            asOfDate,
+            blockId: intentBlock.id,
+            contractVariable: contract.variable,
+        };
+    }
+
+    // 8. Follow-up coverage check
+    if (followUpCoveragePct < contract.requiredFollowUpCoveragePct) {
+        return {
+            action: 'hold',
+            reasons: [`insufficient_followup_evidence: coverage ${followUpCoveragePct}% < required ${contract.requiredFollowUpCoveragePct}%`],
+            evidenceAudit,
+            asOfDate,
+            blockId: intentBlock.id,
+            contractVariable: contract.variable,
+        };
+    }
+
+    // 9. Boundary-at-maximum check
+    if (contract.currentValue >= contract.permittedRange.max) {
+        return {
+            action: 'hold',
+            reasons: [`max_permitted_value_reached: currentValue ${contract.currentValue} >= max ${contract.permittedRange.max}`],
+            evidenceAudit,
+            asOfDate,
+            blockId: intentBlock.id,
+            contractVariable: contract.variable,
+        };
+    }
+
+    // 10. Outcome metric check (if specified)
+    if (targetObj.successCriteria?.evaluationRef) {
+        const metricId = targetObj.successCriteria.evaluationRef.metricId;
+        const matchingProgress = progressResults.find(p => p.metricId === metricId);
+        if (!matchingProgress) {
+            return {
+                action: 'hold',
+                reasons: [`bound_outcome_metric_missing: no progress result for ${metricId}`],
+                evidenceAudit,
+                asOfDate,
+                blockId: intentBlock.id,
+                contractVariable: contract.variable,
+            };
+        }
+        if (!matchingProgress.comparable || matchingProgress.status === 'non_comparable') {
+            return {
+                action: 'hold',
+                reasons: [`bound_outcome_metric_non_comparable: ${metricId} is non-comparable`],
+                evidenceAudit,
+                asOfDate,
+                blockId: intentBlock.id,
+                contractVariable: contract.variable,
+            };
+        }
+        if (matchingProgress.status === 'meaningful_decline' || matchingProgress.status === 'possible_decline') {
+            return {
+                action: 'hold',
+                reasons: [`bound_outcome_metric_declining: ${metricId} has status ${matchingProgress.status}`],
+                evidenceAudit,
+                asOfDate,
+                blockId: intentBlock.id,
+                contractVariable: contract.variable,
+            };
+        }
+    }
+
+    // 11. All criteria met: advance proposal with bounded increment
+    const proposedValue = Math.min(contract.permittedRange.max, contract.currentValue + contract.increment);
+
+    return {
+        action: 'advance_proposal',
+        reasons: ['all_progression_prerequisites_and_evidence_criteria_satisfied'],
+        proposedChange: {
+            targetBinding: contract.targetBinding,
+            variable: contract.variable,
+            unit: contract.unit,
+            previousValue: contract.currentValue,
+            proposedValue,
+        },
+        evidenceAudit,
+        asOfDate,
+        blockId: intentBlock.id,
+        contractVariable: contract.variable,
+    };
+}

--- a/app/src/engine/progressionReview.ts
+++ b/app/src/engine/progressionReview.ts
@@ -41,6 +41,7 @@ export interface ProgressionEvidenceAudit {
     roleRelevantExposureCount: number;
     exposuresObserved: number;
     excludedExposureCount: number;
+    ambiguousOccurrenceCount: number;
     exposuresRequired: number;
     followUpCoveragePct: number;
     requiredFollowUpCoveragePct: number;
@@ -67,8 +68,8 @@ export type ProgressionPrescriptionMatch = 'matched_current_target' | 'partial' 
 /**
  * One canonical occurrence with all evidence already joined to that occurrence by the caller.
  * `coverageCredits` still carry the canonical occurrence id and are verified here. Prescription
- * evidence pins the exact variable/value under review so a stale or different dose cannot be
- * counted merely because it used the same modality or role.
+ * evidence pins the exact source-plan revision and variable/value under review so stale or
+ * different-dose work cannot count merely because it used the same modality or role.
  */
 export interface LinkedProgressionExposureEvidence {
     exposure: PerformedExposureFact;
@@ -78,7 +79,7 @@ export interface LinkedProgressionExposureEvidence {
     deliveredDoseFraction?: number;
     prescription: {
         status: ProgressionPrescriptionMatch;
-        sourceRevision: number;
+        sourcePlanRevision: number;
         sessionId?: string;
         stepId?: string;
         variable: BlockProgressionContract['variable'];
@@ -136,6 +137,7 @@ function emptyAudit(contract?: BlockProgressionContract): ProgressionEvidenceAud
         roleRelevantExposureCount: 0,
         exposuresObserved: 0,
         excludedExposureCount: 0,
+        ambiguousOccurrenceCount: 0,
         exposuresRequired: contract?.minCompletedExposures ?? 0,
         followUpCoveragePct: 0,
         requiredFollowUpCoveragePct: contract?.requiredFollowUpCoveragePct ?? 0,
@@ -177,7 +179,20 @@ function hasExactCoverage(
     );
 }
 
-function coverageMatchesObjective(
+/** Role relevance is intentionally broader than dose qualification: a partial/under-dose
+ * target or allowed-substitution attempt can still carry safety/follow-up evidence. */
+function coverageIsTargetOrAllowedRole(
+    evidence: LinkedProgressionExposureEvidence,
+    objective: BlockObjectiveDefinition,
+): boolean {
+    if (hasExactCoverage(evidence, objective.coverageKey)) return true;
+    return (objective.allowedSubstitutions ?? []).some(substitution =>
+        substitution.targetCoverageKey === objective.coverageKey
+        && substitution.allowedCoverageKeys.some(key => hasExactCoverage(evidence, key)),
+    );
+}
+
+function coverageQualifiesObjective(
     evidence: LinkedProgressionExposureEvidence,
     objective: BlockObjectiveDefinition,
 ): boolean {
@@ -202,10 +217,11 @@ function coverageMatchesObjective(
 function prescriptionMatchesTarget(
     evidence: LinkedProgressionExposureEvidence,
     contract: BlockProgressionContract,
+    expectedSourcePlanRevision: number,
 ): boolean {
     const prescription = evidence.prescription;
     if (prescription.status !== 'matched_current_target') return false;
-    if (!Number.isInteger(prescription.sourceRevision) || prescription.sourceRevision < 1) return false;
+    if (prescription.sourcePlanRevision !== expectedSourcePlanRevision) return false;
     if (prescription.variable !== contract.variable) return false;
     if (prescription.unit !== contract.unit) return false;
     if (!Number.isFinite(prescription.value) || prescription.value !== contract.currentValue) return false;
@@ -214,6 +230,37 @@ function prescriptionMatchesTarget(
     if (contract.targetBinding.stepId !== undefined
         && prescription.stepId !== contract.targetBinding.stepId) return false;
     return true;
+}
+
+/** Fingerprint only behavior-affecting fields consumed by this evaluator. Identical replayed
+ * duplicates dedupe; conflicting duplicates for one canonical occurrence fail closed. */
+function linkedEvidenceFingerprint(evidence: LinkedProgressionExposureEvidence): string {
+    const occurrenceId = evidence.exposure.performedOccurrenceId;
+    const coverage = evidence.coverageCredits
+        .filter(credit => credit.performedOccurrenceId === occurrenceId)
+        .map(credit => `${credit.coverageSetId}|${credit.coverageKey}|${credit.creditKind}|${credit.confidence}|${credit.reasonCode}`)
+        .sort();
+    return JSON.stringify({
+        localDate: evidence.exposure.localDate,
+        coverage,
+        deliveredDoseFraction: evidence.deliveredDoseFraction ?? null,
+        prescription: {
+            status: evidence.prescription.status,
+            sourcePlanRevision: evidence.prescription.sourcePlanRevision,
+            sessionId: evidence.prescription.sessionId ?? null,
+            stepId: evidence.prescription.stepId ?? null,
+            variable: evidence.prescription.variable,
+            unit: evidence.prescription.unit,
+            value: evidence.prescription.value,
+        },
+        outcome: evidence.outcome ? {
+            status: evidence.outcome.status,
+            hasFollowUpData: evidence.outcome.hasFollowUpData,
+            sourceKind: evidence.outcome.sourceSession.kind,
+            sourceId: evidence.outcome.sourceSession.id,
+            sourceDate: evidence.outcome.sourceSession.date,
+        } : null,
+    });
 }
 
 function boundProgressFor(
@@ -375,19 +422,33 @@ export function evaluateProgressionReview(input: ProgressionReviewInput): Progre
     const windowEndDate = input.asOfDate;
 
     const canonicalByOccurrence = new Map<string, LinkedProgressionExposureEvidence>();
+    const ambiguousOccurrenceIds = new Set<string>();
     for (const evidence of input.linkedExposures) {
         const occurrenceId = evidence.exposure.performedOccurrenceId;
         if (!occurrenceId) continue;
         if (evidence.exposure.localDate < windowStartDate || evidence.exposure.localDate > windowEndDate) continue;
-        if (!canonicalByOccurrence.has(occurrenceId)) canonicalByOccurrence.set(occurrenceId, evidence);
+        if (ambiguousOccurrenceIds.has(occurrenceId)) continue;
+
+        const existing = canonicalByOccurrence.get(occurrenceId);
+        if (!existing) {
+            canonicalByOccurrence.set(occurrenceId, evidence);
+            continue;
+        }
+        if (linkedEvidenceFingerprint(existing) !== linkedEvidenceFingerprint(evidence)) {
+            canonicalByOccurrence.delete(occurrenceId);
+            ambiguousOccurrenceIds.add(occurrenceId);
+        }
     }
 
     const candidates = [...canonicalByOccurrence.values()];
     const roleRelevantExposures = candidates.filter(evidence =>
-        coverageMatchesObjective(evidence, targetObjective),
+        coverageIsTargetOrAllowedRole(evidence, targetObjective),
     );
-    const matchingExposures = roleRelevantExposures.filter(evidence =>
-        prescriptionMatchesTarget(evidence, contract),
+    const doseQualifiedExposures = roleRelevantExposures.filter(evidence =>
+        coverageQualifiesObjective(evidence, targetObjective),
+    );
+    const matchingExposures = doseQualifiedExposures.filter(evidence =>
+        prescriptionMatchesTarget(evidence, contract, input.intentBlock.sourcePlanRevision),
     );
 
     const exposuresRequired = Math.max(
@@ -395,37 +456,33 @@ export function evaluateProgressionReview(input: ProgressionReviewInput): Progre
         targetObjective.successCriteria?.minCompletedExposures ?? 0,
     );
 
-    let completedWithFollowUp = 0;
+    let roleRelevantWithFollowUp = 0;
     let adverseCount = 0;
     let cautionCount = 0;
     let unknownCount = 0;
-
-    // Safety evidence from any role-relevant exposure in the observation window matters,
-    // including partial or mismatched dose attempts. Those attempts still do not count as
-    // completed current-target exposures below.
     for (const evidence of roleRelevantExposures) {
-        if (evidence.outcome?.status === 'reactive') adverseCount++;
-        else if (evidence.outcome?.status === 'caution') cautionCount++;
-    }
-    for (const evidence of matchingExposures) {
-        if (evidence.outcome?.hasFollowUpData) completedWithFollowUp++;
+        if (evidence.outcome?.hasFollowUpData) roleRelevantWithFollowUp++;
         if (!evidence.outcome || evidence.outcome.status === 'unknown') unknownCount++;
+        else if (evidence.outcome.status === 'reactive') adverseCount++;
+        else if (evidence.outcome.status === 'caution') cautionCount++;
     }
 
-    const followUpCoveragePct = matchingExposures.length > 0
-        ? Math.min(100, Math.round((completedWithFollowUp / matchingExposures.length) * 100))
+    const followUpCoveragePct = roleRelevantExposures.length > 0
+        ? Math.min(100, Math.round((roleRelevantWithFollowUp / roleRelevantExposures.length) * 100))
         : 0;
+    const uniqueCandidateCount = candidates.length + ambiguousOccurrenceIds.size;
     const evidenceAudit: ProgressionEvidenceAudit = {
         windowStartDate,
         windowEndDate,
-        candidateExposureCount: candidates.length,
+        candidateExposureCount: uniqueCandidateCount,
         roleRelevantExposureCount: roleRelevantExposures.length,
         exposuresObserved: matchingExposures.length,
-        excludedExposureCount: candidates.length - matchingExposures.length,
+        excludedExposureCount: uniqueCandidateCount - matchingExposures.length,
+        ambiguousOccurrenceCount: ambiguousOccurrenceIds.size,
         exposuresRequired,
         followUpCoveragePct,
         requiredFollowUpCoveragePct: contract.requiredFollowUpCoveragePct,
-        missingFollowUpCount: matchingExposures.length - completedWithFollowUp,
+        missingFollowUpCount: roleRelevantExposures.length - roleRelevantWithFollowUp,
         adverseResponseCount: adverseCount,
         cautionResponseCount: cautionCount,
         unknownResponseCount: unknownCount,
@@ -484,6 +541,15 @@ export function evaluateProgressionReview(input: ProgressionReviewInput): Progre
         );
     }
 
+    if (ambiguousOccurrenceIds.size > 0) {
+        return result(
+            'hold',
+            [`conflicting_duplicate_occurrence_evidence: ${ambiguousOccurrenceIds.size} occurrence(s)`],
+            input,
+            evidenceAudit,
+        );
+    }
+
     if (matchingExposures.length < exposuresRequired) {
         return result(
             'hold',
@@ -505,7 +571,7 @@ export function evaluateProgressionReview(input: ProgressionReviewInput): Progre
     if (unknownCount > 0) {
         return result(
             'hold',
-            [`unknown_response_evidence_blocks_advancement: ${unknownCount} target exposure(s)`],
+            [`unknown_response_evidence_blocks_advancement: ${unknownCount} role-relevant exposure(s)`],
             input,
             evidenceAudit,
         );

--- a/app/src/engine/progressionReview.ts
+++ b/app/src/engine/progressionReview.ts
@@ -16,6 +16,7 @@ import type {
     TissueSeverity,
 } from './blockIntent';
 import { isValidLocalDateString, validateIntentBlock } from './blockIntent';
+import { addDaysToLocalDateString } from '../utils/localDate';
 
 export type ProgressionReviewAction = 'advance_proposal' | 'hold' | 'reduce_proposal' | 'redirect';
 
@@ -115,12 +116,6 @@ export interface ProgressionReviewInput {
         hasAdverseTissue: boolean;
         prohibitedRegions?: readonly string[];
     };
-}
-
-function addCalendarDays(date: string, days: number): string {
-    const [year, month, day] = date.split('-').map(Number);
-    const instant = new Date(Date.UTC(year, month - 1, day + days));
-    return `${instant.getUTCFullYear()}-${String(instant.getUTCMonth() + 1).padStart(2, '0')}-${String(instant.getUTCDate()).padStart(2, '0')}`;
 }
 
 function calendarDaysInclusive(startDate: string, endDate: string): number {
@@ -415,7 +410,7 @@ export function evaluateProgressionReview(input: ProgressionReviewInput): Progre
         return result('hold', ['active_restriction_blocks_advancement'], input, audit);
     }
 
-    const rawWindowStart = addCalendarDays(input.asOfDate, -(contract.observationWindowDays - 1));
+    const rawWindowStart = addDaysToLocalDateString(input.asOfDate, -(contract.observationWindowDays - 1));
     const windowStartDate = rawWindowStart > input.intentBlock.dateRange.startDate
         ? rawWindowStart
         : input.intentBlock.dateRange.startDate;


### PR DESCRIPTION
## Summary

This PR delivers **H5 Phase 1** from [ADR-0037: Block Intent and Controlled Progression](docs/adr/0037-block-intent-and-controlled-progression.md): explicit block intent contracts, fail-closed validation, canonical replay identity, and a **pure/report-only** controlled-progression review evaluator.

It intentionally does **not** wire progression into daily recommendation selection and does not add `external-plan@5` yet. The cumulative v5 import remains gated on H4 / `external-plan@4` landing. `POLICY_VERSION` therefore remains unchanged.

## H5a — intent contracts and validation

`app/src/engine/blockIntent.ts` now provides:

- explicit per-objective `develop | maintain` intent and typed objective priority;
- typed dose envelopes and supported coverage-role vocabulary;
- protected roles, bounded substitution rules, prospective success criteria, entry prerequisites and exit criteria;
- a deliberately narrow Phase-1 progression-variable registry (`duration_min -> minutes`) rather than arbitrary executable/free-text field paths;
- explicit authored `reductionAlternative` / `redirectCriteria` rules — no hidden adverse-count thresholds;
- fail-closed validation for source-plan identity/revision, real calendar dates, review timing, finite bounds, progression-unit compatibility, objective-envelope compatibility, substitution qualifications, measured maintenance tolerance, prerequisites, duplicate IDs and per-plan block overlap.

## H5a — canonical replay

`app/src/engine/blockIntentReplay.ts` builds `treatment_intent_replay_v1` and SHA-256 hashes a canonical semantic projection that pins:

- source plan identity/schema/revision/provenance;
- the evaluated `TrainingIntentProfile` priorities and every weekly-commitment field;
- block interval and review timing;
- intent, priority, dose bounds/floor semantics, protected roles, substitutions, success criteria, prerequisites and exit criteria;
- every Phase-1 progression-rule field, including explicit redirect criteria.

Semantically unordered collections are canonicalized. Presentation-only `title`, `notes`, and substitution `rationale` are excluded. Non-finite numbers are rejected instead of being silently serialized to JSON `null` before hashing.

## H5b — evidence-linked progression review

`app/src/engine/progressionReview.ts` derives only:

- `advance_proposal`
- `hold`
- `reduce_proposal`
- `redirect`

The evaluator is report-only and now fails closed on evidence identity:

- applies the authored observation-window lower bound;
- deduplicates by canonical `performedOccurrenceId`;
- requires exact target-role coverage, or an explicitly authored exact substitution whose dose qualification is proven;
- requires a pinned current prescription match for the **same variable, unit, current value and source revision**; stale/different-dose work cannot clear the experiment;
- counts follow-up/outcomes only from joined target evidence rather than every supplied outcome;
- still applies adverse/caution safety evidence from role-relevant **partial/mismatched attempts**, even though those attempts do not count as completed target-dose exposures;
- missing/unknown follow-up evidence blocks advancement;
- matches the full frozen evaluation reference (`id + revision + metricId`), not metric ID alone;
- enforces authored target trend, prerequisites, max block duration, and end-of-block redirect-to-review behavior;
- treats `unclear_within_noise` as insufficient proof of maintenance, consistent with ADR-0037;
- never redirects because of an implicit “N bad responses” rule — redirect is authored explicitly.

A proposal contains concrete before/after values plus the derived delta. No proposal mutates a plan or acquires the H5c singleton experiment slot.

## Review hardening included in this PR

A manual ADR/code review identified and fixed several correctness gaps in the initial implementation:

1. old same-modality work could be counted outside the observation window;
2. unrelated `SessionOutcome`s could influence follow-up/safety counts;
3. progression evidence was role/modality-oriented rather than pinned to the current tested dose;
4. two reactive outcomes caused an undocumented redirect threshold;
5. authored substitutions, prerequisites, success criteria and exact evaluation revisions were incompletely enforced;
6. replay tests did not cover the ADR's semantic mutation matrix, and non-finite JSON values could collapse to `null`;
7. malformed plan dates could reach overlap sorting instead of failing cleanly.

Regression coverage now protects those boundaries, including stale dose evidence, allowed-substitution dose qualification, partial-attempt safety precedence, unknown follow-up, end-of-block behavior, canonical ordering/defaults and display-only replay exclusion.

## Verification

The branch is being validated by the repository CI pipeline (typecheck, lint, full Vitest suite, knowledge/workout validation, Firestore rules, simulations/diff, deterministic judge gates, production build, dependency audits, Python suite and Docker smoke). This section will be updated with the final PR-head result rather than preserving stale pre-review test counts.

## Next steps (post-H4)

1. Rebase/merge the concrete H4 `external-plan@4` artifact.
2. Add cumulative `external-plan@5` with `intentBlocks` instead of reconstructing v4 from ADR text.
3. Implement H5c confirmed revisions separately: revalidate source/safety/capacity, show affected future work, and acquire/release the athlete-scoped singleton progression claim atomically.
4. Keep outcome reports outside automatic recommendation selection unless a later ADR explicitly changes that authority boundary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation for training intent blocks, including dates, objectives, dosage limits, prerequisites, progression rules, and cross-block conflicts.
  * Added deterministic replay payload generation, hashing, and digest verification to support consistent treatment-intent records.
  * Added progression reviews that assess evidence and propose holds, redirects, reductions, or advancement.
* **Tests**
  * Added comprehensive coverage for validation, replay integrity, progression decisions, safety rules, and malformed or conflicting inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->