### PR TITLE
feat(engine): implement ADR-0036 D-WINDOW -- athlete schedule windows (H4)

### DIFF
--- a/app/firestore.rules
+++ b/app/firestore.rules
@@ -672,6 +672,38 @@ service cloud.firestore {
       allow delete: if isOwner(userId);
     }
 
+    // ADR-0036 D-WINDOW: the athlete's versioned schedule, the sole owner of actual
+    // same-date availability. Rules validate the per-document shape only -- the
+    // cross-window non-overlap invariant needs every sibling window for a date at once
+    // and is enforced by `scheduleWindowService.ts`/`scheduleWindows.ts`, the same split
+    // `hasValidExternalPlanRevision` above uses for cross-entry invariants rules cannot see.
+    function hasValidScheduleWindow(userId) {
+      let data = request.resource.data;
+      return hasOwnedUserId(userId)
+        && isValidActivityDate(data.date)
+        && data.keys().hasOnly(['userId', 'date', 'startLocal', 'endLocal', 'label', 'equipment', 'environment', 'revision', 'createdAt', 'updatedAt'])
+        && data.keys().hasAll(['userId', 'date', 'startLocal', 'endLocal', 'revision', 'createdAt', 'updatedAt'])
+        && data.startLocal is string && data.startLocal.matches('^([01][0-9]|2[0-3]):[0-5][0-9]$')
+        && data.endLocal is string && data.endLocal.matches('^([01][0-9]|2[0-3]):[0-5][0-9]$')
+        && data.endLocal > data.startLocal
+        && data.revision is int && data.revision >= 1
+        && data.createdAt is string
+        && data.updatedAt is string
+        && (!('label' in data) || (data.label is string && data.label.size() > 0 && data.label.size() <= 100))
+        && (!('equipment' in data) || hasValidEquipmentList(data.equipment))
+        && (!('environment' in data) || data.environment in ['indoor', 'outdoor', 'either']);
+    }
+
+    match /users/{userId}/schedule_windows/{windowId} {
+      allow read: if isOwner(userId);
+      allow create: if hasValidScheduleWindow(userId);
+      allow update: if hasValidScheduleWindow(userId)
+        && keepsOwnership(userId)
+        && request.resource.data.createdAt == resource.data.createdAt
+        && request.resource.data.revision > resource.data.revision;
+      allow delete: if isOwner(userId);
+    }
+
     function hasValidPlanBlock(userId) {
       let data = request.resource.data;
       return hasOwnedUserId(userId)

--- a/app/firestore.rules
+++ b/app/firestore.rules
@@ -625,8 +625,37 @@ service cloud.firestore {
         && hasValidAxisValue(m, 'neuromuscular');
     }
 
+    function isValidEquipmentItem(item) {
+      return item is string && item.size() <= 50;
+    }
+
+    // Each item must be a string of at most 50 characters, matching
+    // validationCore.ts's MAX_EQUIPMENT_ITEM_LENGTH -- otherwise an owner could persist
+    // e.g. equipment: [42] past rules and have the client-side parser (validateFixedActivity/
+    // validateScheduleWindow) reject the whole document as INVALID on read.
     function hasValidEquipmentList(list) {
-      return list is list && list.size() <= 20;
+      let sz = list.size();
+      return list is list && sz <= 20
+        && (sz <= 0 || isValidEquipmentItem(list[0]))
+        && (sz <= 1 || isValidEquipmentItem(list[1]))
+        && (sz <= 2 || isValidEquipmentItem(list[2]))
+        && (sz <= 3 || isValidEquipmentItem(list[3]))
+        && (sz <= 4 || isValidEquipmentItem(list[4]))
+        && (sz <= 5 || isValidEquipmentItem(list[5]))
+        && (sz <= 6 || isValidEquipmentItem(list[6]))
+        && (sz <= 7 || isValidEquipmentItem(list[7]))
+        && (sz <= 8 || isValidEquipmentItem(list[8]))
+        && (sz <= 9 || isValidEquipmentItem(list[9]))
+        && (sz <= 10 || isValidEquipmentItem(list[10]))
+        && (sz <= 11 || isValidEquipmentItem(list[11]))
+        && (sz <= 12 || isValidEquipmentItem(list[12]))
+        && (sz <= 13 || isValidEquipmentItem(list[13]))
+        && (sz <= 14 || isValidEquipmentItem(list[14]))
+        && (sz <= 15 || isValidEquipmentItem(list[15]))
+        && (sz <= 16 || isValidEquipmentItem(list[16]))
+        && (sz <= 17 || isValidEquipmentItem(list[17]))
+        && (sz <= 18 || isValidEquipmentItem(list[18]))
+        && (sz <= 19 || isValidEquipmentItem(list[19]));
     }
 
     function hasValidAvailabilityContextOverride(m) {

--- a/app/src/emulator/firestoreRules.emulator.test.ts
+++ b/app/src/emulator/firestoreRules.emulator.test.ts
@@ -11,6 +11,7 @@ const ownerId = 'athlete-a';
 const otherUserId = 'athlete-b';
 const recommendationPath = `users/${ownerId}/daily_recommendations/2026-08-07`;
 const fixedActivityPath = `users/${ownerId}/fixed_activities/activity-1`;
+const scheduleWindowPath = `users/${ownerId}/schedule_windows/window-1`;
 const planBlockPath = `users/${ownerId}/plan_blocks/trip-august`;
 const trainingIntentProfilePath = `users/${ownerId}/training_intent/profile`;
 const preferencesPath = `users/${ownerId}/preferences/profile`;
@@ -636,6 +637,94 @@ emulatorDescribe('Firestore security rules', () => {
     it('rejects a fixed activity with a malformed date', async () => {
         const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
         await assertFails(setDoc(doc(ownerDb, fixedActivityPath), { ...validFixedActivity(), date: '08/12/2026' }));
+    });
+
+    // ADR-0036 D-WINDOW: the athlete's versioned schedule.
+    function validScheduleWindow() {
+        return {
+            userId: ownerId,
+            date: '2026-09-10',
+            startLocal: '06:00',
+            endLocal: '07:00',
+            revision: 1,
+            createdAt: '2026-09-01T00:00:00Z',
+            updatedAt: '2026-09-01T00:00:00Z',
+        };
+    }
+
+    it('allows an owner to create a valid schedule window', async () => {
+        const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+        await expect(assertSucceeds(setDoc(doc(ownerDb, scheduleWindowPath), validScheduleWindow()))).resolves.toBeUndefined();
+    });
+
+    it('allows an owner update that bumps revision and preserves createdAt', async () => {
+        await testEnvironment.withSecurityRulesDisabled(async context => {
+            await setDoc(doc(context.firestore(), scheduleWindowPath), validScheduleWindow());
+        });
+        const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+        await expect(assertSucceeds(setDoc(doc(ownerDb, scheduleWindowPath), {
+            ...validScheduleWindow(),
+            endLocal: '07:30',
+            revision: 2,
+            updatedAt: '2026-09-02T00:00:00Z',
+        }))).resolves.toBeUndefined();
+    });
+
+    it('rejects an update that does not bump revision', async () => {
+        await testEnvironment.withSecurityRulesDisabled(async context => {
+            await setDoc(doc(context.firestore(), scheduleWindowPath), validScheduleWindow());
+        });
+        const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+        await assertFails(setDoc(doc(ownerDb, scheduleWindowPath), { ...validScheduleWindow(), endLocal: '07:30' }));
+    });
+
+    it('rejects an update that changes createdAt', async () => {
+        await testEnvironment.withSecurityRulesDisabled(async context => {
+            await setDoc(doc(context.firestore(), scheduleWindowPath), validScheduleWindow());
+        });
+        const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+        await assertFails(setDoc(doc(ownerDb, scheduleWindowPath), { ...validScheduleWindow(), revision: 2, createdAt: '2026-09-05T00:00:00Z' }));
+    });
+
+    it('rejects a schedule window where endLocal is not strictly after startLocal', async () => {
+        const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+        await assertFails(setDoc(doc(ownerDb, scheduleWindowPath), { ...validScheduleWindow(), startLocal: '07:00', endLocal: '07:00' }));
+        await assertFails(setDoc(doc(ownerDb, scheduleWindowPath), { ...validScheduleWindow(), startLocal: '22:00', endLocal: '02:00' }));
+    });
+
+    it('rejects a malformed startLocal/endLocal', async () => {
+        const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+        await assertFails(setDoc(doc(ownerDb, scheduleWindowPath), { ...validScheduleWindow(), startLocal: '6:00' }));
+        await assertFails(setDoc(doc(ownerDb, scheduleWindowPath), { ...validScheduleWindow(), endLocal: '24:00' }));
+    });
+
+    it('rejects a schedule window with an unknown environment', async () => {
+        const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+        await assertFails(setDoc(doc(ownerDb, scheduleWindowPath), { ...validScheduleWindow(), environment: 'space' }));
+    });
+
+    it('rejects a schedule window with an oversized label', async () => {
+        const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+        await assertFails(setDoc(doc(ownerDb, scheduleWindowPath), { ...validScheduleWindow(), label: 'x'.repeat(101) }));
+    });
+
+    it('rejects unauthenticated schedule window access', async () => {
+        const anonDb = testEnvironment.unauthenticatedContext().firestore();
+        await assertFails(setDoc(doc(anonDb, scheduleWindowPath), validScheduleWindow()));
+        await testEnvironment.withSecurityRulesDisabled(async context => {
+            await setDoc(doc(context.firestore(), scheduleWindowPath), validScheduleWindow());
+        });
+        await assertFails(getDoc(doc(anonDb, scheduleWindowPath)));
+    });
+
+    it('rejects cross-user schedule window reads and writes', async () => {
+        await testEnvironment.withSecurityRulesDisabled(async context => {
+            await setDoc(doc(context.firestore(), scheduleWindowPath), validScheduleWindow());
+        });
+        const otherDb = testEnvironment.authenticatedContext(otherUserId).firestore();
+        await assertFails(getDoc(doc(otherDb, scheduleWindowPath)));
+        await assertFails(setDoc(doc(otherDb, scheduleWindowPath), validScheduleWindow()));
+        await assertFails(setDoc(doc(otherDb, `users/${otherUserId}/schedule_windows/window-2`), { ...validScheduleWindow(), userId: ownerId }));
     });
 
     it('rejects a fixed activity with a YYYY-MM-DD-shaped but calendar-impossible date', async () => {

--- a/app/src/emulator/firestoreRules.emulator.test.ts
+++ b/app/src/emulator/firestoreRules.emulator.test.ts
@@ -610,6 +610,12 @@ emulatorDescribe('Firestore security rules', () => {
         await assertFails(setDoc(doc(ownerDb, fixedActivityPath), { ...validFixedActivity(), equipment: Array.from({ length: 21 }, (_, i) => `item-${i}`) }));
     });
 
+    it('rejects a fixed activity with a non-string or oversized equipment item', async () => {
+        const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+        await assertFails(setDoc(doc(ownerDb, fixedActivityPath), { ...validFixedActivity(), equipment: [42] }));
+        await assertFails(setDoc(doc(ownerDb, fixedActivityPath), { ...validFixedActivity(), equipment: ['x'.repeat(51)] }));
+    });
+
     it('allows a fixed activity with a valid availabilityContextOverride (Phase 6.2b / D6-B)', async () => {
         const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
         await expect(assertSucceeds(setDoc(doc(ownerDb, fixedActivityPath), {
@@ -706,6 +712,12 @@ emulatorDescribe('Firestore security rules', () => {
     it('rejects a schedule window with an oversized label', async () => {
         const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
         await assertFails(setDoc(doc(ownerDb, scheduleWindowPath), { ...validScheduleWindow(), label: 'x'.repeat(101) }));
+    });
+
+    it('rejects a schedule window with a non-string or oversized equipment item', async () => {
+        const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+        await assertFails(setDoc(doc(ownerDb, scheduleWindowPath), { ...validScheduleWindow(), equipment: [42] }));
+        await assertFails(setDoc(doc(ownerDb, scheduleWindowPath), { ...validScheduleWindow(), equipment: ['x'.repeat(51)] }));
     });
 
     it('rejects unauthenticated schedule window access', async () => {

--- a/app/src/engine/models.ts
+++ b/app/src/engine/models.ts
@@ -282,6 +282,40 @@ export interface FixedActivity {
     updatedAt: string;
 }
 
+/**
+ * ADR-0036 D-WINDOW: the athlete's versioned schedule -- the sole owner of actual
+ * same-date training availability. A plan's `intraday` request (ADR-0036 D-SCHEMA,
+ * `sessions/externalPlanV4.ts`) is intersected against these at placement time; it can
+ * never create or broaden one. Windows are same-date, positive-duration and
+ * non-overlapping -- an overnight opening must be split into two windows at midnight
+ * (`scheduleWindows.ts` enforces this). Missing windows for a date is the supported
+ * legacy case: `resolveScheduleWindowsForDate` returns `[]`, and callers keep today's
+ * single-slot, untimed availability behavior -- absence never fabricates an AM/PM pair.
+ * First release supports at most one training occurrence per resolved window (D-WINDOW).
+ */
+export interface ScheduleWindow {
+    id: string;
+    userId: string;
+    date: string; // YYYY-MM-DD, Warsaw-local (ADR-0003)
+    startLocal: string; // HH:mm
+    endLocal: string; // HH:mm, strictly after startLocal (same day)
+    /** Display only -- AM/PM style labels are never implicit clock ranges or
+     *  physiological categories (D-WINDOW). */
+    label?: string;
+    /** Equipment actually available during this window. Absent = the athlete's standing
+     *  profile equipment applies unchanged, mirroring `FixedActivity.equipment`'s override
+     *  semantics rather than meaning "no equipment". */
+    equipment?: string[];
+    /** A true window-wide restriction (e.g. a hotel gym slot). Absent = no additional
+     *  restriction beyond the athlete's general context. */
+    environment?: TrainingEnvironment;
+    /** Monotonically increasing per window id; bumped on every update so a stale reader
+     *  (mid-placement) can detect it is looking at superseded availability. */
+    revision: number;
+    createdAt: string;
+    updatedAt: string;
+}
+
 export type EventPriority = 'A' | 'B' | 'C';
 export type EventLifecycle = 'scheduled' | 'completed' | 'cancelled' | 'DNS' | 'DNF' | 'rescheduled';
 

--- a/app/src/engine/scheduleWindows.test.ts
+++ b/app/src/engine/scheduleWindows.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest';
+import type { ScheduleWindow } from './models';
+import {
+    resolveScheduleWindowsForDate,
+    scheduleWindowDurationMinutes,
+    scheduleWindowsOverlap,
+    validateScheduleWindow,
+    validateScheduleWindowSet,
+} from './scheduleWindows';
+
+function makeWindow(overrides: Partial<ScheduleWindow> = {}): ScheduleWindow {
+    return {
+        id: 'w1',
+        userId: 'u1',
+        date: '2026-09-10',
+        startLocal: '06:00',
+        endLocal: '07:00',
+        revision: 1,
+        createdAt: '2026-09-01T00:00:00.000Z',
+        updatedAt: '2026-09-01T00:00:00.000Z',
+        ...overrides,
+    };
+}
+
+describe('validateScheduleWindow', () => {
+    it('accepts a minimal valid window', () => {
+        const result = validateScheduleWindow(makeWindow());
+        expect(result.isValid).toBe(true);
+    });
+
+    it('accepts a window with label/equipment/environment', () => {
+        const result = validateScheduleWindow(makeWindow({ label: 'AM', equipment: ['bike'], environment: 'outdoor' }));
+        expect(result.isValid).toBe(true);
+    });
+
+    it('rejects a non-object payload', () => {
+        expect(validateScheduleWindow(null).isValid).toBe(false);
+        expect(validateScheduleWindow('nope').isValid).toBe(false);
+    });
+
+    it('rejects a missing/invalid date', () => {
+        expect(validateScheduleWindow(makeWindow({ date: undefined as unknown as string })).isValid).toBe(false);
+        expect(validateScheduleWindow(makeWindow({ date: '2026-13-40' })).isValid).toBe(false);
+    });
+
+    it.each(['6:00', '06:0', '24:00', '06:60', 'six am', ''])('rejects a malformed startLocal %s', (bad) => {
+        const result = validateScheduleWindow(makeWindow({ startLocal: bad }));
+        expect(result.isValid).toBe(false);
+    });
+
+    it('rejects a zero-duration window (start == end)', () => {
+        const result = validateScheduleWindow(makeWindow({ startLocal: '06:00', endLocal: '06:00' }));
+        expect(result.isValid).toBe(false);
+    });
+
+    it('rejects a cross-midnight (start after end) window rather than treating it as overnight', () => {
+        const result = validateScheduleWindow(makeWindow({ startLocal: '22:00', endLocal: '02:00' }));
+        expect(result.isValid).toBe(false);
+    });
+
+    it('rejects an oversized label', () => {
+        const result = validateScheduleWindow(makeWindow({ label: 'x'.repeat(101) }));
+        expect(result.isValid).toBe(false);
+    });
+
+    it('rejects an unknown environment', () => {
+        const result = validateScheduleWindow(makeWindow({ environment: 'space' as unknown as ScheduleWindow['environment'] }));
+        expect(result.isValid).toBe(false);
+    });
+
+    it('rejects an oversized equipment list', () => {
+        const result = validateScheduleWindow(makeWindow({ equipment: Array.from({ length: 21 }, (_, i) => `item-${i}`) }));
+        expect(result.isValid).toBe(false);
+    });
+
+    it('rejects a non-positive-integer revision', () => {
+        expect(validateScheduleWindow(makeWindow({ revision: 0 })).isValid).toBe(false);
+        expect(validateScheduleWindow(makeWindow({ revision: 1.5 })).isValid).toBe(false);
+    });
+});
+
+describe('scheduleWindowsOverlap', () => {
+    it('detects a genuine overlap', () => {
+        expect(scheduleWindowsOverlap({ startLocal: '06:00', endLocal: '08:00' }, { startLocal: '07:00', endLocal: '09:00' })).toBe(true);
+    });
+
+    it('treats a shared boundary as non-overlapping (half-open)', () => {
+        expect(scheduleWindowsOverlap({ startLocal: '06:00', endLocal: '08:00' }, { startLocal: '08:00', endLocal: '09:00' })).toBe(false);
+    });
+
+    it('detects full containment as overlap', () => {
+        expect(scheduleWindowsOverlap({ startLocal: '06:00', endLocal: '12:00' }, { startLocal: '07:00', endLocal: '08:00' })).toBe(true);
+    });
+
+    it('reports no overlap for disjoint windows', () => {
+        expect(scheduleWindowsOverlap({ startLocal: '06:00', endLocal: '07:00' }, { startLocal: '18:00', endLocal: '19:00' })).toBe(false);
+    });
+});
+
+describe('validateScheduleWindowSet', () => {
+    it('accepts an empty set', () => {
+        expect(validateScheduleWindowSet([])).toEqual([]);
+    });
+
+    it('accepts multiple non-overlapping same-date windows (AM/PM)', () => {
+        const am = makeWindow({ id: 'am', startLocal: '06:00', endLocal: '07:00' });
+        const pm = makeWindow({ id: 'pm', startLocal: '17:00', endLocal: '18:00' });
+        expect(validateScheduleWindowSet([am, pm])).toEqual([]);
+    });
+
+    it('flags an overlapping pair on the same date', () => {
+        const first = makeWindow({ id: 'a', startLocal: '06:00', endLocal: '08:00' });
+        const second = makeWindow({ id: 'b', startLocal: '07:00', endLocal: '09:00' });
+        const errors = validateScheduleWindowSet([first, second]);
+        expect(errors).toHaveLength(1);
+        expect(errors[0].message).toContain('Overlapping schedule windows');
+    });
+
+    it('does not compare windows across different dates', () => {
+        const first = makeWindow({ id: 'a', date: '2026-09-10', startLocal: '06:00', endLocal: '08:00' });
+        const second = makeWindow({ id: 'b', date: '2026-09-11', startLocal: '07:00', endLocal: '09:00' });
+        expect(validateScheduleWindowSet([first, second])).toEqual([]);
+    });
+});
+
+describe('resolveScheduleWindowsForDate', () => {
+    it('returns [] for a date with no windows -- the supported legacy single-slot case', () => {
+        expect(resolveScheduleWindowsForDate('2026-09-10', [])).toEqual([]);
+        const other = makeWindow({ date: '2026-09-11' });
+        expect(resolveScheduleWindowsForDate('2026-09-10', [other])).toEqual([]);
+    });
+
+    it('returns only the requested date, ordered by start time regardless of input order', () => {
+        const pm = makeWindow({ id: 'pm', date: '2026-09-10', startLocal: '17:00', endLocal: '18:00' });
+        const am = makeWindow({ id: 'am', date: '2026-09-10', startLocal: '06:00', endLocal: '07:00' });
+        const otherDate = makeWindow({ id: 'other', date: '2026-09-11' });
+        const resolved = resolveScheduleWindowsForDate('2026-09-10', [pm, am, otherDate]);
+        expect(resolved.map(w => w.id)).toEqual(['am', 'pm']);
+    });
+});
+
+describe('scheduleWindowDurationMinutes', () => {
+    it('computes elapsed minutes for a same-day window', () => {
+        expect(scheduleWindowDurationMinutes({ startLocal: '06:00', endLocal: '07:30' })).toBe(90);
+    });
+});

--- a/app/src/engine/scheduleWindows.ts
+++ b/app/src/engine/scheduleWindows.ts
@@ -1,0 +1,154 @@
+/* eslint-disable @typescript-eslint/no-explicit-any -- untrusted raw input, matching engine/validation.ts's own convention */
+/**
+ * ADR-0036 D-WINDOW (H4): the athlete's versioned schedule -- pure validation and
+ * same-date resolution for `ScheduleWindow` (`engine/models.ts`). This module owns the
+ * structural contract only: stable window id, Warsaw-local date, local start/end,
+ * optional label, and applicable equipment/environment restrictions. It never resolves
+ * a plan's `intraday` request (`sessions/externalPlanV4.ts`) against these windows --
+ * that intersection is D-PLACEMENT's job, layered on top of this file.
+ *
+ * Recurring availability ("Recurring availability is resolved to dated instances by the
+ * app", D-WINDOW) is intentionally out of scope for this first PR: only already-dated
+ * window instances are modeled and persisted here. A future PR can add a template that
+ * resolves to `ScheduleWindow` instances without changing this file's contract, since
+ * every downstream consumer only ever sees resolved, dated windows.
+ */
+import type { ScheduleWindow, TrainingEnvironment } from './models';
+import { isValidDate, type ValidationError, type ValidationResult } from './validationCore';
+
+const TRAINING_ENVIRONMENTS: TrainingEnvironment[] = ['indoor', 'outdoor', 'either'];
+const HHMM_PATTERN = /^([01]\d|2[0-3]):([0-5]\d)$/;
+const MAX_LABEL_LENGTH = 100;
+const MAX_EQUIPMENT_ITEMS = 20;
+const MAX_EQUIPMENT_ITEM_LENGTH = 50;
+
+/** Minutes since midnight for an already-pattern-validated `HH:mm` string. */
+function minutesFromHHmm(value: string): number {
+    const [hours, minutes] = value.split(':').map(Number);
+    return hours * 60 + minutes;
+}
+
+/** True when two same-date windows share any minute. Half-open on both ends: a window
+ * ending at 12:00 does not conflict with one starting at 12:00. */
+export function scheduleWindowsOverlap(
+    left: Pick<ScheduleWindow, 'startLocal' | 'endLocal'>,
+    right: Pick<ScheduleWindow, 'startLocal' | 'endLocal'>,
+): boolean {
+    return minutesFromHHmm(left.startLocal) < minutesFromHHmm(right.endLocal)
+        && minutesFromHHmm(right.startLocal) < minutesFromHHmm(left.endLocal);
+}
+
+/**
+ * Validates one untrusted `ScheduleWindow` document in isolation. Cross-window overlap
+ * (which needs every window for the date at once) is a separate check --
+ * `validateScheduleWindowSet` below -- the same split `externalPlanV4.ts` uses between
+ * per-session and cross-session validation.
+ */
+export function validateScheduleWindow(raw: any): ValidationResult<ScheduleWindow> {
+    const errors: ValidationError[] = [];
+
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+        return { isValid: false, errors: [{ field: 'window', message: 'Schedule window must be an object' }] };
+    }
+    if (!raw.userId || typeof raw.userId !== 'string') {
+        errors.push({ field: 'userId', message: 'User ID is required' });
+    }
+    if (!raw.date || typeof raw.date !== 'string' || !isValidDate(raw.date)) {
+        errors.push({ field: 'date', message: 'Date must be a valid date (YYYY-MM-DD)' });
+    }
+
+    const startValid = typeof raw.startLocal === 'string' && HHMM_PATTERN.test(raw.startLocal);
+    const endValid = typeof raw.endLocal === 'string' && HHMM_PATTERN.test(raw.endLocal);
+    if (!startValid) errors.push({ field: 'startLocal', message: 'startLocal must be HH:mm' });
+    if (!endValid) errors.push({ field: 'endLocal', message: 'endLocal must be HH:mm' });
+    // Zero-length and cross-midnight intervals are both rejected: an overnight opening
+    // must be split into two same-day windows at midnight (D-WINDOW).
+    if (startValid && endValid && minutesFromHHmm(raw.startLocal) >= minutesFromHHmm(raw.endLocal)) {
+        errors.push({ field: 'endLocal', message: 'endLocal must be strictly after startLocal (same-day, positive duration)' });
+    }
+
+    if (raw.label !== undefined) {
+        if (typeof raw.label !== 'string' || raw.label.length === 0) {
+            errors.push({ field: 'label', message: 'label must be a non-empty string when present' });
+        } else if (raw.label.length > MAX_LABEL_LENGTH) {
+            errors.push({ field: 'label', message: `label must be at most ${MAX_LABEL_LENGTH} characters` });
+        }
+    }
+
+    if (raw.equipment !== undefined) {
+        if (!Array.isArray(raw.equipment) || raw.equipment.length > MAX_EQUIPMENT_ITEMS) {
+            errors.push({ field: 'equipment', message: `equipment must be a list of at most ${MAX_EQUIPMENT_ITEMS} items` });
+        } else if (raw.equipment.some((item: unknown) => typeof item !== 'string' || item.length > MAX_EQUIPMENT_ITEM_LENGTH)) {
+            errors.push({ field: 'equipment', message: `Every equipment item must be a string of at most ${MAX_EQUIPMENT_ITEM_LENGTH} characters` });
+        }
+    }
+
+    if (raw.environment !== undefined && !TRAINING_ENVIRONMENTS.includes(raw.environment)) {
+        errors.push({ field: 'environment', message: `environment must be one of: ${TRAINING_ENVIRONMENTS.join(', ')}` });
+    }
+
+    if (!Number.isInteger(raw.revision) || raw.revision < 1) {
+        errors.push({ field: 'revision', message: 'revision must be a positive integer' });
+    }
+    if (!raw.createdAt || typeof raw.createdAt !== 'string') {
+        errors.push({ field: 'createdAt', message: 'createdAt is required' });
+    }
+    if (!raw.updatedAt || typeof raw.updatedAt !== 'string') {
+        errors.push({ field: 'updatedAt', message: 'updatedAt is required' });
+    }
+
+    if (errors.length > 0) return { isValid: false, errors };
+    return { isValid: true, errors: [], data: raw as ScheduleWindow };
+}
+
+/**
+ * Cross-window validation for one date's set of windows (already individually valid).
+ * Enforces D-WINDOW's "same-date, positive-duration and non-overlapping" -- this is the
+ * boundary D-PLACEMENT relies on to never see two overlapping windows for one date.
+ */
+export function validateScheduleWindowSet(windows: readonly ScheduleWindow[]): ValidationError[] {
+    const errors: ValidationError[] = [];
+    const byDate = new Map<string, ScheduleWindow[]>();
+    for (const window of windows) {
+        const list = byDate.get(window.date) ?? [];
+        list.push(window);
+        byDate.set(window.date, list);
+    }
+    for (const sameDateWindows of byDate.values()) {
+        const sorted = [...sameDateWindows].sort((a, b) => minutesFromHHmm(a.startLocal) - minutesFromHHmm(b.startLocal));
+        for (let i = 1; i < sorted.length; i += 1) {
+            if (scheduleWindowsOverlap(sorted[i - 1], sorted[i])) {
+                errors.push({
+                    field: `windows[${sorted[i - 1].id}, ${sorted[i].id}]`,
+                    message: `Overlapping schedule windows on ${sorted[i].date}: ${sorted[i - 1].id} and ${sorted[i].id}`,
+                });
+            }
+        }
+    }
+    return errors;
+}
+
+/**
+ * Resolves the windows applicable to one Warsaw-local date, ordered by start time.
+ *
+ * An empty result is the supported legacy case (D-WINDOW: "Legacy date-only availability
+ * remains one untimed slot with current behavior; missing metadata never creates an AM
+ * and PM pair") -- callers must keep today's single full-day-budget behavior rather than
+ * treating `[]` as "no availability at all". This function performs no cross-window
+ * validation of its own; callers that persist multiple windows for the same date should
+ * run `validateScheduleWindowSet` first so resolution never has to silently choose which
+ * of two overlapping windows wins.
+ */
+export function resolveScheduleWindowsForDate(
+    date: string,
+    windows: readonly ScheduleWindow[],
+): ScheduleWindow[] {
+    return windows
+        .filter(window => window.date === date)
+        .sort((a, b) => minutesFromHHmm(a.startLocal) - minutesFromHHmm(b.startLocal));
+}
+
+/** Window duration in minutes. Assumes an already-validated window (positive, same-day). */
+export function scheduleWindowDurationMinutes(window: Pick<ScheduleWindow, 'startLocal' | 'endLocal'>): number {
+    return minutesFromHHmm(window.endLocal) - minutesFromHHmm(window.startLocal);
+}

--- a/app/src/services/scheduleWindowService.test.ts
+++ b/app/src/services/scheduleWindowService.test.ts
@@ -53,6 +53,27 @@ describe('ScheduleWindowService persistence shape', () => {
         expect(payload.startLocal).toBe('06:00');
     });
 
+    it('keeps ownership, revision, and timestamps service-owned even if runtime input carries extra fields', async () => {
+        const service = new ScheduleWindowService();
+        const injectedInput = {
+            ...validInput,
+            userId: 'other-user',
+            revision: 99,
+            createdAt: '2000-01-01T00:00:00.000Z',
+            updatedAt: '2000-01-01T00:00:00.000Z',
+        } as unknown as typeof validInput;
+
+        const result = await service.createWindow('u1', injectedInput);
+        const payload = firestore.addDoc.mock.calls[0][1] as Record<string, unknown>;
+
+        expect(result.userId).toBe('u1');
+        expect(result.revision).toBe(1);
+        expect(payload.userId).toBe('u1');
+        expect(payload.revision).toBe(1);
+        expect(payload.createdAt).not.toBe('2000-01-01T00:00:00.000Z');
+        expect(payload.updatedAt).not.toBe('2000-01-01T00:00:00.000Z');
+    });
+
     it('rejects a cross-midnight window (startLocal after endLocal)', async () => {
         const service = new ScheduleWindowService();
         await expect(service.createWindow('u1', { ...validInput, startLocal: '22:00', endLocal: '02:00' }))
@@ -85,6 +106,27 @@ describe('ScheduleWindowService persistence shape', () => {
         expect(firestore.addDoc).toHaveBeenCalled();
     });
 
+    it('fails closed when persisted same-date data is invalid instead of treating it as an empty date', async () => {
+        firestore.getDocs.mockResolvedValue({
+            docs: [docSnapshot('invalid', {
+                userId: 'u1', date: '2026-09-10', startLocal: 'not-a-time', endLocal: '07:30',
+                revision: 1, createdAt: '2026-09-01T00:00:00.000Z', updatedAt: '2026-09-01T00:00:00.000Z',
+            })],
+        });
+        const service = new ScheduleWindowService();
+
+        await expect(service.createWindow('u1', validInput)).rejects.toThrow(/persisted data is invalid/);
+        expect(firestore.addDoc).not.toHaveBeenCalled();
+    });
+
+    it('fails closed when same-date windows are unavailable instead of treating the read as empty', async () => {
+        firestore.getDocs.mockRejectedValueOnce(new Error('offline'));
+        const service = new ScheduleWindowService();
+
+        await expect(service.createWindow('u1', validInput)).rejects.toThrow(/data is unavailable/);
+        expect(firestore.addDoc).not.toHaveBeenCalled();
+    });
+
     it('updateWindow bumps revision and preserves createdAt', async () => {
         firestore.getDoc.mockResolvedValue(docSnapshot('window-1', {
             userId: 'u1', date: '2026-09-10', startLocal: '06:00', endLocal: '07:00',
@@ -97,6 +139,23 @@ describe('ScheduleWindowService persistence shape', () => {
         expect(result.endLocal).toBe('07:30');
         const payload = firestore.setDoc.mock.calls[0][1] as Record<string, unknown>;
         expect(payload.createdAt).toBe('2026-09-01T00:00:00.000Z');
+    });
+
+    it('does not update when the destination date contains invalid persisted schedule data', async () => {
+        firestore.getDoc.mockResolvedValue(docSnapshot('window-1', {
+            userId: 'u1', date: '2026-09-09', startLocal: '06:00', endLocal: '07:00',
+            revision: 1, createdAt: '2026-09-01T00:00:00.000Z', updatedAt: '2026-09-01T00:00:00.000Z',
+        }));
+        firestore.getDocs.mockResolvedValue({
+            docs: [docSnapshot('invalid', {
+                userId: 'u1', date: '2026-09-10', startLocal: '06:30', endLocal: 'bad',
+                revision: 1, createdAt: '2026-09-01T00:00:00.000Z', updatedAt: '2026-09-01T00:00:00.000Z',
+            })],
+        });
+        const service = new ScheduleWindowService();
+
+        await expect(service.updateWindow('u1', 'window-1', { date: '2026-09-10' })).rejects.toThrow(/persisted data is invalid/);
+        expect(firestore.setDoc).not.toHaveBeenCalled();
     });
 
     it('deleteWindow calls deleteDoc on the resolved document reference', async () => {

--- a/app/src/services/scheduleWindowService.test.ts
+++ b/app/src/services/scheduleWindowService.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ScheduleWindow } from '../engine/models';
+
+const firestore = vi.hoisted(() => {
+    return {
+        addDoc: vi.fn(),
+        collection: vi.fn(),
+        deleteDoc: vi.fn(),
+        doc: vi.fn(),
+        getDoc: vi.fn(),
+        getDocs: vi.fn(),
+        query: vi.fn(),
+        setDoc: vi.fn(),
+        where: vi.fn(),
+    };
+});
+
+vi.mock('firebase/firestore', () => firestore);
+vi.mock('../firebase', () => ({ getDb: vi.fn(() => ({})) }));
+
+import { ScheduleWindowService } from './scheduleWindowService';
+
+const validInput: Omit<ScheduleWindow, 'id' | 'userId' | 'revision' | 'createdAt' | 'updatedAt'> = {
+    date: '2026-09-10',
+    startLocal: '06:00',
+    endLocal: '07:00',
+    label: 'AM',
+};
+
+function docSnapshot(id: string, data: Record<string, unknown>) {
+    return { id, exists: () => true, data: () => data };
+}
+
+describe('ScheduleWindowService persistence shape', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        firestore.collection.mockReturnValue({ path: 'schedule_windows' });
+        firestore.doc.mockReturnValue({ path: 'schedule_windows/window-1' });
+        firestore.addDoc.mockResolvedValue({ id: 'window-1' });
+        firestore.setDoc.mockResolvedValue(undefined);
+        firestore.getDocs.mockResolvedValue({ docs: [] });
+    });
+
+    it('creates a valid window and returns it with the generated document id and revision 1', async () => {
+        const service = new ScheduleWindowService();
+        const result = await service.createWindow('u1', validInput);
+
+        expect(result.id).toBe('window-1');
+        const payload = firestore.addDoc.mock.calls[0][1] as Record<string, unknown>;
+        expect(payload).not.toHaveProperty('id');
+        expect(payload.userId).toBe('u1');
+        expect(payload.revision).toBe(1);
+        expect(payload.startLocal).toBe('06:00');
+    });
+
+    it('rejects a cross-midnight window (startLocal after endLocal)', async () => {
+        const service = new ScheduleWindowService();
+        await expect(service.createWindow('u1', { ...validInput, startLocal: '22:00', endLocal: '02:00' }))
+            .rejects.toThrow(/Validation failed/);
+        expect(firestore.addDoc).not.toHaveBeenCalled();
+    });
+
+    it('rejects creating a window that overlaps an existing same-date window', async () => {
+        firestore.getDocs.mockResolvedValue({
+            docs: [docSnapshot('existing', {
+                userId: 'u1', date: '2026-09-10', startLocal: '06:30', endLocal: '07:30',
+                revision: 1, createdAt: '2026-09-01T00:00:00.000Z', updatedAt: '2026-09-01T00:00:00.000Z',
+            })],
+        });
+        const service = new ScheduleWindowService();
+        await expect(service.createWindow('u1', validInput)).rejects.toThrow(/overlaps/);
+        expect(firestore.addDoc).not.toHaveBeenCalled();
+    });
+
+    it('allows creating a non-overlapping second same-date window (AM/PM)', async () => {
+        firestore.getDocs.mockResolvedValue({
+            docs: [docSnapshot('am', {
+                userId: 'u1', date: '2026-09-10', startLocal: '06:00', endLocal: '07:00',
+                revision: 1, createdAt: '2026-09-01T00:00:00.000Z', updatedAt: '2026-09-01T00:00:00.000Z',
+            })],
+        });
+        const service = new ScheduleWindowService();
+        const result = await service.createWindow('u1', { ...validInput, startLocal: '17:00', endLocal: '18:00', label: 'PM' });
+        expect(result.startLocal).toBe('17:00');
+        expect(firestore.addDoc).toHaveBeenCalled();
+    });
+
+    it('updateWindow bumps revision and preserves createdAt', async () => {
+        firestore.getDoc.mockResolvedValue(docSnapshot('window-1', {
+            userId: 'u1', date: '2026-09-10', startLocal: '06:00', endLocal: '07:00',
+            revision: 1, createdAt: '2026-09-01T00:00:00.000Z', updatedAt: '2026-09-01T00:00:00.000Z',
+        }));
+        firestore.getDocs.mockResolvedValue({ docs: [] });
+        const service = new ScheduleWindowService();
+        const result = await service.updateWindow('u1', 'window-1', { endLocal: '07:30' });
+        expect(result.revision).toBe(2);
+        expect(result.endLocal).toBe('07:30');
+        const payload = firestore.setDoc.mock.calls[0][1] as Record<string, unknown>;
+        expect(payload.createdAt).toBe('2026-09-01T00:00:00.000Z');
+    });
+
+    it('deleteWindow calls deleteDoc on the resolved document reference', async () => {
+        const service = new ScheduleWindowService();
+        await service.deleteWindow('u1', 'window-1');
+        expect(firestore.deleteDoc).toHaveBeenCalled();
+    });
+});

--- a/app/src/services/scheduleWindowService.ts
+++ b/app/src/services/scheduleWindowService.ts
@@ -7,7 +7,7 @@ import { getErrorCode } from '../utils/errors';
 
 type ScheduleWindowWithId = ScheduleWindow & { id: string };
 type NewScheduleWindowInput = Omit<ScheduleWindow, 'id' | 'userId' | 'revision' | 'createdAt' | 'updatedAt'>;
-type ScheduleWindowUpdates = Partial<Omit<ScheduleWindow, 'id' | 'userId' | 'createdAt'>>;
+type ScheduleWindowUpdates = Partial<Omit<ScheduleWindow, 'id' | 'userId' | 'revision' | 'createdAt' | 'updatedAt'>>;
 
 /** Builds a document payload containing only stored fields -- `id` is the document key,
  *  not a stored field, mirroring `fixedActivityService.ts`'s `storedActivityPayload`. */
@@ -17,6 +17,7 @@ function storedWindowPayload(window: ScheduleWindow): DocumentData {
     return payload;
 }
 
+/** Parses one untrusted Firestore document through the canonical D-WINDOW validator. */
 function parseWindow(raw: DocumentData): ScheduleWindow | null {
     const validation = validateScheduleWindow(raw);
     return validation.isValid && validation.data ? validation.data : null;
@@ -46,6 +47,8 @@ function parseWindow(raw: DocumentData): ScheduleWindow | null {
 export class ScheduleWindowService {
     private readonly collectionPath = 'schedule_windows';
 
+    /** Reads and validates all persisted windows for one date without collapsing data
+     * corruption or transport/auth failures into the valid legacy "no windows" case. */
     async getWindowsForDateState(userId: string, date: string): Promise<DataState<ScheduleWindowWithId[]>> {
         try {
             const collRef = collection(getDb(), 'users', userId, this.collectionPath);
@@ -78,11 +81,19 @@ export class ScheduleWindowService {
         }
     }
 
+    /** Returns the valid same-date set, including `[]` only when the read itself succeeded
+     * and the date genuinely has no windows. Invalid/unavailable state fails closed so a
+     * write caller can never mistake corrupted or unreadable siblings for an empty date. */
     async getWindowsForDate(userId: string, date: string): Promise<ScheduleWindowWithId[]> {
         const state = await this.getWindowsForDateState(userId, date);
-        return state.status === 'AVAILABLE' ? state.data : [];
+        if (state.status === 'AVAILABLE') return state.data;
+        if (state.status === 'INVALID') {
+            throw new Error(`Cannot read schedule windows for ${date}: persisted data is invalid`);
+        }
+        throw new Error(`Cannot read schedule windows for ${date}: data is unavailable`);
     }
 
+    /** Lists individually valid windows owned by the user, sorted by local date/time. */
     async listAll(userId: string): Promise<ScheduleWindowWithId[]> {
         const collRef = collection(getDb(), 'users', userId, this.collectionPath);
         const q = query(collRef, where('userId', '==', userId));
@@ -95,6 +106,7 @@ export class ScheduleWindowService {
             .sort((a, b) => a.date.localeCompare(b.date) || a.startLocal.localeCompare(b.startLocal));
     }
 
+    /** Reads one window by stable document id, returning null for absent/invalid data. */
     async getWindow(userId: string, windowId: string): Promise<ScheduleWindowWithId | null> {
         const docRef = doc(getDb(), 'users', userId, this.collectionPath, windowId);
         const docSnap = await getDoc(docRef);
@@ -106,10 +118,13 @@ export class ScheduleWindowService {
 
     /** Creates a window, rejecting it up front if it would overlap an existing same-date
      * window -- best-effort only, see the class-level doc comment on the race this does
-     * not close. */
+     * not close. Invalid/unavailable sibling state fails closed rather than being treated
+     * as an empty date. */
     async createWindow(userId: string, input: NewScheduleWindowInput): Promise<ScheduleWindow> {
         const now = new Date().toISOString();
-        const rawData: DocumentData = { userId, revision: 1, createdAt: now, updatedAt: now, ...input };
+        // Service-owned fields come last deliberately: runtime callers cannot override
+        // ownership/revision/timestamps by smuggling extra properties through a typed input.
+        const rawData: DocumentData = { ...input, userId, revision: 1, createdAt: now, updatedAt: now };
         const validation = validateScheduleWindow(rawData);
         if (!validation.isValid || !validation.data) {
             const errorMessages = validation.errors.map(e => `${e.field}: ${e.message}`).join('; ');
@@ -125,6 +140,8 @@ export class ScheduleWindowService {
         return { ...validation.data, id: docRef.id };
     }
 
+    /** Updates one window with a monotonic service-owned revision while checking the
+     * resulting same-date set for overlap. Invalid/unavailable sibling state fails closed. */
     async updateWindow(userId: string, windowId: string, updates: ScheduleWindowUpdates): Promise<ScheduleWindow> {
         const existing = await this.getWindow(userId, windowId);
         if (!existing) throw new Error('Schedule window not found');
@@ -149,6 +166,7 @@ export class ScheduleWindowService {
         return validation.data;
     }
 
+    /** Deletes a single owner-scoped schedule window by stable document id. */
     async deleteWindow(userId: string, windowId: string): Promise<void> {
         const docRef = doc(getDb(), 'users', userId, this.collectionPath, windowId);
         await deleteDoc(docRef);

--- a/app/src/services/scheduleWindowService.ts
+++ b/app/src/services/scheduleWindowService.ts
@@ -29,6 +29,19 @@ function parseWindow(raw: DocumentData): ScheduleWindow | null {
  * Every write is validated client-side against the same base shape firestore.rules
  * enforces server-side, plus the cross-window non-overlap invariant firestore.rules
  * cannot check across sibling documents.
+ *
+ * `createWindow`/`updateWindow`'s overlap check is best-effort, not atomic: it reads
+ * existing same-date siblings, then writes, with no lock in between. Firestore's client
+ * `Transaction.get()` only reads a known `DocumentReference`, not an arbitrary query, so
+ * a client-side transaction cannot close this window either -- two concurrent writes
+ * (two tabs, or a direct SDK write bypassing this service entirely) can still both pass
+ * and persist overlapping windows. `firestore.rules` intentionally validates only
+ * per-document shape/ownership for the same reason `hasValidExternalPlanRevision`'s
+ * comment already documents for cross-entry plan invariants: rules cannot see sibling
+ * documents at write time. Closing this race for real needs a trusted server boundary
+ * (e.g. a Cloud Function serializing writes per user/date), which is out of scope for
+ * this bounded PR; `resolveScheduleWindowsForDate`'s callers should not assume the
+ * result is guaranteed overlap-free under concurrent writers.
  */
 export class ScheduleWindowService {
     private readonly collectionPath = 'schedule_windows';
@@ -92,7 +105,8 @@ export class ScheduleWindowService {
     }
 
     /** Creates a window, rejecting it up front if it would overlap an existing same-date
-     * window -- the cross-document invariant firestore.rules cannot itself enforce. */
+     * window -- best-effort only, see the class-level doc comment on the race this does
+     * not close. */
     async createWindow(userId: string, input: NewScheduleWindowInput): Promise<ScheduleWindow> {
         const now = new Date().toISOString();
         const rawData: DocumentData = { userId, revision: 1, createdAt: now, updatedAt: now, ...input };

--- a/app/src/services/scheduleWindowService.ts
+++ b/app/src/services/scheduleWindowService.ts
@@ -1,0 +1,144 @@
+import { doc, getDoc, setDoc, deleteDoc, collection, query, where, getDocs, addDoc, type DocumentData } from 'firebase/firestore';
+import { getDb } from '../firebase';
+import type { ScheduleWindow } from '../engine/models';
+import type { DataIssue, DataState } from '../engine/dataState';
+import { validateScheduleWindow, validateScheduleWindowSet } from '../engine/scheduleWindows';
+import { getErrorCode } from '../utils/errors';
+
+type ScheduleWindowWithId = ScheduleWindow & { id: string };
+type NewScheduleWindowInput = Omit<ScheduleWindow, 'id' | 'userId' | 'revision' | 'createdAt' | 'updatedAt'>;
+type ScheduleWindowUpdates = Partial<Omit<ScheduleWindow, 'id' | 'userId' | 'createdAt'>>;
+
+/** Builds a document payload containing only stored fields -- `id` is the document key,
+ *  not a stored field, mirroring `fixedActivityService.ts`'s `storedActivityPayload`. */
+function storedWindowPayload(window: ScheduleWindow): DocumentData {
+    const payload: DocumentData = { ...window };
+    delete payload.id;
+    return payload;
+}
+
+function parseWindow(raw: DocumentData): ScheduleWindow | null {
+    const validation = validateScheduleWindow(raw);
+    return validation.isValid && validation.data ? validation.data : null;
+}
+
+/**
+ * Persists `ScheduleWindow` at `users/{userId}/schedule_windows/{windowId}` (ADR-0002
+ * user-owned path). ADR-0036 D-WINDOW: this is the sole owner of actual same-date
+ * training availability -- a plan's `intraday` request never creates or broadens it.
+ * Every write is validated client-side against the same base shape firestore.rules
+ * enforces server-side, plus the cross-window non-overlap invariant firestore.rules
+ * cannot check across sibling documents.
+ */
+export class ScheduleWindowService {
+    private readonly collectionPath = 'schedule_windows';
+
+    async getWindowsForDateState(userId: string, date: string): Promise<DataState<ScheduleWindowWithId[]>> {
+        try {
+            const collRef = collection(getDb(), 'users', userId, this.collectionPath);
+            const q = query(collRef, where('date', '==', date));
+            const querySnapshot = await getDocs(q);
+            const windows: ScheduleWindowWithId[] = [];
+            const issues: DataIssue[] = [];
+            const revisions: string[] = [];
+            for (const windowDoc of querySnapshot.docs) {
+                const raw = { ...windowDoc.data(), id: windowDoc.id };
+                const parsed = parseWindow(raw);
+                if (!parsed || parsed.userId !== userId) {
+                    issues.push({ code: 'schema-validation-failed', documentPath: `users/${userId}/${this.collectionPath}/${windowDoc.id}` });
+                    continue;
+                }
+                windows.push({ ...parsed, id: windowDoc.id });
+                revisions.push(`${windowDoc.id}:${parsed.revision}`);
+            }
+            if (issues.length > 0) return { status: 'INVALID', issues };
+            const overlapErrors = validateScheduleWindowSet(windows);
+            if (overlapErrors.length > 0) {
+                return {
+                    status: 'INVALID',
+                    issues: overlapErrors.map(error => ({ code: 'schedule-window-overlap', field: error.field, documentPath: `users/${userId}/${this.collectionPath}` })),
+                };
+            }
+            return { status: 'AVAILABLE', data: windows, revision: revisions.sort().join('|') || null };
+        } catch (error: unknown) {
+            return { status: 'UNAVAILABLE', operation: 'read schedule windows', retryable: getErrorCode(error) !== 'permission-denied' };
+        }
+    }
+
+    async getWindowsForDate(userId: string, date: string): Promise<ScheduleWindowWithId[]> {
+        const state = await this.getWindowsForDateState(userId, date);
+        return state.status === 'AVAILABLE' ? state.data : [];
+    }
+
+    async listAll(userId: string): Promise<ScheduleWindowWithId[]> {
+        const collRef = collection(getDb(), 'users', userId, this.collectionPath);
+        const q = query(collRef, where('userId', '==', userId));
+        const querySnapshot = await getDocs(q);
+        return querySnapshot.docs
+            .flatMap(d => {
+                const parsed = parseWindow({ ...d.data(), id: d.id });
+                return parsed ? [{ ...parsed, id: d.id }] : [];
+            })
+            .sort((a, b) => a.date.localeCompare(b.date) || a.startLocal.localeCompare(b.startLocal));
+    }
+
+    async getWindow(userId: string, windowId: string): Promise<ScheduleWindowWithId | null> {
+        const docRef = doc(getDb(), 'users', userId, this.collectionPath, windowId);
+        const docSnap = await getDoc(docRef);
+        if (!docSnap.exists()) return null;
+        const parsed = parseWindow({ ...docSnap.data(), id: docSnap.id });
+        if (!parsed || parsed.userId !== userId) return null;
+        return { ...parsed, id: docSnap.id };
+    }
+
+    /** Creates a window, rejecting it up front if it would overlap an existing same-date
+     * window -- the cross-document invariant firestore.rules cannot itself enforce. */
+    async createWindow(userId: string, input: NewScheduleWindowInput): Promise<ScheduleWindow> {
+        const now = new Date().toISOString();
+        const rawData: DocumentData = { userId, revision: 1, createdAt: now, updatedAt: now, ...input };
+        const validation = validateScheduleWindow(rawData);
+        if (!validation.isValid || !validation.data) {
+            const errorMessages = validation.errors.map(e => `${e.field}: ${e.message}`).join('; ');
+            throw new Error(`Validation failed: ${errorMessages}`);
+        }
+        const existing = await this.getWindowsForDate(userId, validation.data.date);
+        const overlapErrors = validateScheduleWindowSet([...existing, { ...validation.data, id: '__new__' }]);
+        if (overlapErrors.length > 0) {
+            throw new Error(`Validation failed: window overlaps an existing schedule window on ${validation.data.date}`);
+        }
+        const collRef = collection(getDb(), 'users', userId, this.collectionPath);
+        const docRef = await addDoc(collRef, storedWindowPayload(validation.data));
+        return { ...validation.data, id: docRef.id };
+    }
+
+    async updateWindow(userId: string, windowId: string, updates: ScheduleWindowUpdates): Promise<ScheduleWindow> {
+        const existing = await this.getWindow(userId, windowId);
+        if (!existing) throw new Error('Schedule window not found');
+        const updatedData: DocumentData = {
+            ...existing,
+            ...updates,
+            revision: existing.revision + 1,
+            updatedAt: new Date().toISOString(),
+        };
+        const validation = validateScheduleWindow(updatedData);
+        if (!validation.isValid || !validation.data) {
+            const errorMessages = validation.errors.map(e => `${e.field}: ${e.message}`).join('; ');
+            throw new Error(`Validation failed: ${errorMessages}`);
+        }
+        const siblings = (await this.getWindowsForDate(userId, validation.data.date)).filter(w => w.id !== windowId);
+        const overlapErrors = validateScheduleWindowSet([...siblings, { ...validation.data, id: windowId }]);
+        if (overlapErrors.length > 0) {
+            throw new Error(`Validation failed: window overlaps an existing schedule window on ${validation.data.date}`);
+        }
+        const docRef = doc(getDb(), 'users', userId, this.collectionPath, windowId);
+        await setDoc(docRef, storedWindowPayload(validation.data), { merge: true });
+        return validation.data;
+    }
+
+    async deleteWindow(userId: string, windowId: string): Promise<void> {
+        const docRef = doc(getDb(), 'users', userId, this.collectionPath, windowId);
+        await deleteDoc(docRef);
+    }
+}
+
+export const scheduleWindowService = new ScheduleWindowService();

--- a/docs/plans/cycling-primary-hybrid-evaluation.md
+++ b/docs/plans/cycling-primary-hybrid-evaluation.md
@@ -345,12 +345,22 @@ supported legacy case: callers must keep today's single untimed-slot behavior ra
 treating an empty result as "no availability", per D-WINDOW: "missing metadata never
 creates an AM and PM pair"). `services/scheduleWindowService.ts` persists these at
 `users/{userId}/schedule_windows/{windowId}` (ADR-0002 user-owned path), rejecting a
-create/update that would overlap an existing same-date window client-side -- the one
-cross-document invariant `firestore.rules` cannot itself check across sibling documents,
-the same split `hasValidExternalPlanRevision`'s comment already documents for
-cross-session plan invariants. `firestore.rules` validates the per-document shape and
-ownership, requires `revision` to strictly increase on update, and keeps `createdAt`
-immutable, mirroring `hasValidFixedActivity`.
+create/update that would overlap an existing same-date window client-side -- a
+best-effort, non-atomic check (read siblings, then write, no lock between): Firestore's
+client `Transaction.get()` only reads a known `DocumentReference`, not an arbitrary
+query, so a client-side transaction cannot close this race either, and two concurrent
+writes (or a direct SDK write bypassing this service) can still both pass and persist
+overlapping windows. `firestore.rules` intentionally validates only per-document shape
+and ownership -- the same split `hasValidExternalPlanRevision`'s comment already
+documents for cross-session plan invariants rules cannot see across sibling documents --
+plus requires `revision` to strictly increase on update, validates each `equipment` item's
+own type/length (not just the list's size -- `hasValidEquipmentList` was fixed in review
+to check this, since it previously let a non-string/oversized item pass rules and then
+fail client-side parsing as `INVALID`), and keeps `createdAt` immutable, mirroring
+`hasValidFixedActivity` (itself now covered by the same equipment-item fix). Closing the
+race for real needs a trusted server
+boundary (e.g. a Cloud Function serializing writes per user/date); out of scope for this
+bounded PR and flagged as a known limitation, not treated as solved.
 
 Recurring availability ("Recurring availability is resolved to dated instances by the
 app", D-WINDOW) is intentionally deferred: this slice only models and persists

--- a/docs/plans/cycling-primary-hybrid-evaluation.md
+++ b/docs/plans/cycling-primary-hybrid-evaluation.md
@@ -1,7 +1,19 @@
 # Cycling-primary hybrid evaluation and recommendation improvements
 
-**Status:** In progress — H1, H2, H2b, H3 and H3-rest (ADR-0035) all delivered; H4 design accepted as ADR-0036 with D-SCHEMA/D-LEDGER delivered, the same-day canonical performed-fact boundary verified, and the fixed-activity cost-reduce duplication unified (ledger-based ranking/admission and D-TIME/D-REASSESS/D-PLACEMENT/D-AUDIT unstarted); H5 design accepted as ADR-0037 with H5a/H5b delivered (H5c and cumulative `external-plan@5` unstarted)
-**Blocked by:** Personal M00/M01 prescription requires current workload/restriction confirmation; H4's remaining wiring (using the ledger's remainder/admission math as an actual ranking input, then D-TIME/D-REASSESS/D-PLACEMENT/D-AUDIT) needs its own decision-affecting PR(s); H5c needs the athlete-scoped singleton progression-claim transaction design, and cumulative `external-plan@5` acceptance is unblocked now that H4's v4 contract has landed.
+**Status:** In progress — H1, H2, H2b, H3 and H3-rest (ADR-0035) all delivered; H4 design
+accepted as ADR-0036 with D-SCHEMA/D-LEDGER/D-TIME delivered, the same-day canonical
+performed-fact boundary verified, the fixed-activity cost-reduce duplication unified, and
+D-WINDOW's athlete-schedule model delivered (unwired) (ledger-based ranking/admission and
+D-PLACEMENT's bundle-placement engine plus its wiring, then D-REASSESS/D-AUDIT,
+unstarted); H5 design accepted as ADR-0037 with H5a/H5b delivered (H5c and cumulative
+`external-plan@5` unstarted)
+**Blocked by:** Personal M00/M01 prescription requires current workload/restriction
+confirmation; H4's remaining wiring (using the ledger's remainder/admission math as an
+actual ranking input, D-PLACEMENT's bundle-placement engine on top of D-WINDOW/D-TIME/
+D-LEDGER, then wiring both into `evaluateTrainingWithIntent` with a real `POLICY_VERSION`
+bump, then D-REASSESS/D-AUDIT) needs its own decision-affecting PR(s); H5c needs the
+athlete-scoped singleton progression-claim transaction design, and cumulative
+`external-plan@5` acceptance is unblocked now that H4's v4 contract has landed.
 **Unlocks:** Reproducible acceptance cases for equipment specificity, block authority and hybrid plan quality.
 
 ## Decision
@@ -240,9 +252,11 @@ also remains blocked on current-workload/restriction confirmation.
 ## H4 — Intraday capacity and post-AM reassessment
 
 **Status:** Design accepted in [ADR-0036](../adr/0036-intraday-training-windows-and-reassessment.md).
-**D-SCHEMA and D-LEDGER delivered** (schema/pure-ledger slice); **same-day canonical
-performed-fact boundary verified**; runtime wiring (the `dailyLedger.ts` refactor, plus
-D-TIME/D-REASSESS/D-PLACEMENT/D-AUDIT) unstarted.
+**D-SCHEMA, D-LEDGER and D-TIME delivered** (schema/pure-ledger/pure-instant slices);
+**same-day canonical performed-fact boundary verified**; **D-WINDOW's athlete-schedule
+model delivered** (persisted, unwired); runtime wiring (the `dailyLedger.ts` refactor,
+plus D-PLACEMENT's bundle-placement engine and its wiring, then D-REASSESS/D-AUDIT)
+unstarted.
 **Dependencies:** ADR-0035 rest support (delivered). The `external-plan@4`/`dailyLedger.ts`
 D-SCHEMA/D-LEDGER slice itself left `POLICY_VERSION` unchanged (neither module is
 consumed by any decision path); the later fixed-activity cost-reduce dedup slice below
@@ -288,6 +302,70 @@ this slice, including the worked example (a 90-minute daily ceiling with 60-minu
 completion leaves at most 30 minutes for PM even though both windows individually offer
 90 minutes) and the exhausted-systemic-cost-blocks-admission case. `simulate:diff` and
 policy-drift show no change from this slice, confirming it is inert until wired.
+
+### D-TIME (delivered)
+
+`engine/localInstant.ts` implements D-TIME as a pure, timestamp-only module:
+`resolveLocalInstant(dateStr, timeStr, timeZone = 'Europe/Warsaw')` resolves a local
+wall-clock date/time to a real instant with an explicit offset, rejecting calendar-invalid
+`dateStr` values and returning `'nonexistent'` for a spring-forward gap or `'ambiguous'`
+(both candidate instants) for a fall-back fold rather than silently choosing an offset;
+`elapsedMinutesBetweenInstants` computes elapsed minutes between two resolved instants.
+`localInstant.test.ts` verifies real 2026 DST transitions in three zones, including two
+review rounds that caught and fixed real bugs (a calendar-invalid-date acceptance bug and
+a DST-offset-discovery bug that only manifested for zones far from UTC -- see the module's
+own header comment for why the offset-sampling window is centered on a rough estimate
+rather than the naive instant). Not wired into anything yet; `simulate:diff`/policy-drift
+show no change from this slice.
+
+### D-WINDOW (delivered, model only)
+
+Investigated first, per the ADR's own instruction: is PR #428's `ScheduleOverlay`
+(`engine/models.ts`, `services/scheduleOverlayService.ts`) the "athlete's versioned
+schedule" D-WINDOW requires? No -- `ScheduleOverlay` is a date-*range* absence/trip model
+(a single `dailyAvailabilityMinutes` number plus dose-scaling multipliers feeding
+`applyPlanningOverlays`), with no clock-time start/end, no stable window id, and no
+support for more than one window per date. D-WINDOW needs exactly what that lacks: a
+stable window id, local start/end times, an optional label, and per-window
+equipment/environment restrictions, with **multiple same-date windows** as the whole
+point (AM/PM). No such model existed anywhere in the codebase before this slice, and
+`resolveAvailability` (`schedule.ts`) still models a single per-date minute budget with no
+window/clock-time concept -- confirmed by reading it, not assumed.
+
+`engine/models.ts`'s new `ScheduleWindow` interface is that model: `id`, `userId`, `date`
+(Warsaw-local `YYYY-MM-DD`), `startLocal`/`endLocal` (`HH:mm`), optional `label`/
+`equipment`/`environment`, and a `revision` bumped on every update. `engine/scheduleWindows.ts`
+is the pure validation/resolution module: `validateScheduleWindow` (per-document shape,
+same-day positive-duration `HH:mm` interval, rejecting cross-midnight spans -- an
+overnight opening must be split at midnight, matching `externalPlanV4.ts`'s `intraday`
+window rule), `validateScheduleWindowSet` (cross-window non-overlap *within* a date,
+correctly scoped so windows on different dates are never compared against each other),
+and `resolveScheduleWindowsForDate` (returns `[]` for a date with no windows -- the
+supported legacy case: callers must keep today's single untimed-slot behavior rather than
+treating an empty result as "no availability", per D-WINDOW: "missing metadata never
+creates an AM and PM pair"). `services/scheduleWindowService.ts` persists these at
+`users/{userId}/schedule_windows/{windowId}` (ADR-0002 user-owned path), rejecting a
+create/update that would overlap an existing same-date window client-side -- the one
+cross-document invariant `firestore.rules` cannot itself check across sibling documents,
+the same split `hasValidExternalPlanRevision`'s comment already documents for
+cross-session plan invariants. `firestore.rules` validates the per-document shape and
+ownership, requires `revision` to strictly increase on update, and keeps `createdAt`
+immutable, mirroring `hasValidFixedActivity`.
+
+Recurring availability ("Recurring availability is resolved to dated instances by the
+app", D-WINDOW) is intentionally deferred: this slice only models and persists
+already-dated window instances. A future recurring-template resolver can add
+`ScheduleWindow` instances without changing this file's contract, since every downstream
+consumer (D-PLACEMENT included) only ever sees resolved, dated windows.
+
+Not wired into `resolveAvailability`, placement, or any decision path -- that intersection
+(a plan's `intraday` request against real resolved windows) is D-PLACEMENT's job, layered
+on top of this model. `scheduleWindows.test.ts`, `scheduleWindowService.test.ts`, and new
+`firestoreRules.emulator.test.ts` cases cover validation, overlap detection (including the
+regression the tests originally caught: cross-date windows were incorrectly flagged as
+overlapping before the cross-window check was scoped per-date), legacy-empty resolution,
+and the Firestore rules' shape/ownership/revision/immutability contract.
+`simulate:diff`/policy-drift show no change from this slice.
 
 ### Same-day canonical performed-fact boundary (verified)
 
@@ -343,9 +421,14 @@ The three different ad hoc dedup mechanisms across these sites (`seenOccurrences
 in `unrepresentedFixedActivityProjection`) are **not yet unified** onto the ledger's
 `occurrenceId`/`revision` model, and none of these call sites yet consult
 `computeDailyLedger`'s remainder or `admitsCandidate` when ranking or admitting a
-candidate. The actual next H4 task is using the ledger's remainder/admission semantics
-as a real ranking/admission input -- that is decision-affecting and needs its own PR,
-then D-TIME/D-REASSESS/D-PLACEMENT/D-AUDIT.
+candidate. The actual next H4 tasks are (1) using the ledger's remainder/admission
+semantics as a real ranking/admission input, (2) D-PLACEMENT's bundle-placement engine
+(resolving a v4 `intraday` bundle's requested windows against real `ScheduleWindow`
+availability, checking combined minute/systemic-cost budget via `dailyLedger.ts`, and an
+atomic confirmed-proposal API analogous to `externalPlacement.ts`'s
+`proposeReplacement`/`applyConfirmedProposal`, but for bundles), and (3) wiring both into
+`evaluateTrainingWithIntent` with a real `POLICY_VERSION` bump -- each decision-affecting
+and scoped as its own PR, then D-REASSESS/D-AUDIT.
 
 ## H5 — Explicit develop/maintain intent and progression
 
@@ -408,6 +491,7 @@ is non-decision-affecting and needs no bump; the explicit-rest follow-up will re
 normal policy/schema/replay review when it changes decision behavior. H4's
 `fixed-activity-cost-dedup-v1` bump reflects the drift gate's mechanical requirement for
 any `planner.ts`/`rules.ts` touch, not an actual behavior change (verified via
-`simulate:diff`); H4's still-pending ledger-based ranking/admission wiring and H5's
-still-pending H5c will require the normal review when they actually change decision
+`simulate:diff`); H4's still-pending ledger-based ranking/admission wiring, D-PLACEMENT's
+bundle-placement engine and its wiring, and H5's still-pending H5c will require the normal
+review when they actually change decision
 behavior. Do not enable experimental personalization simply to improve a judge score.

--- a/docs/plans/cycling-primary-hybrid-implementation-handoff.md
+++ b/docs/plans/cycling-primary-hybrid-implementation-handoff.md
@@ -228,11 +228,13 @@ Useful synthetic software work can proceed without those personal answers.
 ## Work order H4 — Intraday windows and post-AM response
 
 **Status:** Design accepted in [ADR-0036](../adr/0036-intraday-training-windows-and-reassessment.md).
-Step 1 (D-SCHEMA + D-LEDGER) delivered; the same-day canonical performed-fact boundary
-is verified; steps 2-6 (runtime wiring) unstarted.
+Step 1 (D-SCHEMA + D-LEDGER + D-TIME) delivered; the same-day canonical performed-fact
+boundary is verified; D-WINDOW's athlete-schedule model is delivered (unwired); steps 3-6
+(D-PLACEMENT's bundle-placement engine and its wiring, then D-REASSESS/D-AUDIT) unstarted.
 **Dependencies:** ADR-0035 rest support (delivered). Same-day canonical performed
-identity/revision/timing inputs are now verified (see below) -- the remaining
-dependency is simply doing the runtime-wiring work itself.
+identity/revision/timing inputs are now verified (see below), D-TIME's instant resolution
+is delivered, and D-WINDOW's availability model is delivered -- the remaining dependency
+is simply doing the D-PLACEMENT runtime-wiring work itself.
 **Deliverable:** Authored intraday placement and reassessed execution, followed separately
 by automatic multi-window packing after the initial acceptance bar passes.
 
@@ -271,9 +273,38 @@ The accepted implementation sequence is:
    `computeDailyLedger`'s remainder or `admitsCandidate` when ranking/admitting a
    candidate -- D-LEDGER's remainder-based admission is not yet a decision input
    anywhere. Resolving real windows and reserving minutes/cost against actual instants
-   also needs D-TIME (below).
-3. Add atomic, confirmed bundle placement against all destination windows and ADR-0035
-   rest. Preserve completed history and support independent optional-session dropping.
+   also needs D-TIME (delivered, see below) and D-WINDOW (delivered, see below).
+
+   **D-TIME delivered.** `engine/localInstant.ts`'s `resolveLocalInstant`/
+   `elapsedMinutesBetweenInstants` resolve Warsaw-local wall-clock times to real instants
+   with explicit offsets, rejecting calendar-invalid dates and surfacing (never silently
+   resolving) spring-forward-gap and fall-back-fold local times. Verified against real
+   2026 DST transitions in three zones; two review rounds caught and fixed real bugs (a
+   calendar-invalid-date acceptance bug and a far-from-UTC offset-discovery bug). Pure,
+   timestamp-only, not wired into anything yet.
+
+   **D-WINDOW's athlete-schedule model delivered (unwired).** Investigated first, per the
+   ADR: PR #428's `ScheduleOverlay` is a date-range absence/trip model with a single daily
+   minutes number, not the same-date-multi-window model D-WINDOW requires -- confirmed by
+   reading its diff and `schedule.ts`'s `resolveAvailability` (no window/clock-time
+   concept exists anywhere in the codebase). `engine/models.ts`'s new `ScheduleWindow`
+   (stable id, Warsaw-local date, `startLocal`/`endLocal` HH:mm, optional label/equipment/
+   environment, a `revision` bumped on update) plus `engine/scheduleWindows.ts` (pure
+   per-document and cross-window-non-overlap validation, `resolveScheduleWindowsForDate`
+   returning `[]` for the legacy single-untimed-slot case) and
+   `services/scheduleWindowService.ts` (`users/{userId}/schedule_windows/{windowId}`,
+   rejecting an overlapping create/update client-side) are the delivered contract.
+   `firestore.rules` validates per-document shape/ownership/revision-increase/
+   `createdAt`-immutability, mirroring `hasValidFixedActivity`. Recurring-template
+   resolution to dated instances is deliberately deferred to a future slice; only already-
+   dated window instances are modeled here, which is all D-PLACEMENT needs to consume.
+   Not wired into `resolveAvailability` or any decision path.
+3. Add atomic, confirmed bundle placement against all destination `ScheduleWindow`s and
+   ADR-0035 rest, using D-LEDGER's remainder/admission math and D-TIME's elapsed-instant
+   semantics for separation. Preserve completed history and support independent
+   optional-session dropping. Given the size of D-WINDOW + this bundle-placement engine +
+   wiring it into `evaluateTrainingWithIntent`, split this into separate PRs the same way
+   steps 1-2 above did rather than one large change.
 4. At PM launch, capture current symptoms/response, same-day work and availability, rerun
    common gates, and atomically validate the input/ledger revision before reserving.
    A morning PM approval is provisional; missing prerequisite evidence remains pending.
@@ -314,9 +345,13 @@ pinning test confirming `getPerformedTrainingFactsInRange`'s existing behavior a
 `trainingIntent.ts`'s call site are unchanged. Not called from any production/decision
 path yet -- `simulate:diff`/policy-drift confirm no output change.
 
-The next PR should tackle step 2's refactor (wiring the ledger into the existing
-deduction points) before D-TIME/D-REASSESS/D-PLACEMENT, since every later step reads from
-that shared boundary. It no longer needs a separate verification pass first.
+The next PRs should tackle, in order: (a) step 2's refactor (wiring the ledger into the
+existing deduction points), since every later step reads from that shared boundary, then
+(b) D-PLACEMENT's bundle-placement engine (a new module beside `externalPlacement.ts`
+consuming `ScheduleWindow`/`dailyLedger.ts`/`localInstant.ts`, still unwired), then (c)
+wiring both into `evaluateTrainingWithIntent` with a real `POLICY_VERSION` bump and full
+scenario/simulate-diff verification, then D-REASSESS/D-AUDIT. None of these need a
+separate verification pass first -- D-TIME, D-LEDGER and D-WINDOW are all delivered.
 
 ## Work order H5 — Block intent and controlled progression
 

--- a/docs/plans/cycling-primary-hybrid-implementation-handoff.md
+++ b/docs/plans/cycling-primary-hybrid-implementation-handoff.md
@@ -228,9 +228,12 @@ Useful synthetic software work can proceed without those personal answers.
 ## Work order H4 — Intraday windows and post-AM response
 
 **Status:** Design accepted in [ADR-0036](../adr/0036-intraday-training-windows-and-reassessment.md).
-Step 1 (D-SCHEMA + D-LEDGER + D-TIME) delivered; the same-day canonical performed-fact
-boundary is verified; D-WINDOW's athlete-schedule model is delivered (unwired); steps 3-6
-(D-PLACEMENT's bundle-placement engine and its wiring, then D-REASSESS/D-AUDIT) unstarted.
+By capability (not the numbered sequence below, which tracks a different granularity --
+see the note after the numbered list): D-SCHEMA, D-LEDGER (pure module) and D-TIME are
+delivered; the same-day canonical performed-fact boundary is verified; D-WINDOW's
+athlete-schedule model is delivered (unwired). Still unstarted: wiring the ledger's
+remainder/admission semantics into actual ranking/admission decisions, D-PLACEMENT's
+bundle-placement engine and its wiring, and D-REASSESS/D-AUDIT.
 **Dependencies:** ADR-0035 rest support (delivered). Same-day canonical performed
 identity/revision/timing inputs are now verified (see below), D-TIME's instant resolution
 is delivered, and D-WINDOW's availability model is delivered -- the remaining dependency
@@ -238,10 +241,15 @@ is simply doing the D-PLACEMENT runtime-wiring work itself.
 **Deliverable:** Authored intraday placement and reassessed execution, followed separately
 by automatic multi-window packing after the initial acceptance bar passes.
 
-The accepted implementation sequence is:
+The accepted implementation sequence below is numbered by planned PR, not by capability --
+step 1's schema landed first, D-WINDOW's athlete-schedule model (also part of step 1's
+scope) landed in a later, separate PR after step 2's ledger module, and D-TIME (not its
+own numbered step) landed between them. Read the **Status** line above for current
+capability delivery; do not infer from a step's number alone whether everything named in
+its description has actually shipped.
 
-1. **Delivered.** Version `external-plan@4` intraday placement and athlete schedule
-   windows; keep v1/v2/v3 immutable. `sessions/externalPlanV4.ts` adds the session-level
+1. **Schema delivered; athlete schedule windows delivered separately (see below).**
+   Version `external-plan@4` intraday placement; keep v1/v2/v3 immutable. `sessions/externalPlanV4.ts` adds the session-level
    `intraday` object (window/bundleId/order/afterSessionId/minimumSeparationMinutes) on
    top of v3's unchanged envelope/`restDays`, validating intervals, bundle
    membership/order/dependency shape, and rejecting invalid references -- see the
@@ -293,11 +301,15 @@ The accepted implementation sequence is:
    per-document and cross-window-non-overlap validation, `resolveScheduleWindowsForDate`
    returning `[]` for the legacy single-untimed-slot case) and
    `services/scheduleWindowService.ts` (`users/{userId}/schedule_windows/{windowId}`,
-   rejecting an overlapping create/update client-side) are the delivered contract.
-   `firestore.rules` validates per-document shape/ownership/revision-increase/
-   `createdAt`-immutability, mirroring `hasValidFixedActivity`. Recurring-template
-   resolution to dated instances is deliberately deferred to a future slice; only already-
-   dated window instances are modeled here, which is all D-PLACEMENT needs to consume.
+   rejecting an overlapping create/update client-side -- a best-effort, non-atomic check;
+   Firestore's client transactions cannot read an arbitrary query, so this cannot fully
+   close the race against concurrent writers, and full enforcement needs a trusted server
+   boundary, out of scope here) are the delivered contract. `firestore.rules` validates
+   per-document shape/ownership/revision-increase/`createdAt`-immutability (including
+   each `equipment` item's own type/length, not just the list's size), mirroring
+   `hasValidFixedActivity`. Recurring-template resolution to dated instances is
+   deliberately deferred to a future slice; only already-dated window instances are
+   modeled here, which is all D-PLACEMENT needs to consume.
    Not wired into `resolveAvailability` or any decision path.
 3. Add atomic, confirmed bundle placement against all destination `ScheduleWindow`s and
    ADR-0035 rest, using D-LEDGER's remainder/admission math and D-TIME's elapsed-instant


### PR DESCRIPTION
## Summary

First of the split ADR-0036 D-PLACEMENT work. This PR delivers **D-WINDOW only**: the persisted athlete-owned, versioned same-date schedule-window model required before authored AM/PM placement can exist.

## Investigation

PR #428's `ScheduleOverlay` is not D-WINDOW. It is a date-range absence/trip overlay with one `dailyAvailabilityMinutes` value and dose-scaling multipliers. It has no local start/end clock times, stable per-window identity, per-window equipment/environment restrictions, or multiple windows on one date. The existing `resolveAvailability` path likewise remains a single per-date minute budget. D-WINDOW therefore needs a separate model.

## What this PR delivers

- `app/src/engine/models.ts`: `ScheduleWindow` contract (`id`, owner/date, local start/end, optional label/equipment/environment, monotonic revision).
- `app/src/engine/scheduleWindows.ts`: pure validation, same-date positive-duration semantics, cross-window non-overlap validation, date resolution, duration helper, and legacy-empty behavior.
- `app/src/services/scheduleWindowService.ts`: owner-scoped Firestore CRUD at `users/{userId}/schedule_windows/{windowId}` with validated reads and best-effort same-date overlap checks.
- `app/firestore.rules`: owner/shape validation, immutable `createdAt`, monotonic revision updates, and equipment-item validation aligned with the TypeScript parser.
- Unit + Firestore-emulator coverage.
- H4 evaluation/handoff documentation updated for the delivered model and remaining runtime work.

### Review hardening

The deeper review added two concrete fixes:

1. `hasValidEquipmentList` now validates every equipment entry's type/length, closing a rules/parser mismatch for both schedule windows and fixed activities.
2. Schedule-window writes now **fail closed** when the same-date read is `INVALID` or `UNAVAILABLE`. Previously `getWindowsForDate()` flattened those states to `[]`, so a write could incorrectly treat corrupted/unreadable sibling data as an empty date. Create inputs also keep `userId`, revision and timestamps service-owned even if a runtime caller supplies extra fields; update types no longer expose service-owned revision/timestamp fields.

## Important persistence-boundary limitation / blocker

The client-side overlap check is intentionally **not claimed as authoritative under concurrency**. Two clients can read the same sibling set and then both attempt overlapping writes, and owner-authenticated direct SDK writes can bypass the service-level cross-document check. The current Firebase Web `Transaction.get()` API reads `DocumentReference`s, not arbitrary same-date queries, so the existing document-per-window representation cannot make this invariant authoritative with a client transaction alone.

Tracked in **#430 — H4: enforce ScheduleWindow non-overlap at a trusted persistence boundary**.

**#430 is a hard dependency before D-PLACEMENT is wired into recommendation/admission decisions.** This PR remains safe as an additive, unwired model slice; it must not be treated as permission to consume schedule windows in a decision path yet.

## Deferred / out of scope

- Trusted/atomic persistence boundary for non-overlap: #430.
- Recurring availability templates; downstream consumers only need resolved dated `ScheduleWindow`s.
- D-PLACEMENT bundle placement and runtime wiring.
- D-REASSESS / D-AUDIT.

`resolveAvailability`, placement, and recommendation decision paths are untouched. `POLICY_VERSION` remains unchanged.

## Verification

PR-head CI is the authoritative record and must be green before merge. The branch includes focused unit tests for validation/overlap/legacy behavior/service persistence, regressions for invalid/unavailable fail-closed writes and service-owned fields, plus Firestore-emulator coverage for ownership/shape/revision/equipment constraints. The normal CI additionally runs typecheck, lint, full frontend tests with coverage, rules emulator tests, simulation/policy-drift gates, bundle build, Python tests, Docker smoke, and dependency audits.

## Remaining sequence

1. D-WINDOW model (this PR).
2. **#430 persistence-boundary enforcement.**
3. D-PLACEMENT bundle-placement engine consuming authoritative `ScheduleWindow` + `dailyLedger.ts` + `localInstant.ts`.
4. Decision-path wiring with a real `POLICY_VERSION` bump and scenario/simulation verification.
5. D-REASSESS / D-AUDIT in later ADR-0036 slices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for managing dated training schedule windows with local start and end times, labels, equipment, and environment restrictions.
  * Added schedule-window validation, date-based resolution, duration calculation, revision tracking, and ownership controls.
  * Added safeguards against overlapping windows on the same date.

* **Bug Fixes**
  * Equipment lists now reject non-text entries and entries exceeding 50 characters while retaining the 20-item limit.
  * Invalid or unavailable schedule data now fails safely instead of being treated as empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->