### PR TITLE
refactor(engine): unify fixed-activity cost-profile reduce (ADR-0036 H4)

### DIFF
--- a/app/src/engine/fixedActivityCostProfile.test.ts
+++ b/app/src/engine/fixedActivityCostProfile.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { sumFixedActivityCostProfiles, ZERO_COST_PROFILE } from './fixedActivityCostProfile';
+import type { FixedActivity } from './models';
+
+function activity(overrides: Partial<FixedActivity> = {}): FixedActivity {
+    return {
+        id: 'a1', userId: 'athlete-1', title: 'Fixed commitment', date: '2026-08-09', durationMin: 60,
+        isCompleted: false, fixed: true, environment: 'either', equipment: [],
+        createdAt: '2026-08-01T00:00:00Z', updatedAt: '2026-08-01T00:00:00Z',
+        ...overrides,
+    };
+}
+
+// ADR-0036 D-LEDGER: this reduce was previously duplicated near-verbatim in
+// schedule.ts/planner.ts/rules.ts. These tests protect the shared behavior directly;
+// each call site's own date/completion filtering is protected separately by that call
+// site's existing tests (architecture.test.ts, planner.test.ts's Phase 6.2b block, and
+// the rules.ts next-day-projection tests).
+
+describe('sumFixedActivityCostProfiles', () => {
+    it('returns the zero profile for no activities', () => {
+        expect(sumFixedActivityCostProfiles([])).toEqual(ZERO_COST_PROFILE);
+    });
+
+    it('sums each of the six dimensions independently across multiple activities', () => {
+        const result = sumFixedActivityCostProfiles([
+            activity({ id: 'a1', expectedCost: { systemic: 0.2, lowerBody: 0.3 } }),
+            activity({ id: 'a2', expectedCost: { systemic: 0.1, cardiovascular: 0.4, neuromuscular: 0.05 } }),
+        ]);
+
+        expect(result.systemic).toBeCloseTo(0.3);
+        expect(result.cardiovascular).toBeCloseTo(0.4);
+        expect(result.lowerBody).toBeCloseTo(0.3);
+        expect(result.upperBody).toBe(0);
+        expect(result.impactTissue).toBe(0);
+        expect(result.neuromuscular).toBeCloseTo(0.05);
+    });
+
+    // D6-C: a missing expectedCost is "unknown/not modelled" and contributes zero -- it
+    // must never fall back to an invented default cost.
+    it('contributes zero for an activity with no expectedCost at all', () => {
+        const result = sumFixedActivityCostProfiles([activity({ expectedCost: undefined })]);
+        expect(result).toEqual(ZERO_COST_PROFILE);
+    });
+
+    it('does not filter by date or completion -- callers are responsible for pre-scoping the list', () => {
+        const result = sumFixedActivityCostProfiles([
+            activity({ date: '2026-08-09', isCompleted: true, expectedCost: { systemic: 0.5 } }),
+            activity({ date: '2026-09-01', isCompleted: false, expectedCost: { systemic: 0.5 } }),
+        ]);
+        expect(result.systemic).toBe(1);
+    });
+});

--- a/app/src/engine/fixedActivityCostProfile.ts
+++ b/app/src/engine/fixedActivityCostProfile.ts
@@ -1,0 +1,38 @@
+/**
+ * ADR-0036 (H4) D-LEDGER: "refactor... rather than subtracting again downstream." This
+ * six-dimension `WorkoutCostProfile` reduce over a fixed activity's `expectedCost` was
+ * previously duplicated near-verbatim in three places: `schedule.ts`'s
+ * `calculateReservedCapacityProfile`, `planner.ts`'s `fixedActivityCostProfileForDate`,
+ * and `rules.ts`'s `unrepresentedFixedActivityProjection`. This is a pure code-dedup
+ * extraction only -- every call site keeps its own existing date/completion filtering
+ * exactly as before, so behavior is unchanged (see `check-policy-drift.mjs`). It does not
+ * change what counts as "reserved" or introduce the `engine/dailyLedger.ts` remainder/
+ * admission semantics into any decision path; that remains a separate follow-up.
+ *
+ * D6-C: a missing `expectedCost` means "unknown/not modelled" and contributes zero -- a
+ * prior revision defaulted the whole activity to `systemic: 0.2` when `expectedCost` was
+ * absent, an invented heuristic this function must not reintroduce.
+ */
+import type { FixedActivity, WorkoutCostProfile } from './models';
+
+export const ZERO_COST_PROFILE: WorkoutCostProfile = {
+    systemic: 0, cardiovascular: 0, lowerBody: 0, upperBody: 0, impactTissue: 0, neuromuscular: 0,
+};
+
+/** Sums `expectedCost` across the given activities with no filtering of its own --
+ * callers pass an already-scoped list, matching each call site's own pre-existing
+ * date/completion filtering contract exactly. */
+export function sumFixedActivityCostProfiles(activities: readonly FixedActivity[]): WorkoutCostProfile {
+    return activities.reduce((sum, activity) => {
+        const cost = activity.expectedCost;
+        if (!cost) return sum;
+        return {
+            systemic: sum.systemic + (cost.systemic ?? 0),
+            cardiovascular: sum.cardiovascular + (cost.cardiovascular ?? 0),
+            lowerBody: sum.lowerBody + (cost.lowerBody ?? 0),
+            upperBody: sum.upperBody + (cost.upperBody ?? 0),
+            impactTissue: sum.impactTissue + (cost.impactTissue ?? 0),
+            neuromuscular: sum.neuromuscular + (cost.neuromuscular ?? 0),
+        };
+    }, ZERO_COST_PROFILE);
+}

--- a/app/src/engine/planner.ts
+++ b/app/src/engine/planner.ts
@@ -30,6 +30,7 @@ export interface PlannedObjectiveCredit {
     earnedCredit: number;
 }
 import { resolveAvailability } from './schedule';
+import { sumFixedActivityCostProfiles } from './fixedActivityCostProfile';
 import { isTemplatePhaseEligible, evaluatePeriodizationPhase, resolveMultiEventObjectives, type DroppedContributorObjective, type PeriodizationResult } from './periodization';
 import { eligibleTemplates } from './eligibility';
 import { addDaysToLocalDateString, getDayDiff } from '../utils/localDate';
@@ -965,18 +966,7 @@ export function applyFixedActivityStimulusCredit(
 
 export function fixedActivityCostProfileForDate(fixedActivities: FixedActivity[], date: string): WorkoutCostProfile {
     const dayActivities = fixedActivities.filter(a => a.date === date && !a.isCompleted);
-    return dayActivities.reduce((sum, activity) => {
-        const cost = activity.expectedCost;
-        if (!cost) return sum;
-        return {
-            systemic: sum.systemic + (cost.systemic ?? 0),
-            cardiovascular: sum.cardiovascular + (cost.cardiovascular ?? 0),
-            lowerBody: sum.lowerBody + (cost.lowerBody ?? 0),
-            upperBody: sum.upperBody + (cost.upperBody ?? 0),
-            impactTissue: sum.impactTissue + (cost.impactTissue ?? 0),
-            neuromuscular: sum.neuromuscular + (cost.neuromuscular ?? 0),
-        };
-    }, ZERO_COST);
+    return sumFixedActivityCostProfiles(dayActivities);
 }
 
 function accumulateNewDrops(

--- a/app/src/engine/policy.ts
+++ b/app/src/engine/policy.ts
@@ -1,11 +1,12 @@
 /** Increment whenever a change can alter a persisted recommendation decision. (Refactoring does not require a bump) */
 
-export const POLICY_VERSION = '2026-09-authored-rest-day-v1';
+export const POLICY_VERSION = '2026-09-fixed-activity-cost-dedup-v1';
 
 /** Historical versions are intentionally not re-executed by this build. Their compact
  * audits remain readable evidence, but replay is rejected explicitly because the old
  * decision function is not bundled alongside the current policy. */
 export const HISTORICAL_POLICY_VERSIONS = [
+    '2026-09-authored-rest-day-v1',
     '2026-09-outdoor-easy-cycling-anchor-authority-v1',
     '2026-09-outdoor-easy-cycling-v1',
     '2026-09-wearable-free-subjective-mode-v1',

--- a/app/src/engine/rules.ts
+++ b/app/src/engine/rules.ts
@@ -44,6 +44,7 @@ import { getUnresolvedObjectives } from './microcycle';
 import { applyCompletedSessionLoad, type FatigueFusionPolicy } from './fatigue';
 import { SUBJECTIVE_BASELINE_METRICS, type SubjectiveBaseline, type SubjectiveBaselineMetric } from './subjectiveBaseline';
 import { resolveAvailability } from './schedule';
+import { sumFixedActivityCostProfiles } from './fixedActivityCostProfile';
 import { workoutForTemplate } from '../workouts/prescription';
 import { resolveEvergreenPlan } from './evergreenPlanning';
 import { isSevereAdverseRecoveryReadiness } from './evergreenStrategy';
@@ -1236,14 +1237,7 @@ function unrepresentedFixedActivityProjection(
     const represented = fixedActivities.filter(activity => activity.date === date && !activity.isCompleted);
     if (trace.count <= represented.length) return null;
 
-    const representedCost = represented.reduce<WorkoutCostProfile>((sum, activity) => ({
-        systemic: sum.systemic + (activity.expectedCost?.systemic ?? 0),
-        cardiovascular: sum.cardiovascular + (activity.expectedCost?.cardiovascular ?? 0),
-        lowerBody: sum.lowerBody + (activity.expectedCost?.lowerBody ?? 0),
-        upperBody: sum.upperBody + (activity.expectedCost?.upperBody ?? 0),
-        impactTissue: sum.impactTissue + (activity.expectedCost?.impactTissue ?? 0),
-        neuromuscular: sum.neuromuscular + (activity.expectedCost?.neuromuscular ?? 0),
-    }), ZERO_COST);
+    const representedCost = sumFixedActivityCostProfiles(represented);
     const representedStimulus = represented.reduce<WorkoutStimulusProfile>((sum, activity) => ({
         aerobicEndurance: sum.aerobicEndurance + (activity.expectedStimulus?.aerobicEndurance ?? 0),
         thresholdPower: sum.thresholdPower + (activity.expectedStimulus?.thresholdPower ?? 0),

--- a/app/src/engine/schedule.ts
+++ b/app/src/engine/schedule.ts
@@ -6,6 +6,7 @@ import type {
     WorkoutCostProfile,
 } from './models';
 import { resolveMaximumSessionMinutes } from './eligibility';
+import { sumFixedActivityCostProfiles } from './fixedActivityCostProfile';
 
 export interface ResolvedAvailability {
     date: string;
@@ -73,34 +74,16 @@ function resolveOwnedEquipment(
     return owned;
 }
 
-const ZERO_COST_PROFILE: WorkoutCostProfile = {
-    systemic: 0, cardiovascular: 0, lowerBody: 0, upperBody: 0, impactTissue: 0, neuromuscular: 0,
-};
-
 /**
  * Sums reserved dimensional load from future (uncompleted) fixed activities, e.g. evening
  * football. Reserves capacity for the day without injecting pre-mature fatigue before
  * execution -- see planner.ts for where it is folded into same-day ranking and, at end of
- * day, into next-day external fatigue.
- *
- * D6-C: a missing `expectedCost` means "unknown/not modelled" and contributes zero. A
- * prior revision defaulted the whole activity to `systemic: 0.2` when `expectedCost` was
- * absent -- an invented heuristic this function must not reintroduce; the activity's time
- * is still reserved via `durationMin`/`availabilityOverride` regardless.
+ * day, into next-day external fatigue. The activity's time is still reserved via
+ * `durationMin`/`availabilityOverride` regardless of `expectedCost` (see
+ * `fixedActivityCostProfile.ts` for the D6-C "missing cost contributes zero" rule).
  */
 function calculateReservedCapacityProfile(futureActivities: FixedActivity[]): WorkoutCostProfile {
-    return futureActivities.reduce((sum, act) => {
-        const cost = act.expectedCost;
-        if (!cost) return sum;
-        return {
-            systemic: sum.systemic + (cost.systemic ?? 0),
-            cardiovascular: sum.cardiovascular + (cost.cardiovascular ?? 0),
-            lowerBody: sum.lowerBody + (cost.lowerBody ?? 0),
-            upperBody: sum.upperBody + (cost.upperBody ?? 0),
-            impactTissue: sum.impactTissue + (cost.impactTissue ?? 0),
-            neuromuscular: sum.neuromuscular + (cost.neuromuscular ?? 0),
-        };
-    }, ZERO_COST_PROFILE);
+    return sumFixedActivityCostProfiles(futureActivities);
 }
 
 /** Phase 6.2b / D6-B: an activity's own `environment`/`equipment` describe itself, not the

--- a/docs/plans/cycling-primary-hybrid-evaluation.md
+++ b/docs/plans/cycling-primary-hybrid-evaluation.md
@@ -1,7 +1,7 @@
 # Cycling-primary hybrid evaluation and recommendation improvements
 
-**Status:** In progress — H1, H2, H2b, H3 and H3-rest (ADR-0035) all delivered; H4 design accepted as ADR-0036 with D-SCHEMA/D-LEDGER delivered and the same-day canonical performed-fact boundary verified (runtime wiring unstarted); H5 design accepted as ADR-0037 (implementation unstarted)
-**Blocked by:** Personal M00/M01 prescription requires current workload/restriction confirmation; H4 runtime wiring (the `dailyLedger.ts` refactor across `schedule.ts`/`planner.ts`/`rules.ts`, then D-TIME/D-REASSESS/D-PLACEMENT/D-AUDIT) is a decision-affecting change needing its own PR, no longer blocked on verification; H5 runtime requires validated intent mappings and linked response evidence, and cumulative `external-plan@5` acceptance additionally requires the landed H4 contract (ADR-0036).
+**Status:** In progress — H1, H2, H2b, H3 and H3-rest (ADR-0035) all delivered; H4 design accepted as ADR-0036 with D-SCHEMA/D-LEDGER delivered, the same-day canonical performed-fact boundary verified, and the fixed-activity cost-reduce duplication unified (ledger-based ranking/admission and D-TIME/D-REASSESS/D-PLACEMENT/D-AUDIT unstarted); H5 design accepted as ADR-0037 with H5a/H5b delivered (H5c and cumulative `external-plan@5` unstarted)
+**Blocked by:** Personal M00/M01 prescription requires current workload/restriction confirmation; H4's remaining wiring (using the ledger's remainder/admission math as an actual ranking input, then D-TIME/D-REASSESS/D-PLACEMENT/D-AUDIT) needs its own decision-affecting PR(s); H5c needs the athlete-scoped singleton progression-claim transaction design, and cumulative `external-plan@5` acceptance is unblocked now that H4's v4 contract has landed.
 **Unlocks:** Reproducible acceptance cases for equipment specificity, block authority and hybrid plan quality.
 
 ## Decision
@@ -320,34 +320,56 @@ contract and its only current caller (`trainingIntent.ts`) are unchanged.
 pinning test confirming current production behavior (today excluded) is untouched.
 `simulate:diff`/policy-drift show no change.
 
-The actual next H4 task is now the `dailyLedger.ts` wiring refactor: `schedule.ts`'s
-`resolveAvailability`/`calculateReservedCapacityProfile`, `planner.ts`'s
-`fixedActivityCostProfileForDate`/`applyFixedActivityStimulusCredit`/
-`applyFixedActivityCost`, `rules.ts`'s `fixedActivityProjection`/
-`unrepresentedFixedActivityProjection`, and `externalCritique.ts`'s use of
-`fixedActivityCostProfileForDate` currently duplicate the same six-dimension cost/
-stimulus reduce across five-plus call sites with three different ad hoc dedup
-mechanisms (`seenOccurrences`, `appliedFixedCostOccurrences`/
-`appliedProjectionOccurrences`, and a decision-trace delta). That refactor is
-decision-affecting and needs its own PR, then D-TIME/D-REASSESS/D-PLACEMENT/D-AUDIT.
+### Fixed-activity cost-reduce duplication unified (delivered)
+
+`schedule.ts`'s `calculateReservedCapacityProfile`, `planner.ts`'s
+`fixedActivityCostProfileForDate` (also used by `externalCritique.ts`), and `rules.ts`'s
+`unrepresentedFixedActivityProjection` each hand-wrote the same six-dimension
+`WorkoutCostProfile` reduce over `FixedActivity.expectedCost`. `engine/fixedActivityCostProfile.ts`'s
+`sumFixedActivityCostProfiles` now supplies that reduce once; every call site keeps its
+own existing date/completion filtering, so behavior is unchanged. Verified
+byte-identical via `simulate:diff` (same pre-existing, unrelated drift as before) and
+the full test suite. `POLICY_VERSION` was bumped to
+`2026-09-fixed-activity-cost-dedup-v1` regardless, because the drift gate can only
+mechanically prove comment-only equivalence and this refactor restructures the call
+sites' syntax -- not because decision output actually changed.
+
+The three different ad hoc dedup mechanisms across these sites (`seenOccurrences` in
+`applyFixedActivityStimulusCredit`, `appliedFixedCostOccurrences`/
+`appliedProjectionOccurrences` in `generateWeekAheadPlan`, and the decision-trace delta
+in `unrepresentedFixedActivityProjection`) are **not yet unified** onto the ledger's
+`occurrenceId`/`revision` model, and none of these call sites yet consult
+`computeDailyLedger`'s remainder or `admitsCandidate` when ranking or admitting a
+candidate. The actual next H4 task is using the ledger's remainder/admission semantics
+as a real ranking/admission input -- that is decision-affecting and needs its own PR,
+then D-TIME/D-REASSESS/D-PLACEMENT/D-AUDIT.
 
 ## H5 — Explicit develop/maintain intent and progression
 
-**Status:** Design accepted in [ADR-0037](../adr/0037-block-intent-and-controlled-progression.md); implementation unstarted.
-**Dependencies:** Validated intent-to-dose/coverage mappings and canonical completion/response
-linkage for runtime review. `external-plan@5` acceptance depends on the landed H4 contract
-(ADR-0036); manual intent and report-only groundwork does not require H4 runtime release.
+**Status:** Design accepted in [ADR-0037](../adr/0037-block-intent-and-controlled-progression.md).
+**H5a (intent contracts + canonical replay) and H5b (report-only progression review)
+delivered** in `engine/blockIntent.ts`/`blockIntentReplay.ts`/`progressionReview.ts`,
+per the implementation handoff's H5 work order. H5c (athlete-confirmed bounded
+revisions) and cumulative `external-plan@5` are unstarted.
+**Dependencies:** H5c needs the athlete-scoped singleton progression-claim transaction
+design. `external-plan@5` acceptance depends on the landed H4 v4 contract, which has
+landed.
 
 Decision: per-objective `develop | maintain` intent is separate from priority and profile
 commitment. Use existing plan, dose, coverage, response and outcome authorities. New import
 authority belongs in `external-plan@5`; earlier schemas remain unchanged. Maintenance is
 an intended outcome, not a default dose discount or an assertion of preserved performance.
 
-Deliver H5a intent authoring, H5b report-only progression review, then H5c athlete-confirmed
-bounded revisions. One active progression experiment changes one variable within reviewed
-bounds. Missing/adverse follow-up blocks advancement; outcome reports retain no automatic
-selection authority. Hold, reduction and redirect are explicit alternatives. The ADR owns
-the complete compatibility, substitution, evidence, confirmation and replay acceptance bar.
+H5a's delivered `engine/blockIntent.ts` is not wired into `external-plan@5` import yet
+(the ADR's own note: "manual intent and report-only groundwork does not require H4
+runtime release" applied only to the manual-authoring path H5a/H5b actually deliver).
+H5b's `engine/progressionReview.ts` is report-only and not consulted by daily
+recommendation selection; `POLICY_VERSION` is unchanged by either. H5c (athlete-confirmed
+bounded revisions) is the remaining work: one active progression experiment changes one
+variable within reviewed bounds, missing/adverse follow-up blocks advancement, outcome
+reports retain no automatic selection authority, and hold/reduction/redirect remain
+explicit alternatives. The ADR owns the complete compatibility, substitution, evidence,
+confirmation and replay acceptance bar.
 
 ## Reproduction and verification
 
@@ -380,6 +402,9 @@ remain scoped to the unchanged active suite.
 H1 did not change engine behavior and therefore required no policy bump. H2/H2b are
 decision-affecting and are represented by the current policy version above. H3's new test
 is non-decision-affecting and needs no bump; the explicit-rest follow-up will require the
-normal policy/schema/replay review when it changes decision behavior. H4-H5 likewise
-require the normal review when decision behavior changes. Do not enable experimental
-personalization simply to improve a judge score.
+normal policy/schema/replay review when it changes decision behavior. H4's
+`fixed-activity-cost-dedup-v1` bump reflects the drift gate's mechanical requirement for
+any `planner.ts`/`rules.ts` touch, not an actual behavior change (verified via
+`simulate:diff`); H4's still-pending ledger-based ranking/admission wiring and H5's
+still-pending H5c will require the normal review when they actually change decision
+behavior. Do not enable experimental personalization simply to improve a judge score.

--- a/docs/plans/cycling-primary-hybrid-evaluation.md
+++ b/docs/plans/cycling-primary-hybrid-evaluation.md
@@ -243,8 +243,11 @@ also remains blocked on current-workload/restriction confirmation.
 **D-SCHEMA and D-LEDGER delivered** (schema/pure-ledger slice); **same-day canonical
 performed-fact boundary verified**; runtime wiring (the `dailyLedger.ts` refactor, plus
 D-TIME/D-REASSESS/D-PLACEMENT/D-AUDIT) unstarted.
-**Dependencies:** ADR-0035 rest support (delivered). `POLICY_VERSION` is unchanged by
-this work -- no decision behavior is activated yet.
+**Dependencies:** ADR-0035 rest support (delivered). The `external-plan@4`/`dailyLedger.ts`
+D-SCHEMA/D-LEDGER slice itself left `POLICY_VERSION` unchanged (neither module is
+consumed by any decision path); the later fixed-activity cost-reduce dedup slice below
+did bump it, mechanically, per the drift gate's requirement -- not because decision
+behavior actually changed. No H4 slice has activated new decision behavior yet.
 
 Decision: explicit athlete-owned windows, plan-owned sequencing in `external-plan@4`,
 one shared daily minute/load ledger, and fresh post-AM reassessment before PM launch.

--- a/docs/plans/cycling-primary-hybrid-implementation-handoff.md
+++ b/docs/plans/cycling-primary-hybrid-implementation-handoff.md
@@ -25,8 +25,11 @@ the ordinary coverage ordering is unchanged, so an already-met hard role does no
 unnecessary repeats.
 
 The current decision policy version is
-`2026-09-authored-rest-day-v1`. See the evaluation plan for the root
-cause, focused regression tests and required PR-head validation.
+`2026-09-fixed-activity-cost-dedup-v1` (bumped mechanically by the fixed-activity
+cost-reduce dedup slice, not by an actual decision-behavior change -- see `app/src/engine/policy.ts`
+for the authoritative current value, since this line will otherwise go stale again).
+See the evaluation plan for the root cause, focused regression tests and required
+PR-head validation.
 
 H3 was investigated and its executable contracts are delivered (see the work orders below
 and the evaluation plan). The unplanned-date fallback, missed-session replacement,

--- a/docs/plans/cycling-primary-hybrid-implementation-handoff.md
+++ b/docs/plans/cycling-primary-hybrid-implementation-handoff.md
@@ -1,7 +1,7 @@
 # Cycling-primary hybrid: implementation handoff
 
-**Status:** H1, H2, H2b, H3 and H3-rest (ADR-0035) all delivered; H4 design accepted as ADR-0036 with D-SCHEMA/D-LEDGER delivered and the same-day canonical performed-fact boundary verified (runtime wiring unstarted); H5 design accepted as ADR-0037 (implementation unstarted)
-**Blocked by:** H4 runtime wiring (refactoring `schedule.ts`/`planner.ts`/`rules.ts` onto `dailyLedger.ts`, then D-TIME/D-REASSESS/D-PLACEMENT/D-AUDIT) is no longer blocked on verification -- it is ready to start as its own decision-affecting PR. H5 intent groundwork can start now; H5 runtime needs validated intent mappings and linked response evidence, and H5's cumulative `external-plan@5` import acceptance must be based on ADR-0036's landed v4 artifact, not reconstructed from discussion context. Personal M00/M01 prescription needs current athlete inputs.
+**Status:** H1, H2, H2b, H3 and H3-rest (ADR-0035) all delivered; H4 design accepted as ADR-0036 with D-SCHEMA/D-LEDGER delivered, the same-day canonical performed-fact boundary verified, and the fixed-activity cost-reduce duplication unified (D-TIME/D-REASSESS/D-PLACEMENT/D-AUDIT and ledger-based admission unstarted); H5 design accepted as ADR-0037 with H5a (intent contracts, canonical replay) and H5b (report-only progression review) delivered (H5c confirmed revisions and cumulative `external-plan@5` unstarted)
+**Blocked by:** H4's remaining runtime wiring (using `computeDailyLedger`/`admitsCandidate` as an actual ranking/admission input, then D-TIME/D-REASSESS/D-PLACEMENT/D-AUDIT) needs its own decision-affecting PR(s); nothing left blocks starting it. H5c (confirmed bounded revisions, with the athlete-scoped singleton progression claim) and cumulative `external-plan@5` with `intentBlocks` are both ready to start now that H4's v4 artifact has landed. Personal M00/M01 prescription needs current athlete inputs.
 **Unlocks:** A cycling-first recommendation path that preserves feasible strength, respects equipment and time, and supports authored blocks without inventing capacity.
 
 ## Start here
@@ -244,21 +244,31 @@ The accepted implementation sequence is:
    revision ordering/supersession reuses the existing `ExternalPlanService` dispatch
    (now including v4) unchanged. `sessions/externalPlanV4.test.ts` covers the ADR's
    schema-level deterministic cases.
-2. **Ledger delivered as a pure module; refactor into the schedule/planner deduction
-   points is the next task.** `engine/dailyLedger.ts` implements one daily
+2. **Ledger delivered as a pure module. The duplicated six-dimension cost reduce is
+   now unified; using the ledger's remainder/admission semantics for actual ranking
+   decisions is still the next task.** `engine/dailyLedger.ts` implements one daily
    ledger's remainder/reconciliation math (`computeDailyLedger`, `admitsCandidate`,
    `reconcileEntry`), covered by `engine/dailyLedger.test.ts` including the ADR's
    90-minute-ceiling/60-minute-AM worked example and the exhausted-systemic-cost case.
-   **Not yet done:** wiring this into `schedule.ts`'s `resolveAvailability`/
-   `calculateReservedCapacityProfile`, `planner.ts`'s `fixedActivityCostProfileForDate`/
-   `applyFixedActivityStimulusCredit`, and `rules.ts`'s `fixedActivityProjection`/
-   `unrepresentedFixedActivityProjection`, plus `externalCritique.ts`'s own use of
-   `fixedActivityCostProfileForDate` -- today these five-plus call sites still each
-   hand-write an independent per-day cost/stimulus reduce, with three different ad hoc
-   dedup mechanisms (`seenOccurrences`, `appliedFixedCostOccurrences`/
-   `appliedProjectionOccurrences`, and a decision-trace delta); D-LEDGER's "refactor...
-   rather than subtracting again downstream" is not yet satisfied. Resolving real
-   windows and reserving minutes/cost against actual instants also needs D-TIME (below).
+   `engine/fixedActivityCostProfile.ts`'s `sumFixedActivityCostProfiles` now replaces the
+   three near-identical inline reduces in `schedule.ts`'s
+   `calculateReservedCapacityProfile`, `planner.ts`'s `fixedActivityCostProfileForDate`
+   (also used by `externalCritique.ts`), and `rules.ts`'s
+   `unrepresentedFixedActivityProjection` -- a pure duplication-removal refactor, each
+   call site's own date/completion filtering left untouched, verified byte-identical via
+   `simulate:diff` (no new drift) and the full test suite (`POLICY_VERSION` bumped
+   because the gate can only mechanically prove comment-only equivalence, not semantic
+   equivalence across a restructured call site -- not because output actually changed).
+   **Not yet done:** the three still-separate ad hoc dedup mechanisms
+   (`seenOccurrences` in `applyFixedActivityStimulusCredit`,
+   `appliedFixedCostOccurrences`/`appliedProjectionOccurrences` in
+   `generateWeekAheadPlan`, and the decision-trace delta in
+   `unrepresentedFixedActivityProjection`) are not yet unified onto the ledger's
+   `occurrenceId`/`revision` model, and none of these call sites yet consult
+   `computeDailyLedger`'s remainder or `admitsCandidate` when ranking/admitting a
+   candidate -- D-LEDGER's remainder-based admission is not yet a decision input
+   anywhere. Resolving real windows and reserving minutes/cost against actual instants
+   also needs D-TIME (below).
 3. Add atomic, confirmed bundle placement against all destination windows and ADR-0035
    rest. Preserve completed history and support independent optional-session dropping.
 4. At PM launch, capture current symptoms/response, same-day work and availability, rerun
@@ -307,36 +317,44 @@ that shared boundary. It no longer needs a separate verification pass first.
 
 ## Work order H5 — Block intent and controlled progression
 
-**Status:** Design accepted in [ADR-0037](../adr/0037-block-intent-and-controlled-progression.md); implementation unstarted.
-**Dependencies:** Validated intent mappings and canonical completed-work/response linkage.
-`external-plan@5` import depends on the concrete inherited v3/v4 contracts; ADR-0036 is
-accepted and merged, so its v4 artifact is a real dependency to build against rather than
-a discussion-context reconstruction. Single-session manual intent/reporting groundwork can
-start independently of H4 runtime.
+**Status:** Design accepted in [ADR-0037](../adr/0037-block-intent-and-controlled-progression.md).
+**H5a and H5b delivered** (`engine/blockIntent.ts`, `engine/blockIntentReplay.ts`,
+`engine/progressionReview.ts`); H5c and cumulative `external-plan@5` unstarted.
+**Dependencies:** H5c needs the athlete-scoped singleton progression-claim transaction
+design. `external-plan@5` import depends on the concrete inherited v3/v4 contracts;
+ADR-0036's v4 artifact has landed, so it is a real dependency to build against rather
+than a discussion-context reconstruction.
 **Deliverable:** H5a explicit intent, H5b report-only review, H5c confirmed bounded revisions.
 
-1. **H5a — Intent contracts.** Add versioned block objectives with independent intent and
-   priority, typed dose bounds, protected exact roles/substitutions and prospective review
-   criteria. Reuse `PlanDefinition`, `AdaptationDoseRequirement` and the effective-mode
-   boundary. Introduce import `intentBlocks` only in v5; keep earlier schemas unchanged.
-   Preserve profile commitment, rest/taper/safety precedence and forward-only revisions.
-   Define a versioned canonical replay payload that exhaustively covers every authored field
-   capable of changing allocation, adjudication, progression or evaluation behavior. Hash
-   that canonical projection, not an informal subset of block fields. The payload must also
-   pin the `TrainingIntentProfile` revision/canonical snapshot it was evaluated against
-   (`priorities` and every `weeklyCommitment` field) -- these are read at evaluation time but
-   are not themselves part of the block/plan contract, so a later profile edit must not
-   silently change what an already-replayed decision is checked against. Add fixtures that
-   mutate `priorities` and each `weeklyCommitment` field independently and confirm replay
-   fails closed on each.
-2. **H5b — Evidence review.** Use canonical performed work, pinned prescription comparison,
-   linked follow-up responses and existing protocol-aware outcome evaluations. Implement
-   frozen, report-only `advance_proposal | hold | reduce_proposal | redirect` results.
-   Missing or adverse evidence blocks advancement. Require one target variable and reviewed
-   bounds/evidence criteria. Pending proposals are not active experiments; only confirmed
-   activation acquires the athlete-wide singleton progression slot. Do not reuse block-report
-   percentage thresholds as progression clearance.
-3. **H5c — Confirmed revision.** Show concrete before/after dose and affected future work.
+1. **H5a — Intent contracts (delivered).** `engine/blockIntent.ts` provides explicit
+   per-objective `develop | maintain` intent and typed objective priority, typed dose
+   envelopes and coverage-role vocabulary, protected roles, bounded substitution rules,
+   prospective success criteria, entry prerequisites and exit criteria, a Phase-1
+   progression-variable registry (`duration_min -> minutes`), and fail-closed validation
+   (source-plan identity/revision, calendar dates, review timing, finite bounds,
+   unit/envelope compatibility, substitution qualification, prerequisites, duplicate
+   IDs, per-plan block overlap). `engine/blockIntentReplay.ts` builds the
+   `treatment_intent_replay_v1` canonical SHA-256-hashed projection, pinning source plan
+   identity/revision/provenance, the evaluated `TrainingIntentProfile` snapshot, block
+   interval/review timing, and every H5a/progression-rule field; presentation-only
+   fields are excluded and non-finite numbers are rejected rather than silently
+   collapsing to JSON `null`. `blockIntent.test.ts`/`blockIntentReplay.test.ts` cover
+   the deterministic/replay-mutation matrix, including fixtures that mutate `priorities`
+   and each `weeklyCommitment` field independently and confirm replay fails closed.
+   Read the actual delivered code and its ADR references rather than re-deriving the
+   contract from this summary alone.
+2. **H5b — Evidence review (delivered).** `engine/progressionReview.ts` derives only
+   `advance_proposal | hold | reduce_proposal | redirect`, report-only, and fails closed
+   on evidence identity: authored observation-window lower bound, dedup by canonical
+   `performedOccurrenceId`, exact target-role coverage or a proven exact substitution,
+   a pinned current-prescription match (same variable/unit/value/source revision),
+   follow-up counted only from joined target evidence, adverse/caution safety evidence
+   still applied from partial/mismatched attempts, missing follow-up blocks advancement,
+   full frozen evaluation-reference matching, authored trend/prerequisites/max-duration/
+   end-of-block redirect enforcement, and no implicit "N bad responses" redirect
+   threshold. `progressionReview.test.ts` covers this. Not wired into daily
+   recommendation selection; `POLICY_VERSION` unchanged.
+3. **H5c — Confirmed revision (design notes; unstarted).** Show concrete before/after dose and affected future work.
    Confirmation must revalidate source revisions, safety and capacity and atomically create
    one new authored revision. Enforce the one-confirmed-active-experiment-per-athlete rule
    with an athlete-scoped singleton claim/sentinel acquired in the same Firestore transaction


### PR DESCRIPTION
## Summary

First slice of the H4 (ADR-0036) "next task" named in #418/#422: unifying the duplicated fixed-activity cost-profile reduce. This is a pure, verified no-op refactor -- it does not yet wire `engine/dailyLedger.ts`'s remainder/admission math into any ranking decision.

## What changed

- **`app/src/engine/fixedActivityCostProfile.ts`** (new): `sumFixedActivityCostProfiles`, the shared six-dimension `WorkoutCostProfile` reduce over `FixedActivity.expectedCost`, previously duplicated near-verbatim in three places.
- **`app/src/engine/schedule.ts`**: `calculateReservedCapacityProfile` now calls the shared reduce.
- **`app/src/engine/planner.ts`**: `fixedActivityCostProfileForDate` now calls the shared reduce (its own date/completion filtering unchanged); this function is also used by `externalCritique.ts`, updated transparently.
- **`app/src/engine/rules.ts`**: `unrepresentedFixedActivityProjection`'s inline `representedCost` reduce replaced with the shared function.
- **`app/src/engine/fixedActivityCostProfile.test.ts`** (new): direct unit coverage of the shared reduce (zero-activities, multi-dimension summation, missing-`expectedCost` contributes zero, no implicit filtering).
- **`app/src/engine/policy.ts`**: `POLICY_VERSION` bumped to `2026-09-fixed-activity-cost-dedup-v1`. This reflects the policy-drift gate's mechanical requirement whenever `planner.ts`/`rules.ts` are touched at all (it can only prove comment-only equivalence, not semantic equivalence across a restructured call site) -- **not** an actual decision-output change.
- **Docs**: `cycling-primary-hybrid-evaluation.md` / `...-implementation-handoff.md` updated to record this slice, and to sync H5's status (H5a/H5b were delivered in #420, which didn't touch these plan docs, so they were stale).

## What's deliberately not in this PR

- The three still-separate ad hoc dedup mechanisms across these call sites (`seenOccurrences`, `appliedFixedCostOccurrences`/`appliedProjectionOccurrences`, and a decision-trace delta) are not unified onto the ledger's `occurrenceId`/`revision` model.
- None of these call sites yet consult `computeDailyLedger`'s remainder or `admitsCandidate` when ranking/admitting a candidate -- D-LEDGER's remainder-based admission is not a decision input anywhere yet. That's the next, genuinely decision-affecting H4 step.

## Verification

- `npm exec vitest run src/engine/fixedActivityCostProfile.test.ts` plus the full suite -- all passing (3550 tests), including `planner.test.ts`'s Phase 6.2b fixed-activity coverage, `h3AuthoredPlanContracts.test.ts`, `externalEventFixedActivityCredit.test.ts`
- `npm run check`, `npm run build` -- clean
- `npm run test:rules` -- 178/178 (batch/setDoc paths unaffected)
- `npm run simulate:scenarios && npm run simulate:diff` -- identical output to `main` (same pre-existing, previously-confirmed-unrelated drift; no new diff from this change)
- `node scripts/check-policy-drift.mjs origin/main` -- passed, with the expected bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Unified fixed-activity cost calculations across planning, scheduling, and rule-based projections.
  - Fixed-activity costs now aggregate consistently across all supported cost dimensions, including activities with partial or missing cost details.

- **Policy**
  - Older unlogged physical-work policy versions are now classified as historical and rejected for replay.

- **Documentation**
  - Updated project plans and implementation handoff documentation with current delivery status and remaining work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->