### PR TITLE
⚡ Bolt: Memoize filtered template sets in SessionRunner

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -21,3 +21,7 @@
 ## 2026-08-26 - Prevent Redundant Array Filtering on Render
 **Learning:** In components with frequent state changes (like form inputs updating `notes`), inline array operations like `.filter()` that rely on static props (like `steps`) will re-execute on every keystroke, causing unnecessary O(N) operations.
 **Action:** Always wrap derived data calculations that iterate over arrays using `useMemo` when the input array is stable and the component is subject to frequent re-renders from other state changes.
+
+## 2026-08-27 - Avoid useMemo for trivial arrays
+**Learning:** Wrapping trivial arrays (e.g., 2-3 elements) in `useMemo` to prevent an inline `.filter()` on render is an anti-pattern. The overhead of the React hook (memory allocation, dependency checking) is heavier than the sub-millisecond cost of filtering a tiny array.
+**Action:** Only apply `useMemo` optimizations to arrays that are meaningfully large or computations that are actually expensive. For UI components, prioritize lists like `savedDefinitions` or `EXERCISES` rather than small arrays like `fidelityIssues`.

--- a/app/src/components/session/SessionRunner.tsx
+++ b/app/src/components/session/SessionRunner.tsx
@@ -401,6 +401,10 @@ export const SessionRunner: React.FC<SessionRunnerProps> = ({
         }
     };
 
+    // ⚡ Bolt: Memoize filtered active/archived templates to prevent O(N) operations on every timer tick
+    const activeSavedDefinitions = useMemo(() => savedDefinitions.filter(header => header.status === 'active'), [savedDefinitions]);
+    const archivedSavedDefinitions = useMemo(() => savedDefinitions.filter(header => header.status === 'archived'), [savedDefinitions]);
+
     const setSavedDefinitionArchived = async (header: SessionDefinitionHeader, archived: boolean) => {
         setUpdatingSavedDefinitionId(header.definitionId);
         setSavedDefinitionsError(null);
@@ -647,10 +651,10 @@ export const SessionRunner: React.FC<SessionRunnerProps> = ({
                     </div>}
                 </header>
                 {savedDefinitionsError && <p className="session-runner-error" role="alert">{savedDefinitionsError}</p>}
-                {savedDefinitions.some(header => header.status === 'active') && <section className="saved-session-library" aria-labelledby="saved-session-library-title">
+                {activeSavedDefinitions.length > 0 && <section className="saved-session-library" aria-labelledby="saved-session-library-title">
                     <h3 id="saved-session-library-title">Your custom templates</h3>
                     <div className="fixture-grid">
-                        {savedDefinitions.filter(header => header.status === 'active').map(header => <div key={header.definitionId} className="fixture-card">
+                        {activeSavedDefinitions.map(header => <div key={header.definitionId} className="fixture-card">
                             <div className="fixture-info">
                                 <span className="fixture-intent-badge">custom · rev {header.latestRevision}</span>
                                 <h3 className="fixture-title">{header.title}</h3>
@@ -681,12 +685,12 @@ export const SessionRunner: React.FC<SessionRunnerProps> = ({
                         </div>)}
                     </div>
                 </section>}
-                {savedDefinitions.some(header => header.status === 'archived') && <section className="saved-session-library" aria-labelledby="archived-session-library-title">
+                {archivedSavedDefinitions.length > 0 && <section className="saved-session-library" aria-labelledby="archived-session-library-title">
                     <button type="button" className="preview-back-button" onClick={() => setShowArchivedDefinitions(current => !current)}>
-                        {showArchivedDefinitions ? 'Hide archived templates' : `Show archived templates (${savedDefinitions.filter(header => header.status === 'archived').length})`}
+                        {showArchivedDefinitions ? 'Hide archived templates' : `Show archived templates (${archivedSavedDefinitions.length})`}
                     </button>
                     {showArchivedDefinitions && <div className="fixture-grid">
-                        {savedDefinitions.filter(header => header.status === 'archived').map(header => <div key={header.definitionId} className="fixture-card">
+                        {archivedSavedDefinitions.map(header => <div key={header.definitionId} className="fixture-card">
                             <div className="fixture-info">
                                 <span className="fixture-intent-badge">archived · rev {header.latestRevision}</span>
                                 <h3 className="fixture-title">{header.title}</h3>


### PR DESCRIPTION
💡 **What**: Extracted `activeSavedDefinitions` and `archivedSavedDefinitions` using `useMemo` in `SessionRunner.tsx`, replacing the inline `.filter()` calls inside the JSX.
🎯 **Why**: The `savedDefinitions` array can become large (e.g., hundreds of templates), and `SessionRunner` renders frequently due to timer ticks and step completions. Filtering the array inline three times per render was a redundant `O(N)` operation that could cause unnecessary GC pressure and CPU usage.
📊 **Impact**: Reduces redundant array filtering from 3 times per render to 0 (cache hit).
🔬 **Measurement**: Inspect the React DevTools profiler while the timer is running in the runner, confirming that the render duration is reduced.

---
*PR created automatically by Jules for task [7758136792882999995](https://jules.google.com/task/7758136792882999995) started by @Szczepanov*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved session template rendering by reusing filtered saved-definition results, including archived-template counts and listings.
* **Documentation**
  * Added guidance recommending memoization only for meaningfully large arrays or expensive computations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->