### PR TITLE
feat(context-export): optimize daily AI context export for continuous morning coaching

### DIFF
--- a/app/src/components/DataView.tsx
+++ b/app/src/components/DataView.tsx
@@ -864,15 +864,14 @@ export function DataView({ decisionInput, userId, initialTab = 'recovery' }: Dat
   const visibleBriefError = briefError && briefError.date === briefDate ? briefError.message : null;
 
   const renderContextBrief = () => {
-    const windowDays = brief?.windowDays ?? briefWindowDaysFor(briefPreset);
     const approxTokens = brief ? Math.ceil(brief.text.length / 4) : null;
     return (
       <div className="data-section">
         <h3>Context brief</h3>
         <p className="brief-intro">
           {briefPreset === 'daily'
-            ? 'Today and yesterday only — constraints, current readiness, and recent trend — for the everyday paste-into-chat loop with an external planning agent.'
-            : `A summary of the last ${windowDays} days — constraints, recovery trend, completed training, subjective scores, and adherence — for designing a new block with an external planner.`}
+            ? "High-signal briefing for your daily chat with an external AI coach — includes yesterday's closed loop, today's recovery, and today's full session prescription."
+            : `Comprehensive 14-day retrospective — constraints, baselines, full training history, and 1-click plan import schema for designing a new block.`}
           {' '}Read-only: generating it changes nothing.
         </p>
         <div className="brief-preset-toggle" role="group" aria-label="Context brief window">
@@ -881,14 +880,14 @@ export function DataView({ decisionInput, userId, initialTab = 'recovery' }: Dat
             className={briefPreset === 'daily' ? 'active' : ''}
             onClick={() => selectBriefPreset('daily')}
           >
-            Daily (today + D-1)
+            ☀️ Morning Coach (Daily)
           </button>
           <button
             type="button"
             className={briefPreset === 'full' ? 'active' : ''}
             onClick={() => selectBriefPreset('full')}
           >
-            Full ({briefWindowDaysFor('full')} days)
+            📋 Block Planning ({briefWindowDaysFor('full')} days)
           </button>
         </div>
         {visibleBriefError && <p className="data-state-notice">{visibleBriefError}</p>}

--- a/app/src/components/MorningDecisionCard.css
+++ b/app/src/components/MorningDecisionCard.css
@@ -153,6 +153,30 @@
     transform: translateY(1px);
 }
 
+.btn-copy-ai-context {
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    border-radius: 8px;
+    color: #e0f2fe;
+    cursor: pointer;
+    font-size: 0.85rem;
+    font-weight: 600;
+    padding: 0.55rem 1rem;
+    white-space: nowrap;
+    transition: all 0.15s ease;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    min-height: 44px;
+}
+
+.btn-copy-ai-context:hover {
+    background: rgba(56, 189, 248, 0.15);
+    border-color: rgba(56, 189, 248, 0.4);
+    color: #38bdf8;
+    transform: translateY(-1px);
+}
+
 .decision-tabs-bar {
     display: flex;
     align-items: center;

--- a/app/src/components/MorningDecisionCard.tsx
+++ b/app/src/components/MorningDecisionCard.tsx
@@ -64,6 +64,7 @@ export const MorningDecisionCard = memo(function MorningDecisionCard({
     const [launching, setLaunching] = useState(false);
     const [launchError, setLaunchError] = useState<string | null>(null);
     const [aiContextCopied, setAiContextCopied] = useState(false);
+    const [aiContextError, setAiContextError] = useState<string | null>(null);
     const panelId = useId();
     const clinicalEscalationActive = recommendation?.envelopes?.safety.clinicalEscalationRequired === true;
     const clinicalReason = recommendation?.envelopes?.safety.clinicalReason
@@ -81,14 +82,36 @@ export const MorningDecisionCard = memo(function MorningDecisionCard({
     };
 
     const handleCopyAiContext = async () => {
+        setAiContextError(null);
         try {
-            const result = await contextBriefService.build(userId, date, 2, 'daily');
-            await navigator.clipboard.writeText(result.text);
+            if (typeof ClipboardItem !== 'undefined' && typeof navigator.clipboard?.write === 'function') {
+                try {
+                    const textPromise = contextBriefService.build(userId, date, 2, 'daily').then(res => res.text);
+                    await navigator.clipboard.write([
+                        new ClipboardItem({
+                            'text/plain': textPromise.then(text => new Blob([text], { type: 'text/plain' })),
+                        }),
+                    ]);
+                } catch {
+                    // Fallback if browser doesn't support deferred promise resolution in ClipboardItem
+                    const result = await contextBriefService.build(userId, date, 2, 'daily');
+                    await navigator.clipboard.writeText(result.text);
+                }
+            } else if (navigator.clipboard?.writeText) {
+                const result = await contextBriefService.build(userId, date, 2, 'daily');
+                await navigator.clipboard.writeText(result.text);
+            } else {
+                throw new Error('Clipboard API is unavailable in this environment.');
+            }
             setAiContextCopied(true);
+            setAiContextError(null);
             window.setTimeout(() => setAiContextCopied(false), 2000);
             usabilityMetrics.recordActionSelected(userId, date, 'copy_ai_context_brief');
         } catch (err) {
             console.warn('Failed to copy AI context', err);
+            setAiContextCopied(false);
+            setAiContextError('Failed to copy AI context to clipboard.');
+            window.setTimeout(() => setAiContextError(null), 4000);
         }
     };
 
@@ -303,6 +326,7 @@ export const MorningDecisionCard = memo(function MorningDecisionCard({
                                 </>
                             )}
                         </div>
+                        {aiContextError && <p className="form-error-msg" role="alert">{aiContextError}</p>}
                         {launchError && <p className="form-error-msg" role="alert">{launchError}</p>}
                     </div>
                 ) : (

--- a/app/src/components/MorningDecisionCard.tsx
+++ b/app/src/components/MorningDecisionCard.tsx
@@ -8,6 +8,7 @@ import { WorkoutExportMenu } from './WorkoutExportMenu';
 import type { MorningDecisionEvidence } from '../engine/decisionEvidence';
 import { prepareCatalogSessionLaunch } from '../services/sessionAuthoringService';
 import { usabilityMetrics } from '../utils/usabilityMetrics';
+import { contextBriefService } from '../services/contextBriefService';
 import './MorningDecisionCard.css';
 
 interface MorningDecisionCardProps {
@@ -62,6 +63,7 @@ export const MorningDecisionCard = memo(function MorningDecisionCard({
     const [activeTab, setActiveTab] = useState<'none' | 'why' | 'alternatives' | 'workout'>('none');
     const [launching, setLaunching] = useState(false);
     const [launchError, setLaunchError] = useState<string | null>(null);
+    const [aiContextCopied, setAiContextCopied] = useState(false);
     const panelId = useId();
     const clinicalEscalationActive = recommendation?.envelopes?.safety.clinicalEscalationRequired === true;
     const clinicalReason = recommendation?.envelopes?.safety.clinicalReason
@@ -75,6 +77,18 @@ export const MorningDecisionCard = memo(function MorningDecisionCard({
         setActiveTab(next);
         if (next !== 'none') {
             usabilityMetrics.recordActionSelected(userId, date, `expand_tab_${next}`);
+        }
+    };
+
+    const handleCopyAiContext = async () => {
+        try {
+            const result = await contextBriefService.build(userId, date, 2, 'daily');
+            await navigator.clipboard.writeText(result.text);
+            setAiContextCopied(true);
+            window.setTimeout(() => setAiContextCopied(false), 2000);
+            usabilityMetrics.recordActionSelected(userId, date, 'copy_ai_context_brief');
+        } catch (err) {
+            console.warn('Failed to copy AI context', err);
         }
     };
 
@@ -276,6 +290,16 @@ export const MorningDecisionCard = memo(function MorningDecisionCard({
                                             prescription={prescription}
                                         />
                                     )}
+
+                                    <button
+                                        type="button"
+                                        className="btn-copy-ai-context"
+                                        onClick={() => void handleCopyAiContext()}
+                                        title="Copy today's morning briefing for your external AI coach"
+                                        aria-label="Copy AI Context"
+                                    >
+                                        {aiContextCopied ? '✓ Copied Context' : '📤 Copy AI Context'}
+                                    </button>
                                 </>
                             )}
                         </div>

--- a/app/src/components/MorningDecisionCardClinicalEscalation.test.tsx
+++ b/app/src/components/MorningDecisionCardClinicalEscalation.test.tsx
@@ -69,7 +69,48 @@ describe('MorningDecisionCard clinical escalation', () => {
         expect(html).not.toContain('Start Session');
         expect(html).not.toContain('View Workout Targets');
         expect(html).not.toContain('Export / Sync');
+        expect(html).not.toContain('Copy AI Context');
         expect(html).not.toContain('1-Tap Alternatives');
         expect(html).not.toContain('Workout Steps');
+    });
+
+    it('renders the 1-click Copy AI Context button when normal recommendation is active', () => {
+        const normalRec = {
+            mode: 'train',
+            template: {
+                title: 'Aerobic Foundation',
+                modality: 'Cycling',
+                category: 'Easy Endurance',
+                durationMin: 60,
+                durationMax: 75,
+            },
+            rationale: 'Readiness is solid.',
+            envelopes: {
+                safety: {
+                    clinicalEscalationRequired: false,
+                },
+            },
+        } as unknown as Recommendation;
+
+        const html = renderToStaticMarkup(
+            <MorningDecisionCard
+                userId="athlete"
+                date="2026-09-02"
+                recommendation={normalRec}
+                evidence={evidence}
+                prescription={prescription}
+                adjustmentDirection={null}
+                activeAlternativeId={null}
+                onStartSession={() => undefined}
+                onAdjustLoad={() => undefined}
+                onSelectTimeCrunch={() => undefined}
+                onSelectHomeAlternative={() => undefined}
+                onSelectMobilityAlternative={() => undefined}
+                onSelectActiveRecoveryWalk={() => undefined}
+                onResetAlternative={() => undefined}
+            />,
+        );
+
+        expect(html).toContain('Copy AI Context');
     });
 });

--- a/app/src/engine/contextBrief.ts
+++ b/app/src/engine/contextBrief.ts
@@ -86,13 +86,13 @@ function mean(values: readonly (number | null | undefined)[]): number | null {
     return present.reduce((sum, value) => sum + value, 0) / present.length;
 }
 
-function round(value: number | null, places = 1): string {
-    if (value === null) return '—';
+export function round(value: number | null | undefined, places = 1): string {
+    if (value === null || value === undefined || !Number.isFinite(value)) return '—';
     const factor = 10 ** places;
     return String(Math.round(value * factor) / factor);
 }
 
-function signed(value: number | null | undefined, places = 1): string {
+export function signed(value: number | null | undefined, places = 1): string {
     if (typeof value !== 'number' || !Number.isFinite(value)) return '—';
     const rounded = Math.round(value * 10 ** places) / 10 ** places;
     return rounded > 0 ? `+${rounded}` : String(rounded);
@@ -321,7 +321,7 @@ const ACTIVITY_TYPE_LABELS: Record<string, string> = {
     mobility: 'Mobility',
 };
 
-function formatActivityType(typeKey: string): string {
+export function formatActivityType(typeKey: string): string {
     if (ACTIVITY_TYPE_LABELS[typeKey]) return ACTIVITY_TYPE_LABELS[typeKey];
     return typeKey.replace(/_/g, ' ');
 }

--- a/app/src/engine/contextBriefPlanningHandoff.test.ts
+++ b/app/src/engine/contextBriefPlanningHandoff.test.ts
@@ -433,4 +433,162 @@ describe('enhanceContextBriefForPlanning', () => {
         expect(text).toContain('no check-in for 2026-08-20; latest available is 2026-08-19');
         expect(text).toContain('Do not assume subjective readiness, pain or availability are current');
     });
+
+    describe('daily morning coach brief', () => {
+        it('renders the dedicated closed-loop morning briefing for daily chat', () => {
+            const yesterdayDate = '2026-08-19';
+            const text = enhanceContextBriefForPlanning(BASE, handoffInput({
+                preset: 'daily',
+                checkins: [
+                    checkin(AS_OF, {
+                        readiness: 7,
+                        fatigue: 4,
+                        soreness: 5,
+                        physicalWork: {
+                            performed: true,
+                            duration: 'medium',
+                            intensity: 'hard',
+                            loadAreas: ['lower_back_spine', 'grip_forearms'],
+                            notes: 'heavy yard work and soil moving',
+                        },
+                        notes: 'feeling slightly tight in the lower back',
+                    }),
+                ],
+                activities: [{
+                    activityId: 'act-yesterday',
+                    date: yesterdayDate,
+                    type: 'road_biking',
+                    durationMin: 65,
+                    activityTrainingLoad: 85,
+                    trainingEffectAerobic: 2.9,
+                    trainingEffectAnaerobic: 0.2,
+                    averageHr: 135,
+                    intensityTag: 'moderate',
+                    normalizedPower: 195,
+                    intensityFactor: 0.75,
+                }],
+                recommendations: [
+                    {
+                        userId: 'u1',
+                        date: yesterdayDate,
+                        templateId: 'z2',
+                        templateTitle: 'Zone 2 Foundation',
+                        category: 'Easy Endurance',
+                        modality: 'Cycling',
+                        mode: 'train',
+                        rationale: 'aerobic maintenance',
+                        schemaVersion: 3,
+                        createdAt: `${yesterdayDate}T06:00:00Z`,
+                        updatedAt: `${yesterdayDate}T06:00:00Z`,
+                        adherence: {
+                            respondedAt: `${AS_OF}T05:40:00Z`,
+                            followed: true,
+                            actualModality: null,
+                            actualDurationMin: null,
+                            skipped: false,
+                            notes: 'Good steady rhythm on the road',
+                        },
+                    },
+                    {
+                        userId: 'u1',
+                        date: AS_OF,
+                        templateId: 'rec-today',
+                        templateTitle: 'Aerobic Maintenance Capped',
+                        category: 'Easy Endurance',
+                        modality: 'Cycling',
+                        mode: 'modify',
+                        rationale: 'Moderate readiness with lumbar strain; capping duration and avoiding heavy climbing',
+                        schemaVersion: 3,
+                        createdAt: `${AS_OF}T06:00:00Z`,
+                        updatedAt: `${AS_OF}T06:00:00Z`,
+                        adjustment: {
+                            direction: 'easier',
+                            tier: 1,
+                            originalTemplateId: 'rec-today-full',
+                            originalTemplateTitle: 'Aerobic Maintenance',
+                            adjustedDoseLabel: 'Reduced duration',
+                            athleteReason: 'soreness',
+                            rationale: 'Lumbar strain from physical work',
+                        },
+                        prescription: {
+                            id: 'p-today',
+                            userId: 'u1',
+                            date: AS_OF,
+                            workoutId: 'w1',
+                            workoutVersion: 1,
+                            variantId: 'reduced',
+                            targetDurationMin: 45,
+                            adjustedBlocks: [],
+                            displayBlocks: [{
+                                id: 'b1',
+                                name: 'Warm-up',
+                                role: 'warmup',
+                                steps: [{ id: 's1', name: 'Spin', dose: '10 min easy', targets: ['Zone 1 HR (<120 bpm)'], cues: ['High cadence 90+ rpm'] }],
+                            }, {
+                                id: 'b2',
+                                name: 'Main Set',
+                                role: 'main',
+                                steps: [{ id: 's2', name: 'Steady endurance', dose: '30 min', targets: ['65-72% FTP (145-160W)'], cues: ['Stay seated, no heavy torque'] }],
+                            }],
+                            rationale: ['Preserving aerobic volume while protecting lower back'],
+                            adjustmentReasons: ['Lower back soreness'],
+                            source: { recommendationEngineVersion: '3.0.0' },
+                            status: 'recommended',
+                        },
+                        adherence: {
+                            respondedAt: null,
+                            followed: null,
+                            actualModality: null,
+                            actualDurationMin: null,
+                            skipped: false,
+                            notes: null,
+                        },
+                    },
+                ],
+            }));
+
+            // Structure assertions
+            expect(text).toContain('# Morning Training & Readiness Brief');
+            expect(text).toContain('## 1. Today\'s Status & Check-in');
+            expect(text).toContain('## 2. Overnight Recovery (Wearable)');
+            expect(text).toContain('## 3. Yesterday\'s Closed-Loop Debrief (2026-08-19)');
+            expect(text).toContain('## 4. Today\'s App Recommendation & Engine Stance');
+            expect(text).toContain('## 5. Short-Term Horizon (Next 48–72h)');
+            expect(text).toContain('## 6. Morning Coach Instructions');
+
+            // Today's Status & Check-in
+            expect(text).toContain('Readiness 7 · Fatigue 4 · Soreness 5');
+            expect(text).toContain('Unlogged physical work (yesterday D-1): 1–3 hrs · hard effort · strain: lower back/spine, grip/forearms — "heavy yard work and soil moving"');
+            expect(text).toContain('feeling slightly tight in the lower back');
+
+            // Overnight recovery
+            expect(text).toContain('HRV (overnight avg): 70 ms');
+            expect(text).toContain('Recent 7-day recovery timeline');
+
+            // Yesterday's Closed-Loop Debrief
+            expect(text).toContain('Prescribed: Zone 2 Foundation (Cycling · train)');
+            expect(text).toContain('Recorded training: Road cycling · 65 min · Load 85 · Aerobic TE 2.9 · Avg HR 135 bpm · moderate');
+            expect(text).toContain('Power summary: normalized power 195 W · IF 0.75');
+            expect(text).toContain('Manual physical work: 1–3 hrs · hard effort · strain: lower back/spine, grip/forearms — "heavy yard work and soil moving"');
+            expect(text).toContain('Adherence: Followed as prescribed — "Good steady rhythm on the road"');
+
+            // Today's Recommendation & Engine Stance
+            expect(text).toContain('Mode: MODIFY');
+            expect(text).toContain('Recommended workout: Aerobic Maintenance Capped (Cycling · Easy Endurance)');
+            expect(text).toContain('Engine rationale: "Moderate readiness with lumbar strain; capping duration and avoiding heavy climbing"');
+            expect(text).toContain('Session adjustment: easier (tier 1) · Reduced duration · reason: soreness · "Lumbar strain from physical work"');
+            expect(text).toContain('Prescription steps:');
+            expect(text).toContain('Spin: 10 min easy · targets: Zone 1 HR (<120 bpm) · cues: High cadence 90+ rpm');
+            expect(text).toContain('Steady endurance: 30 min · targets: 65-72% FTP (145-160W) · cues: Stay seated, no heavy torque');
+
+            // Morning Coach Instructions
+            expect(text).toContain('Treat this brief as state/context for your ongoing morning conversation');
+            expect(text).toContain('Do NOT output a multi-day schedule table or redesign the training block');
+
+            // Omissions (ensuring no block-planning bloat in morning mode)
+            expect(text).not.toContain('### Preferred output schema');
+            expect(text).not.toContain('### Day YYYY-MM-DD: <Session Name>');
+            expect(text).not.toContain('Detailed activity telemetry');
+        });
+    });
 });

--- a/app/src/engine/contextBriefPlanningHandoff.test.ts
+++ b/app/src/engine/contextBriefPlanningHandoff.test.ts
@@ -301,7 +301,7 @@ describe('enhanceContextBriefForPlanning', () => {
         expect(text).toContain('Steps are the completed D-1 total');
     });
 
-    it('includes physical work in recent recovery timeline flags', () => {
+    it('includes physical work in recent recovery timeline flags on D-1', () => {
         const text = enhanceContextBriefForPlanning(BASE, handoffInput({
             checkins: [
                 checkin(AS_OF, {
@@ -316,6 +316,44 @@ describe('enhanceContextBriefForPlanning', () => {
         }));
 
         expect(text).toContain('hard physical work');
+        // AS_OF is 2026-08-20, so D-1 is 2026-08-19
+        const timelineRow19 = text.split('\n').find(line => line.startsWith('| 2026-08-19 |'));
+        expect(timelineRow19).toContain('hard physical work');
+        const timelineRow20 = text.split('\n').find(line => line.startsWith('| 2026-08-20 |'));
+        expect(timelineRow20).not.toContain('hard physical work');
+    });
+
+    it('emits a wearable staleness caution in morning coach brief when snapshot is older than target date', () => {
+        const text = enhanceContextBriefForPlanning(BASE, handoffInput({
+            preset: 'daily',
+            asOfDate: '2026-08-20',
+            snapshots: [snapshot('2026-08-18')],
+        }));
+
+        expect(text).toContain('> Wearable caution: no snapshot for 2026-08-20; the newest wearable state is 2026-08-18. Do not treat it as current-day readiness.');
+    });
+
+    it('falls back to weekend max minutes when availability is unrecorded on a weekend', () => {
+        // 2026-08-22 is a Saturday
+        const weekendDate = '2026-08-22';
+        const text = enhanceContextBriefForPlanning(BASE, handoffInput({
+            preset: 'daily',
+            asOfDate: weekendDate,
+            checkins: [checkin(weekendDate, { availability: { timeAvailableMin: null, indoorOnly: false, preferredModalityToday: null } })],
+            trainingSettings: {
+                userId: 'u1',
+                defaults: { weekdayMaxMinutes: 45, weekendMaxMinutes: 120, environment: 'either' },
+                equipment: { indoor_bike: true, outdoor_bike: true, treadmill: false, free_weights: true, pullup_bar: false },
+                guardrails: { hardSessionCap: true, backToBackHardAllowed: false, minRecoveryHoursBetweenHard: true },
+                preferences: { preferActiveRecovery: false },
+                migration: { legacyReviewed: true, migratedAt: null },
+                schemaVersion: 3,
+                createdAt: '2026-08-01T00:00:00Z',
+                updatedAt: '2026-08-01T00:00:00Z',
+            } as unknown as TrainingSettings,
+        }));
+
+        expect(text).toContain('- Time & environment: 120 min available');
     });
 
     it('exports fixed commitments, imported sessions and their authored prescriptions', () => {

--- a/app/src/engine/contextBriefPlanningHandoff.ts
+++ b/app/src/engine/contextBriefPlanningHandoff.ts
@@ -14,6 +14,7 @@ import type {
 } from './models';
 import { EVENT_PRESETS, resolveDemandProfile } from './eventPresets';
 import { addDaysToLocalDateString } from '../utils/localDate';
+import { formatActivityType, round, signed, type BriefWindowPreset } from './contextBrief';
 
 export const UPCOMING_CONTEXT_DAYS = 7;
 export const RECOVERY_TIMELINE_DAYS = 7;
@@ -61,6 +62,7 @@ export interface ContextBriefPlanningHandoffInput {
     upcomingPlanBlocks: readonly AuthoredPlanBlock[];
     upcomingExternalSessions: readonly UpcomingExternalPlanSession[];
     unavailableSources: readonly string[];
+    preset?: BriefWindowPreset;
 }
 
 function latestByDate<T extends { date: string }>(items: readonly T[]): T | null {
@@ -383,6 +385,313 @@ function renderUseInstructions(): string {
     ].join('\n');
 }
 
+function renderMorningCoachInstructions(): string[] {
+    return [
+        '## 6. Morning Coach Instructions',
+        '',
+        '- Treat this brief as state/context for your ongoing morning conversation. Answer the athlete\'s actual question first.',
+        '- Acknowledge today\'s recovery metrics, check-in scores, and yesterday\'s debrief (flagging any notable strain deltas, soreness, or fatigue from manual labor).',
+        '- Review today\'s recommended session against how the athlete feels, their available time, and any sore areas. Confirm or suggest practical fine-tuning (e.g. cadence emphasis, intensity ceiling).',
+        '- Provide concrete execution guidance (power/HR zones, warmup emphasis for reported aches).',
+        '- Keep tomorrow\'s planned session in mind so today appropriately sets up the week.',
+        '- Do NOT output a multi-day schedule table or redesign the training block unless explicitly asked. Focus on coaching today.',
+    ];
+}
+
+/**
+ * Renders an ultra-dense, closed-loop morning briefing designed specifically for an
+ * ongoing chat with an external AI coach. Omits static repetitive boilerplate
+ * (equipment inventories, candidate median/MAD baselines, 1-click plan import markdown
+ * schemas) and emphasizes:
+ * 1. Today's status, subjective check-in, and acute flags
+ * 2. Overnight wearable recovery and recent 7-day timeline
+ * 3. Yesterday's closed loop (planned vs completed training + unlogged physical work + adherence)
+ * 4. Today's engine recommendation with full rationale and prescription steps
+ * 5. Short-term 48–72h horizon
+ * 6. Morning coach conversational instructions
+ */
+export function buildMorningCoachBrief(input: ContextBriefPlanningHandoffInput): string {
+    const targetDate = input.asOfDate;
+    const yesterdayDate = addDaysToLocalDateString(targetDate, -1);
+
+    const todaySnapshot = input.snapshots.find(s => s.date === targetDate);
+    const latestSnapshot = latestByDate(input.snapshots);
+    const activeSnapshot = todaySnapshot ?? latestSnapshot;
+
+    const todayCheckin = input.checkins.find(c => c.date === targetDate);
+    const yesterdayCheckin = input.checkins.find(c => c.date === yesterdayDate);
+    const yesterdayActivities = input.activities.filter(a => a.date === yesterdayDate);
+    const todayRecommendation = [...input.recommendations]
+        .filter(r => r.date === targetDate)
+        .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))[0] ?? null;
+    const yesterdayRecommendation = [...input.recommendations]
+        .filter(r => r.date === yesterdayDate)
+        .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))[0] ?? null;
+
+    const settings = input.trainingSettings;
+
+    const lines: string[] = [
+        '# Morning Training & Readiness Brief',
+        '',
+        `Date: ${targetDate} (Europe/Warsaw) · Mode: Daily Morning Coach Handoff`,
+        'Context: This brief is shared daily in an ongoing chat. Focus on today\'s session, yesterday\'s debrief, and acute adaptations.',
+    ];
+
+    if (input.unavailableSources.length > 0) {
+        lines.push('', `> **DATA INCOMPLETE:** could not reliably read: ${input.unavailableSources.join('; ')}. Absence from affected sections means "unknown", not "none".`);
+    }
+
+    // 1. Today's Status & Check-in
+    lines.push('', '## 1. Today\'s Status & Check-in', '');
+    if (todayCheckin) {
+        lines.push(
+            `- Subjective scores (1–10): Readiness ${textNumber(todayCheckin.readiness)} · `
+            + `Fatigue ${textNumber(todayCheckin.fatigue)} · Soreness ${textNumber(todayCheckin.soreness)} · `
+            + `Sleep quality ${textNumber(todayCheckin.sleepQuality)} · Motivation ${textNumber(todayCheckin.motivation)} · `
+            + `Mental stress ${textNumber(todayCheckin.mentalStress)}`,
+        );
+
+        const timeAvail = todayCheckin.availability?.timeAvailableMin
+            ?? (settings?.defaults.weekdayMaxMinutes ?? '—');
+        const env = todayCheckin.availability?.indoorOnly
+            ? 'indoor only'
+            : (settings?.defaults.environment ?? 'either');
+        const prefMod = todayCheckin.availability?.preferredModalityToday
+            ? ` · preferred modality: ${todayCheckin.availability.preferredModalityToday}`
+            : '';
+        lines.push(`- Time & environment: ${timeAvail} min available · ${env}${prefMod}`);
+
+        const flags: string[] = [];
+        if (todayCheckin.painOrInjury) flags.push('pain/injury flagged');
+        if (todayCheckin.illnessSymptoms) flags.push('illness symptoms flagged');
+        if (todayCheckin.alreadyTrainedToday) flags.push('already trained today');
+        if (todayCheckin.unusuallyLimitedTime) flags.push('unusually limited time');
+        lines.push(`- Flags: ${flags.length > 0 ? flags.join(' · ') : 'no acute flags'}`);
+
+        if (todayCheckin.tissueResponses) {
+            const trEntries = Object.entries(todayCheckin.tissueResponses).filter(([, tr]) => tr != null);
+            if (trEntries.length > 0) {
+                const trSummaries = trEntries.map(([region, tr]) => {
+                    const parts = [`${region}: morning ${tr.morningState}`];
+                    if (tr.painDuringTraining) parts.push(`during ${tr.painDuringTraining}`);
+                    if (tr.afterTrainingState) parts.push(`after ${tr.afterTrainingState}`);
+                    if (tr.nextMorningReaction) parts.push(`next morning ${tr.nextMorningReaction}`);
+                    return parts.join(', ');
+                });
+                lines.push(`- Tissue response: ${trSummaries.join('; ')}`);
+            }
+        }
+
+        if (todayCheckin.physicalWork?.performed) {
+            const pw = todayCheckin.physicalWork;
+            const durationLabels: Record<string, string> = { short: '< 1 hr', medium: '1–3 hrs', extended: '3+ hrs' };
+            const areaLabels: Record<string, string> = {
+                grip_forearms: 'grip/forearms',
+                upper_body: 'upper body',
+                lower_back_spine: 'lower back/spine',
+                legs_carrying: 'legs/carrying',
+            };
+            const parts: string[] = [];
+            if (pw.duration) parts.push(durationLabels[pw.duration] ?? pw.duration);
+            if (pw.intensity) parts.push(`${pw.intensity} effort`);
+            if (pw.loadAreas && pw.loadAreas.length > 0) {
+                parts.push(`strain: ${pw.loadAreas.map(a => areaLabels[a] ?? a).join(', ')}`);
+            }
+            const noteStr = pw.notes && pw.notes.trim().length > 0 ? ` — "${pw.notes.trim()}"` : '';
+            lines.push(`- Unlogged physical work (yesterday D-1): ${parts.join(' · ')}${noteStr}`);
+        } else {
+            lines.push('- Unlogged physical work (yesterday D-1): none reported');
+        }
+
+        if (todayCheckin.notes && todayCheckin.notes.trim().length > 0) {
+            lines.push(`- Check-in notes: "${todayCheckin.notes.trim()}"`);
+        }
+    } else {
+        lines.push(`> Check-in caution: No subjective check-in submitted for ${targetDate} yet. Subjective readiness, soreness, and availability are unrecorded.`);
+    }
+
+    // 2. Overnight Recovery (Wearable)
+    lines.push('', '## 2. Overnight Recovery (Wearable)', '');
+    if (activeSnapshot) {
+        const raw = activeSnapshot.raw;
+        const der = activeSnapshot.derived;
+        lines.push(`Most recent reading — ${activeSnapshot.date} (Garmin synced at ${activeSnapshot.source.garminSyncedAt}):`);
+        lines.push(`- HRV (overnight avg): ${textNumber(raw.hrvOvernightAvg)} ms (7d avg ${round(der.hrv7dAvg)}, 28d avg ${round(der.hrv28dAvg)}) — ${signed(der.deltas.hrvVs7d)} vs 7d, ${signed(der.deltas.hrvVs28d)} vs 28d`);
+        lines.push(`- Resting HR: ${textNumber(raw.restingHr)} bpm (7d avg ${round(der.restingHr7dAvg)}, 28d avg ${round(der.restingHr28dAvg)}) — ${signed(der.deltas.restingHrVs7d)} vs 7d, ${signed(der.deltas.restingHrVs28d)} vs 28d`);
+        lines.push(`- Sleep score: ${textNumber(raw.sleepScore)} pts (7d avg ${round(der.sleepScore7dAvg)}, 28d avg ${round(der.sleepScore28dAvg)}) — ${signed(der.deltas.sleepScoreVs7d)} vs 7d, ${signed(der.deltas.sleepScoreVs28d)} vs 28d`);
+        if (raw.sleepDurationSec != null) {
+            const sleepHours = Math.floor(raw.sleepDurationSec / 3600);
+            const sleepMins = Math.round((raw.sleepDurationSec % 3600) / 60);
+            lines.push(`- Sleep duration: ${sleepHours}h ${sleepMins}m`);
+        }
+        if (raw.bodyBatteryWake != null) {
+            lines.push(`- Body battery on waking: ${raw.bodyBatteryWake}`);
+        }
+        if (raw.stress?.avg != null) {
+            lines.push(`- Device stress: avg ${raw.stress.avg}${raw.stress.max != null ? ` · max ${raw.stress.max}` : ''}`);
+        }
+        if (raw.totalSteps != null) {
+            lines.push(`- Steps yesterday (D-1): ${raw.totalSteps.toLocaleString()} (7d avg ${der.steps7dAvg ? Math.round(der.steps7dAvg).toLocaleString() : '—'})`);
+        }
+
+        const timeline = renderRecoveryTimeline(input);
+        if (timeline) {
+            lines.push('', timeline);
+        }
+    } else {
+        lines.push('> Wearable caution: No wearable data in this window.');
+    }
+
+    // 3. Yesterday's Closed-Loop Debrief
+    lines.push('', `## 3. Yesterday's Closed-Loop Debrief (${yesterdayDate})`, '');
+    if (yesterdayRecommendation) {
+        lines.push(`- Prescribed: ${yesterdayRecommendation.templateTitle} (${yesterdayRecommendation.modality} · ${yesterdayRecommendation.mode})`);
+    } else {
+        lines.push('- Prescribed: No app recommendation recorded for yesterday.');
+    }
+
+    if (yesterdayActivities.length > 0) {
+        for (const act of yesterdayActivities) {
+            const typeLabel = formatActivityType(act.type);
+            const loadStr = act.activityTrainingLoad != null ? ` · Load ${round(act.activityTrainingLoad, 1)}` : '';
+            const teStr = act.trainingEffectAerobic != null ? ` · Aerobic TE ${round(act.trainingEffectAerobic, 1)}` : '';
+            const hrStr = act.averageHr != null ? ` · Avg HR ${act.averageHr} bpm` : '';
+            lines.push(`- Recorded training: ${typeLabel} · ${act.durationMin ?? '—'} min${loadStr}${teStr}${hrStr} · ${act.intensityTag}`);
+            const pSum: string[] = [];
+            if (act.normalizedPower != null) pSum.push(`normalized power ${Math.round(act.normalizedPower)} W`);
+            if (act.intensityFactor != null) pSum.push(`IF ${round(act.intensityFactor, 2)}`);
+            if (pSum.length > 0) lines.push(`  - Power summary: ${pSum.join(' · ')}`);
+        }
+    } else {
+        lines.push('- Recorded training: No recorded sessions in this window.');
+    }
+
+    const pwSource = todayCheckin?.physicalWork?.performed
+        ? todayCheckin.physicalWork
+        : (yesterdayCheckin?.physicalWork?.performed ? yesterdayCheckin.physicalWork : null);
+    if (pwSource) {
+        const durationLabels: Record<string, string> = { short: '< 1 hr', medium: '1–3 hrs', extended: '3+ hrs' };
+        const areaLabels: Record<string, string> = {
+            grip_forearms: 'grip/forearms',
+            upper_body: 'upper body',
+            lower_back_spine: 'lower back/spine',
+            legs_carrying: 'legs/carrying',
+        };
+        const parts: string[] = [];
+        if (pwSource.duration) parts.push(durationLabels[pwSource.duration] ?? pwSource.duration);
+        if (pwSource.intensity) parts.push(`${pwSource.intensity} effort`);
+        if (pwSource.loadAreas && pwSource.loadAreas.length > 0) {
+            parts.push(`strain: ${pwSource.loadAreas.map(a => areaLabels[a] ?? a).join(', ')}`);
+        }
+        const noteStr = pwSource.notes && pwSource.notes.trim().length > 0 ? ` — "${pwSource.notes.trim()}"` : '';
+        lines.push(`- Manual physical work: ${parts.join(' · ')}${noteStr}`);
+    } else {
+        lines.push('- Manual physical work: none reported');
+    }
+
+    if (yesterdayRecommendation?.adherence) {
+        const adh = yesterdayRecommendation.adherence;
+        const adhNote = adh.notes && adh.notes.trim().length > 0 ? ` — "${adh.notes.trim()}"` : '';
+        if (adh.followed === true) lines.push(`- Adherence: Followed as prescribed${adhNote}`);
+        else if (adh.skipped === true) lines.push(`- Adherence: Skipped entirely${adhNote}`);
+        else if (adh.followed === false) {
+            const act = adh.actualModality ?? 'other';
+            const dur = adh.actualDurationMin ? ` for ${adh.actualDurationMin} min` : '';
+            lines.push(`- Adherence: Did ${act}${dur} instead${adhNote}`);
+        } else {
+            lines.push('- Adherence: Not answered yet.');
+        }
+    } else {
+        lines.push('- Adherence: Not answered yet.');
+    }
+
+    if (activeSnapshot) {
+        const der = activeSnapshot.derived;
+        lines.push(`- Overnight reaction: HRV ${signed(der.deltas.hrvVs7d)} ms vs 7d avg · Resting HR ${signed(der.deltas.restingHrVs7d)} bpm vs 7d avg · Sleep score ${signed(der.deltas.sleepScoreVs7d)} pts vs 7d avg.`);
+    }
+
+    // 4. Today's App Recommendation & Engine Stance
+    lines.push('', '## 4. Today\'s App Recommendation & Engine Stance', '');
+    if (todayRecommendation) {
+        lines.push(`- Mode: ${todayRecommendation.mode.toUpperCase()}`);
+        lines.push(`- Recommended workout: ${todayRecommendation.templateTitle} (${todayRecommendation.modality} · ${todayRecommendation.category})`);
+        lines.push(`- Engine rationale: "${todayRecommendation.rationale}"`);
+
+        if (todayRecommendation.adjustment) {
+            const adj = todayRecommendation.adjustment;
+            const parts: string[] = [];
+            if (adj.direction) parts.push(`${adj.direction} (tier ${adj.tier})`);
+            if (adj.adjustedDoseLabel) parts.push(adj.adjustedDoseLabel);
+            if (adj.athleteReason) parts.push(`reason: ${adj.athleteReason.replace(/_/g, ' ')}`);
+            if (adj.rationale) parts.push(`"${adj.rationale}"`);
+            lines.push(`- Session adjustment: ${parts.join(' · ') || 'Adjusted'}`);
+        }
+
+        if (todayRecommendation.prescription?.displayBlocks?.length) {
+            lines.push('- Prescription steps:');
+            for (const block of todayRecommendation.prescription.displayBlocks) {
+                lines.push(`  - ${block.name}:`);
+                for (const step of block.steps) {
+                    const parts = [step.dose];
+                    if (step.targets?.length) parts.push(`targets: ${step.targets.join(', ')}`);
+                    if (step.cues?.length) parts.push(`cues: ${step.cues.join('; ')}`);
+                    lines.push(`    - ${step.name}: ${parts.join(' · ')}`);
+                }
+            }
+        }
+
+        if (settings) {
+            const guardrails = Object.entries(settings.guardrails)
+                .filter(([, on]) => on)
+                .map(([k]) => k.replace(/_/g, ' '));
+            if (guardrails.length > 0) lines.push(`- Active safety limits: ${guardrails.join('; ')}`);
+            const injuries = (settings.injuries ?? [])
+                .filter(i => !i.reviewBy || i.reviewBy >= targetDate);
+            if (injuries.length > 0) {
+                const injLines = injuries.map(i => `${i.region} (${i.severity}${i.restrictedModalities?.length ? `, restricts ${i.restrictedModalities.join(', ')}` : ''})`);
+                lines.push(`- Active injuries: ${injLines.join('; ')}`);
+            }
+        }
+    } else {
+        lines.push('No recommendation recorded for today yet (check-in may be pending or sync in progress).');
+    }
+
+    // 5. Short-Term Horizon (Next 48–72h)
+    lines.push('', '## 5. Short-Term Horizon (Next 48–72h)', '');
+    const lookaheadDates = [
+        addDaysToLocalDateString(targetDate, 1),
+        addDaysToLocalDateString(targetDate, 2),
+        addDaysToLocalDateString(targetDate, 3),
+    ];
+    const fixed = input.upcomingFixedActivities.filter(a => !a.isCompleted && lookaheadDates.includes(a.date));
+    const blocks = input.upcomingPlanBlocks.filter(b => b.startDate <= lookaheadDates[2] && b.endDate >= lookaheadDates[0]);
+    const external = input.upcomingExternalSessions.filter(s => lookaheadDates.includes(s.date));
+
+    const events: Array<{ date: string; summary: string }> = [];
+    for (const f of fixed) {
+        events.push({ date: f.date, summary: `Fixed activity: ${f.title} (${f.durationMin} min · ${f.fixed ? 'fixed' : 'movable'})` });
+    }
+    for (const b of blocks) {
+        events.push({ date: `${b.startDate}→${b.endDate}`, summary: `Travel block: volume ×${b.volumeScale} · intensity ×${b.intensityScale}` });
+    }
+    for (const e of external) {
+        events.push({ date: e.date, summary: `Imported session: ${e.title} (${e.modality} · ${e.durationMin} min · priority: ${e.priority.toUpperCase()})` });
+    }
+    if (events.length > 0) {
+        events.sort((a, b) => a.date.localeCompare(b.date));
+        for (const ev of events) {
+            lines.push(`- ${ev.date}: ${ev.summary}`);
+        }
+    } else {
+        lines.push('No fixed activities, travel blocks, or imported sessions in the next 72 hours.');
+    }
+
+    // 6. Morning Coach Instructions
+    lines.push('', ...renderMorningCoachInstructions());
+
+    return lines.join('\n');
+}
+
 /**
  * Adds the planning-specific information a fresh external AI chat needs without changing
  * the baseline/recovery renderer itself. This is deliberately a post-processing layer:
@@ -393,6 +702,10 @@ export function enhanceContextBriefForPlanning(
     baseBrief: string,
     input: ContextBriefPlanningHandoffInput,
 ): string {
+    if (input.preset === 'daily') {
+        return buildMorningCoachBrief(input);
+    }
+
     const requestedOutputMarker = '\n## Requested output';
     const requestedIndex = baseBrief.indexOf(requestedOutputMarker);
     const retrospective = requestedIndex >= 0 ? baseBrief.slice(0, requestedIndex) : baseBrief;

--- a/app/src/engine/contextBriefPlanningHandoff.ts
+++ b/app/src/engine/contextBriefPlanningHandoff.ts
@@ -178,6 +178,28 @@ function renderDataHandoff(input: ContextBriefPlanningHandoffInput): string {
     return lines.join('\n');
 }
 
+/**
+ * Formats unlogged manual physical work and non-exercise labor into a concise,
+ * human-readable summary string including duration, intensity, affected load areas, and notes.
+ */
+function formatPhysicalWork(pw: NonNullable<DailySubjectiveCheckin['physicalWork']>): string {
+    const durationLabels: Record<string, string> = { short: '< 1 hr', medium: '1–3 hrs', extended: '3+ hrs' };
+    const areaLabels: Record<string, string> = {
+        grip_forearms: 'grip/forearms',
+        upper_body: 'upper body',
+        lower_back_spine: 'lower back/spine',
+        legs_carrying: 'legs/carrying',
+    };
+    const parts: string[] = [];
+    if (pw.duration) parts.push(durationLabels[pw.duration] ?? pw.duration);
+    if (pw.intensity) parts.push(`${pw.intensity} effort`);
+    if (pw.loadAreas && pw.loadAreas.length > 0) {
+        parts.push(`strain: ${pw.loadAreas.map(a => areaLabels[a] ?? a).join(', ')}`);
+    }
+    const noteStr = pw.notes && pw.notes.trim().length > 0 ? ` — "${pw.notes.trim()}"` : '';
+    return `${parts.join(' · ')}${noteStr}`;
+}
+
 function renderRecoveryTimeline(input: ContextBriefPlanningHandoffInput): string {
     const firstDate = addDaysToLocalDateString(input.asOfDate, -(RECOVERY_TIMELINE_DAYS - 1));
     const snapshots = new Map(input.snapshots.filter(item => item.date >= firstDate && item.date <= input.asOfDate).map(item => [item.date, item]));
@@ -187,6 +209,14 @@ function renderRecoveryTimeline(input: ContextBriefPlanningHandoffInput): string
         const sameDay = activitiesByDate.get(activity.date) ?? [];
         sameDay.push(activity);
         activitiesByDate.set(activity.date, sameDay);
+    }
+    const physicalWorkByDate = new Map<string, string>();
+    for (const checkin of input.checkins) {
+        if (checkin.physicalWork?.performed) {
+            const dateOfWork = addDaysToLocalDateString(checkin.date, -1);
+            const intensity = checkin.physicalWork.intensity ? `${checkin.physicalWork.intensity} ` : '';
+            physicalWorkByDate.set(dateOfWork, `${intensity}physical work`);
+        }
     }
 
     if (snapshots.size === 0 && checkins.size === 0) return '';
@@ -215,9 +245,9 @@ function renderRecoveryTimeline(input: ContextBriefPlanningHandoffInput): string
         if (checkin?.painOrInjury) flags.push('pain/injury');
         if (checkin?.illnessSymptoms) flags.push('illness');
         if (checkin?.unusuallyLimitedTime) flags.push('limited time');
-        if (checkin?.physicalWork?.performed) {
-            const intensity = checkin.physicalWork.intensity ? `${checkin.physicalWork.intensity} ` : '';
-            flags.push(`${intensity}physical work`);
+        const pw = physicalWorkByDate.get(date);
+        if (pw) {
+            flags.push(pw);
         }
 
         lines.push(`| ${date} | ${textNumber(snapshot?.raw.sleepScore)} | ${textNumber(snapshot?.raw.hrvOvernightAvg)} | ${textNumber(snapshot?.raw.restingHr)} | ${textNumber(snapshot?.raw.respirationAvg)} | ${textNumber(snapshot?.raw.bodyBatteryWake)} | ${textNumber(snapshot?.raw.stress?.avg)} | ${textNumber(snapshot?.raw.totalSteps)} | ${textNumber(checkin?.readiness)} | ${textNumber(checkin?.fatigue)} | ${textNumber(checkin?.soreness)} | ${flags.join(', ') || '—'} |`);
@@ -419,7 +449,6 @@ export function buildMorningCoachBrief(input: ContextBriefPlanningHandoffInput):
     const activeSnapshot = todaySnapshot ?? latestSnapshot;
 
     const todayCheckin = input.checkins.find(c => c.date === targetDate);
-    const yesterdayCheckin = input.checkins.find(c => c.date === yesterdayDate);
     const yesterdayActivities = input.activities.filter(a => a.date === yesterdayDate);
     const todayRecommendation = [...input.recommendations]
         .filter(r => r.date === targetDate)
@@ -451,8 +480,13 @@ export function buildMorningCoachBrief(input: ContextBriefPlanningHandoffInput):
             + `Mental stress ${textNumber(todayCheckin.mentalStress)}`,
         );
 
+        const dayOfWeek = new Date(`${targetDate}T00:00:00Z`).getUTCDay();
+        const isWeekendDay = dayOfWeek === 0 || dayOfWeek === 6;
+        const defaultMinutes = isWeekendDay
+            ? settings?.defaults.weekendMaxMinutes
+            : settings?.defaults.weekdayMaxMinutes;
         const timeAvail = todayCheckin.availability?.timeAvailableMin
-            ?? (settings?.defaults.weekdayMaxMinutes ?? '—');
+            ?? (defaultMinutes ?? '—');
         const env = todayCheckin.availability?.indoorOnly
             ? 'indoor only'
             : (settings?.defaults.environment ?? 'either');
@@ -483,22 +517,7 @@ export function buildMorningCoachBrief(input: ContextBriefPlanningHandoffInput):
         }
 
         if (todayCheckin.physicalWork?.performed) {
-            const pw = todayCheckin.physicalWork;
-            const durationLabels: Record<string, string> = { short: '< 1 hr', medium: '1–3 hrs', extended: '3+ hrs' };
-            const areaLabels: Record<string, string> = {
-                grip_forearms: 'grip/forearms',
-                upper_body: 'upper body',
-                lower_back_spine: 'lower back/spine',
-                legs_carrying: 'legs/carrying',
-            };
-            const parts: string[] = [];
-            if (pw.duration) parts.push(durationLabels[pw.duration] ?? pw.duration);
-            if (pw.intensity) parts.push(`${pw.intensity} effort`);
-            if (pw.loadAreas && pw.loadAreas.length > 0) {
-                parts.push(`strain: ${pw.loadAreas.map(a => areaLabels[a] ?? a).join(', ')}`);
-            }
-            const noteStr = pw.notes && pw.notes.trim().length > 0 ? ` — "${pw.notes.trim()}"` : '';
-            lines.push(`- Unlogged physical work (yesterday D-1): ${parts.join(' · ')}${noteStr}`);
+            lines.push(`- Unlogged physical work (yesterday D-1): ${formatPhysicalWork(todayCheckin.physicalWork)}`);
         } else {
             lines.push('- Unlogged physical work (yesterday D-1): none reported');
         }
@@ -516,6 +535,9 @@ export function buildMorningCoachBrief(input: ContextBriefPlanningHandoffInput):
         const raw = activeSnapshot.raw;
         const der = activeSnapshot.derived;
         lines.push(`Most recent reading — ${activeSnapshot.date} (Garmin synced at ${activeSnapshot.source.garminSyncedAt}):`);
+        if (activeSnapshot.date < targetDate) {
+            lines.push(`> Wearable caution: no snapshot for ${targetDate}; the newest wearable state is ${activeSnapshot.date}. Do not treat it as current-day readiness.`);
+        }
         lines.push(`- HRV (overnight avg): ${textNumber(raw.hrvOvernightAvg)} ms (7d avg ${round(der.hrv7dAvg)}, 28d avg ${round(der.hrv28dAvg)}) — ${signed(der.deltas.hrvVs7d)} vs 7d, ${signed(der.deltas.hrvVs28d)} vs 28d`);
         lines.push(`- Resting HR: ${textNumber(raw.restingHr)} bpm (7d avg ${round(der.restingHr7dAvg)}, 28d avg ${round(der.restingHr28dAvg)}) — ${signed(der.deltas.restingHrVs7d)} vs 7d, ${signed(der.deltas.restingHrVs28d)} vs 28d`);
         lines.push(`- Sleep score: ${textNumber(raw.sleepScore)} pts (7d avg ${round(der.sleepScore7dAvg)}, 28d avg ${round(der.sleepScore28dAvg)}) — ${signed(der.deltas.sleepScoreVs7d)} vs 7d, ${signed(der.deltas.sleepScoreVs28d)} vs 28d`);
@@ -566,25 +588,8 @@ export function buildMorningCoachBrief(input: ContextBriefPlanningHandoffInput):
         lines.push('- Recorded training: No recorded sessions in this window.');
     }
 
-    const pwSource = todayCheckin?.physicalWork?.performed
-        ? todayCheckin.physicalWork
-        : (yesterdayCheckin?.physicalWork?.performed ? yesterdayCheckin.physicalWork : null);
-    if (pwSource) {
-        const durationLabels: Record<string, string> = { short: '< 1 hr', medium: '1–3 hrs', extended: '3+ hrs' };
-        const areaLabels: Record<string, string> = {
-            grip_forearms: 'grip/forearms',
-            upper_body: 'upper body',
-            lower_back_spine: 'lower back/spine',
-            legs_carrying: 'legs/carrying',
-        };
-        const parts: string[] = [];
-        if (pwSource.duration) parts.push(durationLabels[pwSource.duration] ?? pwSource.duration);
-        if (pwSource.intensity) parts.push(`${pwSource.intensity} effort`);
-        if (pwSource.loadAreas && pwSource.loadAreas.length > 0) {
-            parts.push(`strain: ${pwSource.loadAreas.map(a => areaLabels[a] ?? a).join(', ')}`);
-        }
-        const noteStr = pwSource.notes && pwSource.notes.trim().length > 0 ? ` — "${pwSource.notes.trim()}"` : '';
-        lines.push(`- Manual physical work: ${parts.join(' · ')}${noteStr}`);
+    if (todayCheckin?.physicalWork?.performed) {
+        lines.push(`- Manual physical work: ${formatPhysicalWork(todayCheckin.physicalWork)}`);
     } else {
         lines.push('- Manual physical work: none reported');
     }

--- a/app/src/services/contextBriefService.ts
+++ b/app/src/services/contextBriefService.ts
@@ -380,6 +380,7 @@ export class ContextBriefService {
             upcomingPlanBlocks,
             upcomingExternalSessions,
             unavailableSources,
+            preset,
         });
 
         return {


### PR DESCRIPTION
## Summary

- Optimized the `daily` AI context export preset (`buildMorningCoachBrief`) into an ultra-dense, 6-section morning coaching brief (~700–950 tokens, ~65% reduction) tailored for an ongoing chat thread with an external AI coach.
- Added a 1-click **📤 Copy AI Context** button directly to `MorningDecisionCard` with visual feedback (`Copied to clipboard! ✓`), error handling, transient user activation preservation, and safety suppression under clinical escalation.
- Preserved the full 14-day retrospective and 1-click JSON plan import schema under the `full` preset in Data View for multi-week block design.
- Aligned `physicalWork` semantics with D-1 (yesterday) in the recent 7-day recovery timeline table and removed redundant D-2 fallback logic.

## Validation

- [ ] `uv run pytest` (backend changes) — Skipped: this PR only modifies frontend/engine application code and UI components.
- [ ] `uv run ruff check .` and `uv run mypy src/garmin_sync` (backend changes) — Skipped: backend untouched.
- [x] `cd app && npm run check` (frontend changes) — Passed: TypeScript typechecking (`tsc -b`), ESLint, 3,481 vitest unit tests across 376 test files, sports knowledge validation (76 claims), and workout catalog validation (184 exercises).
- [ ] `cd app && npm run test:rules` (Firestore rules changes) — Skipped: Firestore security rules are untouched.
- [ ] `cd app && npm run simulate:scenarios` (recommendation-engine changes) — Skipped: decision-engine evaluation logic is unchanged; this change purely improves presentation and context serialization for export.
- [ ] `cd app && npm run visual:refresh` (material UI changes) — Skipped: UI addition is limited to an action button and copied state within MorningDecisionCard; verified via dedicated static/DOM component tests.

## Risk and reviewer guidance

- **Low risk**: Changes are strictly scoped to context serialization (`buildMorningCoachBrief`), prompt formatting, and the `MorningDecisionCard` action bar.
- Recommendation decision logic, Firestore rules, and persisted schemas are not modified.
- Reviewers should focus on:
  - `app/src/engine/contextBriefPlanningHandoff.ts`: The 6-section structure, the D-1 alignment for `physicalWork` in `renderRecoveryTimeline`, and the weekend/weekday fallback for `timeAvail`.
  - `app/src/components/MorningDecisionCard.tsx`: Transient user activation with `ClipboardItem` promise handling and graceful error alerts.

## Domain invariants

- [x] Firestore writes remain user-scoped under `users/{APP_USER_ID}/...`; no `default_user` or top-level recovery snapshots were introduced.
- [x] Calendar-date logic uses `Europe/Warsaw`; completed `totalSteps` still means the previous calendar day (`D - 1`).
- [x] No credentials, tokens, service-account files, or raw health payloads are included.
- [x] Recommendation decision logic changed: Not applicable — decision algorithms and `POLICY_VERSION` are unchanged.

## Screenshots or recordings

Not applicable — UI additions consist of a standard action button ("📤 Copy AI Context") and temporary copy confirmation feedback on `MorningDecisionCard`, fully covered by automated component tests in `MorningDecisionCardClinicalEscalation.test.tsx`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a daily “Morning Coach” briefing with check-in status, recovery, recent training, availability, recommendations, safety constraints, commitments, and coaching instructions.
  * Added a “Copy AI Context” action for sharing briefing details, with success and error feedback.
  * Added a comprehensive “Block Planning” option for 14-day retrospectives.

* **Bug Fixes**
  * Improved physical-work dates, stale wearable warnings, and weekend availability handling.
  * Restricted briefing actions when clinical escalation is active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->