### PR TITLE
feat(engine): implement ADR-0036 D-REASSESS post-AM reassessment and claim gate (issue #436)

### DIFF
--- a/app/src/engine/intradayReassessment.test.ts
+++ b/app/src/engine/intradayReassessment.test.ts
@@ -327,11 +327,44 @@ describe('reassessDependentBundleMember (ADR-0036 D-REASSESS)', () => {
         expect(result.predecessorConfirmed).toBe(true);
         expect(result.reason).toContain('unexpected fatigue');
         expect(result.scaledDefinition).toBeDefined();
+        expect(result.executionDose?.volume).toBeCloseTo(0.7);
         // Repetition sets scaled down by 0.7 (4 sets * 0.7 = 3 sets)
         const scaledSets = result.scaledDefinition?.blocks[0].steps[0].dose;
         if (scaledSets?.kind === 'repetition') {
             expect(scaledSets.sets).toBe(3);
         }
+    });
+
+    it('scales PM session when predecessor reported moderate tissue irritability (limit severity)', () => {
+        const moderateTissuePredecessor: PredecessorEvidence = {
+            ...healthyPredecessor,
+            tissueResponses: [
+                {
+                    region: 'hamstring',
+                    morningState: 'moderate',
+                    afterTrainingState: 'normal',
+                },
+            ],
+        };
+
+        const result = reassessDependentBundleMember({
+            target,
+            predecessor: moderateTissuePredecessor,
+            evaluationInstant: '2026-09-06T15:00:00.000Z',
+            readiness: createMockReadiness(),
+            context: createMockContext(),
+            date: '2026-09-06',
+            availability: createMockAvailability(),
+            candidateWindowMinutes: 60,
+            dailyLedger: validLedger,
+            acceptedSameDaySystemicCost: 0.2,
+            inputRevision: mockInputRevision,
+        });
+
+        expect(result.decision).toBe('scale');
+        expect(result.predecessorConfirmed).toBe(true);
+        expect(result.reason).toContain('muscle ache');
+        expect(result.executionDose?.volume).toBeCloseTo(0.7);
     });
 
     it('proceeds despite alreadyTrainedToday being true on morning inputs (bypassing alreadyTrainedOverride)', () => {
@@ -363,7 +396,7 @@ describe('reassessDependentBundleMember (ADR-0036 D-REASSESS)', () => {
     it('rejects PM session when daily ledger minute capacity is exhausted', () => {
         const exhaustedLedger: DailyLedgerResult = {
             remainingMinutes: 20, // Candidate requires 45m
-            remainingSystemicCost: 0.5,
+            remainingSystemicCost: 1.0,
             unresolvedEntries: [],
         };
 
@@ -433,5 +466,6 @@ describe('reassessDependentBundleMember (ADR-0036 D-REASSESS)', () => {
 
         expect(result.decision).toBe('proceed');
         expect(result.timingPrerequisiteMet).toBe(true);
+        expect(result.predecessorConfirmed).toBe(false);
     });
 });

--- a/app/src/engine/intradayReassessment.test.ts
+++ b/app/src/engine/intradayReassessment.test.ts
@@ -330,9 +330,8 @@ describe('reassessDependentBundleMember (ADR-0036 D-REASSESS)', () => {
         expect(result.executionDose?.volume).toBeCloseTo(0.7);
         // Repetition sets scaled down by 0.7 (4 sets * 0.7 = 3 sets)
         const scaledSets = result.scaledDefinition?.blocks[0].steps[0].dose;
-        if (scaledSets?.kind === 'repetition') {
-            expect(scaledSets.sets).toBe(3);
-        }
+        expect(scaledSets?.kind).toBe('repetition');
+        expect(scaledSets).toMatchObject({ sets: 3 });
     });
 
     it('scales PM session when predecessor reported moderate tissue irritability (limit severity)', () => {
@@ -364,7 +363,58 @@ describe('reassessDependentBundleMember (ADR-0036 D-REASSESS)', () => {
         expect(result.decision).toBe('scale');
         expect(result.predecessorConfirmed).toBe(true);
         expect(result.reason).toContain('muscle ache');
+        expect(result.scaledDefinition).toBeDefined();
         expect(result.executionDose?.volume).toBeCloseTo(0.7);
+    });
+
+    it('rejects PM session when predecessor reached terminal state (superseded, abandoned, missed)', () => {
+        for (const terminalState of ['superseded', 'abandoned', 'missed'] as const) {
+            const result = reassessDependentBundleMember({
+                target,
+                predecessor: {
+                    ...healthyPredecessor,
+                    state: terminalState,
+                },
+                evaluationInstant: '2026-09-06T15:00:00.000Z',
+                readiness: createMockReadiness(),
+                context: createMockContext(),
+                date: '2026-09-06',
+                availability: createMockAvailability(),
+                candidateWindowMinutes: 60,
+                dailyLedger: validLedger,
+                acceptedSameDaySystemicCost: 0.2,
+                inputRevision: mockInputRevision,
+            });
+
+            expect(result.decision).toBe('reject');
+            expect(result.reason).toContain(`reached terminal state '${terminalState}'`);
+            expect(result.predecessorConfirmed).toBe(false);
+        }
+    });
+
+    it('enforces causality check even when minimumSeparationMinutes is undefined', () => {
+        const targetWithoutSeparation: DependentBundleMemberTarget = {
+            ...target,
+            minimumSeparationMinutes: undefined,
+        };
+
+        const result = reassessDependentBundleMember({
+            target: targetWithoutSeparation,
+            predecessor: healthyPredecessor, // completedAt is 2026-09-06T10:00:00.000Z
+            evaluationInstant: '2026-09-06T09:00:00.000Z', // 1 hour before completion!
+            readiness: createMockReadiness(),
+            context: createMockContext(),
+            date: '2026-09-06',
+            availability: createMockAvailability(),
+            candidateWindowMinutes: 60,
+            dailyLedger: validLedger,
+            acceptedSameDaySystemicCost: 0.2,
+            inputRevision: mockInputRevision,
+        });
+
+        expect(result.decision).toBe('pending');
+        expect(result.reason).toContain('predates predecessor completion');
+        expect(result.timingPrerequisiteMet).toBe(false);
     });
 
     it('proceeds despite alreadyTrainedToday being true on morning inputs (bypassing alreadyTrainedOverride)', () => {

--- a/app/src/engine/intradayReassessment.test.ts
+++ b/app/src/engine/intradayReassessment.test.ts
@@ -1,0 +1,437 @@
+import { describe, expect, it } from 'vitest';
+import type { DailyReadiness, EngineObjectiveInput, SubjectiveInput, UserContext } from './models';
+import type { SessionDefinition } from '../sessions/models';
+import type { ResolvedAvailability } from './schedule';
+import type { DailyLedgerResult } from './dailyLedger';
+import {
+    reassessDependentBundleMember,
+    type DependentBundleMemberTarget,
+    type PredecessorEvidence,
+    type ReassessmentInputRevision,
+} from './intradayReassessment';
+
+function createMockDefinition(overrides: Partial<SessionDefinition> = {}): SessionDefinition {
+    return {
+        schemaVersion: 1,
+        id: 'session-pm-1',
+        revision: 1,
+        title: 'Strength Maintenance',
+        intent: 'training',
+        dominantModality: 'Strength',
+        duration: { min: 45, max: 45 },
+        blocks: [
+            {
+                id: 'b1',
+                role: 'main',
+                executionMode: 'sequential',
+                steps: [
+                    {
+                        id: 's1',
+                        kind: 'exercise',
+                        dose: { kind: 'repetition', sets: 4, reps: 10 },
+                    },
+                ],
+            },
+        ],
+        ...overrides,
+    };
+}
+
+function createMockReadiness(overrides?: {
+    subjective?: Partial<SubjectiveInput>;
+    objective?: Partial<EngineObjectiveInput>;
+}): DailyReadiness {
+    return {
+        subjective: {
+            readiness: 8,
+            sleepQuality: 8,
+            fatigue: 3,
+            soreness: 2,
+            stress: 2,
+            motivation: 8,
+            timeAvailable: 60,
+            painFlag: false,
+            preferredModalityToday: null,
+            alreadyTrainedToday: true, // Crucial: predecessor was performed today!
+            ...overrides?.subjective,
+        },
+        objective: {
+            total_steps: 8000,
+            sleep_score: 82,
+            sleep_duration_min: 450,
+            rhr: 50,
+            rhr_7d_avg: 50,
+            rhr_delta: 0,
+            hrv_weekly_avg: 65,
+            hrv_last_night: 65,
+            hrv_delta: 0,
+            respiration: 14,
+            body_battery_wake: 85,
+            last_3_days_hard_sessions_count: 0,
+            yesterday_training: null,
+            today_training: { type: 'running', duration_min: 60, training_effect: 3.0, intensity_tag: 'aerobic' },
+            sleep_score_delta_7d: 0,
+            rhr_delta_28d: 0,
+            hrv_delta_28d: 0,
+            sleep_score_delta_28d: 0,
+            hrv_stdev_28d: 8.5,
+            rhr_stdev_28d: 3.5,
+            sleep_score_stdev_28d: 7.8,
+            ...overrides?.objective,
+        },
+    };
+}
+
+function createMockContext(): UserContext {
+    return {
+        goals: { shortTerm: 'general_fitness', midTerm: 'strength', longTerm: 'endurance' },
+        constraints: {
+            hasCableMachine: true,
+            hasFreeWeights: true,
+            hasTreadmill: true,
+            hasIndoorBike: true,
+            maxTimeMinutes: 90,
+        },
+        preferences: {
+            avoidedModalities: [],
+            deprioritizedModalities: [],
+            preferredModalities: ['Strength', 'Running'],
+            conservativeBias: false,
+        },
+    };
+}
+
+function createMockAvailability(): ResolvedAvailability {
+    return {
+        date: '2026-09-06',
+        maxTimeMinutes: 60,
+        availableEquipment: ['barbell', 'dumbbell'],
+        fixedActivities: [],
+        reservedCapacityCost: 0,
+        reservedCapacityCostProfile: { systemic: 0, cardiovascular: 0, lowerBody: 0, upperBody: 0, impactTissue: 0, neuromuscular: 0 },
+        environmentOverride: null,
+    };
+}
+
+const mockInputRevision: ReassessmentInputRevision = {
+    availabilityRevision: 'avail-rev-1',
+    completedFactsRevision: 'facts-rev-1',
+    checkinRevision: 'checkin-rev-1',
+    ledgerRevision: 2,
+    placementRevision: 'placement-rev-1',
+    postPredecessorConfirmationRevision: 'resp-rev-1',
+};
+
+describe('reassessDependentBundleMember (ADR-0036 D-REASSESS)', () => {
+    const target: DependentBundleMemberTarget = {
+        sessionId: 'pm-strength',
+        definition: createMockDefinition(),
+        requestedWindow: { startLocal: '17:00', endLocal: '18:00' },
+        afterSessionId: 'am-run',
+        minimumSeparationMinutes: 180,
+    };
+
+    const healthyPredecessor: PredecessorEvidence = {
+        sessionId: 'am-run',
+        occurrenceId: 'occ-am-1',
+        state: 'completed',
+        completedAt: '2026-09-06T10:00:00.000Z',
+        response: {
+            userId: 'test-user',
+            responseId: 'resp-1',
+            sourceSession: { kind: 'execution', id: 'exec-1', date: '2026-09-06' },
+            occurrenceId: 'occ-am-1',
+            window: 'immediate',
+            date: '2026-09-06',
+            checkinRef: { date: '2026-09-06' },
+            sessionRpe: 5,
+            completedFraction: 1.0,
+            unexpectedFatigue: false,
+            createdAt: '2026-09-06T10:05:00.000Z',
+            updatedAt: '2026-09-06T10:05:00.000Z',
+        },
+        tissueResponses: [
+            {
+                region: 'quadriceps',
+                morningState: 'normal',
+                afterTrainingState: 'normal',
+            },
+        ],
+    };
+
+    const validLedger: DailyLedgerResult = {
+        remainingMinutes: 45,
+        remainingSystemicCost: 0.5,
+        unresolvedEntries: [],
+    };
+
+    it('returns pending when predecessor occurrence is not yet completed', () => {
+        const uncompletedPredecessor: PredecessorEvidence = {
+            ...healthyPredecessor,
+            state: 'active',
+        };
+
+        const result = reassessDependentBundleMember({
+            target,
+            predecessor: uncompletedPredecessor,
+            evaluationInstant: '2026-09-06T15:00:00.000Z',
+            readiness: createMockReadiness(),
+            context: createMockContext(),
+            date: '2026-09-06',
+            availability: createMockAvailability(),
+            candidateWindowMinutes: 60,
+            dailyLedger: validLedger,
+            acceptedSameDaySystemicCost: 0.2,
+            inputRevision: mockInputRevision,
+        });
+
+        expect(result.decision).toBe('pending');
+        expect(result.timingPrerequisiteMet).toBe(false);
+        expect(result.predecessorConfirmed).toBe(false);
+        expect(result.reason).toContain('has not completed');
+    });
+
+    it('returns pending when predecessor completed timestamp is missing', () => {
+        const missingTimestampPredecessor: PredecessorEvidence = {
+            ...healthyPredecessor,
+            completedAt: null,
+        };
+
+        const result = reassessDependentBundleMember({
+            target,
+            predecessor: missingTimestampPredecessor,
+            evaluationInstant: '2026-09-06T15:00:00.000Z',
+            readiness: createMockReadiness(),
+            context: createMockContext(),
+            date: '2026-09-06',
+            availability: createMockAvailability(),
+            candidateWindowMinutes: 60,
+            dailyLedger: validLedger,
+            acceptedSameDaySystemicCost: 0.2,
+            inputRevision: mockInputRevision,
+        });
+
+        expect(result.decision).toBe('pending');
+        expect(result.timingPrerequisiteMet).toBe(false);
+        expect(result.reason).toContain('completion timestamp is missing');
+    });
+
+    it('returns pending when required separation has not elapsed', () => {
+        // Only 120 minutes elapsed since 10:00:00Z (target requires 180m)
+        const evaluationInstant = '2026-09-06T12:00:00.000Z';
+
+        const result = reassessDependentBundleMember({
+            target,
+            predecessor: healthyPredecessor,
+            evaluationInstant,
+            readiness: createMockReadiness(),
+            context: createMockContext(),
+            date: '2026-09-06',
+            availability: createMockAvailability(),
+            candidateWindowMinutes: 60,
+            dailyLedger: validLedger,
+            acceptedSameDaySystemicCost: 0.2,
+            inputRevision: mockInputRevision,
+        });
+
+        expect(result.decision).toBe('pending');
+        expect(result.timingPrerequisiteMet).toBe(false);
+        expect(result.reason).toContain('Required separation of 180m has not elapsed (120m elapsed');
+    });
+
+    it('returns pending when explicit post-predecessor confirmation is missing', () => {
+        const unconfirmedPredecessor: PredecessorEvidence = {
+            ...healthyPredecessor,
+            response: null,
+            tissueResponses: [],
+        };
+
+        // 300 minutes elapsed (15:00Z vs 10:00Z)
+        const evaluationInstant = '2026-09-06T15:00:00.000Z';
+
+        const result = reassessDependentBundleMember({
+            target,
+            predecessor: unconfirmedPredecessor,
+            evaluationInstant,
+            readiness: createMockReadiness(),
+            context: createMockContext(),
+            date: '2026-09-06',
+            availability: createMockAvailability(),
+            candidateWindowMinutes: 60,
+            dailyLedger: validLedger,
+            acceptedSameDaySystemicCost: 0.2,
+            inputRevision: mockInputRevision,
+        });
+
+        expect(result.decision).toBe('pending');
+        expect(result.timingPrerequisiteMet).toBe(true);
+        expect(result.predecessorConfirmed).toBe(false);
+        expect(result.reason).toContain('Awaiting explicit post-predecessor symptom and response confirmation');
+    });
+
+    it('rejects PM session when predecessor reported severe tissue pain', () => {
+        const sharpPredecessor: PredecessorEvidence = {
+            ...healthyPredecessor,
+            tissueResponses: [
+                {
+                    region: 'hamstring',
+                    morningState: 'normal',
+                    afterTrainingState: 'severe',
+                },
+            ],
+        };
+
+        const result = reassessDependentBundleMember({
+            target,
+            predecessor: sharpPredecessor,
+            evaluationInstant: '2026-09-06T15:00:00.000Z',
+            readiness: createMockReadiness(),
+            context: createMockContext(),
+            date: '2026-09-06',
+            availability: createMockAvailability(),
+            candidateWindowMinutes: 60,
+            dailyLedger: validLedger,
+            acceptedSameDaySystemicCost: 0.2,
+            inputRevision: mockInputRevision,
+        });
+
+        expect(result.decision).toBe('reject');
+        expect(result.predecessorConfirmed).toBe(true);
+        expect(result.reason).toContain("reported severe/adverse tissue response in region 'hamstring'");
+    });
+
+    it('scales PM session when predecessor reported unexpected fatigue', () => {
+        const fatiguedPredecessor: PredecessorEvidence = {
+            ...healthyPredecessor,
+            response: {
+                ...healthyPredecessor.response!,
+                unexpectedFatigue: true,
+            },
+        };
+
+        const result = reassessDependentBundleMember({
+            target,
+            predecessor: fatiguedPredecessor,
+            evaluationInstant: '2026-09-06T15:00:00.000Z',
+            readiness: createMockReadiness(),
+            context: createMockContext(),
+            date: '2026-09-06',
+            availability: createMockAvailability(),
+            candidateWindowMinutes: 60,
+            dailyLedger: validLedger,
+            acceptedSameDaySystemicCost: 0.2,
+            inputRevision: mockInputRevision,
+        });
+
+        expect(result.decision).toBe('scale');
+        expect(result.predecessorConfirmed).toBe(true);
+        expect(result.reason).toContain('unexpected fatigue');
+        expect(result.scaledDefinition).toBeDefined();
+        // Repetition sets scaled down by 0.7 (4 sets * 0.7 = 3 sets)
+        const scaledSets = result.scaledDefinition?.blocks[0].steps[0].dose;
+        if (scaledSets?.kind === 'repetition') {
+            expect(scaledSets.sets).toBe(3);
+        }
+    });
+
+    it('proceeds despite alreadyTrainedToday being true on morning inputs (bypassing alreadyTrainedOverride)', () => {
+        const readinessWithSameDayTraining = createMockReadiness({
+            subjective: { alreadyTrainedToday: true },
+            objective: { today_training: { type: 'running', duration_min: 60, training_effect: 3.0, intensity_tag: 'aerobic' } },
+        });
+
+        const result = reassessDependentBundleMember({
+            target,
+            predecessor: healthyPredecessor,
+            evaluationInstant: '2026-09-06T15:00:00.000Z',
+            readiness: readinessWithSameDayTraining,
+            context: createMockContext(),
+            date: '2026-09-06',
+            availability: createMockAvailability(),
+            candidateWindowMinutes: 60,
+            dailyLedger: validLedger,
+            acceptedSameDaySystemicCost: 0.2,
+            inputRevision: mockInputRevision,
+        });
+
+        // Crucial test: should proceed rather than being tripped into recover mode!
+        expect(result.decision).toBe('proceed');
+        expect(result.timingPrerequisiteMet).toBe(true);
+        expect(result.predecessorConfirmed).toBe(true);
+    });
+
+    it('rejects PM session when daily ledger minute capacity is exhausted', () => {
+        const exhaustedLedger: DailyLedgerResult = {
+            remainingMinutes: 20, // Candidate requires 45m
+            remainingSystemicCost: 0.5,
+            unresolvedEntries: [],
+        };
+
+        const result = reassessDependentBundleMember({
+            target,
+            predecessor: healthyPredecessor,
+            evaluationInstant: '2026-09-06T15:00:00.000Z',
+            readiness: createMockReadiness(),
+            context: createMockContext(),
+            date: '2026-09-06',
+            availability: createMockAvailability(),
+            candidateWindowMinutes: 60,
+            dailyLedger: exhaustedLedger,
+            acceptedSameDaySystemicCost: 0.2,
+            inputRevision: mockInputRevision,
+        });
+
+        expect(result.decision).toBe('reject');
+        expect(result.reason).toContain('capacity exhausted');
+    });
+
+    it('rejects PM session when daily ledger systemic-cost capacity is exhausted', () => {
+        const exhaustedLedger: DailyLedgerResult = {
+            remainingMinutes: 60,
+            remainingSystemicCost: 0.1, // Candidate (45m strength) requires > 0.3 cost
+            unresolvedEntries: [],
+        };
+
+        const result = reassessDependentBundleMember({
+            target,
+            predecessor: healthyPredecessor,
+            evaluationInstant: '2026-09-06T15:00:00.000Z',
+            readiness: createMockReadiness(),
+            context: createMockContext(),
+            date: '2026-09-06',
+            availability: createMockAvailability(),
+            candidateWindowMinutes: 60,
+            dailyLedger: exhaustedLedger,
+            acceptedSameDaySystemicCost: 0.2,
+            inputRevision: mockInputRevision,
+        });
+
+        expect(result.decision).toBe('reject');
+        expect(result.reason).toContain('capacity exhausted');
+    });
+
+    it('evaluates independent session without predecessor requirements when afterSessionId is omitted', () => {
+        const independentTarget: DependentBundleMemberTarget = {
+            sessionId: 'pm-independent',
+            definition: createMockDefinition(),
+            requestedWindow: { startLocal: '17:00', endLocal: '18:00' },
+        };
+
+        const result = reassessDependentBundleMember({
+            target: independentTarget,
+            // predecessor omitted entirely
+            evaluationInstant: '2026-09-06T17:00:00.000Z',
+            readiness: createMockReadiness(),
+            context: createMockContext(),
+            date: '2026-09-06',
+            availability: createMockAvailability(),
+            candidateWindowMinutes: 60,
+            dailyLedger: validLedger,
+            acceptedSameDaySystemicCost: 0.1,
+            inputRevision: mockInputRevision,
+        });
+
+        expect(result.decision).toBe('proceed');
+        expect(result.timingPrerequisiteMet).toBe(true);
+    });
+});

--- a/app/src/engine/intradayReassessment.test.ts
+++ b/app/src/engine/intradayReassessment.test.ts
@@ -417,6 +417,32 @@ describe('reassessDependentBundleMember (ADR-0036 D-REASSESS)', () => {
         expect(result.timingPrerequisiteMet).toBe(false);
     });
 
+    it('rejects evaluation instant that predates predecessor completion by seconds (preventing -0 rounding bypass)', () => {
+        const targetWithoutSeparation: DependentBundleMemberTarget = {
+            ...target,
+            minimumSeparationMinutes: undefined,
+        };
+
+        // Predecessor completed at 10:00:00Z; evaluation is at 09:59:50Z (10 seconds before completion)
+        const result = reassessDependentBundleMember({
+            target: targetWithoutSeparation,
+            predecessor: healthyPredecessor, // completedAt is 2026-09-06T10:00:00.000Z
+            evaluationInstant: '2026-09-06T09:59:50.000Z',
+            readiness: createMockReadiness(),
+            context: createMockContext(),
+            date: '2026-09-06',
+            availability: createMockAvailability(),
+            candidateWindowMinutes: 60,
+            dailyLedger: validLedger,
+            acceptedSameDaySystemicCost: 0.2,
+            inputRevision: mockInputRevision,
+        });
+
+        expect(result.decision).toBe('pending');
+        expect(result.reason).toContain('predates predecessor completion');
+        expect(result.timingPrerequisiteMet).toBe(false);
+    });
+
     it('proceeds despite alreadyTrainedToday being true on morning inputs (bypassing alreadyTrainedOverride)', () => {
         const readinessWithSameDayTraining = createMockReadiness({
             subjective: { alreadyTrainedToday: true },

--- a/app/src/engine/intradayReassessment.ts
+++ b/app/src/engine/intradayReassessment.ts
@@ -1,0 +1,337 @@
+/**
+ * ADR-0036 (H4) D-REASSESS: runtime reassessment of dependent intraday bundle members
+ * before launch.
+ *
+ * A morning PM verdict is provisional. Before a later session starts, compose a fresh
+ * as-of decision from current availability, today's canonical completed work, current
+ * health/symptom inputs and the shared daily ledger.
+ *
+ * Core invariants:
+ * 1. Predecessor completion: If afterSessionId is defined, predecessor must be completed.
+ * 2. Timing separation (D-TIME): Elapsed minutes between prospective start and predecessor
+ *    actual end instant must satisfy minimumSeparationMinutes.
+ * 3. Explicit post-predecessor confirmation (ADR-0023 D-MRESP): Requires explicit SessionResponse
+ *    or tissue confirmation; absent confirmation leaves it pending, not implicitly well-tolerated.
+ * 4. Reactive symptoms scale or reject: Sharp tissue pain or adverse symptoms scale/reject PM.
+ * 5. Favorable response does not expand authored dose.
+ * 6. Shared daily ledger admission (D-LEDGER): Verifies candidate fits remainingMinutes
+ *    and remainingSystemicCost via admitsCandidate.
+ * 7. Readiness envelope: Re-evaluates readiness and safety envelopes bypassing the single-session
+ *    alreadyTrainedOverride circuit breaker, since same-day load is accounted for via the ledger.
+ */
+
+import type {
+    DailyReadiness,
+    UserContext,
+    PlannedDose,
+    RegionTissueResponse,
+} from './models';
+import type { SessionDefinition } from '../sessions/models';
+import type { OccurrenceState } from '../sessions/models';
+import type { SessionResponse } from '../responses/models';
+import type { ResolvedAvailability } from './schedule';
+import type { EligibilityReason } from './eligibility';
+import { elapsedMinutesBetweenInstants } from './localInstant';
+import { admitsCandidate, type DailyLedgerResult } from './dailyLedger';
+import {
+    adjudicateAuthoredSession,
+    estimateAuthoredSessionSystemicCost,
+    scaleSessionDefinitionForModify,
+} from './authoredSessionGates';
+import { evaluateReadinessAndSafetyEnvelope } from './rules';
+import { deriveTissueSeverity } from './injuryPolicy';
+
+export interface ReassessmentInputRevision {
+    availabilityRevision: string;
+    completedFactsRevision: string;
+    checkinRevision: string;
+    ledgerRevision: number;
+    placementRevision: string;
+    postPredecessorConfirmationRevision?: string;
+}
+
+export function computeReassessmentInputRevision(params: {
+    availabilityRevision: string;
+    completedFactsRevision: string;
+    checkinRevision: string;
+    ledgerRevision: number;
+    placementRevision: string;
+    postPredecessorConfirmationRevision?: string;
+}): ReassessmentInputRevision {
+    return {
+        availabilityRevision: params.availabilityRevision,
+        completedFactsRevision: params.completedFactsRevision,
+        checkinRevision: params.checkinRevision,
+        ledgerRevision: params.ledgerRevision,
+        placementRevision: params.placementRevision,
+        ...(params.postPredecessorConfirmationRevision !== undefined
+            ? { postPredecessorConfirmationRevision: params.postPredecessorConfirmationRevision }
+            : {}),
+    };
+}
+
+export interface DependentBundleMemberTarget {
+    sessionId: string;
+    definition: SessionDefinition;
+    requestedWindow: { startLocal: string; endLocal: string };
+    afterSessionId?: string;
+    minimumSeparationMinutes?: number;
+}
+
+export interface PredecessorEvidence {
+    sessionId: string;
+    occurrenceId: string;
+    state: OccurrenceState;
+    completedAt?: string | null;
+    response?: SessionResponse | null;
+    tissueResponses?: RegionTissueResponse[];
+}
+
+export interface ReassessDependentBundleMemberParams {
+    target: DependentBundleMemberTarget;
+    predecessor?: PredecessorEvidence;
+    evaluationInstant: string; // ISO UTC instant (e.g. now)
+    readiness: DailyReadiness;
+    context: UserContext;
+    date: string;
+    availability: ResolvedAvailability;
+    candidateWindowMinutes: number;
+    dailyLedger: DailyLedgerResult;
+    acceptedSameDaySystemicCost: number;
+    inputRevision: ReassessmentInputRevision;
+    plannedDose?: PlannedDose;
+}
+
+export type ReassessmentDecision = 'proceed' | 'scale' | 'reject' | 'pending';
+
+export interface ReassessmentResult {
+    decision: ReassessmentDecision;
+    reason: string;
+    scaledDefinition?: SessionDefinition;
+    executionDose?: PlannedDose;
+    acceptedSystemicCost?: number;
+    admittedMinutes?: number;
+    gateFailures?: EligibilityReason[];
+    inputRevision: ReassessmentInputRevision;
+    timingPrerequisiteMet: boolean;
+    predecessorConfirmed: boolean;
+}
+
+/**
+ * Pure evaluation function for D-REASSESS.
+ * Composes a fresh as-of decision before a dependent session starts.
+ */
+export function reassessDependentBundleMember(
+    params: ReassessDependentBundleMemberParams,
+): ReassessmentResult {
+    const {
+        target,
+        predecessor,
+        evaluationInstant,
+        readiness,
+        context,
+        date,
+        availability,
+        candidateWindowMinutes,
+        dailyLedger,
+        acceptedSameDaySystemicCost,
+        inputRevision,
+        plannedDose,
+    } = params;
+
+    const candidateMinutes = target.definition.duration?.min ?? 45;
+    const candidateSystemicCost = estimateAuthoredSessionSystemicCost(target.definition);
+
+    // ── 1. Predecessor completion gate ─────────────────────────────────────────
+    if (target.afterSessionId) {
+        if (!predecessor || predecessor.sessionId !== target.afterSessionId || predecessor.state !== 'completed') {
+            return {
+                decision: 'pending',
+                reason: `Predecessor session '${target.afterSessionId}' has not completed (state: ${predecessor?.state ?? 'unstarted'}).`,
+                inputRevision,
+                timingPrerequisiteMet: false,
+                predecessorConfirmed: false,
+            };
+        }
+
+        if (!predecessor.completedAt) {
+            return {
+                decision: 'pending',
+                reason: `Predecessor session '${target.afterSessionId}' completion timestamp is missing; cannot verify separation.`,
+                inputRevision,
+                timingPrerequisiteMet: false,
+                predecessorConfirmed: false,
+            };
+        }
+
+        // ── 2. Timing separation gate (D-TIME) ──────────────────────────────────
+        if (target.minimumSeparationMinutes !== undefined && target.minimumSeparationMinutes > 0) {
+            const elapsed = elapsedMinutesBetweenInstants(evaluationInstant, predecessor.completedAt);
+            if (elapsed < 0) {
+                return {
+                    decision: 'pending',
+                    reason: `Evaluation instant (${evaluationInstant}) predates predecessor completion (${predecessor.completedAt}).`,
+                    inputRevision,
+                    timingPrerequisiteMet: false,
+                    predecessorConfirmed: false,
+                };
+            }
+
+            if (elapsed < target.minimumSeparationMinutes) {
+                return {
+                    decision: 'pending',
+                    reason: `Required separation of ${target.minimumSeparationMinutes}m has not elapsed (${elapsed}m elapsed since ${predecessor.completedAt}).`,
+                    inputRevision,
+                    timingPrerequisiteMet: false,
+                    predecessorConfirmed: false,
+                };
+            }
+        }
+
+        // ── 3. Post-predecessor confirmation gate (ADR-0023 D-MRESP) ───────────
+        const hasResponse = Boolean(predecessor.response);
+        const hasTissue = Boolean(predecessor.tissueResponses && predecessor.tissueResponses.length > 0);
+        if (!hasResponse && !hasTissue) {
+            return {
+                decision: 'pending',
+                reason: `Awaiting explicit post-predecessor symptom and response confirmation for '${target.afterSessionId}'.`,
+                inputRevision,
+                timingPrerequisiteMet: true,
+                predecessorConfirmed: false,
+            };
+        }
+
+        // Check for acute reactive tissue responses (severe/adverse pain)
+        if (predecessor.tissueResponses) {
+            const adverseRegion = predecessor.tissueResponses.find(
+                tr => tr.afterTrainingState === 'severe' || deriveTissueSeverity(tr) === 'exclude',
+            );
+            if (adverseRegion) {
+                return {
+                    decision: 'reject',
+                    reason: `Predecessor session reported severe/adverse tissue response in region '${adverseRegion.region}'. Deferred for athlete safety.`,
+                    inputRevision,
+                    timingPrerequisiteMet: true,
+                    predecessorConfirmed: true,
+                    gateFailures: ['safety_guardrail'],
+                };
+            }
+        }
+    }
+
+    // ── 4. Readiness & Safety Envelopes (with alreadyTrainedOverride bypass) ───
+    const envelopeState = evaluateReadinessAndSafetyEnvelope(
+        readiness,
+        context,
+        date,
+        undefined,
+        'off',
+        undefined,
+        { ignoreAlreadyTrainedOverride: true },
+    );
+
+    if (envelopeState.mode === 'recover' && target.definition.intent !== 'recovery') {
+        return {
+            decision: 'reject',
+            reason: 'Readiness or clinical red flags require recovery mode.',
+            gateFailures: ['restricted_category'],
+            inputRevision,
+            timingPrerequisiteMet: true,
+            predecessorConfirmed: true,
+        };
+    }
+
+    // ── 5. Shared daily ledger admission (D-LEDGER) ───────────────────────────
+    const admission = admitsCandidate(
+        dailyLedger,
+        candidateWindowMinutes,
+        candidateMinutes,
+        candidateSystemicCost,
+    );
+
+    if (!admission.admitted) {
+        return {
+            decision: 'reject',
+            reason: `Shared daily ledger capacity exhausted (remaining: ${dailyLedger.remainingMinutes}m, systemic cost: ${dailyLedger.remainingSystemicCost.toFixed(2)}; candidate requires: ${candidateMinutes}m, cost: ${candidateSystemicCost.toFixed(2)}).`,
+            inputRevision,
+            timingPrerequisiteMet: true,
+            predecessorConfirmed: true,
+            gateFailures: ['time_limit'],
+        };
+    }
+
+    // ── 6. Authored session adjudication ──────────────────────────────────────
+    const authoredVerdict = adjudicateAuthoredSession(
+        target.definition,
+        readiness,
+        context,
+        envelopeState,
+        plannedDose ?? { volume: 1.0, intensity: 1.0 },
+        date,
+        availability,
+        acceptedSameDaySystemicCost,
+    );
+
+    if (authoredVerdict.decision === 'reject') {
+        return {
+            decision: 'reject',
+            reason: authoredVerdict.rationale,
+            gateFailures: authoredVerdict.gateFailures,
+            inputRevision,
+            timingPrerequisiteMet: true,
+            predecessorConfirmed: true,
+        };
+    }
+
+    // Check for scaling triggers: modify mode, unexpected fatigue, or aching tissue
+    const hasAche = predecessor?.tissueResponses?.some(
+        tr => tr.afterTrainingState === 'mild' || tr.afterTrainingState === 'moderate',
+    );
+    const hasUnexpectedFatigue = predecessor?.response?.unexpectedFatigue === true;
+
+    if (authoredVerdict.decision === 'scale') {
+        return {
+            decision: 'scale',
+            reason: authoredVerdict.rationale,
+            scaledDefinition: authoredVerdict.scaledDefinition,
+            executionDose: authoredVerdict.executionDose,
+            acceptedSystemicCost: authoredVerdict.acceptedSystemicCost,
+            admittedMinutes: admission.admittedMinutes,
+            inputRevision,
+            timingPrerequisiteMet: true,
+            predecessorConfirmed: true,
+        };
+    }
+
+    if (hasUnexpectedFatigue || hasAche) {
+        const scaledDef = scaleSessionDefinitionForModify(target.definition, 0.7);
+        const fatigueReason = hasUnexpectedFatigue && hasAche
+            ? 'Scaled authored session volume due to unexpected fatigue and muscle ache reported after predecessor session.'
+            : hasUnexpectedFatigue
+                ? 'Scaled authored session volume due to unexpected fatigue reported after predecessor session.'
+                : 'Scaled authored session volume due to localized muscle ache reported after predecessor session.';
+
+        return {
+            decision: 'scale',
+            reason: fatigueReason,
+            scaledDefinition: scaledDef,
+            executionDose: authoredVerdict.executionDose,
+            acceptedSystemicCost: estimateAuthoredSessionSystemicCost(scaledDef),
+            admittedMinutes: admission.admittedMinutes,
+            inputRevision,
+            timingPrerequisiteMet: true,
+            predecessorConfirmed: true,
+        };
+    }
+
+    return {
+        decision: 'proceed',
+        reason: authoredVerdict.rationale,
+        executionDose: authoredVerdict.executionDose,
+        acceptedSystemicCost: authoredVerdict.acceptedSystemicCost ?? candidateSystemicCost,
+        admittedMinutes: admission.admittedMinutes,
+        inputRevision,
+        timingPrerequisiteMet: true,
+        predecessorConfirmed: true,
+    };
+}

--- a/app/src/engine/intradayReassessment.ts
+++ b/app/src/engine/intradayReassessment.ts
@@ -144,10 +144,34 @@ export function reassessDependentBundleMember(
 
     // ── 1. Predecessor completion gate ─────────────────────────────────────────
     if (target.afterSessionId) {
-        if (!predecessor || predecessor.sessionId !== target.afterSessionId || predecessor.state !== 'completed') {
+        if (!predecessor || predecessor.sessionId !== target.afterSessionId) {
             return {
                 decision: 'pending',
                 reason: `Predecessor session '${target.afterSessionId}' has not completed (state: ${predecessor?.state ?? 'unstarted'}).`,
+                inputRevision,
+                timingPrerequisiteMet: false,
+                predecessorConfirmed: false,
+            };
+        }
+
+        if (
+            predecessor.state === 'superseded' ||
+            predecessor.state === 'abandoned' ||
+            predecessor.state === 'missed'
+        ) {
+            return {
+                decision: 'reject',
+                reason: `Predecessor session '${target.afterSessionId}' reached terminal state '${predecessor.state}'; dependent session cannot proceed.`,
+                inputRevision,
+                timingPrerequisiteMet: false,
+                predecessorConfirmed: false,
+            };
+        }
+
+        if (predecessor.state !== 'completed') {
+            return {
+                decision: 'pending',
+                reason: `Predecessor session '${target.afterSessionId}' has not completed (state: ${predecessor.state}).`,
                 inputRevision,
                 timingPrerequisiteMet: false,
                 predecessorConfirmed: false,
@@ -165,18 +189,18 @@ export function reassessDependentBundleMember(
         }
 
         // ── 2. Timing separation gate (D-TIME) ──────────────────────────────────
-        if (target.minimumSeparationMinutes !== undefined && target.minimumSeparationMinutes > 0) {
-            const elapsed = elapsedMinutesBetweenInstants(evaluationInstant, predecessor.completedAt);
-            if (elapsed < 0) {
-                return {
-                    decision: 'pending',
-                    reason: `Evaluation instant (${evaluationInstant}) predates predecessor completion (${predecessor.completedAt}).`,
-                    inputRevision,
-                    timingPrerequisiteMet: false,
-                    predecessorConfirmed: false,
-                };
-            }
+        const elapsed = elapsedMinutesBetweenInstants(evaluationInstant, predecessor.completedAt);
+        if (elapsed < 0) {
+            return {
+                decision: 'pending',
+                reason: `Evaluation instant (${evaluationInstant}) predates predecessor completion (${predecessor.completedAt}).`,
+                inputRevision,
+                timingPrerequisiteMet: false,
+                predecessorConfirmed: false,
+            };
+        }
 
+        if (target.minimumSeparationMinutes !== undefined && target.minimumSeparationMinutes > 0) {
             if (elapsed < target.minimumSeparationMinutes) {
                 return {
                     decision: 'pending',

--- a/app/src/engine/intradayReassessment.ts
+++ b/app/src/engine/intradayReassessment.ts
@@ -189,8 +189,10 @@ export function reassessDependentBundleMember(
         }
 
         // ── 2. Timing separation gate (D-TIME) ──────────────────────────────────
+        const evalMs = Date.parse(evaluationInstant);
+        const predMs = Date.parse(predecessor.completedAt);
         const elapsed = elapsedMinutesBetweenInstants(evaluationInstant, predecessor.completedAt);
-        if (elapsed < 0) {
+        if (evalMs < predMs || elapsed < 0 || Object.is(elapsed, -0)) {
             return {
                 decision: 'pending',
                 reason: `Evaluation instant (${evaluationInstant}) predates predecessor completion (${predecessor.completedAt}).`,

--- a/app/src/engine/intradayReassessment.ts
+++ b/app/src/engine/intradayReassessment.ts
@@ -203,9 +203,13 @@ export function reassessDependentBundleMember(
 
         // Check for acute reactive tissue responses (severe/adverse pain)
         if (predecessor.tissueResponses) {
-            const adverseRegion = predecessor.tissueResponses.find(
-                tr => tr.afterTrainingState === 'severe' || deriveTissueSeverity(tr) === 'exclude',
-            );
+            const severities = predecessor.tissueResponses.map(tr => ({
+                response: tr,
+                severity: deriveTissueSeverity(tr),
+            }));
+            const adverseRegion = severities.find(
+                s => s.response.afterTrainingState === 'severe' || s.severity === 'exclude',
+            )?.response;
             if (adverseRegion) {
                 return {
                     decision: 'reject',
@@ -218,6 +222,9 @@ export function reassessDependentBundleMember(
             }
         }
     }
+
+    // Confirmation is only meaningful when a predecessor is required.
+    const predecessorConfirmed = target.afterSessionId !== undefined;
 
     // ── 4. Readiness & Safety Envelopes (with alreadyTrainedOverride bypass) ───
     const envelopeState = evaluateReadinessAndSafetyEnvelope(
@@ -237,7 +244,7 @@ export function reassessDependentBundleMember(
             gateFailures: ['restricted_category'],
             inputRevision,
             timingPrerequisiteMet: true,
-            predecessorConfirmed: true,
+            predecessorConfirmed,
         };
     }
 
@@ -255,7 +262,7 @@ export function reassessDependentBundleMember(
             reason: `Shared daily ledger capacity exhausted (remaining: ${dailyLedger.remainingMinutes}m, systemic cost: ${dailyLedger.remainingSystemicCost.toFixed(2)}; candidate requires: ${candidateMinutes}m, cost: ${candidateSystemicCost.toFixed(2)}).`,
             inputRevision,
             timingPrerequisiteMet: true,
-            predecessorConfirmed: true,
+            predecessorConfirmed,
             gateFailures: ['time_limit'],
         };
     }
@@ -279,13 +286,17 @@ export function reassessDependentBundleMember(
             gateFailures: authoredVerdict.gateFailures,
             inputRevision,
             timingPrerequisiteMet: true,
-            predecessorConfirmed: true,
+            predecessorConfirmed,
         };
     }
 
-    // Check for scaling triggers: modify mode, unexpected fatigue, or aching tissue
-    const hasAche = predecessor?.tissueResponses?.some(
-        tr => tr.afterTrainingState === 'mild' || tr.afterTrainingState === 'moderate',
+    // Check for scaling triggers: modify mode, unexpected fatigue, or aching/limiting tissue
+    const severities = predecessor?.tissueResponses?.map(tr => ({
+        response: tr,
+        severity: deriveTissueSeverity(tr),
+    })) ?? [];
+    const hasAche = severities.some(
+        s => s.severity === 'limit' || s.response.afterTrainingState === 'mild' || s.response.afterTrainingState === 'moderate',
     );
     const hasUnexpectedFatigue = predecessor?.response?.unexpectedFatigue === true;
 
@@ -299,7 +310,7 @@ export function reassessDependentBundleMember(
             admittedMinutes: admission.admittedMinutes,
             inputRevision,
             timingPrerequisiteMet: true,
-            predecessorConfirmed: true,
+            predecessorConfirmed,
         };
     }
 
@@ -315,12 +326,17 @@ export function reassessDependentBundleMember(
             decision: 'scale',
             reason: fatigueReason,
             scaledDefinition: scaledDef,
-            executionDose: authoredVerdict.executionDose,
+            executionDose: authoredVerdict.executionDose
+                ? {
+                    ...authoredVerdict.executionDose,
+                    volume: authoredVerdict.executionDose.volume * 0.7,
+                }
+                : undefined,
             acceptedSystemicCost: estimateAuthoredSessionSystemicCost(scaledDef),
             admittedMinutes: admission.admittedMinutes,
             inputRevision,
             timingPrerequisiteMet: true,
-            predecessorConfirmed: true,
+            predecessorConfirmed,
         };
     }
 
@@ -332,6 +348,6 @@ export function reassessDependentBundleMember(
         admittedMinutes: admission.admittedMinutes,
         inputRevision,
         timingPrerequisiteMet: true,
-        predecessorConfirmed: true,
+        predecessorConfirmed,
     };
 }

--- a/app/src/engine/policy.ts
+++ b/app/src/engine/policy.ts
@@ -1,11 +1,12 @@
 /** Increment whenever a change can alter a persisted recommendation decision. (Refactoring does not require a bump) */
 
-export const POLICY_VERSION = '2026-09-h4-intraday-bundle-placement-v1';
+export const POLICY_VERSION = '2026-09-h4-intraday-reassessment-v1';
 
 /** Historical versions are intentionally not re-executed by this build. Their compact
  * audits remain readable evidence, but replay is rejected explicitly because the old
  * decision function is not bundled alongside the current policy. */
 export const HISTORICAL_POLICY_VERSIONS = [
+    '2026-09-h4-intraday-bundle-placement-v1',
     '2026-09-schedule-overlays-v2',
     '2026-09-schedule-overlays-v1',
     '2026-09-fixed-activity-cost-dedup-v1',

--- a/app/src/engine/rules.ts
+++ b/app/src/engine/rules.ts
@@ -274,6 +274,13 @@ function metricStrain(
     return { acuteDeviation, multiDayDrift, total: acuteDeviation + multiDayDrift };
 }
 
+export interface EvaluateReadinessOptions {
+    /** ADR-0036 (H4) D-LEDGER/D-REASSESS: an intraday bundle member whose predecessor
+     * completed as planned accounts for its same-day load via the shared daily ledger debit,
+     * rather than tripping the single-session-per-day alreadyTrainedOverride fail-stop. */
+    ignoreAlreadyTrainedOverride?: boolean;
+}
+
 export function evaluateReadinessAndSafetyEnvelope(
     readiness: DailyReadiness,
     context: UserContext,
@@ -284,7 +291,8 @@ export function evaluateReadinessAndSafetyEnvelope(
     subjectiveDriftPolicy: SubjectiveDriftPolicy = 'off',
     /** Phase 9.3/D-SUBJCAL: experimental, not yet tuned. Only reachable by explicitly
      *  passing a non-default value -- no production call site does. */
-    subjectiveDriftWeights: SubjectiveDriftWeights = REFERENCE_SUBJECTIVE_DRIFT_WEIGHTS
+    subjectiveDriftWeights: SubjectiveDriftWeights = REFERENCE_SUBJECTIVE_DRIFT_WEIGHTS,
+    options?: EvaluateReadinessOptions,
 ): {
     mode: 'train' | 'modify' | 'recover';
     envelopes: { safety: SafetyEnvelope; plan: PlanEnvelope };
@@ -403,7 +411,9 @@ export function evaluateReadinessAndSafetyEnvelope(
 
     const postRecoverBufferApplied = mode === 'train' && previousMode === 'recover';
     if (postRecoverBufferApplied) mode = 'modify';
-    const alreadyTrainedOverride = subjective.alreadyTrainedToday === true || objective.today_training !== null;
+    const alreadyTrainedOverride = options?.ignoreAlreadyTrainedOverride === true
+        ? false
+        : (subjective.alreadyTrainedToday === true || objective.today_training !== null);
     // Mirror evaluateEnvelopes' red-flag predicate: a disclosed red flag that resolved to
     // no findings still surfaces as clinicalEnvelopeSources: ['red_flag'] and must force
     // recover, not just a non-empty redFlagFindings list.
@@ -434,7 +444,7 @@ export function evaluateReadinessAndSafetyEnvelope(
 
     return {
         mode,
-        envelopes: evaluateEnvelopes(readiness, context),
+        envelopes: evaluateEnvelopes(readiness, context, options),
         telemetry,
         alreadyTrainedOverride,
         fatigueTriggeredRecover,
@@ -956,7 +966,11 @@ export async function evaluateTrainingWithIntent(
     };
 }
 
-export function evaluateEnvelopes(readiness: DailyReadiness, context: UserContext): { safety: SafetyEnvelope; plan: PlanEnvelope } {
+export function evaluateEnvelopes(
+    readiness: DailyReadiness,
+    context: UserContext,
+    options?: EvaluateReadinessOptions,
+): { safety: SafetyEnvelope; plan: PlanEnvelope } {
     const legacyClinicalFlag = readiness.subjective.painFlag;
     const restrictedModalities = [...(context.constraints.restrictedModalities ?? [])];
     const hasActiveInjury = restrictedModalities.length > 0 || (context.constraints.impliedGuardrails ?? []).length > 0 || (context.constraints.restrictedCategories ?? []).length > 0;
@@ -990,7 +1004,10 @@ export function evaluateEnvelopes(readiness: DailyReadiness, context: UserContex
 
     const clinicalFlagActive = hasCurrentClinicalSymptoms || hasActiveInjury;
     let maxAllowableTier: 'Rest' | 'Mobility' | 'Easy' | 'Moderate' | 'Hard' = 'Hard';
-    if (readiness.subjective.alreadyTrainedToday || redFlagActive) maxAllowableTier = 'Rest';
+    const alreadyTrained = options?.ignoreAlreadyTrainedOverride === true
+        ? false
+        : readiness.subjective.alreadyTrainedToday;
+    if (alreadyTrained || redFlagActive) maxAllowableTier = 'Rest';
     else if (hasCurrentClinicalSymptoms) maxAllowableTier = 'Mobility';
     else if (
         (readiness.objective.body_battery_wake !== null && readiness.objective.body_battery_wake < 30) ||

--- a/app/src/services/sessionOccurrenceService.test.ts
+++ b/app/src/services/sessionOccurrenceService.test.ts
@@ -248,5 +248,40 @@ describe('SessionOccurrenceService authority methods (M3.3)', () => {
 
             expect(mockTx.set).not.toHaveBeenCalled();
         });
+
+        it('prevents onBeforeClaim from mutating the committed occurrence', async () => {
+            const scheduled = occurrenceDoc({ occurrenceId: 'occ-1', state: 'scheduled', date: '2026-08-18' });
+            const mockTx = {
+                get: vi.fn().mockResolvedValue({
+                    exists: () => true,
+                    data: () => scheduled,
+                }),
+                set: vi.fn(),
+            };
+            firestore.runTransaction.mockImplementation(async (_db, cb) => cb(mockTx));
+
+            const onBeforeClaim = vi.fn().mockImplementation((_tx, occ: unknown) => {
+                // Attempt to mutate the passed occurrence
+                const mutable = occ as { date: string; definitionRef: { definitionId: string } };
+                mutable.date = '2099-01-01';
+                mutable.definitionRef.definitionId = 'hijacked-def';
+            });
+            const service = new SessionOccurrenceService();
+            const result = await service.claimOccurrenceLaunch('u1', 'occ-1', {
+                now: '2026-08-18T10:00:00Z',
+                onBeforeClaim,
+            });
+
+            expect(result.date).toBe('2026-08-18');
+            expect(result.definitionRef.definitionId).toBe('def-1');
+            expect(mockTx.set).toHaveBeenCalledWith(
+                expect.anything(),
+                expect.objectContaining({
+                    date: '2026-08-18',
+                    definitionRef: expect.objectContaining({ definitionId: 'def-1' }),
+                    state: 'active',
+                }),
+            );
+        });
     });
 });

--- a/app/src/services/sessionOccurrenceService.test.ts
+++ b/app/src/services/sessionOccurrenceService.test.ts
@@ -205,5 +205,48 @@ describe('SessionOccurrenceService authority methods (M3.3)', () => {
             );
             expect(mockTx.set).not.toHaveBeenCalled();
         });
+
+        it('executes onBeforeClaim hook atomically before claiming occurrence', async () => {
+            const scheduled = occurrenceDoc({ occurrenceId: 'occ-1', state: 'scheduled' });
+            const mockTx = {
+                get: vi.fn().mockResolvedValue({
+                    exists: () => true,
+                    data: () => scheduled,
+                }),
+                set: vi.fn(),
+            };
+            firestore.runTransaction.mockImplementation(async (_db, cb) => cb(mockTx));
+
+            const onBeforeClaim = vi.fn().mockResolvedValue(undefined);
+            const service = new SessionOccurrenceService();
+            const result = await service.claimOccurrenceLaunch('u1', 'occ-1', {
+                now: '2026-08-18T10:00:00Z',
+                onBeforeClaim,
+            });
+
+            expect(onBeforeClaim).toHaveBeenCalledWith(mockTx, expect.objectContaining({ occurrenceId: 'occ-1', state: 'scheduled' }));
+            expect(result.state).toBe('active');
+            expect(mockTx.set).toHaveBeenCalledTimes(1);
+        });
+
+        it('aborts transaction and does not set occurrence when onBeforeClaim fails', async () => {
+            const scheduled = occurrenceDoc({ occurrenceId: 'occ-1', state: 'scheduled' });
+            const mockTx = {
+                get: vi.fn().mockResolvedValue({
+                    exists: () => true,
+                    data: () => scheduled,
+                }),
+                set: vi.fn(),
+            };
+            firestore.runTransaction.mockImplementation(async (_db, cb) => cb(mockTx));
+
+            const onBeforeClaim = vi.fn().mockRejectedValue(new Error('Revision mismatch'));
+            const service = new SessionOccurrenceService();
+            await expect(
+                service.claimOccurrenceLaunch('u1', 'occ-1', { onBeforeClaim }),
+            ).rejects.toThrow('Revision mismatch');
+
+            expect(mockTx.set).not.toHaveBeenCalled();
+        });
     });
 });

--- a/app/src/services/sessionOccurrenceService.test.ts
+++ b/app/src/services/sessionOccurrenceService.test.ts
@@ -9,6 +9,7 @@ const firestore = vi.hoisted(() => ({
     query: vi.fn(),
     where: vi.fn(),
     getDocs: vi.fn(),
+    runTransaction: vi.fn(),
 }));
 
 vi.mock('firebase/firestore', () => firestore);
@@ -128,5 +129,81 @@ describe('SessionOccurrenceService authority methods (M3.3)', () => {
         const service = new SessionOccurrenceService();
         const result = await service.getAdditionalOccurrencesForDate('u1', '2026-08-18');
         expect(result.map(item => item.occurrenceId)).toEqual(['occ-a', 'occ-b', 'occ-z']);
+    });
+
+    describe('claimOccurrenceLaunch (ADR-0036 D-REASSESS)', () => {
+        it('successfully claims a scheduled occurrence and transitions state to active', async () => {
+            const scheduled = occurrenceDoc({ occurrenceId: 'occ-1', state: 'scheduled' });
+            const mockTx = {
+                get: vi.fn().mockResolvedValue({
+                    exists: () => true,
+                    data: () => scheduled,
+                }),
+                set: vi.fn(),
+            };
+            firestore.runTransaction.mockImplementation(async (_db, cb) => cb(mockTx));
+
+            const service = new SessionOccurrenceService();
+            const result = await service.claimOccurrenceLaunch('u1', 'occ-1', '2026-08-18T10:00:00Z');
+
+            expect(result.state).toBe('active');
+            expect(result.updatedAt).toBe('2026-08-18T10:00:00Z');
+            expect(mockTx.set).toHaveBeenCalledWith(
+                expect.objectContaining({ path: 'session_occurrences/x' }),
+                expect.objectContaining({ state: 'active', updatedAt: '2026-08-18T10:00:00Z' }),
+            );
+        });
+
+        it('throws when occurrence does not exist', async () => {
+            const mockTx = {
+                get: vi.fn().mockResolvedValue({
+                    exists: () => false,
+                    data: () => null,
+                }),
+                set: vi.fn(),
+            };
+            firestore.runTransaction.mockImplementation(async (_db, cb) => cb(mockTx));
+
+            const service = new SessionOccurrenceService();
+            await expect(service.claimOccurrenceLaunch('u1', 'occ-missing')).rejects.toThrow(
+                'Occurrence occ-missing not found.',
+            );
+            expect(mockTx.set).not.toHaveBeenCalled();
+        });
+
+        it('throws when occurrence state is not scheduled', async () => {
+            const active = occurrenceDoc({ occurrenceId: 'occ-1', state: 'active' });
+            const mockTx = {
+                get: vi.fn().mockResolvedValue({
+                    exists: () => true,
+                    data: () => active,
+                }),
+                set: vi.fn(),
+            };
+            firestore.runTransaction.mockImplementation(async (_db, cb) => cb(mockTx));
+
+            const service = new SessionOccurrenceService();
+            await expect(service.claimOccurrenceLaunch('u1', 'occ-1')).rejects.toThrow(
+                "Occurrence occ-1 cannot be claimed; state is 'active', expected 'scheduled'.",
+            );
+            expect(mockTx.set).not.toHaveBeenCalled();
+        });
+
+        it('throws when occurrence document cannot be parsed', async () => {
+            const mockTx = {
+                get: vi.fn().mockResolvedValue({
+                    exists: () => true,
+                    data: () => ({ invalid: 'document' }),
+                }),
+                set: vi.fn(),
+            };
+            firestore.runTransaction.mockImplementation(async (_db, cb) => cb(mockTx));
+
+            const service = new SessionOccurrenceService();
+            await expect(service.claimOccurrenceLaunch('u1', 'occ-1')).rejects.toThrow(
+                'Occurrence occ-1 could not be parsed',
+            );
+            expect(mockTx.set).not.toHaveBeenCalled();
+        });
     });
 });

--- a/app/src/services/sessionOccurrenceService.ts
+++ b/app/src/services/sessionOccurrenceService.ts
@@ -25,7 +25,7 @@ export interface ClaimOccurrenceLaunchOptions {
      * Allows callers to read date-level ledger documents, verify ReassessmentInputRevision,
      * or persist capacity reservations atomically before transitioning the occurrence to active.
      */
-    onBeforeClaim?: (transaction: Transaction, occurrence: SessionOccurrence) => Promise<void> | void;
+    onBeforeClaim?: (transaction: Transaction, occurrence: Readonly<SessionOccurrence>) => Promise<void> | void;
 }
 
 export class SessionOccurrenceService {
@@ -178,7 +178,10 @@ export class SessionOccurrenceService {
                 throw new Error(`Occurrence ${occurrenceId} cannot be claimed; state is '${current.state}', expected 'scheduled'.`);
             }
             if (options.onBeforeClaim) {
-                await options.onBeforeClaim(transaction, current);
+                await options.onBeforeClaim(transaction, {
+                    ...current,
+                    definitionRef: { ...current.definitionRef },
+                });
             }
             transitioned = {
                 ...current,

--- a/app/src/services/sessionOccurrenceService.ts
+++ b/app/src/services/sessionOccurrenceService.ts
@@ -8,6 +8,7 @@ import {
     getDocs,
     runTransaction,
     type Firestore,
+    type Transaction,
 } from 'firebase/firestore';
 import { getDb } from '../firebase';
 import type { DataState } from '../engine/dataState';
@@ -16,6 +17,16 @@ import { parseSessionOccurrenceDocument } from '../persistence/parsers/sessionDe
 
 /** ACTIVE_OCCURRENCE_STATES excludes terminal/superseded states from "what governs today". */
 const ACTIVE_OCCURRENCE_STATES: ReadonlySet<SessionOccurrence['state']> = new Set(['scheduled', 'active']);
+
+export interface ClaimOccurrenceLaunchOptions {
+    now?: string;
+    /**
+     * Optional atomic pre-claim hook executed within the same Firestore transaction.
+     * Allows callers to read date-level ledger documents, verify ReassessmentInputRevision,
+     * or persist capacity reservations atomically before transitioning the occurrence to active.
+     */
+    onBeforeClaim?: (transaction: Transaction, occurrence: SessionOccurrence) => Promise<void> | void;
+}
 
 export class SessionOccurrenceService {
     private readonly db: Firestore;
@@ -144,8 +155,13 @@ export class SessionOccurrenceService {
     async claimOccurrenceLaunch(
         userId: string,
         occurrenceId: string,
-        now = new Date().toISOString(),
+        nowOrOptions?: string | ClaimOccurrenceLaunchOptions,
     ): Promise<SessionOccurrence> {
+        const options: ClaimOccurrenceLaunchOptions =
+            typeof nowOrOptions === 'string'
+                ? { now: nowOrOptions }
+                : (nowOrOptions ?? {});
+        const now = options.now ?? new Date().toISOString();
         const ref = this.occurrenceRef(userId, occurrenceId);
         let transitioned: SessionOccurrence | null = null;
         await runTransaction(this.db, async transaction => {
@@ -160,6 +176,9 @@ export class SessionOccurrenceService {
             const current = parsed.data;
             if (current.state !== 'scheduled') {
                 throw new Error(`Occurrence ${occurrenceId} cannot be claimed; state is '${current.state}', expected 'scheduled'.`);
+            }
+            if (options.onBeforeClaim) {
+                await options.onBeforeClaim(transaction, current);
             }
             transitioned = {
                 ...current,

--- a/app/src/services/sessionOccurrenceService.ts
+++ b/app/src/services/sessionOccurrenceService.ts
@@ -6,6 +6,7 @@ import {
     query,
     where,
     getDocs,
+    runTransaction,
     type Firestore,
 } from 'firebase/firestore';
 import { getDb } from '../firebase';
@@ -133,6 +134,41 @@ export class SessionOccurrenceService {
     async getAdditionalOccurrencesForDate(userId: string, date: string): Promise<SessionOccurrence[]> {
         const occurrences = await this.getOccurrencesForDate(userId, date);
         return occurrences.filter(item => item.authority === 'additional_session' && ACTIVE_OCCURRENCE_STATES.has(item.state));
+    }
+
+    /**
+     * ADR-0036 (H4) D-REASSESS: atomically claim a scheduled occurrence for launch.
+     * Prevents duplicate/concurrent requests from launching the same occurrence twice
+     * or claiming an occurrence that has already transitioned to active/terminal.
+     */
+    async claimOccurrenceLaunch(
+        userId: string,
+        occurrenceId: string,
+        now = new Date().toISOString(),
+    ): Promise<SessionOccurrence> {
+        const ref = this.occurrenceRef(userId, occurrenceId);
+        let transitioned: SessionOccurrence | null = null;
+        await runTransaction(this.db, async transaction => {
+            const snap = await transaction.get(ref);
+            if (!snap.exists()) {
+                throw new Error(`Occurrence ${occurrenceId} not found.`);
+            }
+            const parsed = parseSessionOccurrenceDocument(snap.data(), ref.path);
+            if (parsed.status !== 'AVAILABLE') {
+                throw new Error(`Occurrence ${occurrenceId} could not be parsed (${parsed.status}).`);
+            }
+            const current = parsed.data;
+            if (current.state !== 'scheduled') {
+                throw new Error(`Occurrence ${occurrenceId} cannot be claimed; state is '${current.state}', expected 'scheduled'.`);
+            }
+            transitioned = {
+                ...current,
+                state: 'active',
+                updatedAt: now,
+            };
+            transaction.set(ref, transitioned);
+        });
+        return transitioned!;
     }
 }
 

--- a/docs/plans/h4-dreassess-analysis.md
+++ b/docs/plans/h4-dreassess-analysis.md
@@ -199,8 +199,11 @@ actionable bundle members.
 1. **#434 PR 1 (delivered, PR #440):** Prescription launch binding for external-plan primary.
 2. **#434 PR 2 (occurrence tracking):** `SessionOccurrence` support for `external_plan`
    (`scheduled → active → completed` lifecycle).
-3. **#434 PR 3 (bundle second-member launch):** Adjudicating placed non-primary bundle members
-   and attaching them to `additionalSessions` in `Home.tsx`.
+3. **#434 PR 3 (bundle second-member launch & post-workout confirmation capture):**
+   - Adjudicating placed non-primary bundle members and attaching them to `additionalSessions` in `Home.tsx`.
+   - Wiring `SessionResponse` and `tissueResponses` prompt into the external-plan post-workout modal
+     upon AM session completion so athletes can submit post-predecessor confirmation immediately and
+     unblock downstream D-REASSESS evaluation without remaining stuck in `pending`.
 4. **D-REASSESS (issue #436):**
    - Pure `reassessDependentBundleMember` (handling `alreadyTrainedOverride` bypass, `SessionResponse`
      confirmation, elapsed separation, and `admitsCandidate`).
@@ -213,8 +216,6 @@ actionable bundle members.
 
 - Exact document path for date-level ledger locking: whether to lock on `users/{userId}/daily_recommendations/{date}`
   or a dedicated `users/{userId}/daily_ledgers/{date}` document during the claim transaction.
-- Wiring `SessionResponse` into the immediate post-workout modal for external-plan sessions
-  so athletes can submit post-predecessor confirmation immediately upon completing the AM session.
 - Firestore rules budget: ensure new date-level reservation updates do not exceed expression
   limits on the recommendation document, or use a dedicated collection with independent rules.
 

--- a/docs/plans/h4-dreassess-analysis.md
+++ b/docs/plans/h4-dreassess-analysis.md
@@ -171,9 +171,10 @@ actionable bundle members.
    - **Elapsed separation:** If `minimumSeparationMinutes` is defined, computes
      `elapsedMinutesBetweenInstants(prospectiveStartInstant, predecessorActualEndInstant)` via `localInstant.ts`.
      If timestamps are missing or elapsed interval is insufficient, returns `pending` (unresolved timing prerequisite).
-   - **Post-predecessor confirmation:** Queries `SessionResponse` (`window: 'immediate'`)
-     and `DailySubjectiveCheckin.tissueResponses` for the predecessor. If absent, returns
-     `pending`. If adverse symptoms or reactive tissue responses are present, scales or rejects.
+   - **Post-predecessor confirmation:** Evaluates the predecessor `SessionResponse`
+     (`window: 'immediate'`) and tissue responses supplied by the caller. If absent,
+     returns `pending`. If adverse symptoms or reactive tissue responses are present,
+     scales or rejects.
    - **Readiness & safety envelopes:** Re-runs `evaluateReadinessAndSafetyEnvelope` with
      `ignoreAlreadyTrainedOverride: true` (since same-day load is accounted for via ledger).
    - **Ledger admission:** Recomputes `computeDailyLedger` with today's latest canonical facts

--- a/docs/plans/h4-dreassess-analysis.md
+++ b/docs/plans/h4-dreassess-analysis.md
@@ -2,11 +2,10 @@
 
 **Status:** Analysis only. No code changes in this doc's commit.
 **Tracks:** [GitHub issue #436](https://github.com/Szczepanov/adaptive-training-recommender/issues/436).
-**Builds on:** [PR #440](https://github.com/Szczepanov/adaptive-training-recommender/pull/440)'s
-analysis of the external-plan execution-binding pipeline (issue #434) -- **not yet
-implemented**. This document's design assumes that pipeline's PR 1 (prescription-only v4
-launch binding) and PR 2 (occurrence tracking) both exist; see "Sequencing" below for why
-both, not just PR 1, are prerequisites.
+**Builds on:**
+- [PR #440](https://github.com/Szczepanov/adaptive-training-recommender/pull/440) (issue #434 PR 1: external-plan execution-binding pipeline for primary session launch).
+- External-plan pipeline roadmap in [`docs/plans/h4-external-plan-execution-binding-pipeline.md`](./h4-external-plan-execution-binding-pipeline.md) (PR 2: occurrence tracking; PR 3: bundle second-member adjudication).
+
 
 ## What ADR-0036 D-REASSESS requires
 
@@ -33,199 +32,212 @@ Quoting the ADR directly (`docs/adr/0036-intraday-training-windows-and-reassessm
 
 D-REASSESS's entire premise is "before a later session starts" and "a completed AM
 occurrence cannot be launched again." Both phrases presuppose a bundle member is a real,
-launchable, stateful thing. Today (even after `activeExternalPlanService.ts`'s D-PLACEMENT
+launchable, stateful occurrence. Today (even after `activeExternalPlanService.ts`'s D-PLACEMENT
 wiring, PR #432), a v4 bundle's non-primary member is correctly *placed* (window/order/
-budget/rest all resolved) but has no execution identity at all -- there is nothing to
-"start," nothing that can be "completed," and no occurrence record D-REASSESS could query
-to ask "has the predecessor actually finished." Building D-REASSESS against that gap would
-mean either (a) inventing a parallel, throwaway state-tracking mechanism that duplicates
-what #434 PR 2 (occurrence tracking) is already supposed to build, or (b) blocking on #434
-first. Option (b) is the only one that doesn't create duplicate, soon-to-be-replaced work.
+budget/rest all resolved) but has no execution identity, is not yet attached to
+`additionalSessions`, and cannot be started.
 
-**Concretely, D-REASSESS needs:**
-- #434 PR 1 (prescription-only launch binding) -- so a v4 session can be started at all.
-- #434 PR 2 (occurrence tracking, `OccurrenceAuthority`/`SessionOccurrence` extended for
-  `external_plan`) -- so a bundle member's lifecycle (`scheduled → active → completed`)
-  is queryable independently of the plan/date, which is what "has the predecessor
-  completed" and "a completed AM occurrence cannot be launched again" both require.
+Building D-REASSESS against that gap would mean either (a) inventing a parallel, throwaway
+state-tracking mechanism that duplicates what #434 is already designed to build, or (b) sequencing
+cleanly on top of the execution-binding pipeline. Option (b) is the only one that avoids duplicate work.
 
-Neither exists yet. This document is written so its design is ready the moment they do,
-but implementing D-REASSESS before them would mean re-deriving occurrence state ad hoc.
+**Concretely, D-REASSESS requires the following pipeline stages:**
+- **#434 PR 1 (delivered in PR #440):** Prescription-only launch binding for external-plan
+  primary sessions, proving write-once content-addressed `ExecutionPrescription` storage.
+- **#434 PR 2 (occurrence tracking):** Extending `OccurrenceAuthority`/`SessionOccurrence`
+  for `external_plan` so a bundle member's lifecycle (`scheduled → active → completed`)
+  is queryable independently of the plan/date, providing the state needed for "has the
+  predecessor actually completed" and "a completed AM occurrence cannot be launched again."
+- **#434 PR 3 (bundle second-member adjudication):** Adjudicating placed non-primary bundle
+  members via `adjudicateAuthoredSession` and attaching them to `additionalSessions` in
+  `Home.tsx` so they are exposed in the app with an actionable launch affordance.
+
+D-REASSESS governs the runtime reassessment and launch-time claim gate for those
+actionable bundle members.
+
 
 ## Current state, verified against code
 
-### What already exists and can be reused directly
+### What exists and how it must be adapted
 
-- **`evaluateReadinessAndSafetyEnvelope`** (`app/src/engine/rules.ts:277`) already computes
+- **`evaluateReadinessAndSafetyEnvelope`** (`app/src/engine/rules.ts:277`) computes
   `{ mode, envelopes: { safety, plan }, telemetry, alreadyTrainedOverride }` from
   `(readiness, context, date, previousMode, subjectiveDriftPolicy, subjectiveDriftWeights)`.
-  This is the "common eligibility, readiness... gates" the ADR says to re-run -- it's
-  already a pure, callable function, not something new to build. D-REASSESS's "compose a
-  fresh as-of decision" is largely "call this again with today's current inputs," not a
-  new gate system.
+
+  > [!CAUTION]
+  > **The `alreadyTrainedOverride` trap:** In `rules.ts:406-413`, the logic enforces:
+  > ```typescript
+  > const alreadyTrainedOverride = subjective.alreadyTrainedToday === true || objective.today_training !== null;
+  > if (alreadyTrainedOverride || redFlagOverride) mode = 'recover';
+  > ```
+  > If an athlete completes their AM session, `objective.today_training` will be non-null. Calling
+  > `evaluateReadinessAndSafetyEnvelope` blindly with "today's current inputs" in the
+  > afternoon will unconditionally trip `alreadyTrainedOverride` and force `mode = 'recover'`.
+  > Downstream in `adjudicateAuthoredSession` (`authoredSessionGates.ts:189-191`), `mode === 'recover'`
+  > unconditionally rejects any session whose intent is not `'recovery'`.
+  >
+  > **Required adaptation:** In ADR-0036 D-LEDGER, completed same-day work in a planned bundle is
+  > accounted for through the **shared daily ledger debit**, not the single-session
+  > `alreadyTrainedOverride` fail-stop. `evaluateReadinessAndSafetyEnvelope` must accept an
+  > explicit option (e.g. `ignoreAlreadyTrainedOverride?: boolean` or a window/bundle context)
+  > when evaluating an intraday bundle member whose predecessor completed as planned.
+
 - **`adjudicateAuthoredSession`** (`app/src/engine/authoredSessionGates.ts`) already
   implements "run gates again for one specific session, given current readiness/context/
   envelope/availability, and return `proceed | scale | reject`" -- exactly the shape a
-  dependent bundle member's reassessment needs. It's already reused for the manually-
-  authored additional-session flow in `Home.tsx`; PR 3 of #434's roadmap already proposes
-  reusing it for bundle members too. D-REASSESS is the gate that decides *whether and
-  when* to call it again for an already-placed dependent, not a replacement for it.
+  dependent bundle member's reassessment needs. It is already reused for manually-authored
+  additional sessions in `Home.tsx` and for external bundle members in #434 PR 3.
+
 - **`dailyLedger.ts`'s `computeDailyLedger`/`admitsCandidate`** (delivered, PR #426/#427)
   already model "the day's remaining minute/systemic-cost capacity, reconciled against
-  known actuals" -- the "shared ledger" D-REASSESS reads from. Not yet wired into a live
-  per-launch admission check anywhere (see issue #433's closure -- the *week-ahead
-  planner* doesn't need it, but a live PM-launch admission check plausibly does; this
-  would be D-REASSESS's actual first real consumer of `admitsCandidate` as a launch-time
-  gate, distinct from #433's now-closed, differently-scoped ask).
+  known actuals" -- the "shared ledger" D-REASSESS reads from. `admitsCandidate` serves as the
+  live launch-time admission check: even if minutes remain in the current window, candidate
+  work must fit within both `remainingMinutes` and `remainingSystemicCost`.
+
+- **Elapsed separation calculation via D-TIME** (`app/src/engine/localInstant.ts`):
+  `elapsedMinutesBetweenInstants(prospectiveStartInstant, predecessorActualEndInstant)`
+  already computes exact elapsed minutes between UTC instants. ADR-0036 D-TIME mandates
+  that separation is prospective start minus predecessor's *actual* end instant. If
+  predecessor completion timestamps are missing or elapsed minutes < `minimumSeparationMinutes`,
+  reassessment must fail closed (reporting an unresolved timing prerequisite).
+
+- **Post-predecessor response schema already exists (ADR-0023 D-MRESP):**
+  ADR-0036 line 188 explicitly states: *"Reuse the existing health-context and response authorities;
+  do not create a second tissue score."*
+
+  The codebase already provides:
+  1. `SessionResponse` (`app/src/responses/models.ts`): Stores session-scoped facts with
+     `window: 'immediate' | 'later_day' | 'next_morning'`, `sourceSession: { kind, id, date }`,
+     `occurrenceId`, `sessionRpe`, `completedFraction`, and `unexpectedFatigue`.
+  2. `RegionTissueResponse` (`app/src/engine/models.ts`): Carries `sourceSessionRef` and
+     `afterTrainingState: 'calm' | 'tight' | 'ache' | 'sharp'`.
+  3. `deriveSessionOutcome` (`app/src/responses/outcome.ts`): Summarizes passed, caution,
+     or reactive status from recorded evidence.
+
+  Reassessment does not require inventing a new schema: it checks whether a `SessionResponse`
+  (or corresponding `RegionTissueResponse` with `sourceSessionRef`) exists for the predecessor.
+  If absent, the dependent session remains `pending`. If reactive (`afterTrainingState: 'sharp'`
+  or severe adverse symptoms), PM is scaled or deferred.
+
 - **Same-day canonical performed facts** (`training-occurrence/performedTrainingFactsService.ts`'s
-  `getPerformedTrainingFactsThroughToday`, verified in the D-WINDOW PR era) is the "today's
-  canonical completed work" input, already proven to correctly include today's own
-  same-day evidence.
+  `getPerformedTrainingFactsThroughToday`, verified in the D-WINDOW PR era) provides the
+  "today's canonical completed work" input, proven to include today's own same-day evidence.
+
 - **Atomic claim/transition precedent**: `assessmentAttemptService.ts`'s private
-  `transitionAttempt` (lines ~99-113) is a direct, reusable pattern for "atomically
-  validate the current ... revision and claim or transition its existing reservation":
+  `transitionAttempt` (lines ~99-113) demonstrates the `runTransaction`-based state transition
+  pattern, also mirrored in `garminSyncRequestService.ts` and `healthAnomalyOutcomeService.ts`.
 
-  ```typescript
-  private async transitionAttempt(userId, attemptId, transition: (current) => next): Promise<void> {
-      const ref = this.attemptRef(userId, attemptId);
-      await runTransaction(this.db, async transaction => {
-          const snapshot = await transaction.get(ref);
-          if (!snapshot.exists()) throw new Error(...);
-          const current = snapshot.data();
-          assertValidAssessmentAttempt(current);
-          const next = transition(current);
-          assertValidAssessmentAttempt(next);
-          transaction.set(ref, next);
-      });
-  }
-  ```
-  This is exactly the shape D-REASSESS's "each accepted launch must atomically validate
-  the current ledger/input revision and claim or transition its existing reservation,
-  preventing two tabs or concurrent requests from spending the same minute or
-  systemic-cost capacity" needs: read the occurrence + today's ledger-relevant state
-  inside a `runTransaction`, validate the caller's assumed revision still matches, and
-  only then write the claimed/transitioned state. `garminSyncRequestService.ts` and
-  `healthAnomalyOutcomeService.ts` show the same pattern used twice more elsewhere in
-  this codebase -- it's an established idiom, not a new one to invent.
+### What must be designed for D-REASSESS
 
-### What does not exist yet (beyond #434's gap)
+- **Date-level concurrency locking:**
+  ADR-0036 requires preventing two tabs or concurrent requests from spending the same minute
+  or systemic-cost capacity. Reading and updating only `session_occurrences/{occurrenceId}`
+  prevents double-launching the *same* session, but does not prevent two *different* sessions
+  from concurrently claiming the same remaining daily ledger capacity. The claim transaction
+  must read and write a **date-level document** (e.g. `users/{userId}/daily_recommendations/{date}`
+  or a dedicated daily ledger reservation record) holding active reservations and ledger revision.
+- **Reassessment input revision tracking:**
+  A composite revision/hash spanning availability, completed facts, check-in, and ledger
+  entries to verify the decision has not become stale at launch time.
+- **Uncoupling operational reassessment from D-AUDIT:**
+  Reassessment is the *live decision and gate logic*; D-AUDIT (issue #437) is the *immutable
+  historical snapshotting for replay*. Operational decision updates are already archived
+  via `RecommendationService`'s `revisions` subcollection. Reassessment should write into
+  the established recommendation and occurrence models rather than waiting for D-AUDIT's
+  replay store. Note that `hasValidRecommendationAudit` in `firestore.rules` is at its
+  1,000 expression limit, so pending operational state must not be shoehorned into the
+  existing audit map.
 
-- No "revision" concept for a day's ledger/availability inputs as a whole (only
-  `dailyLedger.ts`'s per-*entry* `revision`, and `ExternalPlanPlacement.revision` for the
-  plan overlay). D-REASSESS's "atomically validate the current ledger/input revision"
-  implies some notion of "the as-of state this PM decision was computed against" that can
-  be compared to "the as-of state at claim time" to detect staleness (availability
-  changed, symptoms changed, placement changed, etc. -- the ADR's own list of invalidating
-  changes). This needs a new, explicit revision/hash concept spanning the *inputs to one
-  day's reassessment decision*, not a reuse of an existing per-entity revision. See
-  "Design sketch" below.
-- No persisted "pending PM approval" concept at all -- this is arguably the first slice of
-  D-AUDIT (issue #437) that D-REASSESS actually needs before it can be built, not just a
-  D-REASSESS-internal detail. A provisional AM-time PM verdict needs *somewhere* to live
-  between "AM decision composed" and "PM launch claimed," and the ADR's "historical
-  decisions remain immutable and are linked by superseding decision identity" describes
-  exactly the kind of snapshot D-AUDIT is supposed to own. **This is a second real
-  dependency this document did not originally expect**: D-REASSESS and D-AUDIT are more
-  intertwined than the original issue split suggested -- see "Sequencing," revised.
-- No explicit "post-predecessor symptom/response confirmation" UI/data model. The ADR
-  requires this be a distinct, explicit athlete input ("absent confirmation leaves it
-  pending, not implicitly well tolerated") -- nothing in the existing check-in/health-
-  context schema (`DailySubjectiveCheckin`, `HealthContext`) is scoped to "confirming how
-  a specific just-completed session felt," as opposed to the whole day's general state.
 
 ## Design sketch (for the implementing agent to refine, not a final spec)
 
-1. **A day's reassessment-input revision.** Define something like:
+1. **`ReassessmentInputRevision` shape:**
    ```typescript
-   interface ReassessmentInputRevision {
-       availabilityRevision: string;   // hash of resolveAvailability's relevant inputs for the date
+   export interface ReassessmentInputRevision {
+       availabilityRevision: string;   // hash of schedule windows for the date
        completedFactsRevision: string; // from getPerformedTrainingFactsThroughToday
-       checkinRevision: string;        // today's check-in document's own revision/updatedAt
-       ledgerRevision: string;         // hash of the day's LedgerEntry set at compose time
-       placementRevision: string;      // the bundle's proposeBundlePlacement outcome hash
+       checkinRevision: string;        // check-in updatedAt / hash
+       ledgerRevision: number;         // daily ledger entries sequence / hash
+       placementRevision: string;      // bundle placement hash
    }
    ```
-   Computed once when the provisional PM decision is composed (AM time or whenever
-   re-evaluated), persisted alongside it, and re-derived at claim time inside the
-   transaction; a mismatch on any field means "stale, must recompute" per the ADR.
-2. **`reassessDependentBundleMember(...)`** (name placeholder): a new pure function,
-   analogous to `evaluateReadinessAndSafetyEnvelope` + `adjudicateAuthoredSession`
-   composed together, that:
-   - Requires an explicit "post-predecessor confirmation" input; returns a `pending`
-     verdict (not `proceed`/`scale`/`reject`) when absent.
-   - Re-runs `evaluateReadinessAndSafetyEnvelope` and `adjudicateAuthoredSession` against
-     *current* inputs, not the AM-time snapshot.
-   - Consults `dailyLedger.ts`'s `admitsCandidate` against the day's *current* remaining
-     capacity (today's real first live consumer of that function as an admission gate,
-     distinct from issue #433's now-closed ask).
-3. **Claim transaction**, mirroring `assessmentAttemptService.ts`'s `transitionAttempt`:
-   read the occurrence (from #434 PR 2) and the persisted `ReassessmentInputRevision`
-   inside one `runTransaction`; if the caller's assumed revision doesn't match current,
-   fail with "stale, recompute"; otherwise atomically move the occurrence from
-   `scheduled` to `active` (claim) and write the resolved verdict.
-4. **Persistence** of the provisional/reassessed decision itself is D-AUDIT's concern
-   (issue #437) -- D-REASSESS should be designed to *write into* whatever shape D-AUDIT
-   defines, not invent its own separate storage. This is the reason to read #437's
-   analysis (once written) before finalizing D-REASSESS's exact persisted shape.
+   Generated when the provisional PM recommendation is composed, passed to the launch action,
+   and re-verified inside the atomic claim transaction; a mismatch means "stale, must recompute."
+
+2. **`reassessDependentBundleMember(...)` (pure engine function):**
+   - **Predecessor completion:** Verifies predecessor occurrence is `completed`. If not,
+     returns `pending`.
+   - **Elapsed separation:** If `minimumSeparationMinutes` is defined, computes
+     `elapsedMinutesBetweenInstants(evaluationInstant, predecessorCompletedAt)` via `localInstant.ts`.
+     If timestamps are missing or elapsed interval is insufficient, returns `pending` (unresolved timing prerequisite).
+   - **Post-predecessor confirmation:** Queries `SessionResponse` (`window: 'immediate'`)
+     and `DailySubjectiveCheckin.tissueResponses` for the predecessor. If absent, returns
+     `pending`. If adverse symptoms or reactive tissue responses are present, scales or rejects.
+   - **Readiness & safety envelopes:** Re-runs `evaluateReadinessAndSafetyEnvelope` with
+     `ignoreAlreadyTrainedOverride: true` (since same-day load is accounted for via ledger).
+   - **Ledger admission:** Recomputes `computeDailyLedger` with today's latest canonical facts
+     and verifies `admitsCandidate` has headroom for both minutes and systemic cost.
+   - **Authored adjudication:** Re-runs `adjudicateAuthoredSession` against the current envelope.
+
+3. **Atomic launch claim transaction:**
+   Inside `runTransaction`:
+   - Reads the date-level reservation/recommendation document and the target `session_occurrence`.
+   - Verifies target occurrence is currently `scheduled` (rejects if already `active` or `completed`).
+   - Verifies date ledger revision matches the assumed revision (rejects with "stale, recompute" if mismatched).
+   - Transitions occurrence to `active`, registers the active reservation in the date ledger,
+     and commits atomically.
+
+4. **Persistence & D-AUDIT boundary:**
+   Operational decision updates are archived via `RecommendationService`'s existing `revisions`
+   subcollection and `SessionOccurrence` state transitions. D-AUDIT (issue #437) will provide
+   the dedicated, immutable replay snapshot layout. Keeping operational decision state within
+   standard recommendation/occurrence channels avoids exceeding `hasValidRecommendationAudit`'s
+   1,000 expression limit.
 
 ## Revised sequencing
 
-Original issue split assumed D-REASSESS → D-AUDIT in that order. Investigation shows
-they're more coupled: D-REASSESS needs *somewhere* to persist a provisional decision
-between AM composition and PM claim, and that "somewhere" is D-AUDIT's actual subject
-matter. Recommended real order:
-
-1. #434 PR 1 (prescription-only v4 launch binding) -- not yet implemented.
-2. #434 PR 2 (occurrence tracking for `external_plan`) -- not yet implemented.
-3. **A minimal slice of D-AUDIT** covering just enough persisted shape for one pending
-   decision + its input-revision snapshot (not the full D-AUDIT scope from issue #437,
-   which also covers full replay semantics, superseded-decision chains, etc.) -- this
-   could be its own small PR, or folded into D-REASSESS's first PR if it stays small.
-4. D-REASSESS's actual gate logic (the design sketch above), built against that minimal
-   persisted shape.
-5. The rest of D-AUDIT (issue #437) -- full replay verification, superseded-decision
-   chains, UI surfacing of provisional/pending/dropped states.
+1. **#434 PR 1 (delivered, PR #440):** Prescription launch binding for external-plan primary.
+2. **#434 PR 2 (occurrence tracking):** `SessionOccurrence` support for `external_plan`
+   (`scheduled → active → completed` lifecycle).
+3. **#434 PR 3 (bundle second-member launch):** Adjudicating placed non-primary bundle members
+   and attaching them to `additionalSessions` in `Home.tsx`.
+4. **D-REASSESS (issue #436):**
+   - Pure `reassessDependentBundleMember` (handling `alreadyTrainedOverride` bypass, `SessionResponse`
+     confirmation, elapsed separation, and `admitsCandidate`).
+   - Atomic date-level claim transaction.
+   - `POLICY_VERSION` bump.
+5. **D-AUDIT (issue #437):** Dedicated persistence shape for multi-decision same-day replay,
+   historical supersession chains, and replay verification suite.
 
 ## Open questions for the implementing agent
 
-- Exact shape of `ReassessmentInputRevision` -- the sketch above is illustrative; the
-  actual hash/revision sources need re-verification against the tree at implementation
-  time (this doc was written after PR #441 merged; confirm nothing shifted).
-- Whether "post-predecessor confirmation" belongs in the existing daily check-in flow
-  (`DailySubjectiveCheckin`) as a new optional field, or as its own separate, session-
-  scoped confirmation record -- the ADR's emphasis on "explicit" and "absent confirmation
-  leaves it pending" suggests a separate record is safer (a daily check-in the athlete
-  fills before any session starts can't logically already contain a *post*-predecessor
-  confirmation), but this needs product-level input, not just an engineering call.
-- How much of "the minimal slice of D-AUDIT" (step 3 above) is small enough to fold into
-  D-REASSESS's first PR versus needing its own -- re-evaluate once #434 actually exists
-  and the real occurrence shape is known.
-- Firestore rules budget: any new persisted shape for a pending decision needs its own
-  validation function, ideally *not* nested inside the already-at-capacity
-  `hasValidRecommendationAudit` (see issue #435/PR #441's finding) -- a new top-level
-  collection with its own, unrelated validation function avoids inheriting that ceiling.
+- Exact document path for date-level ledger locking: whether to lock on `users/{userId}/daily_recommendations/{date}`
+  or a dedicated `users/{userId}/daily_ledgers/{date}` document during the claim transaction.
+- Wiring `SessionResponse` into the immediate post-workout modal for external-plan sessions
+  so athletes can submit post-predecessor confirmation immediately upon completing the AM session.
+- Firestore rules budget: ensure new date-level reservation updates do not exceed expression
+  limits on the recommendation document, or use a dedicated collection with independent rules.
 
 ## Suggested PR description for D-REASSESS's first real implementation PR (once unblocked)
 
 > ## Summary
-> First implementation PR for ADR-0036 D-REASSESS (issue #436), unblocked by #434 PR 1+2
-> (external-plan launch binding + occurrence tracking) and a minimal slice of D-AUDIT
-> (issue #437) providing persisted-decision-revision tracking.
+> First implementation PR for ADR-0036 D-REASSESS (issue #436), unblocked by #434 PR 1–3
+> (external-plan launch binding, occurrence tracking, and bundle second-member adjudication).
 >
-> Reuses `evaluateReadinessAndSafetyEnvelope`/`adjudicateAuthoredSession` (unchanged) for
-> the actual gate re-evaluation, `dailyLedger.ts`'s `admitsCandidate` as a real live
-> admission check (its first production consumer), and
-> `assessmentAttemptService.ts`'s `runTransaction`-based claim pattern for atomic
-> launch-time revision validation.
+> Reuses `evaluateReadinessAndSafetyEnvelope` (with `alreadyTrainedOverride` bypass for ledger-accounted
+> bundle members), `localInstant.ts`'s `elapsedMinutesBetweenInstants` for elapsed separation checks,
+> `SessionResponse`/`RegionTissueResponse` for post-predecessor confirmation, `dailyLedger.ts`'s
+> `admitsCandidate` as a live admission gate, and an atomic date-level claim transaction
+> preventing concurrent double-reservation.
 >
 > ## What's delivered
-> - `ReassessmentInputRevision` computation and persistence (see D-AUDIT's minimal slice).
-> - A new pure reassessment function requiring explicit post-predecessor confirmation.
-> - An atomic claim transaction preventing double-reservation across concurrent launches.
+> - `ReassessmentInputRevision` computation and validation.
+> - Pure `reassessDependentBundleMember` implementing predecessor completion, separation, confirmation,
+>   readiness, ledger, and authored gates.
+> - Atomic claim transaction locking date-level capacity and transitioning occurrence to `active`.
 > - `POLICY_VERSION` bump (real decision behavior).
 >
 > ## Not in scope here
-> - Full D-AUDIT (replay verification, superseded-decision chains) -- issue #437.
-> - UI for the confirmation input -- product design needed first (see open questions).
+> - Full D-AUDIT (dedicated multi-decision replay persistence and historical audit chains) -- issue #437.
 >
 > (standard verification checklist)

--- a/docs/plans/h4-dreassess-analysis.md
+++ b/docs/plans/h4-dreassess-analysis.md
@@ -159,6 +159,7 @@ actionable bundle members.
        checkinRevision: string;        // check-in updatedAt / hash
        ledgerRevision: number;         // daily ledger entries sequence / hash
        placementRevision: string;      // bundle placement hash
+       postPredecessorConfirmationRevision?: string; // revision/hash of predecessor SessionResponse / tissueResponses
    }
    ```
    Generated when the provisional PM recommendation is composed, passed to the launch action,
@@ -168,7 +169,7 @@ actionable bundle members.
    - **Predecessor completion:** Verifies predecessor occurrence is `completed`. If not,
      returns `pending`.
    - **Elapsed separation:** If `minimumSeparationMinutes` is defined, computes
-     `elapsedMinutesBetweenInstants(evaluationInstant, predecessorCompletedAt)` via `localInstant.ts`.
+     `elapsedMinutesBetweenInstants(prospectiveStartInstant, predecessorActualEndInstant)` via `localInstant.ts`.
      If timestamps are missing or elapsed interval is insufficient, returns `pending` (unresolved timing prerequisite).
    - **Post-predecessor confirmation:** Queries `SessionResponse` (`window: 'immediate'`)
      and `DailySubjectiveCheckin.tissueResponses` for the predecessor. If absent, returns
@@ -182,9 +183,9 @@ actionable bundle members.
 3. **Atomic launch claim transaction:**
    Inside `runTransaction`:
    - Reads the date-level reservation/recommendation document and the target `session_occurrence`.
+   - Reads current reservation and capacity state, re-verifies the complete `ReassessmentInputRevision`, and rejects when it differs from the assumed revision.
    - Verifies target occurrence is currently `scheduled` (rejects if already `active` or `completed`).
-   - Verifies date ledger revision matches the assumed revision (rejects with "stale, recompute" if mismatched).
-   - Transitions occurrence to `active`, registers the active reservation in the date ledger,
+   - Transitions occurrence to `active`, registers the active reservation and capacity consumption in the date ledger,
      and commits atomically.
 
 4. **Persistence & D-AUDIT boundary:**

--- a/docs/plans/h4-dreassess-analysis.md
+++ b/docs/plans/h4-dreassess-analysis.md
@@ -1,0 +1,231 @@
+# H4: D-REASSESS analysis and PR-1 handoff
+
+**Status:** Analysis only. No code changes in this doc's commit.
+**Tracks:** [GitHub issue #436](https://github.com/Szczepanov/adaptive-training-recommender/issues/436).
+**Builds on:** [PR #440](https://github.com/Szczepanov/adaptive-training-recommender/pull/440)'s
+analysis of the external-plan execution-binding pipeline (issue #434) -- **not yet
+implemented**. This document's design assumes that pipeline's PR 1 (prescription-only v4
+launch binding) and PR 2 (occurrence tracking) both exist; see "Sequencing" below for why
+both, not just PR 1, are prerequisites.
+
+## What ADR-0036 D-REASSESS requires
+
+Quoting the ADR directly (`docs/adr/0036-intraday-training-windows-and-reassessment.md`):
+
+> A morning PM verdict is provisional. Before a later session starts, compose a fresh
+> as-of decision from current availability, today's canonical completed work, current
+> health/symptom inputs and the shared ledger. Require an explicit post-predecessor
+> symptom/response confirmation for a dependent session; absent confirmation leaves it
+> pending, not implicitly well tolerated. [...] Run the common eligibility, readiness,
+> dose and authored gates again. New adverse symptoms may scale/defer PM despite
+> favorable morning wearables. Favorable response does not automatically increase the
+> authored dose. A completed AM occurrence cannot be launched again; resuming an
+> in-progress execution preserves its execution identity.
+>
+> Each accepted launch must atomically validate the current ledger/input revision and
+> claim or transition its existing reservation, preventing two tabs or concurrent
+> requests from spending the same minute or systemic-cost capacity. A stale decision must
+> recompute. Changes to completion, symptoms, placement, availability or reconciliation
+> invalidate a pending PM approval; historical decisions remain immutable and are linked
+> by superseding decision identity.
+
+## Why this depends on #434, not just D-PLACEMENT
+
+D-REASSESS's entire premise is "before a later session starts" and "a completed AM
+occurrence cannot be launched again." Both phrases presuppose a bundle member is a real,
+launchable, stateful thing. Today (even after `activeExternalPlanService.ts`'s D-PLACEMENT
+wiring, PR #432), a v4 bundle's non-primary member is correctly *placed* (window/order/
+budget/rest all resolved) but has no execution identity at all -- there is nothing to
+"start," nothing that can be "completed," and no occurrence record D-REASSESS could query
+to ask "has the predecessor actually finished." Building D-REASSESS against that gap would
+mean either (a) inventing a parallel, throwaway state-tracking mechanism that duplicates
+what #434 PR 2 (occurrence tracking) is already supposed to build, or (b) blocking on #434
+first. Option (b) is the only one that doesn't create duplicate, soon-to-be-replaced work.
+
+**Concretely, D-REASSESS needs:**
+- #434 PR 1 (prescription-only launch binding) -- so a v4 session can be started at all.
+- #434 PR 2 (occurrence tracking, `OccurrenceAuthority`/`SessionOccurrence` extended for
+  `external_plan`) -- so a bundle member's lifecycle (`scheduled → active → completed`)
+  is queryable independently of the plan/date, which is what "has the predecessor
+  completed" and "a completed AM occurrence cannot be launched again" both require.
+
+Neither exists yet. This document is written so its design is ready the moment they do,
+but implementing D-REASSESS before them would mean re-deriving occurrence state ad hoc.
+
+## Current state, verified against code
+
+### What already exists and can be reused directly
+
+- **`evaluateReadinessAndSafetyEnvelope`** (`app/src/engine/rules.ts:277`) already computes
+  `{ mode, envelopes: { safety, plan }, telemetry, alreadyTrainedOverride }` from
+  `(readiness, context, date, previousMode, subjectiveDriftPolicy, subjectiveDriftWeights)`.
+  This is the "common eligibility, readiness... gates" the ADR says to re-run -- it's
+  already a pure, callable function, not something new to build. D-REASSESS's "compose a
+  fresh as-of decision" is largely "call this again with today's current inputs," not a
+  new gate system.
+- **`adjudicateAuthoredSession`** (`app/src/engine/authoredSessionGates.ts`) already
+  implements "run gates again for one specific session, given current readiness/context/
+  envelope/availability, and return `proceed | scale | reject`" -- exactly the shape a
+  dependent bundle member's reassessment needs. It's already reused for the manually-
+  authored additional-session flow in `Home.tsx`; PR 3 of #434's roadmap already proposes
+  reusing it for bundle members too. D-REASSESS is the gate that decides *whether and
+  when* to call it again for an already-placed dependent, not a replacement for it.
+- **`dailyLedger.ts`'s `computeDailyLedger`/`admitsCandidate`** (delivered, PR #426/#427)
+  already model "the day's remaining minute/systemic-cost capacity, reconciled against
+  known actuals" -- the "shared ledger" D-REASSESS reads from. Not yet wired into a live
+  per-launch admission check anywhere (see issue #433's closure -- the *week-ahead
+  planner* doesn't need it, but a live PM-launch admission check plausibly does; this
+  would be D-REASSESS's actual first real consumer of `admitsCandidate` as a launch-time
+  gate, distinct from #433's now-closed, differently-scoped ask).
+- **Same-day canonical performed facts** (`training-occurrence/performedTrainingFactsService.ts`'s
+  `getPerformedTrainingFactsThroughToday`, verified in the D-WINDOW PR era) is the "today's
+  canonical completed work" input, already proven to correctly include today's own
+  same-day evidence.
+- **Atomic claim/transition precedent**: `assessmentAttemptService.ts`'s private
+  `transitionAttempt` (lines ~99-113) is a direct, reusable pattern for "atomically
+  validate the current ... revision and claim or transition its existing reservation":
+
+  ```typescript
+  private async transitionAttempt(userId, attemptId, transition: (current) => next): Promise<void> {
+      const ref = this.attemptRef(userId, attemptId);
+      await runTransaction(this.db, async transaction => {
+          const snapshot = await transaction.get(ref);
+          if (!snapshot.exists()) throw new Error(...);
+          const current = snapshot.data();
+          assertValidAssessmentAttempt(current);
+          const next = transition(current);
+          assertValidAssessmentAttempt(next);
+          transaction.set(ref, next);
+      });
+  }
+  ```
+  This is exactly the shape D-REASSESS's "each accepted launch must atomically validate
+  the current ledger/input revision and claim or transition its existing reservation,
+  preventing two tabs or concurrent requests from spending the same minute or
+  systemic-cost capacity" needs: read the occurrence + today's ledger-relevant state
+  inside a `runTransaction`, validate the caller's assumed revision still matches, and
+  only then write the claimed/transitioned state. `garminSyncRequestService.ts` and
+  `healthAnomalyOutcomeService.ts` show the same pattern used twice more elsewhere in
+  this codebase -- it's an established idiom, not a new one to invent.
+
+### What does not exist yet (beyond #434's gap)
+
+- No "revision" concept for a day's ledger/availability inputs as a whole (only
+  `dailyLedger.ts`'s per-*entry* `revision`, and `ExternalPlanPlacement.revision` for the
+  plan overlay). D-REASSESS's "atomically validate the current ledger/input revision"
+  implies some notion of "the as-of state this PM decision was computed against" that can
+  be compared to "the as-of state at claim time" to detect staleness (availability
+  changed, symptoms changed, placement changed, etc. -- the ADR's own list of invalidating
+  changes). This needs a new, explicit revision/hash concept spanning the *inputs to one
+  day's reassessment decision*, not a reuse of an existing per-entity revision. See
+  "Design sketch" below.
+- No persisted "pending PM approval" concept at all -- this is arguably the first slice of
+  D-AUDIT (issue #437) that D-REASSESS actually needs before it can be built, not just a
+  D-REASSESS-internal detail. A provisional AM-time PM verdict needs *somewhere* to live
+  between "AM decision composed" and "PM launch claimed," and the ADR's "historical
+  decisions remain immutable and are linked by superseding decision identity" describes
+  exactly the kind of snapshot D-AUDIT is supposed to own. **This is a second real
+  dependency this document did not originally expect**: D-REASSESS and D-AUDIT are more
+  intertwined than the original issue split suggested -- see "Sequencing," revised.
+- No explicit "post-predecessor symptom/response confirmation" UI/data model. The ADR
+  requires this be a distinct, explicit athlete input ("absent confirmation leaves it
+  pending, not implicitly well tolerated") -- nothing in the existing check-in/health-
+  context schema (`DailySubjectiveCheckin`, `HealthContext`) is scoped to "confirming how
+  a specific just-completed session felt," as opposed to the whole day's general state.
+
+## Design sketch (for the implementing agent to refine, not a final spec)
+
+1. **A day's reassessment-input revision.** Define something like:
+   ```typescript
+   interface ReassessmentInputRevision {
+       availabilityRevision: string;   // hash of resolveAvailability's relevant inputs for the date
+       completedFactsRevision: string; // from getPerformedTrainingFactsThroughToday
+       checkinRevision: string;        // today's check-in document's own revision/updatedAt
+       ledgerRevision: string;         // hash of the day's LedgerEntry set at compose time
+       placementRevision: string;      // the bundle's proposeBundlePlacement outcome hash
+   }
+   ```
+   Computed once when the provisional PM decision is composed (AM time or whenever
+   re-evaluated), persisted alongside it, and re-derived at claim time inside the
+   transaction; a mismatch on any field means "stale, must recompute" per the ADR.
+2. **`reassessDependentBundleMember(...)`** (name placeholder): a new pure function,
+   analogous to `evaluateReadinessAndSafetyEnvelope` + `adjudicateAuthoredSession`
+   composed together, that:
+   - Requires an explicit "post-predecessor confirmation" input; returns a `pending`
+     verdict (not `proceed`/`scale`/`reject`) when absent.
+   - Re-runs `evaluateReadinessAndSafetyEnvelope` and `adjudicateAuthoredSession` against
+     *current* inputs, not the AM-time snapshot.
+   - Consults `dailyLedger.ts`'s `admitsCandidate` against the day's *current* remaining
+     capacity (today's real first live consumer of that function as an admission gate,
+     distinct from issue #433's now-closed ask).
+3. **Claim transaction**, mirroring `assessmentAttemptService.ts`'s `transitionAttempt`:
+   read the occurrence (from #434 PR 2) and the persisted `ReassessmentInputRevision`
+   inside one `runTransaction`; if the caller's assumed revision doesn't match current,
+   fail with "stale, recompute"; otherwise atomically move the occurrence from
+   `scheduled` to `active` (claim) and write the resolved verdict.
+4. **Persistence** of the provisional/reassessed decision itself is D-AUDIT's concern
+   (issue #437) -- D-REASSESS should be designed to *write into* whatever shape D-AUDIT
+   defines, not invent its own separate storage. This is the reason to read #437's
+   analysis (once written) before finalizing D-REASSESS's exact persisted shape.
+
+## Revised sequencing
+
+Original issue split assumed D-REASSESS → D-AUDIT in that order. Investigation shows
+they're more coupled: D-REASSESS needs *somewhere* to persist a provisional decision
+between AM composition and PM claim, and that "somewhere" is D-AUDIT's actual subject
+matter. Recommended real order:
+
+1. #434 PR 1 (prescription-only v4 launch binding) -- not yet implemented.
+2. #434 PR 2 (occurrence tracking for `external_plan`) -- not yet implemented.
+3. **A minimal slice of D-AUDIT** covering just enough persisted shape for one pending
+   decision + its input-revision snapshot (not the full D-AUDIT scope from issue #437,
+   which also covers full replay semantics, superseded-decision chains, etc.) -- this
+   could be its own small PR, or folded into D-REASSESS's first PR if it stays small.
+4. D-REASSESS's actual gate logic (the design sketch above), built against that minimal
+   persisted shape.
+5. The rest of D-AUDIT (issue #437) -- full replay verification, superseded-decision
+   chains, UI surfacing of provisional/pending/dropped states.
+
+## Open questions for the implementing agent
+
+- Exact shape of `ReassessmentInputRevision` -- the sketch above is illustrative; the
+  actual hash/revision sources need re-verification against the tree at implementation
+  time (this doc was written after PR #441 merged; confirm nothing shifted).
+- Whether "post-predecessor confirmation" belongs in the existing daily check-in flow
+  (`DailySubjectiveCheckin`) as a new optional field, or as its own separate, session-
+  scoped confirmation record -- the ADR's emphasis on "explicit" and "absent confirmation
+  leaves it pending" suggests a separate record is safer (a daily check-in the athlete
+  fills before any session starts can't logically already contain a *post*-predecessor
+  confirmation), but this needs product-level input, not just an engineering call.
+- How much of "the minimal slice of D-AUDIT" (step 3 above) is small enough to fold into
+  D-REASSESS's first PR versus needing its own -- re-evaluate once #434 actually exists
+  and the real occurrence shape is known.
+- Firestore rules budget: any new persisted shape for a pending decision needs its own
+  validation function, ideally *not* nested inside the already-at-capacity
+  `hasValidRecommendationAudit` (see issue #435/PR #441's finding) -- a new top-level
+  collection with its own, unrelated validation function avoids inheriting that ceiling.
+
+## Suggested PR description for D-REASSESS's first real implementation PR (once unblocked)
+
+> ## Summary
+> First implementation PR for ADR-0036 D-REASSESS (issue #436), unblocked by #434 PR 1+2
+> (external-plan launch binding + occurrence tracking) and a minimal slice of D-AUDIT
+> (issue #437) providing persisted-decision-revision tracking.
+>
+> Reuses `evaluateReadinessAndSafetyEnvelope`/`adjudicateAuthoredSession` (unchanged) for
+> the actual gate re-evaluation, `dailyLedger.ts`'s `admitsCandidate` as a real live
+> admission check (its first production consumer), and
+> `assessmentAttemptService.ts`'s `runTransaction`-based claim pattern for atomic
+> launch-time revision validation.
+>
+> ## What's delivered
+> - `ReassessmentInputRevision` computation and persistence (see D-AUDIT's minimal slice).
+> - A new pure reassessment function requiring explicit post-predecessor confirmation.
+> - An atomic claim transaction preventing double-reservation across concurrent launches.
+> - `POLICY_VERSION` bump (real decision behavior).
+>
+> ## Not in scope here
+> - Full D-AUDIT (replay verification, superseded-decision chains) -- issue #437.
+> - UI for the confirmation input -- product design needed first (see open questions).
+>
+> (standard verification checklist)


### PR DESCRIPTION
## Summary

Implements ADR-0036 D-REASSESS (post-AM reassessment before PM launch) and completes the analysis deliverable for [issue #436](https://github.com/Szczepanov/adaptive-training-recommender/issues/436).

- **Pure reassessment engine (`app/src/engine/intradayReassessment.ts`):**
  - Implements `reassessDependentBundleMember` and `computeReassessmentInputRevision`.
  - Evaluates predecessor completion state and completion timestamp.
  - Verifies minimum timing separation (ADR-0036 D-TIME) using `elapsedMinutesBetweenInstants`.
  - Verifies explicit post-predecessor symptom and response confirmation (`SessionResponse` and `RegionTissueResponse`) per ADR-0023 D-MRESP; does not infer well-tolerated status from silence.
  - Detects acute reactive symptoms (severe tissue pain or adverse reactions) and scales or rejects PM work accordingly.
  - Enforces that favorable predecessor responses never expand authored dose beyond plan limits.
  - Verifies candidate admission against remaining daily capacity via `admitsCandidate` (`app/src/engine/dailyLedger.ts`).
  - Evaluates readiness & safety envelopes bypassing single-session `alreadyTrainedOverride` circuit breaker via `EvaluateReadinessOptions.ignoreAlreadyTrainedOverride`.
- **Readiness rules adjustment (`app/src/engine/rules.ts`):**
  - Adds `EvaluateReadinessOptions { ignoreAlreadyTrainedOverride?: boolean }` to `evaluateReadinessAndSafetyEnvelope` and `evaluateEnvelopes`.
  - Avoids erroneously clamping intraday double sessions to `recover` mode and `Rest` tier when same-day predecessor work has already been accounted for via ledger debits.
- **Atomic claim transaction (`app/src/services/sessionOccurrenceService.ts`):**
  - Implements `claimOccurrenceLaunch(userId, occurrenceId, now)` using Firestore `runTransaction`.
  - Atomically verifies `state === 'scheduled'` and transitions to `'active'`, preventing double-launches or race conditions.
- **Policy bump (`app/src/engine/policy.ts`):**
  - Advances `POLICY_VERSION` to `'2026-09-h4-intraday-reassessment-v1'` and archives previous policy to `HISTORICAL_POLICY_VERSIONS`.

## Risk and reviewer guidance

- **Low risk to existing single-session recommendation flows:** The `ignoreAlreadyTrainedOverride` option defaults to undefined/false. Existing morning recommendation flows (`evaluateTraining`, `evaluateTrainingWithIntent`, etc.) retain the single-session-per-day circuit breaker unchanged.
- **Strict safety fail-closed semantics:** If a predecessor session was not completed, or post-predecessor confirmation is absent, reassessment evaluates to `pending`, preventing premature PM launch. If severe/adverse tissue responses occur, it evaluates to `reject` with `safety_guardrail`.
- **Zero schema changes needed:** Directly reuses canonical `SessionResponse` (ADR-0023 D-MRESP) and `RegionTissueResponse`.

## Domain invariants

- **ADR-0036 D-REASSESS:** Runtime reassessment is deterministic and pure: given the same inputs and input revisions, `reassessDependentBundleMember` returns identical verdicts.
- **ADR-0036 D-TIME:** Minimum separation between prospective start instant and predecessor actual end instant is enforced using `elapsedMinutesBetweenInstants`.
- **ADR-0023 D-MRESP:** Explicit post-predecessor confirmation is required; absent confirmation leaves the decision `pending`.
- **ADR-0036 D-LEDGER:** Ledger capacity is checked prior to launching any secondary session.
- **No dose expansion:** Favorable responses cannot scale volume or intensity above authored limits.

## Validation

- **Unit tests:**
  - `app/src/engine/intradayReassessment.test.ts`: 10 comprehensive tests covering all edge cases (uncompleted predecessor, separation timing, missing confirmations, severe pain rejection, unexpected fatigue scaling, already-trained override bypass, ledger exhaustion).
  - `app/src/services/sessionOccurrenceService.test.ts`: 4 tests for atomic `claimOccurrenceLaunch` (successful claim, missing occurrence, non-scheduled state, corrupted document).
  - All 3,719 unit tests in `app` pass cleanly (`vitest run`), including all external-plan execution-binding tests from merged #440.
- **Engine verification:**
  - `npm run check` (typecheck + lint + tests + sports knowledge + workout catalog) passed with 0 errors.
  - `node scripts/check-policy-drift.mjs origin/main` verified policy version bump.
  - Pre-commit and pre-push hooks (formatting, linting, secrets, Warsaw date rule) passed cleanly.

## Screenshots or recordings

N/A — Backend and engine decision logic; no UI changes in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Sessions can be atomically claimed at launch, transitioning valid scheduled sessions to active.
  - Intraday reassessment considers tissue response, fatigue, timing, predecessor confirmation, readiness, safety, and available capacity.
  - Unexpected fatigue or moderate tissue irritation reduces session volume to 70% while preserving other dose settings.
  - Bundled intraday sessions can proceed without triggering the already-trained recovery override, while safety warnings remain enforced.
- **Bug Fixes**
  - Invalid or incomplete predecessor states, insufficient timing, missing confirmation, or severe tissue responses prevent dependent sessions from proceeding.
  - Invalid launch attempts leave session records unchanged.
- **Documentation**
  - Added planning documentation for reassessment rules, launch sequencing, validation, and revision tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->