### PR TITLE
feat(engine): verify H4 same-day canonical performed-fact boundary

### DIFF
--- a/app/src/training-occurrence/performedTrainingFactsService.sameDay.test.ts
+++ b/app/src/training-occurrence/performedTrainingFactsService.sameDay.test.ts
@@ -1,0 +1,168 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+    getPerformedTrainingFactsInRange,
+    getPerformedTrainingFactsThroughToday,
+} from './performedTrainingFactsService';
+import { performedTrainingOccurrenceRepository as repository } from './repository';
+import type { PerformedTrainingOccurrence } from './models';
+import { activityService } from '../services/activityService';
+import { sessionExecutionService } from '../services/sessionExecutionService';
+import type { NormalizedGarminActivity } from '../engine/models';
+import type { SessionExecution } from '../sessions/models';
+
+// ADR-0036 (H4) D-LEDGER/D-REASSESS need today's own already-completed work. This file
+// verifies the one real gap identified for H4: `getPerformedTrainingFactsInRange`'s
+// `[from, to)` convention structurally excludes `toDateExclusive` (today, for every
+// current caller). Same-day identity/dedup is a separate, already-proven concern (see
+// `reconciliationService.test.ts`'s same-day fixtures) -- this file only exercises the
+// read/hydration boundary.
+
+vi.mock('./repository', () => ({
+    performedTrainingOccurrenceRepository: {
+        queryActiveInDateWindow: vi.fn(),
+    },
+}));
+
+vi.mock('../services/sessionExecutionService', () => ({
+    sessionExecutionService: {
+        getExecution: vi.fn(),
+    },
+}));
+
+vi.mock('../services/activityService', () => ({
+    activityService: {
+        getActivitiesInRange: vi.fn(),
+    },
+}));
+
+vi.mock('../sessions/sessionDefinitionResolver', () => ({
+    resolveSessionDefinition: vi.fn().mockResolvedValue({ status: 'MISSING' }),
+}));
+
+const TODAY = '2026-09-06';
+
+function occurrence(overrides: Partial<PerformedTrainingOccurrence> = {}): PerformedTrainingOccurrence {
+    return {
+        schemaVersion: 1,
+        performedOccurrenceId: 'pto-today-1',
+        userId: 'user-1',
+        status: 'active',
+        localDate: TODAY,
+        modality: 'Strength',
+        sourceRefs: [],
+        reconciliation: { state: 'single_source' },
+        createdAt: `${TODAY}T06:00:00.000Z`,
+        updatedAt: `${TODAY}T07:00:00.000Z`,
+        ...overrides,
+    };
+}
+
+function garminActivity(overrides: Partial<NormalizedGarminActivity> = {}): NormalizedGarminActivity {
+    return {
+        activityId: 'act-today-1',
+        date: TODAY,
+        type: 'strength_training',
+        durationMin: 45,
+        averageHr: 120,
+        trainingEffectAerobic: 1.5,
+        trainingEffectAnaerobic: 0.5,
+        activityTrainingLoad: 60,
+        intensityTag: 'moderate',
+        startedAt: `${TODAY}T06:00:00.000Z`,
+        endedAt: `${TODAY}T06:45:00.000Z`,
+        ...overrides,
+    };
+}
+
+function sessionExecution(overrides: Partial<SessionExecution> = {}): SessionExecution {
+    return {
+        userId: 'user-1',
+        executionId: 'exec-today-1',
+        sessionSource: { kind: 'manual', definitionId: 'test-def', revision: 1, contentHash: 'a'.repeat(64) },
+        date: TODAY,
+        startedAt: `${TODAY}T06:00:00.000Z`,
+        completedAt: `${TODAY}T06:40:00.000Z`,
+        updatedAt: `${TODAY}T06:40:00.000Z`,
+        state: 'completed',
+        schemaVersion: 1,
+        ...overrides,
+    };
+}
+
+describe('getPerformedTrainingFactsThroughToday (ADR-0036 H4 same-day verification)', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(activityService.getActivitiesInRange).mockResolvedValue({ status: 'AVAILABLE', data: [], revision: null });
+        vi.mocked(sessionExecutionService.getExecution).mockResolvedValue({ status: 'MISSING' });
+    });
+
+    it('hydrates a same-day Garmin-sourced occurrence, surviving startedAt/endedAt for later elapsed-separation use', async () => {
+        vi.mocked(repository.queryActiveInDateWindow).mockResolvedValue([
+            occurrence({ sourceRefs: [{ kind: 'provider_activity', provider: 'garmin', activityId: 'act-today-1' }] }),
+        ]);
+        vi.mocked(activityService.getActivitiesInRange).mockResolvedValue({ status: 'AVAILABLE', data: [garminActivity()], revision: null });
+
+        const snapshot = await getPerformedTrainingFactsThroughToday('user-1', TODAY, TODAY);
+
+        // The repository call must actually include today, not stop the day before it.
+        expect(repository.queryActiveInDateWindow).toHaveBeenCalledWith('user-1', TODAY, TODAY);
+        expect(snapshot.exposures).toHaveLength(1);
+        expect(snapshot.exposures[0]).toMatchObject({
+            performedOccurrenceId: 'pto-today-1',
+            localDate: TODAY,
+            startedAt: `${TODAY}T06:00:00.000Z`,
+            endedAt: `${TODAY}T06:45:00.000Z`,
+            sourceKinds: ['provider_activity'],
+        });
+    });
+
+    it('hydrates a same-day structured-execution-sourced occurrence', async () => {
+        vi.mocked(repository.queryActiveInDateWindow).mockResolvedValue([
+            occurrence({ sourceRefs: [{ kind: 'structured_execution', executionId: 'exec-today-1' }] }),
+        ]);
+        vi.mocked(sessionExecutionService.getExecution).mockResolvedValue({ status: 'AVAILABLE', data: sessionExecution(), revision: null });
+
+        const snapshot = await getPerformedTrainingFactsThroughToday('user-1', TODAY, TODAY);
+
+        expect(snapshot.exposures).toHaveLength(1);
+        expect(snapshot.exposures[0]).toMatchObject({
+            performedOccurrenceId: 'pto-today-1',
+            startedAt: `${TODAY}T06:00:00.000Z`,
+            endedAt: `${TODAY}T06:40:00.000Z`,
+            durationMin: 40,
+            sourceKinds: ['structured_execution'],
+        });
+    });
+
+    it('hydrates one exposure, not two, for a same-day occurrence with both a structured and a Garmin source', async () => {
+        vi.mocked(repository.queryActiveInDateWindow).mockResolvedValue([
+            occurrence({
+                sourceRefs: [
+                    { kind: 'structured_execution', executionId: 'exec-today-1' },
+                    { kind: 'provider_activity', provider: 'garmin', activityId: 'act-today-1' },
+                ],
+            }),
+        ]);
+        vi.mocked(sessionExecutionService.getExecution).mockResolvedValue({ status: 'AVAILABLE', data: sessionExecution(), revision: null });
+        vi.mocked(activityService.getActivitiesInRange).mockResolvedValue({ status: 'AVAILABLE', data: [garminActivity()], revision: null });
+
+        const snapshot = await getPerformedTrainingFactsThroughToday('user-1', TODAY, TODAY);
+
+        expect(snapshot.exposures).toHaveLength(1);
+        expect(snapshot.exposures[0].sourceKinds.sort()).toEqual(['provider_activity', 'structured_execution']);
+    });
+
+    it('leaves getPerformedTrainingFactsInRange itself unchanged: today passed as the exclusive boundary still excludes today (current production behavior, e.g. trainingIntent.ts)', async () => {
+        vi.mocked(repository.queryActiveInDateWindow).mockResolvedValue([occurrence()]);
+
+        await getPerformedTrainingFactsInRange('user-1', '2026-09-01', TODAY);
+
+        // toDateExclusive === TODAY means today itself is outside the window -- this is
+        // exactly what every existing production caller does today, and this wrapper
+        // does not change that contract.
+        expect(repository.queryActiveInDateWindow).toHaveBeenCalledWith('user-1', '2026-09-01', '2026-09-05');
+        // The mocked repository still returns the occurrence regardless of the args it
+        // was called with (it's a stub), so assert the *called-with* range directly above
+        // rather than the exposures -- this test's whole point is the argument boundary.
+    });
+});

--- a/app/src/training-occurrence/performedTrainingFactsService.ts
+++ b/app/src/training-occurrence/performedTrainingFactsService.ts
@@ -16,7 +16,7 @@ import { performedTrainingOccurrenceRepository as repository } from './repositor
 import { sessionExecutionService } from '../services/sessionExecutionService';
 import { activityService } from '../services/activityService';
 import { resolveSessionDefinition } from '../sessions/sessionDefinitionResolver';
-import { getPreviousLocalDateString } from '../utils/localDate';
+import { addDaysToLocalDateString, getPreviousLocalDateString } from '../utils/localDate';
 import {
     deriveFactsFromOccurrence,
     categoryForWorkoutId,
@@ -176,4 +176,28 @@ export async function getPerformedTrainingFactsInRange(
         exposures,
         coverageCredits,
     };
+}
+
+/**
+ * ADR-0036 (H4) D-LEDGER/D-REASSESS need today's own already-completed work, not just
+ * history strictly before today. `getPerformedTrainingFactsInRange`'s `[from, to)`
+ * convention structurally excludes `toDateExclusive` itself, so passing today's date as
+ * that boundary -- as every current caller does -- always excludes today (see
+ * `trainingIntent.ts`'s always-pass-`date` call). This wrapper makes "through today,
+ * inclusive" an explicit, correctly-named request instead of relying on callers to
+ * remember to pass tomorrow's date as the exclusive boundary.
+ *
+ * `getPerformedTrainingFactsInRange` itself is unchanged and untouched by this addition:
+ * its hydration logic has no date-relative assumption that data must be historical (see
+ * the H4 same-day verification tests), so this is a pure convenience wrapper, not a new
+ * code path. Not called from any production decision path yet -- adding a same-day read
+ * is a prerequisite for H4 runtime wiring, not itself a decision-affecting change.
+ */
+export function getPerformedTrainingFactsThroughToday(
+    userId: string,
+    fromDateInclusive: string,
+    todayInclusive: string,
+    options: GetPerformedTrainingFactsOptions = {},
+): Promise<PerformedTrainingFactsSnapshot> {
+    return getPerformedTrainingFactsInRange(userId, fromDateInclusive, addDaysToLocalDateString(todayInclusive, 1), options);
 }

--- a/app/src/training-occurrence/reconciliationService.test.ts
+++ b/app/src/training-occurrence/reconciliationService.test.ts
@@ -61,6 +61,15 @@ const structuredFacts = {
     modality: 'strength',
 };
 
+const garminFacts = {
+    sourceRef: { kind: 'provider_activity' as const, provider: 'garmin', activityId: 'act-2' },
+    localDate: '2026-08-26',
+    startedAt: '2026-08-26T06:53:00.000Z',
+    endedAt: '2026-08-26T07:33:00.000Z',
+    durationMin: 40,
+    modality: 'strength',
+};
+
 beforeEach(() => {
     vi.clearAllMocks();
     resetShadowReconciliationCounters();
@@ -90,6 +99,24 @@ describe('reconcileSourceFacts', () => {
         expect(result.outcome).toBe('attached_auto_link');
         expect(repo.createOrGetForSource).not.toHaveBeenCalled();
         expect(repo.attachSource).toHaveBeenCalledWith('user-1', garminOnly.performedOccurrenceId, structuredFacts, expect.objectContaining({ state: 'matched' }));
+        expect(getShadowReconciliationCounters()['training_occurrence.matched']).toBe(1);
+    });
+
+    // ADR-0036 (H4) same-day verification: the mirror of the case above. Same-day
+    // dedup must not be direction-sensitive -- a structured completion logged first,
+    // with a Garmin sync for the same physical workout arriving later the same day,
+    // must converge onto one occurrence exactly as reliably as the reverse order.
+    it('structured-first, Garmin arrives later and clears auto-link -> attaches to the existing structured-only occurrence', async () => {
+        const structuredOnly = occurrence({ sourceRefs: [structuredFacts.sourceRef] });
+        vi.mocked(repo.getBySourceKey).mockResolvedValue(null);
+        vi.mocked(repo.queryActiveInDateWindow).mockResolvedValue([structuredOnly]);
+        vi.mocked(repo.attachSource).mockResolvedValue({ ...structuredOnly, sourceRefs: [...structuredOnly.sourceRefs, garminFacts.sourceRef], reconciliation: { state: 'matched' } });
+
+        const result = await reconcileSourceFacts('user-1', garminFacts);
+
+        expect(result.outcome).toBe('attached_auto_link');
+        expect(repo.createOrGetForSource).not.toHaveBeenCalled();
+        expect(repo.attachSource).toHaveBeenCalledWith('user-1', structuredOnly.performedOccurrenceId, garminFacts, expect.objectContaining({ state: 'matched' }));
         expect(getShadowReconciliationCounters()['training_occurrence.matched']).toBe(1);
     });
 

--- a/docs/plans/cycling-primary-hybrid-evaluation.md
+++ b/docs/plans/cycling-primary-hybrid-evaluation.md
@@ -1,7 +1,7 @@
 # Cycling-primary hybrid evaluation and recommendation improvements
 
-**Status:** In progress — H1, H2, H2b, H3 and H3-rest (ADR-0035) all delivered; H4 design accepted as ADR-0036 with D-SCHEMA/D-LEDGER delivered (runtime wiring unstarted); H5 design accepted as ADR-0037 (implementation unstarted)
-**Blocked by:** Personal M00/M01 prescription requires current workload/restriction confirmation; H4 runtime wiring (D-TIME/D-REASSESS/D-PLACEMENT/D-AUDIT) depends on verification of same-day canonical performed facts; H5 runtime requires validated intent mappings and linked response evidence, and cumulative `external-plan@5` acceptance additionally requires the landed H4 contract (ADR-0036).
+**Status:** In progress — H1, H2, H2b, H3 and H3-rest (ADR-0035) all delivered; H4 design accepted as ADR-0036 with D-SCHEMA/D-LEDGER delivered and the same-day canonical performed-fact boundary verified (runtime wiring unstarted); H5 design accepted as ADR-0037 (implementation unstarted)
+**Blocked by:** Personal M00/M01 prescription requires current workload/restriction confirmation; H4 runtime wiring (the `dailyLedger.ts` refactor across `schedule.ts`/`planner.ts`/`rules.ts`, then D-TIME/D-REASSESS/D-PLACEMENT/D-AUDIT) is a decision-affecting change needing its own PR, no longer blocked on verification; H5 runtime requires validated intent mappings and linked response evidence, and cumulative `external-plan@5` acceptance additionally requires the landed H4 contract (ADR-0036).
 **Unlocks:** Reproducible acceptance cases for equipment specificity, block authority and hybrid plan quality.
 
 ## Decision
@@ -240,11 +240,11 @@ also remains blocked on current-workload/restriction confirmation.
 ## H4 — Intraday capacity and post-AM reassessment
 
 **Status:** Design accepted in [ADR-0036](../adr/0036-intraday-training-windows-and-reassessment.md).
-**D-SCHEMA and D-LEDGER delivered** (schema/pure-ledger slice); runtime wiring
-(D-TIME/D-REASSESS/D-PLACEMENT/D-AUDIT) unstarted.
-**Dependencies:** ADR-0035 rest support (delivered) and a verified same-day canonical
-performed-fact boundary for runtime release. `POLICY_VERSION` is unchanged by this
-slice -- no decision behavior is activated yet.
+**D-SCHEMA and D-LEDGER delivered** (schema/pure-ledger slice); **same-day canonical
+performed-fact boundary verified**; runtime wiring (the `dailyLedger.ts` refactor, plus
+D-TIME/D-REASSESS/D-PLACEMENT/D-AUDIT) unstarted.
+**Dependencies:** ADR-0035 rest support (delivered). `POLICY_VERSION` is unchanged by
+this work -- no decision behavior is activated yet.
 
 Decision: explicit athlete-owned windows, plan-owned sequencing in `external-plan@4`,
 one shared daily minute/load ledger, and fresh post-AM reassessment before PM launch.
@@ -285,6 +285,51 @@ this slice, including the worked example (a 90-minute daily ceiling with 60-minu
 completion leaves at most 30 minutes for PM even though both windows individually offer
 90 minutes) and the exhausted-systemic-cost-blocks-admission case. `simulate:diff` and
 policy-drift show no change from this slice, confirming it is inert until wired.
+
+### Same-day canonical performed-fact boundary (verified)
+
+`getPerformedTrainingFactsInRange`'s only caller (`trainingIntent.ts`) always passes
+today's own date as the exclusive `toDateExclusive` boundary, so today is currently
+excluded from every canonical-facts read the recommendation engine performs -- this was
+the literal blocker named above. Investigation traced the full pipeline
+(`training-occurrence/repository.ts`, `reconciliationService.ts`,
+`engine/performedTrainingFacts.ts`) and found same-day identity/dedup already correct
+and already tested: `reconciliationService.ts`'s candidate matching runs a `+-1
+local-day` window with no wall-clock/"is this today" special-casing, and existing
+`reconciliationService.test.ts` fixtures already exercise same-day auto-link and
+same-day ambiguity (`'Garmin-first, structured arrives later'`, `'same-day two strength
+sessions ... stays ambiguous'`, `'modality mismatch ... same-day, close-timing
+candidate'`). This work added the missing mirror-direction case,
+`'structured-first, Garmin arrives later ... attaches to the existing structured-only
+occurrence'`, so same-day dedup is now proven both ways.
+
+The one real gap was narrower than the blocker's original phrasing suggested: it was
+purely the read-boundary convention, not a defect in hydration. `getPerformedTrainingFactsInRange`
+itself has no date-relative assumption that data must be historical; passing tomorrow's
+date as the exclusive boundary already correctly includes and hydrates today's
+occurrence (structured-execution and Garmin-activity sourced alike, with
+`startedAt`/`endedAt` intact for later D-TIME elapsed-separation use) -- this had simply
+never been exercised by any test or caller. `getPerformedTrainingFactsThroughToday`
+(`training-occurrence/performedTrainingFactsService.ts`) makes that an explicit,
+correctly-named function instead of relying on callers to remember the
+pass-tomorrow-as-exclusive trick. It is not called from any production/decision path
+yet -- exactly like `externalPlanV4.ts`/`dailyLedger.ts` above, this is additive and
+non-decision-affecting; `getPerformedTrainingFactsInRange`'s existing `[from, to)`
+contract and its only current caller (`trainingIntent.ts`) are unchanged.
+`performedTrainingFactsService.sameDay.test.ts` covers the new function directly plus a
+pinning test confirming current production behavior (today excluded) is untouched.
+`simulate:diff`/policy-drift show no change.
+
+The actual next H4 task is now the `dailyLedger.ts` wiring refactor: `schedule.ts`'s
+`resolveAvailability`/`calculateReservedCapacityProfile`, `planner.ts`'s
+`fixedActivityCostProfileForDate`/`applyFixedActivityStimulusCredit`/
+`applyFixedActivityCost`, `rules.ts`'s `fixedActivityProjection`/
+`unrepresentedFixedActivityProjection`, and `externalCritique.ts`'s use of
+`fixedActivityCostProfileForDate` currently duplicate the same six-dimension cost/
+stimulus reduce across five-plus call sites with three different ad hoc dedup
+mechanisms (`seenOccurrences`, `appliedFixedCostOccurrences`/
+`appliedProjectionOccurrences`, and a decision-trace delta). That refactor is
+decision-affecting and needs its own PR, then D-TIME/D-REASSESS/D-PLACEMENT/D-AUDIT.
 
 ## H5 — Explicit develop/maintain intent and progression
 

--- a/docs/plans/cycling-primary-hybrid-implementation-handoff.md
+++ b/docs/plans/cycling-primary-hybrid-implementation-handoff.md
@@ -1,7 +1,7 @@
 # Cycling-primary hybrid: implementation handoff
 
-**Status:** H1, H2, H2b, H3 and H3-rest (ADR-0035) all delivered; H4 design accepted as ADR-0036 with D-SCHEMA/D-LEDGER delivered (runtime wiring unstarted); H5 design accepted as ADR-0037 (implementation unstarted)
-**Blocked by:** H4 runtime wiring (refactoring `schedule.ts`/`planner.ts`/`rules.ts` onto `dailyLedger.ts`, then D-TIME/D-REASSESS/D-PLACEMENT/D-AUDIT) still needs verification of same-day canonical performed facts. H5 intent groundwork can start now; H5 runtime needs validated intent mappings and linked response evidence, and H5's cumulative `external-plan@5` import acceptance must be based on ADR-0036's landed v4 artifact, not reconstructed from discussion context. Personal M00/M01 prescription needs current athlete inputs.
+**Status:** H1, H2, H2b, H3 and H3-rest (ADR-0035) all delivered; H4 design accepted as ADR-0036 with D-SCHEMA/D-LEDGER delivered and the same-day canonical performed-fact boundary verified (runtime wiring unstarted); H5 design accepted as ADR-0037 (implementation unstarted)
+**Blocked by:** H4 runtime wiring (refactoring `schedule.ts`/`planner.ts`/`rules.ts` onto `dailyLedger.ts`, then D-TIME/D-REASSESS/D-PLACEMENT/D-AUDIT) is no longer blocked on verification -- it is ready to start as its own decision-affecting PR. H5 intent groundwork can start now; H5 runtime needs validated intent mappings and linked response evidence, and H5's cumulative `external-plan@5` import acceptance must be based on ADR-0036's landed v4 artifact, not reconstructed from discussion context. Personal M00/M01 prescription needs current athlete inputs.
 **Unlocks:** A cycling-first recommendation path that preserves feasible strength, respects equipment and time, and supports authored blocks without inventing capacity.
 
 ## Start here
@@ -225,9 +225,11 @@ Useful synthetic software work can proceed without those personal answers.
 ## Work order H4 — Intraday windows and post-AM response
 
 **Status:** Design accepted in [ADR-0036](../adr/0036-intraday-training-windows-and-reassessment.md).
-Step 1 (D-SCHEMA + D-LEDGER) delivered; steps 2-6 (runtime wiring) unstarted.
-**Dependencies:** Runtime release requires ADR-0035 rest support (delivered) and tested
-same-day canonical performed identity/revision/timing inputs.
+Step 1 (D-SCHEMA + D-LEDGER) delivered; the same-day canonical performed-fact boundary
+is verified; steps 2-6 (runtime wiring) unstarted.
+**Dependencies:** ADR-0035 rest support (delivered). Same-day canonical performed
+identity/revision/timing inputs are now verified (see below) -- the remaining
+dependency is simply doing the runtime-wiring work itself.
 **Deliverable:** Authored intraday placement and reassessed execution, followed separately
 by automatic multi-window packing after the initial acceptance bar passes.
 
@@ -250,10 +252,13 @@ The accepted implementation sequence is:
    **Not yet done:** wiring this into `schedule.ts`'s `resolveAvailability`/
    `calculateReservedCapacityProfile`, `planner.ts`'s `fixedActivityCostProfileForDate`/
    `applyFixedActivityStimulusCredit`, and `rules.ts`'s `fixedActivityProjection`/
-   `unrepresentedFixedActivityProjection` -- today these four still each hand-write an
-   independent per-day cost/stimulus reduce; D-LEDGER's "refactor... rather than
-   subtracting again downstream" is not yet satisfied. Resolving real windows and
-   reserving minutes/cost against actual instants also needs D-TIME (below).
+   `unrepresentedFixedActivityProjection`, plus `externalCritique.ts`'s own use of
+   `fixedActivityCostProfileForDate` -- today these five-plus call sites still each
+   hand-write an independent per-day cost/stimulus reduce, with three different ad hoc
+   dedup mechanisms (`seenOccurrences`, `appliedFixedCostOccurrences`/
+   `appliedProjectionOccurrences`, and a decision-trace delta); D-LEDGER's "refactor...
+   rather than subtracting again downstream" is not yet satisfied. Resolving real
+   windows and reserving minutes/cost against actual instants also needs D-TIME (below).
 3. Add atomic, confirmed bundle placement against all destination windows and ADR-0035
    rest. Preserve completed history and support independent optional-session dropping.
 4. At PM launch, capture current symptoms/response, same-day work and availability, rerun
@@ -273,9 +278,32 @@ adding duplicate date slots to `packWeeklyDose` is not a valid implementation.
 
 `POLICY_VERSION` is unchanged by step 1: `externalPlanV4.ts` and `dailyLedger.ts` are not
 consumed by any decision path yet, and `simulate:diff`/policy-drift confirm no output
-change. The next PR should tackle step 2's refactor (wiring the ledger into the existing
+change.
+
+**Same-day canonical performed-fact boundary: verified.** Investigation traced the full
+pipeline (`training-occurrence/repository.ts`, `reconciliationService.ts`,
+`engine/performedTrainingFacts.ts`) and found same-day identity/dedup already correct
+and already tested -- `reconciliationService.ts`'s candidate matching runs a `+-1
+local-day` window with no wall-clock/"is this today" special-casing, and existing tests
+already covered same-day auto-link and same-day ambiguity in both source orders (a new
+`'structured-first, Garmin arrives later'` case was added to close the one missing
+mirror direction). The real gap was purely the read-boundary convention:
+`getPerformedTrainingFactsInRange`'s only production caller (`trainingIntent.ts`)
+always passes today as the exclusive boundary, so today was structurally excluded from
+every canonical-facts read -- not a hydration defect, since the function itself has no
+date-relative assumption that data must be historical.
+`getPerformedTrainingFactsThroughToday` (`training-occurrence/performedTrainingFactsService.ts`)
+now makes "through today, inclusive" an explicit, correctly-named function rather than
+relying on callers to remember the pass-tomorrow-as-exclusive trick.
+`performedTrainingFactsService.sameDay.test.ts` proves same-day hydration (structured,
+Garmin, and both-sourced) with `startedAt`/`endedAt` intact for later D-TIME use, plus a
+pinning test confirming `getPerformedTrainingFactsInRange`'s existing behavior and
+`trainingIntent.ts`'s call site are unchanged. Not called from any production/decision
+path yet -- `simulate:diff`/policy-drift confirm no output change.
+
+The next PR should tackle step 2's refactor (wiring the ledger into the existing
 deduction points) before D-TIME/D-REASSESS/D-PLACEMENT, since every later step reads from
-that shared boundary.
+that shared boundary. It no longer needs a separate verification pass first.
 
 ## Work order H5 — Block intent and controlled progression
 


### PR DESCRIPTION
## Summary

Stacked on #418 (base: `claude/cycling-primary-hybrid-eval-e166ea`, not yet merged). Closes the H4 (ADR-0036) blocker documented in that PR: "verification of same-day canonical performed facts."

## What I found

Traced the full canonical-occurrence pipeline (`training-occurrence/repository.ts`, `reconciliationService.ts`, `engine/performedTrainingFacts.ts`) and the gap is narrower than the blocker's original phrasing suggested:

- **Same-day identity/dedup is already correct and already tested.** `reconciliationService.ts`'s candidate matching runs a `±1 local-day` window with no wall-clock/"is this today" special-casing anywhere in the pipeline — every date is pure relative-day arithmetic. Existing `reconciliationService.test.ts` fixtures already prove same-day auto-link and same-day ambiguity in one source order (`'Garmin-first, structured arrives later'`, `'same-day two strength sessions ... stays ambiguous'`). This PR adds the missing mirror-direction case so it's proven both ways.
- **The one real gap** is purely the read-boundary convention: `getPerformedTrainingFactsInRange`'s only production caller (`trainingIntent.ts`) always passes today as the exclusive `toDateExclusive` boundary, so today was structurally excluded from every canonical-facts read — not a hydration defect (the function itself has no date-relative assumption that data must be historical), just something nothing had ever exercised or asked for.

## What changed

- **`training-occurrence/performedTrainingFactsService.ts`**: add `getPerformedTrainingFactsThroughToday(userId, fromDateInclusive, todayInclusive, options)` — a thin, additive wrapper making "through today, inclusive" an explicit, correctly-named function instead of relying on callers to remember to pass tomorrow as the exclusive boundary. `getPerformedTrainingFactsInRange` itself and its only existing caller (`trainingIntent.ts`) are unchanged.
- **`training-occurrence/performedTrainingFactsService.sameDay.test.ts`** (new): proves same-day hydration for structured-execution-sourced, Garmin-sourced, and both-sourced occurrences, with `startedAt`/`endedAt` surviving intact (needed later for D-TIME's elapsed-separation math), plus a pinning test confirming current production behavior (today excluded) is untouched.
- **`training-occurrence/reconciliationService.test.ts`**: adds the structured-first/Garmin-later mirror case.
- **Docs**: record the boundary as verified and narrow the H4 blocker to the actual remaining work — the `dailyLedger.ts` wiring refactor across `schedule.ts`/`planner.ts`/`rules.ts`/`externalCritique.ts` (five-plus call sites currently duplicating the same six-dimension cost/stimulus reduce with three different ad hoc dedup mechanisms), then D-TIME/D-REASSESS/D-PLACEMENT/D-AUDIT.

## What's deliberately not in this PR

Not wired into `trainingIntent.ts` or any decision path — `getPerformedTrainingFactsThroughToday` is additive only, same discipline as `externalPlanV4.ts`/`dailyLedger.ts` in #418. `POLICY_VERSION` is unchanged.

## Verification

- `npm exec vitest run src/training-occurrence/performedTrainingFactsService.sameDay.test.ts src/training-occurrence/reconciliationService.test.ts` — all passing
- `npm run check` — typecheck, lint, full suite (3500 tests), knowledge/workout validation all green
- `npm run build` — succeeds
- `npm run simulate:scenarios && npm run simulate:diff` — no new diff (same pre-existing, already-confirmed-unrelated drift)
- `node scripts/check-policy-drift.mjs 3890857c` — passed, no decision-affecting change

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for retrieving completed training activity through the current day, including same-day records.
  - Same-day activities from multiple sources are now combined without creating duplicates.
  - Existing completion records can be matched with later imported activity.

- **Bug Fixes**
  - Preserved activity timing and duration details during same-day hydration.
  - Maintained exclusive end-date behavior for date-range queries.

- **Documentation**
  - Updated implementation plans and handoff documentation to reflect same-day support and verification status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->