### PR TITLE
feat(engine): implement ADR-0036 D-TIME -- DST-safe local instant resolution (H4)

### DIFF
--- a/app/src/engine/localInstant.test.ts
+++ b/app/src/engine/localInstant.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import { resolveLocalInstant, elapsedMinutesBetweenInstants } from './localInstant';
+
+// Europe/Warsaw 2026 DST transitions (verified against Intl.DateTimeFormat directly):
+// spring-forward 2026-03-29 02:00 -> 03:00 (CET/UTC+1 -> CEST/UTC+2, gap [02:00,03:00));
+// fall-back 2026-10-25 03:00 -> 02:00 (CEST/UTC+2 -> CET/UTC+1, repeated [02:00,03:00)).
+
+describe('resolveLocalInstant (ADR-0036 D-TIME)', () => {
+    it('resolves an ordinary winter (CET, UTC+1) wall-clock time', () => {
+        const result = resolveLocalInstant('2026-08-17', '07:00', 'Europe/Warsaw'); // actually summer, CEST
+        expect(result.status).toBe('resolved');
+        if (result.status !== 'resolved') throw new Error('unreachable');
+        expect(result.offsetMinutes).toBe(120); // CEST = UTC+2
+        expect(result.instant).toBe('2026-08-17T05:00:00.000Z');
+    });
+
+    it('resolves an ordinary winter (CET, UTC+1) date correctly', () => {
+        const result = resolveLocalInstant('2026-01-15', '07:00', 'Europe/Warsaw');
+        expect(result.status).toBe('resolved');
+        if (result.status !== 'resolved') throw new Error('unreachable');
+        expect(result.offsetMinutes).toBe(60); // CET = UTC+1
+        expect(result.instant).toBe('2026-01-15T06:00:00.000Z');
+    });
+
+    it('rejects a spring-forward local time that never existed', () => {
+        const result = resolveLocalInstant('2026-03-29', '02:30', 'Europe/Warsaw');
+        expect(result.status).toBe('nonexistent');
+    });
+
+    it('resolves a spring-forward date just before/after the gap normally', () => {
+        const before = resolveLocalInstant('2026-03-29', '01:30', 'Europe/Warsaw');
+        expect(before.status).toBe('resolved');
+        if (before.status !== 'resolved') throw new Error('unreachable');
+        expect(before.offsetMinutes).toBe(60);
+
+        const after = resolveLocalInstant('2026-03-29', '03:30', 'Europe/Warsaw');
+        expect(after.status).toBe('resolved');
+        if (after.status !== 'resolved') throw new Error('unreachable');
+        expect(after.offsetMinutes).toBe(120);
+    });
+
+    it('reports a fall-back local time as ambiguous with both real candidate instants, earlier first', () => {
+        const result = resolveLocalInstant('2026-10-25', '02:30', 'Europe/Warsaw');
+        expect(result.status).toBe('ambiguous');
+        if (result.status !== 'ambiguous') throw new Error('unreachable');
+        expect(result.candidates).toHaveLength(2);
+        expect(result.candidates[0].offsetMinutes).toBe(120); // still-CEST instance, first chronologically
+        expect(result.candidates[1].offsetMinutes).toBe(60); // CET instance, second chronologically
+        expect(Date.parse(result.candidates[0].instant)).toBeLessThan(Date.parse(result.candidates[1].instant));
+        // Exactly one hour (3600000ms) apart -- the DST fold width.
+        expect(Date.parse(result.candidates[1].instant) - Date.parse(result.candidates[0].instant)).toBe(3600000);
+    });
+
+    it('resolves a fall-back date just before/after the repeated hour normally', () => {
+        const before = resolveLocalInstant('2026-10-25', '01:30', 'Europe/Warsaw');
+        expect(before.status).toBe('resolved');
+        if (before.status !== 'resolved') throw new Error('unreachable');
+        expect(before.offsetMinutes).toBe(120);
+
+        const after = resolveLocalInstant('2026-10-25', '03:30', 'Europe/Warsaw');
+        expect(after.status).toBe('resolved');
+        if (after.status !== 'resolved') throw new Error('unreachable');
+        expect(after.offsetMinutes).toBe(60);
+    });
+
+    it('treats the exact gap boundary (02:00, the first nonexistent minute) as nonexistent and 03:00 (the first valid minute after) as resolved', () => {
+        expect(resolveLocalInstant('2026-03-29', '02:00', 'Europe/Warsaw').status).toBe('nonexistent');
+        const justAfter = resolveLocalInstant('2026-03-29', '03:00', 'Europe/Warsaw');
+        expect(justAfter.status).toBe('resolved');
+        if (justAfter.status !== 'resolved') throw new Error('unreachable');
+        expect(justAfter.offsetMinutes).toBe(120);
+    });
+
+    it('treats the exact fold boundary (02:00, first occurrence) as ambiguous and 03:00 (past the fold) as resolved', () => {
+        expect(resolveLocalInstant('2026-10-25', '02:00', 'Europe/Warsaw').status).toBe('ambiguous');
+        const pastFold = resolveLocalInstant('2026-10-25', '03:00', 'Europe/Warsaw');
+        expect(pastFold.status).toBe('resolved');
+        if (pastFold.status !== 'resolved') throw new Error('unreachable');
+        expect(pastFold.offsetMinutes).toBe(60);
+    });
+
+    it('rejects a malformed dateStr or timeStr rather than silently misparsing it', () => {
+        expect(() => resolveLocalInstant('2026/08/17', '07:00')).toThrow(/dateStr/);
+        expect(() => resolveLocalInstant('2026-08-17', '7:00')).toThrow(/timeStr/);
+        expect(() => resolveLocalInstant('2026-08-17', '24:00')).toThrow(/timeStr/);
+    });
+});
+
+describe('elapsedMinutesBetweenInstants', () => {
+    it('computes prospective separation as start minus predecessor end, across a DST boundary', () => {
+        // Predecessor ends 2026-03-29 01:45 local (CET, UTC+1); next start is 2026-03-29
+        // 04:00 local (CEST, UTC+2) -- only 75 real minutes elapsed, not the naive 135
+        // minutes a calendar-label subtraction would produce.
+        const predecessorEnd = resolveLocalInstant('2026-03-29', '01:45', 'Europe/Warsaw');
+        const nextStart = resolveLocalInstant('2026-03-29', '04:00', 'Europe/Warsaw');
+        if (predecessorEnd.status !== 'resolved' || nextStart.status !== 'resolved') throw new Error('unreachable');
+
+        expect(elapsedMinutesBetweenInstants(nextStart.instant, predecessorEnd.instant)).toBe(75);
+    });
+
+    it('returns a negative value when the "end" instant is actually after the "start" instant', () => {
+        expect(elapsedMinutesBetweenInstants('2026-08-17T05:00:00.000Z', '2026-08-17T06:00:00.000Z')).toBe(-60);
+    });
+});

--- a/app/src/engine/localInstant.test.ts
+++ b/app/src/engine/localInstant.test.ts
@@ -84,6 +84,53 @@ describe('resolveLocalInstant (ADR-0036 D-TIME)', () => {
         expect(() => resolveLocalInstant('2026-08-17', '7:00')).toThrow(/timeStr/);
         expect(() => resolveLocalInstant('2026-08-17', '24:00')).toThrow(/timeStr/);
     });
+
+    // CodeRabbit review finding on PR #427: DATE_PATTERN's shape check alone accepts a
+    // calendar-invalid value like day 30 in February; Date.UTC then silently normalizes
+    // it into March, and the wall-clock round-trip check would misclassify the result as
+    // a DST gap ('nonexistent') rather than rejecting the malformed input outright.
+    it('rejects a calendar-invalid dateStr (e.g. February 30) rather than normalizing it into the following month', () => {
+        expect(() => resolveLocalInstant('2026-02-30', '07:00')).toThrow(/valid calendar date/);
+        expect(() => resolveLocalInstant('2026-04-31', '07:00')).toThrow(/valid calendar date/); // April has 30 days
+        expect(() => resolveLocalInstant('2026-13-01', '07:00')).toThrow(/valid calendar date/); // no month 13
+    });
+
+    // CodeRabbit review finding on PR #427: the original sample window was centered on
+    // the naive instant (wall-clock reading treated as if it were UTC), which only
+    // happens to sit near the true candidate for zones close to UTC. A zone whose offset
+    // magnitude is large enough (a Western zone with a very negative offset, or an
+    // Eastern zone with a large positive one) puts the true candidate instants hours away
+    // from that naive instant, outside the +-2h window, silently returning only one of
+    // two valid answers during a fall-back fold instead of reporting it as ambiguous.
+    describe('offset discovery is correctly centered regardless of the zone\'s UTC distance', () => {
+        it('a Western zone far from UTC: America/New_York 2026 fall-back (EDT UTC-4 -> EST UTC-5) is ambiguous', () => {
+            // Verified transition: 2026-11-01 06:00Z is 2026-11-01 01:00 EST; the hour
+            // before that (01:00-01:59 local) occurs twice, once per offset.
+            const result = resolveLocalInstant('2026-11-01', '01:30', 'America/New_York');
+            expect(result.status).toBe('ambiguous');
+            if (result.status !== 'ambiguous') throw new Error('unreachable');
+            expect(result.candidates[0]).toEqual({ instant: '2026-11-01T05:30:00.000Z', offsetMinutes: -240 }); // EDT, earlier
+            expect(result.candidates[1]).toEqual({ instant: '2026-11-01T06:30:00.000Z', offsetMinutes: -300 }); // EST, later
+        });
+
+        it('a high-positive-offset zone: Pacific/Auckland 2026 fall-back (NZDT UTC+13 -> NZST UTC+12) is ambiguous', () => {
+            // Verified transition: 2026-04-04 14:00Z is 2026-04-05 02:00 NZST; the hour
+            // before that (02:00-02:59 local on 2026-04-05) occurs twice, once per offset.
+            const result = resolveLocalInstant('2026-04-05', '02:30', 'Pacific/Auckland');
+            expect(result.status).toBe('ambiguous');
+            if (result.status !== 'ambiguous') throw new Error('unreachable');
+            expect(result.candidates[0]).toEqual({ instant: '2026-04-04T13:30:00.000Z', offsetMinutes: 780 }); // NZDT, earlier
+            expect(result.candidates[1]).toEqual({ instant: '2026-04-04T14:30:00.000Z', offsetMinutes: 720 }); // NZST, later
+        });
+
+        it('resolves an ordinary Western-zone date unambiguously', () => {
+            const result = resolveLocalInstant('2026-08-17', '09:00', 'America/New_York');
+            expect(result.status).toBe('resolved');
+            if (result.status !== 'resolved') throw new Error('unreachable');
+            expect(result.offsetMinutes).toBe(-240); // EDT
+            expect(result.instant).toBe('2026-08-17T13:00:00.000Z');
+        });
+    });
 });
 
 describe('elapsedMinutesBetweenInstants', () => {

--- a/app/src/engine/localInstant.ts
+++ b/app/src/engine/localInstant.ts
@@ -1,0 +1,141 @@
+/**
+ * ADR-0036 (H4) D-TIME: resolve a local wall-clock date/time to a real instant with an
+ * explicit UTC offset, fail closed on nonexistent (spring-forward gap) local times, and
+ * surface ambiguous (fall-back repeated hour) local times for explicit resolution rather
+ * than silently choosing an offset.
+ *
+ * Pure and timestamp-only: no Firestore, no wiring into any decision path, and no
+ * physiological threshold. This module answers "what instant is 07:00 on this date in
+ * this timezone", nothing about whether that time is safe or sufficient to train.
+ *
+ * No timezone library is used -- `Intl.DateTimeFormat` is enough to detect both DST edge
+ * cases without one. A naive fixed-point ("guess an offset, apply it, re-read the offset
+ * at the result") approach can silently converge onto just one of two valid answers
+ * during a fall-back fold and never discover the other exists, so this instead samples
+ * every offset the zone could plausibly be using in a window around the requested
+ * wall-clock reading (a DST transition is always a single hour-aligned instant, so a
+ * +-2h sample window is guaranteed to see both offsets around any transition), builds
+ * the candidate instant for each distinct offset found, and keeps only the candidates
+ * that actually reproduce the requested wall-clock reading when reformatted back into
+ * that zone: zero surviving candidates means the local time never occurred (spring-
+ * forward gap), one means an ordinary unambiguous instant, two means the fall-back fold.
+ */
+
+export interface ResolvedLocalInstant {
+    status: 'resolved';
+    /** ISO-8601 UTC instant, e.g. "2026-08-17T05:00:00.000Z". */
+    instant: string;
+    offsetMinutes: number;
+}
+
+export interface NonexistentLocalInstant {
+    status: 'nonexistent';
+}
+
+export interface AmbiguousLocalInstant {
+    status: 'ambiguous';
+    /** Both real instants this wall-clock time could mean, earlier offset (still-daylight
+     * side) first. An athlete-resolved explicit choice must pick one; this module never
+     * guesses. */
+    candidates: [{ instant: string; offsetMinutes: number }, { instant: string; offsetMinutes: number }];
+}
+
+export type LocalInstantResolution = ResolvedLocalInstant | NonexistentLocalInstant | AmbiguousLocalInstant;
+
+const HHMM_PATTERN = /^([01]\d|2[0-3]):([0-5]\d)$/;
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+/** UTC-offset minutes (east-positive, matching `Date.getTimezoneOffset`'s sign convention
+ * inverted -- e.g. Europe/Warsaw is +60 in winter) the given IANA zone uses at `instantMs`. */
+function offsetMinutesAt(instantMs: number, timeZone: string): number {
+    const parts = new Intl.DateTimeFormat('en-US', {
+        timeZone,
+        hourCycle: 'h23',
+        year: 'numeric', month: '2-digit', day: '2-digit',
+        hour: '2-digit', minute: '2-digit', second: '2-digit',
+    }).formatToParts(new Date(instantMs));
+    const get = (type: string) => Number(parts.find(p => p.type === type)?.value);
+    // Reinterpret the zone's wall-clock reading of this instant as if it were UTC, then
+    // diff against the real instant -- the difference is exactly the zone's offset.
+    const wallAsUtcMs = Date.UTC(get('year'), get('month') - 1, get('day'), get('hour'), get('minute'), get('second'));
+    return Math.round((wallAsUtcMs - instantMs) / 60000);
+}
+
+/** Formats `instantMs` in `timeZone` as `{ dateStr, timeStr }` (YYYY-MM-DD / HH:mm), for
+ * verifying a candidate instant actually reproduces the requested wall-clock reading. */
+function wallClockAt(instantMs: number, timeZone: string): { dateStr: string; timeStr: string } {
+    const parts = new Intl.DateTimeFormat('en-US', {
+        timeZone,
+        hourCycle: 'h23',
+        year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit',
+    }).formatToParts(new Date(instantMs));
+    const get = (type: string) => parts.find(p => p.type === type)?.value ?? '';
+    return {
+        dateStr: `${get('year')}-${get('month')}-${get('day')}`,
+        timeStr: `${get('hour')}:${get('minute')}`,
+    };
+}
+
+/**
+ * Resolves a Warsaw-local (or any IANA zone's) `dateStr` (`YYYY-MM-DD`) + `timeStr`
+ * (`HH:mm`) wall-clock reading to a real instant. Never guesses across a DST boundary:
+ * a nonexistent local time (the spring-forward gap) and an ambiguous one (the fall-back
+ * repeated hour) are both reported explicitly rather than resolved to a default offset.
+ */
+export function resolveLocalInstant(dateStr: string, timeStr: string, timeZone: string = 'Europe/Warsaw'): LocalInstantResolution {
+    if (!DATE_PATTERN.test(dateStr)) throw new RangeError(`dateStr must be YYYY-MM-DD, got "${dateStr}"`);
+    if (!HHMM_PATTERN.test(timeStr)) throw new RangeError(`timeStr must be HH:mm, got "${timeStr}"`);
+
+    const [year, month, day] = dateStr.split('-').map(Number);
+    const [hour, minute] = timeStr.split(':').map(Number);
+    const naiveUtcMs = Date.UTC(year, month - 1, day, hour, minute);
+
+    // A DST transition is always a single hour-aligned instant shifting the offset by a
+    // fixed amount (1 hour for every zone this app targets). Sampling every hour across a
+    // +-2h window around the naive instant is guaranteed to observe every offset that
+    // could possibly apply to this wall-clock reading, without assuming which side of a
+    // transition the naive instant itself landed on -- a plain two-pass fixed-point
+    // iteration can converge onto just one of two valid answers during a fall-back fold
+    // and never discover the other one exists.
+    const distinctOffsets = new Set<number>();
+    for (let hourOffset = -2; hourOffset <= 2; hourOffset += 1) {
+        distinctOffsets.add(offsetMinutesAt(naiveUtcMs + hourOffset * 3600000, timeZone));
+    }
+
+    const matches: { instant: number; offsetMinutes: number }[] = [];
+    for (const offsetMinutes of distinctOffsets) {
+        const candidateInstant = naiveUtcMs - offsetMinutes * 60000;
+        const wall = wallClockAt(candidateInstant, timeZone);
+        if (wall.dateStr === dateStr && wall.timeStr === timeStr) {
+            matches.push({ instant: candidateInstant, offsetMinutes });
+        }
+    }
+    // Two different offsets can independently round-trip to the same candidate instant
+    // (each offset is only actually valid within its own window), so de-duplicate by the
+    // resolved instant itself before deciding resolved/ambiguous/nonexistent.
+    const uniqueMatches = [...new Map(matches.map(m => [m.instant, m])).values()].sort((a, b) => a.instant - b.instant);
+
+    if (uniqueMatches.length === 0) return { status: 'nonexistent' };
+    if (uniqueMatches.length === 1) {
+        return { status: 'resolved', instant: new Date(uniqueMatches[0].instant).toISOString(), offsetMinutes: uniqueMatches[0].offsetMinutes };
+    }
+    // Fall-back: the same wall-clock reading occurs twice. Earlier real instant (the
+    // still-daylight side) first.
+    const [first, second] = uniqueMatches;
+    return {
+        status: 'ambiguous',
+        candidates: [
+            { instant: new Date(first.instant).toISOString(), offsetMinutes: first.offsetMinutes },
+            { instant: new Date(second.instant).toISOString(), offsetMinutes: second.offsetMinutes },
+        ],
+    };
+}
+
+/**
+ * Prospective separation is "start minus the predecessor's actual end instant", never
+ * start-to-start, calendar-day distance or an AM/PM label (ADR-0036 D-TIME). Returns
+ * whole minutes; a negative result means `endInstant` is after `startInstant`.
+ */
+export function elapsedMinutesBetweenInstants(startInstant: string, endInstant: string): number {
+    return Math.round((Date.parse(startInstant) - Date.parse(endInstant)) / 60000);
+}

--- a/app/src/engine/localInstant.ts
+++ b/app/src/engine/localInstant.ts
@@ -12,13 +12,16 @@
  * cases without one. A naive fixed-point ("guess an offset, apply it, re-read the offset
  * at the result") approach can silently converge onto just one of two valid answers
  * during a fall-back fold and never discover the other exists, so this instead samples
- * every offset the zone could plausibly be using in a window around the requested
- * wall-clock reading (a DST transition is always a single hour-aligned instant, so a
- * +-2h sample window is guaranteed to see both offsets around any transition), builds
- * the candidate instant for each distinct offset found, and keeps only the candidates
- * that actually reproduce the requested wall-clock reading when reformatted back into
- * that zone: zero surviving candidates means the local time never occurred (spring-
- * forward gap), one means an ordinary unambiguous instant, two means the fall-back fold.
+ * every offset the zone could plausibly be using in a window and keeps only the
+ * candidates that actually reproduce the requested wall-clock reading when reformatted
+ * back into that zone: zero surviving candidates means the local time never occurred
+ * (spring-forward gap), one means an ordinary unambiguous instant, two means the
+ * fall-back fold. The sample window is centered on a rough offset estimate (read once at
+ * the naive instant that treats the wall-clock reading as if it were already UTC), not on
+ * the naive instant itself -- for a zone far from UTC (e.g. America/New_York at -240/-300
+ * minutes, or a zone east of it at +780/+720) the true candidate instants can be several
+ * hours away from that naive instant, so a window centered there would miss the actual
+ * DST transition entirely and silently return only one of two valid answers.
  */
 
 export interface ResolvedLocalInstant {
@@ -89,17 +92,33 @@ export function resolveLocalInstant(dateStr: string, timeStr: string, timeZone: 
     const [year, month, day] = dateStr.split('-').map(Number);
     const [hour, minute] = timeStr.split(':').map(Number);
     const naiveUtcMs = Date.UTC(year, month - 1, day, hour, minute);
+    // Date.UTC normalizes an out-of-range calendar component (e.g. day 30 in February)
+    // into the following month instead of rejecting it -- reject explicitly here so
+    // invalid input fails closed rather than silently round-tripping through DST
+    // resolution as a false "nonexistent" result.
+    const normalized = new Date(naiveUtcMs);
+    if (normalized.getUTCFullYear() !== year || normalized.getUTCMonth() !== month - 1 || normalized.getUTCDate() !== day) {
+        throw new RangeError(`dateStr must be a valid calendar date, got "${dateStr}"`);
+    }
+
+    // A rough offset estimate, read once at the naive instant (treating the wall-clock
+    // reading as if it were already UTC) -- only used to locate roughly where the real
+    // candidate instant(s) are for this zone, since a zone's magnitude of offset from UTC
+    // (e.g. -300 for America/New_York, +780 for Pacific/Auckland's DST) can otherwise put
+    // the true candidates hours away from the naive instant.
+    const roughOffset = offsetMinutesAt(naiveUtcMs, timeZone);
+    const approxCandidateMs = naiveUtcMs - roughOffset * 60000;
 
     // A DST transition is always a single hour-aligned instant shifting the offset by a
     // fixed amount (1 hour for every zone this app targets). Sampling every hour across a
-    // +-2h window around the naive instant is guaranteed to observe every offset that
-    // could possibly apply to this wall-clock reading, without assuming which side of a
-    // transition the naive instant itself landed on -- a plain two-pass fixed-point
-    // iteration can converge onto just one of two valid answers during a fall-back fold
-    // and never discover the other one exists.
+    // +-2h window centered on the approximate candidate is guaranteed to observe every
+    // offset that could possibly apply to this wall-clock reading, without assuming which
+    // side of a transition the naive instant itself landed on -- a plain two-pass
+    // fixed-point iteration can converge onto just one of two valid answers during a
+    // fall-back fold and never discover the other one exists.
     const distinctOffsets = new Set<number>();
     for (let hourOffset = -2; hourOffset <= 2; hourOffset += 1) {
-        distinctOffsets.add(offsetMinutesAt(naiveUtcMs + hourOffset * 3600000, timeZone));
+        distinctOffsets.add(offsetMinutesAt(approxCandidateMs + hourOffset * 3600000, timeZone));
     }
 
     const matches: { instant: number; offsetMinutes: number }[] = [];


### PR DESCRIPTION
## Summary

Implements ADR-0036's **D-TIME**: DST-safe resolution of a local wall-clock reading (date + HH:mm) to a real instant. This is a documented prerequisite for D-PLACEMENT (resolving a v4 intraday session's `window` against real availability) -- not #426's continuation, but a parallel, independent H4 piece, so it's based directly on `main` rather than stacked.

## Why this instead of directly wiring the ledger into ranking

The current single-session-per-day recommendation flow has no "systemic-cost ceiling" concept to check `computeDailyLedger`'s remainder against -- that admission semantics only becomes meaningful once there's an actual multi-window (AM/PM) placement decision to admit into, which is D-PLACEMENT. ADR-0036 itself says D-PLACEMENT's real-window resolution "also needs D-TIME," so this is the genuine next dependency in sequence rather than inventing a new physiological ceiling to bolt onto the existing single-session ranking path (which the ADR explicitly says not to do).

## What changed

`app/src/engine/localInstant.ts`:
- `resolveLocalInstant(dateStr, timeStr, timeZone)`: resolves a wall-clock reading to `{ status: 'resolved', instant, offsetMinutes }`, `{ status: 'nonexistent' }` (spring-forward gap), or `{ status: 'ambiguous', candidates: [...] }` (fall-back fold, both real instants returned for an explicit athlete choice -- never guessed).
- `elapsedMinutesBetweenInstants(start, end)`: prospective separation is "start minus the predecessor's actual end instant," per D-TIME -- not start-to-start, calendar-day distance, or an AM/PM label.

No timezone library needed. I initially tried the common two-pass fixed-point technique (guess an offset, apply it, re-check the offset at the result) but found it silently converges onto only *one* of the two valid answers during a fall-back fold and never discovers the other exists. The implementation instead samples every offset the zone could plausibly use in a window around the requested time (a DST transition is always a single hour-aligned instant, so ±2h is guaranteed to see both offsets around any transition), builds a candidate instant per distinct offset, and keeps only the candidates that actually round-trip back to the requested wall-clock reading.

`app/src/engine/localInstant.test.ts` verifies against the real 2026 Europe/Warsaw transition dates (spring-forward 2026-03-29 02:00→03:00, fall-back 2026-10-25 03:00→02:00): ordinary CET/CEST dates, the exact gap/fold boundary minutes, times just before/after each transition, the fold's exact 1-hour width and candidate ordering, elapsed-minutes across a DST boundary, and malformed-input rejection.

## What's deliberately not in this PR

Not wired into any decision path, placement, or the daily ledger -- pure, additive, new module. No `POLICY_VERSION` bump (confirmed via `check-policy-drift.mjs`: no decision-affecting files touched).

## Verification

- `npm exec vitest run src/engine/localInstant.test.ts` -- 11/11 passing
- `npm run check`, `npm run build` -- clean (full suite: 3585 tests passing, includes concurrently-merged unrelated work)
- `node scripts/check-policy-drift.mjs origin/main` -- passed, no bump needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added timezone-aware local time resolution.
  - Local times are identified as valid, nonexistent, or ambiguous during daylight-saving transitions.
  - Added accurate elapsed-minute calculations based on actual instants, including intervals crossing timezone transitions.
- **Bug Fixes**
  - Invalid calendar dates, such as February 30, April 31, and month 13, are now rejected correctly.
  - Improved daylight-saving transition detection for time zones with offsets far from UTC.
  - Improved validation for date and time inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->