### PR TITLE
feat(h4): implement ADR-0036 D-AUDIT intraday decision persistence and replay

### DIFF
--- a/app/firestore.rules
+++ b/app/firestore.rules
@@ -1577,6 +1577,50 @@ service cloud.firestore {
       }
     }
 
+    function hasValidIntradayDecision(userId, decisionId) {
+      let data = request.resource.data;
+      let requiredKeys = [
+        'id', 'userId', 'date', 'asOf', 'policyVersion', 'schemaVersion',
+        'status', 'supersededDecisionId', 'occurrenceId', 'sessionId',
+        'windowId', 'bundleId', 'orderInBundle', 'reassessmentInputRevision',
+        'bundlePlacement', 'ledgerSnapshot', 'verdict'
+      ];
+      return hasOwnedUserId(userId)
+        && data.keys().hasAll(requiredKeys)
+        && data.keys().hasOnly(requiredKeys)
+        && data.id == decisionId
+        && data.id is string && data.id.size() > 0 && data.id.size() <= 128
+        && data.date is string && data.date.matches('^[0-9]{4}-[0-9]{2}-[0-9]{2}$')
+        && data.asOf is string && data.asOf.size() > 0 && data.asOf.size() <= 64
+        && data.policyVersion is string && data.policyVersion.size() > 0 && data.policyVersion.size() <= 128
+        && data.schemaVersion == 1
+        && data.status in ['provisional', 'confirmed', 'superseded', 'dropped']
+        && (data.supersededDecisionId == null || (data.supersededDecisionId is string && data.supersededDecisionId.size() > 0 && data.supersededDecisionId.size() <= 128))
+        && data.occurrenceId is string && data.occurrenceId.size() > 0 && data.occurrenceId.size() <= 128
+        && data.sessionId is string && data.sessionId.size() > 0 && data.sessionId.size() <= 128
+        && data.windowId is string && data.windowId.size() > 0 && data.windowId.size() <= 128
+        && data.bundleId is string && data.bundleId.size() > 0 && data.bundleId.size() <= 128
+        && data.orderInBundle is int && data.orderInBundle >= 0
+        && data.reassessmentInputRevision is map
+        && data.reassessmentInputRevision.keys().hasAll(['availabilityRevision', 'completedFactsRevision', 'checkinRevision', 'ledgerRevision', 'placementRevision'])
+        && data.bundlePlacement is map
+        && data.bundlePlacement.bundleId is string
+        && data.bundlePlacement.outcome in ['placed', 'infeasible']
+        && data.ledgerSnapshot is map
+        && data.ledgerSnapshot.keys().hasAll(['ceilings', 'entries'])
+        && data.ledgerSnapshot.ceilings is map
+        && data.ledgerSnapshot.entries is list
+        && data.verdict is map
+        && data.verdict.decision in ['proceed', 'scale', 'defer', 'skip', 'pending']
+        && data.verdict.reasons is list;
+    }
+
+    match /users/{userId}/intraday_decisions/{decisionId} {
+      allow read: if isOwner(userId);
+      allow create: if hasValidIntradayDecision(userId, decisionId);
+      allow update, delete: if false;
+    }
+
     function hasKnownOutcomeMetric(metricId) {
       return metricId in [
         'cycling_tt_20m_mean_power_w',

--- a/app/firestore.rules
+++ b/app/firestore.rules
@@ -1604,8 +1604,12 @@ service cloud.firestore {
         && data.reassessmentInputRevision is map
         && data.reassessmentInputRevision.keys().hasAll(['availabilityRevision', 'completedFactsRevision', 'checkinRevision', 'ledgerRevision', 'placementRevision'])
         && data.bundlePlacement is map
-        && data.bundlePlacement.bundleId is string
+        && data.bundlePlacement.bundleId is string && data.bundlePlacement.bundleId.size() > 0 && data.bundlePlacement.bundleId.size() <= 128
         && data.bundlePlacement.outcome in ['placed', 'infeasible']
+        && (
+          (data.bundlePlacement.outcome == 'placed' && data.bundlePlacement.bindings is list && data.bundlePlacement.bindings.size() > 0)
+          || (data.bundlePlacement.outcome == 'infeasible' && data.bundlePlacement.reason is string && data.bundlePlacement.reason.size() > 0 && data.bundlePlacement.reason.size() <= 512)
+        )
         && data.ledgerSnapshot is map
         && data.ledgerSnapshot.keys().hasAll(['ceilings', 'entries'])
         && data.ledgerSnapshot.ceilings is map

--- a/app/scripts/fixtures/replay-intraday-decision.json
+++ b/app/scripts/fixtures/replay-intraday-decision.json
@@ -1,0 +1,49 @@
+{
+  "id": "dec-intraday-test",
+  "userId": "athlete-1",
+  "date": "2026-09-06",
+  "asOf": "2026-09-06T07:30:00.000Z",
+  "policyVersion": "2026-09-h4-intraday-bundle-placement-v1",
+  "schemaVersion": 1,
+  "status": "provisional",
+  "supersededDecisionId": null,
+  "occurrenceId": "occ-am-1",
+  "sessionId": "sess-am-1",
+  "windowId": "win-am-1",
+  "bundleId": "bundle-sunday-1",
+  "orderInBundle": 0,
+  "reassessmentInputRevision": {
+    "availabilityRevision": "avail-rev-1",
+    "completedFactsRevision": "facts-rev-1",
+    "checkinRevision": "checkin-rev-1",
+    "ledgerRevision": "ledger-rev-1",
+    "placementRevision": "placement-rev-1"
+  },
+  "bundlePlacement": {
+    "bundleId": "bundle-sunday-1",
+    "outcome": "placed",
+    "bindings": [
+      {
+        "sessionId": "sess-am-1",
+        "windowId": "win-am-1",
+        "boundStartLocal": "08:00",
+        "boundEndLocal": "09:00",
+        "startInstant": "2026-09-06T06:00:00.000Z",
+        "endInstant": "2026-09-06T07:00:00.000Z"
+      }
+    ]
+  },
+  "ledgerSnapshot": {
+    "ceilings": {
+      "dailyMinuteCeiling": 90,
+      "dailySystemicCostCeiling": 0.8
+    },
+    "entries": []
+  },
+  "verdict": {
+    "decision": "proceed",
+    "reasons": [
+      "Capacity verified"
+    ]
+  }
+}

--- a/app/scripts/replay-recommendation-audit.mjs
+++ b/app/scripts/replay-recommendation-audit.mjs
@@ -40,12 +40,26 @@ const server = await createServer({
 });
 
 try {
-  const { replayRecommendationAuditAgainstRevision } = await server.ssrLoadModule('/src/engine/replay.ts');
-  // Always the hashing wrapper: the hash must be recomputed from the supplied bytes, never
-  // read back out of the audit that is being checked.
-  const result = await replayRecommendationAuditAgainstRevision(recommendation, plan);
-  console.log(JSON.stringify(result, null, 2));
-  if (!result.reproducible) process.exitCode = 1;
+  if (recommendation && typeof recommendation === 'object' && 'orderInBundle' in recommendation && 'bundlePlacement' in recommendation) {
+    const { intradayDecisionReplayErrors } = await server.ssrLoadModule('/src/engine/intradayDecision.ts');
+    const { computeContentHash } = await server.ssrLoadModule('/src/engine/externalPlanHash.ts');
+    const externalRevision = plan ? { plan, contentHash: await computeContentHash(plan) } : null;
+    const errors = intradayDecisionReplayErrors(recommendation, externalRevision);
+    const result = {
+      reproducible: errors.length === 0,
+      policyMatchesCurrent: !errors.some(e => e.includes('Policy version')),
+      errors,
+    };
+    console.log(JSON.stringify(result, null, 2));
+    if (!result.reproducible) process.exitCode = 1;
+  } else {
+    const { replayRecommendationAuditAgainstRevision } = await server.ssrLoadModule('/src/engine/replay.ts');
+    // Always the hashing wrapper: the hash must be recomputed from the supplied bytes, never
+    // read back out of the audit that is being checked.
+    const result = await replayRecommendationAuditAgainstRevision(recommendation, plan);
+    console.log(JSON.stringify(result, null, 2));
+    if (!result.reproducible) process.exitCode = 1;
+  }
 } finally {
   await server.close();
 }

--- a/app/src/emulator/intradayDecisionRules.emulator.test.ts
+++ b/app/src/emulator/intradayDecisionRules.emulator.test.ts
@@ -42,7 +42,16 @@ function validRecord() {
         bundlePlacement: {
             bundleId: 'bundle-sunday-1',
             outcome: 'placed',
-            bindings: [],
+            bindings: [
+                {
+                    sessionId: 'sess-am-1',
+                    windowId: 'win-am-1',
+                    boundStartLocal: '08:00',
+                    boundEndLocal: '09:00',
+                    startInstant: '2026-09-06T06:00:00.000Z',
+                    endInstant: '2026-09-06T07:00:00.000Z',
+                },
+            ],
         },
         ledgerSnapshot: {
             ceilings: {
@@ -109,5 +118,30 @@ emulatorDescribe('Intraday decision security rules (ADR-0036 D-AUDIT)', () => {
         await assertFails(setDoc(doc(db, docPath), { ...validRecord(), schemaVersion: 2 }));
         await assertFails(setDoc(doc(db, docPath), { ...validRecord(), orderInBundle: -1 }));
         await assertFails(setDoc(doc(db, docPath), { ...validRecord(), unexpectedKey: true }));
+        await assertFails(setDoc(doc(db, docPath), {
+            ...validRecord(),
+            bundlePlacement: { bundleId: 'bundle-sunday-1', outcome: 'placed', bindings: [] },
+        }));
+        await assertFails(setDoc(doc(db, docPath), {
+            ...validRecord(),
+            bundlePlacement: { bundleId: 'bundle-sunday-1', outcome: 'infeasible' },
+        }));
+        await assertFails(setDoc(doc(db, docPath), {
+            ...validRecord(),
+            bundlePlacement: { bundleId: 'bundle-sunday-1', outcome: 'infeasible', reason: '' },
+        }));
+    });
+
+    it('accepts valid infeasible proposals with a non-empty reason', async () => {
+        const db = testEnvironment.authenticatedContext(ownerId).firestore();
+        const infeasibleRecord = {
+            ...validRecord(),
+            bundlePlacement: {
+                bundleId: 'bundle-sunday-1',
+                outcome: 'infeasible',
+                reason: 'No available schedule window',
+            },
+        };
+        await assertSucceeds(setDoc(doc(db, docPath), infeasibleRecord));
     });
 });

--- a/app/src/emulator/intradayDecisionRules.emulator.test.ts
+++ b/app/src/emulator/intradayDecisionRules.emulator.test.ts
@@ -1,0 +1,113 @@
+import { readFileSync } from 'node:fs';
+import { afterAll, afterEach, beforeAll, describe, it } from 'vitest';
+import {
+    assertFails,
+    assertSucceeds,
+    initializeTestEnvironment,
+    type RulesTestEnvironment,
+} from '@firebase/rules-unit-testing';
+import { deleteDoc, doc, getDoc, setDoc, updateDoc } from 'firebase/firestore';
+
+const emulatorDescribe = process.env.FIRESTORE_EMULATOR_HOST ? describe : describe.skip;
+let testEnvironment: RulesTestEnvironment;
+
+const ownerId = 'athlete-intraday-decision';
+const otherId = 'other-intraday-decision';
+const decisionId = 'dec-2026-09-06-am';
+const date = '2026-09-06';
+const docPath = `users/${ownerId}/intraday_decisions/${decisionId}`;
+
+function validRecord() {
+    return {
+        id: decisionId,
+        userId: ownerId,
+        date,
+        asOf: '2026-09-06T07:30:00.000Z',
+        policyVersion: '2026-09-h4-intraday-bundle-placement-v1',
+        schemaVersion: 1,
+        status: 'provisional',
+        supersededDecisionId: null,
+        occurrenceId: 'occ-am-1',
+        sessionId: 'sess-am-1',
+        windowId: 'win-am-1',
+        bundleId: 'bundle-sunday-1',
+        orderInBundle: 0,
+        reassessmentInputRevision: {
+            availabilityRevision: 'avail-rev-1',
+            completedFactsRevision: 'facts-rev-1',
+            checkinRevision: 'checkin-rev-1',
+            ledgerRevision: 'ledger-rev-1',
+            placementRevision: 'placement-rev-1',
+        },
+        bundlePlacement: {
+            bundleId: 'bundle-sunday-1',
+            outcome: 'placed',
+            bindings: [],
+        },
+        ledgerSnapshot: {
+            ceilings: {
+                dailyMinuteCeiling: 90,
+                dailySystemicCostCeiling: 0.8,
+            },
+            entries: [],
+        },
+        verdict: {
+            decision: 'proceed',
+            reasons: ['Capacity verified'],
+        },
+    };
+}
+
+emulatorDescribe('Intraday decision security rules (ADR-0036 D-AUDIT)', () => {
+    beforeAll(async () => {
+        testEnvironment = await initializeTestEnvironment({
+            projectId: 'demo-adaptive-training-intraday-decision',
+            firestore: { rules: readFileSync('firestore.rules', 'utf8') },
+        });
+    });
+
+    afterEach(async () => {
+        await testEnvironment.clearFirestore();
+    });
+
+    afterAll(async () => {
+        await testEnvironment.cleanup();
+    });
+
+    it('allows the owner to create and read a valid decision record', async () => {
+        const db = testEnvironment.authenticatedContext(ownerId).firestore();
+        await assertSucceeds(setDoc(doc(db, docPath), validRecord()));
+        await assertSucceeds(getDoc(doc(db, docPath)));
+    });
+
+    it('rejects cross-user reads and writes', async () => {
+        const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+        await assertSucceeds(setDoc(doc(ownerDb, docPath), validRecord()));
+
+        const otherDb = testEnvironment.authenticatedContext(otherId).firestore();
+        await assertFails(getDoc(doc(otherDb, docPath)));
+        await assertFails(setDoc(doc(otherDb, docPath), { ...validRecord(), userId: otherId }));
+    });
+
+    it('strictly enforces write-once immutability (updates and deletes are forbidden)', async () => {
+        const db = testEnvironment.authenticatedContext(ownerId).firestore();
+        await assertSucceeds(setDoc(doc(db, docPath), validRecord()));
+        await assertFails(updateDoc(doc(db, docPath), { status: 'confirmed' }));
+        await assertFails(deleteDoc(doc(db, docPath)));
+    });
+
+    it('requires document ID to match payload id', async () => {
+        const db = testEnvironment.authenticatedContext(ownerId).firestore();
+        const mismatchedPath = `users/${ownerId}/intraday_decisions/different-id`;
+        await assertFails(setDoc(doc(db, mismatchedPath), validRecord()));
+    });
+
+    it('rejects malformed payloads and invalid enums', async () => {
+        const db = testEnvironment.authenticatedContext(ownerId).firestore();
+        await assertFails(setDoc(doc(db, docPath), { ...validRecord(), status: 'invalid_status' }));
+        await assertFails(setDoc(doc(db, docPath), { ...validRecord(), date: '09-06-2026' }));
+        await assertFails(setDoc(doc(db, docPath), { ...validRecord(), schemaVersion: 2 }));
+        await assertFails(setDoc(doc(db, docPath), { ...validRecord(), orderInBundle: -1 }));
+        await assertFails(setDoc(doc(db, docPath), { ...validRecord(), unexpectedKey: true }));
+    });
+});

--- a/app/src/engine/intradayDecision.test.ts
+++ b/app/src/engine/intradayDecision.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest';
+import {
+    validateIntradayDecisionRecord,
+    intradayDecisionReplayErrors,
+    type IntradayDecisionRecord,
+    type IntradayDecisionStatus,
+    type IntradayDecisionVerdictOutcome,
+} from './intradayDecision';
+import { POLICY_VERSION } from './policy';
+import { EXTERNAL_PLAN_SCHEMA_V4, type ExternalTrainingPlanV4 } from '../sessions/externalPlanV4';
+import type { ExternalTrainingPlan } from './models';
+
+function sampleRecord(overrides: Partial<IntradayDecisionRecord> = {}): IntradayDecisionRecord {
+    return {
+        id: 'decision-1',
+        userId: 'athlete-1',
+        date: '2026-09-06',
+        asOf: '2026-09-06T08:00:00.000Z',
+        policyVersion: POLICY_VERSION,
+        schemaVersion: 1,
+        status: 'provisional',
+        supersededDecisionId: null,
+        occurrenceId: 'occ-1',
+        sessionId: 'session-am',
+        windowId: 'window-morning',
+        bundleId: 'bundle-sunday',
+        orderInBundle: 0,
+        reassessmentInputRevision: {
+            availabilityRevision: 'avail-rev-1',
+            completedFactsRevision: 'facts-rev-1',
+            checkinRevision: 'checkin-rev-1',
+            ledgerRevision: 'ledger-rev-1',
+            placementRevision: 'placement-rev-1',
+        },
+        bundlePlacement: {
+            bundleId: 'bundle-sunday',
+            outcome: 'placed',
+            bindings: [
+                {
+                    sessionId: 'session-am',
+                    windowId: 'window-morning',
+                    boundStartLocal: '08:00',
+                    boundEndLocal: '09:00',
+                    startInstant: '2026-09-06T06:00:00.000Z',
+                    endInstant: '2026-09-06T07:00:00.000Z',
+                },
+            ],
+        },
+        ledgerSnapshot: {
+            ceilings: {
+                dailyMinuteCeiling: 90,
+                dailySystemicCostCeiling: 0.8,
+            },
+            entries: [],
+        },
+        verdict: {
+            decision: 'proceed',
+            reasons: ['Capacity fits morning window'],
+        },
+        ...overrides,
+    };
+}
+
+function samplePlanV4(): ExternalTrainingPlanV4 {
+    return {
+        schema: EXTERNAL_PLAN_SCHEMA_V4,
+        planId: 'plan-1',
+        revision: 1,
+        title: 'Hybrid Plan',
+        startDate: '2026-09-01',
+        weekCount: 2,
+        restDays: [],
+        sessions: [
+            {
+                id: 'session-am',
+                title: 'Morning Easy',
+                priority: 'key',
+                placement: { preferredDay: 'sunday', week: 1, flexibility: 'preferred', ifMissed: 'drop' },
+                gating: { modality: 'running', intensity: 'easy', durationMin: 30, durationMax: 60, environment: 'outdoor', equipment: [] },
+                definition: {
+                    schemaVersion: 1,
+                    id: 'def-1',
+                    revision: 1,
+                    title: 'Morning Easy',
+                    intent: 'training',
+                    blocks: [],
+                },
+                intraday: {
+                    bundleId: 'bundle-sunday',
+                    order: 0,
+                    window: { startLocal: '08:00', endLocal: '09:30' },
+                },
+            },
+        ],
+    };
+}
+
+describe('intradayDecision validation and replay', () => {
+    it('validates a valid record and preserves its fields', () => {
+        const record = sampleRecord();
+        const validated = validateIntradayDecisionRecord(record);
+        expect(validated).toEqual(record);
+    });
+
+    it('rejects malformed records and invalid dates', () => {
+        expect(() => validateIntradayDecisionRecord(null)).toThrow(TypeError);
+        expect(() => validateIntradayDecisionRecord({ ...sampleRecord(), date: 'invalid-date' })).toThrow(TypeError);
+        expect(() => validateIntradayDecisionRecord({ ...sampleRecord(), asOf: 'not-a-date' })).toThrow(TypeError);
+        expect(() => validateIntradayDecisionRecord({ ...sampleRecord(), schemaVersion: 2 as unknown as 1 })).toThrow(TypeError);
+        expect(() => validateIntradayDecisionRecord({ ...sampleRecord(), status: 'bogus' as unknown as IntradayDecisionStatus })).toThrow(TypeError);
+        expect(() => validateIntradayDecisionRecord({ ...sampleRecord(), orderInBundle: -1 })).toThrow(RangeError);
+        expect(() => validateIntradayDecisionRecord({
+            ...sampleRecord(),
+            ledgerSnapshot: { ceilings: { dailyMinuteCeiling: -10, dailySystemicCostCeiling: 0.5 }, entries: [] },
+        })).toThrow(TypeError);
+        expect(() => validateIntradayDecisionRecord({
+            ...sampleRecord(),
+            verdict: { decision: 'unknown' as unknown as IntradayDecisionVerdictOutcome, reasons: [] },
+        })).toThrow(TypeError);
+    });
+
+    it('replays a clean record against matching external plan revision with 0 errors', () => {
+        const record = sampleRecord();
+        const plan = samplePlanV4();
+        const errors = intradayDecisionReplayErrors(record, { plan: plan as unknown as ExternalTrainingPlan, contentHash: 'hash-1' });
+        expect(errors).toEqual([]);
+    });
+
+    it('flags policy version mismatches during replay', () => {
+        const record = sampleRecord({ policyVersion: 'historical-policy-v0' });
+        const errors = intradayDecisionReplayErrors(record);
+        expect(errors).toContain(`Policy version historical-policy-v0 does not match current build policy version ${POLICY_VERSION}`);
+    });
+
+    it('detects bundle placement mismatches during replay', () => {
+        const record = sampleRecord({
+            bundleId: 'bundle-1',
+            bundlePlacement: {
+                bundleId: 'bundle-2',
+                outcome: 'placed',
+                bindings: [],
+            },
+        });
+        const errors = intradayDecisionReplayErrors(record);
+        expect(errors.some(e => e.includes('Bundle identity mismatch'))).toBe(true);
+        expect(errors.some(e => e.includes('contains no window bindings'))).toBe(true);
+    });
+
+    it('detects external plan mismatch when session order or bundle disagrees', () => {
+        const record = sampleRecord({ orderInBundle: 1 });
+        const plan = samplePlanV4();
+        const errors = intradayDecisionReplayErrors(record, { plan: plan as unknown as ExternalTrainingPlan, contentHash: 'hash-1' });
+        expect(errors.some(e => e.includes('Session order mismatch'))).toBe(true);
+    });
+
+    it('detects missing session in external plan', () => {
+        const record = sampleRecord({ sessionId: 'session-unknown' });
+        const plan = samplePlanV4();
+        const errors = intradayDecisionReplayErrors(record, { plan: plan as unknown as ExternalTrainingPlan, contentHash: 'hash-1' });
+        expect(errors.some(e => e.includes('is not present in plan'))).toBe(true);
+    });
+});

--- a/app/src/engine/intradayDecision.test.ts
+++ b/app/src/engine/intradayDecision.test.ts
@@ -117,6 +117,39 @@ describe('intradayDecision validation and replay', () => {
             ...sampleRecord(),
             verdict: { decision: 'unknown' as unknown as IntradayDecisionVerdictOutcome, reasons: [] },
         })).toThrow(TypeError);
+        expect(() => validateIntradayDecisionRecord({
+            ...sampleRecord(),
+            bundlePlacement: { bundleId: 'b1', outcome: 'placed', bindings: [] },
+        })).toThrow(TypeError);
+        expect(() => validateIntradayDecisionRecord({
+            ...sampleRecord(),
+            bundlePlacement: { bundleId: 'b1', outcome: 'placed', bindings: 'not-an-array' as unknown as [] },
+        })).toThrow(TypeError);
+        expect(() => validateIntradayDecisionRecord({
+            ...sampleRecord(),
+            bundlePlacement: { bundleId: 'b1', outcome: 'placed', bindings: [{ sessionId: 's1' }] as unknown as [] },
+        })).toThrow(TypeError);
+        expect(() => validateIntradayDecisionRecord({
+            ...sampleRecord(),
+            bundlePlacement: { bundleId: 'b1', outcome: 'infeasible' },
+        })).toThrow(TypeError);
+        expect(() => validateIntradayDecisionRecord({
+            ...sampleRecord(),
+            bundlePlacement: { bundleId: 'b1', outcome: 'infeasible', reason: '' },
+        })).toThrow(TypeError);
+    });
+
+    it('validates an infeasible proposal with a non-empty reason', () => {
+        const record = sampleRecord({
+            bundlePlacement: {
+                bundleId: 'bundle-sunday',
+                outcome: 'infeasible',
+                reason: 'No available schedule window satisfies the session duration',
+            },
+        });
+        const validated = validateIntradayDecisionRecord(record);
+        expect(validated.bundlePlacement.outcome).toBe('infeasible');
+        expect(validated.bundlePlacement.reason).toBe('No available schedule window satisfies the session duration');
     });
 
     it('replays a clean record against matching external plan revision with 0 errors', () => {
@@ -144,6 +177,17 @@ describe('intradayDecision validation and replay', () => {
         const errors = intradayDecisionReplayErrors(record);
         expect(errors.some(e => e.includes('Bundle identity mismatch'))).toBe(true);
         expect(errors.some(e => e.includes('contains no window bindings'))).toBe(true);
+
+        // Defensively handles non-array truthy bindings without throwing TypeError
+        const malformedRecord = sampleRecord({
+            bundlePlacement: {
+                bundleId: 'bundle-sunday',
+                outcome: 'placed',
+                bindings: 'invalid' as unknown as [],
+            },
+        });
+        const malformedErrors = intradayDecisionReplayErrors(malformedRecord);
+        expect(malformedErrors.some(e => e.includes('contains no window bindings'))).toBe(true);
     });
 
     it('detects external plan mismatch when session order or bundle disagrees', () => {

--- a/app/src/engine/intradayDecision.ts
+++ b/app/src/engine/intradayDecision.ts
@@ -9,7 +9,7 @@
  * supersession chains are maintained via `supersededDecisionId`.
  */
 
-import type { BundlePlacementProposal } from './intradayBundlePlacement';
+import type { BundlePlacementProposal, ResolvedWindowBinding } from './intradayBundlePlacement';
 import type { LedgerCeilings, LedgerEntry } from './dailyLedger';
 import type { ExternalRevisionEvidence } from './replay';
 import { POLICY_VERSION } from './policy';
@@ -144,11 +144,46 @@ export function validateIntradayDecisionRecord(raw: unknown): IntradayDecisionRe
         throw new TypeError('bundlePlacement must be a non-null object');
     }
     const bp = data.bundlePlacement as Record<string, unknown>;
-    assertString(bp.bundleId, 'bundlePlacement.bundleId', 1, 128);
+    const placementBundleId = assertString(bp.bundleId, 'bundlePlacement.bundleId', 1, 128);
     if (bp.outcome !== 'placed' && bp.outcome !== 'infeasible') {
         throw new TypeError('bundlePlacement.outcome must be "placed" or "infeasible"');
     }
-    const bundlePlacement = data.bundlePlacement as BundlePlacementProposal;
+
+    let bundlePlacement: BundlePlacementProposal;
+    if (bp.outcome === 'placed') {
+        if (!Array.isArray(bp.bindings)) {
+            throw new TypeError('bundlePlacement.bindings must be an array when outcome is "placed"');
+        }
+        if (bp.bindings.length === 0) {
+            throw new TypeError('bundlePlacement.bindings must contain at least one binding when outcome is "placed"');
+        }
+        const validatedBindings: ResolvedWindowBinding[] = bp.bindings.map((b, idx) => {
+            if (!b || typeof b !== 'object') {
+                throw new TypeError(`bundlePlacement.bindings[${idx}] must be a non-null object`);
+            }
+            const item = b as Record<string, unknown>;
+            return {
+                sessionId: assertString(item.sessionId, `bundlePlacement.bindings[${idx}].sessionId`, 1, 128),
+                windowId: assertString(item.windowId, `bundlePlacement.bindings[${idx}].windowId`, 1, 128),
+                boundStartLocal: assertString(item.boundStartLocal, `bundlePlacement.bindings[${idx}].boundStartLocal`, 1, 64),
+                boundEndLocal: assertString(item.boundEndLocal, `bundlePlacement.bindings[${idx}].boundEndLocal`, 1, 64),
+                startInstant: assertString(item.startInstant, `bundlePlacement.bindings[${idx}].startInstant`, 1, 64),
+                endInstant: assertString(item.endInstant, `bundlePlacement.bindings[${idx}].endInstant`, 1, 64),
+            };
+        });
+        bundlePlacement = {
+            bundleId: placementBundleId,
+            outcome: 'placed',
+            bindings: validatedBindings,
+        };
+    } else {
+        const reason = assertString(bp.reason, 'bundlePlacement.reason', 1, 512);
+        bundlePlacement = {
+            bundleId: placementBundleId,
+            outcome: 'infeasible',
+            reason,
+        };
+    }
 
     if (!data.ledgerSnapshot || typeof data.ledgerSnapshot !== 'object') {
         throw new TypeError('ledgerSnapshot must be a non-null object');
@@ -237,10 +272,10 @@ export function intradayDecisionReplayErrors(
             errors.push(`Bundle identity mismatch: record references ${record.bundleId} but bundlePlacement recorded ${bp.bundleId}`);
         }
         if (bp.outcome === 'placed') {
-            if (!bp.bindings || bp.bindings.length === 0) {
+            if (!Array.isArray(bp.bindings) || bp.bindings.length === 0) {
                 errors.push('Bundle placement marked placed but contains no window bindings');
             } else {
-                const targetBinding = bp.bindings.find(b => b.sessionId === record.sessionId);
+                const targetBinding = bp.bindings.find(b => b && typeof b === 'object' && b.sessionId === record.sessionId);
                 if (!targetBinding) {
                     errors.push(`Bundle placement does not bind target session ${record.sessionId}`);
                 } else if (targetBinding.windowId !== record.windowId) {
@@ -248,7 +283,7 @@ export function intradayDecisionReplayErrors(
                 }
             }
         } else if (bp.outcome === 'infeasible') {
-            if (!bp.reason) {
+            if (typeof bp.reason !== 'string' || bp.reason.trim().length === 0) {
                 errors.push('Bundle placement marked infeasible but contains no failure reason');
             }
         } else {

--- a/app/src/engine/intradayDecision.ts
+++ b/app/src/engine/intradayDecision.ts
@@ -1,0 +1,294 @@
+/**
+ * ADR-0036 (H4) D-AUDIT: Intraday decision record, validation, and replay verification.
+ *
+ * Persists immutable decision-level audit snapshots of intraday training window
+ * placement, ledger capacity, input revisions, and reassessment verdicts in a
+ * dedicated user-scoped subcollection (`users/{userId}/intraday_decisions/{decisionId}`).
+ *
+ * Write-once append-only semantics: decision records are never updated in-place;
+ * supersession chains are maintained via `supersededDecisionId`.
+ */
+
+import type { BundlePlacementProposal } from './intradayBundlePlacement';
+import type { LedgerCeilings, LedgerEntry } from './dailyLedger';
+import type { ExternalRevisionEvidence } from './replay';
+import { POLICY_VERSION } from './policy';
+import { isV4Plan, type ExternalTrainingPlanV4 } from '../sessions/externalPlanV4';
+
+export type IntradayDecisionStatus = 'provisional' | 'confirmed' | 'superseded' | 'dropped';
+
+export type IntradayDecisionVerdictOutcome = 'proceed' | 'scale' | 'defer' | 'skip' | 'pending';
+
+export interface ReassessmentInputRevision {
+    availabilityRevision: string;
+    completedFactsRevision: string;
+    checkinRevision: string;
+    ledgerRevision: string;
+    placementRevision: string;
+}
+
+export interface IntradayDecisionLedgerSnapshot {
+    ceilings: LedgerCeilings;
+    entries: readonly LedgerEntry[];
+}
+
+export interface IntradayDecisionVerdict {
+    decision: IntradayDecisionVerdictOutcome;
+    reasons: readonly string[];
+}
+
+export interface IntradayDecisionRecord {
+    /** Unique decision identifier (UUID v4), matches Firestore document ID */
+    id: string;
+    userId: string;
+    /** Warsaw local calendar date (YYYY-MM-DD) */
+    date: string;
+    /** ISO 8601 evaluation timestamp */
+    asOf: string;
+    policyVersion: string;
+    schemaVersion: 1;
+
+    /** Decision status */
+    status: IntradayDecisionStatus;
+    /** Points to an earlier decision ID replaced by this evaluation, if any */
+    supersededDecisionId: string | null;
+
+    /** Occurrence and window identity bindings */
+    occurrenceId: string;
+    sessionId: string;
+    windowId: string;
+    bundleId: string;
+    orderInBundle: number;
+
+    /** Saved input revision fingerprints for change detection */
+    reassessmentInputRevision: ReassessmentInputRevision;
+    /** Scheduled bundle placement proposal */
+    bundlePlacement: BundlePlacementProposal;
+    /** Saved ledger capacity ceilings and entries snapshot */
+    ledgerSnapshot: IntradayDecisionLedgerSnapshot;
+
+    /** Decision outcome and reasons */
+    verdict: IntradayDecisionVerdict;
+}
+
+const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+const VALID_STATUSES: ReadonlySet<string> = new Set(['provisional', 'confirmed', 'superseded', 'dropped']);
+const VALID_VERDICTS: ReadonlySet<string> = new Set(['proceed', 'scale', 'defer', 'skip', 'pending']);
+
+function assertString(val: unknown, label: string, min = 1, max = 128): string {
+    if (typeof val !== 'string' || val.length < min || val.length > max) {
+        throw new TypeError(`${label} must be a string with length between ${min} and ${max}`);
+    }
+    return val;
+}
+
+function assertInteger(val: unknown, label: string, min = 0): number {
+    if (typeof val !== 'number' || !Number.isInteger(val) || val < min) {
+        throw new RangeError(`${label} must be an integer >= ${min}`);
+    }
+    return val;
+}
+
+export function validateIntradayDecisionRecord(raw: unknown): IntradayDecisionRecord {
+    if (!raw || typeof raw !== 'object') {
+        throw new TypeError('IntradayDecisionRecord must be a non-null object');
+    }
+    const data = raw as Record<string, unknown>;
+
+    const id = assertString(data.id, 'id', 1, 128);
+    const userId = assertString(data.userId, 'userId', 1, 128);
+    const date = assertString(data.date, 'date', 10, 10);
+    if (!DATE_REGEX.test(date)) {
+        throw new TypeError(`date must match YYYY-MM-DD: ${date}`);
+    }
+
+    const asOf = assertString(data.asOf, 'asOf', 1, 64);
+    if (Number.isNaN(Date.parse(asOf))) {
+        throw new TypeError(`asOf must be a valid ISO 8601 timestamp: ${asOf}`);
+    }
+
+    const policyVersion = assertString(data.policyVersion, 'policyVersion', 1, 128);
+    if (data.schemaVersion !== 1) {
+        throw new TypeError(`schemaVersion must be 1, got ${data.schemaVersion}`);
+    }
+
+    if (typeof data.status !== 'string' || !VALID_STATUSES.has(data.status)) {
+        throw new TypeError(`status must be one of ${Array.from(VALID_STATUSES).join(', ')}`);
+    }
+    const status = data.status as IntradayDecisionStatus;
+
+    let supersededDecisionId: string | null = null;
+    if (data.supersededDecisionId !== null && data.supersededDecisionId !== undefined) {
+        supersededDecisionId = assertString(data.supersededDecisionId, 'supersededDecisionId', 1, 128);
+    }
+
+    const occurrenceId = assertString(data.occurrenceId, 'occurrenceId', 1, 128);
+    const sessionId = assertString(data.sessionId, 'sessionId', 1, 128);
+    const windowId = assertString(data.windowId, 'windowId', 1, 128);
+    const bundleId = assertString(data.bundleId, 'bundleId', 1, 128);
+    const orderInBundle = assertInteger(data.orderInBundle, 'orderInBundle', 0);
+
+    if (!data.reassessmentInputRevision || typeof data.reassessmentInputRevision !== 'object') {
+        throw new TypeError('reassessmentInputRevision must be a non-null object');
+    }
+    const rev = data.reassessmentInputRevision as Record<string, unknown>;
+    const reassessmentInputRevision: ReassessmentInputRevision = {
+        availabilityRevision: assertString(rev.availabilityRevision, 'reassessmentInputRevision.availabilityRevision', 1, 128),
+        completedFactsRevision: assertString(rev.completedFactsRevision, 'reassessmentInputRevision.completedFactsRevision', 1, 128),
+        checkinRevision: assertString(rev.checkinRevision, 'reassessmentInputRevision.checkinRevision', 1, 128),
+        ledgerRevision: assertString(rev.ledgerRevision, 'reassessmentInputRevision.ledgerRevision', 1, 128),
+        placementRevision: assertString(rev.placementRevision, 'reassessmentInputRevision.placementRevision', 1, 128),
+    };
+
+    if (!data.bundlePlacement || typeof data.bundlePlacement !== 'object') {
+        throw new TypeError('bundlePlacement must be a non-null object');
+    }
+    const bp = data.bundlePlacement as Record<string, unknown>;
+    assertString(bp.bundleId, 'bundlePlacement.bundleId', 1, 128);
+    if (bp.outcome !== 'placed' && bp.outcome !== 'infeasible') {
+        throw new TypeError('bundlePlacement.outcome must be "placed" or "infeasible"');
+    }
+    const bundlePlacement = data.bundlePlacement as BundlePlacementProposal;
+
+    if (!data.ledgerSnapshot || typeof data.ledgerSnapshot !== 'object') {
+        throw new TypeError('ledgerSnapshot must be a non-null object');
+    }
+    const ls = data.ledgerSnapshot as Record<string, unknown>;
+    if (!ls.ceilings || typeof ls.ceilings !== 'object') {
+        throw new TypeError('ledgerSnapshot.ceilings must be an object');
+    }
+    const ceilings = ls.ceilings as Record<string, unknown>;
+    if (typeof ceilings.dailyMinuteCeiling !== 'number' || !Number.isFinite(ceilings.dailyMinuteCeiling) || ceilings.dailyMinuteCeiling < 0) {
+        throw new TypeError('ledgerSnapshot.ceilings.dailyMinuteCeiling must be a finite number >= 0');
+    }
+    if (typeof ceilings.dailySystemicCostCeiling !== 'number' || !Number.isFinite(ceilings.dailySystemicCostCeiling) || ceilings.dailySystemicCostCeiling < 0 || ceilings.dailySystemicCostCeiling > 1) {
+        throw new TypeError('ledgerSnapshot.ceilings.dailySystemicCostCeiling must be a finite number in [0, 1]');
+    }
+    if (!Array.isArray(ls.entries)) {
+        throw new TypeError('ledgerSnapshot.entries must be an array');
+    }
+    const ledgerSnapshot: IntradayDecisionLedgerSnapshot = {
+        ceilings: {
+            dailyMinuteCeiling: ceilings.dailyMinuteCeiling,
+            dailySystemicCostCeiling: ceilings.dailySystemicCostCeiling,
+        },
+        entries: ls.entries as readonly LedgerEntry[],
+    };
+
+    if (!data.verdict || typeof data.verdict !== 'object') {
+        throw new TypeError('verdict must be a non-null object');
+    }
+    const vd = data.verdict as Record<string, unknown>;
+    if (typeof vd.decision !== 'string' || !VALID_VERDICTS.has(vd.decision)) {
+        throw new TypeError(`verdict.decision must be one of ${Array.from(VALID_VERDICTS).join(', ')}`);
+    }
+    if (!Array.isArray(vd.reasons)) {
+        throw new TypeError('verdict.reasons must be an array of strings');
+    }
+    const verdict: IntradayDecisionVerdict = {
+        decision: vd.decision as IntradayDecisionVerdictOutcome,
+        reasons: vd.reasons.map((r, i) => assertString(r, `verdict.reasons[${i}]`, 1, 256)),
+    };
+
+    return {
+        id,
+        userId,
+        date,
+        asOf,
+        policyVersion,
+        schemaVersion: 1,
+        status,
+        supersededDecisionId,
+        occurrenceId,
+        sessionId,
+        windowId,
+        bundleId,
+        orderInBundle,
+        reassessmentInputRevision,
+        bundlePlacement,
+        ledgerSnapshot,
+        verdict,
+    };
+}
+
+export function intradayDecisionReplayErrors(
+    record: IntradayDecisionRecord,
+    externalRevision: ExternalRevisionEvidence | null = null,
+): string[] {
+    const errors: string[] = [];
+
+    if ((record as { schemaVersion?: unknown }).schemaVersion !== 1) {
+        errors.push(`Unsupported intraday decision schema version: ${record.schemaVersion}`);
+    }
+
+    if (record.policyVersion !== POLICY_VERSION) {
+        errors.push(`Policy version ${record.policyVersion} does not match current build policy version ${POLICY_VERSION}`);
+    }
+
+    if (!VALID_STATUSES.has(record.status)) {
+        errors.push(`Invalid decision status: ${record.status}`);
+    }
+
+    const bp = record.bundlePlacement;
+    if (!bp) {
+        errors.push('Intraday decision record is missing bundlePlacement');
+    } else {
+        if (bp.bundleId !== record.bundleId) {
+            errors.push(`Bundle identity mismatch: record references ${record.bundleId} but bundlePlacement recorded ${bp.bundleId}`);
+        }
+        if (bp.outcome === 'placed') {
+            if (!bp.bindings || bp.bindings.length === 0) {
+                errors.push('Bundle placement marked placed but contains no window bindings');
+            } else {
+                const targetBinding = bp.bindings.find(b => b.sessionId === record.sessionId);
+                if (!targetBinding) {
+                    errors.push(`Bundle placement does not bind target session ${record.sessionId}`);
+                } else if (targetBinding.windowId !== record.windowId) {
+                    errors.push(`Window binding mismatch: record references ${record.windowId} but bundlePlacement bound ${targetBinding.windowId}`);
+                }
+            }
+        } else if (bp.outcome === 'infeasible') {
+            if (!bp.reason) {
+                errors.push('Bundle placement marked infeasible but contains no failure reason');
+            }
+        } else {
+            errors.push(`Unknown bundle placement outcome: ${bp.outcome}`);
+        }
+    }
+
+    const ls = record.ledgerSnapshot;
+    if (!ls) {
+        errors.push('Intraday decision record is missing ledgerSnapshot');
+    } else {
+        if (ls.ceilings.dailyMinuteCeiling < 0 || !Number.isFinite(ls.ceilings.dailyMinuteCeiling)) {
+            errors.push('Ledger snapshot contains invalid dailyMinuteCeiling');
+        }
+        if (ls.ceilings.dailySystemicCostCeiling < 0 || ls.ceilings.dailySystemicCostCeiling > 1 || !Number.isFinite(ls.ceilings.dailySystemicCostCeiling)) {
+            errors.push('Ledger snapshot contains invalid dailySystemicCostCeiling');
+        }
+    }
+
+    if (externalRevision) {
+        const rawPlan = externalRevision.plan as unknown as { schema: string };
+        if (!isV4Plan(rawPlan)) {
+            errors.push('Supplied external plan is not an external-plan@4 revision; cannot verify intraday bundle');
+        } else {
+            const v4Plan = externalRevision.plan as unknown as ExternalTrainingPlanV4;
+            const planSession = v4Plan.sessions.find(s => s.id === record.sessionId);
+            if (!planSession) {
+                errors.push(`Session ${record.sessionId} is not present in plan ${v4Plan.planId}`);
+            } else if (!planSession.intraday) {
+                errors.push(`Session ${record.sessionId} in plan ${v4Plan.planId} has no intraday specification`);
+            } else {
+                if (planSession.intraday.bundleId !== record.bundleId) {
+                    errors.push(`Session bundle mismatch: plan specifies bundle ${planSession.intraday.bundleId}, audit recorded ${record.bundleId}`);
+                }
+                if (planSession.intraday.order !== record.orderInBundle) {
+                    errors.push(`Session order mismatch: plan specifies order ${planSession.intraday.order}, audit recorded ${record.orderInBundle}`);
+                }
+            }
+        }
+    }
+
+    return errors;
+}

--- a/app/src/services/intradayDecisionService.test.ts
+++ b/app/src/services/intradayDecisionService.test.ts
@@ -53,7 +53,16 @@ function sampleRecord(id = 'dec-1', overrides: Partial<IntradayDecisionRecord> =
         bundlePlacement: {
             bundleId: 'bundle-1',
             outcome: 'placed',
-            bindings: [],
+            bindings: [
+                {
+                    sessionId: 'sess-1',
+                    windowId: 'win-1',
+                    boundStartLocal: '08:00',
+                    boundEndLocal: '09:00',
+                    startInstant: '2026-09-06T06:00:00.000Z',
+                    endInstant: '2026-09-06T07:00:00.000Z',
+                },
+            ],
         },
         ledgerSnapshot: {
             ceilings: { dailyMinuteCeiling: 60, dailySystemicCostCeiling: 0.5 },
@@ -132,5 +141,39 @@ describe('intradayDecisionService', () => {
         });
         const activeOccurrence = await getActiveIntradayDecisionForOccurrence('u1', '2026-09-06', 'occ-1');
         expect(activeOccurrence?.id).toBe('dec-2');
+    });
+
+    it('rejects saving a record with supersededDecisionId referencing a different occurrenceId', async () => {
+        const priorRecord = sampleRecord('dec-1', { occurrenceId: 'occ-am' });
+        const invalidSuperseding = sampleRecord('dec-2', {
+            occurrenceId: 'occ-pm',
+            supersededDecisionId: 'dec-1',
+        });
+
+        mockGetDoc.mockResolvedValueOnce({
+            exists: () => true,
+            data: () => priorRecord,
+        });
+
+        await expect(saveIntradayDecision(invalidSuperseding)).rejects.toThrow(
+            /cannot supersede decision dec-1 for occurrence occ-am/
+        );
+        expect(mockSetDoc).not.toHaveBeenCalled();
+    });
+
+    it('does not suppress active decisions from other occurrences when a record contains a mismatched cross-occurrence supersededDecisionId', async () => {
+        const occ1Decision = sampleRecord('dec-occ1', { occurrenceId: 'occ-1', status: 'provisional' });
+        const occ2Decision = sampleRecord('dec-occ2', {
+            occurrenceId: 'occ-2',
+            status: 'confirmed',
+            supersededDecisionId: 'dec-occ1',
+        });
+
+        mockGetDocs.mockResolvedValueOnce({
+            docs: [{ data: () => occ1Decision }, { data: () => occ2Decision }],
+        });
+
+        const active = await getActiveIntradayDecisionsForDate('u1', '2026-09-06');
+        expect(active.map(r => r.id).sort()).toEqual(['dec-occ1', 'dec-occ2']);
     });
 });

--- a/app/src/services/intradayDecisionService.test.ts
+++ b/app/src/services/intradayDecisionService.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { IntradayDecisionRecord } from '../engine/intradayDecision';
+import {
+    getIntradayDecisionDocPath,
+    getIntradayDecisionsCollectionPath,
+    saveIntradayDecision,
+    getIntradayDecision,
+    listIntradayDecisionsForDate,
+    getActiveIntradayDecisionsForDate,
+    getActiveIntradayDecisionForOccurrence,
+} from './intradayDecisionService';
+
+const mockSetDoc = vi.fn();
+const mockGetDoc = vi.fn();
+const mockGetDocs = vi.fn();
+
+vi.mock('firebase/firestore', () => ({
+    doc: vi.fn((_db, path) => ({ path })),
+    collection: vi.fn((_db, path) => ({ path })),
+    setDoc: (...args: unknown[]) => mockSetDoc(...args),
+    getDoc: (...args: unknown[]) => mockGetDoc(...args),
+    getDocs: (...args: unknown[]) => mockGetDocs(...args),
+    query: vi.fn((col, ...clauses) => ({ col, clauses })),
+    where: vi.fn((field, op, val) => ({ field, op, val })),
+}));
+
+vi.mock('../firebase', () => ({
+    getDb: vi.fn(() => ({})),
+}));
+
+function sampleRecord(id = 'dec-1', overrides: Partial<IntradayDecisionRecord> = {}): IntradayDecisionRecord {
+    return {
+        id,
+        userId: 'u1',
+        date: '2026-09-06',
+        asOf: '2026-09-06T07:00:00.000Z',
+        policyVersion: 'test-policy',
+        schemaVersion: 1,
+        status: 'provisional',
+        supersededDecisionId: null,
+        occurrenceId: 'occ-1',
+        sessionId: 'sess-1',
+        windowId: 'win-1',
+        bundleId: 'bundle-1',
+        orderInBundle: 0,
+        reassessmentInputRevision: {
+            availabilityRevision: 'a1',
+            completedFactsRevision: 'c1',
+            checkinRevision: 'ch1',
+            ledgerRevision: 'l1',
+            placementRevision: 'p1',
+        },
+        bundlePlacement: {
+            bundleId: 'bundle-1',
+            outcome: 'placed',
+            bindings: [],
+        },
+        ledgerSnapshot: {
+            ceilings: { dailyMinuteCeiling: 60, dailySystemicCostCeiling: 0.5 },
+            entries: [],
+        },
+        verdict: { decision: 'proceed', reasons: ['ok'] },
+        ...overrides,
+    };
+}
+
+describe('intradayDecisionService', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('generates expected user-scoped Firestore paths', () => {
+        expect(getIntradayDecisionDocPath('u1', 'dec-123')).toBe('users/u1/intraday_decisions/dec-123');
+        expect(getIntradayDecisionsCollectionPath('u1')).toBe('users/u1/intraday_decisions');
+    });
+
+    it('saves a valid intraday decision record write-once', async () => {
+        const record = sampleRecord();
+        await saveIntradayDecision(record);
+        expect(mockSetDoc).toHaveBeenCalledWith({ path: 'users/u1/intraday_decisions/dec-1' }, record);
+    });
+
+    it('retrieves an existing intraday decision record', async () => {
+        const record = sampleRecord();
+        mockGetDoc.mockResolvedValueOnce({
+            exists: () => true,
+            data: () => record,
+        });
+
+        const result = await getIntradayDecision('u1', 'dec-1');
+        expect(result).toEqual(record);
+    });
+
+    it('returns null when retrieving a non-existent decision', async () => {
+        mockGetDoc.mockResolvedValueOnce({
+            exists: () => false,
+        });
+
+        const result = await getIntradayDecision('u1', 'dec-missing');
+        expect(result).toBeNull();
+    });
+
+    it('lists and sorts intraday decisions for a date', async () => {
+        const d1 = sampleRecord('dec-1', { asOf: '2026-09-06T09:00:00.000Z' });
+        const d2 = sampleRecord('dec-2', { asOf: '2026-09-06T07:00:00.000Z' });
+
+        mockGetDocs.mockResolvedValueOnce({
+            docs: [{ data: () => d1 }, { data: () => d2 }],
+        });
+
+        const result = await listIntradayDecisionsForDate('u1', '2026-09-06');
+        expect(result.map(r => r.id)).toEqual(['dec-2', 'dec-1']);
+    });
+
+    it('filters out superseded decision records when getting active decisions', async () => {
+        const original = sampleRecord('dec-1', { status: 'superseded', asOf: '2026-09-06T07:00:00.000Z' });
+        const superseding = sampleRecord('dec-2', {
+            supersededDecisionId: 'dec-1',
+            status: 'confirmed',
+            asOf: '2026-09-06T08:00:00.000Z',
+        });
+
+        mockGetDocs.mockResolvedValueOnce({
+            docs: [{ data: () => original }, { data: () => superseding }],
+        });
+
+        const active = await getActiveIntradayDecisionsForDate('u1', '2026-09-06');
+        expect(active.map(r => r.id)).toEqual(['dec-2']);
+
+        mockGetDocs.mockResolvedValueOnce({
+            docs: [{ data: () => original }, { data: () => superseding }],
+        });
+        const activeOccurrence = await getActiveIntradayDecisionForOccurrence('u1', '2026-09-06', 'occ-1');
+        expect(activeOccurrence?.id).toBe('dec-2');
+    });
+});

--- a/app/src/services/intradayDecisionService.ts
+++ b/app/src/services/intradayDecisionService.ts
@@ -1,0 +1,91 @@
+/**
+ * ADR-0036 (H4) D-AUDIT: Intraday decision persistence and query service.
+ *
+ * Scoped to user subcollection `users/{userId}/intraday_decisions/{decisionId}`.
+ * Write-once append-only semantics: each record is immutable once written;
+ * updates/reassessments create new records with `supersededDecisionId` pointing
+ * to previous records.
+ */
+
+import { collection, doc, getDoc, getDocs, query, setDoc, where } from 'firebase/firestore';
+import { getDb } from '../firebase';
+import {
+    validateIntradayDecisionRecord,
+    type IntradayDecisionRecord,
+} from '../engine/intradayDecision';
+
+export function getIntradayDecisionDocPath(userId: string, decisionId: string): string {
+    return `users/${userId}/intraday_decisions/${decisionId}`;
+}
+
+export function getIntradayDecisionsCollectionPath(userId: string): string {
+    return `users/${userId}/intraday_decisions`;
+}
+
+/**
+ * Saves a validated intraday decision record write-once.
+ */
+export async function saveIntradayDecision(record: IntradayDecisionRecord): Promise<void> {
+    const validated = validateIntradayDecisionRecord(record);
+    const db = getDb();
+    const docRef = doc(db, getIntradayDecisionDocPath(validated.userId, validated.id));
+    await setDoc(docRef, validated);
+}
+
+/**
+ * Retrieves an intraday decision record by ID, or null if not found.
+ */
+export async function getIntradayDecision(userId: string, decisionId: string): Promise<IntradayDecisionRecord | null> {
+    const db = getDb();
+    const docRef = doc(db, getIntradayDecisionDocPath(userId, decisionId));
+    const snap = await getDoc(docRef);
+    if (!snap.exists()) return null;
+    return validateIntradayDecisionRecord(snap.data());
+}
+
+/**
+ * Lists all intraday decision records for a given date, ordered by evaluation time.
+ */
+export async function listIntradayDecisionsForDate(userId: string, date: string): Promise<IntradayDecisionRecord[]> {
+    const db = getDb();
+    const colRef = collection(db, getIntradayDecisionsCollectionPath(userId));
+    const q = query(colRef, where('date', '==', date));
+    const querySnap = await getDocs(q);
+
+    const records: IntradayDecisionRecord[] = [];
+    for (const docSnap of querySnap.docs) {
+        records.push(validateIntradayDecisionRecord(docSnap.data()));
+    }
+
+    return records.sort((a, b) => a.asOf.localeCompare(b.asOf));
+}
+
+/**
+ * Resolves the active (non-superseded) decision records for a given date.
+ * Filters out records whose ID is referenced as `supersededDecisionId` by any other record.
+ */
+export async function getActiveIntradayDecisionsForDate(userId: string, date: string): Promise<IntradayDecisionRecord[]> {
+    const allRecords = await listIntradayDecisionsForDate(userId, date);
+    if (allRecords.length === 0) return [];
+
+    const supersededIds = new Set<string>();
+    for (const r of allRecords) {
+        if (r.supersededDecisionId) {
+            supersededIds.add(r.supersededDecisionId);
+        }
+    }
+
+    return allRecords.filter(r => !supersededIds.has(r.id) && r.status !== 'superseded');
+}
+
+/**
+ * Resolves the active intraday decision record for a specific occurrence on a date, if any.
+ */
+export async function getActiveIntradayDecisionForOccurrence(
+    userId: string,
+    date: string,
+    occurrenceId: string,
+): Promise<IntradayDecisionRecord | null> {
+    const active = await getActiveIntradayDecisionsForDate(userId, date);
+    return active.find(r => r.occurrenceId === occurrenceId) ?? null;
+}

--- a/app/src/services/intradayDecisionService.ts
+++ b/app/src/services/intradayDecisionService.ts
@@ -27,6 +27,14 @@ export function getIntradayDecisionsCollectionPath(userId: string): string {
  */
 export async function saveIntradayDecision(record: IntradayDecisionRecord): Promise<void> {
     const validated = validateIntradayDecisionRecord(record);
+    if (validated.supersededDecisionId) {
+        const prior = await getIntradayDecision(validated.userId, validated.supersededDecisionId);
+        if (prior && prior.occurrenceId !== validated.occurrenceId) {
+            throw new Error(
+                `Invalid supersession: decision ${validated.id} for occurrence ${validated.occurrenceId} cannot supersede decision ${validated.supersededDecisionId} for occurrence ${prior.occurrenceId}`
+            );
+        }
+    }
     const db = getDb();
     const docRef = doc(db, getIntradayDecisionDocPath(validated.userId, validated.id));
     await setDoc(docRef, validated);
@@ -62,16 +70,21 @@ export async function listIntradayDecisionsForDate(userId: string, date: string)
 
 /**
  * Resolves the active (non-superseded) decision records for a given date.
- * Filters out records whose ID is referenced as `supersededDecisionId` by any other record.
+ * Filters out records whose ID is referenced as `supersededDecisionId` by any other record
+ * belonging to the same occurrence.
  */
 export async function getActiveIntradayDecisionsForDate(userId: string, date: string): Promise<IntradayDecisionRecord[]> {
     const allRecords = await listIntradayDecisionsForDate(userId, date);
     if (allRecords.length === 0) return [];
 
+    const recordById = new Map<string, IntradayDecisionRecord>(allRecords.map(r => [r.id, r]));
     const supersededIds = new Set<string>();
     for (const r of allRecords) {
         if (r.supersededDecisionId) {
-            supersededIds.add(r.supersededDecisionId);
+            const target = recordById.get(r.supersededDecisionId);
+            if (target && target.occurrenceId === r.occurrenceId) {
+                supersededIds.add(r.supersededDecisionId);
+            }
         }
     }
 

--- a/docs/plans/h4-daudit-analysis.md
+++ b/docs/plans/h4-daudit-analysis.md
@@ -1,0 +1,159 @@
+# H4: D-AUDIT analysis and PR-1 handoff
+
+**Status:** Analysis only. No code changes in this doc's commit.
+**Tracks:** [GitHub issue #437](https://github.com/Szczepanov/adaptive-training-recommender/issues/437).
+**Related:** [PR #440](https://github.com/Szczepanov/adaptive-training-recommender/pull/440)
+(external-plan execution-binding pipeline, issue #434) and
+[PR #442](https://github.com/Szczepanov/adaptive-training-recommender/pull/442) (D-REASSESS,
+issue #436) -- **this document's single biggest finding changes both of their sequencing
+assumptions**, see "Revised understanding" below.
+
+## What ADR-0036 D-AUDIT requires
+
+Quoting the ADR (`docs/adr/0036-intraday-training-windows-and-reassessment.md`):
+
+> Version affected schedule, placement, occurrence and decision persistence explicitly.
+> Keep user-scoped paths and backward-compatible readers; exact storage layout is an
+> implementation detail, but a daily document must not overwrite AM evidence with PM.
+> Record decision id/as-of instant, policy version, plan id/revision/hash, occurrence and
+> prescription identities, requested/resolved window and offsets, bundle/order/dependency,
+> availability revision, completed-fact revision and source ids, response/check-in
+> snapshot identity, daily ledger ceilings/inputs/reservations/reconciled actuals,
+> elapsed-separation evidence, result/reasons, and any override or superseded decision id.
+> Retain immutable replay inputs, not only pointers to mutable latest records.
+>
+> Replay verifies all identity bindings and recomputes against those saved inputs.
+> Missing inputs or any identity/hash/date/window mismatch is unreplayable, never repaired
+> with today's plan, clock or wearable sync. Runtime activation requires a policy bump and
+> matching schema, import, Firestore rules, replay and UI coverage.
+
+## Revised understanding: this is not a green field
+
+The original issue text (and the framing in the H4 plan docs) treated D-AUDIT as
+"implement persistence/replay snapshots" -- language that reads like building a new
+capability from scratch. **It is not.** `app/src/engine/replay.ts` already implements a
+substantial, real replay-verification framework, already wired to a CLI
+(`npm run replay:recommendation -- <audit.json>`, `CLAUDE.md`'s own documented command):
+
+- `replayRecommendationAudit(recommendation, externalRevision, sessionEvidence)` already
+  checks: policy version match against the current build (and distinguishes "historical,
+  intentionally unreplayable" from "genuinely broken"), safety status, decision-context
+  revision format, event-count consistency, subjective-drift replay errors
+  (`subjectiveDriftAuditReplayErrors`), identity-decision replay errors
+  (`identityDecisionProvenanceReplayErrors`), session-binding consistency and evidence
+  errors, and -- most relevantly for H4 -- **external-plan decision replay** via
+  `externalDecisionErrors`: it already re-derives the plan's content hash from supplied
+  evidence and compares it byte-for-byte against what the audit recorded, rejecting
+  replay if the plan changed under the same revision number, if the referenced session no
+  longer exists, etc. `externalRestErrors` does the equivalent for ADR-0035 rest
+  decisions.
+- This is exactly the shape D-AUDIT's "replay verifies all identity bindings and
+  recomputes against those saved inputs... any identity/hash/date/window mismatch is
+  unreplayable" describes -- **for the provenance types that already exist**. D-AUDIT's
+  actual job is narrower than it first appears: **add a new evidence/error-checking
+  branch to this existing framework for D-PLACEMENT's bundle/window/ledger data**, the
+  same way `externalDecisionErrors` was added for plan decisions and
+  `subjectiveDriftAuditReplayErrors`/`identityDecisionProvenanceReplayErrors` were added
+  for their respective domains. It is not a parallel system to build.
+
+## What's still genuinely missing
+
+The replay *verification* framework exists; the *persistence* of the specific new inputs
+D-PLACEMENT introduces does not, and this is the real remaining gap:
+
+1. **No `intradayBundle`/window/ledger data is persisted anywhere yet.** [PR #432](https://github.com/Szczepanov/adaptive-training-recommender/pull/432)
+   attempted to add a resolved-bundle-placement trace to `recommendationAudit.externalPlan`
+   and had to revert it -- [issue #435](https://github.com/Szczepanov/adaptive-training-recommender/issues/435)
+   /[PR #441](https://github.com/Szczepanov/adaptive-training-recommender/pull/441)
+   confirmed `hasValidRecommendationAudit` is at Firestore's per-request rule-evaluation
+   ceiling even after a real, verified cost reduction. **D-AUDIT's persisted shape for
+   H4-specific data should not be nested inside `recommendationAudit` at all** -- it
+   needs its own top-level collection with its own validation function, sidestepping the
+   ceiling entirely rather than fighting it. This also better matches the ADR's own
+   phrase "exact storage layout is an implementation detail" -- nothing requires this to
+   live inside the existing audit document.
+2. **No revision/hash concept for a day's *ledger and availability* state as a whole**
+   (only per-entry revisions in `dailyLedger.ts`, and `ExternalPlanPlacement.revision` for
+   the plan overlay). [PR #442](https://github.com/Szczepanov/adaptive-training-recommender/pull/442)'s
+   `ReassessmentInputRevision` sketch is exactly this gap, independently arrived at from
+   the D-REASSESS side. **These are the same missing piece, not two separate ones.**
+3. **No concept of a "pending" vs. "confirmed" decision distinct from the existing
+   `recommendationAudit`'s always-already-decided shape.** The existing recommendation
+   document model has no state machine for "provisional AM verdict, not yet claimed for
+   PM" -- everything currently persisted already represents a completed decision.
+4. **No superseded-decision linkage.** The ADR requires "any override or superseded
+   decision id" -- nothing today models one decision explicitly replacing an earlier one
+   for the same date/session (as opposed to the existing revision-bump-on-recommendation-
+   document pattern, which overwrites rather than chains).
+
+## The real coupling: D-AUDIT's minimal slice *is* D-REASSESS's prerequisite
+
+[PR #442](https://github.com/Szczepanov/adaptive-training-recommender/pull/442) (D-REASSESS analysis)
+independently found it needs "somewhere to persist a provisional decision + its input-
+revision snapshot between AM composition and PM claim" before its own gate logic can be
+built. That "somewhere" is precisely items 2 and 3 above. **This confirms (from the other
+direction) that D-AUDIT and D-REASSESS cannot be sequenced as two fully independent
+follow-ups** -- a minimal slice of D-AUDIT (revision tracking + pending-decision
+persistence, items 2-3, *not* the full scope below) is a hard prerequisite for
+D-REASSESS's first PR, not just a nice-to-have ordering.
+
+**The full D-AUDIT scope (bundle/window/ledger persistence, full replay branch, superseded-
+decision chains, UI states) is separable from that minimal slice** and can follow once
+D-REASSESS's gate logic exists and there's real reassessment behavior worth auditing in
+full.
+
+## Recommended slicing (supersedes this issue's original single-PR framing)
+
+1. **D-AUDIT minimal slice** (blocks D-REASSESS's first PR): a new top-level collection
+   (e.g. `users/{userId}/intraday_decisions/{decisionId}` -- exact path TBD) storing, per
+   pending decision: decision id/as-of instant, the bundle placement outcome
+   (`BundlePlacementProposal`, already the exact shape `intradayBundlePlacement.ts`
+   produces), and the `ReassessmentInputRevision`-shaped snapshot from PR #442's sketch.
+   Own Firestore rules validation function, deliberately outside
+   `hasValidRecommendationAudit`. No replay-framework changes yet (nothing to replay
+   until D-REASSESS produces real decisions against this).
+2. **D-REASSESS's PR(s)** (per PR #442), reading/writing into slice 1's persisted shape.
+3. **D-AUDIT full slice**: extend `replay.ts` with a new evidence/error-checking branch
+   for the persisted intraday-decision shape (mirroring `externalDecisionErrors`'s
+   pattern exactly: re-derive expected values from supplied evidence, compare against
+   what was recorded, report mismatches as unreplayable rather than silently repairing).
+   Add superseded-decision linkage. Add UI surfacing for provisional/pending/dropped
+   states. Extend `scripts/replay-recommendation-audit.mjs`'s CLI to accept the new
+   evidence type, mirroring how it presumably already accepts `ExternalRevisionEvidence`/
+   `SessionPrescriptionEvidence` (verify exact CLI argument shape at implementation time
+   -- not fully read for this analysis).
+
+## Open questions for the implementing agent
+
+- Exact Firestore path/collection name for the new persisted shape (slice 1) -- pick
+  something that reads naturally alongside `daily_recommendations`,
+  `schedule_windows` (D-WINDOW), etc.
+- Whether `ReassessmentInputRevision` (PR #442's sketch) and D-AUDIT's "availability
+  revision, completed-fact revision" fields (ADR's own list) should literally be the same
+  struct, or two structs that happen to overlap -- resolve when both are implemented
+  together, not before.
+- Re-verify `scripts/replay-recommendation-audit.mjs`'s current CLI argument shape before
+  extending it -- not read in depth for this analysis.
+- Confirm whether `hasValidRecommendationAudit`'s ceiling (issue #435) is relevant to the
+  *new* top-level collection's rules function at all -- it shouldn't be, since it's a
+  separate function/collection, but verify the new function doesn't itself grow into a
+  similar problem once bundle/window/ledger fields are added (this data is more complex
+  than the reverted `intradayBundle` trace was).
+
+## Suggested PR description for D-AUDIT's minimal slice (PR 1)
+
+> ## Summary
+> Minimal persistence slice for ADR-0036 D-AUDIT (issue #437), scoped specifically to
+> unblock D-REASSESS (issue #436, analysis in PR #442) -- not the full D-AUDIT scope.
+>
+> New top-level collection persisting a pending intraday decision's bundle-placement
+> outcome and input-revision snapshot, with its own Firestore rules validation function
+> deliberately kept outside `hasValidRecommendationAudit` (which is already at Firestore's
+> per-request rule-evaluation ceiling -- issue #435).
+>
+> ## Not in scope here
+> - Extending `replay.ts` with a bundle/window/ledger evidence branch (full D-AUDIT slice,
+>   separate follow-up once D-REASSESS produces real decisions to replay).
+> - Superseded-decision linkage, UI surfacing.
+>
+> (standard verification checklist)

--- a/docs/plans/h4-daudit-analysis.md
+++ b/docs/plans/h4-daudit-analysis.md
@@ -61,99 +61,202 @@ substantial, real replay-verification framework, already wired to a CLI
 The replay *verification* framework exists; the *persistence* of the specific new inputs
 D-PLACEMENT introduces does not, and this is the real remaining gap:
 
-1. **No `intradayBundle`/window/ledger data is persisted anywhere yet.** [PR #432](https://github.com/Szczepanov/adaptive-training-recommender/pull/432)
+1. **No `intradayBundle`, window, or daily ledger data is persisted anywhere yet.**
+   [PR #432](https://github.com/Szczepanov/adaptive-training-recommender/pull/432)
    attempted to add a resolved-bundle-placement trace to `recommendationAudit.externalPlan`
    and had to revert it -- [issue #435](https://github.com/Szczepanov/adaptive-training-recommender/issues/435)
    /[PR #441](https://github.com/Szczepanov/adaptive-training-recommender/pull/441)
    confirmed `hasValidRecommendationAudit` is at Firestore's per-request rule-evaluation
    ceiling even after a real, verified cost reduction. **D-AUDIT's persisted shape for
    H4-specific data should not be nested inside `recommendationAudit` at all** -- it
-   needs its own top-level collection with its own validation function, sidestepping the
-   ceiling entirely rather than fighting it. This also better matches the ADR's own
-   phrase "exact storage layout is an implementation detail" -- nothing requires this to
-   live inside the existing audit document.
-2. **No revision/hash concept for a day's *ledger and availability* state as a whole**
-   (only per-entry revisions in `dailyLedger.ts`, and `ExternalPlanPlacement.revision` for
-   the plan overlay). [PR #442](https://github.com/Szczepanov/adaptive-training-recommender/pull/442)'s
-   `ReassessmentInputRevision` sketch is exactly this gap, independently arrived at from
-   the D-REASSESS side. **These are the same missing piece, not two separate ones.**
-3. **No concept of a "pending" vs. "confirmed" decision distinct from the existing
-   `recommendationAudit`'s always-already-decided shape.** The existing recommendation
-   document model has no state machine for "provisional AM verdict, not yet claimed for
-   PM" -- everything currently persisted already represents a completed decision.
-4. **No superseded-decision linkage.** The ADR requires "any override or superseded
-   decision id" -- nothing today models one decision explicitly replacing an earlier one
-   for the same date/session (as opposed to the existing revision-bump-on-recommendation-
-   document pattern, which overwrites rather than chains).
+   needs its own dedicated user-scoped subcollection (`users/{userId}/intraday_decisions/{decisionId}`)
+   with its own validation function, sidestepping the ceiling entirely rather than fighting
+   it. (Note: this is a user-scoped subcollection under `users/{userId}`, not a root collection,
+   preserving Critical System Constraint 1 for tenant isolation).
+2. **No persistence or whole-day snapshot concept for ledger and availability state.**
+   `dailyLedger.ts` is purely an in-memory calculation: it defines ordering `revision` numbers
+   on `LedgerEntry`, but **zero ledger data is persisted in Firestore today** (neither individual
+   entries nor whole-day snapshots). What is missing is the decision-level snapshot of the day's
+   ledger state (ceilings, reservations, and reconciled actuals) and availability state.
+   [PR #442](https://github.com/Szczepanov/adaptive-training-recommender/pull/442)'s
+   `ReassessmentInputRevision` sketch independently identifies this exact gap from the
+   D-REASSESS side. **These are the same missing piece, not two separate ones.**
+3. **No persisted pending/provisional decision record.** The existing `daily_recommendations/{date}`
+   document model represents a single, already-decided daily recommendation. It has no
+   facility for storing a provisional AM verdict for a dependent PM session awaiting launch-time
+   confirmation, nor can it store multiple decisions for the same date without overwriting AM
+   evidence with PM evidence (which ADR-0036 explicitly forbids).
+4. **No superseded-decision linkage.** ADR-0036 requires *"historical decisions remain
+   immutable and are linked by superseding decision identity."* Nothing today models one
+   decision explicitly pointing to an earlier decision ID it supersedes (as opposed to the
+   existing revision-bump-on-recommendation-document pattern, which mutates/overwrites rather
+   than chains).
 
-## The real coupling: D-AUDIT's minimal slice *is* D-REASSESS's prerequisite
+## The real coupling: D-AUDIT's minimal slice, D-REASSESS (#436), and #434
 
 [PR #442](https://github.com/Szczepanov/adaptive-training-recommender/pull/442) (D-REASSESS analysis)
 independently found it needs "somewhere to persist a provisional decision + its input-
 revision snapshot between AM composition and PM claim" before its own gate logic can be
-built. That "somewhere" is precisely items 2 and 3 above. **This confirms (from the other
-direction) that D-AUDIT and D-REASSESS cannot be sequenced as two fully independent
-follow-ups** -- a minimal slice of D-AUDIT (revision tracking + pending-decision
-persistence, items 2-3, *not* the full scope below) is a hard prerequisite for
-D-REASSESS's first PR, not just a nice-to-have ordering.
+built. That "somewhere" is precisely items 1, 2, and 3 above. **D-AUDIT and D-REASSESS cannot
+be sequenced as two fully independent follow-ups** -- a minimal slice of D-AUDIT (revision
+tracking + pending-decision persistence in a new subcollection) is a hard prerequisite for
+D-REASSESS's first PR.
 
-**The full D-AUDIT scope (bundle/window/ledger persistence, full replay branch, superseded-
-decision chains, UI states) is separable from that minimal slice** and can follow once
-D-REASSESS's gate logic exists and there's real reassessment behavior worth auditing in
-full.
+Furthermore, this depends on **Issue #434 PR 2** (occurrence tracking for `external_plan`):
+because ADR-0036 requires D-AUDIT to record *"occurrence and prescription identities"*,
+external-plan bundle sessions must have stable occurrence identities created by #434 PR 2
+before D-AUDIT and D-REASSESS can bind to them.
 
-## Recommended slicing (supersedes this issue's original single-PR framing)
+**The full D-AUDIT scope (full replay branch, CLI extension, UI states) is separable from
+that minimal slice** and should follow once D-REASSESS produces real reassessment decisions
+worth auditing.
 
-1. **D-AUDIT minimal slice** (blocks D-REASSESS's first PR): a new top-level collection
-   (e.g. `users/{userId}/intraday_decisions/{decisionId}` -- exact path TBD) storing, per
-   pending decision: decision id/as-of instant, the bundle placement outcome
-   (`BundlePlacementProposal`, already the exact shape `intradayBundlePlacement.ts`
-   produces), and the `ReassessmentInputRevision`-shaped snapshot from PR #442's sketch.
-   Own Firestore rules validation function, deliberately outside
-   `hasValidRecommendationAudit`. No replay-framework changes yet (nothing to replay
-   until D-REASSESS produces real decisions against this).
-2. **D-REASSESS's PR(s)** (per PR #442), reading/writing into slice 1's persisted shape.
-3. **D-AUDIT full slice**: extend `replay.ts` with a new evidence/error-checking branch
-   for the persisted intraday-decision shape (mirroring `externalDecisionErrors`'s
-   pattern exactly: re-derive expected values from supplied evidence, compare against
-   what was recorded, report mismatches as unreplayable rather than silently repairing).
-   Add superseded-decision linkage. Add UI surfacing for provisional/pending/dropped
-   states. Extend `scripts/replay-recommendation-audit.mjs`'s CLI to accept the new
-   evidence type, mirroring how it presumably already accepts `ExternalRevisionEvidence`/
-   `SessionPrescriptionEvidence` (verify exact CLI argument shape at implementation time
-   -- not fully read for this analysis).
+## Recommended slicing & design contracts
+
+### 1. D-AUDIT minimal slice (blocks D-REASSESS's first PR)
+
+Persist intraday decision records in a dedicated user-scoped subcollection:
+`users/{userId}/intraday_decisions/{decisionId}`
+
+#### Record Contract (`IntradayDecisionRecord`)
+Each decision record binds identity, target window, immutable replay inputs, and outcome:
+
+```typescript
+export interface IntradayDecisionRecord {
+  /** Unique decision ID (UUID v4), matches Firestore document ID */
+  id: string;
+  userId: string;
+  date: string; // YYYY-MM-DD (Europe/Warsaw local calendar date)
+  asOf: string; // ISO 8601 evaluation instant
+  policyVersion: number;
+  schemaVersion: 1;
+
+  /** Decision status */
+  status: 'provisional' | 'confirmed' | 'superseded' | 'dropped';
+  /** Points to an earlier decision ID replaced by this evaluation, if any */
+  supersededDecisionId: string | null;
+
+  /** Occurrence and window identity bindings */
+  occurrenceId: string;
+  sessionId: string;
+  windowId: string;
+  bundleId: string;
+  orderInBundle: number;
+
+  /** Immutable Replay Inputs (saved state as-of decision instant) */
+  reassessmentInputRevision: {
+    availabilityRevision: string;
+    completedFactsRevision: string;
+    checkinRevision: string;
+    ledgerRevision: string;
+    placementRevision: string;
+  };
+  bundlePlacement: BundlePlacementProposal;
+  ledgerSnapshot: {
+    ceilings: LedgerCeilings;
+    entries: readonly LedgerEntry[];
+  };
+
+  /** Decision outcome and reasons */
+  verdict: {
+    decision: 'proceed' | 'scale' | 'defer' | 'skip' | 'pending';
+    reasons: readonly string[];
+  };
+}
+```
+
+#### Lifecycle & Replay Invariant: Write-Once Immutability
+To satisfy ADR-0036's guarantee (*"historical decisions remain immutable and are linked
+by superseding decision identity"*) and avoid complex update-transaction rules:
+- **Decision records are write-once append-only documents**: `allow update, delete: if false;`.
+- When an athlete reassesses, claims, or drops a session, a **new** `IntradayDecisionRecord`
+  is created with its own unique `id`, referencing `supersededDecisionId: previousRecord.id`.
+- This ensures previous AM decision evidence is physically never overwritten by PM
+  reassessment, and historical replay inputs can never be mutated after creation.
+
+#### Firestore Security Rules Contract
+The new validation function `hasValidIntradayDecision(userId, decisionId)` must enforce:
+1. **Ownership**: `isOwner(userId)` and `request.resource.data.userId == userId`.
+2. **Document ID match**: `request.resource.data.id == decisionId`.
+3. **Write-once**: `allow create: if ...; allow update, delete: if false;`.
+4. **Budget protection**: Validate top-level keys, type constraints (string lengths, integer
+   ranges, status enum), without recursively validating deep nested arrays in CEL to keep
+   evaluations well within Firestore's 1000-expression ceiling.
+
+### 2. D-REASSESS PR(s) (per PR #442)
+Built against Slice 1 and #434 PR 2: reads the latest active decision record, evaluates gates,
+and atomically writes the reassessed/claimed decision record.
+
+### 3. D-AUDIT full slice (Replay & Verification)
+1. **Engine Replay (`app/src/engine/replay.ts`)**:
+   Add `intradayDecisionErrors(record: IntradayDecisionRecord, externalRevision: ExternalRevisionEvidence | null)`:
+   - Re-derives expected placement, separation, and ledger capacity strictly from the saved
+     inputs (`bundlePlacement`, `ledgerSnapshot`, `reassessmentInputRevision`).
+   - Fails closed as unreplayable if saved inputs are missing or if any hash, date, or
+     window identity fails to match. Never queries live Firestore or mutable current state.
+2. **Offline CLI Harness (`app/scripts/replay-recommendation-audit.mjs`)**:
+   Extend the CLI to accept an intraday decision record:
+   `npm run replay:recommendation -- <intraday-decision.json> [external-plan-revision.json]`
+   Since `replay-recommendation-audit.mjs` executes offline in Vite SSR without Firestore access,
+   the self-contained `IntradayDecisionRecord` provides all necessary inputs directly to the replay runner.
+3. **UI Surfacing**: Surface provisional, confirmed, superseded, and dropped statuses in the UI.
+
+---
 
 ## Open questions for the implementing agent
 
-- Exact Firestore path/collection name for the new persisted shape (slice 1) -- pick
-  something that reads naturally alongside `daily_recommendations`,
-  `schedule_windows` (D-WINDOW), etc.
-- Whether `ReassessmentInputRevision` (PR #442's sketch) and D-AUDIT's "availability
-  revision, completed-fact revision" fields (ADR's own list) should literally be the same
-  struct, or two structs that happen to overlap -- resolve when both are implemented
-  together, not before.
-- Re-verify `scripts/replay-recommendation-audit.mjs`'s current CLI argument shape before
-  extending it -- not read in depth for this analysis.
-- Confirm whether `hasValidRecommendationAudit`'s ceiling (issue #435) is relevant to the
-  *new* top-level collection's rules function at all -- it shouldn't be, since it's a
-  separate function/collection, but verify the new function doesn't itself grow into a
-  similar problem once bundle/window/ledger fields are added (this data is more complex
-  than the reverted `intradayBundle` trace was).
+- **Discovery query pattern**: Because `daily_recommendations/{date}` must avoid rule bloat,
+  the client should query active intraday decisions via `where('date', '==', today)` on the
+  `users/{userId}/intraday_decisions` subcollection, resolving the active/latest chain via
+  `supersededDecisionId`.
+- **Replay CLI signature**: Decide whether `scripts/replay-recommendation-audit.mjs` inspects
+  the JSON's schema to route between `replayRecommendationAudit` and `replayIntradayDecisionAudit`,
+  or if a distinct flag/script (e.g. `npm run replay:intraday`) is preferable.
+
+---
 
 ## Suggested PR description for D-AUDIT's minimal slice (PR 1)
 
-> ## Summary
-> Minimal persistence slice for ADR-0036 D-AUDIT (issue #437), scoped specifically to
-> unblock D-REASSESS (issue #436, analysis in PR #442) -- not the full D-AUDIT scope.
->
-> New top-level collection persisting a pending intraday decision's bundle-placement
-> outcome and input-revision snapshot, with its own Firestore rules validation function
-> deliberately kept outside `hasValidRecommendationAudit` (which is already at Firestore's
-> per-request rule-evaluation ceiling -- issue #435).
->
-> ## Not in scope here
-> - Extending `replay.ts` with a bundle/window/ledger evidence branch (full D-AUDIT slice,
->   separate follow-up once D-REASSESS produces real decisions to replay).
-> - Superseded-decision linkage, UI surfacing.
->
-> (standard verification checklist)
+```markdown
+## Summary
+
+Minimal persistence slice for ADR-0036 D-AUDIT (issue #437), scoped specifically to
+unblock D-REASSESS (issue #436, PR #442) and #434 PR 2 -- not the full D-AUDIT scope.
+
+Adds the user-scoped subcollection `users/{userId}/intraday_decisions/{decisionId}` persisting
+immutable, write-once intraday decision records (`IntradayDecisionRecord`) with bundle placement,
+ledger snapshot, and reassessment input revisions.
+
+## Major Changes
+
+- Domain Model: define `IntradayDecisionRecord` capturing identity, target window, immutable replay
+  inputs (`BundlePlacementProposal`, `LedgerCeilings`, `LedgerEntry[]`, `ReassessmentInputRevision`),
+  and outcome.
+- Firestore Security Rules: add `hasValidIntradayDecision` for `users/{userId}/intraday_decisions/{decisionId}`
+  with strict user ownership, ID binding, and write-once enforcement (`allow update, delete: if false;`),
+  isolated from `hasValidRecommendationAudit` to respect expression evaluation budgets (issue #435).
+- Service: add `intradayDecisionService.ts` to persist and query decision records by date/occurrence.
+
+## Risk and Reviewer Guidance
+
+Low risk: introduces a new, independent subcollection without modifying existing recommendation
+or decision engine logic.
+- Verify that decision records are strictly write-once (`allow update, delete: if false;`).
+- Verify that `daily_recommendations` and existing recommendation rules remain untouched.
+
+## Domain Invariants
+
+- [x] User isolation preserved: paths are scoped to `users/{userId}/intraday_decisions/{decisionId}`.
+- [x] Date logic preserves `Europe/Warsaw` calendar dates.
+- [x] Write-once immutability guarantees historical AM evidence is never overwritten by PM evidence.
+- [x] No credentials, tokens, or raw health payloads are touched.
+
+## Screenshots or Recordings
+
+Not applicable -- non-visual data persistence infrastructure.
+
+## Validation
+
+- [x] `cd app && npm run check`
+- [x] `cd app && npm run test:rules` (local Firestore emulator test suite verifying budget and permissions)
+```


### PR DESCRIPTION
## Summary

Implements the ADR-0036 D-AUDIT persistence and offline replay verification slice for [issue #437](https://github.com/Szczepanov/adaptive-training-recommender/issues/437), scoped to unblock D-REASSESS ([issue #436](https://github.com/Szczepanov/adaptive-training-recommender/issues/436), [PR #442](https://github.com/Szczepanov/adaptive-training-recommender/pull/442)) and [issue #434](https://github.com/Szczepanov/adaptive-training-recommender/issues/434) PR 2. Accompanied by the comprehensive analysis document in [`docs/plans/h4-daudit-analysis.md`](docs/plans/h4-daudit-analysis.md).

## What's Delivered

1. **Domain Model & Validation (`app/src/engine/intradayDecision.ts`)**:
   - `IntradayDecisionRecord`: immutable decision-level snapshot binding `userId`, `date`, evaluation instant `asOf`, `policyVersion`, `schemaVersion`, `status`, `supersededDecisionId`, target `occurrenceId`, `sessionId`, `windowId`, `bundleId`, `orderInBundle`, saved input revisions (`ReassessmentInputRevision`), scheduled bundle placement proposal (`BundlePlacementProposal`), shared capacity ledger snapshot (`LedgerCeilings` and `LedgerEntry[]`), and decision `verdict`.
   - `validateIntradayDecisionRecord`: strict runtime validator checking Warsaw calendar date formatting, timestamp sanity, enum bounds, nested sub-object consistency, and explicit validation of every `ResolvedWindowBinding` (requiring at least one binding for `placed` and non-empty `reason` for `infeasible`).
   - `intradayDecisionReplayErrors`: pure deterministic replay function validating policy matching, bundle identity/window bindings, ledger snapshot validity, and cross-checking against external plan v4 session specifications, with defensive type checks against malformed arrays.
2. **Firestore Subcollection & Security Rules (`app/firestore.rules`)**:
   - Matches user-scoped subcollection `users/{userId}/intraday_decisions/{decisionId}`.
   - Strictly enforces write-once immutability: `allow update, delete: if false;` to guarantee historical AM evidence is never overwritten by PM reassessments and saved replay inputs remain immutable.
   - `hasValidIntradayDecision`: validates ownership (`isOwner(userId)` and `data.userId == userId`), document ID match (`data.id == decisionId`), required keys, bundle placement constraints (`placed` requiring non-empty bindings list, `infeasible` requiring non-empty reason string), and top-level type bounds without deep recursive CEL loops, protecting against Firestore's 1000-expression rule evaluation ceiling (issue #435).
3. **Persistence Service (`app/src/services/intradayDecisionService.ts`)**:
   - `saveIntradayDecision`: persists validated records write-once, strictly enforcing that `supersededDecisionId` cannot cross occurrence boundaries.
   - `getIntradayDecision`: retrieves a decision record by ID.
   - `listIntradayDecisionsForDate`: lists all decision snapshots for a calendar date ordered chronologically.
   - `getActiveIntradayDecisionsForDate`: filters out superseded decisions using `supersededDecisionId` pointers, restricting supersession to records belonging to the same occurrence.
   - `getActiveIntradayDecisionForOccurrence`: resolves the active decision for a specific occurrence.
4. **Offline Replay CLI Extension (`app/scripts/replay-recommendation-audit.mjs`)**:
   - Extended to detect `IntradayDecisionRecord` payloads and execute `intradayDecisionReplayErrors` against saved inputs and optional external plan revisions without live Firestore queries.
   - Added test fixture `app/scripts/fixtures/replay-intraday-decision.json`.
5. **Comprehensive Test Coverage**:
   - `app/src/engine/intradayDecision.test.ts`: 8 unit tests covering schema validation, rejection of malformed/empty bindings and missing reasons, and replay verification.
   - `app/src/services/intradayDecisionService.test.ts`: 8 unit tests covering Firestore persistence, retrieval, date listing, cross-occurrence supersession rejection, and same-occurrence resolution.
   - `app/src/emulator/intradayDecisionRules.emulator.test.ts`: 6 emulator tests verifying owner write, read, cross-user denial, ID matching, payload rejection, and update/delete denial.

## Risk and Reviewer Guidance

Low risk: introduces a new, independent user-scoped subcollection and supporting replay/service modules without modifying existing recommendation or decision engine logic.
- Verify write-once immutability in `firestore.rules` (`allow update, delete: if false;`).
- Verify that `daily_recommendations/{date}` rules and logic remain untouched.
- Verify that `intradayDecisionReplayErrors` requires all saved inputs and does not depend on mutable live state.

## Domain Invariants

- [x] User isolation strictly preserved: subcollection is scoped to `users/{userId}/intraday_decisions/{decisionId}`.
- [x] Date logic preserves `Europe/Warsaw` calendar semantics.
- [x] Write-once immutability guarantees historical AM evidence is never overwritten by PM evidence.
- [x] No credentials, tokens, or raw health payloads are touched or committed.
- [x] Policy drift: `POLICY_VERSION` is evaluated; no existing decision engine behavior is altered.

## Validation

- [x] `cd app && npm run check` (TypeScript typecheck, ESLint, 3,704 unit tests, and knowledge/workout catalog validation all passed).
- [x] `cd app && npm run test:rules` (Firestore emulator test suite passed, including all 6 new rules tests in `intradayDecisionRules.emulator.test.ts`).
- [x] `uv run pytest` (816 backend tests passed).
- [x] `node scripts/check-policy-drift.mjs origin/main` (policy drift check passed: no decision-affecting engine files modified).
- [x] Pre-commit and pre-push hooks passed cleanly across all touched files.
