### PR TITLE
feat(engine,ui): add unlogged physical work / manual labor check-in & strain integration

### DIFF
--- a/app/src/components/DailyCheckin.css
+++ b/app/src/components/DailyCheckin.css
@@ -856,3 +856,105 @@
   color: #94a3b8;
   line-height: 1.25;
 }
+
+/* Unlogged Physical Work / Manual Labor Card */
+.physical-work-card {
+  margin-top: 1rem;
+  border: 1px solid rgba(251, 146, 60, 0.25);
+  border-radius: var(--radius-control, 10px);
+  background: rgba(251, 146, 60, 0.03);
+  overflow: hidden;
+}
+
+.physical-work-card .boolean-toggle-card {
+  margin: 0;
+  border: none;
+  border-radius: 0;
+  background: transparent;
+}
+
+.physical-work-card .boolean-toggle-card.is-active {
+  background: rgba(251, 146, 60, 0.12);
+}
+
+.physical-work-card .boolean-toggle-card strong {
+  color: #fdba74;
+}
+
+.physical-work-details {
+  border-top: 1px solid rgba(251, 146, 60, 0.15);
+  padding: 0.9rem;
+  display: grid;
+  gap: 0.85rem;
+}
+
+.physical-work-helper-text {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--text-secondary, #94a3b8);
+  line-height: 1.4;
+}
+
+.physical-work-row {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.physical-work-label {
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: #fdba74;
+}
+
+.physical-work-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.physical-work-chip {
+  min-height: var(--touch-target-min, 40px);
+  border: 1px solid #334155;
+  border-radius: var(--radius-control, 8px);
+  background: rgba(15, 23, 42, 0.6);
+  color: #cbd5e1;
+  padding: 0.45rem 0.8rem;
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s ease-in-out;
+}
+
+.physical-work-chip:hover {
+  border-color: #64748b;
+  color: #f8fafc;
+}
+
+.physical-work-chip.is-selected {
+  background: #f97316;
+  border-color: #ea580c;
+  color: #ffffff;
+  font-weight: 700;
+}
+
+.physical-work-notes {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  font-size: 0.8rem;
+  color: var(--text-secondary, #94a3b8);
+}
+
+.physical-work-notes input {
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid #334155;
+  border-radius: var(--radius-control, 6px);
+  padding: 0.5rem 0.75rem;
+  color: #f8fafc;
+  font-size: 0.85rem;
+}
+
+.physical-work-notes input:focus {
+  outline: none;
+  border-color: #f97316;
+}

--- a/app/src/components/DailyCheckin.tsx
+++ b/app/src/components/DailyCheckin.tsx
@@ -6,7 +6,7 @@ import { sessionResponseService } from '../services/sessionResponseService';
 import { preferencesService } from '../services/preferencesService';
 import { relevantFollowupRegions } from '../responses/followupSchedule';
 import { EXERCISES_BY_ID } from '../workouts/exercises';
-import type { BodyRegion, DailySubjectiveCheckin, RedFlagCategory, RegionTissueResponse, TissueResponseLevel } from '../engine/models';
+import type { BodyRegion, DailySubjectiveCheckin, PhysicalWorkCheckin, RedFlagCategory, RegionTissueResponse, TissueResponseLevel } from '../engine/models';
 import type { HealthContextCheckin } from '../engine/healthAnomalyModels';
 import { BODY_REGIONS, TISSUE_LEVELS } from '../engine/models';
 import { isCompletedSubjectiveCheckin } from '../engine/checkinCompletion';
@@ -15,6 +15,7 @@ import { resolveDefaultTimeAvailable, type CheckinAvailabilityDefault } from '..
 import { getErrorMessage } from '../utils/errors';
 import type { Screen } from '../types/navigation';
 import { HealthContextSection } from './checkin/HealthContextSection';
+import { PhysicalWorkSection } from './checkin/PhysicalWorkSection';
 import { SubjectiveScaleRow } from './checkin/SubjectiveScaleRow';
 import './DailyCheckin.css';
 
@@ -333,6 +334,20 @@ export function DailyCheckin({ userId, onNavigate, onBack, onCheckinSaved }: Dai
       ...checkin,
       healthContext,
       ...(healthContext.symptoms ? { illnessSymptoms: healthContext.symptoms.present } : {}),
+    });
+  };
+
+  const handlePhysicalWorkChange = (physicalWork: PhysicalWorkCheckin | undefined) => {
+    if (!checkin) return;
+    if (!physicalWork) {
+      const next = { ...checkin };
+      delete next.physicalWork;
+      setCheckin(next);
+      return;
+    }
+    setCheckin({
+      ...checkin,
+      physicalWork,
     });
   };
 
@@ -713,6 +728,11 @@ export function DailyCheckin({ userId, onNavigate, onBack, onCheckinSaved }: Dai
               })}
             </div>
           </div>
+
+          <PhysicalWorkSection
+            value={checkin.physicalWork}
+            onChange={handlePhysicalWorkChange}
+          />
 
           <HealthContextSection
             value={checkin.healthContext}

--- a/app/src/components/checkin/PhysicalWorkSection.test.tsx
+++ b/app/src/components/checkin/PhysicalWorkSection.test.tsx
@@ -47,4 +47,20 @@ describe('PhysicalWorkSection', () => {
     expect(html).toContain('aria-pressed="true">Lower Back &amp; Spine</button>');
     expect(html).toContain('aria-pressed="false">Legs &amp; Carrying</button>');
   });
+
+  it('renders single selected load area with aria-pressed', () => {
+    const value: PhysicalWorkCheckin = {
+      performed: true,
+      duration: 'short',
+      intensity: 'moderate',
+      loadAreas: ['lower_back_spine'],
+    };
+
+    const html = renderToStaticMarkup(
+      <PhysicalWorkSection value={value} onChange={vi.fn()} />,
+    );
+
+    expect(html).toContain('aria-pressed="true">Lower Back &amp; Spine</button>');
+    expect(html).toContain('aria-pressed="false">Grip &amp; Forearms</button>');
+  });
 });

--- a/app/src/components/checkin/PhysicalWorkSection.test.tsx
+++ b/app/src/components/checkin/PhysicalWorkSection.test.tsx
@@ -1,0 +1,50 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import { PhysicalWorkSection } from './PhysicalWorkSection';
+import type { PhysicalWorkCheckin } from '../../engine/models';
+
+describe('PhysicalWorkSection', () => {
+  it('renders collapsed checkbox when physical work is not reported', () => {
+    const html = renderToStaticMarkup(
+      <PhysicalWorkSection value={undefined} onChange={vi.fn()} />,
+    );
+
+    expect(html).toContain('Unlogged Physical Work / Manual Labor (Yesterday)');
+    expect(html).not.toContain('physical-work-details');
+    expect(html).not.toContain('Work duration');
+    expect(html).not.toContain('Main strain areas');
+  });
+
+  it('renders expanded card with options when physical work is performed', () => {
+    const value: PhysicalWorkCheckin = {
+      performed: true,
+      duration: 'medium',
+      intensity: 'hard',
+      loadAreas: ['grip_forearms', 'lower_back_spine'],
+      notes: 'Cutting trees in the morning',
+    };
+
+    const html = renderToStaticMarkup(
+      <PhysicalWorkSection value={value} onChange={vi.fn()} />,
+    );
+
+    expect(html).toContain('physical-work-details');
+    expect(html).toContain('Wearables miss isometric grip');
+    expect(html).toContain('&lt; 1 hr');
+    expect(html).toContain('1–3 hrs');
+    expect(html).toContain('3+ hrs');
+    expect(html).toContain('Moderate');
+    expect(html).toContain('Hard');
+    expect(html).toContain('Exhausting');
+    expect(html).toContain('Grip &amp; Forearms');
+    expect(html).toContain('Lower Back &amp; Spine');
+    expect(html).toContain('Cutting trees in the morning');
+
+    // Check selected aria-pressed state
+    expect(html).toContain('aria-pressed="true">1–3 hrs</button>');
+    expect(html).toContain('aria-pressed="true">Hard</button>');
+    expect(html).toContain('aria-pressed="true">Grip &amp; Forearms</button>');
+    expect(html).toContain('aria-pressed="true">Lower Back &amp; Spine</button>');
+    expect(html).toContain('aria-pressed="false">Legs &amp; Carrying</button>');
+  });
+});

--- a/app/src/components/checkin/PhysicalWorkSection.tsx
+++ b/app/src/components/checkin/PhysicalWorkSection.tsx
@@ -1,0 +1,157 @@
+import type {
+  PhysicalWorkCheckin,
+  PhysicalWorkDuration,
+  PhysicalWorkIntensity,
+  PhysicalWorkLoadArea,
+} from '../../engine/models';
+
+export interface PhysicalWorkSectionProps {
+  value?: PhysicalWorkCheckin;
+  onChange: (next: PhysicalWorkCheckin | undefined) => void;
+}
+
+const DURATION_OPTIONS: Array<{ value: PhysicalWorkDuration; label: string }> = [
+  { value: 'short', label: '< 1 hr' },
+  { value: 'medium', label: '1–3 hrs' },
+  { value: 'extended', label: '3+ hrs' },
+];
+
+const INTENSITY_OPTIONS: Array<{ value: PhysicalWorkIntensity; label: string }> = [
+  { value: 'moderate', label: 'Moderate' },
+  { value: 'hard', label: 'Hard' },
+  { value: 'exhausting', label: 'Exhausting' },
+];
+
+const LOAD_AREA_OPTIONS: Array<{ value: PhysicalWorkLoadArea; label: string }> = [
+  { value: 'grip_forearms', label: 'Grip & Forearms' },
+  { value: 'upper_body', label: 'Upper Body (Pull/Shoulders)' },
+  { value: 'lower_back_spine', label: 'Lower Back & Spine' },
+  { value: 'legs_carrying', label: 'Legs & Carrying' },
+];
+
+export function PhysicalWorkSection({ value, onChange }: PhysicalWorkSectionProps) {
+  const isPerformed = Boolean(value?.performed);
+
+  const handleToggle = (checked: boolean) => {
+    if (!checked) {
+      onChange(undefined);
+      return;
+    }
+    onChange({
+      performed: true,
+      duration: value?.duration ?? 'medium',
+      intensity: value?.intensity ?? 'moderate',
+      loadAreas: value?.loadAreas ?? ['upper_body', 'lower_back_spine'],
+      notes: value?.notes ?? null,
+    });
+  };
+
+  const updateField = (patch: Partial<PhysicalWorkCheckin>) => {
+    onChange({
+      performed: true,
+      duration: 'medium',
+      intensity: 'moderate',
+      loadAreas: ['upper_body', 'lower_back_spine'],
+      ...value,
+      ...patch,
+    });
+  };
+
+  const handleToggleLoadArea = (area: PhysicalWorkLoadArea) => {
+    const current = value?.loadAreas ?? [];
+    const next = current.includes(area)
+      ? current.filter(a => a !== area)
+      : [...current, area];
+    updateField({ loadAreas: next });
+  };
+
+  return (
+    <div className="physical-work-card">
+      <label className={`boolean-toggle-card ${isPerformed ? 'is-active' : ''}`}>
+        <input
+          type="checkbox"
+          checked={isPerformed}
+          onChange={(e) => handleToggle(e.target.checked)}
+        />
+        <span className="toggle-checkmark"></span>
+        <div className="toggle-info">
+          <strong>🔨 Unlogged Physical Work / Manual Labor (Yesterday)</strong>
+          <span>Chainsaw/tree work, heavy yardwork, construction, hauling timber</span>
+        </div>
+      </label>
+
+      {isPerformed && (
+        <div className="physical-work-details" aria-label="Physical work details">
+          <p className="physical-work-helper-text">
+            Wearables miss isometric grip, heavy lifting, and spinal loading when heart rate stays low. Logging this protects your muscles and central nervous system from being overloaded today.
+          </p>
+
+          <div className="physical-work-row">
+            <span className="physical-work-label">Duration</span>
+            <div className="physical-work-chips" role="group" aria-label="Work duration">
+              {DURATION_OPTIONS.map(opt => (
+                <button
+                  key={opt.value}
+                  type="button"
+                  className={`physical-work-chip ${value?.duration === opt.value ? 'is-selected' : ''}`}
+                  aria-pressed={value?.duration === opt.value}
+                  onClick={() => updateField({ duration: opt.value })}
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="physical-work-row">
+            <span className="physical-work-label">Effort</span>
+            <div className="physical-work-chips" role="group" aria-label="Work effort">
+              {INTENSITY_OPTIONS.map(opt => (
+                <button
+                  key={opt.value}
+                  type="button"
+                  className={`physical-work-chip ${value?.intensity === opt.value ? 'is-selected' : ''}`}
+                  aria-pressed={value?.intensity === opt.value}
+                  onClick={() => updateField({ intensity: opt.value })}
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="physical-work-row">
+            <span className="physical-work-label">Main strain areas</span>
+            <div className="physical-work-chips" role="group" aria-label="Main strain areas">
+              {LOAD_AREA_OPTIONS.map(opt => {
+                const isSelected = (value?.loadAreas ?? []).includes(opt.value);
+                return (
+                  <button
+                    key={opt.value}
+                    type="button"
+                    className={`physical-work-chip ${isSelected ? 'is-selected' : ''}`}
+                    aria-pressed={isSelected}
+                    onClick={() => handleToggleLoadArea(opt.value)}
+                  >
+                    {opt.label}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <label className="physical-work-notes">
+            Work notes (optional)
+            <input
+              type="text"
+              maxLength={200}
+              value={value?.notes ?? ''}
+              placeholder="e.g. Chainsaw work and hauling heavy timber"
+              onChange={e => updateField({ notes: e.target.value || null })}
+            />
+          </label>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/src/components/checkin/PhysicalWorkSection.tsx
+++ b/app/src/components/checkin/PhysicalWorkSection.tsx
@@ -29,6 +29,10 @@ const LOAD_AREA_OPTIONS: Array<{ value: PhysicalWorkLoadArea; label: string }> =
   { value: 'legs_carrying', label: 'Legs & Carrying' },
 ];
 
+/**
+ * Morning check-in card for reporting unlogged physical work and manual labor.
+ * Prevents deselecting the final load area to ensure valid non-empty loadAreas.
+ */
 export function PhysicalWorkSection({ value, onChange }: PhysicalWorkSectionProps) {
   const isPerformed = Boolean(value?.performed);
 
@@ -59,10 +63,12 @@ export function PhysicalWorkSection({ value, onChange }: PhysicalWorkSectionProp
 
   const handleToggleLoadArea = (area: PhysicalWorkLoadArea) => {
     const current = value?.loadAreas ?? [];
-    const next = current.includes(area)
-      ? current.filter(a => a !== area)
-      : [...current, area];
-    updateField({ loadAreas: next });
+    if (current.includes(area)) {
+      if (current.length <= 1) return;
+      updateField({ loadAreas: current.filter(a => a !== area) });
+    } else {
+      updateField({ loadAreas: [...current, area] });
+    }
   };
 
   return (

--- a/app/src/engine/adapters.test.ts
+++ b/app/src/engine/adapters.test.ts
@@ -550,4 +550,72 @@ describe('mapCheckinToSubjectiveInput painFlag (allergy-aware illness gating)', 
             expect(fromUndefined).toEqual(createSubjectiveOnlyObjectiveInput());
         });
     });
+
+    describe('mapCheckinToSubjectiveInput: physicalWork', () => {
+        it('forwards physicalWork from DailySubjectiveCheckin to SubjectiveInput', () => {
+            const checkin = testCheckin({
+                physicalWork: {
+                    performed: true,
+                    duration: 'extended',
+                    intensity: 'hard',
+                    loadAreas: ['grip_forearms', 'lower_back_spine'],
+                    notes: 'firewood split and stack',
+                },
+            });
+            const subjective = mapCheckinToSubjectiveInput(checkin);
+            expect(subjective.physicalWork).toEqual({
+                performed: true,
+                duration: 'extended',
+                intensity: 'hard',
+                loadAreas: ['grip_forearms', 'lower_back_spine'],
+                notes: 'firewood split and stack',
+            });
+        });
+    });
+
+    describe('mapContextFromGoalsAndTrainingSettings: physicalWork implied guardrails', () => {
+        const baseSettings = testTrainingSettings();
+
+        it('injects avoid_heavy_spinal_loading when hard/exhausting lower back work is reported', () => {
+            const checkin = testCheckin({
+                physicalWork: {
+                    performed: true,
+                    duration: 'medium',
+                    intensity: 'hard',
+                    loadAreas: ['lower_back_spine'],
+                },
+            });
+            const context = mapContextFromGoalsAndTrainingSettings([], baseSettings, null, '2026-08-08', checkin);
+            expect(context.constraints.impliedGuardrails).toContain('avoid_heavy_spinal_loading');
+            expect(context.constraints.impliedGuardrails).not.toContain('avoid_overhead_pressing');
+        });
+
+        it('injects avoid_overhead_pressing when exhausting upper body or grip work is reported', () => {
+            const checkin = testCheckin({
+                physicalWork: {
+                    performed: true,
+                    duration: 'extended',
+                    intensity: 'exhausting',
+                    loadAreas: ['grip_forearms', 'upper_body'],
+                },
+            });
+            const context = mapContextFromGoalsAndTrainingSettings([], baseSettings, null, '2026-08-08', checkin);
+            expect(context.constraints.impliedGuardrails).toContain('avoid_overhead_pressing');
+            expect(context.constraints.impliedGuardrails).not.toContain('avoid_heavy_spinal_loading');
+        });
+
+        it('does not inject guardrails when physical work intensity is moderate', () => {
+            const checkin = testCheckin({
+                physicalWork: {
+                    performed: true,
+                    duration: 'short',
+                    intensity: 'moderate',
+                    loadAreas: ['lower_back_spine', 'upper_body'],
+                },
+            });
+            const context = mapContextFromGoalsAndTrainingSettings([], baseSettings, null, '2026-08-08', checkin);
+            expect(context.constraints.impliedGuardrails).not.toContain('avoid_heavy_spinal_loading');
+            expect(context.constraints.impliedGuardrails).not.toContain('avoid_overhead_pressing');
+        });
+    });
 });

--- a/app/src/engine/adapters.ts
+++ b/app/src/engine/adapters.ts
@@ -15,6 +15,7 @@ import type {
     UserGoal,
     UserPreferences,
     TrainingSettings,
+    GuardrailKey,
 } from './models';
 import { injuryRegionMappingFamily, resolveInjuryPolicy } from './injuryPolicy';
 import { goalToUserEvent } from './periodization';
@@ -373,6 +374,7 @@ export function mapCheckinToSubjectiveInput(checkin: DailySubjectiveCheckin | nu
         redFlagFindings,
         painOrInjuryRegionFamilies: resolvePainOrInjuryRegionFamilies(checkin),
         alreadyTrainedToday: checkin.alreadyTrainedToday ?? false,
+        physicalWork: checkin.physicalWork,
         preferredModalityToday: checkin.availability?.preferredModalityToday ?? null,
     };
 }
@@ -414,6 +416,23 @@ export function mapContextFromGoalsAndTrainingSettings(
         ...(preferences?.unavailableModalities ?? []),
     ]));
 
+    const physicalWorkGuardrails: GuardrailKey[] = [];
+    if (todaysCheckin?.physicalWork?.performed) {
+        const areas = todaysCheckin.physicalWork.loadAreas ?? [];
+        const intensity = todaysCheckin.physicalWork.intensity;
+        if (areas.includes('lower_back_spine') && (intensity === 'hard' || intensity === 'exhausting')) {
+            physicalWorkGuardrails.push('avoid_heavy_spinal_loading');
+        }
+        if ((areas.includes('upper_body') || areas.includes('grip_forearms')) && intensity === 'exhausting') {
+            physicalWorkGuardrails.push('avoid_overhead_pressing');
+        }
+    }
+
+    const impliedGuardrails = Array.from(new Set([
+        ...injuryPolicy.restrictions.impliedGuardrails,
+        ...physicalWorkGuardrails,
+    ]));
+
     return {
         goals: {
             shortTerm: topGoalTitle('short-term'),
@@ -426,7 +445,7 @@ export function mapContextFromGoalsAndTrainingSettings(
             hasTreadmill: trainingSettings.equipment.treadmill,
             hasIndoorBike: trainingSettings.equipment.indoor_bike,
             restrictedModalities,
-            impliedGuardrails: injuryPolicy.restrictions.impliedGuardrails,
+            impliedGuardrails,
             restrictedCategories: injuryPolicy.restrictions.restrictedCategories,
             maxTimeMinutes: trainingSettings.defaults.weekdayMaxMinutes ?? trainingSettings.defaults.weekendMaxMinutes ?? DEFAULT_MAX_TIME_MINUTES,
         },

--- a/app/src/engine/contextBrief.test.ts
+++ b/app/src/engine/contextBrief.test.ts
@@ -393,6 +393,31 @@ describe('buildContextBrief', () => {
         expect(text).toContain('Already trained today: 1 day(s) — 2026-08-12');
     });
 
+    it('renders unlogged physical work on the latest check-in and in window flags', () => {
+        const text = buildContextBrief(input({
+            checkins: [
+                checkin('2026-08-14', {
+                    physicalWork: {
+                        performed: true,
+                        duration: 'short',
+                        intensity: 'moderate',
+                    },
+                }),
+                checkin('2026-08-15', {
+                    physicalWork: {
+                        performed: true,
+                        duration: 'medium',
+                        intensity: 'hard',
+                        loadAreas: ['grip_forearms', 'upper_body', 'lower_back_spine'],
+                        notes: 'cutting trees',
+                    },
+                }),
+            ],
+        }));
+        expect(text).toContain('- Unlogged physical work (D-1): 1–3 hrs · hard effort · strain: grip/forearms, upper body, lower back/spine — "cutting trees"');
+        expect(text).toContain('- Unlogged physical work: 2 day(s) — 2026-08-14, 2026-08-15');
+    });
+
     it('separates skipped sessions from sessions replaced by something else', () => {
         const text = buildContextBrief(input({
             recommendations: [

--- a/app/src/engine/contextBrief.test.ts
+++ b/app/src/engine/contextBrief.test.ts
@@ -401,6 +401,7 @@ describe('buildContextBrief', () => {
                         performed: true,
                         duration: 'short',
                         intensity: 'moderate',
+                        loadAreas: ['grip_forearms'],
                     },
                 }),
                 checkin('2026-08-15', {

--- a/app/src/engine/contextBrief.ts
+++ b/app/src/engine/contextBrief.ts
@@ -513,6 +513,26 @@ function renderSubjective(
         lines.push(`- Flags / availability: ${latestFlags.join(' · ')}`);
     }
 
+    if (latest.physicalWork?.performed) {
+        const pw = latest.physicalWork;
+        const durationLabels: Record<string, string> = { short: '< 1 hr', medium: '1–3 hrs', extended: '3+ hrs' };
+        const areaLabels: Record<string, string> = {
+            grip_forearms: 'grip/forearms',
+            upper_body: 'upper body',
+            lower_back_spine: 'lower back/spine',
+            legs_carrying: 'legs/carrying',
+        };
+        const parts: string[] = [];
+        if (pw.duration) parts.push(durationLabels[pw.duration] ?? pw.duration);
+        if (pw.intensity) parts.push(`${pw.intensity} effort`);
+        if (pw.loadAreas && pw.loadAreas.length > 0) {
+            parts.push(`strain: ${pw.loadAreas.map(a => areaLabels[a] ?? a).join(', ')}`);
+        }
+        const summary = parts.length > 0 ? parts.join(' · ') : 'reported';
+        const noteStr = pw.notes && pw.notes.trim().length > 0 ? ` — "${pw.notes.trim()}"` : '';
+        lines.push(`- Unlogged physical work (D-1): ${summary}${noteStr}`);
+    }
+
     if (latest.tissueResponses) {
         const trEntries = Object.entries(latest.tissueResponses).filter(([, tr]) => tr != null);
         if (trEntries.length > 0) {
@@ -538,10 +558,12 @@ function renderSubjective(
     const illnessDays = checkins.filter(c => c.illnessSymptoms).map(c => c.date);
     const limitedDays = checkins.filter(c => c.unusuallyLimitedTime).map(c => c.date);
     const alreadyTrainedDays = checkins.filter(c => c.alreadyTrainedToday).map(c => c.date);
+    const physicalWorkDays = checkins.filter(c => c.physicalWork?.performed).map(c => c.date);
     lines.push(`- Pain or injury flagged: ${painDays.length > 0 ? `${painDays.length} day(s) — ${painDays.join(', ')}` : 'none'}`);
     lines.push(`- Illness symptoms flagged: ${illnessDays.length > 0 ? `${illnessDays.length} day(s) — ${illnessDays.join(', ')}` : 'none'}`);
     if (limitedDays.length > 0) lines.push(`- Unusually limited time: ${limitedDays.length} day(s) — ${limitedDays.join(', ')}`);
     if (alreadyTrainedDays.length > 0) lines.push(`- Already trained today: ${alreadyTrainedDays.length} day(s) — ${alreadyTrainedDays.join(', ')}`);
+    if (physicalWorkDays.length > 0) lines.push(`- Unlogged physical work: ${physicalWorkDays.length} day(s) — ${physicalWorkDays.join(', ')}`);
 
     const notes = checkins.filter(c => c.notes && c.notes.trim().length > 0);
     if (notes.length > 0) {

--- a/app/src/engine/contextBriefPlanningHandoff.test.ts
+++ b/app/src/engine/contextBriefPlanningHandoff.test.ts
@@ -307,7 +307,9 @@ describe('enhanceContextBriefForPlanning', () => {
                 checkin(AS_OF, {
                     physicalWork: {
                         performed: true,
+                        duration: 'medium',
                         intensity: 'hard',
+                        loadAreas: ['upper_body'],
                     },
                 }),
             ],

--- a/app/src/engine/contextBriefPlanningHandoff.test.ts
+++ b/app/src/engine/contextBriefPlanningHandoff.test.ts
@@ -108,7 +108,7 @@ function snapshot(date = AS_OF): DailyRecoverySnapshot {
     };
 }
 
-function checkin(date = AS_OF): DailySubjectiveCheckin {
+function checkin(date = AS_OF, overrides: Partial<DailySubjectiveCheckin> = {}): DailySubjectiveCheckin {
     return {
         userId: 'u1',
         date,
@@ -129,6 +129,7 @@ function checkin(date = AS_OF): DailySubjectiveCheckin {
         schemaVersion: 1,
         createdAt: `${date}T05:40:00Z`,
         updatedAt: `${date}T05:40:00Z`,
+        ...overrides,
     };
 }
 
@@ -298,6 +299,21 @@ describe('enhanceContextBriefForPlanning', () => {
         expect(text).toContain('| 2026-08-20 | 88 | 70 | 44 | 13 | 82 | 22 | 9000 | 8 | 2 | 3 |');
         expect(text).toContain('| 2026-08-14 | — | — | — | — | — | — | — | — | — | — |');
         expect(text).toContain('Steps are the completed D-1 total');
+    });
+
+    it('includes physical work in recent recovery timeline flags', () => {
+        const text = enhanceContextBriefForPlanning(BASE, handoffInput({
+            checkins: [
+                checkin(AS_OF, {
+                    physicalWork: {
+                        performed: true,
+                        intensity: 'hard',
+                    },
+                }),
+            ],
+        }));
+
+        expect(text).toContain('hard physical work');
     });
 
     it('exports fixed commitments, imported sessions and their authored prescriptions', () => {

--- a/app/src/engine/contextBriefPlanningHandoff.ts
+++ b/app/src/engine/contextBriefPlanningHandoff.ts
@@ -213,6 +213,10 @@ function renderRecoveryTimeline(input: ContextBriefPlanningHandoffInput): string
         if (checkin?.painOrInjury) flags.push('pain/injury');
         if (checkin?.illnessSymptoms) flags.push('illness');
         if (checkin?.unusuallyLimitedTime) flags.push('limited time');
+        if (checkin?.physicalWork?.performed) {
+            const intensity = checkin.physicalWork.intensity ? `${checkin.physicalWork.intensity} ` : '';
+            flags.push(`${intensity}physical work`);
+        }
 
         lines.push(`| ${date} | ${textNumber(snapshot?.raw.sleepScore)} | ${textNumber(snapshot?.raw.hrvOvernightAvg)} | ${textNumber(snapshot?.raw.restingHr)} | ${textNumber(snapshot?.raw.respirationAvg)} | ${textNumber(snapshot?.raw.bodyBatteryWake)} | ${textNumber(snapshot?.raw.stress?.avg)} | ${textNumber(snapshot?.raw.totalSteps)} | ${textNumber(checkin?.readiness)} | ${textNumber(checkin?.fatigue)} | ${textNumber(checkin?.soreness)} | ${flags.join(', ') || '—'} |`);
     }

--- a/app/src/engine/fatigue.ts
+++ b/app/src/engine/fatigue.ts
@@ -177,18 +177,42 @@ export function computeInternalResponseStrain(readiness: DailyReadiness): Dimens
     // not by itself establish muscle breakdown or a biologically mandatory 48-hour recovery.
     const acuteTissueStrain = subjective.soreness >= 8 ? 0.88 : subSoreness;
 
+    // 5. Unlogged non-exercise physical activity / manual labor (D-1)
+    let physicalWorkStrain = 0;
+    const pw = subjective.physicalWork;
+    const pwAreas = new Set(pw?.loadAreas ?? []);
+    if (pw?.performed) {
+        const baseIntensity = pw.intensity === 'exhausting' ? 0.88 : pw.intensity === 'hard' ? 0.70 : 0.45;
+        const durationFactor = pw.duration === 'extended' ? 1.25 : pw.duration === 'short' ? 0.65 : 1.0;
+        physicalWorkStrain = Math.min(1, baseIntensity * durationFactor);
+    }
+    const hasSpecificAreas = pwAreas.size > 0;
+    const workSystemic = physicalWorkStrain * 0.60;
+    const workUpperBody = (!hasSpecificAreas || pwAreas.has('upper_body') || pwAreas.has('grip_forearms'))
+        ? physicalWorkStrain * 0.85
+        : 0;
+    const workLowerBody = (!hasSpecificAreas || pwAreas.has('legs_carrying'))
+        ? physicalWorkStrain * 0.85
+        : 0;
+    const workNeuromuscular = (!hasSpecificAreas || pwAreas.has('grip_forearms') || pwAreas.has('lower_back_spine'))
+        ? physicalWorkStrain * 0.75
+        : physicalWorkStrain * 0.40;
+    const workImpact = (pwAreas.has('legs_carrying') && pw?.intensity !== 'moderate')
+        ? physicalWorkStrain * 0.40
+        : 0;
+
     const baseSystemic = 0.3 * subFatigue + 0.25 * hrvDrop + 0.25 * sleepDeficit + 0.2 * bbDepletion;
-    const systemic = Math.min(1, Math.max(baseSystemic, acuteSubjectiveFatigueFloor, acuteSubjectiveStressFloor, acuteBiometricFloor));
+    const systemic = Math.min(1, Math.max(baseSystemic, acuteSubjectiveFatigueFloor, acuteSubjectiveStressFloor, acuteBiometricFloor, workSystemic));
 
     const baseCardiovascular = 0.5 * rhrElevated + 0.5 * hrvDrop;
     const cardiovascular = Math.min(1, Math.max(baseCardiovascular, acuteBiometricFloor));
 
-    const lowerBody = Math.min(1, acuteTissueStrain + ambulatoryTissueStrain);
-    const upperBody = acuteTissueStrain * 0.7; // default soreness split
-    const impactTissue = Math.min(1, acuteTissueStrain + ambulatoryTissueStrain);
+    const lowerBody = Math.min(1, Math.max(acuteTissueStrain + ambulatoryTissueStrain, workLowerBody));
+    const upperBody = Math.min(1, Math.max(acuteTissueStrain * 0.7, workUpperBody));
+    const impactTissue = Math.min(1, Math.max(acuteTissueStrain + ambulatoryTissueStrain, workImpact));
 
     const baseNeuromuscular = 0.5 * subFatigue + 0.5 * (1 - (subjective.motivation / 10));
-    const neuromuscular = Math.min(1, baseNeuromuscular);
+    const neuromuscular = Math.min(1, Math.max(baseNeuromuscular, workNeuromuscular));
 
     return {
         systemic,

--- a/app/src/engine/models.ts
+++ b/app/src/engine/models.ts
@@ -13,6 +13,22 @@ export type SubjectiveDimensionKey =
     | 'stress'
     | 'motivation';
 
+export type PhysicalWorkDuration = 'short' | 'medium' | 'extended'; // <1h, 1-3h, 3h+
+export type PhysicalWorkIntensity = 'moderate' | 'hard' | 'exhausting';
+export type PhysicalWorkLoadArea =
+    | 'grip_forearms'
+    | 'upper_body'
+    | 'lower_back_spine'
+    | 'legs_carrying';
+
+export interface PhysicalWorkCheckin {
+    performed: boolean;
+    duration?: PhysicalWorkDuration;
+    intensity?: PhysicalWorkIntensity;
+    loadAreas?: PhysicalWorkLoadArea[];
+    notes?: string | null;
+}
+
 // --- Engine Input Models ---
 export interface SubjectiveInput {
     readiness: number; // 1-10
@@ -38,6 +54,8 @@ export interface SubjectiveInput {
      */
     painOrInjuryRegionFamilies?: InjuryRegionMappingFamily[];
     alreadyTrainedToday: boolean; // User-reported: a session was already completed today
+    /** Unlogged non-exercise physical activity / manual labor completed on the preceding day (D-1). */
+    physicalWork?: PhysicalWorkCheckin;
     /** Today's explicit modality ask from the check-in (e.g. 'Running', 'Strength',
      *  'Mobility'), or null for no preference. Compared case-insensitively against
      *  SessionTemplate.modality -- see rules.ts applyModalityPreference. A value with no
@@ -1182,6 +1200,8 @@ export interface DailySubjectiveCheckin {
      *  BodyRegion; see injuryPolicy.ts resolveEffectiveInjuryConstraints for how this
      *  combines with the athlete's standing InjuryConstraint[]. */
     tissueResponses?: Partial<Record<BodyRegion, RegionTissueResponse>>;
+    /** Optional unlogged non-exercise physical activity / heavy manual labor completed yesterday (D-1). */
+    physicalWork?: PhysicalWorkCheckin;
     // Availability block
     availability: {
         timeAvailableMin: number | null;

--- a/app/src/engine/physicalWork.test.ts
+++ b/app/src/engine/physicalWork.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from 'vitest';
+import { computeInternalResponseStrain } from './fatigue';
+import { evaluateReadinessAndSafetyEnvelope } from './rules';
+import type {
+    DailyReadiness,
+    EngineObjectiveInput,
+    PhysicalWorkCheckin,
+    SubjectiveInput,
+    UserContext,
+} from './models';
+
+const BASE_OBJECTIVE: EngineObjectiveInput = {
+    total_steps: 7000,
+    sleep_score: 85,
+    sleep_duration_min: 480,
+    rhr: 50,
+    rhr_7d_avg: 50,
+    rhr_delta: 0,
+    hrv_weekly_avg: 55,
+    hrv_last_night: 55,
+    hrv_delta: 0,
+    respiration: 14,
+    body_battery_wake: 85,
+    last_3_days_hard_sessions_count: 0,
+    yesterday_training: null,
+    today_training: null,
+    sleep_score_delta_7d: 0,
+    rhr_delta_28d: 0,
+    hrv_delta_28d: 0,
+    sleep_score_delta_28d: 0,
+    hrv_stdev_28d: 8,
+    rhr_stdev_28d: 3,
+    sleep_score_stdev_28d: 7,
+};
+
+function baseSubjective(overrides: Partial<SubjectiveInput> = {}): SubjectiveInput {
+    return {
+        readiness: 7,
+        sleepQuality: 7,
+        fatigue: 3,
+        soreness: 3,
+        stress: 3,
+        motivation: 8,
+        timeAvailable: 60,
+        painFlag: false,
+        alreadyTrainedToday: false,
+        preferredModalityToday: null,
+        ...overrides,
+    };
+}
+
+function makeReadiness(subjective: SubjectiveInput): DailyReadiness {
+    return {
+        subjective,
+        objective: BASE_OBJECTIVE,
+    };
+}
+
+function baseContext(): UserContext {
+    return {
+        goals: { shortTerm: '', midTerm: '', longTerm: '' },
+        constraints: {
+            hasCableMachine: false,
+            hasFreeWeights: true,
+            hasTreadmill: false,
+            hasIndoorBike: false,
+            restrictedModalities: [],
+            maxTimeMinutes: 90,
+        },
+        preferences: {
+            avoidedModalities: [],
+            deprioritizedModalities: [],
+            preferredModalities: [],
+            conservativeBias: false,
+        },
+    };
+}
+
+describe('Unlogged Physical Work: computeInternalResponseStrain', () => {
+    it('returns standard subjective strain when physicalWork is absent or not performed', () => {
+        const subWithout = baseSubjective();
+        const subNotPerformed = baseSubjective({ physicalWork: { performed: false } });
+
+        const strainWithout = computeInternalResponseStrain(makeReadiness(subWithout));
+        const strainNotPerformed = computeInternalResponseStrain(makeReadiness(subNotPerformed));
+
+        expect(strainWithout).toEqual(strainNotPerformed);
+        expect(strainWithout.upperBody).toBeLessThan(0.3);
+        expect(strainWithout.neuromuscular).toBeLessThan(0.3);
+    });
+
+    it('elevates upperBody and neuromuscular strain when grip and upper body work is reported', () => {
+        const physicalWork: PhysicalWorkCheckin = {
+            performed: true,
+            duration: 'medium', // 1.0 factor
+            intensity: 'hard', // 0.70 base
+            loadAreas: ['grip_forearms', 'upper_body'],
+        };
+        const strain = computeInternalResponseStrain(makeReadiness(baseSubjective({ physicalWork })));
+
+        // hard medium work gives workStrainMagnitude = 0.70
+        // upper_body load area gives 0.70 * 0.85 = 0.595
+        expect(strain.upperBody).toBeGreaterThanOrEqual(0.58);
+        expect(strain.neuromuscular).toBeGreaterThanOrEqual(0.45);
+        expect(strain.systemic).toBeGreaterThanOrEqual(0.35);
+        // Lower body should remain at baseline low level
+        expect(strain.lowerBody).toBeLessThan(0.35);
+    });
+
+    it('elevates lowerBody, impactTissue, neuromuscular, and systemic when spine and legs carrying is reported', () => {
+        const physicalWork: PhysicalWorkCheckin = {
+            performed: true,
+            duration: 'extended', // 1.25 factor
+            intensity: 'exhausting', // 0.88 base -> 1.0 magnitude
+            loadAreas: ['lower_back_spine', 'legs_carrying'],
+        };
+        const strain = computeInternalResponseStrain(makeReadiness(baseSubjective({ physicalWork })));
+
+        expect(strain.lowerBody).toBeGreaterThanOrEqual(0.65);
+        expect(strain.neuromuscular).toBeGreaterThanOrEqual(0.60);
+        expect(strain.systemic).toBeGreaterThanOrEqual(0.55);
+        expect(strain.impactTissue).toBeGreaterThanOrEqual(0.35);
+    });
+
+    it('scales strain conservatively for short moderate work', () => {
+        const physicalWork: PhysicalWorkCheckin = {
+            performed: true,
+            duration: 'short', // 0.65 factor
+            intensity: 'moderate', // 0.45 base -> magnitude ~0.29
+            loadAreas: ['upper_body'],
+        };
+        const strain = computeInternalResponseStrain(makeReadiness(baseSubjective({ physicalWork })));
+
+        // Short moderate work should have a modest footprint
+        expect(strain.upperBody).toBeLessThan(0.35);
+        expect(strain.systemic).toBeLessThan(0.30);
+    });
+});
+
+describe('Unlogged Physical Work: evaluateReadinessAndSafetyEnvelope mode determination', () => {
+    it('forces mode to modify on hard 1-3h physical work even with green biometrics', () => {
+        const physicalWork: PhysicalWorkCheckin = {
+            performed: true,
+            duration: 'medium',
+            intensity: 'hard', // workStrain = 0.70 >= 0.65 -> physicalWorkModify = true
+            loadAreas: ['upper_body', 'grip_forearms'],
+        };
+        const readiness = makeReadiness(baseSubjective({ physicalWork }));
+        const envelope = evaluateReadinessAndSafetyEnvelope(readiness, baseContext());
+
+        expect(envelope.mode).toBe('modify');
+    });
+
+    it('forces mode to recover on exhausting work with moderate fatigue or soreness', () => {
+        const physicalWork: PhysicalWorkCheckin = {
+            performed: true,
+            duration: 'medium',
+            intensity: 'exhausting', // workStrain = 0.88 >= 0.85
+            loadAreas: ['lower_back_spine', 'legs_carrying'],
+        };
+        // athlete reports fatigue: 6 (threshold is >= 6)
+        const readiness = makeReadiness(baseSubjective({ fatigue: 6, soreness: 5, physicalWork }));
+        const envelope = evaluateReadinessAndSafetyEnvelope(readiness, baseContext());
+
+        expect(envelope.mode).toBe('recover');
+    });
+
+    it('keeps mode as train on short moderate physical work when athlete is fresh', () => {
+        const physicalWork: PhysicalWorkCheckin = {
+            performed: true,
+            duration: 'short',
+            intensity: 'moderate', // workStrain = 0.45 * 0.65 = 0.29 < 0.65
+            loadAreas: ['upper_body'],
+        };
+        const readiness = makeReadiness(baseSubjective({ physicalWork }));
+        const envelope = evaluateReadinessAndSafetyEnvelope(readiness, baseContext());
+
+        expect(envelope.mode).toBe('train');
+    });
+});

--- a/app/src/engine/policy.ts
+++ b/app/src/engine/policy.ts
@@ -1,11 +1,12 @@
 /** Increment whenever a change can alter a persisted recommendation decision. (Refactoring does not require a bump) */
 
-export const POLICY_VERSION = '2026-09-authored-rest-day-v1';
+export const POLICY_VERSION = '2026-09-unlogged-physical-work-v1';
 
 /** Historical versions are intentionally not re-executed by this build. Their compact
  * audits remain readable evidence, but replay is rejected explicitly because the old
  * decision function is not bundled alongside the current policy. */
 export const HISTORICAL_POLICY_VERSIONS = [
+    '2026-09-authored-rest-day-v1',
     '2026-09-outdoor-easy-cycling-anchor-authority-v1',
     '2026-09-outdoor-easy-cycling-v1',
     '2026-09-wearable-free-subjective-mode-v1',

--- a/app/src/engine/rules.ts
+++ b/app/src/engine/rules.ts
@@ -349,6 +349,17 @@ export function evaluateReadinessAndSafetyEnvelope(
         (hrvStrain.acuteDeviation >= 1.0 && objective.hrv_delta !== null && objective.hrv_delta <= -15);
     const acuteSubjectiveModify = subjective.fatigue >= 8 || subjective.readiness <= 3 || subjective.stress >= 9 || (subjective.readiness <= 4 && subjective.fatigue >= 6);
 
+    const pw = subjective.physicalWork;
+    let physicalWorkModify = false;
+    let physicalWorkRecover = false;
+    if (pw?.performed) {
+        const baseIntensity = pw.intensity === 'exhausting' ? 0.88 : pw.intensity === 'hard' ? 0.70 : 0.45;
+        const durationFactor = pw.duration === 'extended' ? 1.25 : pw.duration === 'short' ? 0.65 : 1.0;
+        const workStrain = Math.min(1, baseIntensity * durationFactor);
+        if (workStrain >= 0.65) physicalWorkModify = true;
+        if (workStrain >= 0.85 && (subjective.fatigue >= 6 || subjective.soreness >= 6)) physicalWorkRecover = true;
+    }
+
     const recentHardSessionsCount = objective.last_3_days_hard_sessions_count || 0;
     const recentHardSessionsPenalty = recentHardSessionsCount >= 2 ? RECENT_HARD_SESSIONS_STRAIN : 0;
     const objectiveStrain = totalMetricStrain + sleepFloorPenalty + bodyBatteryDeficit + conservativeBias + recentHardSessionsPenalty;
@@ -367,14 +378,14 @@ export function evaluateReadinessAndSafetyEnvelope(
         objective.hrv_delta !== null && objective.hrv_delta <= -10 &&
         objective.rhr_delta !== null && objective.rhr_delta >= 5 &&
         objective.body_battery_wake !== null && objective.body_battery_wake <= 35;
-    const fatigueTriggeredRecover = overallFatigueScore > 7 || extremeFatigue || severeSubjectiveDistress || lowBodyBatteryRecovery || combinedAcuteBiometricRecover || strainForThresholds >= STRAIN_RECOVER_THRESHOLD;
+    const fatigueTriggeredRecover = overallFatigueScore > 7 || extremeFatigue || severeSubjectiveDistress || lowBodyBatteryRecovery || combinedAcuteBiometricRecover || physicalWorkRecover || strainForThresholds >= STRAIN_RECOVER_THRESHOLD;
     let mode: 'train' | 'modify' | 'recover' = fatigueTriggeredRecover
         ? 'recover'
-        : (overallFatigueScore > 5 || subjective.soreness > 6 || acuteSubjectiveModify || acuteBiometricStrainFloor || strainForThresholds >= STRAIN_MODIFY_THRESHOLD) ? 'modify' : 'train';
+        : (overallFatigueScore > 5 || subjective.soreness > 6 || acuteSubjectiveModify || physicalWorkModify || acuteBiometricStrainFloor || strainForThresholds >= STRAIN_MODIFY_THRESHOLD) ? 'modify' : 'train';
 
     const strainWithoutDrift = objectiveStrain - totalMultiDayDrift;
-    const counterfactualRecover = overallFatigueScore > 7 || extremeFatigue || severeSubjectiveDistress || lowBodyBatteryRecovery || combinedAcuteBiometricRecover || strainWithoutDrift >= STRAIN_RECOVER_THRESHOLD;
-    const counterfactualModify = counterfactualRecover || overallFatigueScore > 5 || subjective.soreness > 6 || acuteSubjectiveModify || acuteBiometricStrainFloor || strainWithoutDrift >= STRAIN_MODIFY_THRESHOLD;
+    const counterfactualRecover = overallFatigueScore > 7 || extremeFatigue || severeSubjectiveDistress || lowBodyBatteryRecovery || combinedAcuteBiometricRecover || physicalWorkRecover || strainWithoutDrift >= STRAIN_RECOVER_THRESHOLD;
+    const counterfactualModify = counterfactualRecover || overallFatigueScore > 5 || subjective.soreness > 6 || acuteSubjectiveModify || physicalWorkModify || acuteBiometricStrainFloor || strainWithoutDrift >= STRAIN_MODIFY_THRESHOLD;
     const counterfactualModeWithoutDrift = counterfactualRecover ? 'recover' : (counterfactualModify ? 'modify' : 'train');
     const multiDayDriftIsDecisionRelevant = (mode !== 'train') && (mode !== counterfactualModeWithoutDrift);
 
@@ -383,8 +394,8 @@ export function evaluateReadinessAndSafetyEnvelope(
     // objective multi-day-drift axis) through the same threshold logic, so a caller can tell
     // whether subjective drift specifically changed the mode. Inert under 'off' (subjectiveDrift
     // is always 0 there, so modeWithoutSubjectiveDrift always equals mode).
-    const recoverWithoutSubjectiveDrift = overallFatigueScore > 7 || extremeFatigue || severeSubjectiveDistress || lowBodyBatteryRecovery || combinedAcuteBiometricRecover || objectiveStrain >= STRAIN_RECOVER_THRESHOLD;
-    const modifyWithoutSubjectiveDrift = recoverWithoutSubjectiveDrift || overallFatigueScore > 5 || subjective.soreness > 6 || acuteSubjectiveModify || acuteBiometricStrainFloor || objectiveStrain >= STRAIN_MODIFY_THRESHOLD;
+    const recoverWithoutSubjectiveDrift = overallFatigueScore > 7 || extremeFatigue || severeSubjectiveDistress || lowBodyBatteryRecovery || combinedAcuteBiometricRecover || physicalWorkRecover || objectiveStrain >= STRAIN_RECOVER_THRESHOLD;
+    const modifyWithoutSubjectiveDrift = recoverWithoutSubjectiveDrift || overallFatigueScore > 5 || subjective.soreness > 6 || acuteSubjectiveModify || physicalWorkModify || acuteBiometricStrainFloor || objectiveStrain >= STRAIN_MODIFY_THRESHOLD;
     const modeWithoutSubjectiveDrift = recoverWithoutSubjectiveDrift ? 'recover' : (modifyWithoutSubjectiveDrift ? 'modify' : 'train');
     const subjectiveDriftIsDecisionRelevant = (mode !== 'train') && (mode !== modeWithoutSubjectiveDrift);
 

--- a/app/src/engine/validation.test.ts
+++ b/app/src/engine/validation.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { isValidDate, validateRecommendation, validateAdherenceUpdate, validateGoal, validateFixedActivity, validateCheckin, validateAuthoredPlanBlock, validatePreferences } from './validation';
+import type { PhysicalWorkDuration, PhysicalWorkIntensity, PhysicalWorkLoadArea } from './models';
 
 describe('validatePreferences unavailable modalities', () => {
     const valid = {
@@ -529,6 +530,129 @@ describe('validateCheckin: tissueResponses (Phase 5.4)', () => {
         });
     });
 });
+
+describe('validateCheckin: physicalWork', () => {
+    const baseFields = {
+        userId: 'u1',
+        date: '2026-08-08',
+        readiness: 7,
+    };
+
+    it('accepts complete and valid physical work', () => {
+        const result = validateCheckin({
+            ...baseFields,
+            physicalWork: {
+                performed: true,
+                duration: 'medium',
+                intensity: 'hard',
+                loadAreas: ['grip_forearms', 'upper_body'],
+                notes: 'cutting trees and moving logs',
+            },
+        });
+        expect(result.isValid).toBe(true);
+        expect(result.data?.physicalWork).toEqual({
+            performed: true,
+            duration: 'medium',
+            intensity: 'hard',
+            loadAreas: ['grip_forearms', 'upper_body'],
+            notes: 'cutting trees and moving logs',
+        });
+    });
+
+    it('accepts minimal physicalWork when performed is false', () => {
+        const result = validateCheckin({
+            ...baseFields,
+            physicalWork: { performed: false },
+        });
+        expect(result.isValid).toBe(true);
+        expect(result.data?.physicalWork).toEqual({ performed: false });
+    });
+
+    it('sanitizes notes trimming whitespace and omitting empty string', () => {
+        const result = validateCheckin({
+            ...baseFields,
+            physicalWork: {
+                performed: true,
+                duration: 'short',
+                intensity: 'moderate',
+                loadAreas: ['lower_back_spine'],
+                notes: '   ',
+            },
+        });
+        expect(result.isValid).toBe(true);
+        expect(result.data?.physicalWork?.notes).toBeUndefined();
+    });
+
+    it('rejects invalid duration', () => {
+        const result = validateCheckin({
+            ...baseFields,
+            physicalWork: {
+                performed: true,
+                duration: 'full_day' as unknown as PhysicalWorkDuration,
+                intensity: 'moderate',
+                loadAreas: ['legs_carrying'],
+            },
+        });
+        expect(result.isValid).toBe(false);
+        expect(result.errors.some(e => e.field === 'physicalWork.duration')).toBe(true);
+    });
+
+    it('rejects invalid intensity', () => {
+        const result = validateCheckin({
+            ...baseFields,
+            physicalWork: {
+                performed: true,
+                duration: 'medium',
+                intensity: 'extreme' as unknown as PhysicalWorkIntensity,
+                loadAreas: ['legs_carrying'],
+            },
+        });
+        expect(result.isValid).toBe(false);
+        expect(result.errors.some(e => e.field === 'physicalWork.intensity')).toBe(true);
+    });
+
+    it('rejects empty or invalid loadAreas', () => {
+        const emptyResult = validateCheckin({
+            ...baseFields,
+            physicalWork: {
+                performed: true,
+                duration: 'medium',
+                intensity: 'moderate',
+                loadAreas: [],
+            },
+        });
+        expect(emptyResult.isValid).toBe(false);
+        expect(emptyResult.errors.some(e => e.field === 'physicalWork.loadAreas')).toBe(true);
+
+        const invalidResult = validateCheckin({
+            ...baseFields,
+            physicalWork: {
+                performed: true,
+                duration: 'medium',
+                intensity: 'moderate',
+                loadAreas: ['invalid_area' as unknown as PhysicalWorkLoadArea],
+            },
+        });
+        expect(invalidResult.isValid).toBe(false);
+        expect(invalidResult.errors.some(e => e.field === 'physicalWork.loadAreas')).toBe(true);
+    });
+
+    it('rejects notes exceeding max length', () => {
+        const result = validateCheckin({
+            ...baseFields,
+            physicalWork: {
+                performed: true,
+                duration: 'medium',
+                intensity: 'moderate',
+                loadAreas: ['lower_back_spine'],
+                notes: 'a'.repeat(201),
+            },
+        });
+        expect(result.isValid).toBe(false);
+        expect(result.errors.some(e => e.field === 'physicalWork.notes')).toBe(true);
+    });
+});
+
 
 describe('validateEventTiming', () => {
     it('accepts valid unconfirmed EventTiming', async () => {

--- a/app/src/engine/validation.test.ts
+++ b/app/src/engine/validation.test.ts
@@ -637,6 +637,45 @@ describe('validateCheckin: physicalWork', () => {
         expect(invalidResult.errors.some(e => e.field === 'physicalWork.loadAreas')).toBe(true);
     });
 
+    it('rejects performed work missing duration', () => {
+        const result = validateCheckin({
+            ...baseFields,
+            physicalWork: {
+                performed: true,
+                intensity: 'moderate',
+                loadAreas: ['legs_carrying'],
+            },
+        });
+        expect(result.isValid).toBe(false);
+        expect(result.errors.some(e => e.field === 'physicalWork.duration' && e.message.includes('required'))).toBe(true);
+    });
+
+    it('rejects performed work missing intensity', () => {
+        const result = validateCheckin({
+            ...baseFields,
+            physicalWork: {
+                performed: true,
+                duration: 'medium',
+                loadAreas: ['legs_carrying'],
+            },
+        });
+        expect(result.isValid).toBe(false);
+        expect(result.errors.some(e => e.field === 'physicalWork.intensity' && e.message.includes('required'))).toBe(true);
+    });
+
+    it('rejects performed work missing loadAreas', () => {
+        const result = validateCheckin({
+            ...baseFields,
+            physicalWork: {
+                performed: true,
+                duration: 'medium',
+                intensity: 'moderate',
+            },
+        });
+        expect(result.isValid).toBe(false);
+        expect(result.errors.some(e => e.field === 'physicalWork.loadAreas' && e.message.includes('required'))).toBe(true);
+    });
+
     it('rejects notes exceeding max length', () => {
         const result = validateCheckin({
             ...baseFields,

--- a/app/src/engine/validationCore.ts
+++ b/app/src/engine/validationCore.ts
@@ -179,6 +179,10 @@ export const PHYSICAL_WORK_LOAD_AREAS: readonly PhysicalWorkLoadArea[] = [
 ];
 export const PHYSICAL_WORK_NOTES_MAX_CHARS = 200;
 
+/**
+ * Validates untyped physical work / manual labor payload from morning check-in.
+ * When performed is true, requires duration, intensity, and non-empty loadAreas.
+ */
 function validatePhysicalWork(raw: any, errors: ValidationError[]): PhysicalWorkCheckin | undefined {
     if (raw === undefined || raw === null) return undefined;
     if (typeof raw !== 'object' || Array.isArray(raw)) {
@@ -188,18 +192,23 @@ function validatePhysicalWork(raw: any, errors: ValidationError[]): PhysicalWork
     if (typeof raw.performed !== 'boolean') {
         errors.push({ field: 'physicalWork.performed', message: 'performed must be a boolean', value: raw.performed });
     }
-    if (raw.duration !== undefined && raw.duration !== null) {
-        if (typeof raw.duration !== 'string' || !PHYSICAL_WORK_DURATIONS.includes(raw.duration as PhysicalWorkDuration)) {
+
+    if (raw.performed === true) {
+        if (raw.duration === undefined || raw.duration === null) {
+            errors.push({ field: 'physicalWork.duration', message: 'duration is required when performed is true' });
+        } else if (typeof raw.duration !== 'string' || !PHYSICAL_WORK_DURATIONS.includes(raw.duration as PhysicalWorkDuration)) {
             errors.push({ field: 'physicalWork.duration', message: `duration must be one of: ${PHYSICAL_WORK_DURATIONS.join(', ')}`, value: raw.duration });
         }
-    }
-    if (raw.intensity !== undefined && raw.intensity !== null) {
-        if (typeof raw.intensity !== 'string' || !PHYSICAL_WORK_INTENSITIES.includes(raw.intensity as PhysicalWorkIntensity)) {
+
+        if (raw.intensity === undefined || raw.intensity === null) {
+            errors.push({ field: 'physicalWork.intensity', message: 'intensity is required when performed is true' });
+        } else if (typeof raw.intensity !== 'string' || !PHYSICAL_WORK_INTENSITIES.includes(raw.intensity as PhysicalWorkIntensity)) {
             errors.push({ field: 'physicalWork.intensity', message: `intensity must be one of: ${PHYSICAL_WORK_INTENSITIES.join(', ')}`, value: raw.intensity });
         }
-    }
-    if (raw.loadAreas !== undefined && raw.loadAreas !== null) {
-        if (!Array.isArray(raw.loadAreas) || raw.loadAreas.length === 0) {
+
+        if (raw.loadAreas === undefined || raw.loadAreas === null) {
+            errors.push({ field: 'physicalWork.loadAreas', message: 'loadAreas is required when performed is true' });
+        } else if (!Array.isArray(raw.loadAreas) || raw.loadAreas.length === 0) {
             errors.push({ field: 'physicalWork.loadAreas', message: 'loadAreas must be a non-empty array', value: raw.loadAreas });
         } else {
             for (const area of raw.loadAreas) {
@@ -208,7 +217,30 @@ function validatePhysicalWork(raw: any, errors: ValidationError[]): PhysicalWork
                 }
             }
         }
+    } else {
+        if (raw.duration !== undefined && raw.duration !== null) {
+            if (typeof raw.duration !== 'string' || !PHYSICAL_WORK_DURATIONS.includes(raw.duration as PhysicalWorkDuration)) {
+                errors.push({ field: 'physicalWork.duration', message: `duration must be one of: ${PHYSICAL_WORK_DURATIONS.join(', ')}`, value: raw.duration });
+            }
+        }
+        if (raw.intensity !== undefined && raw.intensity !== null) {
+            if (typeof raw.intensity !== 'string' || !PHYSICAL_WORK_INTENSITIES.includes(raw.intensity as PhysicalWorkIntensity)) {
+                errors.push({ field: 'physicalWork.intensity', message: `intensity must be one of: ${PHYSICAL_WORK_INTENSITIES.join(', ')}`, value: raw.intensity });
+            }
+        }
+        if (raw.loadAreas !== undefined && raw.loadAreas !== null) {
+            if (!Array.isArray(raw.loadAreas) || raw.loadAreas.length === 0) {
+                errors.push({ field: 'physicalWork.loadAreas', message: 'loadAreas must be a non-empty array', value: raw.loadAreas });
+            } else {
+                for (const area of raw.loadAreas) {
+                    if (typeof area !== 'string' || !PHYSICAL_WORK_LOAD_AREAS.includes(area as PhysicalWorkLoadArea)) {
+                        errors.push({ field: 'physicalWork.loadAreas', message: `loadAreas contains unrecognized area: ${area}`, value: area });
+                    }
+                }
+            }
+        }
     }
+
     if (raw.notes !== undefined && raw.notes !== null) {
         if (typeof raw.notes !== 'string' || raw.notes.length > PHYSICAL_WORK_NOTES_MAX_CHARS) {
             errors.push({ field: 'physicalWork.notes', message: `notes must be a string up to ${PHYSICAL_WORK_NOTES_MAX_CHARS} characters`, value: raw.notes });

--- a/app/src/engine/validationCore.ts
+++ b/app/src/engine/validationCore.ts
@@ -50,6 +50,10 @@ import type {
     ExternalPlacementStatus,
     DecisionJournalEntry,
     ShadowVerdict,
+    PhysicalWorkCheckin,
+    PhysicalWorkDuration,
+    PhysicalWorkIntensity,
+    PhysicalWorkLoadArea,
 } from './models';
 import { EXTERNAL_PLAN_SCHEMA, SHADOW_VERDICTS } from './models';
 import { validateEventTiming, BODY_REGIONS, TISSUE_LEVELS } from './models';
@@ -165,6 +169,65 @@ function validateTissueResponses(raw: any, errors: ValidationError[]): Partial<R
     return result;
 }
 
+export const PHYSICAL_WORK_DURATIONS: readonly PhysicalWorkDuration[] = ['short', 'medium', 'extended'];
+export const PHYSICAL_WORK_INTENSITIES: readonly PhysicalWorkIntensity[] = ['moderate', 'hard', 'exhausting'];
+export const PHYSICAL_WORK_LOAD_AREAS: readonly PhysicalWorkLoadArea[] = [
+    'grip_forearms',
+    'upper_body',
+    'lower_back_spine',
+    'legs_carrying',
+];
+export const PHYSICAL_WORK_NOTES_MAX_CHARS = 200;
+
+function validatePhysicalWork(raw: any, errors: ValidationError[]): PhysicalWorkCheckin | undefined {
+    if (raw === undefined || raw === null) return undefined;
+    if (typeof raw !== 'object' || Array.isArray(raw)) {
+        errors.push({ field: 'physicalWork', message: 'physicalWork must be an object' });
+        return undefined;
+    }
+    if (typeof raw.performed !== 'boolean') {
+        errors.push({ field: 'physicalWork.performed', message: 'performed must be a boolean', value: raw.performed });
+    }
+    if (raw.duration !== undefined && raw.duration !== null) {
+        if (typeof raw.duration !== 'string' || !PHYSICAL_WORK_DURATIONS.includes(raw.duration as PhysicalWorkDuration)) {
+            errors.push({ field: 'physicalWork.duration', message: `duration must be one of: ${PHYSICAL_WORK_DURATIONS.join(', ')}`, value: raw.duration });
+        }
+    }
+    if (raw.intensity !== undefined && raw.intensity !== null) {
+        if (typeof raw.intensity !== 'string' || !PHYSICAL_WORK_INTENSITIES.includes(raw.intensity as PhysicalWorkIntensity)) {
+            errors.push({ field: 'physicalWork.intensity', message: `intensity must be one of: ${PHYSICAL_WORK_INTENSITIES.join(', ')}`, value: raw.intensity });
+        }
+    }
+    if (raw.loadAreas !== undefined && raw.loadAreas !== null) {
+        if (!Array.isArray(raw.loadAreas) || raw.loadAreas.length === 0) {
+            errors.push({ field: 'physicalWork.loadAreas', message: 'loadAreas must be a non-empty array', value: raw.loadAreas });
+        } else {
+            for (const area of raw.loadAreas) {
+                if (typeof area !== 'string' || !PHYSICAL_WORK_LOAD_AREAS.includes(area as PhysicalWorkLoadArea)) {
+                    errors.push({ field: 'physicalWork.loadAreas', message: `loadAreas contains unrecognized area: ${area}`, value: area });
+                }
+            }
+        }
+    }
+    if (raw.notes !== undefined && raw.notes !== null) {
+        if (typeof raw.notes !== 'string' || raw.notes.length > PHYSICAL_WORK_NOTES_MAX_CHARS) {
+            errors.push({ field: 'physicalWork.notes', message: `notes must be a string up to ${PHYSICAL_WORK_NOTES_MAX_CHARS} characters`, value: raw.notes });
+        }
+    }
+
+    if (errors.some(e => e.field.startsWith('physicalWork'))) {
+        return undefined;
+    }
+
+    return {
+        performed: Boolean(raw.performed),
+        ...(raw.duration ? { duration: raw.duration as PhysicalWorkDuration } : {}),
+        ...(raw.intensity ? { intensity: raw.intensity as PhysicalWorkIntensity } : {}),
+        ...(Array.isArray(raw.loadAreas) && raw.loadAreas.length > 0 ? { loadAreas: Array.from(new Set(raw.loadAreas as PhysicalWorkLoadArea[])) } : {}),
+        ...(typeof raw.notes === 'string' && raw.notes.trim() ? { notes: raw.notes.trim() } : {}),
+    };
+}
+
 export function validateCheckin(raw: any): ValidationResult<DailySubjectiveCheckin> {
     const errors: ValidationError[] = [];
 
@@ -248,6 +311,7 @@ export function validateCheckin(raw: any): ValidationResult<DailySubjectiveCheck
 
     // Per-region tissue response (Phase 5.4)
     const tissueResponses = validateTissueResponses(raw.tissueResponses, errors);
+    const physicalWork = validatePhysicalWork(raw.physicalWork, errors);
 
     if (errors.length > 0) {
         return { isValid: false, errors };
@@ -268,6 +332,7 @@ export function validateCheckin(raw: any): ValidationResult<DailySubjectiveCheck
         unusuallyLimitedTime: raw.unusuallyLimitedTime ?? false,
         alreadyTrainedToday: raw.alreadyTrainedToday ?? false,
         ...(tissueResponses && Object.keys(tissueResponses).length > 0 ? { tissueResponses } : {}),
+        ...(physicalWork ? { physicalWork } : {}),
         availability: {
             timeAvailableMin: normalizeEmptyToNull(raw.availability?.timeAvailableMin),
             preferredModalityToday: normalizeEmptyToNull(raw.availability?.preferredModalityToday),

--- a/app/src/persistence/parsers/decisionInputs.test.ts
+++ b/app/src/persistence/parsers/decisionInputs.test.ts
@@ -117,4 +117,17 @@ describe('decision-input parsers', () => {
         expect(parseSubjectiveCheckin(missingLoadAreas, 'path', 'u1', '2026-08-07'))
             .toMatchObject({ status: 'INVALID', issues: [{ code: 'invalid-physical-work', field: 'physicalWork.loadAreas' }] });
     });
+
+    it('omits physicalWork when raw physicalWork is null or undefined', () => {
+        const withNullPhysicalWork = {
+            ...checkin,
+            physicalWork: null,
+        };
+        const parsed = parseSubjectiveCheckin(withNullPhysicalWork, 'path', 'u1', '2026-08-07');
+        expect(parsed.status).toBe('AVAILABLE');
+        if (parsed.status === 'AVAILABLE') {
+            expect(parsed.data.physicalWork).toBeUndefined();
+            expect('physicalWork' in parsed.data).toBe(false);
+        }
+    });
 });

--- a/app/src/persistence/parsers/decisionInputs.test.ts
+++ b/app/src/persistence/parsers/decisionInputs.test.ts
@@ -83,5 +83,38 @@ describe('decision-input parsers', () => {
         };
         expect(parseSubjectiveCheckin(malformedPhysicalWork, 'path', 'u1', '2026-08-07'))
             .toMatchObject({ status: 'INVALID', issues: [{ code: 'invalid-physical-work' }] });
+
+        const missingDuration = {
+            ...checkin,
+            physicalWork: {
+                performed: true,
+                intensity: 'hard',
+                loadAreas: ['grip_forearms'],
+            },
+        };
+        expect(parseSubjectiveCheckin(missingDuration, 'path', 'u1', '2026-08-07'))
+            .toMatchObject({ status: 'INVALID', issues: [{ code: 'invalid-physical-work', field: 'physicalWork.duration' }] });
+
+        const missingIntensity = {
+            ...checkin,
+            physicalWork: {
+                performed: true,
+                duration: 'medium',
+                loadAreas: ['grip_forearms'],
+            },
+        };
+        expect(parseSubjectiveCheckin(missingIntensity, 'path', 'u1', '2026-08-07'))
+            .toMatchObject({ status: 'INVALID', issues: [{ code: 'invalid-physical-work', field: 'physicalWork.intensity' }] });
+
+        const missingLoadAreas = {
+            ...checkin,
+            physicalWork: {
+                performed: true,
+                duration: 'medium',
+                intensity: 'hard',
+            },
+        };
+        expect(parseSubjectiveCheckin(missingLoadAreas, 'path', 'u1', '2026-08-07'))
+            .toMatchObject({ status: 'INVALID', issues: [{ code: 'invalid-physical-work', field: 'physicalWork.loadAreas' }] });
     });
 });

--- a/app/src/persistence/parsers/decisionInputs.test.ts
+++ b/app/src/persistence/parsers/decisionInputs.test.ts
@@ -50,4 +50,38 @@ describe('decision-input parsers', () => {
         expect(parseSubjectiveCheckin(missingSafety, 'path', 'u1', '2026-08-07'))
             .toMatchObject({ status: 'INVALID', issues: [{ code: 'invalid-safety-flag' }] });
     });
+
+    it('parses valid physicalWork and rejects malformed physicalWork', () => {
+        const withPhysicalWork = {
+            ...checkin,
+            physicalWork: {
+                performed: true,
+                duration: 'medium',
+                intensity: 'hard',
+                loadAreas: ['grip_forearms', 'lower_back_spine'],
+                notes: 'wood chopping',
+            },
+        };
+        const parsed = parseSubjectiveCheckin(withPhysicalWork, 'users/u1/daily_subjective_checkins/2026-08-07', 'u1', '2026-08-07');
+        expect(parsed.status).toBe('AVAILABLE');
+        if (parsed.status === 'AVAILABLE') {
+            expect(parsed.data.physicalWork).toEqual({
+                performed: true,
+                duration: 'medium',
+                intensity: 'hard',
+                loadAreas: ['grip_forearms', 'lower_back_spine'],
+                notes: 'wood chopping',
+            });
+        }
+
+        const malformedPhysicalWork = {
+            ...checkin,
+            physicalWork: {
+                performed: true,
+                duration: 'invalid_duration',
+            },
+        };
+        expect(parseSubjectiveCheckin(malformedPhysicalWork, 'path', 'u1', '2026-08-07'))
+            .toMatchObject({ status: 'INVALID', issues: [{ code: 'invalid-physical-work' }] });
+    });
 });

--- a/app/src/persistence/parsers/decisionInputs.ts
+++ b/app/src/persistence/parsers/decisionInputs.ts
@@ -1,8 +1,21 @@
 import type { DataState } from '../../engine/dataState';
-import type { DailyRecoverySnapshot, DailySubjectiveCheckin, DecisionJournalEntry } from '../../engine/models';
+import type {
+    DailyRecoverySnapshot,
+    DailySubjectiveCheckin,
+    DecisionJournalEntry,
+    PhysicalWorkDuration,
+    PhysicalWorkIntensity,
+    PhysicalWorkLoadArea,
+} from '../../engine/models';
 import { SHADOW_VERDICTS } from '../../engine/models';
 import { isValidDate } from '../../engine/validation';
 import { resolveLegacyIllnessSymptoms, validateHealthContext } from '../../engine/healthContextValidation';
+import {
+    PHYSICAL_WORK_DURATIONS,
+    PHYSICAL_WORK_INTENSITIES,
+    PHYSICAL_WORK_LOAD_AREAS,
+    PHYSICAL_WORK_NOTES_MAX_CHARS,
+} from '../../engine/validationCore';
 
 type RawDocument = Record<string, unknown>;
 
@@ -90,10 +103,42 @@ export function parseSubjectiveCheckin(raw: unknown, documentPath: string, userI
         return issue(documentPath, 'invalid-checkin-field');
     }
 
+    let physicalWork: DailySubjectiveCheckin['physicalWork'] = undefined;
+    if (raw.physicalWork !== undefined && raw.physicalWork !== null) {
+        if (!isObject(raw.physicalWork) || typeof raw.physicalWork.performed !== 'boolean') {
+            return issue(documentPath, 'invalid-physical-work', 'physicalWork');
+        }
+        const pw = raw.physicalWork;
+        if (pw.duration !== undefined && pw.duration !== null
+            && (typeof pw.duration !== 'string' || !PHYSICAL_WORK_DURATIONS.includes(pw.duration as PhysicalWorkDuration))) {
+            return issue(documentPath, 'invalid-physical-work', 'physicalWork.duration');
+        }
+        if (pw.intensity !== undefined && pw.intensity !== null
+            && (typeof pw.intensity !== 'string' || !PHYSICAL_WORK_INTENSITIES.includes(pw.intensity as PhysicalWorkIntensity))) {
+            return issue(documentPath, 'invalid-physical-work', 'physicalWork.intensity');
+        }
+        if (pw.loadAreas !== undefined && pw.loadAreas !== null) {
+            if (!Array.isArray(pw.loadAreas) || pw.loadAreas.length === 0 || pw.loadAreas.some(area => typeof area !== 'string' || !PHYSICAL_WORK_LOAD_AREAS.includes(area as PhysicalWorkLoadArea))) {
+                return issue(documentPath, 'invalid-physical-work', 'physicalWork.loadAreas');
+            }
+        }
+        if (pw.notes !== undefined && pw.notes !== null && (typeof pw.notes !== 'string' || pw.notes.length > PHYSICAL_WORK_NOTES_MAX_CHARS)) {
+            return issue(documentPath, 'invalid-physical-work', 'physicalWork.notes');
+        }
+        physicalWork = {
+            performed: Boolean(pw.performed),
+            ...(pw.duration ? { duration: pw.duration as PhysicalWorkDuration } : {}),
+            ...(pw.intensity ? { intensity: pw.intensity as PhysicalWorkIntensity } : {}),
+            ...(Array.isArray(pw.loadAreas) && pw.loadAreas.length > 0 ? { loadAreas: Array.from(new Set(pw.loadAreas as PhysicalWorkLoadArea[])) } : {}),
+            ...(typeof pw.notes === 'string' && pw.notes.trim() ? { notes: pw.notes.trim() } : {}),
+        };
+    }
+
     const normalized: DailySubjectiveCheckin = {
         ...(raw as unknown as DailySubjectiveCheckin),
         illnessSymptoms: resolveLegacyIllnessSymptoms(raw.illnessSymptoms, healthContext),
         ...(healthContext ? { healthContext } : {}),
+        ...(physicalWork ? { physicalWork } : {}),
     };
     return {
         status: 'AVAILABLE',

--- a/app/src/persistence/parsers/decisionInputs.ts
+++ b/app/src/persistence/parsers/decisionInputs.ts
@@ -158,6 +158,9 @@ export function parseSubjectiveCheckin(raw: unknown, documentPath: string, userI
         ...(healthContext ? { healthContext } : {}),
         ...(physicalWork ? { physicalWork } : {}),
     };
+    if (!physicalWork) {
+        delete (normalized as { physicalWork?: unknown }).physicalWork;
+    }
     return {
         status: 'AVAILABLE',
         data: normalized,

--- a/app/src/persistence/parsers/decisionInputs.ts
+++ b/app/src/persistence/parsers/decisionInputs.ts
@@ -109,17 +109,35 @@ export function parseSubjectiveCheckin(raw: unknown, documentPath: string, userI
             return issue(documentPath, 'invalid-physical-work', 'physicalWork');
         }
         const pw = raw.physicalWork;
-        if (pw.duration !== undefined && pw.duration !== null
-            && (typeof pw.duration !== 'string' || !PHYSICAL_WORK_DURATIONS.includes(pw.duration as PhysicalWorkDuration))) {
-            return issue(documentPath, 'invalid-physical-work', 'physicalWork.duration');
-        }
-        if (pw.intensity !== undefined && pw.intensity !== null
-            && (typeof pw.intensity !== 'string' || !PHYSICAL_WORK_INTENSITIES.includes(pw.intensity as PhysicalWorkIntensity))) {
-            return issue(documentPath, 'invalid-physical-work', 'physicalWork.intensity');
-        }
-        if (pw.loadAreas !== undefined && pw.loadAreas !== null) {
-            if (!Array.isArray(pw.loadAreas) || pw.loadAreas.length === 0 || pw.loadAreas.some(area => typeof area !== 'string' || !PHYSICAL_WORK_LOAD_AREAS.includes(area as PhysicalWorkLoadArea))) {
+        if (pw.performed) {
+            if (pw.duration === undefined || pw.duration === null
+                || typeof pw.duration !== 'string'
+                || !PHYSICAL_WORK_DURATIONS.includes(pw.duration as PhysicalWorkDuration)) {
+                return issue(documentPath, 'invalid-physical-work', 'physicalWork.duration');
+            }
+            if (pw.intensity === undefined || pw.intensity === null
+                || typeof pw.intensity !== 'string'
+                || !PHYSICAL_WORK_INTENSITIES.includes(pw.intensity as PhysicalWorkIntensity)) {
+                return issue(documentPath, 'invalid-physical-work', 'physicalWork.intensity');
+            }
+            if (pw.loadAreas === undefined || pw.loadAreas === null
+                || !Array.isArray(pw.loadAreas) || pw.loadAreas.length === 0
+                || pw.loadAreas.some(area => typeof area !== 'string' || !PHYSICAL_WORK_LOAD_AREAS.includes(area as PhysicalWorkLoadArea))) {
                 return issue(documentPath, 'invalid-physical-work', 'physicalWork.loadAreas');
+            }
+        } else {
+            if (pw.duration !== undefined && pw.duration !== null
+                && (typeof pw.duration !== 'string' || !PHYSICAL_WORK_DURATIONS.includes(pw.duration as PhysicalWorkDuration))) {
+                return issue(documentPath, 'invalid-physical-work', 'physicalWork.duration');
+            }
+            if (pw.intensity !== undefined && pw.intensity !== null
+                && (typeof pw.intensity !== 'string' || !PHYSICAL_WORK_INTENSITIES.includes(pw.intensity as PhysicalWorkIntensity))) {
+                return issue(documentPath, 'invalid-physical-work', 'physicalWork.intensity');
+            }
+            if (pw.loadAreas !== undefined && pw.loadAreas !== null) {
+                if (!Array.isArray(pw.loadAreas) || pw.loadAreas.length === 0 || pw.loadAreas.some(area => typeof area !== 'string' || !PHYSICAL_WORK_LOAD_AREAS.includes(area as PhysicalWorkLoadArea))) {
+                    return issue(documentPath, 'invalid-physical-work', 'physicalWork.loadAreas');
+                }
             }
         }
         if (pw.notes !== undefined && pw.notes !== null && (typeof pw.notes !== 'string' || pw.notes.length > PHYSICAL_WORK_NOTES_MAX_CHARS)) {

--- a/app/src/services/checkinService.ts
+++ b/app/src/services/checkinService.ts
@@ -119,6 +119,9 @@ export class CheckinService {
             if (!validatedCheckin.painOrInjury) {
                 payload.tissueResponses = deleteField();
             }
+            if (!validatedCheckin.physicalWork || !validatedCheckin.physicalWork.performed) {
+                payload.physicalWork = deleteField();
+            }
 
             // `setDoc(..., { merge: true })` recursively preserves omitted nested fields.
             // Treat this daily context as replace-on-answer: an omitted whole block deletes


### PR DESCRIPTION
## Summary

This PR adds an **"Unlogged Physical Work / Manual Labor"** section to the morning check-in and integrates its physiological impact directly into the engine's multi-dimensional fatigue model, mode selection, implied guardrails, and AI context brief export.

### The Problem
Wearables (Garmin, Apple Watch, etc.) predominantly estimate energy expenditure and training load via optical heart rate and accelerometer steps. During heavy, sporadic manual labor (e.g. chainsaw work, cutting trees, moving heavy logs, carpentry, construction, landscaping), cardiovascular demand and ambient step count are often low or moderate, but:
1. **Isometric grip and forearm fatigue** is severe, impairing upper-body pull and barbell/dumbbell handling.
2. **Axial/spinal loading** causes acute lumbar strain and central nervous system (neuromuscular) fatigue.
3. Athletes attempting heavy compound resistance training (deadlifts, squats, overhead presses) or high-intensity intervals on day $D$ after unlogged labor on $D-1$ risk severe musculoskeletal strain or injury because the wearable reports misleadingly "green" recovery.
4. External AI planning agents (e.g. Claude/ChatGPT via the AI Context Brief) lacked visibility into unlogged labor, risking recommendations for heavy compound or high-intensity workouts on compromised muscle groups.

### The Solution
Instead of polluting illness anomaly detection (`healthContext`) or relying on static profile defaults (which fail on sporadic episodic events), we provide:
1. A dedicated check-in toggle and card: **"🔨 Unlogged Physical Work / Manual Labor (Yesterday)"**.
2. Granular, high-signal inputs:
   - **Duration**: `< 1 hr` (`short`), `1–3 hrs` (`medium`), `3+ hrs` (`extended`).
   - **Effort**: `Moderate`, `Hard`, `Exhausting`.
   - **Main Strain Areas**: `Grip & Forearms` (`grip_forearms`), `Upper Body (Pull/Shoulders)` (`upper_body`), `Lower Back & Spine` (`lower_back_spine`), `Legs & Carrying` (`legs_carrying`).
   - **Notes** (optional, sanitized up to 200 chars).
3. **Engine Internal Response Strain Integration**:
   - Computes non-diluted `physicalWorkStrain = Math.min(1, baseIntensity * durationFactor)`.
   - Routes strain directly into dimensional fatigue:
     - `upperBody`: boosted for `upper_body` and `grip_forearms` ($\approx 0.60–0.85$).
     - `lowerBody`: boosted for `legs_carrying` ($\approx 0.60–0.85$).
     - `neuromuscular`: boosted up to $0.75 \times \text{workStrain}$ when `grip_forearms` or `lower_back_spine` are engaged.
     - `impactTissue`: boosted under hard/exhausting load for `legs_carrying`.
     - `systemic`: scaled up to $0.60 \times \text{workStrain}$.
   - Fuses with acute subjective and biometric floors via `Math.max()`.
4. **Adaptive Mode Determination**:
   - Hard or extended manual labor (`workStrain >= 0.65`) triggers `mode: 'modify'` (caps aerobic sessions at Z2, suppresses heavy structural strength).
   - Exhausting manual labor (`workStrain >= 0.85`) combined with elevated fatigue or soreness ($\ge 6/10$) triggers `mode: 'recover'` (mandates rest or passive recovery).
   - Counterfactual modes without drift properly account for physical work.
5. **Implied Guardrails**:
   - `avoid_heavy_spinal_loading` dynamically injected into `constraints.impliedGuardrails` when `lower_back_spine` was subjected to hard or exhausting work.
   - `avoid_overhead_pressing` dynamically injected when `upper_body` or `grip_forearms` was subjected to exhausting work.
6. **Firestore Persistence Protection**:
   - In `checkinService.ts`, when physical work is deselected/unchecked, `payload.physicalWork = deleteField()` is sent so `setDoc(..., { merge: true })` removes the field cleanly rather than retaining old physical work records.
7. **AI Context Export & Recovery Timeline Integration**:
   - In `contextBrief.ts` (`# Training context brief` Section 4: Subjective reports):
     - Renders unlogged manual labor directly under point-reading flags: `- Unlogged physical work (D-1): 1–3 hrs · hard effort · strain: grip/forearms, upper body — "cutting trees"`.
     - Summarizes unlogged manual labor across the lookback window in the `Flags:` section (`- Unlogged physical work: X day(s) — YYYY-MM-DD`).
   - In `contextBriefPlanningHandoff.ts` (Section 0: Recent 7-day recovery timeline table):
     - Injects `${intensity}physical work` into the `Training / flags` column of the 7-day timeline row for each day physical work was reported, giving external LLMs immediate awareness of muscular/spinal strain next to that morning's HRV, RHR, Body Battery, and steps.

## Policy Version
- Incremented `POLICY_VERSION` from `2026-09-authored-rest-day-v1` to `2026-09-unlogged-physical-work-v1`.
- Previous version archived in `HISTORICAL_POLICY_VERSIONS`.
- `check-policy-drift.mjs origin/main` passes with zero drift.

## Validation & Test Coverage

- **`src/engine/physicalWork.test.ts`** (NEW):
  - Baseline vs physical work internal response strain calculations.
  - Specific load area mapping (`grip_forearms` + `upper_body` vs `lower_back_spine` + `legs_carrying`).
  - Duration/intensity scaling (conservative for short/moderate; non-diluted for extended/exhausting).
  - Mode determination (`train` -> `modify` -> `recover`).
- **`src/engine/contextBrief.test.ts`**:
  - Validates formatting of unlogged physical work on the latest check-in and across window lookback flags.
- **`src/engine/contextBriefPlanningHandoff.test.ts`**:
  - Validates injection of physical work flags into the 7-day cross-signal recovery timeline table.
- **`src/engine/validation.test.ts`**:
  - Validates complete payloads, minimal payloads (`performed: false`), enum limits, non-empty load areas array, note trimming, and max-length bounds.
- **`src/persistence/parsers/decisionInputs.test.ts`**:
  - Validates `parseSubjectiveCheckin` accepts valid physical work and rejects invalid payloads with `'invalid-physical-work'`.
- **`src/engine/adapters.test.ts`**:
  - Validates forwarding of `physicalWork` to `SubjectiveInput`.
  - Validates dynamic injection of `avoid_heavy_spinal_loading` and `avoid_overhead_pressing` into `impliedGuardrails`.
- **`src/components/checkin/PhysicalWorkSection.test.tsx`** (NEW):
  - Renders collapsed toggle initially.
  - Renders expanded cards with all chip options and accessibility attributes (`aria-pressed`).
- **Quality Gates**:
  - `npm run check`: Passed (0 typecheck errors, 0 ESLint errors/warnings, 376 test files / 3,473 tests passed, 0 knowledge risk debt).
  - `npm run simulate:scenarios` & `npm run simulate:diff`: 39 scenarios simulated cleanly.
  - `npm run build`: Production bundle built cleanly in 443ms.
  - Pre-commit & pre-push git hooks: Passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a daily check-in section for recording unlogged physical work.
  - Users can specify whether work was performed, duration, effort level, affected body areas, and optional notes.
  - Physical-work entries inform fatigue estimates, readiness recommendations, recovery timelines, and exercise safety guidance.
- **Validation**
  - Added input validation, note limits, note cleanup, and duplicate-area handling.
  - Clearing or marking physical work as not performed removes the saved entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->