### PR TITLE
feat(sessions): implement external-plan execution-binding pipeline (PR 1)

### DIFF
--- a/app/src/components/Home.tsx
+++ b/app/src/components/Home.tsx
@@ -17,7 +17,7 @@ import type { SessionReferenceBinding } from '../sessions/models';
 import type { DataState } from '../engine/dataState';
 import { recommendationService } from '../services/recommendationService';
 import { prepareAuthoredOccurrenceLaunch, prepareCatalogSessionLaunch, prepareExternalPlanSessionLaunch } from '../services/sessionAuthoringService';
-import type { ExternalPlanSessionV4 } from '../sessions/externalPlanV4';
+import { isV4Plan, type ExternalPlanSessionV4 } from '../sessions/externalPlanV4';
 import { resolveSessionDefinition } from '../sessions/sessionDefinitionResolver';
 import { fixedActivityService } from '../services/fixedActivityService';
 import { scheduleWindowService } from '../services/scheduleWindowService';
@@ -474,7 +474,9 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
             console.warn('Failed to prepare the catalog session binding for today\'s recommendation:', err);
           }
         } else if (
-          (recommendationWithPrescription.externalVerdict?.decision === 'proceed' || recommendationWithPrescription.externalVerdict?.decision === 'scale') &&
+          activeExternal &&
+          isV4Plan(activeExternal.plan) &&
+          recommendationWithPrescription.externalVerdict?.decision === 'proceed' &&
           recommendationWithPrescription.template.id !== 'rest_01' &&
           externalContext &&
           'definition' in externalContext.session
@@ -488,7 +490,6 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
                 contentHash: externalContext.contentHash,
                 session: externalContext.session as ExternalPlanSessionV4,
               },
-              recommendationWithPrescription.externalVerdict.scaledSummary,
             );
             if (!isCurrent()) return;
             primarySession = launch.binding;

--- a/app/src/components/Home.tsx
+++ b/app/src/components/Home.tsx
@@ -16,7 +16,8 @@ import type { AuthoredPlanBlock, BodyRegion, DailyDecisionInput, Recommendation,
 import type { SessionReferenceBinding } from '../sessions/models';
 import type { DataState } from '../engine/dataState';
 import { recommendationService } from '../services/recommendationService';
-import { prepareAuthoredOccurrenceLaunch, prepareCatalogSessionLaunch } from '../services/sessionAuthoringService';
+import { prepareAuthoredOccurrenceLaunch, prepareCatalogSessionLaunch, prepareExternalPlanSessionLaunch } from '../services/sessionAuthoringService';
+import type { ExternalPlanSessionV4 } from '../sessions/externalPlanV4';
 import { resolveSessionDefinition } from '../sessions/sessionDefinitionResolver';
 import { fixedActivityService } from '../services/fixedActivityService';
 import { scheduleWindowService } from '../services/scheduleWindowService';
@@ -471,6 +472,28 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
             primarySession = launch.binding;
           } catch (err) {
             console.warn('Failed to prepare the catalog session binding for today\'s recommendation:', err);
+          }
+        } else if (
+          (recommendationWithPrescription.externalVerdict?.decision === 'proceed' || recommendationWithPrescription.externalVerdict?.decision === 'scale') &&
+          recommendationWithPrescription.template.id !== 'rest_01' &&
+          externalContext &&
+          'definition' in externalContext.session
+        ) {
+          try {
+            const launch = await prepareExternalPlanSessionLaunch(
+              userId,
+              {
+                planId: externalContext.planId,
+                revision: externalContext.revision,
+                contentHash: externalContext.contentHash,
+                session: externalContext.session as ExternalPlanSessionV4,
+              },
+              recommendationWithPrescription.externalVerdict.scaledSummary,
+            );
+            if (!isCurrent()) return;
+            primarySession = launch.binding;
+          } catch (err) {
+            console.warn('Failed to prepare the external-plan session binding for today\'s recommendation:', err);
           }
         }
 

--- a/app/src/services/executionPrescriptionService.test.ts
+++ b/app/src/services/executionPrescriptionService.test.ts
@@ -1,0 +1,249 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ExecutionPrescription } from '../sessions/models';
+import { hashExecutionPrescription } from '../sessions/sessionDefinitionHash';
+
+const { docStore, mockDoc, mockGetDoc, mockRunTransaction, state } = vi.hoisted(() => {
+    const docStore = new Map<string, Record<string, unknown>>();
+    const state = { versionCounter: 0 };
+
+    function pathOf(segments: unknown[]): string {
+        return segments.filter(segment => typeof segment === 'string').join('/');
+    }
+
+    const mockDoc = vi.fn((...args: unknown[]) => ({ path: pathOf(args) }));
+    const mockGetDoc = vi.fn(async (ref: { path: string }) => {
+        const data = docStore.get(ref.path);
+        return { exists: () => data !== undefined, data: () => data };
+    });
+
+    const mockRunTransaction = vi.fn(async (_db: unknown, fn: (tx: unknown) => Promise<unknown>) => {
+        // Simulate Firestore retry on contention
+        for (let attempt = 0; attempt < 5; attempt++) {
+            const readVersion = state.versionCounter;
+            const tx = {
+                get: vi.fn(async (ref: { path: string }) => {
+                    const data = docStore.get(ref.path);
+                    return { exists: () => data !== undefined, data: () => data };
+                }),
+                set: vi.fn((ref: { path: string }, data: Record<string, unknown>) => {
+                    if (state.versionCounter !== readVersion) {
+                        throw new Error('TRANSACTION_CONTENTION');
+                    }
+                    state.versionCounter++;
+                    docStore.set(ref.path, data);
+                }),
+            };
+
+            try {
+                return await fn(tx);
+            } catch (err: unknown) {
+                if ((err as Error).message === 'TRANSACTION_CONTENTION') {
+                    continue;
+                }
+                throw err;
+            }
+        }
+        throw new Error('Transaction retry limit exceeded');
+    });
+
+    return { docStore, mockDoc, mockGetDoc, mockRunTransaction, state };
+});
+
+vi.mock('firebase/firestore', () => ({
+    doc: mockDoc,
+    getDoc: mockGetDoc,
+    runTransaction: mockRunTransaction,
+}));
+vi.mock('../firebase', () => ({ getDb: vi.fn(() => ({})) }));
+
+import { ExecutionPrescriptionService } from './executionPrescriptionService';
+
+function makeBasePrescription(): Omit<ExecutionPrescription, 'prescriptionHash'> {
+    return {
+        schemaVersion: 1,
+        sessionSource: {
+            kind: 'external_plan',
+            planId: 'plan-test',
+            revision: 1,
+            sessionId: 'session-abc',
+            contentHash: 'a'.repeat(64),
+        },
+        definitionHash: 'b'.repeat(64),
+        blocks: [{
+            id: 'block-1',
+            role: 'main',
+            executionMode: 'sequential',
+            steps: [{
+                id: 'step-1',
+                kind: 'exercise',
+                title: 'Bench Press',
+                exerciseRef: { kind: 'catalog', exerciseId: 'bench-press' },
+                dose: { kind: 'repetition', sets: 3, reps: 10 },
+            }],
+        }],
+        displayMetadata: {
+            title: 'Upper Body Strength',
+            intent: 'training',
+            dominantModality: 'strength',
+        },
+        createdAt: '2026-09-06T10:00:00.000Z',
+    };
+}
+
+describe('ExecutionPrescriptionService', () => {
+    let service: ExecutionPrescriptionService;
+
+    beforeEach(() => {
+        docStore.clear();
+        state.versionCounter = 0;
+        vi.clearAllMocks();
+        service = new ExecutionPrescriptionService({} as never);
+    });
+
+    describe('savePrescription (atomic transaction)', () => {
+        it('saves a valid prescription inside a transaction', async () => {
+            const raw = makeBasePrescription();
+            const prescriptionHash = await hashExecutionPrescription({ ...raw, prescriptionHash: '' });
+            const prescription: ExecutionPrescription = { ...raw, prescriptionHash };
+
+            await service.savePrescription('u1', prescription);
+
+            expect(mockRunTransaction).toHaveBeenCalledOnce();
+            const stored = docStore.get('users/u1/execution_prescriptions/' + prescriptionHash);
+            expect(stored).toBeDefined();
+            expect(stored?.userId).toBe('u1');
+            expect(stored?.prescriptionHash).toBe(prescriptionHash);
+            expect(stored?.createdAt).toBe('2026-09-06T10:00:00.000Z');
+        });
+
+        it('rejects prescription if claimed prescriptionHash does not match computed hash', async () => {
+            const raw = makeBasePrescription();
+            const prescription: ExecutionPrescription = { ...raw, prescriptionHash: 'invalid_hash_value' };
+
+            await expect(service.savePrescription('u1', prescription)).rejects.toThrow(/Prescription hash mismatch/);
+            expect(mockRunTransaction).not.toHaveBeenCalled();
+        });
+
+        it('is idempotent and preserves existing record if identical content is already stored', async () => {
+            const raw = makeBasePrescription();
+            const prescriptionHash = await hashExecutionPrescription({ ...raw, prescriptionHash: '' });
+            const firstPrescription: ExecutionPrescription = { ...raw, prescriptionHash, createdAt: '2026-09-06T10:00:00.000Z' };
+            const secondPrescription: ExecutionPrescription = { ...raw, prescriptionHash, createdAt: '2026-09-06T11:00:00.000Z' };
+
+            await service.savePrescription('u1', firstPrescription);
+            await service.savePrescription('u1', secondPrescription);
+
+            const stored = docStore.get('users/u1/execution_prescriptions/' + prescriptionHash);
+            // Write-once semantics: first createdAt is preserved
+            expect(stored?.createdAt).toBe('2026-09-06T10:00:00.000Z');
+        });
+
+        it('preserves the earliest write when concurrent calls share the same prescriptionHash with different timestamps', async () => {
+            const raw = makeBasePrescription();
+            const prescriptionHash = await hashExecutionPrescription({ ...raw, prescriptionHash: '' });
+            const earliestTime = '2026-09-06T08:00:00.000Z';
+            const laterTime = '2026-09-06T08:00:05.000Z';
+
+            const firstPrescription: ExecutionPrescription = {
+                ...raw,
+                prescriptionHash,
+                createdAt: earliestTime,
+            };
+            const secondPrescription: ExecutionPrescription = {
+                ...raw,
+                prescriptionHash,
+                createdAt: laterTime,
+            };
+
+            // Simulate concurrent invocation
+            await Promise.all([
+                service.savePrescription('u1', firstPrescription),
+                service.savePrescription('u1', secondPrescription),
+            ]);
+
+            const stored = docStore.get('users/u1/execution_prescriptions/' + prescriptionHash);
+            expect(stored).toBeDefined();
+            // Earliest write remains stored
+            expect(stored?.createdAt).toBe(earliestTime);
+        });
+
+        it('preserves earliest write even when concurrent transactions experience contention and retry', async () => {
+            const raw = makeBasePrescription();
+            const prescriptionHash = await hashExecutionPrescription({ ...raw, prescriptionHash: '' });
+            const earliestTime = '2026-09-06T09:00:00.000Z';
+            const laterTime = '2026-09-06T09:00:10.000Z';
+
+            const earlyPrescription: ExecutionPrescription = {
+                ...raw,
+                prescriptionHash,
+                createdAt: earliestTime,
+            };
+            const latePrescription: ExecutionPrescription = {
+                ...raw,
+                prescriptionHash,
+                createdAt: laterTime,
+            };
+
+            const p1 = service.savePrescription('u1', earlyPrescription);
+            const p2 = (async () => {
+                await new Promise(r => setTimeout(r, 2));
+                return service.savePrescription('u1', latePrescription);
+            })();
+
+            await Promise.all([p1, p2]);
+
+            const stored = docStore.get('users/u1/execution_prescriptions/' + prescriptionHash);
+            expect(stored?.createdAt).toBe(earliestTime);
+        });
+
+        it('throws an error if existing document has corrupted hash', async () => {
+            const raw = makeBasePrescription();
+            const prescriptionHash = await hashExecutionPrescription({ ...raw, prescriptionHash: '' });
+            const validPrescription: ExecutionPrescription = { ...raw, prescriptionHash };
+
+            // Store corrupted record with same prescriptionHash key but altered definitionHash
+            docStore.set('users/u1/execution_prescriptions/' + prescriptionHash, {
+                ...validPrescription,
+                definitionHash: 'corrupted_hash'.padEnd(64, '0'),
+            });
+
+            await expect(service.savePrescription('u1', validPrescription)).rejects.toThrow(
+                /does not match its content hash/,
+            );
+        });
+    });
+
+    describe('getPrescription', () => {
+        it('returns MISSING when document does not exist', async () => {
+            const result = await service.getPrescription('u1', 'nonexistent_hash');
+            expect(result).toEqual({ status: 'MISSING' });
+        });
+
+        it('returns AVAILABLE when document exists and has valid shape and hash', async () => {
+            const raw = makeBasePrescription();
+            const prescriptionHash = await hashExecutionPrescription({ ...raw, prescriptionHash: '' });
+            const prescription: ExecutionPrescription = { ...raw, prescriptionHash };
+
+            docStore.set('users/u1/execution_prescriptions/' + prescriptionHash, prescription as unknown as Record<string, unknown>);
+
+            const result = await service.getPrescription('u1', prescriptionHash);
+            expect(result.status).toBe('AVAILABLE');
+            if (result.status === 'AVAILABLE') {
+                expect(result.data.prescriptionHash).toBe(prescriptionHash);
+                expect(result.revision).toBeNull();
+            }
+        });
+
+        it('returns INVALID when document fails shape validation or hash verification', async () => {
+            const raw = makeBasePrescription();
+            const prescriptionHash = await hashExecutionPrescription({ ...raw, prescriptionHash: '' });
+            docStore.set('users/u1/execution_prescriptions/' + prescriptionHash, {
+                schemaVersion: 999,
+                prescriptionHash,
+            });
+
+            const result = await service.getPrescription('u1', prescriptionHash);
+            expect(result.status).toBe('INVALID');
+        });
+    });
+});

--- a/app/src/services/executionPrescriptionService.test.ts
+++ b/app/src/services/executionPrescriptionService.test.ts
@@ -138,7 +138,7 @@ describe('ExecutionPrescriptionService', () => {
             expect(stored?.createdAt).toBe('2026-09-06T10:00:00.000Z');
         });
 
-        it('preserves the earliest write when concurrent calls share the same prescriptionHash with different timestamps', async () => {
+        it('preserves the first committed write when concurrent calls share the same prescriptionHash with different timestamps', async () => {
             const raw = makeBasePrescription();
             const prescriptionHash = await hashExecutionPrescription({ ...raw, prescriptionHash: '' });
             const earliestTime = '2026-09-06T08:00:00.000Z';
@@ -163,11 +163,11 @@ describe('ExecutionPrescriptionService', () => {
 
             const stored = docStore.get('users/u1/execution_prescriptions/' + prescriptionHash);
             expect(stored).toBeDefined();
-            // Earliest write remains stored
+            // First-commit write remains stored
             expect(stored?.createdAt).toBe(earliestTime);
         });
 
-        it('preserves earliest write even when concurrent transactions experience contention and retry', async () => {
+        it('preserves first committed write even when concurrent transactions experience contention and retry', async () => {
             const raw = makeBasePrescription();
             const prescriptionHash = await hashExecutionPrescription({ ...raw, prescriptionHash: '' });
             const earliestTime = '2026-09-06T09:00:00.000Z';
@@ -194,6 +194,34 @@ describe('ExecutionPrescriptionService', () => {
 
             const stored = docStore.get('users/u1/execution_prescriptions/' + prescriptionHash);
             expect(stored?.createdAt).toBe(earliestTime);
+        });
+
+        it('enforces first-commit immutability: arrival with earlier timestamp does not overwrite committed record', async () => {
+            const raw = makeBasePrescription();
+            const prescriptionHash = await hashExecutionPrescription({ ...raw, prescriptionHash: '' });
+            const committedTime = '2026-09-06T12:00:00.000Z';
+            const earlierTime = '2026-09-06T10:00:00.000Z';
+
+            const firstPrescription: ExecutionPrescription = {
+                ...raw,
+                prescriptionHash,
+                createdAt: committedTime,
+            };
+            const secondPrescription: ExecutionPrescription = {
+                ...raw,
+                prescriptionHash,
+                createdAt: earlierTime,
+            };
+
+            // First write commits
+            await service.savePrescription('u1', firstPrescription);
+
+            // Second write with earlier timestamp arrives
+            await service.savePrescription('u1', secondPrescription);
+
+            const stored = docStore.get('users/u1/execution_prescriptions/' + prescriptionHash);
+            // Write-once first-commit semantics: the committed record is not updated or overwritten
+            expect(stored?.createdAt).toBe(committedTime);
         });
 
         it('throws an error if existing document has corrupted hash', async () => {

--- a/app/src/services/executionPrescriptionService.ts
+++ b/app/src/services/executionPrescriptionService.ts
@@ -1,7 +1,7 @@
 import {
     doc,
     getDoc,
-    setDoc,
+    runTransaction,
     type Firestore,
 } from 'firebase/firestore';
 import { getDb } from '../firebase';
@@ -52,19 +52,21 @@ export class ExecutionPrescriptionService {
         }
 
         const ref = this.prescriptionRef(userId, prescription.prescriptionHash);
-        const existing = await getDoc(ref);
-        if (existing.exists()) {
-            const persisted = existing.data() as ExecutionPrescription;
-            const persistedHash = await hashExecutionPrescription(persisted);
-            if (persistedHash !== prescription.prescriptionHash) {
-                throw new Error(`Stored prescription ${prescription.prescriptionHash} does not match its content hash`);
+        await runTransaction(this.db, async transaction => {
+            const existing = await transaction.get(ref);
+            if (existing.exists()) {
+                const persisted = existing.data() as ExecutionPrescription;
+                const persistedHash = await hashExecutionPrescription(persisted);
+                if (persistedHash !== prescription.prescriptionHash) {
+                    throw new Error(`Stored prescription ${prescription.prescriptionHash} does not match its content hash`);
+                }
+                return;
             }
-            return;
-        }
 
-        await setDoc(ref, {
-            ...prescription,
-            userId,
+            transaction.set(ref, {
+                ...prescription,
+                userId,
+            });
         });
     }
 

--- a/app/src/services/executionPrescriptionService.ts
+++ b/app/src/services/executionPrescriptionService.ts
@@ -45,6 +45,15 @@ export class ExecutionPrescriptionService {
         return doc(this.db, 'users', userId, 'execution_prescriptions', prescriptionHash);
     }
 
+    /**
+     * Persists an execution prescription using write-once, first-commit semantics (ADR-0023).
+     *
+     * Execution prescriptions are immutable and content-addressed; Firestore security rules
+     * strictly forbid updates (`allow update, delete: if false`). If a record with the same
+     * `prescriptionHash` has already been committed, the transaction validates that the stored
+     * content hash matches and exits without modifying the existing document, preserving the
+     * first committed write (including its `createdAt` timestamp).
+     */
     async savePrescription(userId: string, prescription: ExecutionPrescription): Promise<void> {
         const computedHash = await hashExecutionPrescription(prescription);
         if (prescription.prescriptionHash !== computedHash) {

--- a/app/src/services/sessionAuthoringService.test.ts
+++ b/app/src/services/sessionAuthoringService.test.ts
@@ -190,18 +190,18 @@ describe('prepareExternalPlanSessionLaunch (ADR-0036 H4)', () => {
         expect(savedPrescription.createdAt).toBe('2026-09-06T12:00:00.000Z');
     });
 
-    it('respects summaryOverride when provided (e.g. from scale verdict)', async () => {
+    it('applies a summary override before hashing and persistence', async () => {
         const externalPlan = makeV4ExternalPlan();
         const launch = await prepareExternalPlanSessionLaunch(
             'u1',
             externalPlan,
-            'Scaled: 3x3min intervals (volume reduced due to readiness)',
+            'Alternative execution summary',
         );
 
         expect(launch.binding.prescriptionHash).toMatch(/^[0-9a-f]{64}$/);
         const lastSave = services.prescription.savePrescription.mock.calls.at(-1);
         const savedPrescription = lastSave![1];
-        expect(savedPrescription.displayMetadata?.summary).toBe('Scaled: 3x3min intervals (volume reduced due to readiness)');
+        expect(savedPrescription.displayMetadata?.summary).toBe('Alternative execution summary');
     });
 
     it('is idempotent: preparing the same external plan session twice produces the same hash and preserves write-once persistence', async () => {
@@ -221,6 +221,15 @@ describe('prepareExternalPlanSessionLaunch (ADR-0036 H4)', () => {
         const first = await prepareExternalPlanSessionLaunch('u1', externalPlan, undefined, '2026-01-01T00:00:00.000Z');
         const second = await prepareExternalPlanSessionLaunch('u1', externalPlan, undefined, '2026-12-31T23:59:59.999Z');
         expect(second.binding.prescriptionHash).toBe(first.binding.prescriptionHash);
+    });
+
+    it('rejects target-event sessions because they are advisory fixed-activity inputs', async () => {
+        const externalPlan = makeV4ExternalPlan();
+        externalPlan.session.isEvent = true;
+
+        await expect(prepareExternalPlanSessionLaunch('u1', externalPlan)).rejects.toThrow(/target events are advisory/i);
+        expect(services.prescription.savePrescription).not.toHaveBeenCalled();
+        expect(services.occurrence.saveOccurrence).not.toHaveBeenCalled();
     });
 
     it('defensively throws if definition fails validation', async () => {

--- a/app/src/services/sessionAuthoringService.test.ts
+++ b/app/src/services/sessionAuthoringService.test.ts
@@ -10,8 +10,9 @@ vi.mock('./executionPrescriptionService', () => ({ executionPrescriptionService:
 vi.mock('./sessionOccurrenceService', () => ({ sessionOccurrenceService: services.occurrence }));
 
 import { resolveWorkoutPrescription } from '../workouts/prescription';
-import { prepareAuthoredOccurrenceLaunch, prepareCatalogSessionLaunch } from './sessionAuthoringService';
+import { prepareAuthoredOccurrenceLaunch, prepareCatalogSessionLaunch, prepareExternalPlanSessionLaunch } from './sessionAuthoringService';
 import type { SessionDefinition } from '../sessions/models';
+import type { ExternalPlanSessionV4 } from '../sessions/externalPlanV4';
 
 function makeTestPrescription(templateId: string) {
     const rec = {
@@ -86,5 +87,117 @@ describe('prepareAuthoredOccurrenceLaunch (M3.3)', () => {
         expect(saved.sessionSource).toEqual(source);
         expect(saved.definitionHash).toBe(source.contentHash);
         expect(saved.blocks).toEqual(definition.blocks);
+    });
+});
+
+describe('prepareExternalPlanSessionLaunch (ADR-0036 H4)', () => {
+    function makeV4ExternalPlan(overrides?: Partial<SessionDefinition>): {
+        planId: string;
+        revision: number;
+        contentHash: string;
+        session: ExternalPlanSessionV4;
+    } {
+        const definition: SessionDefinition = {
+            schemaVersion: 1,
+            id: 'ext-session-1',
+            revision: 1,
+            title: 'VO2 Max Intervals',
+            summary: '5x3min intervals at 115% FTP',
+            intent: 'training',
+            dominantModality: 'cycling',
+            duration: { min: 60, max: 60 },
+            blocks: [{
+                id: 'main',
+                role: 'main',
+                executionMode: 'sequential',
+                steps: [
+                    { id: 'interval-1', kind: 'exercise', title: 'Work', exerciseRef: { kind: 'catalog', exerciseId: 'cycling-work' }, dose: { kind: 'duration', seconds: 180 } },
+                ],
+            }],
+            ...overrides,
+        };
+
+        return {
+            planId: 'plan-xyz',
+            revision: 2,
+            contentHash: 'c'.repeat(64),
+            session: {
+                id: 'session-101',
+                title: 'VO2 Max Intervals',
+                priority: 'key',
+                placement: { week: 1, preferredDay: 'tuesday', flexibility: 'fixed', ifMissed: 'drop' },
+                gating: {
+                    modality: 'cycling',
+                    intensity: 'hard',
+                    durationMin: 60,
+                    durationMax: 60,
+                    environment: 'indoor',
+                    equipment: ['indoor_bike'],
+                },
+                definition,
+            },
+        };
+    }
+
+    it('saves a write-once prescription and returns an external_plan binding with no occurrence', async () => {
+        const externalPlan = makeV4ExternalPlan();
+        const launch = await prepareExternalPlanSessionLaunch('u1', externalPlan, undefined, '2026-09-06T12:00:00.000Z');
+
+        expect(launch.binding.sessionSource).toEqual({
+            kind: 'external_plan',
+            planId: 'plan-xyz',
+            revision: 2,
+            sessionId: 'session-101',
+            contentHash: 'c'.repeat(64),
+        });
+        expect(launch.binding.occurrenceId).toBeUndefined();
+        expect(launch.binding.prescriptionHash).toMatch(/^[0-9a-f]{64}$/);
+        expect(services.occurrence.saveOccurrence).not.toHaveBeenCalled();
+
+        const lastSave = services.prescription.savePrescription.mock.calls.at(-1);
+        expect(lastSave).toBeDefined();
+        const [savedUserId, savedPrescription] = lastSave!;
+        expect(savedUserId).toBe('u1');
+        expect(savedPrescription.prescriptionHash).toBe(launch.binding.prescriptionHash);
+        expect(savedPrescription.sessionSource).toEqual(launch.binding.sessionSource);
+        expect(savedPrescription.blocks).toEqual(externalPlan.session.definition.blocks);
+        expect(savedPrescription.displayMetadata).toEqual({
+            title: 'VO2 Max Intervals',
+            summary: '5x3min intervals at 115% FTP',
+            intent: 'training',
+            dominantModality: 'cycling',
+            duration: { min: 60, max: 60 },
+        });
+        expect(savedPrescription.createdAt).toBe('2026-09-06T12:00:00.000Z');
+    });
+
+    it('respects summaryOverride when provided (e.g. from scale verdict)', async () => {
+        const externalPlan = makeV4ExternalPlan();
+        const launch = await prepareExternalPlanSessionLaunch(
+            'u1',
+            externalPlan,
+            'Scaled: 3x3min intervals (volume reduced due to readiness)',
+        );
+
+        expect(launch.binding.prescriptionHash).toMatch(/^[0-9a-f]{64}$/);
+        const lastSave = services.prescription.savePrescription.mock.calls.at(-1);
+        const savedPrescription = lastSave![1];
+        expect(savedPrescription.displayMetadata?.summary).toBe('Scaled: 3x3min intervals (volume reduced due to readiness)');
+    });
+
+    it('is idempotent: preparing the same external plan session twice produces the same hash', async () => {
+        const externalPlan = makeV4ExternalPlan();
+        const first = await prepareExternalPlanSessionLaunch('u1', externalPlan);
+        const second = await prepareExternalPlanSessionLaunch('u1', externalPlan);
+        expect(second.binding.prescriptionHash).toBe(first.binding.prescriptionHash);
+    });
+
+    it('defensively throws if definition fails validation', async () => {
+        // An invalid definition with empty title
+        const externalPlan = makeV4ExternalPlan({
+            title: '',
+        });
+
+        await expect(prepareExternalPlanSessionLaunch('u1', externalPlan)).rejects.toThrow();
     });
 });

--- a/app/src/services/sessionAuthoringService.test.ts
+++ b/app/src/services/sessionAuthoringService.test.ts
@@ -1,10 +1,23 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Recommendation } from '../engine/models';
+import type { ExecutionPrescription } from '../sessions/models';
 
-const services = vi.hoisted(() => ({
-    prescription: { savePrescription: vi.fn().mockResolvedValue(undefined) },
-    occurrence: { saveOccurrence: vi.fn().mockResolvedValue(undefined) },
-}));
+const services = vi.hoisted(() => {
+    const store = new Map<string, ExecutionPrescription>();
+    return {
+        store,
+        prescription: {
+            savePrescription: vi.fn(async (_userId: string, prescription: ExecutionPrescription) => {
+                if (store.has(prescription.prescriptionHash)) {
+                    // write-once semantics matching ExecutionPrescriptionService.savePrescription
+                    return;
+                }
+                store.set(prescription.prescriptionHash, prescription);
+            }),
+        },
+        occurrence: { saveOccurrence: vi.fn().mockResolvedValue(undefined) },
+    };
+});
 
 vi.mock('./executionPrescriptionService', () => ({ executionPrescriptionService: services.prescription }));
 vi.mock('./sessionOccurrenceService', () => ({ sessionOccurrenceService: services.occurrence }));
@@ -13,6 +26,12 @@ import { resolveWorkoutPrescription } from '../workouts/prescription';
 import { prepareAuthoredOccurrenceLaunch, prepareCatalogSessionLaunch, prepareExternalPlanSessionLaunch } from './sessionAuthoringService';
 import type { SessionDefinition } from '../sessions/models';
 import type { ExternalPlanSessionV4 } from '../sessions/externalPlanV4';
+
+beforeEach(() => {
+    services.store.clear();
+    services.prescription.savePrescription.mockClear();
+    services.occurrence.saveOccurrence.mockClear();
+});
 
 function makeTestPrescription(templateId: string) {
     const rec = {
@@ -185,11 +204,16 @@ describe('prepareExternalPlanSessionLaunch (ADR-0036 H4)', () => {
         expect(savedPrescription.displayMetadata?.summary).toBe('Scaled: 3x3min intervals (volume reduced due to readiness)');
     });
 
-    it('is idempotent: preparing the same external plan session twice produces the same hash', async () => {
+    it('is idempotent: preparing the same external plan session twice produces the same hash and preserves write-once persistence', async () => {
         const externalPlan = makeV4ExternalPlan();
-        const first = await prepareExternalPlanSessionLaunch('u1', externalPlan);
-        const second = await prepareExternalPlanSessionLaunch('u1', externalPlan);
+        const first = await prepareExternalPlanSessionLaunch('u1', externalPlan, undefined, '2026-09-06T10:00:00.000Z');
+        const second = await prepareExternalPlanSessionLaunch('u1', externalPlan, undefined, '2026-09-06T11:00:00.000Z');
         expect(second.binding.prescriptionHash).toBe(first.binding.prescriptionHash);
+
+        const stored = services.store.get(first.binding.prescriptionHash);
+        expect(stored).toBeDefined();
+        // Verifies write-once persistence: the second invocation did not overwrite the original record
+        expect(stored?.createdAt).toBe('2026-09-06T10:00:00.000Z');
     });
 
     it('omits volatile createdAt from the prescription hash payload', async () => {

--- a/app/src/services/sessionAuthoringService.test.ts
+++ b/app/src/services/sessionAuthoringService.test.ts
@@ -192,6 +192,13 @@ describe('prepareExternalPlanSessionLaunch (ADR-0036 H4)', () => {
         expect(second.binding.prescriptionHash).toBe(first.binding.prescriptionHash);
     });
 
+    it('omits volatile createdAt from the prescription hash payload', async () => {
+        const externalPlan = makeV4ExternalPlan();
+        const first = await prepareExternalPlanSessionLaunch('u1', externalPlan, undefined, '2026-01-01T00:00:00.000Z');
+        const second = await prepareExternalPlanSessionLaunch('u1', externalPlan, undefined, '2026-12-31T23:59:59.999Z');
+        expect(second.binding.prescriptionHash).toBe(first.binding.prescriptionHash);
+    });
+
     it('defensively throws if definition fails validation', async () => {
         // An invalid definition with empty title
         const externalPlan = makeV4ExternalPlan({

--- a/app/src/services/sessionAuthoringService.test.ts
+++ b/app/src/services/sessionAuthoringService.test.ts
@@ -216,6 +216,22 @@ describe('prepareExternalPlanSessionLaunch (ADR-0036 H4)', () => {
         expect(stored?.createdAt).toBe('2026-09-06T10:00:00.000Z');
     });
 
+    it('preserves the earliest write when concurrent launches share a prescriptionHash with different timestamps', async () => {
+        const externalPlan = makeV4ExternalPlan();
+        const earliestTime = '2026-09-06T10:00:00.000Z';
+        const laterTime = '2026-09-06T10:05:00.000Z';
+
+        const [first, second] = await Promise.all([
+            prepareExternalPlanSessionLaunch('u1', externalPlan, undefined, earliestTime),
+            prepareExternalPlanSessionLaunch('u1', externalPlan, undefined, laterTime),
+        ]);
+
+        expect(first.binding.prescriptionHash).toBe(second.binding.prescriptionHash);
+        const stored = services.store.get(first.binding.prescriptionHash);
+        expect(stored).toBeDefined();
+        expect(stored?.createdAt).toBe(earliestTime);
+    });
+
     it('omits volatile createdAt from the prescription hash payload', async () => {
         const externalPlan = makeV4ExternalPlan();
         const first = await prepareExternalPlanSessionLaunch('u1', externalPlan, undefined, '2026-01-01T00:00:00.000Z');

--- a/app/src/services/sessionAuthoringService.test.ts
+++ b/app/src/services/sessionAuthoringService.test.ts
@@ -216,7 +216,7 @@ describe('prepareExternalPlanSessionLaunch (ADR-0036 H4)', () => {
         expect(stored?.createdAt).toBe('2026-09-06T10:00:00.000Z');
     });
 
-    it('preserves the earliest write when concurrent launches share a prescriptionHash with different timestamps', async () => {
+    it('preserves the first committed write when concurrent launches share a prescriptionHash with different timestamps', async () => {
         const externalPlan = makeV4ExternalPlan();
         const earliestTime = '2026-09-06T10:00:00.000Z';
         const laterTime = '2026-09-06T10:05:00.000Z';

--- a/app/src/services/sessionAuthoringService.ts
+++ b/app/src/services/sessionAuthoringService.ts
@@ -152,13 +152,14 @@ export async function prepareAuthoredOccurrenceLaunch(
 /**
  * Freezes the execution-prescription snapshot for a v4 external-plan session (ADR-0036
  * H4). Mirrors prepareCatalogSessionLaunch's shape: no session_occurrences record --
- * an external-plan session's identity is already (planId, revision, sessionId, date),
- * the same reasoning a catalog recommendation's (workoutId, catalogVersion) needs no
- * separate occurrence doc either.
+ * the immutable authored source is already identified by
+ * (planId, revision, sessionId, contentHash), while the recommendation/execution carries
+ * the date separately. Target-event sessions are deliberately rejected: rules.ts treats
+ * them as fixed-activity/advisory inputs rather than executable primary recommendations.
  *
- * Idempotent and safe to call every time an external-plan recommendation is composed:
- * `executionPrescriptionService.savePrescription` no-ops when the same content-addressed
- * hash is already stored.
+ * Idempotent and safe to call every time an executable external-plan recommendation is
+ * composed: `executionPrescriptionService.savePrescription` no-ops when the same
+ * content-addressed hash is already stored.
  */
 export async function prepareExternalPlanSessionLaunch(
     userId: string,
@@ -171,6 +172,10 @@ export async function prepareExternalPlanSessionLaunch(
     summaryOverride?: string,
     now = new Date().toISOString(),
 ): Promise<PreparedSessionLaunch> {
+    if (externalPlan.session.isEvent) {
+        throw new Error('External-plan target events are advisory fixed-activity inputs and cannot be launched as primary sessions.');
+    }
+
     const definition = externalPlan.session.definition;
     // Defense in depth: already validated at import time (validateExternalSessionV2,
     // reused unchanged by v4), but every other launch path re-validates too.

--- a/app/src/services/sessionAuthoringService.ts
+++ b/app/src/services/sessionAuthoringService.ts
@@ -1,6 +1,7 @@
 import type { SessionDefinition, ExecutionPrescription, SessionReferenceBinding } from '../sessions/models';
 import type { PreparedSessionLaunch } from '../sessions/sessionLaunch';
 import type { WorkoutPrescription } from '../workouts/models';
+import type { ExternalPlanSessionV4 } from '../sessions/externalPlanV4';
 import { validateSessionDefinition } from '../sessions/validation';
 import { adaptCatalogPrescriptionToSessionDefinition, createExecutionPrescriptionFromCatalog } from '../sessions/catalogSessionAdapter';
 import { executionPrescriptionService } from './executionPrescriptionService';
@@ -143,6 +144,77 @@ export async function prepareAuthoredOccurrenceLaunch(
         binding: {
             sessionSource: source,
             occurrenceId,
+            prescriptionHash,
+        },
+    };
+}
+
+/**
+ * Freezes the execution-prescription snapshot for a v4 external-plan session (ADR-0036
+ * H4). Mirrors prepareCatalogSessionLaunch's shape: no session_occurrences record --
+ * an external-plan session's identity is already (planId, revision, sessionId, date),
+ * the same reasoning a catalog recommendation's (workoutId, catalogVersion) needs no
+ * separate occurrence doc either.
+ *
+ * Idempotent and safe to call every time an external-plan recommendation is composed:
+ * `executionPrescriptionService.savePrescription` no-ops when the same content-addressed
+ * hash is already stored.
+ */
+export async function prepareExternalPlanSessionLaunch(
+    userId: string,
+    externalPlan: {
+        planId: string;
+        revision: number;
+        contentHash: string;
+        session: ExternalPlanSessionV4;
+    },
+    summaryOverride?: string,
+    now = new Date().toISOString(),
+): Promise<PreparedSessionLaunch> {
+    const definition = externalPlan.session.definition;
+    // Defense in depth: already validated at import time (validateExternalSessionV2,
+    // reused unchanged by v4), but every other launch path re-validates too.
+    const validation = validateSessionDefinition(definition);
+    if (!validation.ok) {
+        throw new Error(validation.issues.map(issue => `${issue.path}: ${issue.message}`).join('\n'));
+    }
+
+    const definitionHash = await hashSessionDefinition(definition);
+    const sessionSource: Extract<SessionReferenceBinding['sessionSource'], { kind: 'external_plan' }> = {
+        kind: 'external_plan',
+        planId: externalPlan.planId,
+        revision: externalPlan.revision,
+        sessionId: externalPlan.session.id,
+        contentHash: externalPlan.contentHash,
+    };
+
+    const effectiveSummary = summaryOverride ?? definition.summary;
+    const unsignedPrescription: ExecutionPrescription = {
+        schemaVersion: 1,
+        prescriptionHash: '',
+        sessionSource,
+        definitionHash,
+        blocks: definition.blocks,
+        displayMetadata: {
+            title: definition.title,
+            ...(effectiveSummary !== undefined ? { summary: effectiveSummary } : {}),
+            intent: definition.intent,
+            ...(definition.dominantModality !== undefined ? { dominantModality: definition.dominantModality } : {}),
+            ...(definition.duration !== undefined ? { duration: definition.duration } : {}),
+        },
+        createdAt: now,
+    };
+
+    const prescriptionHash = await hashExecutionPrescription(unsignedPrescription);
+    await executionPrescriptionService.savePrescription(userId, {
+        ...unsignedPrescription,
+        prescriptionHash,
+    });
+
+    return {
+        definition,
+        binding: {
+            sessionSource,
             prescriptionHash,
         },
     };

--- a/app/src/services/sessionAuthoringService.ts
+++ b/app/src/services/sessionAuthoringService.ts
@@ -205,6 +205,9 @@ export async function prepareExternalPlanSessionLaunch(
         createdAt: now,
     };
 
+    // Note: hashExecutionPrescription delegates to canonicalExecutionPrescriptionJson,
+    // which explicitly omits createdAt (ADR-0023 D-MSNAP) so that identical sessions produce
+    // identical content-addressed hashes regardless of invocation timestamp.
     const prescriptionHash = await hashExecutionPrescription(unsignedPrescription);
     await executionPrescriptionService.savePrescription(userId, {
         ...unsignedPrescription,

--- a/docs/plans/h4-external-plan-execution-binding-pipeline.md
+++ b/docs/plans/h4-external-plan-execution-binding-pipeline.md
@@ -14,7 +14,7 @@ bundle's second member (the original H4 ask), and not even for today's single pr
 external-plan session. External-plan sessions (`external-plan@1..4`) have never been
 wired into the newer multidomain execution pipeline:
 
-```
+```text
 SessionReferenceBinding -> sessionOccurrenceService -> executionPrescriptionService -> SessionRunner
 ```
 
@@ -172,6 +172,13 @@ piece (bundle launch, D-REASSESS) builds on.
            sessionSource,
            definitionHash,
            blocks: definition.blocks,
+           displayMetadata: {
+               title: definition.title,
+               ...(definition.summary !== undefined ? { summary: definition.summary } : {}),
+               intent: definition.intent,
+               ...(definition.dominantModality !== undefined ? { dominantModality: definition.dominantModality } : {}),
+               ...(definition.duration !== undefined ? { duration: definition.duration } : {}),
+           },
            createdAt: new Date().toISOString(),
        };
        const prescriptionHash = await hashExecutionPrescription(unsignedPrescription);

--- a/docs/plans/h4-external-plan-execution-binding-pipeline.md
+++ b/docs/plans/h4-external-plan-execution-binding-pipeline.md
@@ -44,7 +44,7 @@ occurrenceId: launch.binding.occurrenceId, prescriptionHash: launch.binding.pres
 })`, confirmed at `SessionRunner.tsx:331,353,447`). There is no code path that starts a
 session without going through this `PreparedSessionLaunch` shape.
 
-### Why v4 (not v1-v3) is the actually-tractable target
+### Why v4 is the targeted scope for PR 1
 
 - `ExternalPlanSessionV4.definition: SessionDefinition` (`sessions/externalPlanV4.ts:62`)
   is the **exact same structured type** `SessionRunner` already consumes for manual/catalog
@@ -57,12 +57,14 @@ session without going through this `PreparedSessionLaunch` shape.
   re-run defensively. This removes what looked like a risk (re-validating untrusted-shaped
   imported JSON at launch time) — it's already been checked once, and defense-in-depth
   re-validation at launch is cheap and consistent with the existing manual/catalog paths.
-- v1/v2/v3 sessions instead carry `prescription: { summary: string }` — free text, not a
-  `SessionDefinition`. Making *those* launchable through `SessionRunner` would require a
-  much larger authoring/parsing project (turning free text into structured blocks) that
-  has nothing to do with H4 or D-PLACEMENT, since intraday bundles are a v4-only capability
-  (`intraday` is declared only on `ExternalPlanSessionV4`). **Scope this pipeline to v4
-  only; leave v1-v3's existing text-display path completely untouched.**
+- Note on older schemas: `external-plan@1` carries only free-text `prescription: { summary: string }`.
+  `external-plan@2` (M3.6) and `external-plan@3` (ADR-0035) introduced and retained structured
+  `definition: SessionDefinition` (and `sessionDefinitionResolver.ts:245-247` already resolves
+  v2, v3, and v4 identically via `isV2Session`). However, intraday bundles are a v4-only capability
+  (`intraday` is declared only on `ExternalPlanSessionV4`). **Scoping this initial pipeline to
+  v4 keeps PR 1 strictly bounded to proving out the execution binding alongside H4 D-PLACEMENT
+  bundle resolution**, without risking regressions on legacy plans. Broader enablement across v2/v3
+  can follow trivially once v4 is validated.
 
 ### What's missing, concretely
 
@@ -147,44 +149,46 @@ piece (bundle launch, D-REASSESS) builds on.
     * separate occurrence doc either. v1-v3 sessions (prescription: {summary}, no
     * SessionDefinition) are out of scope -- this only accepts a v4 ExternalPlanContext.
     */
-   export async function prepareExternalPlanSessionLaunch(
-       userId: string,
-       externalPlan: { planId: string; revision: number; contentHash: string; session: ExternalPlanSessionV4 },
-   ): Promise<PreparedSessionLaunch> {
-       const definition = externalPlan.session.definition;
-       // Defense in depth: already validated at import time (validateExternalSessionV2,
-       // reused unchanged by v4), but every other launch path re-validates too.
-       const validation = validateSessionDefinition(definition);
-       if (!validation.ok) {
-           throw new Error(validation.issues.map(issue => `${issue.path}: ${issue.message}`).join('\n'));
-       }
-       const definitionHash = await hashSessionDefinition(definition);
-       const sessionSource: Extract<SessionReferenceBinding['sessionSource'], { kind: 'external_plan' }> = {
-           kind: 'external_plan',
-           planId: externalPlan.planId,
-           revision: externalPlan.revision,
-           sessionId: externalPlan.session.id,
-           contentHash: externalPlan.contentHash,
-       };
-       const unsignedPrescription: ExecutionPrescription = {
-           schemaVersion: 1,
-           prescriptionHash: '',
-           sessionSource,
-           definitionHash,
-           blocks: definition.blocks,
-           displayMetadata: {
-               title: definition.title,
-               ...(definition.summary !== undefined ? { summary: definition.summary } : {}),
-               intent: definition.intent,
-               ...(definition.dominantModality !== undefined ? { dominantModality: definition.dominantModality } : {}),
-               ...(definition.duration !== undefined ? { duration: definition.duration } : {}),
-           },
-           createdAt: new Date().toISOString(),
-       };
-       const prescriptionHash = await hashExecutionPrescription(unsignedPrescription);
-       await executionPrescriptionService.savePrescription(userId, { ...unsignedPrescription, prescriptionHash });
-       return { definition, binding: { sessionSource, prescriptionHash } };
-   }
+    export async function prepareExternalPlanSessionLaunch(
+        userId: string,
+        externalPlan: { planId: string; revision: number; contentHash: string; session: ExternalPlanSessionV4 },
+        summaryOverride?: string,
+    ): Promise<PreparedSessionLaunch> {
+        const definition = externalPlan.session.definition;
+        // Defense in depth: already validated at import time (validateExternalSessionV2,
+        // reused unchanged by v4), but every other launch path re-validates too.
+        const validation = validateSessionDefinition(definition);
+        if (!validation.ok) {
+            throw new Error(validation.issues.map(issue => `${issue.path}: ${issue.message}`).join('\n'));
+        }
+        const definitionHash = await hashSessionDefinition(definition);
+        const sessionSource: Extract<SessionReferenceBinding['sessionSource'], { kind: 'external_plan' }> = {
+            kind: 'external_plan',
+            planId: externalPlan.planId,
+            revision: externalPlan.revision,
+            sessionId: externalPlan.session.id,
+            contentHash: externalPlan.contentHash,
+        };
+        const effectiveSummary = summaryOverride ?? definition.summary;
+        const unsignedPrescription: ExecutionPrescription = {
+            schemaVersion: 1,
+            prescriptionHash: '',
+            sessionSource,
+            definitionHash,
+            blocks: definition.blocks,
+            displayMetadata: {
+                title: definition.title,
+                ...(effectiveSummary !== undefined ? { summary: effectiveSummary } : {}),
+                intent: definition.intent,
+                ...(definition.dominantModality !== undefined ? { dominantModality: definition.dominantModality } : {}),
+                ...(definition.duration !== undefined ? { duration: definition.duration } : {}),
+            },
+            createdAt: new Date().toISOString(),
+        };
+        const prescriptionHash = await hashExecutionPrescription(unsignedPrescription);
+        await executionPrescriptionService.savePrescription(userId, { ...unsignedPrescription, prescriptionHash });
+        return { definition, binding: { sessionSource, prescriptionHash } };
+    }
    ```
    Exact field names/types need re-verification against current `sessionAuthoringService.ts`
    at implementation time (this doc was written against the tree as of PR #432 merging;
@@ -193,16 +197,51 @@ piece (bundle launch, D-REASSESS) builds on.
 2. **`app/src/components/Home.tsx`** — after `evaluateTrainingWithIntent` returns and
    `recommendationWithPrescription`/`primarySession` are being assembled (the existing
    `if (recommendationWithPrescription.prescription) { ... prepareCatalogSessionLaunch ... }`
-   block, roughly lines 433-471 as of this writing): add an `else if` branch for when the
-   recommendation came from `adjudicatedExternalRecommendation` instead (check for
-   `recommendationWithPrescription.externalPrescription` being present, or thread a typed
-   discriminant through if that's cleaner) and the plan session is v4
-   (`isV4Plan`/`hasIntraday`-style narrowing, or simpler: check `'definition' in session`
-   since only v4's session carries it in a way distinguishable from v1-v3's
-   `prescription`-shaped session — verify exact narrowing at implementation time). Call
-   `prepareExternalPlanSessionLaunch` and set `primarySession = launch.binding`.
+   block): add an `else if` branch for when the recommendation came from
+   `adjudicatedExternalRecommendation`.
 
-3. **Decide whether `externalPrescription`/`externalVerdict`/`decisionTrace.externalPlan`
+   **CRITICAL DOMAIN SAFETY GATE:**
+   In `rules.ts:659`, `externalPrescription` is *unconditionally* populated whenever an
+   external plan session is present, even if the engine ruled `skip` (clinical red flag or
+   safety-restricted modality) or `defer` (recovery mode), or if the recommended template was
+   swapped to canonical Rest (`rest_01`). A `primarySession` binding must **NEVER** be created
+   for a skipped or deferred session.
+
+   Gate the launch preparation strictly on:
+   ```typescript
+   const verdict = recommendationWithPrescription.externalVerdict?.decision;
+   const isActionable = verdict === 'proceed' || verdict === 'scale';
+   const notRest = recommendationWithPrescription.template.id !== 'rest_01';
+   if (isActionable && notRest && externalContext && 'definition' in externalContext.session) {
+       try {
+           const launch = await prepareExternalPlanSessionLaunch(
+               userId,
+               {
+                   planId: externalContext.planId,
+                   revision: externalContext.revision,
+                   contentHash: externalContext.contentHash,
+                   session: externalContext.session as ExternalPlanSessionV4,
+               },
+               recommendationWithPrescription.externalVerdict?.scaledSummary,
+           );
+           if (!isCurrent()) return;
+           primarySession = launch.binding;
+       } catch (err) {
+           console.warn('Failed to prepare the external-plan session binding for today\'s recommendation:', err);
+       }
+   }
+   ```
+
+3. **Behavior on `scale` verdict:**
+   For catalog sessions, `resolveWorkoutPrescription` produces `adjustedBlocks`. External-plan
+   sessions currently lack a block-level auto-scaling transformer (only
+   `session.scaling.reducedSummary` and volume/intensity scalar bounds exist). In PR 1,
+   `session.definition` blocks remain the authored blocks, while `displayMetadata.summary`
+   captures `verdict.scaledSummary` (passed via `summaryOverride` above) so the athlete and
+   subsequent replays see the intended reduction. A full block-level scaling engine for external
+   definitions is deferred to a future PR.
+
+4. **Decide whether `externalPrescription`/`externalVerdict`/`decisionTrace.externalPlan`
    stay populated alongside the new `primarySession`, or whether `primarySession` replaces
    them once populated.** Recommendation: **keep both** for this PR. `externalPrescription`
    is still what today's UI (`ExternalVerdictBanner`, `ExternalPlanWeek`) renders for
@@ -211,14 +250,14 @@ piece (bundle launch, D-REASSESS) builds on.
    that didn't exist before. Removing the old fields would be a separate, larger UI
    migration and is not needed to unblock D-PLACEMENT/D-REASSESS.
 
-4. **UI: something needs to let the athlete actually launch it.** Check whatever renders
-   `primarySession` today for catalog sessions (likely in `Home.tsx` or a session-card
-   component) and confirm a v4 external-plan `primarySession` renders the same "Start"
-   affordance. This may already work for free if the rendering logic only branches on
-   `primarySession` being present, not on its `sessionSource.kind` — verify at
-   implementation time rather than assuming.
+5. **UI: launch affordance already verified.**
+   Inspection of `MorningDecisionCard.tsx:286` confirms it already checks
+   `(canLaunchCurrentPrescription || (recommendation.primarySession && onStartSession))`.
+   Once `primarySession` is populated, the "Start Workout" hero button renders automatically
+   without UI rewrites. Note: load adjustments (`easier`/`harder`) in `MorningDecisionCard.tsx`
+   rely on catalog prescriptions and are naturally inactive for external sessions.
 
-5. **Tests:**
+6. **Tests:**
    - `sessionAuthoringService.test.ts` (or a new sibling file): unit tests for
      `prepareExternalPlanSessionLaunch` — valid v4 session produces a correct binding and
      saved prescription; an invalid `definition` (if one could ever reach this function
@@ -231,17 +270,18 @@ piece (bundle launch, D-REASSESS) builds on.
    - `SessionRunner.tsx`'s existing tests should not need changes if `PreparedSessionLaunch`'s
      shape is respected exactly — verify by running its existing suite after wiring this in.
 
-6. **No `POLICY_VERSION` bump needed for the launch mechanism itself** (this doesn't change
+7. **No `POLICY_VERSION` bump needed for the launch mechanism itself** (this doesn't change
    *which* session is recommended, only how an already-recommended v4 session can be
-   started) — but re-verify this claim once the exact `Home.tsx` diff is known; if it
-   turns out to change `primarySession`'s presence/absence in ways that affect persisted
-   `daily_recommendations` documents' validated shape, check `firestore.rules`'
-   `hasValidSessionReferenceBinding` accepts `kind: 'external_plan'` (it currently
-   validates generically against `SessionSourceRef`'s discriminated union shape --
-   confirm `kind: 'external_plan'`'s specific field set is already covered there, or add
-   it; this is a much smaller rules change than the `hasValidRecommendationAudit` ceiling
-   problem documented in issue #435 / PR #432, since `hasValidSessionReferenceBinding` is
-   a separate, smaller function).
+   started) — but re-verify this claim once the exact `Home.tsx` diff is known.
+   - **Firestore rules status:** `firestore.rules:1218-1222` (`hasValidSessionSource`) and
+     `1234-1241` (`hasValidSessionReferenceBinding`) already accept `kind: 'external_plan'` with
+     `['kind', 'planId', 'revision', 'sessionId', 'contentHash']` and optional `occurrenceId`.
+     No rules change is needed to support the binding.
+   - **Expression budget risk:** `hasValidRecommendationAudit` (`firestore.rules:321-376`) is near
+     Firestore's ~1,000 expression limit. When an external-plan recommendation populates both
+     `externalPlan` (lines 368-376) and `primarySession` (line 358), both branches will evaluate
+     simultaneously. Running `npm run test:rules` during PR 1 implementation is required to verify
+     that the evaluation budget remains within limits.
 
 ### Suggested PR description (paste and adapt)
 
@@ -252,31 +292,34 @@ piece (bundle launch, D-REASSESS) builds on.
 > not even for today's single primary external-plan session, which has never been
 > launchable through `SessionRunner`.
 >
-> Scoped to v4 only (mirroring the `catalog` no-occurrence-record precedent): v4 sessions
-> already carry a real `SessionDefinition` (unlike v1-v3's free-text `prescription`), and
-> that `definition` is already validated by `validateSessionDefinition` at import time.
-> No `OccurrenceAuthority`/`SessionOccurrence` schema change in this PR -- an
+> Scoped to v4 for H4 intraday bundle continuity (mirroring the `catalog` no-occurrence-record precedent):
+> while v2/v3 plans also carry structured `SessionDefinition`, v4 is the specific target
+> for H4 intraday bundles. `definition` is already validated by `validateSessionDefinition`
+> at import time. No `OccurrenceAuthority`/`SessionOccurrence` schema change in this PR -- an
 > external-plan session's identity is already `(planId, revision, sessionId, date)`,
 > needing no separate occurrence doc, the same reasoning a catalog recommendation
 > already relies on.
 >
 > ## What's delivered
 > - `sessionAuthoringService.ts`: new `prepareExternalPlanSessionLaunch`, mirroring
->   `prepareCatalogSessionLaunch`'s shape.
+>   `prepareCatalogSessionLaunch`'s shape, snapshotting `displayMetadata` and supporting
+>   `summaryOverride` for scaled sessions.
 > - `Home.tsx`: wires it into the existing external-plan recommendation branch,
->   populating `primarySession` for a v4 session (kept alongside the existing
->   `externalPrescription`/`externalVerdict`/`decisionTrace.externalPlan` fields, which
->   still drive today's plan-week display -- not removed).
-> - v1-v3 sessions' existing text-display-only path is completely untouched.
+>   populating `primarySession` for actionable v4 sessions (`verdict.decision in ['proceed', 'scale']`
+>   and `template.id !== 'rest_01'`).
+> - Crucial domain safety gate: skipped or deferred external sessions (e.g. clinical red flags,
+>   recovery mode) never receive a `primarySession` binding.
+> - Existing `externalPrescription`/`externalVerdict`/`decisionTrace.externalPlan` fields are
+>   preserved alongside `primarySession` to keep today's plan-week display intact.
 >
 > ## Not in scope here
 > - Occurrence tracking (needed for D-REASSESS's predecessor-completion check and
 >   multi-occurrence bundle launches) -- separate follow-up PR.
 > - Surfacing a bundle's second member as a real `additionalSessions` entry -- needs the
 >   occurrence-tracking follow-up first.
-> - Any change to v1-v3 external-plan sessions.
+> - Full block-level scaling transformation for external definitions (uses `summaryOverride` in PR 1).
 >
-> ## Verification
+> ## Validation
 > (standard checklist: typecheck, lint, full vitest, build, rules emulator tests,
 > simulate:scenarios/diff, check-policy-drift.mjs)
 
@@ -300,18 +343,16 @@ piece (bundle launch, D-REASSESS) builds on.
    session starts" requires that later session to be a real, launchable thing with
    trackable state.
 
-## Open questions / risks for the implementing agent to resolve
+## Verified facts & risks for the implementing agent
 
-- Confirm the exact current shape of `Home.tsx`'s recommendation-assembly block --
-  line numbers above are approximate and will have shifted.
-- Confirm `hasValidSessionReferenceBinding` (`firestore.rules`) already accepts
-  `kind: 'external_plan'`'s field set, or add it (small, isolated change --
-  not the same tightly-budgeted function as `hasValidRecommendationAudit`,
-  see issue #435).
-- Decide the exact v1-v3-vs-v4 narrowing check used in `Home.tsx` to gate this new
-  branch (suggested: reuse whatever type guard already exists for `isV4Plan`/session
-  narrowing elsewhere, e.g. `activeExternalPlanService.ts`'s `hasIntraday`-style pattern,
-  rather than inventing a new one).
-- Verify whether any UI component needs an explicit code change to render a "Start"
-  affordance for a `primarySession` whose `sessionSource.kind` is `'external_plan'`, or
-  whether existing rendering logic is already source-kind-agnostic.
+- **Firestore rules support verified:** `firestore.rules:1218-1222` already accepts
+  `kind: 'external_plan'` with `['kind', 'planId', 'revision', 'sessionId', 'contentHash']`.
+  No rules change is needed.
+- **Rules budget risk:** When `primarySession` is present on an external plan recommendation,
+  `hasValidRecommendationAudit` evaluates both `externalPlan` and `primarySession`.
+  Run `npm run test:rules` to ensure the 1,000 expression limit is not exceeded.
+- **UI launch affordance verified:** `MorningDecisionCard.tsx:286` already checks
+  `(canLaunchCurrentPrescription || (recommendation.primarySession && onStartSession))`.
+  The "Start Workout" button appears automatically once `primarySession` is populated.
+- **Domain safety invariant:** Ensure `Home.tsx` checks `verdict === 'proceed' || verdict === 'scale'`
+  and `template.id !== 'rest_01'`. Never bind `primarySession` on `skip` or `defer`.

--- a/docs/plans/h4-external-plan-execution-binding-pipeline.md
+++ b/docs/plans/h4-external-plan-execution-binding-pipeline.md
@@ -1,0 +1,310 @@
+# H4: external-plan execution-binding pipeline — analysis and PR-1 handoff
+
+**Status:** Analysis only. No code changes in this doc's commit. Written for another
+agent (or a future session) to implement against.
+**Tracks:** [GitHub issue #434](https://github.com/Szczepanov/adaptive-training-recommender/issues/434).
+**Discovered by:** investigation while wiring ADR-0036 (H4) D-PLACEMENT into the decision
+path ([PR #432](https://github.com/Szczepanov/adaptive-training-recommender/pull/432)).
+
+## Root cause
+
+`SessionSourceRef`'s `kind: 'external_plan'` variant is declared in `app/src/sessions/models.ts`
+but is **never actually constructed anywhere in the codebase** — not for a v4 intraday
+bundle's second member (the original H4 ask), and not even for today's single primary
+external-plan session. External-plan sessions (`external-plan@1..4`) have never been
+wired into the newer multidomain execution pipeline:
+
+```
+SessionReferenceBinding -> sessionOccurrenceService -> executionPrescriptionService -> SessionRunner
+```
+
+Instead, an external-plan session's primary-session path
+(`adjudicatedExternalRecommendation` in `app/src/engine/rules.ts`) produces
+`externalPrescription`/`externalVerdict`/`decisionTrace.externalPlan` — a parallel,
+older, **text-display-only** contract. `Recommendation.primarySession` (the
+`SessionReferenceBinding` field `SessionRunner` actually consumes to start a structured
+session) is left `undefined` for every external-plan recommendation today. This is why
+building "the same launch flow a manual/catalog session already has" for an external-plan
+session is a real, non-trivial gap, not a small wiring tweak.
+
+## Current state, verified against code
+
+### The three existing `SessionSourceRef` kinds and how each is built
+
+| kind | Built by | Occurrence record? | Notes |
+|---|---|---|---|
+| `catalog` | `prepareCatalogSessionLaunch` (`sessionAuthoringService.ts`) | No | Identity is `(workoutId, catalogVersion)`; today's recommendation already made the selection decision (D-MAUTH), so no separate occurrence doc is needed. |
+| `manual` | `prepareUnplannedSessionLaunch` / `prepareAuthoredOccurrenceLaunch` | Yes, in `session_occurrences` | The occurrence record is created *earlier*, when the athlete authors the session via `ManualSessionBuilder`; launch only freezes the execution-prescription snapshot for it. |
+| `unplanned_fixture` | *(not investigated further; out of scope for this doc)* | — | — |
+
+Every one of these ends in the same shape, `PreparedSessionLaunch = { definition:
+SessionDefinition, binding: SessionReferenceBinding }`, which `SessionRunner.tsx` requires
+verbatim (`runner.startSession(launch.definition, launch.binding.sessionSource, {
+occurrenceId: launch.binding.occurrenceId, prescriptionHash: launch.binding.prescriptionHash
+})`, confirmed at `SessionRunner.tsx:331,353,447`). There is no code path that starts a
+session without going through this `PreparedSessionLaunch` shape.
+
+### Why v4 (not v1-v3) is the actually-tractable target
+
+- `ExternalPlanSessionV4.definition: SessionDefinition` (`sessions/externalPlanV4.ts:62`)
+  is the **exact same structured type** `SessionRunner` already consumes for manual/catalog
+  sessions.
+- `validateExternalSessionV2` (which v4 reuses unchanged for its `definition`-based content,
+  per that file's own header comment) already calls `validateSessionDefinition(raw.definition)`
+  at import time (`externalPlanV2.ts:105`). **A v4 session's `definition` is therefore
+  already guaranteed to pass `validateSessionDefinition` before it ever reaches launch
+  code** — the same gate `prepareUnplannedSessionLaunch`/`prepareAuthoredOccurrenceLaunch`
+  re-run defensively. This removes what looked like a risk (re-validating untrusted-shaped
+  imported JSON at launch time) — it's already been checked once, and defense-in-depth
+  re-validation at launch is cheap and consistent with the existing manual/catalog paths.
+- v1/v2/v3 sessions instead carry `prescription: { summary: string }` — free text, not a
+  `SessionDefinition`. Making *those* launchable through `SessionRunner` would require a
+  much larger authoring/parsing project (turning free text into structured blocks) that
+  has nothing to do with H4 or D-PLACEMENT, since intraday bundles are a v4-only capability
+  (`intraday` is declared only on `ExternalPlanSessionV4`). **Scope this pipeline to v4
+  only; leave v1-v3's existing text-display path completely untouched.**
+
+### What's missing, concretely
+
+1. **No `prepareExternalPlanSessionLaunch`-equivalent function.** Nothing builds
+   `{ sessionSource: { kind: 'external_plan', planId, revision, sessionId, contentHash },
+   prescriptionHash, occurrenceId? }` from a v4 `ExternalPlanContext`
+   (`activeExternalPlanService.ts`'s existing output shape already has every field this
+   needs except a way to freeze the prescription).
+2. **`OccurrenceAuthority` has no `'external_plan'` member** (`sessions/models.ts:215-219`:
+   `'unplanned_log' | 'schedule' | 'replace_recommendation' | 'additional_session'`), and
+   `SessionOccurrence.definitionRef` (`{ definitionId, revision, contentHash }`,
+   `sessions/models.ts:234-238`) has no field for `planId`/`sessionId`/bundle membership.
+   Extending this schema (plus its Firestore rules validation) is real, separate work --
+   **not required for a first slice**, because (mirroring the `catalog` precedent above) an
+   external-plan session's identity is already fully determined by
+   `(planId, revision, sessionId, date)` without needing a separate occurrence document.
+   An occurrence record only becomes necessary once something needs to track *execution
+   state* independently of the plan/date (D-REASSESS's "has the predecessor actually
+   completed" check, and multi-occurrence bundle launches where more than one external
+   session can be active on one date) -- see "Future PRs" below.
+3. **`rules.ts`'s `adjudicatedExternalRecommendation` never populates `primarySession`.**
+   Wiring in the new launch function means deciding whether this happens inside
+   `rules.ts` (making the binding itself part of the pure decision function — awkward,
+   since binding creation is `async`/has Firestore side effects, and `rules.ts` is
+   otherwise synchronous/pure) or in the caller (`Home.tsx`, mirroring exactly how
+   `prepareCatalogSessionLaunch`/`prepareAuthoredOccurrenceLaunch` are already called
+   *after* `evaluateTrainingWithIntent` returns, at lines ~433-471 of `Home.tsx` in the
+   current tree). **The caller-side pattern is almost certainly correct** — it's the
+   existing precedent for every other session kind, and keeps `rules.ts` pure.
+
+## Design options considered
+
+### Option A — Prescription-only, no occurrence record (recommended for PR 1)
+
+Mirror the `catalog` path exactly: freeze a content-addressed `ExecutionPrescription`
+with `sessionSource: { kind: 'external_plan', ... }`, no `session_occurrences` write, no
+`OccurrenceAuthority`/`definitionRef` schema change. `primarySession` gets populated for a
+v4 recommendation the same way it already does for catalog/manual ones. This alone makes
+a v4 external-plan session **launchable through `SessionRunner`** and replayable through
+the same prescription-hash boundary everything else uses — a large, real capability gap
+closed — without touching occurrence schema at all.
+
+**Tradeoff:** does not yet give D-REASSESS a way to check "has the predecessor bundle
+member's occurrence actually completed" (there's no occurrence record to query), and does
+not yet let a bundle's second member become an independently-tracked `additionalSessions`
+entry with its own lifecycle state (`scheduled` → `active` → `completed`). Both of those
+need real occurrence tracking — deliberately deferred to a follow-up PR (see below), not
+because they don't matter, but because they're separable and this slice is valuable on
+its own.
+
+### Option B — Full occurrence tracking now
+
+Extend `OccurrenceAuthority` with `'external_plan'`, extend or replace
+`SessionOccurrence.definitionRef` to carry plan/session identity (or add a parallel
+`externalPlanRef` field alongside it), and build real occurrence records for v4
+external-plan sessions from the start. Bigger and riskier as a first PR: touches
+`sessions/models.ts` (a widely-imported shared type), `firestore.rules`' `session_occurrences`
+validation, and `sessionOccurrenceService.ts`'s query/write surface, all before proving
+out the simpler prescription-only path even works end-to-end through `SessionRunner`.
+
+**Decision (confirmed with the repo owner):** ship Option A first.
+
+## Recommended PR 1 scope
+
+**Goal:** a v4 external-plan session's primary recommendation gets a real
+`SessionReferenceBinding` (`kind: 'external_plan'`) and becomes launchable through
+`SessionRunner`, exactly like a catalog session today. No occurrence record. No change to
+v1-v3 sessions' existing display-only path. No change to bundle/`additionalSessions`
+surfacing (that's PR 2+, see below) — this PR is specifically about making the **existing
+single primary external-plan session** real, since that's the prerequisite every later
+piece (bundle launch, D-REASSESS) builds on.
+
+### Concrete changes
+
+1. **`app/src/services/sessionAuthoringService.ts`** — add:
+   ```typescript
+   /**
+    * Freezes the execution-prescription snapshot for a v4 external-plan session (ADR-0036
+    * H4). Mirrors prepareCatalogSessionLaunch's shape: no session_occurrences record --
+    * an external-plan session's identity is already (planId, revision, sessionId, date),
+    * the same reasoning a catalog recommendation's (workoutId, catalogVersion) needs no
+    * separate occurrence doc either. v1-v3 sessions (prescription: {summary}, no
+    * SessionDefinition) are out of scope -- this only accepts a v4 ExternalPlanContext.
+    */
+   export async function prepareExternalPlanSessionLaunch(
+       userId: string,
+       externalPlan: { planId: string; revision: number; contentHash: string; session: ExternalPlanSessionV4 },
+   ): Promise<PreparedSessionLaunch> {
+       const definition = externalPlan.session.definition;
+       // Defense in depth: already validated at import time (validateExternalSessionV2,
+       // reused unchanged by v4), but every other launch path re-validates too.
+       const validation = validateSessionDefinition(definition);
+       if (!validation.ok) {
+           throw new Error(validation.issues.map(issue => `${issue.path}: ${issue.message}`).join('\n'));
+       }
+       const definitionHash = await hashSessionDefinition(definition);
+       const sessionSource: Extract<SessionReferenceBinding['sessionSource'], { kind: 'external_plan' }> = {
+           kind: 'external_plan',
+           planId: externalPlan.planId,
+           revision: externalPlan.revision,
+           sessionId: externalPlan.session.id,
+           contentHash: externalPlan.contentHash,
+       };
+       const unsignedPrescription: ExecutionPrescription = {
+           schemaVersion: 1,
+           prescriptionHash: '',
+           sessionSource,
+           definitionHash,
+           blocks: definition.blocks,
+           createdAt: new Date().toISOString(),
+       };
+       const prescriptionHash = await hashExecutionPrescription(unsignedPrescription);
+       await executionPrescriptionService.savePrescription(userId, { ...unsignedPrescription, prescriptionHash });
+       return { definition, binding: { sessionSource, prescriptionHash } };
+   }
+   ```
+   Exact field names/types need re-verification against current `sessionAuthoringService.ts`
+   at implementation time (this doc was written against the tree as of PR #432 merging;
+   confirm nothing shifted).
+
+2. **`app/src/components/Home.tsx`** — after `evaluateTrainingWithIntent` returns and
+   `recommendationWithPrescription`/`primarySession` are being assembled (the existing
+   `if (recommendationWithPrescription.prescription) { ... prepareCatalogSessionLaunch ... }`
+   block, roughly lines 433-471 as of this writing): add an `else if` branch for when the
+   recommendation came from `adjudicatedExternalRecommendation` instead (check for
+   `recommendationWithPrescription.externalPrescription` being present, or thread a typed
+   discriminant through if that's cleaner) and the plan session is v4
+   (`isV4Plan`/`hasIntraday`-style narrowing, or simpler: check `'definition' in session`
+   since only v4's session carries it in a way distinguishable from v1-v3's
+   `prescription`-shaped session — verify exact narrowing at implementation time). Call
+   `prepareExternalPlanSessionLaunch` and set `primarySession = launch.binding`.
+
+3. **Decide whether `externalPrescription`/`externalVerdict`/`decisionTrace.externalPlan`
+   stay populated alongside the new `primarySession`, or whether `primarySession` replaces
+   them once populated.** Recommendation: **keep both** for this PR. `externalPrescription`
+   is still what today's UI (`ExternalVerdictBanner`, `ExternalPlanWeek`) renders for
+   the plan-week overview and the athlete's own annotation/verdict flow; `primarySession`
+   is strictly additive, enabling a *new* "Start Session" action through `SessionRunner`
+   that didn't exist before. Removing the old fields would be a separate, larger UI
+   migration and is not needed to unblock D-PLACEMENT/D-REASSESS.
+
+4. **UI: something needs to let the athlete actually launch it.** Check whatever renders
+   `primarySession` today for catalog sessions (likely in `Home.tsx` or a session-card
+   component) and confirm a v4 external-plan `primarySession` renders the same "Start"
+   affordance. This may already work for free if the rendering logic only branches on
+   `primarySession` being present, not on its `sessionSource.kind` — verify at
+   implementation time rather than assuming.
+
+5. **Tests:**
+   - `sessionAuthoringService.test.ts` (or a new sibling file): unit tests for
+     `prepareExternalPlanSessionLaunch` — valid v4 session produces a correct binding and
+     saved prescription; an invalid `definition` (if one could ever reach this function
+     despite import-time validation — test the defensive re-validation path) throws.
+   - An integration-level test (wherever `Home.tsx`'s recommendation-assembly logic is
+     covered, if anywhere — check for existing `Home.test.tsx`-style coverage of the
+     catalog/manual launch branches to mirror) confirming a v4 primary session gets a
+     `primarySession` binding while a v1-v3 primary session does not (regression guard for
+     "v1-v3 stays untouched").
+   - `SessionRunner.tsx`'s existing tests should not need changes if `PreparedSessionLaunch`'s
+     shape is respected exactly — verify by running its existing suite after wiring this in.
+
+6. **No `POLICY_VERSION` bump needed for the launch mechanism itself** (this doesn't change
+   *which* session is recommended, only how an already-recommended v4 session can be
+   started) — but re-verify this claim once the exact `Home.tsx` diff is known; if it
+   turns out to change `primarySession`'s presence/absence in ways that affect persisted
+   `daily_recommendations` documents' validated shape, check `firestore.rules`'
+   `hasValidSessionReferenceBinding` accepts `kind: 'external_plan'` (it currently
+   validates generically against `SessionSourceRef`'s discriminated union shape --
+   confirm `kind: 'external_plan'`'s specific field set is already covered there, or add
+   it; this is a much smaller rules change than the `hasValidRecommendationAudit` ceiling
+   problem documented in issue #435 / PR #432, since `hasValidSessionReferenceBinding` is
+   a separate, smaller function).
+
+### Suggested PR description (paste and adapt)
+
+> ## Summary
+> First PR of the external-plan execution-binding pipeline (issue #434), discovered
+> missing while wiring ADR-0036 H4 D-PLACEMENT ([PR #432](https://github.com/Szczepanov/adaptive-training-recommender/pull/432)).
+> `SessionSourceRef`'s `kind: 'external_plan'` was declared but never constructed --
+> not even for today's single primary external-plan session, which has never been
+> launchable through `SessionRunner`.
+>
+> Scoped to v4 only (mirroring the `catalog` no-occurrence-record precedent): v4 sessions
+> already carry a real `SessionDefinition` (unlike v1-v3's free-text `prescription`), and
+> that `definition` is already validated by `validateSessionDefinition` at import time.
+> No `OccurrenceAuthority`/`SessionOccurrence` schema change in this PR -- an
+> external-plan session's identity is already `(planId, revision, sessionId, date)`,
+> needing no separate occurrence doc, the same reasoning a catalog recommendation
+> already relies on.
+>
+> ## What's delivered
+> - `sessionAuthoringService.ts`: new `prepareExternalPlanSessionLaunch`, mirroring
+>   `prepareCatalogSessionLaunch`'s shape.
+> - `Home.tsx`: wires it into the existing external-plan recommendation branch,
+>   populating `primarySession` for a v4 session (kept alongside the existing
+>   `externalPrescription`/`externalVerdict`/`decisionTrace.externalPlan` fields, which
+>   still drive today's plan-week display -- not removed).
+> - v1-v3 sessions' existing text-display-only path is completely untouched.
+>
+> ## Not in scope here
+> - Occurrence tracking (needed for D-REASSESS's predecessor-completion check and
+>   multi-occurrence bundle launches) -- separate follow-up PR.
+> - Surfacing a bundle's second member as a real `additionalSessions` entry -- needs the
+>   occurrence-tracking follow-up first.
+> - Any change to v1-v3 external-plan sessions.
+>
+> ## Verification
+> (standard checklist: typecheck, lint, full vitest, build, rules emulator tests,
+> simulate:scenarios/diff, check-policy-drift.mjs)
+
+## Future PRs (roadmap beyond PR 1)
+
+1. **PR 1** (this doc): prescription-only v4 launch binding. No occurrence record.
+2. **PR 2 — occurrence tracking.** Extend `OccurrenceAuthority` with `'external_plan'`
+   (or find a less invasive alternative — e.g. a parallel `externalPlanRef` on
+   `SessionOccurrence` instead of overloading `definitionRef`; evaluate both at
+   implementation time) and create a real occurrence record when a v4 external-plan
+   session launches, so its lifecycle (`scheduled → active → completed`) is queryable
+   independently of the plan/date. This is the prerequisite for:
+3. **PR 3 — bundle second-member launch.** Once occurrence tracking exists, a v4 intraday
+   bundle's non-primary members (already correctly *placed* by
+   `activeExternalPlanService.ts`'s `resolveIntradayBundlePlacement`, PR #432) can be
+   adjudicated via `adjudicateAuthoredSession` (reusing the exact pattern `Home.tsx`
+   already uses for manually-authored additional sessions, per the manual
+   `additionalOccurrences` loop) and surfaced as real `additionalSessions` entries the
+   athlete can independently launch.
+4. **PR 4 — D-REASSESS** (issue #436) becomes meaningful once PR 3 exists: "before a later
+   session starts" requires that later session to be a real, launchable thing with
+   trackable state.
+
+## Open questions / risks for the implementing agent to resolve
+
+- Confirm the exact current shape of `Home.tsx`'s recommendation-assembly block --
+  line numbers above are approximate and will have shifted.
+- Confirm `hasValidSessionReferenceBinding` (`firestore.rules`) already accepts
+  `kind: 'external_plan'`'s field set, or add it (small, isolated change --
+  not the same tightly-budgeted function as `hasValidRecommendationAudit`,
+  see issue #435).
+- Decide the exact v1-v3-vs-v4 narrowing check used in `Home.tsx` to gate this new
+  branch (suggested: reuse whatever type guard already exists for `isV4Plan`/session
+  narrowing elsewhere, e.g. `activeExternalPlanService.ts`'s `hasIntraday`-style pattern,
+  rather than inventing a new one).
+- Verify whether any UI component needs an explicit code change to render a "Start"
+  affordance for a `primarySession` whose `sessionSource.kind` is `'external_plan'`, or
+  whether existing rendering logic is already source-kind-agnostic.

--- a/docs/plans/h4-external-plan-execution-binding-pipeline.md
+++ b/docs/plans/h4-external-plan-execution-binding-pipeline.md
@@ -1,360 +1,274 @@
-# H4: external-plan execution-binding pipeline — analysis and PR-1 handoff
+# H4: external-plan execution-binding pipeline — PR-1 implementation and follow-up roadmap
 
-**Status:** Analysis only. No code changes in this doc's commit. Written for another
-agent (or a future session) to implement against.
+**Status:** PR 1 implemented in [PR #440](https://github.com/Szczepanov/adaptive-training-recommender/pull/440).
+This document records the original gap, the invariants enforced by PR 1, and the remaining
+follow-up work.
+
 **Tracks:** [GitHub issue #434](https://github.com/Szczepanov/adaptive-training-recommender/issues/434).
-**Discovered by:** investigation while wiring ADR-0036 (H4) D-PLACEMENT into the decision
-path ([PR #432](https://github.com/Szczepanov/adaptive-training-recommender/pull/432)).
 
-## Root cause
+**Origin:** the gap was discovered while wiring ADR-0036 (H4) D-PLACEMENT into the decision
+path in [PR #432](https://github.com/Szczepanov/adaptive-training-recommender/pull/432).
 
-`SessionSourceRef`'s `kind: 'external_plan'` variant is declared in `app/src/sessions/models.ts`
-but is **never actually constructed anywhere in the codebase** — not for a v4 intraday
-bundle's second member (the original H4 ask), and not even for today's single primary
-external-plan session. External-plan sessions (`external-plan@1..4`) have never been
-wired into the newer multidomain execution pipeline:
+## Original gap
+
+Before PR 1, `SessionSourceRef` declared `kind: 'external_plan'`, but production code never
+constructed that source for a recommendation. External-plan sessions therefore stayed on the
+older display/adjudication contract:
 
 ```text
-SessionReferenceBinding -> sessionOccurrenceService -> executionPrescriptionService -> SessionRunner
+externalPrescription + externalVerdict + decisionTrace.externalPlan
 ```
 
-Instead, an external-plan session's primary-session path
-(`adjudicatedExternalRecommendation` in `app/src/engine/rules.ts`) produces
-`externalPrescription`/`externalVerdict`/`decisionTrace.externalPlan` — a parallel,
-older, **text-display-only** contract. `Recommendation.primarySession` (the
-`SessionReferenceBinding` field `SessionRunner` actually consumes to start a structured
-session) is left `undefined` for every external-plan recommendation today. This is why
-building "the same launch flow a manual/catalog session already has" for an external-plan
-session is a real, non-trivial gap, not a small wiring tweak.
+while executable catalog/manual sessions used the source-neutral path:
 
-## Current state, verified against code
+```text
+SessionReferenceBinding -> ExecutionPrescription -> SessionRunner
+```
 
-### The three existing `SessionSourceRef` kinds and how each is built
+That meant even a structured `external-plan@4` primary session could be displayed and
+adjudicated but not launched through the immutable prescription boundary used by
+`SessionRunner`.
 
-| kind | Built by | Occurrence record? | Notes |
-|---|---|---|---|
-| `catalog` | `prepareCatalogSessionLaunch` (`sessionAuthoringService.ts`) | No | Identity is `(workoutId, catalogVersion)`; today's recommendation already made the selection decision (D-MAUTH), so no separate occurrence doc is needed. |
-| `manual` | `prepareUnplannedSessionLaunch` / `prepareAuthoredOccurrenceLaunch` | Yes, in `session_occurrences` | The occurrence record is created *earlier*, when the athlete authors the session via `ManualSessionBuilder`; launch only freezes the execution-prescription snapshot for it. |
-| `unplanned_fixture` | *(not investigated further; out of scope for this doc)* | — | — |
+PR 1 closes that gap for the existing **single primary v4 session**. It deliberately does not
+yet create external-plan occurrences or make secondary intraday-bundle members independently
+launchable.
 
-Every one of these ends in the same shape, `PreparedSessionLaunch = { definition:
-SessionDefinition, binding: SessionReferenceBinding }`, which `SessionRunner.tsx` requires
-verbatim (`runner.startSession(launch.definition, launch.binding.sessionSource, {
-occurrenceId: launch.binding.occurrenceId, prescriptionHash: launch.binding.prescriptionHash
-})`, confirmed at `SessionRunner.tsx:331,353,447`). There is no code path that starts a
-session without going through this `PreparedSessionLaunch` shape.
+## Why PR 1 is v4-only
 
-### Why v4 is the targeted scope for PR 1
+`external-plan@2`, `@3`, and `@4` all carry a normalized `SessionDefinition`, but v4 is the
+schema that introduces ADR-0036 intraday bundles and therefore the first schema that needs the
+new execution-binding pipeline for H4 continuity.
 
-- `ExternalPlanSessionV4.definition: SessionDefinition` (`sessions/externalPlanV4.ts:62`)
-  is the **exact same structured type** `SessionRunner` already consumes for manual/catalog
-  sessions.
-- `validateExternalSessionV2` (which v4 reuses unchanged for its `definition`-based content,
-  per that file's own header comment) already calls `validateSessionDefinition(raw.definition)`
-  at import time (`externalPlanV2.ts:105`). **A v4 session's `definition` is therefore
-  already guaranteed to pass `validateSessionDefinition` before it ever reaches launch
-  code** — the same gate `prepareUnplannedSessionLaunch`/`prepareAuthoredOccurrenceLaunch`
-  re-run defensively. This removes what looked like a risk (re-validating untrusted-shaped
-  imported JSON at launch time) — it's already been checked once, and defense-in-depth
-  re-validation at launch is cheap and consistent with the existing manual/catalog paths.
-- Note on older schemas: `external-plan@1` carries only free-text `prescription: { summary: string }`.
-  `external-plan@2` (M3.6) and `external-plan@3` (ADR-0035) introduced and retained structured
-  `definition: SessionDefinition` (and `sessionDefinitionResolver.ts:245-247` already resolves
-  v2, v3, and v4 identically via `isV2Session`). However, intraday bundles are a v4-only capability
-  (`intraday` is declared only on `ExternalPlanSessionV4`). **Scoping this initial pipeline to
-  v4 keeps PR 1 strictly bounded to proving out the execution binding alongside H4 D-PLACEMENT
-  bundle resolution**, without risking regressions on legacy plans. Broader enablement across v2/v3
-  can follow trivially once v4 is validated.
+`ExternalPlanSessionV4.definition` is already validated at import time. The v4 validator strips
+the v4-only `intraday` field and delegates the shared session envelope/definition checks to the
+v2 validator, which calls `validateSessionDefinition`. The launch helper still re-runs
+`validateSessionDefinition` defensively, matching the other launch paths.
 
-### What's missing, concretely
+Legacy v1-v3 behavior is intentionally unchanged in PR 1. Broader enablement can be considered
+separately once the v4 path has proven stable.
 
-1. **No `prepareExternalPlanSessionLaunch`-equivalent function.** Nothing builds
-   `{ sessionSource: { kind: 'external_plan', planId, revision, sessionId, contentHash },
-   prescriptionHash, occurrenceId? }` from a v4 `ExternalPlanContext`
-   (`activeExternalPlanService.ts`'s existing output shape already has every field this
-   needs except a way to freeze the prescription).
-2. **`OccurrenceAuthority` has no `'external_plan'` member** (`sessions/models.ts:215-219`:
-   `'unplanned_log' | 'schedule' | 'replace_recommendation' | 'additional_session'`), and
-   `SessionOccurrence.definitionRef` (`{ definitionId, revision, contentHash }`,
-   `sessions/models.ts:234-238`) has no field for `planId`/`sessionId`/bundle membership.
-   Extending this schema (plus its Firestore rules validation) is real, separate work --
-   **not required for a first slice**, because (mirroring the `catalog` precedent above) an
-   external-plan session's identity is already fully determined by
-   `(planId, revision, sessionId, date)` without needing a separate occurrence document.
-   An occurrence record only becomes necessary once something needs to track *execution
-   state* independently of the plan/date (D-REASSESS's "has the predecessor actually
-   completed" check, and multi-occurrence bundle launches where more than one external
-   session can be active on one date) -- see "Future PRs" below.
-3. **`rules.ts`'s `adjudicatedExternalRecommendation` never populates `primarySession`.**
-   Wiring in the new launch function means deciding whether this happens inside
-   `rules.ts` (making the binding itself part of the pure decision function — awkward,
-   since binding creation is `async`/has Firestore side effects, and `rules.ts` is
-   otherwise synchronous/pure) or in the caller (`Home.tsx`, mirroring exactly how
-   `prepareCatalogSessionLaunch`/`prepareAuthoredOccurrenceLaunch` are already called
-   *after* `evaluateTrainingWithIntent` returns, at lines ~433-471 of `Home.tsx` in the
-   current tree). **The caller-side pattern is almost certainly correct** — it's the
-   existing precedent for every other session kind, and keeps `rules.ts` pure.
+## PR-1 design
 
-## Design options considered
+### 1. Prescription-only binding; no occurrence record
 
-### Option A — Prescription-only, no occurrence record (recommended for PR 1)
+`prepareExternalPlanSessionLaunch` in
+`app/src/services/sessionAuthoringService.ts` freezes an immutable execution prescription and
+returns a `SessionReferenceBinding` with:
 
-Mirror the `catalog` path exactly: freeze a content-addressed `ExecutionPrescription`
-with `sessionSource: { kind: 'external_plan', ... }`, no `session_occurrences` write, no
-`OccurrenceAuthority`/`definitionRef` schema change. `primarySession` gets populated for a
-v4 recommendation the same way it already does for catalog/manual ones. This alone makes
-a v4 external-plan session **launchable through `SessionRunner`** and replayable through
-the same prescription-hash boundary everything else uses — a large, real capability gap
-closed — without touching occurrence schema at all.
+```typescript
+{
+  sessionSource: {
+    kind: 'external_plan',
+    planId,
+    revision,
+    sessionId,
+    contentHash,
+  },
+  prescriptionHash,
+}
+```
 
-**Tradeoff:** does not yet give D-REASSESS a way to check "has the predecessor bundle
-member's occurrence actually completed" (there's no occurrence record to query), and does
-not yet let a bundle's second member become an independently-tracked `additionalSessions`
-entry with its own lifecycle state (`scheduled` → `active` → `completed`). Both of those
-need real occurrence tracking — deliberately deferred to a follow-up PR (see below), not
-because they don't matter, but because they're separable and this slice is valuable on
-its own.
+The immutable authored source is identified by `(planId, revision, sessionId, contentHash)`.
+The recommendation/execution carries the calendar date separately; date is not part of
+`SessionSourceRef`.
 
-### Option B — Full occurrence tracking now
+This mirrors the catalog launch model: the recommendation already owns selection authority, so
+starting it does not need to fabricate a separate `session_occurrences` record.
 
-Extend `OccurrenceAuthority` with `'external_plan'`, extend or replace
-`SessionOccurrence.definitionRef` to carry plan/session identity (or add a parallel
-`externalPlanRef` field alongside it), and build real occurrence records for v4
-external-plan sessions from the start. Bigger and riskier as a first PR: touches
-`sessions/models.ts` (a widely-imported shared type), `firestore.rules`' `session_occurrences`
-validation, and `sessionOccurrenceService.ts`'s query/write surface, all before proving
-out the simpler prescription-only path even works end-to-end through `SessionRunner`.
+### 2. Content-addressed execution snapshot
 
-**Decision (confirmed with the repo owner):** ship Option A first.
+The helper:
 
-## Recommended PR 1 scope
+1. rejects non-executable external target events;
+2. defensively validates the `SessionDefinition`;
+3. hashes the definition;
+4. constructs the `external_plan` source identity;
+5. snapshots blocks plus display metadata;
+6. hashes the execution prescription;
+7. persists it through `executionPrescriptionService.savePrescription`;
+8. returns the binding for `SessionRunner`.
 
-**Goal:** a v4 external-plan session's primary recommendation gets a real
-`SessionReferenceBinding` (`kind: 'external_plan'`) and becomes launchable through
-`SessionRunner`, exactly like a catalog session today. No occurrence record. No change to
-v1-v3 sessions' existing display-only path. No change to bundle/`additionalSessions`
-surfacing (that's PR 2+, see below) — this PR is specifically about making the **existing
-single primary external-plan session** real, since that's the prerequisite every later
-piece (bundle launch, D-REASSESS) builds on.
+`displayMetadata` is included so stored prescriptions satisfy the resolver/service validation
+contract and retain the historical title/summary/intent/modality/duration context.
 
-### Concrete changes
+`createdAt` remains persisted provenance but is intentionally excluded from
+`canonicalExecutionPrescriptionJson`. Re-preparing the same source and executable content
+therefore yields the same `prescriptionHash` even when invocation timestamps differ.
 
-1. **`app/src/services/sessionAuthoringService.ts`** — add:
-   ```typescript
-   /**
-    * Freezes the execution-prescription snapshot for a v4 external-plan session (ADR-0036
-    * H4). Mirrors prepareCatalogSessionLaunch's shape: no session_occurrences record --
-    * an external-plan session's identity is already (planId, revision, sessionId, date),
-    * the same reasoning a catalog recommendation's (workoutId, catalogVersion) needs no
-    * separate occurrence doc either. v1-v3 sessions (prescription: {summary}, no
-    * SessionDefinition) are out of scope -- this only accepts a v4 ExternalPlanContext.
-    */
-    export async function prepareExternalPlanSessionLaunch(
-        userId: string,
-        externalPlan: { planId: string; revision: number; contentHash: string; session: ExternalPlanSessionV4 },
-        summaryOverride?: string,
-    ): Promise<PreparedSessionLaunch> {
-        const definition = externalPlan.session.definition;
-        // Defense in depth: already validated at import time (validateExternalSessionV2,
-        // reused unchanged by v4), but every other launch path re-validates too.
-        const validation = validateSessionDefinition(definition);
-        if (!validation.ok) {
-            throw new Error(validation.issues.map(issue => `${issue.path}: ${issue.message}`).join('\n'));
-        }
-        const definitionHash = await hashSessionDefinition(definition);
-        const sessionSource: Extract<SessionReferenceBinding['sessionSource'], { kind: 'external_plan' }> = {
-            kind: 'external_plan',
-            planId: externalPlan.planId,
-            revision: externalPlan.revision,
-            sessionId: externalPlan.session.id,
-            contentHash: externalPlan.contentHash,
-        };
-        const effectiveSummary = summaryOverride ?? definition.summary;
-        const unsignedPrescription: ExecutionPrescription = {
-            schemaVersion: 1,
-            prescriptionHash: '',
-            sessionSource,
-            definitionHash,
-            blocks: definition.blocks,
-            displayMetadata: {
-                title: definition.title,
-                ...(effectiveSummary !== undefined ? { summary: effectiveSummary } : {}),
-                intent: definition.intent,
-                ...(definition.dominantModality !== undefined ? { dominantModality: definition.dominantModality } : {}),
-                ...(definition.duration !== undefined ? { duration: definition.duration } : {}),
-            },
-            createdAt: new Date().toISOString(),
-        };
-        const prescriptionHash = await hashExecutionPrescription(unsignedPrescription);
-        await executionPrescriptionService.savePrescription(userId, { ...unsignedPrescription, prescriptionHash });
-        return { definition, binding: { sessionSource, prescriptionHash } };
-    }
-   ```
-   Exact field names/types need re-verification against current `sessionAuthoringService.ts`
-   at implementation time (this doc was written against the tree as of PR #432 merging;
-   confirm nothing shifted).
+### 3. Caller-side wiring keeps the engine pure
 
-2. **`app/src/components/Home.tsx`** — after `evaluateTrainingWithIntent` returns and
-   `recommendationWithPrescription`/`primarySession` are being assembled (the existing
-   `if (recommendationWithPrescription.prescription) { ... prepareCatalogSessionLaunch ... }`
-   block): add an `else if` branch for when the recommendation came from
-   `adjudicatedExternalRecommendation`.
+`Home.tsx` prepares the binding only after `evaluateTrainingWithIntent` has returned. Binding
+creation is asynchronous and persists a prescription, so it does not belong in the pure
+recommendation engine.
 
-   **CRITICAL DOMAIN SAFETY GATE:**
-   In `rules.ts:659`, `externalPrescription` is *unconditionally* populated whenever an
-   external plan session is present, even if the engine ruled `skip` (clinical red flag or
-   safety-restricted modality) or `defer` (recovery mode), or if the recommended template was
-   swapped to canonical Rest (`rest_01`). A `primarySession` binding must **NEVER** be created
-   for a skipped or deferred session.
+This is the same architectural boundary already used for catalog/manual launch preparation.
 
-    Gate the launch preparation strictly on:
-    ```typescript
-    const isV4 = activeExternal && isV4Plan(activeExternal.plan);
-    const isProceed = recommendationWithPrescription.externalVerdict?.decision === 'proceed';
-    const notRest = recommendationWithPrescription.template.id !== 'rest_01';
-    if (isV4 && isProceed && notRest && externalContext && 'definition' in externalContext.session) {
-        try {
-            const launch = await prepareExternalPlanSessionLaunch(
-                userId,
-                {
-                    planId: externalContext.planId,
-                    revision: externalContext.revision,
-                    contentHash: externalContext.contentHash,
-                    session: externalContext.session as ExternalPlanSessionV4,
-                },
-            );
-            if (!isCurrent()) return;
-            primarySession = launch.binding;
-        } catch (err) {
-            console.warn('Failed to prepare the external-plan session binding for today\'s recommendation:', err);
-        }
-    }
-    ```
+## Safety and correctness gates
 
-3. **Behavior on `scale` verdict:**
-   For catalog sessions, `resolveWorkoutPrescription` produces `adjustedBlocks`. External-plan
-   sessions currently lack a block-level auto-scaling transformer (only
-   `session.scaling.reducedSummary` and volume/intensity scalar bounds exist). Launching
-   unscaled blocks when a session was adjudicated as `scale` would run the full authored
-   workout without the advised reduction. Therefore, in PR 1, `primarySession` is **strictly
-   excluded** on `scale` verdicts (in addition to `skip` and `defer`), and is only bound when
-   the verdict is `proceed`. `ExternalVerdictBanner` continues to render the scaled summary and
-   prescribed reduction text for the athlete. A full block-level scaling engine for external
-   definitions is deferred to a future PR.
+PR 1 uses a deliberately narrow launch policy.
 
-4. **Decide whether `externalPrescription`/`externalVerdict`/`decisionTrace.externalPlan`
-   stay populated alongside the new `primarySession`, or whether `primarySession` replaces
-   them once populated.** Recommendation: **keep both** for this PR. `externalPrescription`
-   is still what today's UI (`ExternalVerdictBanner`, `ExternalPlanWeek`) renders for
-   the plan-week overview and the athlete's own annotation/verdict flow; `primarySession`
-   is strictly additive, enabling a *new* "Start Session" action through `SessionRunner`
-   that didn't exist before. Removing the old fields would be a separate, larger UI
-   migration and is not needed to unblock D-PLACEMENT/D-REASSESS.
+### Runtime schema gate
 
-5. **UI: launch affordance already verified.**
-   Inspection of `MorningDecisionCard.tsx:286` confirms it already checks
-   `(canLaunchCurrentPrescription || (recommendation.primarySession && onStartSession))`.
-   Once `primarySession` is populated, the "Start Workout" hero button renders automatically
-   without UI rewrites. Note: load adjustments (`easier`/`harder`) in `MorningDecisionCard.tsx`
-   rely on catalog prescriptions and are naturally inactive for external sessions.
+A binding is created only when the active plan passes the real v4 schema discriminator:
 
-6. **Tests:**
-   - `sessionAuthoringService.test.ts` (or a new sibling file): unit tests for
-     `prepareExternalPlanSessionLaunch` — valid v4 session produces a correct binding and
-     saved prescription; an invalid `definition` (if one could ever reach this function
-     despite import-time validation — test the defensive re-validation path) throws.
-   - An integration-level test (wherever `Home.tsx`'s recommendation-assembly logic is
-     covered, if anywhere — check for existing `Home.test.tsx`-style coverage of the
-     catalog/manual launch branches to mirror) confirming a v4 primary session gets a
-     `primarySession` binding while a v1-v3 primary session does not (regression guard for
-     "v1-v3 stays untouched").
-   - `SessionRunner.tsx`'s existing tests should not need changes if `PreparedSessionLaunch`'s
-     shape is respected exactly — verify by running its existing suite after wiring this in.
+```typescript
+activeExternal && isV4Plan(activeExternal.plan)
+```
 
-7. **No `POLICY_VERSION` bump needed for the launch mechanism itself** (this doesn't change
-   *which* session is recommended, only how an already-recommended v4 session can be
-   started) — but re-verify this claim once the exact `Home.tsx` diff is known.
-   - **Firestore rules status:** `firestore.rules:1218-1222` (`hasValidSessionSource`) and
-     `1234-1241` (`hasValidSessionReferenceBinding`) already accept `kind: 'external_plan'` with
-     `['kind', 'planId', 'revision', 'sessionId', 'contentHash']` and optional `occurrenceId`.
-     No rules change is needed to support the binding.
-   - **Expression budget risk:** `hasValidRecommendationAudit` (`firestore.rules:321-376`) is near
-     Firestore's ~1,000 expression limit. When an external-plan recommendation populates both
-     `externalPlan` (lines 368-376) and `primarySession` (line 358), both branches will evaluate
-     simultaneously. Running `npm run test:rules` during PR 1 implementation is required to verify
-     that the evaluation budget remains within limits.
+The mere presence of `session.definition` is not sufficient because v2/v3 sessions also have
+structured definitions.
 
-### Suggested PR description (paste and adapt)
+### Verdict gate: `proceed` only
 
-> ## Summary
-> First PR of the external-plan execution-binding pipeline (issue #434), discovered
-> missing while wiring ADR-0036 H4 D-PLACEMENT ([PR #432](https://github.com/Szczepanov/adaptive-training-recommender/pull/432)).
-> `SessionSourceRef`'s `kind: 'external_plan'` was declared but never constructed --
-> not even for today's single primary external-plan session, which has never been
-> launchable through `SessionRunner`.
->
-> Scoped to v4 for H4 intraday bundle continuity (mirroring the `catalog` no-occurrence-record precedent):
-> while v2/v3 plans also carry structured `SessionDefinition`, v4 is the specific target
-> for H4 intraday bundles. `definition` is already validated by `validateSessionDefinition`
-> at import time. No `OccurrenceAuthority`/`SessionOccurrence` schema change in this PR -- an
-> external-plan session's identity is already `(planId, revision, sessionId, date)`,
-> needing no separate occurrence doc, the same reasoning a catalog recommendation
-> already relies on.
->
-> ## What's delivered
-> - `sessionAuthoringService.ts`: new `prepareExternalPlanSessionLaunch`, mirroring
->   `prepareCatalogSessionLaunch`'s shape, snapshotting `displayMetadata` and supporting
->   `summaryOverride` for scaled sessions.
-> - `Home.tsx`: wires it into the existing external-plan recommendation branch,
->   populating `primarySession` for actionable v4 sessions (`verdict.decision in ['proceed', 'scale']`
->   and `template.id !== 'rest_01'`).
-> - Crucial domain safety gate: skipped or deferred external sessions (e.g. clinical red flags,
->   recovery mode) never receive a `primarySession` binding.
-> - Existing `externalPrescription`/`externalVerdict`/`decisionTrace.externalPlan` fields are
->   preserved alongside `primarySession` to keep today's plan-week display intact.
->
-> ## Not in scope here
-> - Occurrence tracking (needed for D-REASSESS's predecessor-completion check and
->   multi-occurrence bundle launches) -- separate follow-up PR.
-> - Surfacing a bundle's second member as a real `additionalSessions` entry -- needs the
->   occurrence-tracking follow-up first.
-> - Full block-level scaling transformation for external definitions (`scale` verdict is strictly excluded from `primarySession` launch until block scaling exists).
->
-> ## Validation
-> (standard checklist: typecheck, lint, full vitest, build, rules emulator tests,
-> simulate:scenarios/diff, check-policy-drift.mjs)
+A v4 external session receives `primarySession` only when:
 
-## Future PRs (roadmap beyond PR 1)
+```typescript
+recommendationWithPrescription.externalVerdict?.decision === 'proceed'
+```
 
-1. **PR 1** (this doc): prescription-only v4 launch binding. No occurrence record.
-2. **PR 2 — occurrence tracking.** Extend `OccurrenceAuthority` with `'external_plan'`
-   (or find a less invasive alternative — e.g. a parallel `externalPlanRef` on
-   `SessionOccurrence` instead of overloading `definitionRef`; evaluate both at
-   implementation time) and create a real occurrence record when a v4 external-plan
-   session launches, so its lifecycle (`scheduled → active → completed`) is queryable
-   independently of the plan/date. This is the prerequisite for:
-3. **PR 3 — bundle second-member launch.** Once occurrence tracking exists, a v4 intraday
-   bundle's non-primary members (already correctly *placed* by
-   `activeExternalPlanService.ts`'s `resolveIntradayBundlePlacement`, PR #432) can be
-   adjudicated via `adjudicateAuthoredSession` (reusing the exact pattern `Home.tsx`
-   already uses for manually-authored additional sessions, per the manual
-   `additionalOccurrences` loop) and surfaced as real `additionalSessions` entries the
-   athlete can independently launch.
-4. **PR 4 — D-REASSESS** (issue #436) becomes meaningful once PR 3 exists: "before a later
-   session starts" requires that later session to be a real, launchable thing with
-   trackable state.
+`skip`, `defer`, and `scale` do not receive an executable binding.
 
-## Verified facts & risks for the implementing agent
+### Why `scale` is excluded
 
-- **Firestore rules support verified:** `firestore.rules:1218-1222` already accepts
-  `kind: 'external_plan'` with `['kind', 'planId', 'revision', 'sessionId', 'contentHash']`.
-  No rules change is needed.
-- **Rules budget risk:** When `primarySession` is present on an external plan recommendation,
-  `hasValidRecommendationAudit` evaluates both `externalPlan` and `primarySession`.
-  Run `npm run test:rules` to ensure the 1,000 expression limit is not exceeded.
-- **UI launch affordance verified:** `MorningDecisionCard.tsx:286` already checks
-  `(canLaunchCurrentPrescription || (recommendation.primarySession && onStartSession))`.
-  The "Start Workout" button appears automatically once `primarySession` is populated.
-- **Domain safety invariant:** Ensure `Home.tsx` checks `activeExternal && isV4Plan(activeExternal.plan)`,
-  `verdict === 'proceed'`, and `template.id !== 'rest_01'`. Never bind `primarySession` on
-  `skip`, `defer`, or `scale` (until block-scaling exists, preventing execution of unscaled blocks).
+External-plan adjudication can return reduction guidance, but PR 1 does not contain a
+block-level transformer that turns the authored `SessionDefinition.blocks` into the reduced
+execution the verdict describes. Launching the original blocks on a `scale` verdict would be
+unsafe and semantically wrong.
+
+Until an explicit external-definition scaling path exists, the UI may display the scaling
+advice but must not offer the authored full session as the executable prescription.
+
+### Rest gate
+
+Canonical Rest (`rest_01`) never receives an external launch binding.
+
+### External target events are advisory, not executable sessions
+
+Imported sessions with `isEvent: true` have a distinct engine role: `rules.ts` reconciles them
+as fixed-activity/advisory inputs while the normal planner may still recommend another
+session. An `externalVerdict` can therefore exist even when the external event is **not** the
+recommended executable session.
+
+`prepareExternalPlanSessionLaunch` rejects `isEvent` sessions as defense in depth. This prevents
+an advisory event from becoming `primarySession` if a caller ever invokes the helper from an
+ambiguous recommendation state.
+
+This event guard is important because launch eligibility must be based on the executable
+recommendation, not merely on the presence of `externalVerdict` metadata.
+
+## Coexistence with the existing external-plan UI/audit contract
+
+PR 1 keeps these fields:
+
+- `externalPrescription`;
+- `externalVerdict`;
+- `decisionTrace.externalPlan`.
+
+They remain useful for the plan-week UI, verdict messaging, provenance, and replay. The new
+`primarySession` binding is additive: it gives an eligible v4 primary recommendation an
+immutable structured launch path without forcing a larger UI/audit migration in the same PR.
+
+`MorningDecisionCard` already knows how to expose the start action when `primarySession` and
+`onStartSession` are present, so no new visual launch component is required.
+
+## Persistence and resolver behavior
+
+On launch, `App.tsx` resolves the stored binding through `resolveSessionDefinition` using both
+`sessionSource` and `prescriptionHash`.
+
+For an external-plan source, the resolver:
+
+1. reloads the stored immutable plan revision;
+2. verifies its content hash;
+3. locates `sessionId`;
+4. reconstructs the normalized definition;
+5. verifies the stored prescription source and definition hash;
+6. applies the snapshotted executable blocks.
+
+This keeps launch/replay tied to the exact imported plan revision rather than re-deriving a
+session from unrelated live state.
+
+## Tests added/maintained in PR 1
+
+`sessionAuthoringService.test.ts` covers:
+
+- correct `external_plan` binding identity;
+- no `session_occurrences` write in PR 1;
+- persisted blocks and display metadata;
+- deterministic `prescriptionHash` across different `createdAt` values;
+- write-once/idempotency behavior of the test persistence fake;
+- summary override participation in the stored snapshot;
+- defensive rejection of an invalid `SessionDefinition`;
+- defensive rejection of `isEvent` sessions before persistence.
+
+The existing full CI/rules/scenario suites remain the integration backstop for catalog/manual
+launch behavior, recommendation persistence, and Firestore validation.
+
+## Firestore rules and current main
+
+The `external_plan` source shape is already accepted by Firestore recommendation/prescription
+validation. PR 1 does not need a new source schema in rules.
+
+The original analysis identified rule-expression-budget risk when both `externalPlan` audit
+metadata and `primarySession` are present. [PR #441](https://github.com/Szczepanov/adaptive-training-recommender/pull/441)
+was subsequently merged to `main` to deduplicate `primarySession`/`additionalSessions`
+validation in `hasValidRecommendationAudit`. PR #440 must therefore continue to validate
+cleanly against current `main`, not only against its original base commit.
+
+## Deliberately out of scope for PR 1
+
+### Occurrence tracking
+
+`OccurrenceAuthority` still has no external-plan authority, and `SessionOccurrence` does not
+yet carry external plan/session identity. PR 1 therefore does not create an external-plan
+occurrence lifecycle.
+
+Occurrence tracking is needed once execution state must be queried independently of the daily
+recommendation — especially predecessor completion for D-REASSESS and multiple launchable
+bundle members on one date.
+
+### Secondary intraday-bundle members
+
+PR 1 only makes the already-selected primary v4 session executable. It does not surface a
+bundle's second/third member as `additionalSessions`.
+
+### D-REASSESS
+
+Before a later bundle session can be re-assessed immediately before launch, that later session
+must first exist as an independently launchable, trackable entity. That depends on the
+occurrence/bundle work below.
+
+### Block-level external scaling
+
+A future implementation may transform external `SessionDefinition.blocks` according to an
+accepted scale verdict, then hash and persist the transformed execution snapshot. Until that
+exists, `scale` remains display/advice only and cannot launch.
+
+## Follow-up roadmap
+
+1. **PR 1 — implemented here:** prescription-only v4 primary-session launch binding, no
+   occurrence record.
+2. **PR 2 — occurrence tracking:** introduce a source-appropriate external-plan occurrence
+   identity/lifecycle without overloading manual `definitionRef` semantics. Evaluate whether
+   this is best represented by an `externalPlanRef` branch/union rather than forcing
+   `planId`/`sessionId` into manual-definition fields.
+3. **PR 3 — bundle member execution:** use resolved intraday placement to adjudicate and
+   surface non-primary v4 members as independently launchable `additionalSessions` entries.
+4. **PR 4 — D-REASSESS:** before a dependent/later member starts, reconcile real predecessor
+   completion and elapsed separation against execution evidence, then re-adjudicate using
+   current readiness/safety/availability state.
+5. **Optional later work — block scaling:** add a deterministic, testable external-definition
+   scaling transform before allowing `scale` verdicts to produce launch bindings.
+
+## Governing invariants for follow-up PRs
+
+- Keep recommendation selection/adjudication pure; persistence belongs in caller/services.
+- Never infer v4 from the presence of `definition`; use the schema discriminator.
+- Never create a launch binding for `skip`, `defer`, or untransformed `scale` verdicts.
+- Never turn imported target-event advisory metadata into an executable primary session.
+- Preserve `contentHash`/`prescriptionHash` verification boundaries during replay.
+- Do not silently extend v1-v3 execution behavior while implementing H4 v4 bundle features.
+- Do not create occurrence records merely to mirror another source type; add them when an
+  independent lifecycle/evidence identity is actually required.
+- Keep Firestore expression-budget tests in the required validation set whenever recommendation
+  binding/audit fields change.

--- a/docs/plans/h4-external-plan-execution-binding-pipeline.md
+++ b/docs/plans/h4-external-plan-execution-binding-pipeline.md
@@ -207,38 +207,39 @@ piece (bundle launch, D-REASSESS) builds on.
    swapped to canonical Rest (`rest_01`). A `primarySession` binding must **NEVER** be created
    for a skipped or deferred session.
 
-   Gate the launch preparation strictly on:
-   ```typescript
-   const verdict = recommendationWithPrescription.externalVerdict?.decision;
-   const isActionable = verdict === 'proceed' || verdict === 'scale';
-   const notRest = recommendationWithPrescription.template.id !== 'rest_01';
-   if (isActionable && notRest && externalContext && 'definition' in externalContext.session) {
-       try {
-           const launch = await prepareExternalPlanSessionLaunch(
-               userId,
-               {
-                   planId: externalContext.planId,
-                   revision: externalContext.revision,
-                   contentHash: externalContext.contentHash,
-                   session: externalContext.session as ExternalPlanSessionV4,
-               },
-               recommendationWithPrescription.externalVerdict?.scaledSummary,
-           );
-           if (!isCurrent()) return;
-           primarySession = launch.binding;
-       } catch (err) {
-           console.warn('Failed to prepare the external-plan session binding for today\'s recommendation:', err);
-       }
-   }
-   ```
+    Gate the launch preparation strictly on:
+    ```typescript
+    const isV4 = activeExternal && isV4Plan(activeExternal.plan);
+    const isProceed = recommendationWithPrescription.externalVerdict?.decision === 'proceed';
+    const notRest = recommendationWithPrescription.template.id !== 'rest_01';
+    if (isV4 && isProceed && notRest && externalContext && 'definition' in externalContext.session) {
+        try {
+            const launch = await prepareExternalPlanSessionLaunch(
+                userId,
+                {
+                    planId: externalContext.planId,
+                    revision: externalContext.revision,
+                    contentHash: externalContext.contentHash,
+                    session: externalContext.session as ExternalPlanSessionV4,
+                },
+            );
+            if (!isCurrent()) return;
+            primarySession = launch.binding;
+        } catch (err) {
+            console.warn('Failed to prepare the external-plan session binding for today\'s recommendation:', err);
+        }
+    }
+    ```
 
 3. **Behavior on `scale` verdict:**
    For catalog sessions, `resolveWorkoutPrescription` produces `adjustedBlocks`. External-plan
    sessions currently lack a block-level auto-scaling transformer (only
-   `session.scaling.reducedSummary` and volume/intensity scalar bounds exist). In PR 1,
-   `session.definition` blocks remain the authored blocks, while `displayMetadata.summary`
-   captures `verdict.scaledSummary` (passed via `summaryOverride` above) so the athlete and
-   subsequent replays see the intended reduction. A full block-level scaling engine for external
+   `session.scaling.reducedSummary` and volume/intensity scalar bounds exist). Launching
+   unscaled blocks when a session was adjudicated as `scale` would run the full authored
+   workout without the advised reduction. Therefore, in PR 1, `primarySession` is **strictly
+   excluded** on `scale` verdicts (in addition to `skip` and `defer`), and is only bound when
+   the verdict is `proceed`. `ExternalVerdictBanner` continues to render the scaled summary and
+   prescribed reduction text for the athlete. A full block-level scaling engine for external
    definitions is deferred to a future PR.
 
 4. **Decide whether `externalPrescription`/`externalVerdict`/`decisionTrace.externalPlan`
@@ -317,7 +318,7 @@ piece (bundle launch, D-REASSESS) builds on.
 >   multi-occurrence bundle launches) -- separate follow-up PR.
 > - Surfacing a bundle's second member as a real `additionalSessions` entry -- needs the
 >   occurrence-tracking follow-up first.
-> - Full block-level scaling transformation for external definitions (uses `summaryOverride` in PR 1).
+> - Full block-level scaling transformation for external definitions (`scale` verdict is strictly excluded from `primarySession` launch until block scaling exists).
 >
 > ## Validation
 > (standard checklist: typecheck, lint, full vitest, build, rules emulator tests,
@@ -354,5 +355,6 @@ piece (bundle launch, D-REASSESS) builds on.
 - **UI launch affordance verified:** `MorningDecisionCard.tsx:286` already checks
   `(canLaunchCurrentPrescription || (recommendation.primarySession && onStartSession))`.
   The "Start Workout" button appears automatically once `primarySession` is populated.
-- **Domain safety invariant:** Ensure `Home.tsx` checks `verdict === 'proceed' || verdict === 'scale'`
-  and `template.id !== 'rest_01'`. Never bind `primarySession` on `skip` or `defer`.
+- **Domain safety invariant:** Ensure `Home.tsx` checks `activeExternal && isV4Plan(activeExternal.plan)`,
+  `verdict === 'proceed'`, and `template.id !== 'rest_01'`. Never bind `primarySession` on
+  `skip`, `defer`, or `scale` (until block-scaling exists, preventing execution of unscaled blocks).


### PR DESCRIPTION
## Summary

- Implements PR 1 of the external-plan execution-binding pipeline for [issue #434](https://github.com/Szczepanov/adaptive-training-recommender/issues/434) as planned in [`docs/plans/h4-external-plan-execution-binding-pipeline.md`](docs/plans/h4-external-plan-execution-binding-pipeline.md).
- Closes the execution gap for external-plan sessions: enables actionable v4 imported sessions to construct a valid `SessionReferenceBinding` (`kind: 'external_plan'`) and save an immutable, content-addressed `ExecutionPrescription` write-once, allowing the session to be launched and tracked via `SessionRunner.tsx`.
- Enforces critical domain safety and version gating in `Home.tsx`:
  - Enforces `activeExternal && isV4Plan(activeExternal.plan)` to ensure legacy v1–v3 plans remain on their un-bound path.
  - Strictly requires `externalVerdict.decision === 'proceed'` and `template.id !== 'rest_01'` to bind `primarySession`. Sessions with `skip`, `defer`, or `scale` verdicts do not receive a launch binding (preventing execution of unscaled blocks on scaled recommendations until block-scaling is implemented).
- Adds `prepareExternalPlanSessionLaunch` in `sessionAuthoringService.ts` with defensive validation (`validateSessionDefinition`), deterministic hashing (`definitionHash`, `prescriptionHash`), and write-once persistence via `executionPrescriptionService.savePrescription`.
- Defensively rejects imported `isEvent` target-event sessions at the launch-preparation boundary. External events are advisory/fixed-activity inputs and can carry external verdict metadata while the planner recommends a different executable session; they must never become an external-plan `primarySession` through an ambiguous caller path.
- Explicitly verifies that volatile `createdAt` provenance is excluded from the canonical execution prescription hash payload (ADR-0023 D-MSNAP).
- Adds comprehensive unit test coverage in `sessionAuthoringService.test.ts` for idempotency, `createdAt` hash omission, summary overrides, event rejection, and defensive validation.
- Reworks the H4 handoff document to distinguish implemented PR-1 invariants from PR-2+ occurrence/bundle/reassessment work, and records compatibility with the Firestore validation deduplication merged in #441.

## Validation

- [x] `uv run pytest` (backend changes)
- [x] `cd app && npm run check` (frontend changes)
- [x] `cd app && npm run test:rules` (Firestore rules changes)
- [x] `cd app && npm run simulate:scenarios` (recommendation-engine changes)
- [ ] `uv run ruff check .` and `uv run mypy src/garmin_sync` (backend changes — no backend source files modified)
- [ ] `cd app && npm run visual:refresh` (material UI changes — no visual UI layout modified)

Results:
- `uv run pytest`: 782 passed in 6.84s.
- `cd app && npm run check`: 3,693 passed across 395 suites; 0 TypeScript errors, 0 ESLint errors; knowledge & workout catalogs validated.
- `cd app && npm run test:rules`: 190 passed across 12 test files in the local Firestore emulator, verifying rules budget and expression limits for `SessionReferenceBinding` with `kind: 'external_plan'`.
- `cd app && npm run simulate:scenarios` & `simulate:diff`: 39 scenarios simulated; no unintended drift.
- `cd app && node scripts/check-policy-drift.mjs origin/main`: passed; no decision-affecting engine files modified.
- `npx vitest run src/services/sessionAuthoringService.test.ts`: 9 passed after the event-advisory regression test was added.
- GitHub CI Pipeline #2564: passed on head `69378af`; GitHub tested synthetic merge `b9caae7` against current `main` `c24a87b` (including #441).

## Risk and reviewer guidance

Low risk: scoped strictly to v4 external-plan sessions with defensive validation and idempotency.
1. Inspect the safety gate in `Home.tsx:476-483`: verify that `primarySession` requires `isV4Plan(activeExternal.plan)`, `externalVerdict.decision === 'proceed'`, and non-rest templates.
2. Inspect `prepareExternalPlanSessionLaunch` in `sessionAuthoringService.ts`: verify that target events are rejected, `displayMetadata` is preserved, `createdAt` is omitted from the hash via `canonicalExecutionPrescriptionJson`, and no redundant `session_occurrences` records are created.
3. Reviewer confirmation that `firestore.rules` already supports `kind: 'external_plan'` with optional `occurrenceId`, and full emulator suite passes cleanly. PR #441 has already landed on `main` to deduplicate `primarySession`/`additionalSessions` recommendation-audit validation.

## Domain invariants

- [x] Firestore writes remain user-scoped under `users/{APP_USER_ID}/...`; execution prescriptions are saved under `users/{userId}/execution_prescriptions/{hash}`.
- [x] Calendar-date logic uses `Europe/Warsaw`; no UTC `toISOString().split('T')[0]` regressions introduced.
- [x] No credentials, tokens, service-account files, or raw health payloads are included.
- [x] Recommendation decision logic was not changed; `POLICY_VERSION` drift was still evaluated with `check-policy-drift.mjs` and no decision-affecting engine files were modified.

## Screenshots or recordings

Not applicable — non-visual logic and data-binding wiring; existing `MorningDecisionCard` launch button affords starting the workout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - External Plan V4 sessions can be prepared and launched for valid definitions when recommendations receive an actionable “proceed” verdict.
  - Session preparation preserves plan bindings, content-addressed prescriptions, metadata, and display details while preventing duplicate records.
  - Optional summary overrides are retained for external-plan sessions.

- **Bug Fixes**
  - “Scale” verdicts no longer create a primary session.
  - Invalid or advisory target-event plans are rejected before persistence.
  - Launch failures no longer interrupt recommendation generation.

- **Documentation**
  - Clarified launch eligibility, validation, safety behavior, and verification coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->