### PR TITLE
test(engine): mock schedule overlay service in decision composer tests

### DIFF
--- a/app/src/engine/composer.test.ts
+++ b/app/src/engine/composer.test.ts
@@ -9,6 +9,7 @@ const services = vi.hoisted(() => ({
     settings: { getTrainingSettingsState: vi.fn() },
     preferences: { getPreferencesState: vi.fn() },
     intentProfile: { getProfileState: vi.fn() },
+    overlays: { getOverlaysInRangeState: vi.fn() },
 }));
 vi.mock('../services/recoverySnapshotService', () => ({ recoverySnapshotService: services.recovery }));
 vi.mock('../services/checkinService', () => ({ checkinService: services.checkin }));
@@ -16,6 +17,7 @@ vi.mock('../services/goalService', () => ({ goalService: services.goals }));
 vi.mock('../services/trainingSettingsService', () => ({ trainingSettingsService: services.settings }));
 vi.mock('../services/preferencesService', () => ({ preferencesService: services.preferences }));
 vi.mock('../services/trainingIntentProfileService', () => ({ trainingIntentProfileService: services.intentProfile }));
+vi.mock('../services/scheduleOverlayService', () => ({ scheduleOverlayService: services.overlays }));
 
 import { DecisionComposer } from './composer';
 
@@ -54,6 +56,7 @@ describe('DecisionComposer training intent profile source', () => {
         services.goals.getActiveGoalsState.mockResolvedValue({ status: 'AVAILABLE', data: [], revision: null });
         services.settings.getTrainingSettingsState.mockResolvedValue({ status: 'AVAILABLE', data: settings, revision: null });
         services.preferences.getPreferencesState.mockResolvedValue({ status: 'MISSING' });
+        services.overlays.getOverlaysInRangeState.mockResolvedValue({ status: 'AVAILABLE', data: [], revision: null });
     });
 
     it('preserves a missing profile as a supported compatibility input', async () => {
@@ -86,6 +89,7 @@ describe('DecisionComposer Phase 9.4 subjective baseline boundary', () => {
         services.settings.getTrainingSettingsState.mockResolvedValue({ status: 'AVAILABLE', data: settings, revision: null });
         services.preferences.getPreferencesState.mockResolvedValue({ status: 'MISSING' });
         services.intentProfile.getProfileState.mockResolvedValue({ status: 'MISSING' });
+        services.overlays.getOverlaysInRangeState.mockResolvedValue({ status: 'AVAILABLE', data: [], revision: null });
     });
 
     it('performs exactly one bounded history read ending at the decision date exclusively and computes a mature baseline', async () => {
@@ -137,5 +141,64 @@ describe('DecisionComposer Phase 9.4 subjective baseline boundary', () => {
         });
         const input = await new DecisionComposer().composeDailyDecisionInput('u1', date);
         expect(input.subjectiveBaseline).toBeNull();
+    });
+});
+
+describe('DecisionComposer schedule overlays source', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        services.recovery.getRecoverySnapshotState.mockResolvedValue({ status: 'MISSING' });
+        services.checkin.getCheckinState.mockResolvedValue({ status: 'MISSING' });
+        services.checkin.getCheckinsInRangeState.mockResolvedValue({ status: 'MISSING' });
+        services.goals.getActiveGoalsState.mockResolvedValue({ status: 'AVAILABLE', data: [], revision: null });
+        services.settings.getTrainingSettingsState.mockResolvedValue({ status: 'AVAILABLE', data: settings, revision: null });
+        services.preferences.getPreferencesState.mockResolvedValue({ status: 'MISSING' });
+        services.intentProfile.getProfileState.mockResolvedValue({ status: 'MISSING' });
+    });
+
+    it('carries available schedule overlays and summarized source state into composed input', async () => {
+        const overlay = {
+            id: 'ov-1',
+            userId: 'u1',
+            category: 'active_sport' as const,
+            sport: 'skiing' as const,
+            startDate: '2026-08-10',
+            endDate: '2026-08-12',
+            expectedCost: 'high' as const,
+            dailyAvailabilityMinutes: 0,
+            allowAlternativeWorkouts: false,
+            createdAt: '2026-08-01T00:00:00Z',
+            updatedAt: '2026-08-01T00:00:00Z',
+        };
+        services.overlays.getOverlaysInRangeState.mockResolvedValue({
+            status: 'AVAILABLE',
+            data: [overlay],
+            revision: 'ov-r1',
+        });
+
+        const input = await new DecisionComposer().composeDailyDecisionInput('u1', '2026-08-10');
+        expect(input.scheduleOverlays).toEqual([overlay]);
+        expect(input.sourceStates?.scheduleOverlays).toEqual({ status: 'AVAILABLE', revision: 'ov-r1' });
+    });
+
+    it('throws when schedule overlays are unavailable', async () => {
+        services.overlays.getOverlaysInRangeState.mockResolvedValue({
+            status: 'UNAVAILABLE',
+            operation: 'read schedule overlays',
+            retryable: true,
+        });
+
+        await expect(new DecisionComposer().composeDailyDecisionInput('u1', '2026-08-10'))
+            .rejects.toThrow('Schedule overlays are temporarily unavailable. Please retry.');
+    });
+
+    it('throws when schedule overlays are invalid', async () => {
+        services.overlays.getOverlaysInRangeState.mockResolvedValue({
+            status: 'INVALID',
+            issues: [{ code: 'schema-validation-failed', documentPath: 'users/u1/schedule_overlays/bad' }],
+        });
+
+        await expect(new DecisionComposer().composeDailyDecisionInput('u1', '2026-08-10'))
+            .rejects.toThrow('Schedule overlays are invalid. Please review or remove the affected schedule block.');
     });
 });

--- a/app/src/engine/composer.test.ts
+++ b/app/src/engine/composer.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { addDaysToLocalDateString } from '../utils/localDate';
-import type { DailySubjectiveCheckin } from './models';
+import type { DailySubjectiveCheckin, ScheduleOverlay } from './models';
 
 const services = vi.hoisted(() => ({
     recovery: { getRecoverySnapshotState: vi.fn() },
@@ -157,16 +157,25 @@ describe('DecisionComposer schedule overlays source', () => {
     });
 
     it('carries available schedule overlays and summarized source state into composed input', async () => {
-        const overlay = {
+        const overlay: ScheduleOverlay = {
             id: 'ov-1',
             userId: 'u1',
-            category: 'active_sport' as const,
-            sport: 'skiing' as const,
+            title: 'Ski trip',
+            category: 'active_sport',
+            sport: 'skiing',
             startDate: '2026-08-10',
             endDate: '2026-08-12',
-            expectedCost: 'high' as const,
+            expectedCost: {
+                systemic: 0.8,
+                cardiovascular: 0.8,
+                lowerBody: 0.6,
+                upperBody: 0.0,
+                impactTissue: 0.4,
+                neuromuscular: 0.5,
+            },
             dailyAvailabilityMinutes: 0,
-            allowAlternativeWorkouts: false,
+            volumeScale: 0.5,
+            intensityScale: 0.5,
             createdAt: '2026-08-01T00:00:00Z',
             updatedAt: '2026-08-01T00:00:00Z',
         };


### PR DESCRIPTION
﻿## Summary
Fixes the frontend deployment build failure in CI/CD run [34031746116](https://github.com/Szczepanov/adaptive-training-recommender/actions/runs/34031746116) (`Deploy Production E2E`).

### Problem & Root Cause
In PR #428, `DecisionComposer.composeDailyDecisionInput` was updated to fetch athlete schedule overlays via `scheduleOverlayService.getOverlaysInRangeState(...)`. If the overlay read returns `UNAVAILABLE` or `INVALID`, the composer deliberately fails closed by throwing an error (`Schedule overlays are temporarily unavailable. Please retry.`).

However, `app/src/engine/composer.test.ts` was not updated to mock `scheduleOverlayService`, unlike all other injected data services (`recoverySnapshotService`, `checkinService`, `goalService`, `trainingSettingsService`, `preferencesService`, `trainingIntentProfileService`).

When executing tests in an environment where Firebase configuration is present (such as during the production deploy workflow's `npm run build`), `scheduleOverlayService` attempted live unauthenticated reads against Firestore, which returned `{ status: 'UNAVAILABLE' }` and threw an unhandled error across all 6 test cases in `composer.test.ts`.

### Changes
1. **Mock `scheduleOverlayService`**: Added `scheduleOverlayService` to `vi.hoisted` mocks and registered `vi.mock('../services/scheduleOverlayService', ...)` in `app/src/engine/composer.test.ts`.
2. **Default mock behavior**: Configured default response `{ status: 'AVAILABLE', data: [], revision: null }` in `beforeEach` fixtures so existing tests run cleanly without live network dependencies.
3. **Explicit test coverage**: Added a dedicated `describe('DecisionComposer schedule overlays source')` test suite to verify:
   - Available schedule overlays and their summarized source state are properly passed into the composed input.
   - Composer throws the expected error when schedule overlays are `UNAVAILABLE`.
   - Composer throws the expected error when schedule overlays are `INVALID`.

### Verification
- `npm test -- src/engine/composer.test.ts` passed (9/9 tests).
- `npm run check` passed (394 passed test files, 3,870 tests, typecheck, lint, knowledge validation, workout validation).
- `npm run build` completed successfully.
- `uv run pytest` passed (782 backend tests).
- `uv run ruff check .` and `uv run mypy src/garmin_sync` passed with 0 issues.
- `node scripts/check-policy-drift.mjs HEAD^` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for schedule overlays included in composed input when available.
  * Added validation for unavailable or invalid overlay states and their corresponding errors.
  * Added checks that overlay information is represented with the expected summarized source state.
  * Updated test scenarios to use valid overlay and workout cost data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->