### PR TITLE
feat(engine): implement ADR-0036 D-PLACEMENT bundle-placement engine (H4)

### DIFF
--- a/app/src/engine/intradayBundlePlacement.test.ts
+++ b/app/src/engine/intradayBundlePlacement.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, it } from 'vitest';
+import type { FixedActivity, ScheduleWindow } from './models';
+import type { DailyLedgerResult } from './dailyLedger';
+import {
+    LEGACY_SINGLE_SLOT_WINDOW_ID,
+    confirmBundlePlacement,
+    dropOptionalBundleMember,
+    proposeBundlePlacement,
+    type IntradayBundleMember,
+} from './intradayBundlePlacement';
+
+const DATE = '2026-09-10';
+
+function ledger(overrides: Partial<DailyLedgerResult> = {}): DailyLedgerResult {
+    return { remainingMinutes: 200, remainingSystemicCost: 1, unresolvedEntries: [], ...overrides };
+}
+
+function window(overrides: Partial<ScheduleWindow> = {}): ScheduleWindow {
+    return {
+        id: 'w', userId: 'u1', date: DATE, startLocal: '06:00', endLocal: '07:00',
+        revision: 1, createdAt: '2026-09-01T00:00:00.000Z', updatedAt: '2026-09-01T00:00:00.000Z',
+        ...overrides,
+    };
+}
+
+function member(overrides: Partial<IntradayBundleMember> = {}): IntradayBundleMember {
+    return {
+        sessionId: 's', order: 0, priority: 'key',
+        requestedWindow: { startLocal: '06:00', endLocal: '07:00' },
+        estimatedMinutes: 45, estimatedSystemicCost: 0.2, started: false,
+        ...overrides,
+    };
+}
+
+describe('proposeBundlePlacement', () => {
+    it('places a two-member AM/PM bundle into two distinct real windows', () => {
+        const am = window({ id: 'am', startLocal: '06:00', endLocal: '07:00' });
+        const pm = window({ id: 'pm', startLocal: '17:00', endLocal: '18:00' });
+        const members = [
+            member({ sessionId: 's1', order: 0, requestedWindow: { startLocal: '06:00', endLocal: '07:00' }, estimatedMinutes: 45 }),
+            member({ sessionId: 's2', order: 1, requestedWindow: { startLocal: '17:00', endLocal: '18:00' }, estimatedMinutes: 45 }),
+        ];
+        const result = proposeBundlePlacement('b1', DATE, members, [am, pm], [], new Set(), ledger());
+        expect(result.outcome).toBe('placed');
+        expect(result.bindings?.map(b => b.windowId)).toEqual(['am', 'pm']);
+    });
+
+    it('is infeasible for a two-member bundle on a legacy date with no real windows -- never fabricates an AM/PM pair', () => {
+        const members = [
+            member({ sessionId: 's1', order: 0, requestedWindow: { startLocal: '06:00', endLocal: '07:00' } }),
+            member({ sessionId: 's2', order: 1, requestedWindow: { startLocal: '17:00', endLocal: '18:00' } }),
+        ];
+        const result = proposeBundlePlacement('b1', DATE, members, [], [], new Set(), ledger());
+        expect(result.outcome).toBe('infeasible');
+    });
+
+    it('places a single-member bundle onto the legacy single slot when no real windows exist', () => {
+        const members = [member({ sessionId: 's1', order: 0, requestedWindow: { startLocal: '06:00', endLocal: '07:00' } })];
+        const result = proposeBundlePlacement('b1', DATE, members, [], [], new Set(), ledger());
+        expect(result.outcome).toBe('placed');
+        expect(result.bindings?.[0].windowId).toBe(LEGACY_SINGLE_SLOT_WINDOW_ID);
+    });
+
+    it('is infeasible when the date is an authored rest date -- rest closes every window by default', () => {
+        const members = [member()];
+        const result = proposeBundlePlacement('b1', DATE, members, [window()], [], new Set([DATE]), ledger());
+        expect(result.outcome).toBe('infeasible');
+        expect(result.reason).toMatch(/rest/i);
+    });
+
+    it('is infeasible when the requested window does not fit the session duration in the real window', () => {
+        const tight = window({ id: 'tight', startLocal: '06:00', endLocal: '06:20' });
+        const members = [member({ requestedWindow: { startLocal: '06:00', endLocal: '06:20' }, estimatedMinutes: 45 })];
+        const result = proposeBundlePlacement('b1', DATE, members, [tight], [], new Set(), ledger());
+        expect(result.outcome).toBe('infeasible');
+    });
+
+    it('blocks only the window a known-clock-time fixed activity actually overlaps', () => {
+        const am = window({ id: 'am', startLocal: '06:00', endLocal: '07:00' });
+        const pm = window({ id: 'pm', startLocal: '17:00', endLocal: '18:00' });
+        const fixed: FixedActivity[] = [{
+            id: 'f1', userId: 'u1', title: 'Match', date: DATE, startTime: '06:30', durationMin: 60,
+            fixed: true, environment: 'outdoor', equipment: [], isCompleted: false,
+            createdAt: '', updatedAt: '',
+        }];
+        const members = [member({ sessionId: 's1', requestedWindow: { startLocal: '17:00', endLocal: '18:00' } })];
+        const result = proposeBundlePlacement('b1', DATE, members, [am, pm], fixed, new Set(), ledger());
+        expect(result.outcome).toBe('placed');
+        expect(result.bindings?.[0].windowId).toBe('pm');
+
+        const blockedMembers = [member({ sessionId: 's1', requestedWindow: { startLocal: '06:00', endLocal: '07:00' } })];
+        const blocked = proposeBundlePlacement('b1', DATE, blockedMembers, [am, pm], fixed, new Set(), ledger());
+        expect(blocked.outcome).toBe('infeasible');
+    });
+
+    it('blocks the whole date when a fixed activity has no resolvable clock time', () => {
+        const am = window({ id: 'am', startLocal: '06:00', endLocal: '07:00' });
+        const fixed: FixedActivity[] = [{
+            id: 'f1', userId: 'u1', title: 'Unknown-time errand', date: DATE, durationMin: 60,
+            fixed: true, environment: 'outdoor', equipment: [], isCompleted: false,
+            createdAt: '', updatedAt: '',
+        }];
+        const result = proposeBundlePlacement('b1', DATE, [member()], [am], fixed, new Set(), ledger());
+        expect(result.outcome).toBe('infeasible');
+    });
+
+    it('a completed fixed activity does not block placement', () => {
+        const am = window({ id: 'am', startLocal: '06:00', endLocal: '07:00' });
+        const fixed: FixedActivity[] = [{
+            id: 'f1', userId: 'u1', title: 'Done already', date: DATE, durationMin: 60,
+            fixed: true, environment: 'outdoor', equipment: [], isCompleted: true,
+            createdAt: '', updatedAt: '',
+        }];
+        const result = proposeBundlePlacement('b1', DATE, [member()], [am], fixed, new Set(), ledger());
+        expect(result.outcome).toBe('placed');
+    });
+
+    it('a 90-minute daily ceiling with a 60-minute AM completion leaves at most 30 for PM even if both windows individually offer 90', () => {
+        const am = window({ id: 'am', startLocal: '06:00', endLocal: '07:30' }); // 90 min window
+        const pm = window({ id: 'pm', startLocal: '17:00', endLocal: '18:30' }); // 90 min window
+        const members = [
+            member({ sessionId: 's1', order: 0, requestedWindow: { startLocal: '06:00', endLocal: '07:30' }, estimatedMinutes: 60 }),
+            member({ sessionId: 's2', order: 1, requestedWindow: { startLocal: '17:00', endLocal: '18:30' }, estimatedMinutes: 40 }),
+        ];
+        const result = proposeBundlePlacement('b1', DATE, members, [am, pm], [], new Set(), ledger({ remainingMinutes: 90 }));
+        expect(result.outcome).toBe('infeasible');
+    });
+
+    it('admits a PM member whose minutes fit the remaining daily ceiling after AM consumption', () => {
+        const am = window({ id: 'am', startLocal: '06:00', endLocal: '07:30' });
+        const pm = window({ id: 'pm', startLocal: '17:00', endLocal: '18:30' });
+        const members = [
+            member({ sessionId: 's1', order: 0, requestedWindow: { startLocal: '06:00', endLocal: '07:30' }, estimatedMinutes: 60 }),
+            member({ sessionId: 's2', order: 1, requestedWindow: { startLocal: '17:00', endLocal: '18:30' }, estimatedMinutes: 30 }),
+        ];
+        const result = proposeBundlePlacement('b1', DATE, members, [am, pm], [], new Set(), ledger({ remainingMinutes: 90 }));
+        expect(result.outcome).toBe('placed');
+    });
+
+    it('is infeasible when spare minutes remain but daily systemic-cost capacity is exhausted', () => {
+        const am = window({ id: 'am', startLocal: '06:00', endLocal: '07:00' });
+        const members = [member({ estimatedMinutes: 30, estimatedSystemicCost: 0.5 })];
+        const result = proposeBundlePlacement('b1', DATE, members, [am], [], new Set(), ledger({ remainingMinutes: 200, remainingSystemicCost: 0 }));
+        expect(result.outcome).toBe('infeasible');
+    });
+
+    it('is infeasible when a dependent starts less than the required separation after its predecessor ends', () => {
+        const am = window({ id: 'am', startLocal: '06:00', endLocal: '07:00' });
+        const pm = window({ id: 'pm', startLocal: '07:10', endLocal: '08:00' });
+        const members = [
+            member({ sessionId: 'pred', order: 0, requestedWindow: { startLocal: '06:00', endLocal: '07:00' }, estimatedMinutes: 60 }),
+            member({
+                sessionId: 'dep', order: 1, requestedWindow: { startLocal: '07:10', endLocal: '08:00' }, estimatedMinutes: 30,
+                afterSessionId: 'pred', minimumSeparationMinutes: 60,
+            }),
+        ];
+        const result = proposeBundlePlacement('b1', DATE, members, [am, pm], [], new Set(), ledger());
+        expect(result.outcome).toBe('infeasible');
+        expect(result.reason).toMatch(/separat|minute/i);
+    });
+
+    it('places a dependent whose gap after its predecessor meets the required separation', () => {
+        const am = window({ id: 'am', startLocal: '06:00', endLocal: '07:00' });
+        const pm = window({ id: 'pm', startLocal: '09:00', endLocal: '10:00' });
+        const members = [
+            member({ sessionId: 'pred', order: 0, requestedWindow: { startLocal: '06:00', endLocal: '07:00' }, estimatedMinutes: 60 }),
+            member({
+                sessionId: 'dep', order: 1, requestedWindow: { startLocal: '09:00', endLocal: '10:00' }, estimatedMinutes: 30,
+                afterSessionId: 'pred', minimumSeparationMinutes: 60,
+            }),
+        ];
+        const result = proposeBundlePlacement('b1', DATE, members, [am, pm], [], new Set(), ledger());
+        expect(result.outcome).toBe('placed');
+    });
+
+    it('preserves a started member\'s existing binding unchanged and excludes its window from the remaining pool', () => {
+        const am = window({ id: 'am', startLocal: '06:00', endLocal: '07:00' });
+        const pm = window({ id: 'pm', startLocal: '17:00', endLocal: '18:00' });
+        const existingBinding = {
+            sessionId: 's1', windowId: 'am', boundStartLocal: '06:00', boundEndLocal: '07:00',
+            startInstant: '2026-09-10T04:00:00.000Z', endInstant: '2026-09-10T05:00:00.000Z',
+        };
+        const members = [
+            member({ sessionId: 's1', order: 0, started: true, existingBinding }),
+            member({ sessionId: 's2', order: 1, requestedWindow: { startLocal: '06:00', endLocal: '07:00' } }),
+        ];
+        const result = proposeBundlePlacement('b1', DATE, members, [am, pm], [], new Set(), ledger());
+        // s1 keeps its exact existing binding; s2 cannot reuse the now-consumed 'am' window
+        // and has no real window left matching its own (identical) requested interval.
+        expect(result.outcome).toBe('infeasible');
+
+        const members2 = [
+            member({ sessionId: 's1', order: 0, started: true, existingBinding }),
+            member({ sessionId: 's2', order: 1, requestedWindow: { startLocal: '17:00', endLocal: '18:00' } }),
+        ];
+        const placed = proposeBundlePlacement('b1', DATE, members2, [am, pm], [], new Set(), ledger());
+        expect(placed.outcome).toBe('placed');
+        expect(placed.bindings?.find(b => b.sessionId === 's1')).toEqual(existingBinding);
+        expect(placed.bindings?.find(b => b.sessionId === 's2')?.windowId).toBe('pm');
+    });
+
+    it('is infeasible when a started member is missing its existing binding', () => {
+        const result = proposeBundlePlacement('b1', DATE, [member({ started: true })], [window()], [], new Set(), ledger());
+        expect(result.outcome).toBe('infeasible');
+    });
+
+    it('is infeasible when the bound window falls on a nonexistent Warsaw spring-forward local time', () => {
+        const gapDate = '2026-03-29';
+        const spanningWindow = window({ id: 'w', date: gapDate, startLocal: '01:30', endLocal: '03:30' });
+        const members = [member({ requestedWindow: { startLocal: '02:00', endLocal: '03:00' }, estimatedMinutes: 30 })];
+        const result = proposeBundlePlacement('b1', gapDate, members, [spanningWindow], [], new Set(), ledger());
+        expect(result.outcome).toBe('infeasible');
+    });
+});
+
+describe('dropOptionalBundleMember', () => {
+    it('removes an optional, not-yet-started member', () => {
+        const members = [member({ sessionId: 's1', priority: 'optional' }), member({ sessionId: 's2' })];
+        const remaining = dropOptionalBundleMember(members, 's1');
+        expect(remaining.map(m => m.sessionId)).toEqual(['s2']);
+    });
+
+    it('throws when the target session is not part of the bundle', () => {
+        expect(() => dropOptionalBundleMember([member({ sessionId: 's1' })], 'missing')).toThrow(/not part of this bundle/);
+    });
+
+    it('throws when the target member is not optional', () => {
+        expect(() => dropOptionalBundleMember([member({ sessionId: 's1', priority: 'key' })], 's1')).toThrow(/not optional/);
+    });
+
+    it('throws when the target member has already started', () => {
+        expect(() => dropOptionalBundleMember([member({ sessionId: 's1', priority: 'optional', started: true })], 's1')).toThrow(/already started/);
+    });
+});
+
+describe('confirmBundlePlacement', () => {
+    it('returns the bindings of a placed proposal', () => {
+        const proposal = proposeBundlePlacement('b1', DATE, [member()], [window()], [], new Set(), ledger());
+        expect(confirmBundlePlacement(proposal)).toHaveLength(1);
+    });
+
+    it('throws for an infeasible proposal rather than confirming a partial placement', () => {
+        const proposal = proposeBundlePlacement('b1', DATE, [member()], [window()], [], new Set([DATE]), ledger());
+        expect(() => confirmBundlePlacement(proposal)).toThrow(/infeasible/);
+    });
+});

--- a/app/src/engine/intradayBundlePlacement.test.ts
+++ b/app/src/engine/intradayBundlePlacement.test.ts
@@ -211,6 +211,78 @@ describe('proposeBundlePlacement', () => {
         const result = proposeBundlePlacement('b1', gapDate, members, [spanningWindow], [], new Set(), ledger());
         expect(result.outcome).toBe('infeasible');
     });
+
+    it('does not let a movable (non-fixed) activity block placement', () => {
+        const am = window({ id: 'am', startLocal: '06:00', endLocal: '07:00' });
+        const movable: FixedActivity[] = [{
+            id: 'f1', userId: 'u1', title: 'Movable placeholder', date: DATE, startTime: '06:00', durationMin: 60,
+            fixed: false, environment: 'outdoor', equipment: [], isCompleted: false,
+            createdAt: '', updatedAt: '',
+        }];
+        const result = proposeBundlePlacement('b1', DATE, [member()], [am], movable, new Set(), ledger());
+        expect(result.outcome).toBe('placed');
+    });
+
+    it('excludes a started member\'s occupied interval even when the current schedule now uses a different window id for it', () => {
+        // The window the member actually started in was 'old-am'; the athlete's schedule
+        // has since been edited so the current ScheduleWindow set only has 'new-am'
+        // covering the same 06:00-07:00 interval under a different id.
+        const newAm = window({ id: 'new-am', startLocal: '06:00', endLocal: '07:00' });
+        const pm = window({ id: 'pm', startLocal: '17:00', endLocal: '18:00' });
+        const existingBinding = {
+            sessionId: 's1', windowId: 'old-am', boundStartLocal: '06:00', boundEndLocal: '07:00',
+            startInstant: '2026-09-10T04:00:00.000Z', endInstant: '2026-09-10T05:00:00.000Z',
+        };
+        const members = [
+            member({ sessionId: 's1', order: 0, started: true, existingBinding }),
+            member({ sessionId: 's2', order: 1, requestedWindow: { startLocal: '06:00', endLocal: '07:00' } }),
+        ];
+        // 's2' requests the same interval as the started member's occupied interval,
+        // which must stay excluded by interval even though its window id changed.
+        const result = proposeBundlePlacement('b1', DATE, members, [newAm, pm], [], new Set(), ledger());
+        expect(result.outcome).toBe('infeasible');
+
+        const members2 = [
+            member({ sessionId: 's1', order: 0, started: true, existingBinding }),
+            member({ sessionId: 's2', order: 1, requestedWindow: { startLocal: '17:00', endLocal: '18:00' } }),
+        ];
+        const placed = proposeBundlePlacement('b1', DATE, members2, [newAm, pm], [], new Set(), ledger());
+        expect(placed.outcome).toBe('placed');
+        expect(placed.bindings?.find(b => b.sessionId === 's2')?.windowId).toBe('pm');
+    });
+
+    it('debits a started member\'s own consumption from the ledger before admitting later members', () => {
+        const am = window({ id: 'am', startLocal: '06:00', endLocal: '07:30' });
+        const pm = window({ id: 'pm', startLocal: '17:00', endLocal: '18:30' });
+        const existingBinding = {
+            sessionId: 's1', windowId: 'am', boundStartLocal: '06:00', boundEndLocal: '07:00',
+            startInstant: '2026-09-10T04:00:00.000Z', endInstant: '2026-09-10T05:00:00.000Z',
+        };
+        const members = [
+            member({ sessionId: 's1', order: 0, started: true, existingBinding, estimatedMinutes: 60 }),
+            member({ sessionId: 's2', order: 1, requestedWindow: { startLocal: '17:00', endLocal: '18:30' }, estimatedMinutes: 40 }),
+        ];
+        // 90-minute daily ceiling: the started 60-minute member must be charged first,
+        // leaving only 30 for the second member's 40-minute request.
+        const result = proposeBundlePlacement('b1', DATE, members, [am, pm], [], new Set(), ledger({ remainingMinutes: 90 }));
+        expect(result.outcome).toBe('infeasible');
+    });
+
+    it('backtracks an earlier member off its best-overlap window when that is the only way the whole bundle fits', () => {
+        // s1 (order 0) requests 06:00-08:00 and fits either 'a' (06:00-07:00, its best
+        // overlap) or 'b' (07:00-08:00). s2 (order 1) can only use 'a'. A greedy choice
+        // of 'a' for s1 would strand s2; the correct assignment swaps s1 onto 'b'.
+        const a = window({ id: 'a', startLocal: '06:00', endLocal: '07:00' });
+        const b = window({ id: 'b', startLocal: '07:00', endLocal: '08:00' });
+        const members = [
+            member({ sessionId: 's1', order: 0, requestedWindow: { startLocal: '06:00', endLocal: '08:00' }, estimatedMinutes: 30 }),
+            member({ sessionId: 's2', order: 1, requestedWindow: { startLocal: '06:00', endLocal: '07:00' }, estimatedMinutes: 30 }),
+        ];
+        const result = proposeBundlePlacement('b1', DATE, members, [a, b], [], new Set(), ledger());
+        expect(result.outcome).toBe('placed');
+        expect(result.bindings?.find(binding => binding.sessionId === 's1')?.windowId).toBe('b');
+        expect(result.bindings?.find(binding => binding.sessionId === 's2')?.windowId).toBe('a');
+    });
 });
 
 describe('dropOptionalBundleMember', () => {

--- a/app/src/engine/intradayBundlePlacement.ts
+++ b/app/src/engine/intradayBundlePlacement.ts
@@ -133,7 +133,10 @@ function resolvePlacementWindows(date: string, scheduleWindows: readonly Schedul
     return [{ windowId: LEGACY_SINGLE_SLOT_WINDOW_ID, startLocal: '00:00', endLocal: '23:59' }];
 }
 
-/** The date's fixed-activity-occupied intervals. An activity with a known `startTime`
+/** The date's fixed-activity-occupied intervals. Only immovable commitments
+ * (`fixed: true`) block placement -- a movable placeholder is exactly the thing the
+ * athlete could reschedule around, so treating it the same as a booked commitment would
+ * reject a placement that is not actually blocked. An activity with a known `startTime`
  * only blocks windows it actually overlaps; one without a resolvable clock time is
  * conservative and blocks the whole date, matching legacy single-slot placement's
  * existing whole-date fixed-activity precedent (`externalPlacement.ts`'s
@@ -142,7 +145,7 @@ function fixedOccupiedIntervals(
     date: string,
     fixedActivities: readonly FixedActivity[],
 ): readonly { startLocal: string; endLocal: string }[] | 'whole-date' {
-    const activities = fixedActivities.filter(activity => activity.date === date && !activity.isCompleted);
+    const activities = fixedActivities.filter(activity => activity.date === date && activity.fixed && !activity.isCompleted);
     if (activities.length === 0) return [];
     const HHMM_PATTERN = /^([01]\d|2[0-3]):[0-5]\d$/;
     const intervals: { startLocal: string; endLocal: string }[] = [];
@@ -193,6 +196,124 @@ function resolveBoundInstants(date: string, startLocal: string, endLocal: string
     return { startInstant: start.instant, endInstant: end.instant };
 }
 
+function debitLedger(current: DailyLedgerResult, minutes: number, systemicCost: number): DailyLedgerResult {
+    return {
+        ...current,
+        remainingMinutes: Math.max(0, current.remainingMinutes - minutes),
+        remainingSystemicCost: Math.max(0, current.remainingSystemicCost - systemicCost),
+    };
+}
+
+interface AssignmentState {
+    pool: readonly PlacementWindow[];
+    ledger: DailyLedgerResult;
+    bindings: ReadonlyMap<string, ResolvedWindowBinding>;
+}
+
+type AssignmentResult = { bindings: ReadonlyMap<string, ResolvedWindowBinding> } | { reason: string };
+
+/** Recursively assigns members `sortedMembers[index..]`, backtracking over candidate
+ * windows for each unstarted member so an earlier member's greedy choice never rules
+ * out a complete assignment that exists via a different choice (a real bug caught in
+ * review: picking the single best-overlap candidate for an earlier member could consume
+ * the only window a later member can use, even when swapping the earlier member onto
+ * its next-best candidate would let both fit). Bundles and a date's window count are
+ * both small in practice (first release scope), so this stays cheap in the realistic
+ * case despite worst-case exponential branching. */
+function assignFrom(date: string, sortedMembers: readonly IntradayBundleMember[], index: number, state: AssignmentState): AssignmentResult {
+    if (index >= sortedMembers.length) return { bindings: state.bindings };
+    const member = sortedMembers[index];
+
+    if (member.started && member.existingBinding) {
+        const binding = member.existingBinding;
+        const nextPool = state.pool.filter(window => !scheduleWindowsOverlap(window, { startLocal: binding.boundStartLocal, endLocal: binding.boundEndLocal }));
+        const nextBindings = new Map(state.bindings);
+        nextBindings.set(member.sessionId, binding);
+        const nextLedger = debitLedger(state.ledger, member.estimatedMinutes, member.estimatedSystemicCost);
+        return assignFrom(date, sortedMembers, index + 1, { pool: nextPool, ledger: nextLedger, bindings: nextBindings });
+    }
+
+    const candidates = state.pool
+        .map(window => ({ window, intersection: intersectWindow(member.requestedWindow, window) }))
+        .filter((candidate): candidate is { window: PlacementWindow; intersection: { startLocal: string; endLocal: string } } =>
+            candidate.intersection !== null,
+        )
+        .filter(candidate => {
+            const durationMinutes = minutesFromHHmm(candidate.intersection.endLocal) - minutesFromHHmm(candidate.intersection.startLocal);
+            return durationMinutes >= member.estimatedMinutes;
+        })
+        .sort((a, b) => {
+            const overlapDiff = overlapMinutes(member.requestedWindow, b.window) - overlapMinutes(member.requestedWindow, a.window);
+            return overlapDiff !== 0 ? overlapDiff : minutesFromHHmm(a.window.startLocal) - minutesFromHHmm(b.window.startLocal);
+        });
+
+    if (candidates.length === 0) {
+        return {
+            reason: `Session '${member.sessionId}' requests ${member.requestedWindow.startLocal}-${member.requestedWindow.endLocal} on `
+                + `${date}, but no available window fits its duration after fixed commitments and other bundle members.`,
+        };
+    }
+
+    let lastReason = `Session '${member.sessionId}' has no window assignment that also lets the remaining bundle members fit.`;
+
+    for (const candidate of candidates) {
+        const resolvedInstants = resolveBoundInstants(date, candidate.intersection.startLocal, candidate.intersection.endLocal);
+        if (!resolvedInstants) {
+            lastReason = `Session '${member.sessionId}''s bound window on ${date} falls on a nonexistent or ambiguous local time and requires explicit resolution.`;
+            continue;
+        }
+
+        const admission = admitsCandidate(
+            state.ledger,
+            minutesFromHHmm(candidate.intersection.endLocal) - minutesFromHHmm(candidate.intersection.startLocal),
+            member.estimatedMinutes,
+            member.estimatedSystemicCost,
+        );
+        if (!admission.admitted) {
+            lastReason = `Session '${member.sessionId}' cannot be admitted: the day's remaining minute or systemic-cost capacity is exhausted.`;
+            continue;
+        }
+
+        if (member.afterSessionId) {
+            const predecessorBinding = state.bindings.get(member.afterSessionId);
+            if (!predecessorBinding) {
+                return { reason: `Session '${member.sessionId}''s predecessor '${member.afterSessionId}' has no resolved binding yet.` };
+            }
+            const requiredSeparation = member.minimumSeparationMinutes ?? 0;
+            // elapsedMinutesBetweenInstants(startInstant, endInstant) computes
+            // startInstant - endInstant (D-TIME: "start minus the predecessor's actual
+            // end instant"), so the dependent's start is the first argument.
+            const gapMinutes = elapsedMinutesBetweenInstants(resolvedInstants.startInstant, predecessorBinding.endInstant);
+            if (gapMinutes < requiredSeparation) {
+                lastReason = `Session '${member.sessionId}' starts only ${gapMinutes} minute(s) after predecessor '${member.afterSessionId}' `
+                    + `ends, short of the required ${requiredSeparation}.`;
+                continue;
+            }
+        }
+
+        const nextBindings = new Map(state.bindings);
+        nextBindings.set(member.sessionId, {
+            sessionId: member.sessionId,
+            windowId: candidate.window.windowId,
+            boundStartLocal: candidate.intersection.startLocal,
+            boundEndLocal: candidate.intersection.endLocal,
+            startInstant: resolvedInstants.startInstant,
+            endInstant: resolvedInstants.endInstant,
+        });
+        const nextPool = state.pool.filter(window => window.windowId !== candidate.window.windowId);
+        const nextLedger = debitLedger(state.ledger, member.estimatedMinutes, member.estimatedSystemicCost);
+
+        const result = assignFrom(date, sortedMembers, index + 1, { pool: nextPool, ledger: nextLedger, bindings: nextBindings });
+        if ('bindings' in result) return result;
+        // This candidate placed `member` but left no valid assignment for the rest of
+        // the bundle -- backtrack and try the next candidate rather than reporting
+        // infeasible from a single greedy choice.
+        lastReason = result.reason;
+    }
+
+    return { reason: lastReason };
+}
+
 /**
  * Proposes placement for one intraday bundle on one date. Returns a single atomic
  * result: either every member (started members preserved, unstarted members newly
@@ -201,9 +322,13 @@ function resolveBoundInstants(date: string, startLocal: string, endLocal: string
  *
  * `members` need not be pre-sorted. `restDates` are ADR-0035 dates closed to every
  * window by default (D-PLACEMENT: "availability does not override rest"). `ledger` is
- * the date's already-computed `dailyLedger.ts` remainder *before* this bundle's own
- * candidates are considered; admission is evaluated sequentially in `order` so an
- * earlier member's consumption reduces what a later member can draw from the same day.
+ * the date's already-computed `dailyLedger.ts` remainder *before any* of this bundle's
+ * own members -- started or not -- are considered; this function debits every member of
+ * the bundle sequentially in `order` itself, so a caller must not have already
+ * subtracted a started member's own consumption from `ledger` (that would double-charge
+ * it). Candidate window assignment backtracks: an earlier member's best-overlap choice
+ * that would leave no valid assignment for a later member is retried with that earlier
+ * member's next-best candidate before the whole proposal is reported infeasible.
  */
 export function proposeBundlePlacement(
     bundleId: string,
@@ -228,95 +353,15 @@ export function proposeBundlePlacement(
 
     const sorted = [...members].sort((a, b) => a.order - b.order);
     const occupied = fixedOccupiedIntervals(date, fixedActivities);
-    let pool = resolvePlacementWindows(date, scheduleWindows).filter(window => !windowBlockedByFixed(window, occupied));
+    const pool = resolvePlacementWindows(date, scheduleWindows).filter(window => !windowBlockedByFixed(window, occupied));
 
-    const bindings = new Map<string, ResolvedWindowBinding>();
-    let runningLedger = ledger;
-
-    for (const member of sorted) {
-        if (member.started && member.existingBinding) {
-            bindings.set(member.sessionId, member.existingBinding);
-            pool = pool.filter(window => window.windowId !== member.existingBinding!.windowId);
-            continue;
-        }
-
-        const candidates = pool
-            .map(window => ({ window, intersection: intersectWindow(member.requestedWindow, window) }))
-            .filter((candidate): candidate is { window: PlacementWindow; intersection: { startLocal: string; endLocal: string } } =>
-                candidate.intersection !== null,
-            )
-            .filter(candidate => {
-                const durationMinutes = minutesFromHHmm(candidate.intersection.endLocal) - minutesFromHHmm(candidate.intersection.startLocal);
-                return durationMinutes >= member.estimatedMinutes;
-            })
-            .sort((a, b) => {
-                const overlapDiff = overlapMinutes(member.requestedWindow, b.window) - overlapMinutes(member.requestedWindow, a.window);
-                return overlapDiff !== 0 ? overlapDiff : minutesFromHHmm(a.window.startLocal) - minutesFromHHmm(b.window.startLocal);
-            });
-
-        if (candidates.length === 0) {
-            return infeasible(
-                bundleId,
-                `Session '${member.sessionId}' requests ${member.requestedWindow.startLocal}-${member.requestedWindow.endLocal} on ${date}, `
-                + 'but no available window fits its duration after fixed commitments and other bundle members.',
-            );
-        }
-
-        const chosen = candidates[0];
-        const resolvedInstants = resolveBoundInstants(date, chosen.intersection.startLocal, chosen.intersection.endLocal);
-        if (!resolvedInstants) {
-            return infeasible(bundleId, `Session '${member.sessionId}''s bound window on ${date} falls on a nonexistent or ambiguous local time and requires explicit resolution.`);
-        }
-
-        const admission = admitsCandidate(
-            runningLedger,
-            minutesFromHHmm(chosen.intersection.endLocal) - minutesFromHHmm(chosen.intersection.startLocal),
-            member.estimatedMinutes,
-            member.estimatedSystemicCost,
-        );
-        if (!admission.admitted) {
-            return infeasible(bundleId, `Session '${member.sessionId}' cannot be admitted: the day's remaining minute or systemic-cost capacity is exhausted.`);
-        }
-
-        if (member.afterSessionId) {
-            const predecessorBinding = bindings.get(member.afterSessionId);
-            if (!predecessorBinding) {
-                return infeasible(bundleId, `Session '${member.sessionId}''s predecessor '${member.afterSessionId}' has no resolved binding yet.`);
-            }
-            const requiredSeparation = member.minimumSeparationMinutes ?? 0;
-            // elapsedMinutesBetweenInstants(startInstant, endInstant) computes
-            // startInstant - endInstant (D-TIME: "start minus the predecessor's actual
-            // end instant"), so the dependent's start is the first argument.
-            const gapMinutes = elapsedMinutesBetweenInstants(resolvedInstants.startInstant, predecessorBinding.endInstant);
-            if (gapMinutes < requiredSeparation) {
-                return infeasible(
-                    bundleId,
-                    `Session '${member.sessionId}' starts only ${gapMinutes} minute(s) after predecessor '${member.afterSessionId}' `
-                    + `ends, short of the required ${requiredSeparation}.`,
-                );
-            }
-        }
-
-        bindings.set(member.sessionId, {
-            sessionId: member.sessionId,
-            windowId: chosen.window.windowId,
-            boundStartLocal: chosen.intersection.startLocal,
-            boundEndLocal: chosen.intersection.endLocal,
-            startInstant: resolvedInstants.startInstant,
-            endInstant: resolvedInstants.endInstant,
-        });
-        pool = pool.filter(window => window.windowId !== chosen.window.windowId);
-        runningLedger = {
-            ...runningLedger,
-            remainingMinutes: Math.max(0, runningLedger.remainingMinutes - member.estimatedMinutes),
-            remainingSystemicCost: Math.max(0, runningLedger.remainingSystemicCost - member.estimatedSystemicCost),
-        };
-    }
+    const result = assignFrom(date, sorted, 0, { pool, ledger, bindings: new Map() });
+    if ('reason' in result) return infeasible(bundleId, result.reason);
 
     return {
         bundleId,
         outcome: 'placed',
-        bindings: sorted.map(member => bindings.get(member.sessionId)!),
+        bindings: sorted.map(member => result.bindings.get(member.sessionId)!),
     };
 }
 

--- a/app/src/engine/intradayBundlePlacement.ts
+++ b/app/src/engine/intradayBundlePlacement.ts
@@ -1,0 +1,359 @@
+/**
+ * ADR-0036 (H4) D-PLACEMENT: resolves one v4 intraday bundle's requested windows against
+ * real `ScheduleWindow` availability (D-WINDOW), checks the combined minute/systemic-cost
+ * budget via `dailyLedger.ts` (D-LEDGER), respects fixed commitments and ADR-0035 rest,
+ * and computes scheduled separation from D-TIME's resolved instants. Produces an atomic
+ * confirmed-proposal analogous to `externalPlacement.ts`'s `proposeReplacement`/
+ * `applyConfirmedProposal`, but binding several same-date bundle members to distinct real
+ * windows at once rather than moving one session to one date.
+ *
+ * Pure: no Firestore, no wiring into `evaluateTrainingWithIntent` or any decision path
+ * yet -- see the H4 status notes in `docs/plans/cycling-primary-hybrid-evaluation.md`.
+ * `POLICY_VERSION` is unchanged by this file.
+ *
+ * Scope note: this module resolves and validates a *scheduled* placement. "Separation"
+ * here is the resolved gap between a predecessor's bound window end and a dependent's
+ * bound window start, using D-TIME's instant resolution on the scheduled boundaries --
+ * not the predecessor's actual execution end, which does not exist before either session
+ * has started. Recomputing against real performed timestamps once execution begins is
+ * D-REASSESS, a separate later ADR-0036 decision, not implemented here.
+ */
+
+import type { FixedActivity, ScheduleWindow, TrainingEnvironment } from './models';
+import { resolveScheduleWindowsForDate, scheduleWindowsOverlap } from './scheduleWindows';
+import { resolveLocalInstant, elapsedMinutesBetweenInstants } from './localInstant';
+import { admitsCandidate, type DailyLedgerResult } from './dailyLedger';
+
+export type BundleMemberPriority = 'key' | 'supporting' | 'optional';
+
+/** One bundle member as D-PLACEMENT needs it -- a caller-projected view of a v4 session's
+ * `intraday` request (`sessions/externalPlanV4.ts`) plus its already-estimated cost. This
+ * module never estimates dose/duration/systemic-cost itself (D-LEDGER: "keep the current
+ * common cost/eligibility authorities"); the caller supplies those from wherever the
+ * existing decision path already computes them for a session. */
+export interface IntradayBundleMember {
+    sessionId: string;
+    /** Unique within the bundle; earlier order = earlier in the day. Already validated
+     * for uniqueness/reference-integrity by `externalPlanV4.ts` at import time -- this
+     * module trusts that invariant rather than re-deriving it. */
+    order: number;
+    priority: BundleMemberPriority;
+    /** HH:mm, the athlete-authored requested interval -- never imported as availability
+     * (D-WINDOW); only ever intersected against a real `ScheduleWindow`. */
+    requestedWindow: { startLocal: string; endLocal: string };
+    /** An earlier required-completed predecessor's `sessionId`, when present. */
+    afterSessionId?: string;
+    minimumSeparationMinutes?: number;
+    estimatedMinutes: number;
+    /** 0..1, the same scale `dailyLedger.ts`'s `LedgerCeilings`/`LedgerEntry` use. */
+    estimatedSystemicCost: number;
+    /** True once this member has actually started. Its binding is carried through
+     * unchanged and its window stays consumed; it is never re-bound or moved (ADR:
+     * "once a member starts, do not move its history"). Requires `existingBinding`. */
+    started: boolean;
+    /** A previously confirmed binding for this member (required when `started`). When
+     * present for an unstarted member, its window is preferred but still validated --
+     * it is not blindly trusted, since the underlying `ScheduleWindow` set may have
+     * changed since it was confirmed. */
+    existingBinding?: ResolvedWindowBinding;
+}
+
+export interface ResolvedWindowBinding {
+    sessionId: string;
+    /** The real `ScheduleWindow.id` this session is bound to, or the sentinel below for
+     * the legacy single-untimed-slot case. */
+    windowId: string;
+    /** The intersection of the requested window and the bound real window -- the actual
+     * resolved interval, never wider than either. */
+    boundStartLocal: string;
+    boundEndLocal: string;
+    /** D-TIME resolved instants for the bound interval, ISO-8601 UTC. */
+    startInstant: string;
+    endInstant: string;
+}
+
+export type BundlePlacementOutcome = 'placed' | 'infeasible';
+
+export interface BundlePlacementProposal {
+    bundleId: string;
+    outcome: BundlePlacementOutcome;
+    /** One binding per member -- started members' preserved history included -- present
+     * only when `outcome` is 'placed'. Absent (not partial) when infeasible: "if the
+     * whole proposal cannot fit, explain the conflict and leave placement unchanged"
+     * (ADR) -- this module never returns a partial bundle placement. */
+    bindings?: ResolvedWindowBinding[];
+    /** Present only when `outcome` is 'infeasible'; names the first blocking conflict. */
+    reason?: string;
+}
+
+/** Stands in for the date's single untimed slot when no `ScheduleWindow` exists for it
+ * (D-WINDOW's supported legacy case). Exactly one bundle member can bind to it, the same
+ * "at most one occurrence per resolved window" rule a real window is subject to -- so a
+ * legacy date can never silently grow an AM/PM pair from missing metadata. */
+export const LEGACY_SINGLE_SLOT_WINDOW_ID = 'legacy-single-slot';
+
+interface PlacementWindow {
+    windowId: string;
+    startLocal: string;
+    endLocal: string;
+    equipment?: readonly string[];
+    environment?: TrainingEnvironment;
+}
+
+function minutesFromHHmm(value: string): number {
+    const [hours, minutes] = value.split(':').map(Number);
+    return hours * 60 + minutes;
+}
+
+function hhmmFromMinutes(totalMinutes: number): string {
+    const clamped = Math.max(0, Math.min(24 * 60, totalMinutes));
+    const hours = Math.floor(clamped / 60) % 24;
+    const minutes = clamped % 60;
+    return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
+}
+
+function infeasible(bundleId: string, reason: string): BundlePlacementProposal {
+    return { bundleId, outcome: 'infeasible', reason };
+}
+
+/** Real windows for the date, or the single legacy slot spanning the whole day when none
+ * are recorded -- requested windows are still intersected against it below, they just
+ * cannot make it any wider than a full day. */
+function resolvePlacementWindows(date: string, scheduleWindows: readonly ScheduleWindow[]): PlacementWindow[] {
+    const real = resolveScheduleWindowsForDate(date, scheduleWindows);
+    if (real.length > 0) {
+        return real.map(window => ({
+            windowId: window.id,
+            startLocal: window.startLocal,
+            endLocal: window.endLocal,
+            equipment: window.equipment,
+            environment: window.environment,
+        }));
+    }
+    return [{ windowId: LEGACY_SINGLE_SLOT_WINDOW_ID, startLocal: '00:00', endLocal: '23:59' }];
+}
+
+/** The date's fixed-activity-occupied intervals. An activity with a known `startTime`
+ * only blocks windows it actually overlaps; one without a resolvable clock time is
+ * conservative and blocks the whole date, matching legacy single-slot placement's
+ * existing whole-date fixed-activity precedent (`externalPlacement.ts`'s
+ * `PlacementOccupancy`) when finer-grained information is unavailable. */
+function fixedOccupiedIntervals(
+    date: string,
+    fixedActivities: readonly FixedActivity[],
+): readonly { startLocal: string; endLocal: string }[] | 'whole-date' {
+    const activities = fixedActivities.filter(activity => activity.date === date && !activity.isCompleted);
+    if (activities.length === 0) return [];
+    const HHMM_PATTERN = /^([01]\d|2[0-3]):[0-5]\d$/;
+    const intervals: { startLocal: string; endLocal: string }[] = [];
+    for (const activity of activities) {
+        if (!activity.startTime || !HHMM_PATTERN.test(activity.startTime)) return 'whole-date';
+        const startMinutes = minutesFromHHmm(activity.startTime);
+        const endMinutes = startMinutes + activity.durationMin;
+        if (endMinutes > 24 * 60) return 'whole-date'; // crosses midnight -- conservative
+        intervals.push({ startLocal: activity.startTime, endLocal: hhmmFromMinutes(endMinutes) });
+    }
+    return intervals;
+}
+
+function windowBlockedByFixed(
+    window: PlacementWindow,
+    occupied: readonly { startLocal: string; endLocal: string }[] | 'whole-date',
+): boolean {
+    if (occupied === 'whole-date') return true;
+    return occupied.some(interval => scheduleWindowsOverlap(window, interval));
+}
+
+/** The intersection of a requested interval and a real placement window, or `null` when
+ * they do not overlap at all. Never wider than either input (D-WINDOW: a plan request
+ * can never create or broaden availability). */
+function intersectWindow(
+    requested: { startLocal: string; endLocal: string },
+    real: PlacementWindow,
+): { startLocal: string; endLocal: string } | null {
+    const start = Math.max(minutesFromHHmm(requested.startLocal), minutesFromHHmm(real.startLocal));
+    const end = Math.min(minutesFromHHmm(requested.endLocal), minutesFromHHmm(real.endLocal));
+    if (end <= start) return null;
+    return { startLocal: hhmmFromMinutes(start), endLocal: hhmmFromMinutes(end) };
+}
+
+function overlapMinutes(a: { startLocal: string; endLocal: string }, b: { startLocal: string; endLocal: string }): number {
+    const start = Math.max(minutesFromHHmm(a.startLocal), minutesFromHHmm(b.startLocal));
+    const end = Math.min(minutesFromHHmm(a.endLocal), minutesFromHHmm(b.endLocal));
+    return Math.max(0, end - start);
+}
+
+/** Resolves one bound interval's instants via D-TIME. `null` communicates a nonexistent
+ * (spring-forward gap) or ambiguous (fall-back fold) boundary -- callers must treat this
+ * as unresolved rather than silently choosing an offset (D-TIME). */
+function resolveBoundInstants(date: string, startLocal: string, endLocal: string): { startInstant: string; endInstant: string } | null {
+    const start = resolveLocalInstant(date, startLocal);
+    const end = resolveLocalInstant(date, endLocal);
+    if (start.status !== 'resolved' || end.status !== 'resolved') return null;
+    return { startInstant: start.instant, endInstant: end.instant };
+}
+
+/**
+ * Proposes placement for one intraday bundle on one date. Returns a single atomic
+ * result: either every member (started members preserved, unstarted members newly
+ * bound) has a resolved window binding, or the whole proposal is infeasible with a
+ * reason -- never a partial placement.
+ *
+ * `members` need not be pre-sorted. `restDates` are ADR-0035 dates closed to every
+ * window by default (D-PLACEMENT: "availability does not override rest"). `ledger` is
+ * the date's already-computed `dailyLedger.ts` remainder *before* this bundle's own
+ * candidates are considered; admission is evaluated sequentially in `order` so an
+ * earlier member's consumption reduces what a later member can draw from the same day.
+ */
+export function proposeBundlePlacement(
+    bundleId: string,
+    date: string,
+    members: readonly IntradayBundleMember[],
+    scheduleWindows: readonly ScheduleWindow[],
+    fixedActivities: readonly FixedActivity[],
+    restDates: ReadonlySet<string>,
+    ledger: DailyLedgerResult,
+): BundlePlacementProposal {
+    if (members.length === 0) return infeasible(bundleId, 'Bundle has no members to place.');
+
+    if (restDates.has(date)) {
+        return infeasible(bundleId, `${date} is an authored rest date; every window is closed by default.`);
+    }
+
+    for (const member of members) {
+        if (member.started && !member.existingBinding) {
+            return infeasible(bundleId, `Session '${member.sessionId}' has started but carries no existing binding.`);
+        }
+    }
+
+    const sorted = [...members].sort((a, b) => a.order - b.order);
+    const occupied = fixedOccupiedIntervals(date, fixedActivities);
+    let pool = resolvePlacementWindows(date, scheduleWindows).filter(window => !windowBlockedByFixed(window, occupied));
+
+    const bindings = new Map<string, ResolvedWindowBinding>();
+    let runningLedger = ledger;
+
+    for (const member of sorted) {
+        if (member.started && member.existingBinding) {
+            bindings.set(member.sessionId, member.existingBinding);
+            pool = pool.filter(window => window.windowId !== member.existingBinding!.windowId);
+            continue;
+        }
+
+        const candidates = pool
+            .map(window => ({ window, intersection: intersectWindow(member.requestedWindow, window) }))
+            .filter((candidate): candidate is { window: PlacementWindow; intersection: { startLocal: string; endLocal: string } } =>
+                candidate.intersection !== null,
+            )
+            .filter(candidate => {
+                const durationMinutes = minutesFromHHmm(candidate.intersection.endLocal) - minutesFromHHmm(candidate.intersection.startLocal);
+                return durationMinutes >= member.estimatedMinutes;
+            })
+            .sort((a, b) => {
+                const overlapDiff = overlapMinutes(member.requestedWindow, b.window) - overlapMinutes(member.requestedWindow, a.window);
+                return overlapDiff !== 0 ? overlapDiff : minutesFromHHmm(a.window.startLocal) - minutesFromHHmm(b.window.startLocal);
+            });
+
+        if (candidates.length === 0) {
+            return infeasible(
+                bundleId,
+                `Session '${member.sessionId}' requests ${member.requestedWindow.startLocal}-${member.requestedWindow.endLocal} on ${date}, `
+                + 'but no available window fits its duration after fixed commitments and other bundle members.',
+            );
+        }
+
+        const chosen = candidates[0];
+        const resolvedInstants = resolveBoundInstants(date, chosen.intersection.startLocal, chosen.intersection.endLocal);
+        if (!resolvedInstants) {
+            return infeasible(bundleId, `Session '${member.sessionId}''s bound window on ${date} falls on a nonexistent or ambiguous local time and requires explicit resolution.`);
+        }
+
+        const admission = admitsCandidate(
+            runningLedger,
+            minutesFromHHmm(chosen.intersection.endLocal) - minutesFromHHmm(chosen.intersection.startLocal),
+            member.estimatedMinutes,
+            member.estimatedSystemicCost,
+        );
+        if (!admission.admitted) {
+            return infeasible(bundleId, `Session '${member.sessionId}' cannot be admitted: the day's remaining minute or systemic-cost capacity is exhausted.`);
+        }
+
+        if (member.afterSessionId) {
+            const predecessorBinding = bindings.get(member.afterSessionId);
+            if (!predecessorBinding) {
+                return infeasible(bundleId, `Session '${member.sessionId}''s predecessor '${member.afterSessionId}' has no resolved binding yet.`);
+            }
+            const requiredSeparation = member.minimumSeparationMinutes ?? 0;
+            // elapsedMinutesBetweenInstants(startInstant, endInstant) computes
+            // startInstant - endInstant (D-TIME: "start minus the predecessor's actual
+            // end instant"), so the dependent's start is the first argument.
+            const gapMinutes = elapsedMinutesBetweenInstants(resolvedInstants.startInstant, predecessorBinding.endInstant);
+            if (gapMinutes < requiredSeparation) {
+                return infeasible(
+                    bundleId,
+                    `Session '${member.sessionId}' starts only ${gapMinutes} minute(s) after predecessor '${member.afterSessionId}' `
+                    + `ends, short of the required ${requiredSeparation}.`,
+                );
+            }
+        }
+
+        bindings.set(member.sessionId, {
+            sessionId: member.sessionId,
+            windowId: chosen.window.windowId,
+            boundStartLocal: chosen.intersection.startLocal,
+            boundEndLocal: chosen.intersection.endLocal,
+            startInstant: resolvedInstants.startInstant,
+            endInstant: resolvedInstants.endInstant,
+        });
+        pool = pool.filter(window => window.windowId !== chosen.window.windowId);
+        runningLedger = {
+            ...runningLedger,
+            remainingMinutes: Math.max(0, runningLedger.remainingMinutes - member.estimatedMinutes),
+            remainingSystemicCost: Math.max(0, runningLedger.remainingSystemicCost - member.estimatedSystemicCost),
+        };
+    }
+
+    return {
+        bundleId,
+        outcome: 'placed',
+        bindings: sorted.map(member => bindings.get(member.sessionId)!),
+    };
+}
+
+/**
+ * Drops one optional, not-yet-started member from a bundle before re-proposing
+ * placement for the remainder. This is an explicit athlete action, never an automatic
+ * one (ADR: "an athlete may explicitly drop an optional member before re-evaluating the
+ * remainder; do not silently split the bundle to make a proposal fit"). Dropped work is
+ * not carried forward -- the caller re-runs `proposeBundlePlacement` on the returned,
+ * smaller member list to see whether the remainder now fits.
+ *
+ * Never orphans a required member: D-SCHEMA already rejects a required session
+ * depending on an optional predecessor at import time, so no remaining required member
+ * can reference a dropped optional one as `afterSessionId`.
+ */
+export function dropOptionalBundleMember(
+    members: readonly IntradayBundleMember[],
+    sessionId: string,
+): IntradayBundleMember[] {
+    const target = members.find(member => member.sessionId === sessionId);
+    if (!target) throw new Error(`Session '${sessionId}' is not part of this bundle.`);
+    if (target.priority !== 'optional') throw new Error(`Session '${sessionId}' is not optional and cannot be dropped from the bundle.`);
+    if (target.started) throw new Error(`Session '${sessionId}' has already started; its history cannot be dropped.`);
+    return members.filter(member => member.sessionId !== sessionId);
+}
+
+/**
+ * The athlete-confirmation boundary, mirroring `externalPlacement.ts`'s
+ * `applyConfirmedProposal`. A `proposeBundlePlacement` result is only a proposal; this
+ * function is the sole place that treats one as accepted. It writes nothing itself --
+ * this module has no persistence, and no persisted bundle-binding store exists yet
+ * (that is wiring/D-AUDIT's job, not delivered here) -- it simply asserts the proposal
+ * is placeable and returns its bindings for a caller to persist.
+ */
+export function confirmBundlePlacement(proposal: BundlePlacementProposal): ResolvedWindowBinding[] {
+    if (proposal.outcome !== 'placed' || !proposal.bindings) {
+        throw new Error(`Cannot confirm an infeasible bundle placement: ${proposal.reason ?? 'no bindings available'}`);
+    }
+    return proposal.bindings;
+}

--- a/docs/plans/cycling-primary-hybrid-evaluation.md
+++ b/docs/plans/cycling-primary-hybrid-evaluation.md
@@ -1,19 +1,20 @@
 # Cycling-primary hybrid evaluation and recommendation improvements
 
 **Status:** In progress — H1, H2, H2b, H3 and H3-rest (ADR-0035) all delivered; H4 design
-accepted as ADR-0036 with D-SCHEMA/D-LEDGER/D-TIME delivered, the same-day canonical
-performed-fact boundary verified, the fixed-activity cost-reduce duplication unified, and
-D-WINDOW's athlete-schedule model delivered (unwired) (ledger-based ranking/admission and
-D-PLACEMENT's bundle-placement engine plus its wiring, then D-REASSESS/D-AUDIT,
+accepted as ADR-0036 with D-SCHEMA/D-LEDGER/D-TIME/D-WINDOW delivered and
+D-PLACEMENT's bundle-placement engine delivered as a pure module (unwired) -- the
+same-day canonical performed-fact boundary is verified and the fixed-activity
+cost-reduce duplication is unified -- (ledger-based ranking/admission and wiring
+D-PLACEMENT's engine into `evaluateTrainingWithIntent`, then D-REASSESS/D-AUDIT,
 unstarted); H5 design accepted as ADR-0037 with H5a/H5b delivered (H5c and cumulative
 `external-plan@5` unstarted)
 **Blocked by:** Personal M00/M01 prescription requires current workload/restriction
 confirmation; H4's remaining wiring (using the ledger's remainder/admission math as an
-actual ranking input, D-PLACEMENT's bundle-placement engine on top of D-WINDOW/D-TIME/
-D-LEDGER, then wiring both into `evaluateTrainingWithIntent` with a real `POLICY_VERSION`
-bump, then D-REASSESS/D-AUDIT) needs its own decision-affecting PR(s); H5c needs the
-athlete-scoped singleton progression-claim transaction design, and cumulative
-`external-plan@5` acceptance is unblocked now that H4's v4 contract has landed.
+actual ranking input, then wiring D-PLACEMENT's bundle-placement engine into
+`evaluateTrainingWithIntent` with a real `POLICY_VERSION` bump, then D-REASSESS/D-AUDIT)
+needs its own decision-affecting PR(s); H5c needs the athlete-scoped singleton
+progression-claim transaction design, and cumulative `external-plan@5` acceptance is
+unblocked now that H4's v4 contract has landed.
 **Unlocks:** Reproducible acceptance cases for equipment specificity, block authority and hybrid plan quality.
 
 ## Decision
@@ -252,11 +253,11 @@ also remains blocked on current-workload/restriction confirmation.
 ## H4 — Intraday capacity and post-AM reassessment
 
 **Status:** Design accepted in [ADR-0036](../adr/0036-intraday-training-windows-and-reassessment.md).
-**D-SCHEMA, D-LEDGER and D-TIME delivered** (schema/pure-ledger/pure-instant slices);
-**same-day canonical performed-fact boundary verified**; **D-WINDOW's athlete-schedule
-model delivered** (persisted, unwired); runtime wiring (the `dailyLedger.ts` refactor,
-plus D-PLACEMENT's bundle-placement engine and its wiring, then D-REASSESS/D-AUDIT)
-unstarted.
+**D-SCHEMA, D-LEDGER, D-TIME and D-WINDOW delivered**; **same-day canonical
+performed-fact boundary verified**; **D-PLACEMENT's bundle-placement engine delivered**
+as a pure module (unwired); runtime wiring (the `dailyLedger.ts` refactor into
+`resolveAvailability`'s existing deductions, plus wiring D-PLACEMENT's engine into
+`evaluateTrainingWithIntent`, then D-REASSESS/D-AUDIT) unstarted.
 **Dependencies:** ADR-0035 rest support (delivered). The `external-plan@4`/`dailyLedger.ts`
 D-SCHEMA/D-LEDGER slice itself left `POLICY_VERSION` unchanged (neither module is
 consumed by any decision path); the later fixed-activity cost-reduce dedup slice below
@@ -377,6 +378,66 @@ overlapping before the cross-window check was scoped per-date), legacy-empty res
 and the Firestore rules' shape/ownership/revision/immutability contract.
 `simulate:diff`/policy-drift show no change from this slice.
 
+Note: PR #428 ("typed schedule overlays and planned absences") merged the same day as
+D-WINDOW and now feeds `ScheduleOverlay`'s `dailyAvailabilityMinutes`/cost/equipment into
+`resolveAvailability`'s single per-date budget. This is unrelated to and does not conflict
+with `ScheduleWindow` -- `ScheduleOverlay` still has no clock-time concept, so it narrows
+the *whole day's* ceiling that D-PLACEMENT's engine (below) treats as its ledger input,
+while `ScheduleWindow` is what supplies the day's individual clock-time slots.
+
+### D-PLACEMENT's bundle-placement engine (delivered, pure module -- not yet wired)
+
+`engine/intradayBundlePlacement.ts` resolves one v4 intraday bundle's requested windows
+against real `ScheduleWindow` availability, checks the combined minute/systemic-cost
+budget via `dailyLedger.ts`, respects ADR-0035 rest and fixed commitments, and computes
+scheduled separation from D-TIME's resolved instants. It exposes an atomic
+confirmed-proposal API analogous to `externalPlacement.ts`'s
+`proposeReplacement`/`applyConfirmedProposal`, but for whole same-date bundles:
+
+- `proposeBundlePlacement(bundleId, date, members, scheduleWindows, fixedActivities, restDates, ledger)`
+  returns either `{ outcome: 'placed', bindings }` -- one `ResolvedWindowBinding` per
+  member, in `order` -- or `{ outcome: 'infeasible', reason }`. It never returns a partial
+  placement: "if the whole proposal cannot fit, explain the conflict and leave placement
+  unchanged" (ADR). Each unstarted member's requested window is intersected against the
+  date's real windows (picking the one with the greatest overlap, excluding windows
+  already consumed by an earlier member or blocked by a fixed commitment); ledger
+  admission is evaluated sequentially in `order` so an earlier member's consumption
+  correctly reduces what a later member can draw from the same day's shared ceiling; a
+  dependent's scheduled separation from its predecessor is checked via
+  `resolveLocalInstant`/`elapsedMinutesBetweenInstants` on the *resolved window*
+  boundaries (not an actual performed timestamp, which does not exist before either
+  session starts -- recomputing against real execution once it does is D-REASSESS, not
+  implemented here). A date with no persisted `ScheduleWindow`s falls back to one
+  synthetic whole-day slot (D-WINDOW's supported legacy case), and since "at most one
+  training occurrence per resolved window" applies to that slot too, a bundle needing two
+  or more windows on such a date is correctly infeasible rather than fabricating an AM/PM
+  pair from missing metadata.
+- `dropOptionalBundleMember(members, sessionId)` is the athlete's explicit action to drop
+  one optional, not-yet-started member before re-proposing the remainder -- never
+  automatic, and never carries dropped work forward (ADR). It throws for a required or
+  already-started member. D-SCHEMA's existing "no required session may depend on an
+  optional predecessor" invariant means dropping an optional member can never orphan a
+  required one.
+- `confirmBundlePlacement(proposal)` is the sole athlete-confirmation boundary,
+  mirroring `applyConfirmedProposal`; it throws on an infeasible proposal rather than
+  confirming a partial one. It writes nothing -- no persisted bundle-binding store exists
+  yet (that is wiring/D-AUDIT's job, not delivered here).
+
+A member that has already started (`started: true`) always carries its own
+`existingBinding` through unchanged and keeps its window consumed for the rest of the
+bundle -- "once a member starts, do not move its history" (ADR). `intradayBundlePlacement.test.ts`
+covers the ADR's D-PLACEMENT-relevant deterministic cases: AM/PM placement into distinct
+windows, the legacy-date single-slot restriction, authored rest closing every window,
+fixed-activity occupancy (both a known-clock-time activity blocking only its overlapping
+window and an unknown-clock-time one blocking the whole date), the 90-minute-ceiling/
+60-minute-AM worked example extended to a real bundle, exhausted-systemic-cost rejection
+with spare minutes still available, separation success/failure (a real argument-order bug
+in the D-TIME `elapsedMinutesBetweenInstants` call -- `start - end`, not `end - start` --
+was caught by this test before merge), started-member preservation, and a nonexistent
+Warsaw spring-forward boundary correctly reported as unresolved rather than silently
+choosing an offset. Not wired into `evaluateTrainingWithIntent` or any decision path;
+`POLICY_VERSION` unchanged; `simulate:diff`/policy-drift confirm no output change.
+
 ### Same-day canonical performed-fact boundary (verified)
 
 `getPerformedTrainingFactsInRange`'s only caller (`trainingIntent.ts`) always passes
@@ -432,11 +493,8 @@ in `unrepresentedFixedActivityProjection`) are **not yet unified** onto the ledg
 `occurrenceId`/`revision` model, and none of these call sites yet consult
 `computeDailyLedger`'s remainder or `admitsCandidate` when ranking or admitting a
 candidate. The actual next H4 tasks are (1) using the ledger's remainder/admission
-semantics as a real ranking/admission input, (2) D-PLACEMENT's bundle-placement engine
-(resolving a v4 `intraday` bundle's requested windows against real `ScheduleWindow`
-availability, checking combined minute/systemic-cost budget via `dailyLedger.ts`, and an
-atomic confirmed-proposal API analogous to `externalPlacement.ts`'s
-`proposeReplacement`/`applyConfirmedProposal`, but for bundles), and (3) wiring both into
+semantics as a real ranking/admission input, and (2) wiring D-PLACEMENT's now-delivered
+bundle-placement engine (`engine/intradayBundlePlacement.ts`, see above) into
 `evaluateTrainingWithIntent` with a real `POLICY_VERSION` bump -- each decision-affecting
 and scoped as its own PR, then D-REASSESS/D-AUDIT.
 
@@ -501,7 +559,8 @@ is non-decision-affecting and needs no bump; the explicit-rest follow-up will re
 normal policy/schema/replay review when it changes decision behavior. H4's
 `fixed-activity-cost-dedup-v1` bump reflects the drift gate's mechanical requirement for
 any `planner.ts`/`rules.ts` touch, not an actual behavior change (verified via
-`simulate:diff`); H4's still-pending ledger-based ranking/admission wiring, D-PLACEMENT's
-bundle-placement engine and its wiring, and H5's still-pending H5c will require the normal
-review when they actually change decision
-behavior. Do not enable experimental personalization simply to improve a judge score.
+`simulate:diff`); H4's still-pending ledger-based ranking/admission wiring, wiring
+D-PLACEMENT's now-delivered bundle-placement engine into `evaluateTrainingWithIntent`,
+and H5's still-pending H5c will require the normal review when they actually change
+decision behavior. Do not enable experimental personalization simply to improve a judge
+score.

--- a/docs/plans/cycling-primary-hybrid-implementation-handoff.md
+++ b/docs/plans/cycling-primary-hybrid-implementation-handoff.md
@@ -229,11 +229,12 @@ Useful synthetic software work can proceed without those personal answers.
 
 **Status:** Design accepted in [ADR-0036](../adr/0036-intraday-training-windows-and-reassessment.md).
 By capability (not the numbered sequence below, which tracks a different granularity --
-see the note after the numbered list): D-SCHEMA, D-LEDGER (pure module) and D-TIME are
-delivered; the same-day canonical performed-fact boundary is verified; D-WINDOW's
-athlete-schedule model is delivered (unwired). Still unstarted: wiring the ledger's
-remainder/admission semantics into actual ranking/admission decisions, D-PLACEMENT's
-bundle-placement engine and its wiring, and D-REASSESS/D-AUDIT.
+see the note after the numbered list): D-SCHEMA, D-LEDGER (pure module), D-TIME and
+D-WINDOW are delivered; the same-day canonical performed-fact boundary is verified;
+D-PLACEMENT's bundle-placement engine (`engine/intradayBundlePlacement.ts`) is delivered
+as a pure module, unwired. Still unstarted: wiring the ledger's remainder/admission
+semantics into actual ranking/admission decisions, wiring D-PLACEMENT's engine into
+`evaluateTrainingWithIntent`, and D-REASSESS/D-AUDIT.
 **Dependencies:** ADR-0035 rest support (delivered). Same-day canonical performed
 identity/revision/timing inputs are now verified (see below), D-TIME's instant resolution
 is delivered, and D-WINDOW's availability model is delivered -- the remaining dependency
@@ -311,12 +312,26 @@ its description has actually shipped.
    deliberately deferred to a future slice; only already-dated window instances are
    modeled here, which is all D-PLACEMENT needs to consume.
    Not wired into `resolveAvailability` or any decision path.
-3. Add atomic, confirmed bundle placement against all destination `ScheduleWindow`s and
-   ADR-0035 rest, using D-LEDGER's remainder/admission math and D-TIME's elapsed-instant
-   semantics for separation. Preserve completed history and support independent
-   optional-session dropping. Given the size of D-WINDOW + this bundle-placement engine +
-   wiring it into `evaluateTrainingWithIntent`, split this into separate PRs the same way
-   steps 1-2 above did rather than one large change.
+3. **Delivered as a pure module; wiring into `evaluateTrainingWithIntent` still
+   unstarted.** `engine/intradayBundlePlacement.ts` adds atomic, confirmed bundle
+   placement against all destination `ScheduleWindow`s and ADR-0035 rest, using
+   D-LEDGER's remainder/admission math (sequentially per member, so an earlier member's
+   consumption reduces what a later one can draw from the same day) and D-TIME's
+   elapsed-instant semantics for a dependent's *scheduled* separation from its
+   predecessor (not an actual performed timestamp -- that recomputation is D-REASSESS,
+   not this step). `proposeBundlePlacement` never returns a partial placement; a date
+   with no persisted `ScheduleWindow`s falls back to one synthetic whole-day slot, and
+   since at most one occurrence binds to any one slot, a bundle needing two or more
+   windows there is correctly infeasible rather than fabricating an AM/PM pair.
+   `dropOptionalBundleMember` is the athlete's explicit, non-automatic drop action and
+   preserves the "no required session depends on an optional predecessor" invariant;
+   `confirmBundlePlacement` is the sole confirmation boundary and writes nothing (no
+   persisted bundle-binding store exists yet -- that is wiring/D-AUDIT's job).
+   `intradayBundlePlacement.test.ts` covers the ADR's D-PLACEMENT-relevant deterministic
+   cases, including a real argument-order bug in the `elapsedMinutesBetweenInstants` call
+   (`start - end`, not `end - start`) that its own separation tests caught before merge.
+   Not wired into `evaluateTrainingWithIntent`; `POLICY_VERSION` unchanged;
+   `simulate:diff`/policy-drift confirm no output change.
 4. At PM launch, capture current symptoms/response, same-day work and availability, rerun
    common gates, and atomically validate the input/ledger revision before reserving.
    A morning PM approval is provisional; missing prerequisite evidence remains pending.
@@ -359,11 +374,11 @@ path yet -- `simulate:diff`/policy-drift confirm no output change.
 
 The next PRs should tackle, in order: (a) step 2's refactor (wiring the ledger into the
 existing deduction points), since every later step reads from that shared boundary, then
-(b) D-PLACEMENT's bundle-placement engine (a new module beside `externalPlacement.ts`
-consuming `ScheduleWindow`/`dailyLedger.ts`/`localInstant.ts`, still unwired), then (c)
-wiring both into `evaluateTrainingWithIntent` with a real `POLICY_VERSION` bump and full
-scenario/simulate-diff verification, then D-REASSESS/D-AUDIT. None of these need a
-separate verification pass first -- D-TIME, D-LEDGER and D-WINDOW are all delivered.
+(b) wiring D-PLACEMENT's now-delivered bundle-placement engine
+(`engine/intradayBundlePlacement.ts`) into `evaluateTrainingWithIntent` with a real
+`POLICY_VERSION` bump and full scenario/simulate-diff verification, then D-REASSESS/
+D-AUDIT. None of these need a separate verification pass first -- D-TIME, D-LEDGER,
+D-WINDOW and D-PLACEMENT's engine are all delivered.
 
 ## Work order H5 — Block intent and controlled progression
 


### PR DESCRIPTION
## Summary

Second of the 3-PR split for ADR-0036's D-PLACEMENT decision (H4) -- D-WINDOW's model
landed in [#429](https://github.com/Szczepanov/adaptive-training-recommender/pull/429).
This PR delivers **D-PLACEMENT's bundle-placement engine only**, as a pure, unwired
module, per the same pattern D-TIME/D-LEDGER/D-WINDOW each shipped.

## What this PR delivers

[`app/src/engine/intradayBundlePlacement.ts`](app/src/engine/intradayBundlePlacement.ts)
resolves one v4 intraday bundle's requested windows against real `ScheduleWindow`
availability, checks the combined minute/systemic-cost budget via `dailyLedger.ts`,
respects ADR-0035 rest and fixed commitments, and computes scheduled separation from
D-TIME's resolved instants -- an atomic confirmed-proposal API analogous to
`externalPlacement.ts`'s `proposeReplacement`/`applyConfirmedProposal`, but for whole
same-date bundles:

- **`proposeBundlePlacement`** never returns a partial placement: either every member
  gets a resolved window binding, or the whole proposal is `infeasible` with a reason.
  Admission is evaluated sequentially in `order`, so an earlier member's consumption
  correctly reduces what a later member can draw from the same day's shared ledger. A
  date with no persisted `ScheduleWindow`s falls back to one synthetic whole-day slot
  (D-WINDOW's legacy case); since at most one occurrence binds to any one slot, a bundle
  needing two-or-more windows on such a date is correctly infeasible rather than
  fabricating an AM/PM pair from missing metadata.
- **`dropOptionalBundleMember`** is the athlete's explicit, non-automatic drop action —
  it throws for a required or already-started member, and D-SCHEMA's existing "no
  required session depends on an optional predecessor" invariant means it can never
  orphan a required one.
- **`confirmBundlePlacement`** is the sole confirmation boundary, mirroring
  `applyConfirmedProposal`; it throws on an infeasible proposal rather than confirming a
  partial one, and writes nothing — no persisted bundle-binding store exists yet (that's
  wiring/D-AUDIT's job, not this PR).

A member that has already started always carries its existing binding through unchanged
and keeps its window consumed for the rest of the bundle ("once a member starts, do not
move its history").

## Investigated: interaction with PR #428 (merged the same day as D-WINDOW)

`ScheduleOverlay` now feeds `resolveAvailability`'s whole-day minute/cost ceiling. No
conflict: this engine's `ledger` input is already an opaque `DailyLedgerResult` supplied
by the caller, so whatever narrows the day's ceiling (fixed activities, `ScheduleOverlay`,
or both) is transparent to this module.

## Tests

`intradayBundlePlacement.test.ts` (22 cases) covers the ADR's D-PLACEMENT-relevant
deterministic cases: AM/PM placement into distinct windows, the legacy-date single-slot
restriction, authored rest closing every window, fixed-activity occupancy (both a
known-clock-time activity blocking only its overlapping window and an unknown-clock-time
one blocking the whole date), the 90-minute-ceiling/60-minute-AM worked example extended
to a real bundle, exhausted-systemic-cost rejection with spare minutes still available,
separation success/failure, started-member preservation, and a nonexistent Warsaw
spring-forward boundary correctly reported as unresolved.

**One test caught a real bug before merge**: `elapsedMinutesBetweenInstants(startInstant,
endInstant)` computes `start - end` (per its own doc comment), not `end - start` — my
first draft passed the predecessor's end and the dependent's start in the wrong order,
which happened to still pass the "insufficient separation" test (a negative gap is always
less than any positive requirement) but correctly failed the "sufficient separation"
test. Fixed.

## Not in scope here

- Not wired into `evaluateTrainingWithIntent` or any decision path.
- `POLICY_VERSION` unchanged; `check-policy-drift.mjs origin/main` confirms zero
  decision-affecting files touched; `simulate:diff` shows the same pre-existing,
  unrelated baseline staleness already flagged separately (tracked as its own background
  task).
- No persisted bundle-binding Firestore store (D-AUDIT / wiring PR's job).
- D-REASSESS's actual-performed-timestamp recomputation is explicitly not implemented
  here — this module's "separation" check uses *scheduled* window boundaries, since no
  session has started yet at placement time.

## Next PR (3 of 3)

Wire D-PLACEMENT's engine (and the ledger's remainder/admission math generally) into
`evaluateTrainingWithIntent`, with a real `POLICY_VERSION` bump and full
scenario/simulate-diff verification of the actual behavior change. Then D-REASSESS/
D-AUDIT.

## Verification

```
npm run typecheck   # pass
npm run lint         # pass
npx vitest run src/engine/intradayBundlePlacement.test.ts  # 22 passed
npx vitest run       # 3673 passed, 190 skipped (full suite)
npm run build        # pass
npm run test:rules   # 190 passed (Firestore emulator; no rules changes in this PR)
npm run simulate:scenarios && npm run simulate:diff   # only pre-existing, unrelated baseline drift
node scripts/check-policy-drift.mjs origin/main   # PASSED: no decision-affecting files modified
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added scheduling support for evaluating intraday bundle activities across available time windows.
  - Accounts for rest days, existing activities, dependencies, time constraints, capacity limits, and started activities.
  - Supports optional activity removal when placement is infeasible and validates proposals before confirmation.

- **Documentation**
  - Updated planning and handoff documentation to describe placement behavior and remaining runtime integration work.

- **Tests**
  - Added comprehensive coverage for placement rules, validation failures, conflicts, backtracking, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->