### PR TITLE
fix(rules): dedupe primarySession/additionalSessions validation in hasValidRecommendationAudit

### DIFF
--- a/app/firestore.rules
+++ b/app/firestore.rules
@@ -355,8 +355,19 @@ service cloud.firestore {
           || (('overridden' in audit.externalRest) && audit.externalRest.overridden == true)
           || audit.candidateScores.size() == 0)
         && (!('droppedContributorObjectives' in audit) || (audit.droppedContributorObjectives is list && audit.droppedContributorObjectives.size() <= 64))
-        && (!('primarySession' in audit) || hasValidSessionReferenceBinding(audit.primarySession))
-        && (!('additionalSessions' in audit) || hasValidAdditionalSessions(audit.additionalSessions))
+        // `provenance.ts`'s buildRecommendationAudit sets audit.primarySession/
+        // additionalSessions to the exact same value as the sibling top-level
+        // request.resource.data.primarySession/additionalSessions field (never an
+        // independently-derived copy) -- hasValidRecommendation already runs the full
+        // hasValidSessionReferenceBinding/hasValidAdditionalSessions structural
+        // validation on those top-level fields. Re-running that same (non-trivial: up to
+        // 4 additional-session bindings, each checking several source-kind shapes)
+        // validation a second time here on an identical value was pure duplicate rule-
+        // evaluation cost; a single equality check against the already-validated
+        // top-level field is enough and meaningfully reduces this audit's total
+        // evaluation cost (see the per-request rule-evaluation ceiling note below).
+        && (!('primarySession' in audit) || audit.primarySession == request.resource.data.primarySession)
+        && (!('additionalSessions' in audit) || audit.additionalSessions == request.resource.data.additionalSessions)
         // ADR-0036 (H4) D-PLACEMENT: a v4 intraday bundle's resolved window trace was
         // intended to persist here for display, but this whole audit is already right at
         // Firestore's per-request rule-evaluation ceiling -- adding even a minimal
@@ -364,7 +375,14 @@ service cloud.firestore {
         // suite, not a guess) pushed a create/update over "the maximum of 1000
         // expressions to evaluate". That display field is deliberately not persisted;
         // `activeExternalPlanService.ts`'s bundle-aware primary-session selection (the
-        // actual decision-affecting behavior) does not depend on it.
+        // actual decision-affecting behavior) does not depend on it. The
+        // primarySession/additionalSessions dedup above (issue #435) is a real, verified
+        // reduction in this audit's evaluation cost, but re-tested with the emulator
+        // suite and confirmed **still not enough headroom** for even the same minimal
+        // intradayBundle check -- the ceiling error recurred identically. Whoever revisits
+        // this next needs a bigger reduction than that one dedup (see issue #435's
+        // remaining candidates: knowledge-lineage unrolled-array cost, identity-provenance
+        // `get()` lookups, or moving this field outside `recommendationAudit` entirely).
         && (!('externalPlan' in audit) || (
           audit.externalPlan is map
           && audit.externalPlan.keys().hasOnly(['planId', 'revision', 'sessionId', 'contentHash'])


### PR DESCRIPTION
## Summary

Partial progress on [issue #435](https://github.com/Szczepanov/adaptive-training-recommender/issues/435) (Firestore rule-evaluation budget for `hasValidRecommendationAudit`). **Does not fully resolve the ceiling problem** — see below.

## What I found

`provenance.ts`'s `buildRecommendationAudit` sets `recommendationAudit.primarySession`/`additionalSessions` to the **exact same value** as the sibling top-level `Recommendation.primarySession`/`additionalSessions` field — never an independently-derived copy. `hasValidRecommendation` already runs the full `hasValidSessionReferenceBinding`/`hasValidAdditionalSessions` structural validation (up to 4 additional-session bindings, each checking several source-kind shapes — non-trivial) on those top-level fields. `hasValidRecommendationAudit` was then re-running that same validation a second time on an identical value — pure duplicate rule-evaluation cost.

## What this PR does

Replaces the audit copy's full structural re-validation with a single equality check against the already-validated top-level field. This is a real, verified reduction in the function's total evaluation cost.

**No functional/security weakening**: the equality check is at least as strict as before — a malicious direct write with a self-consistent-but-mismatched `audit.primarySession` (which the old independent re-validation would have separately accepted) is now rejected.

## What I re-tested and found: not enough on its own

I re-attempted restoring the `intradayBundle` field reverted in [PR #432](https://github.com/Szczepanov/adaptive-training-recommender/pull/432) after this dedup, expecting the freed budget to make room. It didn't — the identical `"maximum of 1000 expressions to evaluate"` ceiling error recurred, verified with the emulator suite. Left a comment in the rules file documenting this and naming candidate next steps for whoever continues #435: the knowledge-lineage unrolled-array cost (64 entries × several checks each), the identity-provenance `get()` lookups, or moving the `intradayBundle` field outside `recommendationAudit` entirely.

## Verification

```
npm run typecheck   # pass
npm run lint         # pass
npx vitest run       # 3688 passed, 190 skipped (full suite)
npm run build        # pass
npm run test:rules   # 190 passed (several flaky unrelated failures on retries, traced to a stray leftover Firestore emulator JVM process from an earlier session run holding resources -- killed it, then consistently clean)
npm run simulate:scenarios && npm run simulate:diff   # no new drift
node scripts/check-policy-drift.mjs origin/main   # PASSED: no decision-affecting engine files modified (this is a rules-only change, not decision behavior)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of recommendation session data by ensuring it matches the corresponding top-level recommendation fields.
  * Continued omitting persistence and validation of the v4 intraday bundle display trace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->