### PR TITLE
feat(engine): wire ADR-0036 D-PLACEMENT bundle engine into primary-session selection (H4)

### DIFF
--- a/app/firestore.rules
+++ b/app/firestore.rules
@@ -357,6 +357,14 @@ service cloud.firestore {
         && (!('droppedContributorObjectives' in audit) || (audit.droppedContributorObjectives is list && audit.droppedContributorObjectives.size() <= 64))
         && (!('primarySession' in audit) || hasValidSessionReferenceBinding(audit.primarySession))
         && (!('additionalSessions' in audit) || hasValidAdditionalSessions(audit.additionalSessions))
+        // ADR-0036 (H4) D-PLACEMENT: a v4 intraday bundle's resolved window trace was
+        // intended to persist here for display, but this whole audit is already right at
+        // Firestore's per-request rule-evaluation ceiling -- adding even a minimal
+        // 3-expression check for one more optional field (verified with the emulator
+        // suite, not a guess) pushed a create/update over "the maximum of 1000
+        // expressions to evaluate". That display field is deliberately not persisted;
+        // `activeExternalPlanService.ts`'s bundle-aware primary-session selection (the
+        // actual decision-affecting behavior) does not depend on it.
         && (!('externalPlan' in audit) || (
           audit.externalPlan is map
           && audit.externalPlan.keys().hasOnly(['planId', 'revision', 'sessionId', 'contentHash'])

--- a/app/src/components/Home.tsx
+++ b/app/src/components/Home.tsx
@@ -19,6 +19,8 @@ import { recommendationService } from '../services/recommendationService';
 import { prepareAuthoredOccurrenceLaunch, prepareCatalogSessionLaunch } from '../services/sessionAuthoringService';
 import { resolveSessionDefinition } from '../sessions/sessionDefinitionResolver';
 import { fixedActivityService } from '../services/fixedActivityService';
+import { scheduleWindowService } from '../services/scheduleWindowService';
+import { computeDailyLedger } from '../engine/dailyLedger';
 import { planBlockService } from '../services/planBlockService';
 import { decisionJournalService } from '../services/decisionJournalService';
 import { resolveEngineShadowVerdict } from '../engine/shadowAgreement';
@@ -414,7 +416,32 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
         if (activeExternalState.status === 'INVALID' || activeExternalState.status === 'UNAVAILABLE') {
           console.warn(`External plan could not be read (${activeExternalState.status}); today falls back to the ranked path.`);
         }
-        const externalContext = activeExternal ? externalPlanContextForDate(activeExternal, input.date) : null;
+
+        // ADR-0036 (H4) D-PLACEMENT: only relevant when the active plan is v4 with an
+        // intraday bundle placed today; resolveIntradayBundlePlacement returns null
+        // otherwise and externalPlanContextForDate falls back to its exact pre-D-PLACEMENT
+        // behavior. Ledger ceilings are derived from today's already-resolved availability
+        // (no persisted occurrence-level ledger entries are wired in yet -- that broader
+        // ledger-based ranking/admission unification is a separate, later H4 task).
+        const scheduleWindowsState = await scheduleWindowService.getWindowsForDateState(userId, input.date);
+        if (!isCurrent()) return;
+        if (scheduleWindowsState.status === 'INVALID' || scheduleWindowsState.status === 'UNAVAILABLE') {
+          console.warn(`Schedule windows for today could not be read (${scheduleWindowsState.status}); intraday bundle placement falls back to the legacy single-slot case.`);
+        }
+        const todaysScheduleWindows = scheduleWindowsState.status === 'AVAILABLE' ? scheduleWindowsState.data : [];
+        const earlyAvailability = resolveAvailability(input.date, subjective, planWeekActivities, context, input.scheduleOverlays);
+        const bundleLedger = computeDailyLedger(
+          {
+            dailyMinuteCeiling: earlyAvailability.maxTimeMinutes,
+            dailySystemicCostCeiling: Math.max(0, 1 - earlyAvailability.reservedCapacityCost),
+          },
+          [],
+        );
+        const externalContext = activeExternal ? externalPlanContextForDate(activeExternal, input.date, {
+          scheduleWindows: todaysScheduleWindows,
+          fixedActivities: planWeekActivities,
+          ledger: bundleLedger,
+        }) : null;
         const externalRestContext = activeExternal ? externalRestContextForDate(activeExternal, input.date) : null;
 
         const baseRecommendation = await evaluateTrainingWithIntent(

--- a/app/src/components/Home.tsx
+++ b/app/src/components/Home.tsx
@@ -437,11 +437,17 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
           },
           [],
         );
-        const externalContext = activeExternal ? externalPlanContextForDate(activeExternal, input.date, {
-          scheduleWindows: todaysScheduleWindows,
-          fixedActivities: planWeekActivities,
-          ledger: bundleLedger,
-        }) : null;
+        // An unreadable fixed-activities read must not silently become "no fixed
+        // commitments today": bundle placement would then be free to bind a window a
+        // real (but unreadable) fixed activity actually occupies. Omit bundleContext
+        // entirely in that case, falling back to the exact pre-D-PLACEMENT priority-based
+        // primary selection. An unreadable schedule-windows read is safe to keep --
+        // `resolveIntradayBundlePlacement` already treats an empty list as the
+        // intentional legacy single-slot fallback (D-WINDOW), not a data-loss signal.
+        const bundleContext = planWeekActivitiesState.status === 'AVAILABLE'
+          ? { scheduleWindows: todaysScheduleWindows, fixedActivities: planWeekActivities, ledger: bundleLedger }
+          : undefined;
+        const externalContext = activeExternal ? externalPlanContextForDate(activeExternal, input.date, bundleContext) : null;
         const externalRestContext = activeExternal ? externalRestContextForDate(activeExternal, input.date) : null;
 
         const baseRecommendation = await evaluateTrainingWithIntent(

--- a/app/src/engine/policy.ts
+++ b/app/src/engine/policy.ts
@@ -1,11 +1,12 @@
 /** Increment whenever a change can alter a persisted recommendation decision. (Refactoring does not require a bump) */
 
-export const POLICY_VERSION = '2026-09-schedule-overlays-v2';
+export const POLICY_VERSION = '2026-09-h4-intraday-bundle-placement-v1';
 
 /** Historical versions are intentionally not re-executed by this build. Their compact
  * audits remain readable evidence, but replay is rejected explicitly because the old
  * decision function is not bundled alongside the current policy. */
 export const HISTORICAL_POLICY_VERSIONS = [
+    '2026-09-schedule-overlays-v2',
     '2026-09-schedule-overlays-v1',
     '2026-09-fixed-activity-cost-dedup-v1',
     '2026-09-unlogged-physical-work-v1',

--- a/app/src/services/activeExternalPlanService.intradayBundle.test.ts
+++ b/app/src/services/activeExternalPlanService.intradayBundle.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest';
+import { resolvePlacement } from '../engine/externalPlacement';
+import { computeDailyLedger } from '../engine/dailyLedger';
+import type { ScheduleWindow, ExternalPlanHeader } from '../engine/models';
+import { EXTERNAL_PLAN_SCHEMA_V4 } from '../sessions/externalPlanV4';
+import fixture01 from '../sessions/fixtures/01-full-body-maintenance.json';
+import {
+    externalPlanContextForDate,
+    placedSessionForDate,
+    resolveIntradayBundlePlacement,
+    type ActiveExternalPlan,
+    type IntradayBundlePlacementContext,
+} from './activeExternalPlanService';
+
+const DATE = '2026-08-17'; // the plan's Monday startDate
+
+function intradaySession(overrides: Record<string, unknown> = {}) {
+    return {
+        id: 's-am', title: 'AM', priority: 'key',
+        placement: { week: 1, preferredDay: 'monday', flexibility: 'preferred', ifMissed: 'drop' },
+        gating: { modality: 'strength', intensity: 'moderate', durationMin: 45, durationMax: 55, environment: 'either', equipment: [] },
+        definition: fixture01,
+        intraday: { window: { startLocal: '06:00', endLocal: '07:00' }, bundleId: 'double-monday', order: 0 },
+        ...overrides,
+    };
+}
+
+function planV4(sessions: Record<string, unknown>[]) {
+    return {
+        schema: EXTERNAL_PLAN_SCHEMA_V4,
+        planId: 'v4-bundle-1', revision: 1, title: 'Bundle plan',
+        startDate: DATE, weekCount: 1,
+        sessions, restDays: [],
+    } as const;
+}
+
+function header(): ExternalPlanHeader {
+    return {
+        userId: 'u1', planId: 'v4-bundle-1', revision: 1, title: 'Bundle plan',
+        startDate: DATE, weekCount: 1, contentHash: 'hash-1',
+        importedAt: '2026-08-16T10:00:00Z', supersededFrom: null, updatedAt: '2026-08-16T10:00:00Z',
+    };
+}
+
+function activePlan(sessions: Record<string, unknown>[]): ActiveExternalPlan {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test fixture, matches the untyped JSON import shape validateExternalTrainingPlanV4 already accepts
+    const plan = planV4(sessions) as any;
+    return { header: header(), plan, placement: null, placed: resolvePlacement(plan, null, {}) };
+}
+
+function scheduleWindow(overrides: Partial<ScheduleWindow> = {}): ScheduleWindow {
+    return {
+        id: 'w', userId: 'u1', date: DATE, startLocal: '06:00', endLocal: '07:00',
+        revision: 1, createdAt: '2026-08-01T00:00:00.000Z', updatedAt: '2026-08-01T00:00:00.000Z',
+        ...overrides,
+    };
+}
+
+function bundleContext(overrides: Partial<IntradayBundlePlacementContext> = {}): IntradayBundlePlacementContext {
+    return {
+        scheduleWindows: [],
+        fixedActivities: [],
+        ledger: computeDailyLedger({ dailyMinuteCeiling: 200, dailySystemicCostCeiling: 1 }, []),
+        ...overrides,
+    };
+}
+
+describe('resolveIntradayBundlePlacement', () => {
+    it('returns null when no placed session for the date carries intraday', () => {
+        const active = activePlan([{
+            id: 'plain', title: 'Plain', priority: 'key',
+            placement: { week: 1, preferredDay: 'monday', flexibility: 'preferred', ifMissed: 'drop' },
+            gating: { modality: 'strength', intensity: 'moderate', durationMin: 45, durationMax: 55, environment: 'either', equipment: [] },
+            definition: fixture01,
+        }]);
+        expect(resolveIntradayBundlePlacement(active, DATE, bundleContext())).toBeNull();
+    });
+
+    it('resolves a feasible two-member bundle against real schedule windows', () => {
+        const active = activePlan([
+            intradaySession({ id: 's-am', intraday: { window: { startLocal: '06:00', endLocal: '07:00' }, bundleId: 'double-monday', order: 0 } }),
+            intradaySession({ id: 's-pm', title: 'PM', intraday: { window: { startLocal: '17:00', endLocal: '18:00' }, bundleId: 'double-monday', order: 1 } }),
+        ]);
+        const result = resolveIntradayBundlePlacement(active, DATE, bundleContext({
+            scheduleWindows: [scheduleWindow({ id: 'am', startLocal: '06:00', endLocal: '07:00' }), scheduleWindow({ id: 'pm', startLocal: '17:00', endLocal: '18:00' })],
+        }));
+        expect(result?.outcome).toBe('placed');
+        expect(result?.bindings?.map(b => b.sessionId)).toEqual(['s-am', 's-pm']);
+    });
+
+    it('reports infeasible when the date is authored rest', () => {
+        // D-SCHEMA import validation would reject an intraday session sharing a date with
+        // an authored rest directive, but resolveIntradayBundlePlacement itself must still
+        // fail closed if it ever sees that combination (e.g. an older revision's overlay),
+        // so this constructs that state directly rather than through resolvePlacement.
+        const plan = { ...planV4([intradaySession()]), restDays: [{ id: 'r1', week: 1, day: 'monday' }] };
+        const active: ActiveExternalPlan = {
+            header: header(),
+            plan: plan as unknown as ActiveExternalPlan['plan'],
+            placement: null,
+            placed: [{ session: intradaySession() as unknown as ActiveExternalPlan['placed'][number]['session'], date: DATE, status: 'planned', moved: false }],
+        };
+        const result = resolveIntradayBundlePlacement(active, DATE, bundleContext());
+        expect(result?.outcome).toBe('infeasible');
+    });
+});
+
+describe('placedSessionForDate with bundleContext', () => {
+    it('picks the bundle\'s earliest-order member as primary even when priority tie-break would pick the other', () => {
+        // s-pm has higher priority ('key') than s-am ('supporting'); pure priority
+        // tie-break would pick s-pm, but the bundle's order (s-am is order 0) must win
+        // once the bundle resolves feasibly.
+        const active = activePlan([
+            intradaySession({ id: 's-am', priority: 'supporting', intraday: { window: { startLocal: '06:00', endLocal: '07:00' }, bundleId: 'double-monday', order: 0 } }),
+            intradaySession({ id: 's-pm', title: 'PM', priority: 'key', intraday: { window: { startLocal: '17:00', endLocal: '18:00' }, bundleId: 'double-monday', order: 1 } }),
+        ]);
+        const context = bundleContext({
+            scheduleWindows: [scheduleWindow({ id: 'am', startLocal: '06:00', endLocal: '07:00' }), scheduleWindow({ id: 'pm', startLocal: '17:00', endLocal: '18:00' })],
+        });
+        expect(placedSessionForDate(active, DATE, context)?.session.id).toBe('s-am');
+        // Omitting bundleContext keeps the exact pre-D-PLACEMENT priority-based pick.
+        expect(placedSessionForDate(active, DATE)?.session.id).toBe('s-pm');
+    });
+
+    it('falls back to priority tie-break when the bundle is infeasible', () => {
+        const active = activePlan([
+            intradaySession({ id: 's-am', priority: 'supporting', intraday: { window: { startLocal: '06:00', endLocal: '07:00' }, bundleId: 'double-monday', order: 0 }, definition: { ...fixture01, duration: { min: 500, max: 500 } } }),
+            intradaySession({ id: 's-pm', title: 'PM', priority: 'key', intraday: { window: { startLocal: '17:00', endLocal: '18:00' }, bundleId: 'double-monday', order: 1 } }),
+        ]);
+        // No real windows and a 500-minute member forces the legacy single-slot bundle infeasible.
+        const context = bundleContext();
+        expect(placedSessionForDate(active, DATE, context)?.session.id).toBe('s-pm');
+    });
+});
+
+describe('externalPlanContextForDate with bundleContext', () => {
+    it('resolves to the bundle\'s earliest-order primary session when bundleContext makes the bundle feasible', () => {
+        const active = activePlan([
+            intradaySession({ id: 's-am', priority: 'supporting', intraday: { window: { startLocal: '06:00', endLocal: '07:00' }, bundleId: 'double-monday', order: 0 } }),
+            intradaySession({ id: 's-pm', title: 'PM', priority: 'key', intraday: { window: { startLocal: '17:00', endLocal: '18:00' }, bundleId: 'double-monday', order: 1 } }),
+        ]);
+        const context = bundleContext({
+            scheduleWindows: [scheduleWindow({ id: 'am', startLocal: '06:00', endLocal: '07:00' }), scheduleWindow({ id: 'pm', startLocal: '17:00', endLocal: '18:00' })],
+        });
+        expect(externalPlanContextForDate(active, DATE, context)?.session.id).toBe('s-am');
+        // Omitting bundleContext keeps the exact pre-D-PLACEMENT priority-based pick.
+        expect(externalPlanContextForDate(active, DATE)?.session.id).toBe('s-pm');
+    });
+});

--- a/app/src/services/activeExternalPlanService.intradayBundle.test.ts
+++ b/app/src/services/activeExternalPlanService.intradayBundle.test.ts
@@ -88,6 +88,65 @@ describe('resolveIntradayBundlePlacement', () => {
         expect(result?.bindings?.map(b => b.sessionId)).toEqual(['s-am', 's-pm']);
     });
 
+    it('does not merge two distinct bundle instances that land on the same date, and lets the first feasible one win', () => {
+        // An athlete's explicit per-session overlay can move any single session --
+        // including one bundle member independently of its siblings -- to an arbitrary
+        // date, so two unrelated bundle instances (different bundleId, same week) can end
+        // up with intraday-bearing sessions placed on the same date. This constructs that
+        // state directly (bypassing resolvePlacement, which would not itself produce this
+        // from one revision's authored data) to exercise the grouping boundary.
+        const groupA = [
+            intradaySession({ id: 'a1', intraday: { window: { startLocal: '06:00', endLocal: '07:00' }, bundleId: 'bundle-a', order: 0 } }),
+            intradaySession({ id: 'a2', intraday: { window: { startLocal: '17:00', endLocal: '18:00' }, bundleId: 'bundle-a', order: 1 } }),
+        ];
+        const groupB = [
+            intradaySession({ id: 'b1', intraday: { window: { startLocal: '20:00', endLocal: '21:00' }, bundleId: 'bundle-b', order: 0 } }),
+        ];
+        const active: ActiveExternalPlan = {
+            header: header(),
+            plan: planV4([...groupA, ...groupB]) as unknown as ActiveExternalPlan['plan'],
+            placement: null,
+            placed: [...groupA, ...groupB].map(session => ({
+                session: session as unknown as ActiveExternalPlan['placed'][number]['session'],
+                date: DATE, status: 'planned' as const, moved: false,
+            })),
+        };
+        const context = bundleContext({
+            scheduleWindows: [scheduleWindow({ id: 'am', startLocal: '06:00', endLocal: '07:00' }), scheduleWindow({ id: 'pm', startLocal: '17:00', endLocal: '18:00' })],
+        });
+
+        // 'bundle-a' < 'bundle-b' alphabetically and resolves feasibly against the real
+        // windows; it must win without group B's unfitting session ever being merged in.
+        const result = resolveIntradayBundlePlacement(active, DATE, context);
+        expect(result?.outcome).toBe('placed');
+        expect(result?.bindings?.map(b => b.sessionId)).toEqual(['a1', 'a2']);
+        expect(placedSessionForDate(active, DATE, context)?.session.id).toBe('a1');
+    });
+
+    it('lets a later-ordered feasible bundle instance win over an earlier infeasible one, deterministically', () => {
+        const infeasibleFirst = [
+            // 'bundle-a' sorts first but requests a window with no matching real availability.
+            intradaySession({ id: 'a1', intraday: { window: { startLocal: '20:00', endLocal: '21:00' }, bundleId: 'bundle-a', order: 0 } }),
+        ];
+        const feasibleSecond = [
+            intradaySession({ id: 'b1', intraday: { window: { startLocal: '06:00', endLocal: '07:00' }, bundleId: 'bundle-b', order: 0 } }),
+        ];
+        const active: ActiveExternalPlan = {
+            header: header(),
+            plan: planV4([...infeasibleFirst, ...feasibleSecond]) as unknown as ActiveExternalPlan['plan'],
+            placement: null,
+            placed: [...infeasibleFirst, ...feasibleSecond].map(session => ({
+                session: session as unknown as ActiveExternalPlan['placed'][number]['session'],
+                date: DATE, status: 'planned' as const, moved: false,
+            })),
+        };
+        const context = bundleContext({ scheduleWindows: [scheduleWindow({ id: 'am', startLocal: '06:00', endLocal: '07:00' })] });
+
+        const result = resolveIntradayBundlePlacement(active, DATE, context);
+        expect(result?.outcome).toBe('placed');
+        expect(result?.bindings?.map(b => b.sessionId)).toEqual(['b1']);
+    });
+
     it('reports infeasible when the date is authored rest', () => {
         // D-SCHEMA import validation would reject an intraday session sharing a date with
         // an authored rest directive, but resolveIntradayBundlePlacement itself must still

--- a/app/src/services/activeExternalPlanService.ts
+++ b/app/src/services/activeExternalPlanService.ts
@@ -5,13 +5,18 @@ import type {
     ExternalPlanHeader,
     ExternalPlanPlacement,
     FixedActivity,
+    ScheduleWindow,
 } from '../engine/models';
 import type { ExternalPlanContext, ExternalRestContext } from '../engine/rules';
+import { estimateAuthoredSessionSystemicCost } from '../engine/authoredSessionGates';
+import type { DailyLedgerResult } from '../engine/dailyLedger';
+import { proposeBundlePlacement, type BundlePlacementProposal, type IntradayBundleMember } from '../engine/intradayBundlePlacement';
 import { externalPlanService, type ExternalPlanService } from './externalPlanService';
 // M3.6: an active plan may be any supported schema version -- resolvePlacement and most
 // downstream session handling read envelope fields shared by every version. ADR-0035 adds
 // plan-level rest directives in v3, resolved separately below rather than faked as sessions.
-import type { AnyExternalTrainingPlan as ExternalTrainingPlan } from '../sessions/externalPlanV2';
+import type { AnyExternalTrainingPlan as ExternalTrainingPlan, AnyExternalPlanSession as ExternalPlanSession } from '../sessions/externalPlanV2';
+import type { ExternalIntradayPlacement, ExternalPlanSessionV4 } from '../sessions/externalPlanV4';
 
 export interface ActiveExternalPlan {
     header: ExternalPlanHeader;
@@ -39,21 +44,6 @@ export function placedSessionsForDate(active: ActiveExternalPlan, date: string):
 }
 
 /**
- * Primary session for today's singular external adjudication path. On an intentional
- * double/triple day choose the plan author's strongest priority, then session id for a
- * deterministic tie-break rather than depending on array/input order.
- */
-export function placedSessionForDate(active: ActiveExternalPlan, date: string): PlacedSession | null {
-    const sessions = placedSessionsForDate(active, date);
-    if (sessions.length === 0) return null;
-    if (sessions.length === 1) return sessions[0];
-    return [...sessions].sort((left, right) =>
-        PRIORITY_RANK[right.session.priority] - PRIORITY_RANK[left.session.priority]
-        || left.session.id.localeCompare(right.session.id),
-    )[0];
-}
-
-/**
  * Read-only plural projection of every placed session on a date. This is useful to callers
  * that need to inspect/render the full authored day. The live recommendation engine still
  * accepts one `ExternalPlanContext`; callers must not interpret this helper as evidence
@@ -68,13 +58,120 @@ export function externalPlanContextsForDate(active: ActiveExternalPlan, date: st
     }));
 }
 
+function hasIntraday(session: ExternalPlanSession): session is ExternalPlanSessionV4 & { intraday: ExternalIntradayPlacement } {
+    return 'intraday' in session && session.intraday !== undefined;
+}
+
+/**
+ * ADR-0036 (H4) D-PLACEMENT: inputs a bundle-aware caller must already have to hand --
+ * the athlete's real same-date availability windows, the fixed activities that could
+ * occupy part of the date, and the day's already-resolved shared minute/systemic-cost
+ * ledger. This module never estimates dose/duration/cost itself; it reuses the same
+ * `estimateAuthoredSessionSystemicCost`/`SessionDefinition.duration` authorities the
+ * manually-authored additional-session path already uses (ADR: "keep the current common
+ * cost/eligibility authorities").
+ */
+export interface IntradayBundlePlacementContext {
+    scheduleWindows: readonly ScheduleWindow[];
+    fixedActivities: readonly FixedActivity[];
+    ledger: DailyLedgerResult;
+}
+
+/**
+ * D-PLACEMENT: resolves the real window/order/rest/budget placement for one date's v4
+ * intraday bundle, or `null` when no session placed on that date carries `intraday`.
+ * Trusts D-SCHEMA's already-validated invariant that every intraday-bearing session
+ * placed on one authored date shares a single `bundleId` (`validateIntradayBundles`'s
+ * per-`(week, day)` scoping) rather than re-deriving it.
+ */
+export function resolveIntradayBundlePlacement(
+    active: ActiveExternalPlan,
+    date: string,
+    context: IntradayBundlePlacementContext,
+): BundlePlacementProposal | null {
+    const bundleSessions = placedSessionsForDate(active, date)
+        .filter((placed): placed is PlacedSession & { session: ExternalPlanSessionV4 & { intraday: ExternalIntradayPlacement } } => hasIntraday(placed.session));
+    if (bundleSessions.length === 0) return null;
+
+    const bundleId = bundleSessions[0].session.intraday.bundleId;
+    const members: IntradayBundleMember[] = bundleSessions.map(placed => {
+        const { intraday, definition, priority, id } = placed.session;
+        return {
+            sessionId: id,
+            order: intraday.order,
+            priority,
+            requestedWindow: intraday.window,
+            afterSessionId: intraday.afterSessionId,
+            minimumSeparationMinutes: intraday.minimumSeparationMinutes,
+            estimatedMinutes: definition.duration?.max ?? definition.duration?.min ?? 45,
+            estimatedSystemicCost: estimateAuthoredSessionSystemicCost(definition),
+            // Placement-correctness resolution only: execution status is not wired in
+            // here. Every member is evaluated as not-yet-started; reconciling against
+            // actual launch/completion is D-REASSESS, not this PR.
+            started: false,
+        };
+    });
+
+    const restDates = new Set(resolveRestDatesByDate(active.plan).keys());
+    return proposeBundlePlacement(bundleId, date, members, context.scheduleWindows, context.fixedActivities, restDates, context.ledger);
+}
+
+/**
+ * Primary session for today's singular external adjudication path. On an intentional
+ * double/triple day choose the plan author's strongest priority, then session id for a
+ * deterministic tie-break rather than depending on array/input order.
+ *
+ * When `bundleContext` is supplied and this date's sessions include a v4 intraday bundle
+ * that resolves feasibly (D-PLACEMENT), the bundle's own earliest-`order` member is the
+ * authored day's primary intent -- real window/rest/budget feasibility is now proven,
+ * not just priority-guessed. An infeasible or absent bundle falls back to the exact
+ * priority-rank tie-break this function already used before D-PLACEMENT existed.
+ */
+export function placedSessionForDate(
+    active: ActiveExternalPlan,
+    date: string,
+    bundleContext?: IntradayBundlePlacementContext,
+): PlacedSession | null {
+    const sessions = placedSessionsForDate(active, date);
+    if (sessions.length === 0) return null;
+
+    if (bundleContext) {
+        const bundlePlacement = resolveIntradayBundlePlacement(active, date, bundleContext);
+        if (bundlePlacement?.outcome === 'placed') {
+            const bundleSessions = sessions.filter((placed): placed is PlacedSession & { session: ExternalPlanSessionV4 & { intraday: ExternalIntradayPlacement } } => hasIntraday(placed.session));
+            const earliest = [...bundleSessions].sort((left, right) => left.session.intraday.order - right.session.intraday.order)[0];
+            return earliest;
+        }
+    }
+
+    if (sessions.length === 1) return sessions[0];
+    return [...sessions].sort((left, right) =>
+        PRIORITY_RANK[right.session.priority] - PRIORITY_RANK[left.session.priority]
+        || left.session.id.localeCompare(right.session.id),
+    )[0];
+}
+
 /**
  * Builds the primary adjudication input for one day, or null when nothing is placed. The
  * `contentHash` comes from the stored header rather than being recomputed here, so the
  * decision audit records the hash the import actually agreed to (ADR-0019 D-IMMUT).
+ *
+ * `bundleContext`, when supplied, activates D-PLACEMENT: the primary session is chosen
+ * bundle-order-aware rather than purely by priority (see `placedSessionForDate`).
+ * Launching this session still goes through the single-session path unchanged; a second
+ * bundle member is not independently launchable yet (no execution-binding pipeline
+ * exists for external plans at all, primary included -- building one is a separate
+ * future project). The resolved bundle placement is not persisted for display here --
+ * `hasValidRecommendationAudit`'s `externalPlan` shape is already at Firestore's
+ * per-request rule-evaluation ceiling and has no room left for it (verified with the
+ * emulator suite); see the comment there.
  */
-export function externalPlanContextForDate(active: ActiveExternalPlan, date: string): ExternalPlanContext | null {
-    const placed = placedSessionForDate(active, date);
+export function externalPlanContextForDate(
+    active: ActiveExternalPlan,
+    date: string,
+    bundleContext?: IntradayBundlePlacementContext,
+): ExternalPlanContext | null {
+    const placed = placedSessionForDate(active, date, bundleContext);
     if (!placed) return null;
     return {
         planId: active.plan.planId,

--- a/app/src/services/activeExternalPlanService.ts
+++ b/app/src/services/activeExternalPlanService.ts
@@ -77,24 +77,8 @@ export interface IntradayBundlePlacementContext {
     ledger: DailyLedgerResult;
 }
 
-/**
- * D-PLACEMENT: resolves the real window/order/rest/budget placement for one date's v4
- * intraday bundle, or `null` when no session placed on that date carries `intraday`.
- * Trusts D-SCHEMA's already-validated invariant that every intraday-bearing session
- * placed on one authored date shares a single `bundleId` (`validateIntradayBundles`'s
- * per-`(week, day)` scoping) rather than re-deriving it.
- */
-export function resolveIntradayBundlePlacement(
-    active: ActiveExternalPlan,
-    date: string,
-    context: IntradayBundlePlacementContext,
-): BundlePlacementProposal | null {
-    const bundleSessions = placedSessionsForDate(active, date)
-        .filter((placed): placed is PlacedSession & { session: ExternalPlanSessionV4 & { intraday: ExternalIntradayPlacement } } => hasIntraday(placed.session));
-    if (bundleSessions.length === 0) return null;
-
-    const bundleId = bundleSessions[0].session.intraday.bundleId;
-    const members: IntradayBundleMember[] = bundleSessions.map(placed => {
+function toMembers(bundleSessions: readonly (PlacedSession & { session: ExternalPlanSessionV4 & { intraday: ExternalIntradayPlacement } })[]): IntradayBundleMember[] {
+    return bundleSessions.map(placed => {
         const { intraday, definition, priority, id } = placed.session;
         return {
             sessionId: id,
@@ -111,9 +95,51 @@ export function resolveIntradayBundlePlacement(
             started: false,
         };
     });
+}
+
+/**
+ * D-PLACEMENT: resolves the real window/order/rest/budget placement for one date's v4
+ * intraday bundle, or `null` when no session placed on that date carries `intraday`.
+ *
+ * `bundleId` is only unique within a plan week (D-SCHEMA scopes it per `(week, bundleId)`,
+ * not per resolved date), and an athlete's explicit per-session overlay can move any
+ * single session -- including one bundle member independently of its siblings -- to an
+ * arbitrary date. So two different bundle instances (different weeks, coincidentally
+ * reusing the same descriptive `bundleId`, or one bundle's stray member relocated onto
+ * another bundle's date) can both have intraday-bearing sessions placed on the same date.
+ * This groups by `(week, bundleId)` first rather than assuming every intraday-bearing
+ * session on the date belongs to one bundle. If more than one group resolves, the first
+ * to place feasibly wins (groups ordered deterministically by key); if none place, the
+ * first group's infeasible result is reported, so the outcome never depends on object/
+ * array iteration order.
+ */
+export function resolveIntradayBundlePlacement(
+    active: ActiveExternalPlan,
+    date: string,
+    context: IntradayBundlePlacementContext,
+): BundlePlacementProposal | null {
+    const bundleSessions = placedSessionsForDate(active, date)
+        .filter((placed): placed is PlacedSession & { session: ExternalPlanSessionV4 & { intraday: ExternalIntradayPlacement } } => hasIntraday(placed.session));
+    if (bundleSessions.length === 0) return null;
+
+    const groups = new Map<string, (PlacedSession & { session: ExternalPlanSessionV4 & { intraday: ExternalIntradayPlacement } })[]>();
+    for (const placed of bundleSessions) {
+        const key = `${placed.session.placement.week}:${placed.session.intraday.bundleId}`;
+        const group = groups.get(key) ?? [];
+        group.push(placed);
+        groups.set(key, group);
+    }
 
     const restDates = new Set(resolveRestDatesByDate(active.plan).keys());
-    return proposeBundlePlacement(bundleId, date, members, context.scheduleWindows, context.fixedActivities, restDates, context.ledger);
+    let firstResult: BundlePlacementProposal | null = null;
+    for (const key of [...groups.keys()].sort()) {
+        const groupSessions = groups.get(key)!;
+        const bundleId = groupSessions[0].session.intraday.bundleId;
+        const result = proposeBundlePlacement(bundleId, date, toMembers(groupSessions), context.scheduleWindows, context.fixedActivities, restDates, context.ledger);
+        firstResult ??= result;
+        if (result.outcome === 'placed') return result;
+    }
+    return firstResult;
 }
 
 /**
@@ -137,11 +163,15 @@ export function placedSessionForDate(
 
     if (bundleContext) {
         const bundlePlacement = resolveIntradayBundlePlacement(active, date, bundleContext);
-        if (bundlePlacement?.outcome === 'placed') {
-            const bundleSessions = sessions.filter((placed): placed is PlacedSession & { session: ExternalPlanSessionV4 & { intraday: ExternalIntradayPlacement } } => hasIntraday(placed.session));
-            const earliest = [...bundleSessions].sort((left, right) => left.session.intraday.order - right.session.intraday.order)[0];
-            return earliest;
-        }
+        // `bindings` is already ordered by ascending `order` (proposeBundlePlacement maps
+        // over its sorted member list), so its first entry is the winning bundle's own
+        // earliest-order member -- derived from the one bundle instance that actually
+        // resolved, never re-derived by scanning every intraday-bearing session on the
+        // date (which could span more than one bundle instance; see
+        // `resolveIntradayBundlePlacement`'s doc comment).
+        const primaryId = bundlePlacement?.outcome === 'placed' ? bundlePlacement.bindings?.[0]?.sessionId : undefined;
+        const primary = primaryId ? sessions.find(placed => placed.session.id === primaryId) : undefined;
+        if (primary) return primary;
     }
 
     if (sessions.length === 1) return sessions[0];

--- a/docs/plans/cycling-primary-hybrid-evaluation.md
+++ b/docs/plans/cycling-primary-hybrid-evaluation.md
@@ -1,20 +1,22 @@
 # Cycling-primary hybrid evaluation and recommendation improvements
 
 **Status:** In progress — H1, H2, H2b, H3 and H3-rest (ADR-0035) all delivered; H4 design
-accepted as ADR-0036 with D-SCHEMA/D-LEDGER/D-TIME/D-WINDOW delivered and
-D-PLACEMENT's bundle-placement engine delivered as a pure module (unwired) -- the
-same-day canonical performed-fact boundary is verified and the fixed-activity
-cost-reduce duplication is unified -- (ledger-based ranking/admission and wiring
-D-PLACEMENT's engine into `evaluateTrainingWithIntent`, then D-REASSESS/D-AUDIT,
-unstarted); H5 design accepted as ADR-0037 with H5a/H5b delivered (H5c and cumulative
-`external-plan@5` unstarted)
+accepted as ADR-0036 with D-SCHEMA/D-LEDGER/D-TIME/D-WINDOW delivered, D-PLACEMENT's
+bundle-placement engine delivered as a pure module, and that engine's placement-
+correctness wired into `activeExternalPlanService.ts`'s primary-session selection for v4
+intraday bundles (real `POLICY_VERSION` bump) -- the same-day canonical performed-fact
+boundary is verified and the fixed-activity cost-reduce duplication is unified -- (broader
+ledger-based ranking/admission unification, a bundle's resolved placement surfaced for
+display/persistence, and D-REASSESS/D-AUDIT, unstarted); H5 design accepted as ADR-0037
+with H5a/H5b delivered (H5c and cumulative `external-plan@5` unstarted)
 **Blocked by:** Personal M00/M01 prescription requires current workload/restriction
-confirmation; H4's remaining wiring (using the ledger's remainder/admission math as an
-actual ranking input, then wiring D-PLACEMENT's bundle-placement engine into
-`evaluateTrainingWithIntent` with a real `POLICY_VERSION` bump, then D-REASSESS/D-AUDIT)
-needs its own decision-affecting PR(s); H5c needs the athlete-scoped singleton
-progression-claim transaction design, and cumulative `external-plan@5` acceptance is
-unblocked now that H4's v4 contract has landed.
+confirmation; H4's remaining work (unifying `planner.ts`'s three ad hoc dedup mechanisms
+onto the ledger's remainder/admission semantics as a real ranking input; persisting a
+bundle's resolved placement for display, currently blocked on `firestore.rules`' audit
+shape already sitting at Firestore's per-request rule-evaluation ceiling -- see the H4
+section below; then D-REASSESS/D-AUDIT) needs its own decision-affecting PR(s); H5c needs
+the athlete-scoped singleton progression-claim transaction design, and cumulative
+`external-plan@5` acceptance is unblocked now that H4's v4 contract has landed.
 **Unlocks:** Reproducible acceptance cases for equipment specificity, block authority and hybrid plan quality.
 
 ## Decision
@@ -255,14 +257,18 @@ also remains blocked on current-workload/restriction confirmation.
 **Status:** Design accepted in [ADR-0036](../adr/0036-intraday-training-windows-and-reassessment.md).
 **D-SCHEMA, D-LEDGER, D-TIME and D-WINDOW delivered**; **same-day canonical
 performed-fact boundary verified**; **D-PLACEMENT's bundle-placement engine delivered**
-as a pure module (unwired); runtime wiring (the `dailyLedger.ts` refactor into
-`resolveAvailability`'s existing deductions, plus wiring D-PLACEMENT's engine into
-`evaluateTrainingWithIntent`, then D-REASSESS/D-AUDIT) unstarted.
+as a pure module, and its **placement-correctness wired** into
+`activeExternalPlanService.ts`'s primary-session selection for v4 intraday bundles (real
+`POLICY_VERSION` bump -- see the "D-PLACEMENT wiring" subsection below for exactly what
+this does and does not activate). Still unstarted: the `dailyLedger.ts` refactor into
+`resolveAvailability`'s existing deductions and `planner.ts`'s three ad hoc dedup
+mechanisms, persisting a bundle's resolved placement for display, and D-REASSESS/D-AUDIT.
 **Dependencies:** ADR-0035 rest support (delivered). The `external-plan@4`/`dailyLedger.ts`
 D-SCHEMA/D-LEDGER slice itself left `POLICY_VERSION` unchanged (neither module is
-consumed by any decision path); the later fixed-activity cost-reduce dedup slice below
-did bump it, mechanically, per the drift gate's requirement -- not because decision
-behavior actually changed. No H4 slice has activated new decision behavior yet.
+consumed by any decision path); the fixed-activity cost-reduce dedup slice bumped it
+mechanically, per the drift gate's requirement, not because decision behavior actually
+changed. The D-PLACEMENT wiring slice below is the first H4 slice to activate real new
+decision behavior.
 
 Decision: explicit athlete-owned windows, plan-owned sequencing in `external-plan@4`,
 one shared daily minute/load ledger, and fresh post-AM reassessment before PM launch.
@@ -435,8 +441,64 @@ with spare minutes still available, separation success/failure (a real argument-
 in the D-TIME `elapsedMinutesBetweenInstants` call -- `start - end`, not `end - start` --
 was caught by this test before merge), started-member preservation, and a nonexistent
 Warsaw spring-forward boundary correctly reported as unresolved rather than silently
-choosing an offset. Not wired into `evaluateTrainingWithIntent` or any decision path;
-`POLICY_VERSION` unchanged; `simulate:diff`/policy-drift confirm no output change.
+choosing an offset. Not wired into `evaluateTrainingWithIntent` or any decision path at
+the time this engine landed; `POLICY_VERSION` unchanged; `simulate:diff`/policy-drift
+confirmed no output change. Its placement-correctness wiring is delivered separately,
+immediately below.
+
+### D-PLACEMENT wiring: placement-correctness only (delivered)
+
+Scope decided explicitly with the repo owner after investigation surfaced that "wire the
+bundle engine into `evaluateTrainingWithIntent`" split into two very differently-sized
+tasks. First: even v1-v3 "double days" already collapse to one visible session --
+`activeExternalPlanService.ts`'s `placedSessionForDate` picks the single highest-priority
+session when several are placed on one date, and its sibling `externalPlanContextsForDate`
+already documented "callers must not interpret this helper as evidence that secondary
+same-day sessions have been independently adjudicated or made executable." Second, and
+more fundamental: `SessionSourceRef`'s `kind: 'external_plan'` variant is declared in
+`sessions/models.ts` but was never actually constructed anywhere -- external plans have
+never been wired into the `SessionReferenceBinding` -> `sessionOccurrenceService` ->
+`executionPrescriptionService` -> launch pipeline `additionalSessions` depends on, not even
+for today's single primary external session. Making a bundle's second member independently
+*launchable* therefore means building that whole pipeline from scratch first, as its own
+multi-PR foundational project -- explicitly out of scope here.
+
+What *is* delivered: `activeExternalPlanService.ts`'s `resolveIntradayBundlePlacement`
+detects a v4 intraday bundle placed on a date, builds `IntradayBundleMember[]` from the
+plan's sessions (`estimatedMinutes`/`estimatedSystemicCost` reused from
+`authoredSessionGates.ts`'s `estimateAuthoredSessionSystemicCost`/`SessionDefinition.duration`,
+the same authorities the manually-authored additional-session path already uses), and
+calls `proposeBundlePlacement`. `placedSessionForDate` and `externalPlanContextForDate`
+each gained an optional `bundleContext` parameter (`{ scheduleWindows, fixedActivities,
+ledger }`, defaulting to omitted = the exact pre-D-PLACEMENT behavior unchanged): when
+supplied and the bundle resolves feasibly, the bundle's earliest-`order` member becomes
+the day's primary session -- real window/rest/budget feasibility now decides, not a
+priority guess -- falling back to the original priority-rank tie-break when the bundle is
+absent or infeasible. `Home.tsx` supplies `bundleContext` by fetching the date's
+`ScheduleWindow`s and deriving `ledger` from `resolveAvailability`'s already-resolved
+minute/cost ceiling via `computeDailyLedger` with no persisted occurrence-level entries
+(that broader ledger-based ranking/admission unification, `planner.ts`'s three ad hoc
+dedup mechanisms, remains separate and unstarted). Launching the selected session still
+goes through the exact unchanged single-session path.
+
+Surfacing the bundle's *resolved binding data* for display (a decisionTrace field on
+`ExternalPlanContext`/`ExternalDecisionProvenance`) was attempted and reverted: even a
+minimal 3-expression structural check for one new optional field pushed
+`hasValidRecommendationAudit`'s `externalPlan` validation over Firestore's per-request
+rule-evaluation ceiling ("the maximum of 1000 expressions to evaluate"), a real failure
+the emulator suite caught, not a hypothetical. That audit shape has no headroom left
+without a separate effort to reduce its existing evaluation cost elsewhere first, so the
+resolved bundle placement is computed and acted on but not persisted this PR.
+
+`activeExternalPlanService.intradayBundle.test.ts` covers `resolveIntradayBundlePlacement`
+(null for no intraday session, a feasible two-member resolution, an infeasible rest-date
+case) and the bundle-aware primary-session tie-break (order beats priority when feasible,
+falls back to priority when infeasible). This genuinely changes decision behavior for any
+v4 plan authoring an intraday bundle, so `POLICY_VERSION` bumped for real this time --
+`check-policy-drift.mjs` only warns (does not fail) that the changed files aren't in its
+tracked engine-file glob, since the change lives in `services/`/`components/` rather than
+`engine/`; `simulate:diff` shows no new drift because no scenario in the corpus authors a
+v4 intraday plan yet.
 
 ### Same-day canonical performed-fact boundary (verified)
 
@@ -492,11 +554,13 @@ The three different ad hoc dedup mechanisms across these sites (`seenOccurrences
 in `unrepresentedFixedActivityProjection`) are **not yet unified** onto the ledger's
 `occurrenceId`/`revision` model, and none of these call sites yet consult
 `computeDailyLedger`'s remainder or `admitsCandidate` when ranking or admitting a
-candidate. The actual next H4 tasks are (1) using the ledger's remainder/admission
-semantics as a real ranking/admission input, and (2) wiring D-PLACEMENT's now-delivered
-bundle-placement engine (`engine/intradayBundlePlacement.ts`, see above) into
-`evaluateTrainingWithIntent` with a real `POLICY_VERSION` bump -- each decision-affecting
-and scoped as its own PR, then D-REASSESS/D-AUDIT.
+candidate. D-PLACEMENT's own placement-correctness wiring is delivered (see the
+"D-PLACEMENT wiring" subsection above). The remaining H4 tasks are (1) using the ledger's
+remainder/admission semantics as a real ranking/admission input across these three sites,
+(2) building the external-plan `SessionReferenceBinding` execution-binding pipeline (a
+separate multi-PR foundational project) before a bundle's second member can be
+independently launchable, and (3) D-REASSESS/D-AUDIT -- each decision-affecting and
+scoped as its own PR.
 
 ## H5 — Explicit develop/maintain intent and progression
 
@@ -557,10 +621,12 @@ H1 did not change engine behavior and therefore required no policy bump. H2/H2b 
 decision-affecting and are represented by the current policy version above. H3's new test
 is non-decision-affecting and needs no bump; the explicit-rest follow-up will require the
 normal policy/schema/replay review when it changes decision behavior. H4's
-`fixed-activity-cost-dedup-v1` bump reflects the drift gate's mechanical requirement for
+`fixed-activity-cost-dedup-v1` bump reflected the drift gate's mechanical requirement for
 any `planner.ts`/`rules.ts` touch, not an actual behavior change (verified via
-`simulate:diff`); H4's still-pending ledger-based ranking/admission wiring, wiring
-D-PLACEMENT's now-delivered bundle-placement engine into `evaluateTrainingWithIntent`,
-and H5's still-pending H5c will require the normal review when they actually change
-decision behavior. Do not enable experimental personalization simply to improve a judge
+`simulate:diff`); `h4-intraday-bundle-placement-v1` is H4's first bump for a real behavior
+change (D-PLACEMENT's bundle-aware primary-session selection). H4's still-pending
+ledger-based ranking/admission wiring across `planner.ts`'s three dedup mechanisms, the
+external-plan execution-binding pipeline, and H5's still-pending H5c will require the
+normal review when they actually change decision behavior. Do not enable experimental
+personalization simply to improve a judge
 score.

--- a/docs/plans/cycling-primary-hybrid-evaluation.md
+++ b/docs/plans/cycling-primary-hybrid-evaluation.md
@@ -391,7 +391,7 @@ with `ScheduleWindow` -- `ScheduleOverlay` still has no clock-time concept, so i
 the *whole day's* ceiling that D-PLACEMENT's engine (below) treats as its ledger input,
 while `ScheduleWindow` is what supplies the day's individual clock-time slots.
 
-### D-PLACEMENT's bundle-placement engine (delivered, pure module -- not yet wired)
+### D-PLACEMENT's bundle-placement engine (delivered, pure module; placement-correctness wiring below)
 
 `engine/intradayBundlePlacement.ts` resolves one v4 intraday bundle's requested windows
 against real `ScheduleWindow` availability, checks the combined minute/systemic-cost

--- a/docs/plans/cycling-primary-hybrid-implementation-handoff.md
+++ b/docs/plans/cycling-primary-hybrid-implementation-handoff.md
@@ -232,13 +232,18 @@ By capability (not the numbered sequence below, which tracks a different granula
 see the note after the numbered list): D-SCHEMA, D-LEDGER (pure module), D-TIME and
 D-WINDOW are delivered; the same-day canonical performed-fact boundary is verified;
 D-PLACEMENT's bundle-placement engine (`engine/intradayBundlePlacement.ts`) is delivered
-as a pure module, unwired. Still unstarted: wiring the ledger's remainder/admission
-semantics into actual ranking/admission decisions, wiring D-PLACEMENT's engine into
-`evaluateTrainingWithIntent`, and D-REASSESS/D-AUDIT.
+and its placement-correctness is wired into `activeExternalPlanService.ts`'s
+primary-session selection (real `POLICY_VERSION` bump). Still unstarted: unifying
+`planner.ts`'s three ad hoc dedup mechanisms onto the ledger's remainder/admission
+semantics as a real ranking/admission input; building the external-plan
+`SessionReferenceBinding` execution-binding pipeline (discovered missing even for today's
+single primary session -- a separate multi-PR foundational project, required before a
+bundle's second member can be independently launchable or its placement persisted for
+display); and D-REASSESS/D-AUDIT.
 **Dependencies:** ADR-0035 rest support (delivered). Same-day canonical performed
 identity/revision/timing inputs are now verified (see below), D-TIME's instant resolution
-is delivered, and D-WINDOW's availability model is delivered -- the remaining dependency
-is simply doing the D-PLACEMENT runtime-wiring work itself.
+is delivered, D-WINDOW's availability model is delivered, and D-PLACEMENT's engine and its
+placement-correctness wiring are delivered.
 **Deliverable:** Authored intraday placement and reassessed execution, followed separately
 by automatic multi-window packing after the initial acceptance bar passes.
 
@@ -312,8 +317,8 @@ its description has actually shipped.
    deliberately deferred to a future slice; only already-dated window instances are
    modeled here, which is all D-PLACEMENT needs to consume.
    Not wired into `resolveAvailability` or any decision path.
-3. **Delivered as a pure module; wiring into `evaluateTrainingWithIntent` still
-   unstarted.** `engine/intradayBundlePlacement.ts` adds atomic, confirmed bundle
+3. **Delivered as a pure module; placement-correctness wired (see below).**
+   `engine/intradayBundlePlacement.ts` adds atomic, confirmed bundle
    placement against all destination `ScheduleWindow`s and ADR-0035 rest, using
    D-LEDGER's remainder/admission math (sequentially per member, so an earlier member's
    consumption reduces what a later one can draw from the same day) and D-TIME's
@@ -330,8 +335,46 @@ its description has actually shipped.
    `intradayBundlePlacement.test.ts` covers the ADR's D-PLACEMENT-relevant deterministic
    cases, including a real argument-order bug in the `elapsedMinutesBetweenInstants` call
    (`start - end`, not `end - start`) that its own separation tests caught before merge.
-   Not wired into `evaluateTrainingWithIntent`; `POLICY_VERSION` unchanged;
-   `simulate:diff`/policy-drift confirm no output change.
+   When it landed, this engine was not wired into `evaluateTrainingWithIntent`;
+   `POLICY_VERSION` was unchanged and `simulate:diff`/policy-drift confirmed no output
+   change. Its placement-correctness wiring landed separately (see below).
+
+   **Placement-correctness wiring: delivered.** Scoped explicitly with the repo owner
+   after investigation split "wire the bundle engine into `evaluateTrainingWithIntent`"
+   into two very differently-sized tasks: even v1-v3 "double days" already collapse to
+   one visible session today (`placedSessionForDate`'s existing priority tie-break, and
+   `externalPlanContextsForDate`'s own doc comment warning against treating plural
+   placement as evidence of independent adjudication), and -- more fundamentally --
+   `SessionSourceRef`'s `kind: 'external_plan'` variant is declared but was never actually
+   constructed anywhere; external plans have never been wired into the
+   `SessionReferenceBinding` execution-binding pipeline `additionalSessions` depends on,
+   not even for today's single primary session. Building that pipeline is therefore its
+   own separate multi-PR foundational project, out of scope here.
+
+   What's delivered instead: `activeExternalPlanService.ts`'s new
+   `resolveIntradayBundlePlacement` builds `IntradayBundleMember[]` from a date's placed
+   v4 sessions (reusing `authoredSessionGates.ts`'s `estimateAuthoredSessionSystemicCost`/
+   `SessionDefinition.duration` for cost/duration, the same authorities the manual
+   additional-session path already uses) and calls `proposeBundlePlacement`.
+   `placedSessionForDate`/`externalPlanContextForDate` each gained an optional
+   `bundleContext` parameter (omitted = exact prior behavior unchanged): when supplied and
+   the bundle resolves feasibly, the earliest-`order` member becomes primary instead of a
+   priority guess. `Home.tsx` supplies `bundleContext` from `scheduleWindowService` and a
+   `computeDailyLedger`-derived ceiling (no persisted occurrence-level entries yet -- the
+   broader ledger unification above remains separate). Launching still goes through the
+   unchanged single-session path. Surfacing the bundle's resolved binding for display was
+   attempted and reverted: even a minimal 3-expression check for one new optional
+   `decisionTrace` field pushed `hasValidRecommendationAudit`'s `externalPlan` validation
+   over Firestore's per-request rule-evaluation ceiling (verified with the emulator suite,
+   a real failure, not a hypothetical) -- that audit shape has no headroom left without a
+   separate effort to reduce its existing cost first.
+   `activeExternalPlanService.intradayBundle.test.ts` covers the new resolution function
+   and the bundle-aware primary-session tie-break. `POLICY_VERSION` bumped for real
+   (`2026-09-h4-intraday-bundle-placement-v1`) since this genuinely changes which session
+   is recommended for a v4 intraday-bundle date; `check-policy-drift.mjs` only warns
+   (non-blocking) since the changed files live in `services/`/`components/`, outside its
+   tracked `engine/` glob; `simulate:diff` shows no new drift since no scenario in the
+   corpus authors a v4 intraday plan yet.
 4. At PM launch, capture current symptoms/response, same-day work and availability, rerun
    common gates, and atomically validate the input/ledger revision before reserving.
    A morning PM approval is provisional; missing prerequisite evidence remains pending.
@@ -372,13 +415,15 @@ pinning test confirming `getPerformedTrainingFactsInRange`'s existing behavior a
 `trainingIntent.ts`'s call site are unchanged. Not called from any production/decision
 path yet -- `simulate:diff`/policy-drift confirm no output change.
 
-The next PRs should tackle, in order: (a) step 2's refactor (wiring the ledger into the
-existing deduction points), since every later step reads from that shared boundary, then
-(b) wiring D-PLACEMENT's now-delivered bundle-placement engine
-(`engine/intradayBundlePlacement.ts`) into `evaluateTrainingWithIntent` with a real
-`POLICY_VERSION` bump and full scenario/simulate-diff verification, then D-REASSESS/
-D-AUDIT. None of these need a separate verification pass first -- D-TIME, D-LEDGER,
-D-WINDOW and D-PLACEMENT's engine are all delivered.
+D-PLACEMENT's own placement-correctness wiring is delivered (see above). The next PRs
+should tackle: (a) step 2's refactor (wiring the ledger into `resolveAvailability`'s
+existing deduction points, then unifying `planner.ts`'s three ad hoc dedup mechanisms onto
+it as a real ranking/admission input), (b) the external-plan `SessionReferenceBinding`
+execution-binding pipeline (its own multi-PR foundational project -- needed before a
+bundle's second member can be independently launched, or its placement persisted for
+display once `firestore.rules`' audit shape has room), then (c) D-REASSESS/D-AUDIT. None
+of these need a separate verification pass first -- D-TIME, D-LEDGER, D-WINDOW and
+D-PLACEMENT (engine and wiring) are all delivered.
 
 ## Work order H5 — Block intent and controlled progression
 


### PR DESCRIPTION
## Summary

Third of the 3-PR H4 D-PLACEMENT split (D-WINDOW model in [#429](https://github.com/Szczepanov/adaptive-training-recommender/pull/429), bundle-placement engine in [#431](https://github.com/Szczepanov/adaptive-training-recommender/pull/431)).

## Scope, decided explicitly after investigation

"Wire the bundle engine into `evaluateTrainingWithIntent`" turned out to split into two very differently-sized tasks, confirmed with the repo owner before writing code:

1. **Even v1-v3 "double days" already collapse to one visible session today** — `activeExternalPlanService.ts`'s `placedSessionForDate` picks the single highest-priority session when several are placed on one date, and its own doc comment on `externalPlanContextsForDate` already warns "callers must not interpret this helper as evidence that secondary same-day sessions have been independently adjudicated or made executable."
2. **More fundamentally**: `SessionSourceRef`'s `kind: 'external_plan'` variant is declared in `sessions/models.ts` but is **never actually constructed anywhere** — external plans have never been wired into the `SessionReferenceBinding` → `sessionOccurrenceService` → `executionPrescriptionService` → launch pipeline `additionalSessions` depends on, not even for today's single primary external session.

Making a bundle's second member independently *launchable* therefore means building that whole execution-binding pipeline from scratch — its own multi-PR foundational project, explicitly out of scope here. This PR delivers **placement-correctness only**.

## What's delivered

- [`activeExternalPlanService.ts`](app/src/services/activeExternalPlanService.ts): new `resolveIntradayBundlePlacement` detects a v4 intraday bundle placed on a date, builds `IntradayBundleMember[]` (cost/duration reused from `authoredSessionGates.ts`'s `estimateAuthoredSessionSystemicCost`/`SessionDefinition.duration` — the same authorities the manual additional-session path already uses), and calls `proposeBundlePlacement`.
- `placedSessionForDate`/`externalPlanContextForDate` each gained an optional `bundleContext` parameter (omitted = exact prior behavior unchanged): when supplied and the bundle resolves feasibly, the earliest-`order` member becomes the day's primary session — real window/rest/budget feasibility now decides, not a priority guess. Falls back to the original tie-break when the bundle is absent or infeasible.
- [`Home.tsx`](app/src/components/Home.tsx) supplies `bundleContext` from `scheduleWindowService` and a `computeDailyLedger`-derived ceiling off `resolveAvailability`'s already-resolved budget (no persisted occurrence-level ledger entries yet — that broader ledger unification across `planner.ts`'s three ad hoc dedup mechanisms stays separate).
- `POLICY_VERSION` bumped for real (`2026-09-h4-intraday-bundle-placement-v1`) — this genuinely changes which session is recommended for a v4 intraday-bundle date.

## Attempted and reverted: persisting the bundle trace for display

I tried adding a `decisionTrace.externalPlan.intradayBundle` field so the athlete could see their PM session's resolved binding. Even a **minimal 3-expression structural check** for that one optional map pushed `hasValidRecommendationAudit`'s `externalPlan` validation over Firestore's per-request rule-evaluation ceiling — **"the maximum of 1000 expressions to evaluate"**, a real failure the emulator suite caught, not a hypothetical. That audit shape is already at capacity; making room needs a separate effort to reduce its existing evaluation cost first. Reverted cleanly; the resolved placement is computed and acted on (drives primary-session selection) but not persisted this PR.

## Tests

`activeExternalPlanService.intradayBundle.test.ts` (7 cases) covers `resolveIntradayBundlePlacement` (null for no intraday session, a feasible two-member resolution, an infeasible rest-date case) and the bundle-aware primary-session tie-break (order beats priority when feasible, falls back to priority when infeasible).

## Verification

```
npm run typecheck   # pass
npm run lint         # pass
npx vitest run       # 3683 passed, 190 skipped (full suite)
npm run build        # pass
npm run test:rules   # 190 passed (one unrelated flaky failure on first run, outcomeEvaluationRules.emulator.test.ts, confirmed by clean rerun -- not touched by this PR)
npm run simulate:scenarios && npm run simulate:diff   # no new drift; no scenario in the corpus authors a v4 intraday plan yet
node scripts/check-policy-drift.mjs origin/main   # WARNING (non-blocking): POLICY_VERSION changed but the changed files (services/, components/) aren't in the script's tracked engine/ glob -- expected, since this is a real behavior change living outside engine/
```

## Not in scope here

- Full ledger-based ranking/admission unification across `planner.ts`'s three ad hoc dedup mechanisms.
- The external-plan `SessionReferenceBinding` execution-binding pipeline (separate multi-PR project).
- Persisting the bundle's resolved placement for display (blocked on Firestore rules evaluation budget).
- D-REASSESS/D-AUDIT (separate, later ADR-0036 decisions).

Both H4 plan docs updated with a "D-PLACEMENT wiring" subsection covering what shipped, what was investigated and descoped, and why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for placing v4 intraday plan bundles across daily schedule windows.
  * The earliest successfully placed session is now selected as the primary session.
  * Availability calculations account for fixed activities, rest dates, duration, ordering, and existing ledger state.

* **Bug Fixes**
  * Preserved legacy behavior when schedule data is unavailable or bundle placement cannot be completed.
  * Improved handling of incomplete intraday metadata and multiple bundles on the same date.

* **Documentation**
  * Updated planning and implementation documentation to reflect current placement behavior and remaining limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->