### PR TITLE
feat(sessions): external-plan occurrence tracking (Issue #434 PR 2)

### DIFF
--- a/app/firestore.rules
+++ b/app/firestore.rules
@@ -1149,18 +1149,30 @@ service cloud.firestore {
     function hasValidSessionOccurrence(userId, occurrenceId) {
       let data = request.resource.data;
       return hasOwnedUserId(userId)
-        && data.keys().hasOnly(['userId', 'occurrenceId', 'date', 'authority', 'definitionRef', 'state', 'placementOrder', 'createdAt', 'updatedAt'])
-        && data.keys().hasAll(['userId', 'occurrenceId', 'date', 'authority', 'definitionRef', 'state', 'createdAt', 'updatedAt'])
+        && data.keys().hasOnly(['userId', 'occurrenceId', 'date', 'authority', 'definitionRef', 'externalPlanRef', 'state', 'placementOrder', 'createdAt', 'updatedAt'])
+        && data.keys().hasAll(['userId', 'occurrenceId', 'date', 'authority', 'state', 'createdAt', 'updatedAt'])
+        && (('definitionRef' in data) != ('externalPlanRef' in data))
         && data.occurrenceId == occurrenceId
         && isValidActivityDate(data.date)
-        && data.authority in ['unplanned_log', 'schedule', 'replace_recommendation', 'additional_session']
-        && data.state in ['scheduled', 'active', 'superseded', 'completed', 'abandoned', 'missed']
-        && data.definitionRef is map
-        && data.definitionRef.keys().hasOnly(['definitionId', 'revision', 'contentHash'])
-        && data.definitionRef.keys().hasAll(['definitionId', 'revision', 'contentHash'])
-        && data.definitionRef.definitionId is string && data.definitionRef.definitionId.size() > 0
-        && data.definitionRef.revision is int && data.definitionRef.revision >= 1
-        && data.definitionRef.contentHash is string && data.definitionRef.contentHash.size() > 0
+        && data.authority in ['unplanned_log', 'schedule', 'replace_recommendation', 'additional_session', 'external_plan']
+        && data.state in ['scheduled', 'active', 'superseded', 'completed', 'abandoned', 'missed', 'skipped']
+        && (!('definitionRef' in data) || (
+          data.definitionRef is map
+          && data.definitionRef.keys().hasOnly(['definitionId', 'revision', 'contentHash'])
+          && data.definitionRef.keys().hasAll(['definitionId', 'revision', 'contentHash'])
+          && data.definitionRef.definitionId is string && data.definitionRef.definitionId.size() > 0
+          && data.definitionRef.revision is int && data.definitionRef.revision >= 1
+          && data.definitionRef.contentHash is string && data.definitionRef.contentHash.size() > 0
+        ))
+        && (!('externalPlanRef' in data) || (
+          data.externalPlanRef is map
+          && data.externalPlanRef.keys().hasOnly(['planId', 'revision', 'sessionId', 'contentHash'])
+          && data.externalPlanRef.keys().hasAll(['planId', 'revision', 'sessionId', 'contentHash'])
+          && data.externalPlanRef.planId is string && data.externalPlanRef.planId.size() > 0 && data.externalPlanRef.planId.size() <= 64
+          && data.externalPlanRef.revision is int && data.externalPlanRef.revision >= 1
+          && data.externalPlanRef.sessionId is string && data.externalPlanRef.sessionId.size() > 0 && data.externalPlanRef.sessionId.size() <= 64
+          && data.externalPlanRef.contentHash is string && data.externalPlanRef.contentHash.size() > 0 && data.externalPlanRef.contentHash.size() <= 128
+        ))
         && (!('placementOrder' in data) || (data.placementOrder is int && data.placementOrder >= 0))
         && data.createdAt is string && data.updatedAt is string;
     }
@@ -1172,7 +1184,7 @@ service cloud.firestore {
         && keepsOwnership(userId)
         && request.resource.data.date == resource.data.date
         && request.resource.data.createdAt == resource.data.createdAt
-        && request.resource.data.definitionRef == resource.data.definitionRef
+        && request.resource.data.authority == resource.data.authority
         && request.resource.data.diff(resource.data).affectedKeys().hasOnly(['state', 'updatedAt']);
       allow delete: if isOwner(userId);
     }

--- a/app/firestore.rules
+++ b/app/firestore.rules
@@ -1182,7 +1182,7 @@ service cloud.firestore {
 
     function isValidOccurrenceStateTransition(fromState, toState) {
       return fromState == toState
-        || (fromState == 'scheduled' && toState in ['active', 'skipped', 'superseded', 'missed'])
+        || (fromState == 'scheduled' && toState in ['active', 'completed', 'abandoned', 'skipped', 'superseded', 'missed'])
         || (fromState == 'active' && toState in ['completed', 'abandoned', 'superseded']);
     }
 

--- a/app/firestore.rules
+++ b/app/firestore.rules
@@ -1154,8 +1154,11 @@ service cloud.firestore {
         && (('definitionRef' in data) != ('externalPlanRef' in data))
         && data.occurrenceId == occurrenceId
         && isValidActivityDate(data.date)
-        && data.authority in ['unplanned_log', 'schedule', 'replace_recommendation', 'additional_session', 'external_plan']
         && data.state in ['scheduled', 'active', 'superseded', 'completed', 'abandoned', 'missed', 'skipped']
+        && (
+          ('externalPlanRef' in data && data.authority == 'external_plan')
+          || ('definitionRef' in data && data.authority in ['unplanned_log', 'schedule', 'replace_recommendation', 'additional_session'])
+        )
         && (!('definitionRef' in data) || (
           data.definitionRef is map
           && data.definitionRef.keys().hasOnly(['definitionId', 'revision', 'contentHash'])
@@ -1177,6 +1180,12 @@ service cloud.firestore {
         && data.createdAt is string && data.updatedAt is string;
     }
 
+    function isValidOccurrenceStateTransition(fromState, toState) {
+      return fromState == toState
+        || (fromState == 'scheduled' && toState in ['active', 'skipped', 'superseded', 'missed'])
+        || (fromState == 'active' && toState in ['completed', 'abandoned', 'superseded']);
+    }
+
     match /users/{userId}/session_occurrences/{occurrenceId} {
       allow read: if isOwner(userId);
       allow create: if hasValidSessionOccurrence(userId, occurrenceId);
@@ -1185,6 +1194,7 @@ service cloud.firestore {
         && request.resource.data.date == resource.data.date
         && request.resource.data.createdAt == resource.data.createdAt
         && request.resource.data.authority == resource.data.authority
+        && isValidOccurrenceStateTransition(resource.data.state, request.resource.data.state)
         && request.resource.data.diff(resource.data).affectedKeys().hasOnly(['state', 'updatedAt']);
       allow delete: if isOwner(userId);
     }

--- a/app/src/components/Home.tsx
+++ b/app/src/components/Home.tsx
@@ -11,9 +11,9 @@ import { resolvePlanningContext } from '../engine/planningMode';
 import { resolveExecutionDose } from '../engine/dose';
 import { resolveAvailability } from '../engine/schedule';
 import { adjudicateAuthoredSession, createAuthoredSessionTemplate, estimateAuthoredSessionSystemicCost } from '../engine/authoredSessionGates';
-import { sessionOccurrenceService } from '../services/sessionOccurrenceService';
 import type { AuthoredPlanBlock, BodyRegion, DailyDecisionInput, Recommendation, NextDayPotentialPlan, DailyRecommendation, DecisionJournalEntry, FixedActivity, ShadowVerdict } from '../engine/models';
-import type { SessionReferenceBinding } from '../sessions/models';
+import { isManualOccurrence, type SessionReferenceBinding } from '../sessions/models';
+import { sessionOccurrenceService } from '../services/sessionOccurrenceService';
 import type { DataState } from '../engine/dataState';
 import { recommendationService } from '../services/recommendationService';
 import { prepareAuthoredOccurrenceLaunch, prepareCatalogSessionLaunch, prepareExternalPlanSessionLaunch } from '../services/sessionAuthoringService';
@@ -490,6 +490,7 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
                 contentHash: externalContext.contentHash,
                 session: externalContext.session as ExternalPlanSessionV4,
               },
+              { date: input.date },
             );
             if (!isCurrent()) return;
             primarySession = launch.binding;
@@ -520,7 +521,7 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
           let acceptedSameDaySystemicCost = baseRecommendation.template.systemicCost;
           let acceptedSameDayMinutes = baseRecommendation.template.durationMin;
 
-          if (replaceOccurrence) {
+          if (replaceOccurrence && isManualOccurrence(replaceOccurrence)) {
             const source = {
               kind: 'manual' as const,
               definitionId: replaceOccurrence.definitionRef.definitionId,
@@ -591,6 +592,7 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
           const additionalBindings: SessionReferenceBinding[] = [];
           const additionalNotices: string[] = [];
           for (const occurrence of additionalOccurrences) {
+            if (!isManualOccurrence(occurrence)) continue;
             const source = {
               kind: 'manual' as const,
               definitionId: occurrence.definitionRef.definitionId,

--- a/app/src/emulator/firestoreRules.emulator.test.ts
+++ b/app/src/emulator/firestoreRules.emulator.test.ts
@@ -1333,6 +1333,24 @@ emulatorDescribe('Firestore security rules', () => {
         };
     }
 
+    function validExternalPlanSessionOccurrence() {
+        return {
+            userId: ownerId,
+            occurrenceId: 'occ-ext-1',
+            date: '2026-08-18',
+            authority: 'external_plan',
+            state: 'scheduled',
+            externalPlanRef: {
+                planId: 'plan-1',
+                revision: 1,
+                sessionId: 'session-1',
+                contentHash: 'hash-abc-123',
+            },
+            createdAt: '2026-08-18T10:00:00Z',
+            updatedAt: '2026-08-18T10:00:00Z',
+        };
+    }
+
     function validSessionExecution() {
         return {
             userId: ownerId,
@@ -1518,12 +1536,67 @@ emulatorDescribe('Firestore security rules', () => {
             authority: 'additional_session',
         }))).resolves.toBeUndefined();
 
+        // external_plan succeeds in Issue #434 PR 2
+        await expect(assertSucceeds(setDoc(doc(ownerDb, `${sessionOccPath}-ext`), validExternalPlanSessionOccurrence()))).resolves.toBeUndefined();
+
         // unknown authority is rejected
         await assertFails(setDoc(doc(ownerDb, `${sessionOccPath}-unknown`), {
             ...validSessionOccurrence(),
             occurrenceId: 'occ-unplanned-1-unknown',
             authority: 'bogus_authority',
         }));
+    });
+
+    it('allows external-plan occurrence lifecycle (scheduled -> active -> completed / skipped) and enforces mutual exclusivity of refs', async () => {
+        const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+        const occPath = `users/${ownerId}/session_occurrences/occ-ext-lifecycle`;
+        const baseOcc = {
+            ...validExternalPlanSessionOccurrence(),
+            occurrenceId: 'occ-ext-lifecycle',
+        };
+
+        // 1. Create scheduled external-plan occurrence
+        await expect(assertSucceeds(setDoc(doc(ownerDb, occPath), baseOcc))).resolves.toBeUndefined();
+
+        // 2. Transition to active
+        await expect(assertSucceeds(setDoc(doc(ownerDb, occPath), {
+            ...baseOcc,
+            state: 'active',
+            updatedAt: '2026-08-18T10:05:00Z',
+        }))).resolves.toBeUndefined();
+
+        // 3. Transition to completed
+        await expect(assertSucceeds(setDoc(doc(ownerDb, occPath), {
+            ...baseOcc,
+            state: 'completed',
+            updatedAt: '2026-08-18T11:00:00Z',
+        }))).resolves.toBeUndefined();
+
+        // 4. Create another occurrence with skipped state
+        const skippedPath = `users/${ownerId}/session_occurrences/occ-ext-skipped`;
+        await expect(assertSucceeds(setDoc(doc(ownerDb, skippedPath), {
+            ...validExternalPlanSessionOccurrence(),
+            occurrenceId: 'occ-ext-skipped',
+            state: 'skipped',
+        }))).resolves.toBeUndefined();
+
+        // 5. Rejects an occurrence with both definitionRef and externalPlanRef
+        const bothPath = `users/${ownerId}/session_occurrences/occ-ext-both`;
+        await assertFails(setDoc(doc(ownerDb, bothPath), {
+            ...validExternalPlanSessionOccurrence(),
+            occurrenceId: 'occ-ext-both',
+            definitionRef: {
+                definitionId: 'def-full-body',
+                revision: 1,
+                contentHash: 'hash-abc-123',
+            },
+        }));
+
+        // 6. Rejects an occurrence with neither ref
+        const neitherPath = `users/${ownerId}/session_occurrences/occ-ext-neither`;
+        const noRef = { ...validExternalPlanSessionOccurrence(), occurrenceId: 'occ-ext-neither' };
+        delete (noRef as { externalPlanRef?: unknown }).externalPlanRef;
+        await assertFails(setDoc(doc(ownerDb, neitherPath), noRef));
     });
 
     it('allows recommendations with primarySession and additionalSessions bindings', async () => {

--- a/app/src/emulator/firestoreRules.emulator.test.ts
+++ b/app/src/emulator/firestoreRules.emulator.test.ts
@@ -1537,7 +1537,10 @@ emulatorDescribe('Firestore security rules', () => {
         }))).resolves.toBeUndefined();
 
         // external_plan succeeds in Issue #434 PR 2
-        await expect(assertSucceeds(setDoc(doc(ownerDb, `${sessionOccPath}-ext`), validExternalPlanSessionOccurrence()))).resolves.toBeUndefined();
+        await expect(assertSucceeds(setDoc(doc(ownerDb, `${sessionOccPath}-ext`), {
+            ...validExternalPlanSessionOccurrence(),
+            occurrenceId: 'occ-unplanned-1-ext',
+        }))).resolves.toBeUndefined();
 
         // unknown authority is rejected
         await assertFails(setDoc(doc(ownerDb, `${sessionOccPath}-unknown`), {

--- a/app/src/emulator/firestoreRules.emulator.test.ts
+++ b/app/src/emulator/firestoreRules.emulator.test.ts
@@ -1598,18 +1598,26 @@ emulatorDescribe('Firestore security rules', () => {
             updatedAt: '2026-08-18T10:05:00Z',
         }));
 
-        // 4c. Scheduled occurrence cannot jump directly to completed
+        // 4c. Scheduled occurrence can transition directly to completed (production state before PR 3 claims)
         const directPath = `users/${ownerId}/session_occurrences/occ-ext-direct`;
         await expect(assertSucceeds(setDoc(doc(ownerDb, directPath), {
             ...validExternalPlanSessionOccurrence(),
             occurrenceId: 'occ-ext-direct',
             state: 'scheduled',
         }))).resolves.toBeUndefined();
-        await assertFails(setDoc(doc(ownerDb, directPath), {
+        await expect(assertSucceeds(setDoc(doc(ownerDb, directPath), {
             ...validExternalPlanSessionOccurrence(),
             occurrenceId: 'occ-ext-direct',
             state: 'completed',
             updatedAt: '2026-08-18T11:00:00Z',
+        }))).resolves.toBeUndefined();
+
+        // 4d. Terminal completed occurrence cannot transition back to scheduled
+        await assertFails(setDoc(doc(ownerDb, directPath), {
+            ...validExternalPlanSessionOccurrence(),
+            occurrenceId: 'occ-ext-direct',
+            state: 'scheduled',
+            updatedAt: '2026-08-18T11:05:00Z',
         }));
 
         // 5. Rejects an occurrence with both definitionRef and externalPlanRef

--- a/app/src/emulator/firestoreRules.emulator.test.ts
+++ b/app/src/emulator/firestoreRules.emulator.test.ts
@@ -1575,6 +1575,13 @@ emulatorDescribe('Firestore security rules', () => {
             updatedAt: '2026-08-18T11:00:00Z',
         }))).resolves.toBeUndefined();
 
+        // 3b. Completed occurrence cannot transition back to active
+        await assertFails(setDoc(doc(ownerDb, occPath), {
+            ...baseOcc,
+            state: 'active',
+            updatedAt: '2026-08-18T11:05:00Z',
+        }));
+
         // 4. Create another occurrence with skipped state
         const skippedPath = `users/${ownerId}/session_occurrences/occ-ext-skipped`;
         await expect(assertSucceeds(setDoc(doc(ownerDb, skippedPath), {
@@ -1582,6 +1589,28 @@ emulatorDescribe('Firestore security rules', () => {
             occurrenceId: 'occ-ext-skipped',
             state: 'skipped',
         }))).resolves.toBeUndefined();
+
+        // 4b. Skipped occurrence cannot transition back to active
+        await assertFails(setDoc(doc(ownerDb, skippedPath), {
+            ...validExternalPlanSessionOccurrence(),
+            occurrenceId: 'occ-ext-skipped',
+            state: 'active',
+            updatedAt: '2026-08-18T10:05:00Z',
+        }));
+
+        // 4c. Scheduled occurrence cannot jump directly to completed
+        const directPath = `users/${ownerId}/session_occurrences/occ-ext-direct`;
+        await expect(assertSucceeds(setDoc(doc(ownerDb, directPath), {
+            ...validExternalPlanSessionOccurrence(),
+            occurrenceId: 'occ-ext-direct',
+            state: 'scheduled',
+        }))).resolves.toBeUndefined();
+        await assertFails(setDoc(doc(ownerDb, directPath), {
+            ...validExternalPlanSessionOccurrence(),
+            occurrenceId: 'occ-ext-direct',
+            state: 'completed',
+            updatedAt: '2026-08-18T11:00:00Z',
+        }));
 
         // 5. Rejects an occurrence with both definitionRef and externalPlanRef
         const bothPath = `users/${ownerId}/session_occurrences/occ-ext-both`;
@@ -1600,6 +1629,22 @@ emulatorDescribe('Firestore security rules', () => {
         const noRef = { ...validExternalPlanSessionOccurrence(), occurrenceId: 'occ-ext-neither' };
         delete (noRef as { externalPlanRef?: unknown }).externalPlanRef;
         await assertFails(setDoc(doc(ownerDb, neitherPath), noRef));
+
+        // 7. Rejects externalPlanRef paired with non-external_plan authority
+        const mismatchedExtPath = `users/${ownerId}/session_occurrences/occ-ext-mismatched`;
+        await assertFails(setDoc(doc(ownerDb, mismatchedExtPath), {
+            ...validExternalPlanSessionOccurrence(),
+            occurrenceId: 'occ-ext-mismatched',
+            authority: 'replace_recommendation',
+        }));
+
+        // 8. Rejects definitionRef paired with external_plan authority
+        const mismatchedDefPath = `users/${ownerId}/session_occurrences/occ-def-mismatched`;
+        await assertFails(setDoc(doc(ownerDb, mismatchedDefPath), {
+            ...validSessionOccurrence(),
+            occurrenceId: 'occ-def-mismatched',
+            authority: 'external_plan',
+        }));
     });
 
     it('allows recommendations with primarySession and additionalSessions bindings', async () => {

--- a/app/src/engine/intradayReassessment.test.ts
+++ b/app/src/engine/intradayReassessment.test.ts
@@ -367,8 +367,8 @@ describe('reassessDependentBundleMember (ADR-0036 D-REASSESS)', () => {
         expect(result.executionDose?.volume).toBeCloseTo(0.7);
     });
 
-    it('rejects PM session when predecessor reached terminal state (superseded, abandoned, missed)', () => {
-        for (const terminalState of ['superseded', 'abandoned', 'missed'] as const) {
+    it('rejects PM session when predecessor reached terminal state (superseded, abandoned, missed, skipped)', () => {
+        for (const terminalState of ['superseded', 'abandoned', 'missed', 'skipped'] as const) {
             const result = reassessDependentBundleMember({
                 target,
                 predecessor: {

--- a/app/src/engine/intradayReassessment.ts
+++ b/app/src/engine/intradayReassessment.ts
@@ -157,7 +157,8 @@ export function reassessDependentBundleMember(
         if (
             predecessor.state === 'superseded' ||
             predecessor.state === 'abandoned' ||
-            predecessor.state === 'missed'
+            predecessor.state === 'missed' ||
+            predecessor.state === 'skipped'
         ) {
             return {
                 decision: 'reject',

--- a/app/src/engine/replay.ts
+++ b/app/src/engine/replay.ts
@@ -1,5 +1,5 @@
 import type { DailyRecommendation, ExternalDecisionProvenance, ExternalRestDirective, ExternalRestProvenance, ExternalTrainingPlan } from './models';
-import type { SessionReferenceBinding } from '../sessions/models';
+import { isExternalPlanOccurrence, isManualOccurrence, type SessionReferenceBinding } from '../sessions/models';
 import { computeContentHash } from './externalPlanHash';
 import { resolveRestDate } from './externalPlacement';
 import { externalTemplateId, isExternalTemplateId } from './externalSessionProfiles';
@@ -377,9 +377,18 @@ export async function replayRecommendationAuditAgainstSessions(
             const occurrence = await sessionOccurrenceService.getOccurrence(userId, binding.occurrenceId);
             if (occurrence.status !== 'AVAILABLE' || occurrence.data.date !== recommendation.date) continue;
             if (binding.sessionSource.kind === 'manual' && (
-                occurrence.data.definitionRef.definitionId !== binding.sessionSource.definitionId
+                !isManualOccurrence(occurrence.data)
+                || occurrence.data.definitionRef.definitionId !== binding.sessionSource.definitionId
                 || occurrence.data.definitionRef.revision !== binding.sessionSource.revision
                 || occurrence.data.definitionRef.contentHash !== binding.sessionSource.contentHash
+            )) continue;
+
+            if (binding.sessionSource.kind === 'external_plan' && (
+                !isExternalPlanOccurrence(occurrence.data)
+                || occurrence.data.externalPlanRef.planId !== binding.sessionSource.planId
+                || occurrence.data.externalPlanRef.revision !== binding.sessionSource.revision
+                || occurrence.data.externalPlanRef.sessionId !== binding.sessionSource.sessionId
+                || occurrence.data.externalPlanRef.contentHash !== binding.sessionSource.contentHash
             )) continue;
 
             const expectedAuthority = audit?.authoredOccurrence?.occurrenceId === binding.occurrenceId

--- a/app/src/hooks/useSessionRunner.ts
+++ b/app/src/hooks/useSessionRunner.ts
@@ -635,20 +635,22 @@ export function useSessionRunner(userId: string, fixtures: readonly SessionDefin
             }
         }
 
+        if (execution.occurrenceId) {
+            await sessionOccurrenceService.queueOccurrenceTransition(
+                userId,
+                execution.occurrenceId,
+                'completed',
+                now,
+                batch,
+            );
+        }
+
         await sessionExecutionService.transitionExecution(userId, execution.executionId, 'completed', {
             sessionRpe: payload?.sessionRpe,
             notes: payload?.notes,
         }, batch);
         await batch.commit();
         setExecution(completedExecution);
-
-        if (execution.occurrenceId) {
-            try {
-                await sessionOccurrenceService.transitionOccurrenceState(userId, execution.occurrenceId, 'completed', now);
-            } catch (err) {
-                console.warn('[useSessionRunner] Failed to transition occurrence to completed:', err);
-            }
-        }
 
         // PR 1 (ADR-0034) shadow reconciliation: fire-and-forget, never affects
         // completion UX or this function's behavior/return value.
@@ -664,16 +666,21 @@ export function useSessionRunner(userId: string, fixtures: readonly SessionDefin
         } catch (err) {
             console.warn('[useSessionRunner] Failed to persist rest event:', err);
         }
+        const now = new Date().toISOString();
+        const batch = writeBatch(getDb());
+        if (execution.occurrenceId) {
+            await sessionOccurrenceService.queueOccurrenceTransition(
+                userId,
+                execution.occurrenceId,
+                'abandoned',
+                now,
+                batch,
+            );
+        }
         await sessionExecutionService.transitionExecution(userId, execution.executionId, 'abandoned', {
             notes,
-        });
-        if (execution.occurrenceId) {
-            try {
-                await sessionOccurrenceService.transitionOccurrenceState(userId, execution.occurrenceId, 'abandoned');
-            } catch (err) {
-                console.warn('[useSessionRunner] Failed to transition occurrence to abandoned:', err);
-            }
-        }
+        }, batch);
+        await batch.commit();
         setExecution(prev => prev ? { ...prev, state: 'abandoned' } : null);
     }, [execution, userId, closeActiveRest]);
 

--- a/app/src/hooks/useSessionRunner.ts
+++ b/app/src/hooks/useSessionRunner.ts
@@ -635,22 +635,25 @@ export function useSessionRunner(userId: string, fixtures: readonly SessionDefin
             }
         }
 
-        if (execution.occurrenceId) {
-            await sessionOccurrenceService.queueOccurrenceTransition(
-                userId,
-                execution.occurrenceId,
-                'completed',
-                now,
-                batch,
-            );
-        }
-
         await sessionExecutionService.transitionExecution(userId, execution.executionId, 'completed', {
             sessionRpe: payload?.sessionRpe,
             notes: payload?.notes,
         }, batch);
         await batch.commit();
         setExecution(completedExecution);
+
+        if (execution.occurrenceId) {
+            try {
+                await sessionOccurrenceService.transitionOccurrenceState(
+                    userId,
+                    execution.occurrenceId,
+                    'completed',
+                    now,
+                );
+            } catch (err) {
+                console.warn('[useSessionRunner] Failed to transition occurrence state to completed:', err);
+            }
+        }
 
         // PR 1 (ADR-0034) shadow reconciliation: fire-and-forget, never affects
         // completion UX or this function's behavior/return value.
@@ -668,20 +671,24 @@ export function useSessionRunner(userId: string, fixtures: readonly SessionDefin
         }
         const now = new Date().toISOString();
         const batch = writeBatch(getDb());
-        if (execution.occurrenceId) {
-            await sessionOccurrenceService.queueOccurrenceTransition(
-                userId,
-                execution.occurrenceId,
-                'abandoned',
-                now,
-                batch,
-            );
-        }
         await sessionExecutionService.transitionExecution(userId, execution.executionId, 'abandoned', {
             notes,
         }, batch);
         await batch.commit();
         setExecution(prev => prev ? { ...prev, state: 'abandoned' } : null);
+
+        if (execution.occurrenceId) {
+            try {
+                await sessionOccurrenceService.transitionOccurrenceState(
+                    userId,
+                    execution.occurrenceId,
+                    'abandoned',
+                    now,
+                );
+            } catch (err) {
+                console.warn('[useSessionRunner] Failed to transition occurrence state to abandoned:', err);
+            }
+        }
     }, [execution, userId, closeActiveRest]);
 
     return {

--- a/app/src/hooks/useSessionRunner.ts
+++ b/app/src/hooks/useSessionRunner.ts
@@ -11,6 +11,7 @@ import type {
 } from '../sessions/models';
 import { getDb } from '../firebase';
 import { sessionExecutionService } from '../services/sessionExecutionService';
+import { sessionOccurrenceService } from '../services/sessionOccurrenceService';
 import { checkinService } from '../services/checkinService';
 import { preferencesService } from '../services/preferencesService';
 import { trainingSettingsService } from '../services/trainingSettingsService';
@@ -641,6 +642,14 @@ export function useSessionRunner(userId: string, fixtures: readonly SessionDefin
         await batch.commit();
         setExecution(completedExecution);
 
+        if (execution.occurrenceId) {
+            try {
+                await sessionOccurrenceService.transitionOccurrenceState(userId, execution.occurrenceId, 'completed', now);
+            } catch (err) {
+                console.warn('[useSessionRunner] Failed to transition occurrence to completed:', err);
+            }
+        }
+
         // PR 1 (ADR-0034) shadow reconciliation: fire-and-forget, never affects
         // completion UX or this function's behavior/return value.
         void reconcileStructuredCompletion(userId, completedExecution, definition?.dominantModality)
@@ -658,6 +667,13 @@ export function useSessionRunner(userId: string, fixtures: readonly SessionDefin
         await sessionExecutionService.transitionExecution(userId, execution.executionId, 'abandoned', {
             notes,
         });
+        if (execution.occurrenceId) {
+            try {
+                await sessionOccurrenceService.transitionOccurrenceState(userId, execution.occurrenceId, 'abandoned');
+            } catch (err) {
+                console.warn('[useSessionRunner] Failed to transition occurrence to abandoned:', err);
+            }
+        }
         setExecution(prev => prev ? { ...prev, state: 'abandoned' } : null);
     }, [execution, userId, closeActiveRest]);
 

--- a/app/src/services/sessionAuthoringService.test.ts
+++ b/app/src/services/sessionAuthoringService.test.ts
@@ -15,7 +15,19 @@ const services = vi.hoisted(() => {
                 store.set(prescription.prescriptionHash, prescription);
             }),
         },
-        occurrence: { saveOccurrence: vi.fn().mockResolvedValue(undefined) },
+        occurrence: {
+            saveOccurrence: vi.fn().mockResolvedValue(undefined),
+            getOrCreateExternalPlanOccurrence: vi.fn().mockImplementation(async (userId, date, ref) => ({
+                userId,
+                occurrenceId: 'occ-ext-created',
+                date,
+                authority: 'external_plan',
+                externalPlanRef: ref,
+                state: 'scheduled',
+                createdAt: '2026-09-06T12:00:00.000Z',
+                updatedAt: '2026-09-06T12:00:00.000Z',
+            })),
+        },
     };
 });
 
@@ -31,6 +43,7 @@ beforeEach(() => {
     services.store.clear();
     services.prescription.savePrescription.mockClear();
     services.occurrence.saveOccurrence.mockClear();
+    services.occurrence.getOrCreateExternalPlanOccurrence.mockClear();
 });
 
 function makeTestPrescription(templateId: string) {
@@ -188,6 +201,29 @@ describe('prepareExternalPlanSessionLaunch (ADR-0036 H4)', () => {
             duration: { min: 60, max: 60 },
         });
         expect(savedPrescription.createdAt).toBe('2026-09-06T12:00:00.000Z');
+    });
+
+    it('creates and binds an external-plan occurrence when date is provided in options', async () => {
+        const externalPlan = makeV4ExternalPlan();
+        const launch = await prepareExternalPlanSessionLaunch('u1', externalPlan, {
+            date: '2026-09-06',
+            now: '2026-09-06T12:00:00.000Z',
+        });
+
+        expect(launch.binding.sessionSource.kind).toBe('external_plan');
+        expect(launch.binding.occurrenceId).toBe('occ-ext-created');
+        expect(services.occurrence.getOrCreateExternalPlanOccurrence).toHaveBeenCalledWith(
+            'u1',
+            '2026-09-06',
+            {
+                planId: 'plan-xyz',
+                revision: 2,
+                sessionId: 'session-101',
+                contentHash: 'c'.repeat(64),
+            },
+            undefined,
+            '2026-09-06T12:00:00.000Z',
+        );
     });
 
     it('applies a summary override before hashing and persistence', async () => {

--- a/app/src/services/sessionAuthoringService.test.ts
+++ b/app/src/services/sessionAuthoringService.test.ts
@@ -315,6 +315,62 @@ describe('prepareExternalPlanSessionLaunch (ADR-0036 H4)', () => {
         expect(services.prescription.savePrescription).not.toHaveBeenCalled();
     });
 
+    it('rejects a supplied occurrence that is already in completed state', async () => {
+        const externalPlan = makeV4ExternalPlan();
+        services.occurrence.getOccurrence.mockResolvedValueOnce({
+            status: 'AVAILABLE',
+            data: {
+                userId: 'u1',
+                occurrenceId: 'occ-ext-completed',
+                date: '2026-09-06',
+                authority: 'external_plan',
+                externalPlanRef: {
+                    planId: 'plan-xyz',
+                    revision: 2,
+                    sessionId: 'session-101',
+                    contentHash: 'c'.repeat(64),
+                },
+                state: 'completed',
+                createdAt: '2026-09-06T12:00:00.000Z',
+                updatedAt: '2026-09-06T12:00:00.000Z',
+            },
+        });
+
+        await expect(prepareExternalPlanSessionLaunch('u1', externalPlan, {
+            occurrenceId: 'occ-ext-completed',
+            date: '2026-09-06',
+        })).rejects.toThrow(/does not match the launch source/i);
+        expect(services.prescription.savePrescription).not.toHaveBeenCalled();
+    });
+
+    it('rejects a supplied occurrence that is in skipped state', async () => {
+        const externalPlan = makeV4ExternalPlan();
+        services.occurrence.getOccurrence.mockResolvedValueOnce({
+            status: 'AVAILABLE',
+            data: {
+                userId: 'u1',
+                occurrenceId: 'occ-ext-skipped',
+                date: '2026-09-06',
+                authority: 'external_plan',
+                externalPlanRef: {
+                    planId: 'plan-xyz',
+                    revision: 2,
+                    sessionId: 'session-101',
+                    contentHash: 'c'.repeat(64),
+                },
+                state: 'skipped',
+                createdAt: '2026-09-06T12:00:00.000Z',
+                updatedAt: '2026-09-06T12:00:00.000Z',
+            },
+        });
+
+        await expect(prepareExternalPlanSessionLaunch('u1', externalPlan, {
+            occurrenceId: 'occ-ext-skipped',
+            date: '2026-09-06',
+        })).rejects.toThrow(/does not match the launch source/i);
+        expect(services.prescription.savePrescription).not.toHaveBeenCalled();
+    });
+
     it('applies a summary override before hashing and persistence', async () => {
         const externalPlan = makeV4ExternalPlan();
         const launch = await prepareExternalPlanSessionLaunch(

--- a/app/src/services/sessionAuthoringService.test.ts
+++ b/app/src/services/sessionAuthoringService.test.ts
@@ -245,6 +245,31 @@ describe('prepareExternalPlanSessionLaunch (ADR-0036 H4)', () => {
         );
     });
 
+    it('rejects a date-only launch when existing occurrence is in a terminal state', async () => {
+        const externalPlan = makeV4ExternalPlan();
+        services.occurrence.getOrCreateExternalPlanOccurrence.mockResolvedValueOnce({
+            userId: 'u1',
+            occurrenceId: 'occ-ext-completed',
+            date: '2026-09-06',
+            authority: 'external_plan',
+            externalPlanRef: {
+                planId: 'plan-xyz',
+                revision: 2,
+                sessionId: 'session-101',
+                contentHash: 'c'.repeat(64),
+            },
+            state: 'completed',
+            createdAt: '2026-09-06T12:00:00.000Z',
+            updatedAt: '2026-09-06T12:00:00.000Z',
+        });
+
+        await expect(prepareExternalPlanSessionLaunch('u1', externalPlan, {
+            date: '2026-09-06',
+            now: '2026-09-06T12:00:00.000Z',
+        })).rejects.toThrow(/does not match the launch source/i);
+        expect(services.prescription.savePrescription).not.toHaveBeenCalled();
+    });
+
     it('validates and binds a supplied external-plan occurrence before persisting the prescription', async () => {
         const externalPlan = makeV4ExternalPlan();
         const launch = await prepareExternalPlanSessionLaunch('u1', externalPlan, {

--- a/app/src/services/sessionAuthoringService.test.ts
+++ b/app/src/services/sessionAuthoringService.test.ts
@@ -17,6 +17,24 @@ const services = vi.hoisted(() => {
         },
         occurrence: {
             saveOccurrence: vi.fn().mockResolvedValue(undefined),
+            getOccurrence: vi.fn().mockImplementation(async (userId: string, occurrenceId: string) => ({
+                status: 'AVAILABLE' as const,
+                data: {
+                    userId,
+                    occurrenceId,
+                    date: '2026-09-06',
+                    authority: 'external_plan' as const,
+                    externalPlanRef: {
+                        planId: 'plan-xyz',
+                        revision: 2,
+                        sessionId: 'session-101',
+                        contentHash: 'c'.repeat(64),
+                    },
+                    state: 'scheduled' as const,
+                    createdAt: '2026-09-06T12:00:00.000Z',
+                    updatedAt: '2026-09-06T12:00:00.000Z',
+                },
+            })),
             getOrCreateExternalPlanOccurrence: vi.fn().mockImplementation(async (userId, date, ref) => ({
                 userId,
                 occurrenceId: 'occ-ext-created',
@@ -43,6 +61,7 @@ beforeEach(() => {
     services.store.clear();
     services.prescription.savePrescription.mockClear();
     services.occurrence.saveOccurrence.mockClear();
+    services.occurrence.getOccurrence.mockClear();
     services.occurrence.getOrCreateExternalPlanOccurrence.mockClear();
 });
 
@@ -224,6 +243,76 @@ describe('prepareExternalPlanSessionLaunch (ADR-0036 H4)', () => {
             undefined,
             '2026-09-06T12:00:00.000Z',
         );
+    });
+
+    it('validates and binds a supplied external-plan occurrence before persisting the prescription', async () => {
+        const externalPlan = makeV4ExternalPlan();
+        const launch = await prepareExternalPlanSessionLaunch('u1', externalPlan, {
+            occurrenceId: 'occ-ext-existing',
+            date: '2026-09-06',
+            now: '2026-09-06T12:00:00.000Z',
+        });
+
+        expect(services.occurrence.getOccurrence).toHaveBeenCalledWith('u1', 'occ-ext-existing');
+        expect(services.occurrence.getOrCreateExternalPlanOccurrence).not.toHaveBeenCalled();
+        expect(launch.binding.occurrenceId).toBe('occ-ext-existing');
+        expect(services.prescription.savePrescription).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects a supplied occurrence whose external source identity does not match', async () => {
+        const externalPlan = makeV4ExternalPlan();
+        services.occurrence.getOccurrence.mockResolvedValueOnce({
+            status: 'AVAILABLE',
+            data: {
+                userId: 'u1',
+                occurrenceId: 'occ-ext-wrong',
+                date: '2026-09-06',
+                authority: 'external_plan',
+                externalPlanRef: {
+                    planId: 'plan-xyz',
+                    revision: 2,
+                    sessionId: 'different-session',
+                    contentHash: 'c'.repeat(64),
+                },
+                state: 'scheduled',
+                createdAt: '2026-09-06T12:00:00.000Z',
+                updatedAt: '2026-09-06T12:00:00.000Z',
+            },
+        });
+
+        await expect(prepareExternalPlanSessionLaunch('u1', externalPlan, {
+            occurrenceId: 'occ-ext-wrong',
+            date: '2026-09-06',
+        })).rejects.toThrow(/does not match the launch source/i);
+        expect(services.prescription.savePrescription).not.toHaveBeenCalled();
+    });
+
+    it('rejects a supplied occurrence from a different recommendation date', async () => {
+        const externalPlan = makeV4ExternalPlan();
+        services.occurrence.getOccurrence.mockResolvedValueOnce({
+            status: 'AVAILABLE',
+            data: {
+                userId: 'u1',
+                occurrenceId: 'occ-ext-existing',
+                date: '2026-09-05',
+                authority: 'external_plan',
+                externalPlanRef: {
+                    planId: 'plan-xyz',
+                    revision: 2,
+                    sessionId: 'session-101',
+                    contentHash: 'c'.repeat(64),
+                },
+                state: 'scheduled',
+                createdAt: '2026-09-05T12:00:00.000Z',
+                updatedAt: '2026-09-05T12:00:00.000Z',
+            },
+        });
+
+        await expect(prepareExternalPlanSessionLaunch('u1', externalPlan, {
+            occurrenceId: 'occ-ext-existing',
+            date: '2026-09-06',
+        })).rejects.toThrow(/expected 2026-09-06/i);
+        expect(services.prescription.savePrescription).not.toHaveBeenCalled();
     });
 
     it('applies a summary override before hashing and persistence', async () => {

--- a/app/src/services/sessionAuthoringService.ts
+++ b/app/src/services/sessionAuthoringService.ts
@@ -1,4 +1,4 @@
-import type { SessionDefinition, ExecutionPrescription, SessionReferenceBinding } from '../sessions/models';
+import { isExternalPlanOccurrence, type SessionDefinition, type ExecutionPrescription, type SessionReferenceBinding } from '../sessions/models';
 import type { PreparedSessionLaunch } from '../sessions/sessionLaunch';
 import type { WorkoutPrescription } from '../workouts/models';
 import type { ExternalPlanSessionV4 } from '../sessions/externalPlanV4';
@@ -159,10 +159,11 @@ export interface PrepareExternalPlanSessionLaunchOptions {
 
 /**
  * Freezes the execution-prescription snapshot for a v4 external-plan session (ADR-0036
- * H4). If a date is supplied (or an occurrenceId), an external-plan occurrence is
- * created/resolved idempotently through sessionOccurrenceService and attached to the
- * launch binding. Target-event sessions are deliberately rejected: rules.ts treats
- * them as fixed-activity/advisory inputs rather than executable primary recommendations.
+ * H4). A supplied date creates/resolves an external-plan occurrence idempotently. A
+ * supplied occurrenceId is read back and verified against the exact external source (and
+ * date when supplied) before it can be attached to the launch binding. Target-event
+ * sessions are deliberately rejected: rules.ts treats them as fixed-activity/advisory
+ * inputs rather than executable primary recommendations.
  *
  * Idempotent and safe to call every time an executable external-plan recommendation is
  * composed: `executionPrescriptionService.savePrescription` no-ops when the same
@@ -210,6 +211,44 @@ export async function prepareExternalPlanSessionLaunch(
         contentHash: externalPlan.contentHash,
     };
 
+    let effectiveOccurrenceId = options.occurrenceId;
+    if (effectiveOccurrenceId) {
+        const occurrence = await sessionOccurrenceService.getOccurrence(userId, effectiveOccurrenceId);
+        if (occurrence.status !== 'AVAILABLE') {
+            throw new Error(`External-plan occurrence ${effectiveOccurrenceId} is not available (${occurrence.status}).`);
+        }
+        const occurrenceData = occurrence.data;
+        if (
+            !isExternalPlanOccurrence(occurrenceData)
+            || occurrenceData.userId !== userId
+            || occurrenceData.externalPlanRef.planId !== sessionSource.planId
+            || occurrenceData.externalPlanRef.revision !== sessionSource.revision
+            || occurrenceData.externalPlanRef.sessionId !== sessionSource.sessionId
+            || occurrenceData.externalPlanRef.contentHash !== sessionSource.contentHash
+        ) {
+            throw new Error(`External-plan occurrence ${effectiveOccurrenceId} does not match the launch source.`);
+        }
+        if (options.date !== undefined && occurrenceData.date !== options.date) {
+            throw new Error(
+                `External-plan occurrence ${effectiveOccurrenceId} is for ${occurrenceData.date}, expected ${options.date}.`,
+            );
+        }
+    } else if (options.date) {
+        const occurrence = await sessionOccurrenceService.getOrCreateExternalPlanOccurrence(
+            userId,
+            options.date,
+            {
+                planId: externalPlan.planId,
+                revision: externalPlan.revision,
+                sessionId: externalPlan.session.id,
+                contentHash: externalPlan.contentHash,
+            },
+            options.placementOrder,
+            now,
+        );
+        effectiveOccurrenceId = occurrence.occurrenceId;
+    }
+
     const effectiveSummary = options.summaryOverride ?? definition.summary;
     const unsignedPrescription: ExecutionPrescription = {
         schemaVersion: 1,
@@ -235,23 +274,6 @@ export async function prepareExternalPlanSessionLaunch(
         ...unsignedPrescription,
         prescriptionHash,
     });
-
-    let effectiveOccurrenceId = options.occurrenceId;
-    if (!effectiveOccurrenceId && options.date) {
-        const occurrence = await sessionOccurrenceService.getOrCreateExternalPlanOccurrence(
-            userId,
-            options.date,
-            {
-                planId: externalPlan.planId,
-                revision: externalPlan.revision,
-                sessionId: externalPlan.session.id,
-                contentHash: externalPlan.contentHash,
-            },
-            options.placementOrder,
-            now,
-        );
-        effectiveOccurrenceId = occurrence.occurrenceId;
-    }
 
     return {
         definition,

--- a/app/src/services/sessionAuthoringService.ts
+++ b/app/src/services/sessionAuthoringService.ts
@@ -247,6 +247,9 @@ export async function prepareExternalPlanSessionLaunch(
             options.placementOrder,
             now,
         );
+        if (occurrence.state !== 'scheduled') {
+            throw new Error(`External-plan occurrence ${occurrence.occurrenceId} does not match the launch source.`);
+        }
         effectiveOccurrenceId = occurrence.occurrenceId;
     }
 

--- a/app/src/services/sessionAuthoringService.ts
+++ b/app/src/services/sessionAuthoringService.ts
@@ -220,6 +220,7 @@ export async function prepareExternalPlanSessionLaunch(
         const occurrenceData = occurrence.data;
         if (
             !isExternalPlanOccurrence(occurrenceData)
+            || occurrenceData.state !== 'scheduled'
             || occurrenceData.userId !== userId
             || occurrenceData.externalPlanRef.planId !== sessionSource.planId
             || occurrenceData.externalPlanRef.revision !== sessionSource.revision

--- a/app/src/services/sessionAuthoringService.ts
+++ b/app/src/services/sessionAuthoringService.ts
@@ -149,12 +149,19 @@ export async function prepareAuthoredOccurrenceLaunch(
     };
 }
 
+export interface PrepareExternalPlanSessionLaunchOptions {
+    summaryOverride?: string;
+    now?: string;
+    date?: string;
+    occurrenceId?: string;
+    placementOrder?: number;
+}
+
 /**
  * Freezes the execution-prescription snapshot for a v4 external-plan session (ADR-0036
- * H4). Mirrors prepareCatalogSessionLaunch's shape: no session_occurrences record --
- * the immutable authored source is already identified by
- * (planId, revision, sessionId, contentHash), while the recommendation/execution carries
- * the date separately. Target-event sessions are deliberately rejected: rules.ts treats
+ * H4). If a date is supplied (or an occurrenceId), an external-plan occurrence is
+ * created/resolved idempotently through sessionOccurrenceService and attached to the
+ * launch binding. Target-event sessions are deliberately rejected: rules.ts treats
  * them as fixed-activity/advisory inputs rather than executable primary recommendations.
  *
  * Idempotent and safe to call every time an executable external-plan recommendation is
@@ -169,12 +176,22 @@ export async function prepareExternalPlanSessionLaunch(
         contentHash: string;
         session: ExternalPlanSessionV4;
     },
-    summaryOverride?: string,
-    now = new Date().toISOString(),
+    summaryOverrideOrOptions?: string | PrepareExternalPlanSessionLaunchOptions,
+    nowFallback = new Date().toISOString(),
 ): Promise<PreparedSessionLaunch> {
     if (externalPlan.session.isEvent) {
         throw new Error('External-plan target events are advisory fixed-activity inputs and cannot be launched as primary sessions.');
     }
+
+    const options: PrepareExternalPlanSessionLaunchOptions =
+        typeof summaryOverrideOrOptions === 'object' && summaryOverrideOrOptions !== null
+            ? summaryOverrideOrOptions
+            : {
+                summaryOverride: summaryOverrideOrOptions,
+                now: nowFallback,
+            };
+
+    const now = options.now ?? nowFallback;
 
     const definition = externalPlan.session.definition;
     // Defense in depth: already validated at import time (validateExternalSessionV2,
@@ -193,7 +210,7 @@ export async function prepareExternalPlanSessionLaunch(
         contentHash: externalPlan.contentHash,
     };
 
-    const effectiveSummary = summaryOverride ?? definition.summary;
+    const effectiveSummary = options.summaryOverride ?? definition.summary;
     const unsignedPrescription: ExecutionPrescription = {
         schemaVersion: 1,
         prescriptionHash: '',
@@ -219,10 +236,28 @@ export async function prepareExternalPlanSessionLaunch(
         prescriptionHash,
     });
 
+    let effectiveOccurrenceId = options.occurrenceId;
+    if (!effectiveOccurrenceId && options.date) {
+        const occurrence = await sessionOccurrenceService.getOrCreateExternalPlanOccurrence(
+            userId,
+            options.date,
+            {
+                planId: externalPlan.planId,
+                revision: externalPlan.revision,
+                sessionId: externalPlan.session.id,
+                contentHash: externalPlan.contentHash,
+            },
+            options.placementOrder,
+            now,
+        );
+        effectiveOccurrenceId = occurrence.occurrenceId;
+    }
+
     return {
         definition,
         binding: {
             sessionSource,
+            ...(effectiveOccurrenceId ? { occurrenceId: effectiveOccurrenceId } : {}),
             prescriptionHash,
         },
     };

--- a/app/src/services/sessionOccurrenceService.test.ts
+++ b/app/src/services/sessionOccurrenceService.test.ts
@@ -351,7 +351,7 @@ describe('SessionOccurrenceService authority methods (M3.3)', () => {
             );
         });
 
-        it('getOrCreateExternalPlanOccurrence returns existing occurrence if document exists at deterministic ID', async () => {
+        it('getOrCreateExternalPlanOccurrence returns existing occurrence transactionally if document exists at deterministic ID', async () => {
             const existing = {
                 userId: 'u1',
                 occurrenceId: 'ext_2026-08-18_0123456789abcdef01234567',
@@ -362,22 +362,30 @@ describe('SessionOccurrenceService authority methods (M3.3)', () => {
                 createdAt: '2026-08-18T00:00:00Z',
                 updatedAt: '2026-08-18T00:00:00Z',
             };
-            firestore.getDoc.mockResolvedValue({
-                exists: () => true,
-                data: () => existing,
-                ref: { path: 'x' },
-            });
+            const mockTx = {
+                get: vi.fn().mockResolvedValue({
+                    exists: () => true,
+                    data: () => existing,
+                    ref: { path: 'users/u1/session_occurrences/ext_2026-08-18_0123456789abcdef01234567' },
+                }),
+                set: vi.fn(),
+            };
+            firestore.runTransaction.mockImplementation(async (_db, cb) => cb(mockTx));
 
             const service = new SessionOccurrenceService();
             const result = await service.getOrCreateExternalPlanOccurrence('u1', '2026-08-18', extPlanRef);
 
             expect(result.occurrenceId).toBe('ext_2026-08-18_0123456789abcdef01234567');
             expect(result.state).toBe('scheduled');
-            expect(firestore.setDoc).not.toHaveBeenCalled();
+            expect(mockTx.set).not.toHaveBeenCalled();
         });
 
-        it('getOrCreateExternalPlanOccurrence creates a new occurrence with deterministic ID if none exists', async () => {
-            firestore.getDoc.mockResolvedValue({ exists: () => false });
+        it('getOrCreateExternalPlanOccurrence transactionally creates a new occurrence with deterministic ID if none exists', async () => {
+            const mockTx = {
+                get: vi.fn().mockResolvedValue({ exists: () => false }),
+                set: vi.fn(),
+            };
+            firestore.runTransaction.mockImplementation(async (_db, cb) => cb(mockTx));
 
             const service = new SessionOccurrenceService();
             const result = await service.getOrCreateExternalPlanOccurrence('u1', '2026-08-18', extPlanRef);
@@ -385,7 +393,7 @@ describe('SessionOccurrenceService authority methods (M3.3)', () => {
             expect(result.authority).toBe('external_plan');
             expect(result.state).toBe('scheduled');
             expect(result.occurrenceId).toMatch(/^ext_2026-08-18_[a-f0-9]{24}$/);
-            expect(firestore.setDoc).toHaveBeenCalledTimes(1);
+            expect(mockTx.set).toHaveBeenCalledTimes(1);
         });
     });
 
@@ -413,6 +421,23 @@ describe('SessionOccurrenceService authority methods (M3.3)', () => {
             expect(id1).toBe(id3);
             expect(id1).not.toBe(id2);
             expect(id1).toMatch(/^ext_2026-08-18_[a-f0-9]{24}$/);
+        });
+
+        it('produces distinct IDs for colon-containing identifiers that would otherwise collide', async () => {
+            const idA = await deterministicExternalPlanOccurrenceId('2026-08-18', {
+                planId: 'plan:part1',
+                sessionId: 'part2',
+                revision: 1,
+                contentHash: 'a'.repeat(64),
+            });
+            const idB = await deterministicExternalPlanOccurrenceId('2026-08-18', {
+                planId: 'plan',
+                sessionId: 'part1:part2',
+                revision: 1,
+                contentHash: 'a'.repeat(64),
+            });
+
+            expect(idA).not.toBe(idB);
         });
     });
 

--- a/app/src/services/sessionOccurrenceService.test.ts
+++ b/app/src/services/sessionOccurrenceService.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { SessionOccurrence } from '../sessions/models';
+import type { ExternalPlanSessionOccurrence, ManualOccurrenceRef, SessionOccurrence } from '../sessions/models';
 
 const firestore = vi.hoisted(() => ({
     doc: vi.fn(),
@@ -17,7 +17,7 @@ vi.mock('../firebase', () => ({ getDb: vi.fn(() => ({})) }));
 
 import { SessionOccurrenceService } from './sessionOccurrenceService';
 
-const definitionRef: SessionOccurrence['definitionRef'] = {
+const definitionRef: ManualOccurrenceRef = {
     definitionId: 'def-1', revision: 1, contentHash: 'a'.repeat(64),
 };
 
@@ -27,7 +27,7 @@ function occurrenceDoc(overrides: Partial<SessionOccurrence>): SessionOccurrence
         authority: 'schedule', definitionRef, state: 'scheduled',
         createdAt: '2026-08-18T00:00:00Z', updatedAt: '2026-08-18T00:00:00Z',
         ...overrides,
-    };
+    } as SessionOccurrence;
 }
 
 describe('SessionOccurrenceService authority methods (M3.3)', () => {
@@ -273,7 +273,7 @@ describe('SessionOccurrenceService authority methods (M3.3)', () => {
             });
 
             expect(result.date).toBe('2026-08-18');
-            expect(result.definitionRef.definitionId).toBe('def-1');
+            expect(result.definitionRef?.definitionId).toBe('def-1');
             expect(mockTx.set).toHaveBeenCalledWith(
                 expect.anything(),
                 expect.objectContaining({
@@ -282,6 +282,188 @@ describe('SessionOccurrenceService authority methods (M3.3)', () => {
                     state: 'active',
                 }),
             );
+        });
+
+        it('successfully claims an external-plan occurrence and defensively copies externalPlanRef', async () => {
+            const extPlanRef = { planId: 'p-1', revision: 1, sessionId: 's-1', contentHash: 'c'.repeat(64) };
+            const extScheduled = {
+                userId: 'u1',
+                occurrenceId: 'occ-ext-1',
+                date: '2026-08-18',
+                authority: 'external_plan' as const,
+                externalPlanRef: extPlanRef,
+                state: 'scheduled' as const,
+                createdAt: '2026-08-18T00:00:00Z',
+                updatedAt: '2026-08-18T00:00:00Z',
+            };
+            const mockTx = {
+                get: vi.fn().mockResolvedValue({
+                    exists: () => true,
+                    data: () => extScheduled,
+                }),
+                set: vi.fn(),
+            };
+            firestore.runTransaction.mockImplementation(async (_db, cb) => cb(mockTx));
+
+            const onBeforeClaim = vi.fn().mockImplementation((_tx, occ: unknown) => {
+                const o = occ as { externalPlanRef?: { planId: string } };
+                if (o.externalPlanRef) o.externalPlanRef.planId = 'tampered';
+            });
+
+            const service = new SessionOccurrenceService();
+            const result = await service.claimOccurrenceLaunch('u1', 'occ-ext-1', {
+                now: '2026-08-18T10:00:00Z',
+                onBeforeClaim,
+            });
+
+            expect(result.state).toBe('active');
+            expect((result as ExternalPlanSessionOccurrence).externalPlanRef.planId).toBe('p-1');
+            expect('definitionRef' in result).toBe(false);
+            expect(mockTx.set).toHaveBeenCalledWith(
+                expect.anything(),
+                expect.objectContaining({
+                    state: 'active',
+                    externalPlanRef: expect.objectContaining({ planId: 'p-1' }),
+                }),
+            );
+        });
+    });
+
+    describe('External-plan occurrence management (Issue #434 PR 2)', () => {
+        const extPlanRef = { planId: 'p-1', revision: 1, sessionId: 's-1', contentHash: 'c'.repeat(64) };
+
+        it('scheduleExternalPlanOccurrence persists with external_plan authority and scheduled state', async () => {
+            const service = new SessionOccurrenceService();
+            const result = await service.scheduleExternalPlanOccurrence('u1', '2026-08-18', extPlanRef, 1);
+
+            expect(result.authority).toBe('external_plan');
+            expect(result.state).toBe('scheduled');
+            expect(result.externalPlanRef).toEqual(extPlanRef);
+            expect(result.placementOrder).toBe(1);
+            expect(firestore.setDoc).toHaveBeenCalledWith(
+                expect.anything(),
+                expect.objectContaining({
+                    authority: 'external_plan',
+                    state: 'scheduled',
+                    externalPlanRef: extPlanRef,
+                }),
+            );
+        });
+
+        it('getOrCreateExternalPlanOccurrence returns existing occurrence if one already exists for (planId, sessionId)', async () => {
+            const existing = {
+                userId: 'u1',
+                occurrenceId: 'occ-ext-existing',
+                date: '2026-08-18',
+                authority: 'external_plan' as const,
+                externalPlanRef: extPlanRef,
+                state: 'active' as const,
+                createdAt: '2026-08-18T00:00:00Z',
+                updatedAt: '2026-08-18T00:00:00Z',
+            };
+            firestore.getDocs.mockResolvedValue({
+                docs: [{ data: () => existing, ref: { path: 'x' } }],
+            });
+
+            const service = new SessionOccurrenceService();
+            const result = await service.getOrCreateExternalPlanOccurrence('u1', '2026-08-18', extPlanRef);
+
+            expect(result.occurrenceId).toBe('occ-ext-existing');
+            expect(result.state).toBe('active');
+            expect(firestore.setDoc).not.toHaveBeenCalled();
+        });
+
+        it('getOrCreateExternalPlanOccurrence creates a new occurrence if none exists', async () => {
+            firestore.getDocs.mockResolvedValue({ docs: [] });
+
+            const service = new SessionOccurrenceService();
+            const result = await service.getOrCreateExternalPlanOccurrence('u1', '2026-08-18', extPlanRef);
+
+            expect(result.authority).toBe('external_plan');
+            expect(result.state).toBe('scheduled');
+            expect(firestore.setDoc).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('transitionOccurrenceState (lifecycle)', () => {
+        it('transitions active occurrence to completed', async () => {
+            const active = occurrenceDoc({ occurrenceId: 'occ-1', state: 'active' });
+            const mockTx = {
+                get: vi.fn().mockResolvedValue({
+                    exists: () => true,
+                    data: () => active,
+                }),
+                set: vi.fn(),
+            };
+            firestore.runTransaction.mockImplementation(async (_db, cb) => cb(mockTx));
+
+            const service = new SessionOccurrenceService();
+            const result = await service.transitionOccurrenceState('u1', 'occ-1', 'completed', '2026-08-18T11:00:00Z');
+
+            expect(result.state).toBe('completed');
+            expect(result.updatedAt).toBe('2026-08-18T11:00:00Z');
+            expect(mockTx.set).toHaveBeenCalledWith(
+                expect.anything(),
+                expect.objectContaining({ state: 'completed', updatedAt: '2026-08-18T11:00:00Z' }),
+            );
+        });
+
+        it('transitions scheduled occurrence to skipped', async () => {
+            const scheduled = occurrenceDoc({ occurrenceId: 'occ-1', state: 'scheduled' });
+            const mockTx = {
+                get: vi.fn().mockResolvedValue({
+                    exists: () => true,
+                    data: () => scheduled,
+                }),
+                set: vi.fn(),
+            };
+            firestore.runTransaction.mockImplementation(async (_db, cb) => cb(mockTx));
+
+            const service = new SessionOccurrenceService();
+            const result = await service.transitionOccurrenceState('u1', 'occ-1', 'skipped');
+
+            expect(result.state).toBe('skipped');
+            expect(mockTx.set).toHaveBeenCalledWith(
+                expect.anything(),
+                expect.objectContaining({ state: 'skipped' }),
+            );
+        });
+
+        it('no-ops when occurrence is already in the target state', async () => {
+            const active = occurrenceDoc({ occurrenceId: 'occ-1', state: 'active' });
+            const mockTx = {
+                get: vi.fn().mockResolvedValue({
+                    exists: () => true,
+                    data: () => active,
+                }),
+                set: vi.fn(),
+            };
+            firestore.runTransaction.mockImplementation(async (_db, cb) => cb(mockTx));
+
+            const service = new SessionOccurrenceService();
+            const result = await service.transitionOccurrenceState('u1', 'occ-1', 'active');
+
+            expect(result.state).toBe('active');
+            expect(mockTx.set).not.toHaveBeenCalled();
+        });
+
+        it('throws when transitioning from a terminal state', async () => {
+            const completed = occurrenceDoc({ occurrenceId: 'occ-1', state: 'completed' });
+            const mockTx = {
+                get: vi.fn().mockResolvedValue({
+                    exists: () => true,
+                    data: () => completed,
+                }),
+                set: vi.fn(),
+            };
+            firestore.runTransaction.mockImplementation(async (_db, cb) => cb(mockTx));
+
+            const service = new SessionOccurrenceService();
+            await expect(
+                service.transitionOccurrenceState('u1', 'occ-1', 'active'),
+            ).rejects.toThrow("Cannot transition occurrence occ-1 from terminal state 'completed' to 'active'.");
+
+            expect(mockTx.set).not.toHaveBeenCalled();
         });
     });
 });

--- a/app/src/services/sessionOccurrenceService.test.ts
+++ b/app/src/services/sessionOccurrenceService.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { WriteBatch } from 'firebase/firestore';
 import type { ExternalPlanSessionOccurrence, ManualOccurrenceRef, SessionOccurrence } from '../sessions/models';
 
 const firestore = vi.hoisted(() => ({
@@ -350,7 +351,7 @@ describe('SessionOccurrenceService authority methods (M3.3)', () => {
             );
         });
 
-        it('getOrCreateExternalPlanOccurrence returns existing occurrence if one already exists for (planId, sessionId)', async () => {
+        it('getOrCreateExternalPlanOccurrence returns existing occurrence if full source identity matches', async () => {
             const existing = {
                 userId: 'u1',
                 occurrenceId: 'occ-ext-existing',
@@ -373,7 +374,32 @@ describe('SessionOccurrenceService authority methods (M3.3)', () => {
             expect(firestore.setDoc).not.toHaveBeenCalled();
         });
 
-        it('getOrCreateExternalPlanOccurrence creates a new occurrence if none exists', async () => {
+        it('getOrCreateExternalPlanOccurrence creates new occurrence if revision or contentHash differs', async () => {
+            const existingRev1 = {
+                userId: 'u1',
+                occurrenceId: 'occ-ext-rev-1',
+                date: '2026-08-18',
+                authority: 'external_plan' as const,
+                externalPlanRef: extPlanRef,
+                state: 'completed' as const,
+                createdAt: '2026-08-18T00:00:00Z',
+                updatedAt: '2026-08-18T00:00:00Z',
+            };
+            firestore.getDocs.mockResolvedValue({
+                docs: [{ data: () => existingRev1, ref: { path: 'x' } }],
+            });
+
+            const revisedPlanRef = { ...extPlanRef, revision: 2, contentHash: 'd'.repeat(64) };
+            const service = new SessionOccurrenceService();
+            const result = await service.getOrCreateExternalPlanOccurrence('u1', '2026-08-18', revisedPlanRef);
+
+            expect(result.occurrenceId).not.toBe('occ-ext-rev-1');
+            expect(result.occurrenceId).toContain('ext_2026-08-18_p-1_s-1_r2');
+            expect(result.state).toBe('scheduled');
+            expect(firestore.setDoc).toHaveBeenCalledTimes(1);
+        });
+
+        it('getOrCreateExternalPlanOccurrence creates a new occurrence with deterministic ID if none exists', async () => {
             firestore.getDocs.mockResolvedValue({ docs: [] });
 
             const service = new SessionOccurrenceService();
@@ -381,6 +407,7 @@ describe('SessionOccurrenceService authority methods (M3.3)', () => {
 
             expect(result.authority).toBe('external_plan');
             expect(result.state).toBe('scheduled');
+            expect(result.occurrenceId).toContain('ext_2026-08-18_p-1_s-1_r1');
             expect(firestore.setDoc).toHaveBeenCalledTimes(1);
         });
     });
@@ -447,6 +474,29 @@ describe('SessionOccurrenceService authority methods (M3.3)', () => {
             expect(mockTx.set).not.toHaveBeenCalled();
         });
 
+        it('throws when attempting an illegal transition (e.g. scheduled to completed, active to scheduled)', async () => {
+            const scheduled = occurrenceDoc({ occurrenceId: 'occ-1', state: 'scheduled' });
+            const mockTx = {
+                get: vi.fn().mockResolvedValue({
+                    exists: () => true,
+                    data: () => scheduled,
+                }),
+                set: vi.fn(),
+            };
+            firestore.runTransaction.mockImplementation(async (_db, cb) => cb(mockTx));
+
+            const service = new SessionOccurrenceService();
+            await expect(
+                service.transitionOccurrenceState('u1', 'occ-1', 'completed'),
+            ).rejects.toThrow("Cannot transition occurrence occ-1 from 'scheduled' to 'completed'.");
+
+            const active = occurrenceDoc({ occurrenceId: 'occ-2', state: 'active' });
+            mockTx.get.mockResolvedValue({ exists: () => true, data: () => active });
+            await expect(
+                service.transitionOccurrenceState('u1', 'occ-2', 'scheduled'),
+            ).rejects.toThrow("Cannot transition occurrence occ-2 from 'active' to 'scheduled'.");
+        });
+
         it('throws when transitioning from a terminal state', async () => {
             const completed = occurrenceDoc({ occurrenceId: 'occ-1', state: 'completed' });
             const mockTx = {
@@ -461,9 +511,29 @@ describe('SessionOccurrenceService authority methods (M3.3)', () => {
             const service = new SessionOccurrenceService();
             await expect(
                 service.transitionOccurrenceState('u1', 'occ-1', 'active'),
-            ).rejects.toThrow("Cannot transition occurrence occ-1 from terminal state 'completed' to 'active'.");
+            ).rejects.toThrow("Cannot transition occurrence occ-1 from 'completed' to 'active'.");
 
             expect(mockTx.set).not.toHaveBeenCalled();
+        });
+
+        it('queueOccurrenceTransition queues state change into batch', async () => {
+            const active = occurrenceDoc({ occurrenceId: 'occ-1', state: 'active' });
+            firestore.getDoc.mockResolvedValue({
+                exists: () => true,
+                data: () => active,
+            });
+            const mockBatch = {
+                set: vi.fn(),
+            };
+
+            const service = new SessionOccurrenceService();
+            const result = await service.queueOccurrenceTransition('u1', 'occ-1', 'completed', '2026-08-18T12:00:00Z', mockBatch as unknown as WriteBatch);
+
+            expect(result.state).toBe('completed');
+            expect(mockBatch.set).toHaveBeenCalledWith(
+                expect.anything(),
+                expect.objectContaining({ state: 'completed', updatedAt: '2026-08-18T12:00:00Z' }),
+            );
         });
     });
 });

--- a/app/src/services/sessionOccurrenceService.test.ts
+++ b/app/src/services/sessionOccurrenceService.test.ts
@@ -16,7 +16,7 @@ const firestore = vi.hoisted(() => ({
 vi.mock('firebase/firestore', () => firestore);
 vi.mock('../firebase', () => ({ getDb: vi.fn(() => ({})) }));
 
-import { SessionOccurrenceService } from './sessionOccurrenceService';
+import { SessionOccurrenceService, deterministicExternalPlanOccurrenceId } from './sessionOccurrenceService';
 
 const definitionRef: ManualOccurrenceRef = {
     definitionId: 'def-1', revision: 1, contentHash: 'a'.repeat(64),
@@ -351,64 +351,68 @@ describe('SessionOccurrenceService authority methods (M3.3)', () => {
             );
         });
 
-        it('getOrCreateExternalPlanOccurrence returns existing occurrence if full source identity matches', async () => {
+        it('getOrCreateExternalPlanOccurrence returns existing occurrence if document exists at deterministic ID', async () => {
             const existing = {
                 userId: 'u1',
-                occurrenceId: 'occ-ext-existing',
+                occurrenceId: 'ext_2026-08-18_0123456789abcdef01234567',
                 date: '2026-08-18',
                 authority: 'external_plan' as const,
                 externalPlanRef: extPlanRef,
-                state: 'active' as const,
+                state: 'scheduled' as const,
                 createdAt: '2026-08-18T00:00:00Z',
                 updatedAt: '2026-08-18T00:00:00Z',
             };
-            firestore.getDocs.mockResolvedValue({
-                docs: [{ data: () => existing, ref: { path: 'x' } }],
+            firestore.getDoc.mockResolvedValue({
+                exists: () => true,
+                data: () => existing,
+                ref: { path: 'x' },
             });
 
             const service = new SessionOccurrenceService();
             const result = await service.getOrCreateExternalPlanOccurrence('u1', '2026-08-18', extPlanRef);
 
-            expect(result.occurrenceId).toBe('occ-ext-existing');
-            expect(result.state).toBe('active');
+            expect(result.occurrenceId).toBe('ext_2026-08-18_0123456789abcdef01234567');
+            expect(result.state).toBe('scheduled');
             expect(firestore.setDoc).not.toHaveBeenCalled();
         });
 
-        it('getOrCreateExternalPlanOccurrence creates new occurrence if revision or contentHash differs', async () => {
-            const existingRev1 = {
-                userId: 'u1',
-                occurrenceId: 'occ-ext-rev-1',
-                date: '2026-08-18',
-                authority: 'external_plan' as const,
-                externalPlanRef: extPlanRef,
-                state: 'completed' as const,
-                createdAt: '2026-08-18T00:00:00Z',
-                updatedAt: '2026-08-18T00:00:00Z',
-            };
-            firestore.getDocs.mockResolvedValue({
-                docs: [{ data: () => existingRev1, ref: { path: 'x' } }],
-            });
-
-            const revisedPlanRef = { ...extPlanRef, revision: 2, contentHash: 'd'.repeat(64) };
-            const service = new SessionOccurrenceService();
-            const result = await service.getOrCreateExternalPlanOccurrence('u1', '2026-08-18', revisedPlanRef);
-
-            expect(result.occurrenceId).not.toBe('occ-ext-rev-1');
-            expect(result.occurrenceId).toContain('ext_2026-08-18_p-1_s-1_r2');
-            expect(result.state).toBe('scheduled');
-            expect(firestore.setDoc).toHaveBeenCalledTimes(1);
-        });
-
         it('getOrCreateExternalPlanOccurrence creates a new occurrence with deterministic ID if none exists', async () => {
-            firestore.getDocs.mockResolvedValue({ docs: [] });
+            firestore.getDoc.mockResolvedValue({ exists: () => false });
 
             const service = new SessionOccurrenceService();
             const result = await service.getOrCreateExternalPlanOccurrence('u1', '2026-08-18', extPlanRef);
 
             expect(result.authority).toBe('external_plan');
             expect(result.state).toBe('scheduled');
-            expect(result.occurrenceId).toContain('ext_2026-08-18_p-1_s-1_r1');
+            expect(result.occurrenceId).toMatch(/^ext_2026-08-18_[a-f0-9]{24}$/);
             expect(firestore.setDoc).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('deterministicExternalPlanOccurrenceId', () => {
+        it('produces collision-resistant deterministic hex ID without string collapsing', async () => {
+            const id1 = await deterministicExternalPlanOccurrenceId('2026-08-18', {
+                planId: 'plan a',
+                sessionId: 'session b',
+                revision: 1,
+                contentHash: 'a'.repeat(64),
+            });
+            const id2 = await deterministicExternalPlanOccurrenceId('2026-08-18', {
+                planId: 'plan_a',
+                sessionId: 'session_b',
+                revision: 1,
+                contentHash: 'a'.repeat(64),
+            });
+            const id3 = await deterministicExternalPlanOccurrenceId('2026-08-18', {
+                planId: 'plan a',
+                sessionId: 'session b',
+                revision: 1,
+                contentHash: 'a'.repeat(64),
+            });
+
+            expect(id1).toBe(id3);
+            expect(id1).not.toBe(id2);
+            expect(id1).toMatch(/^ext_2026-08-18_[a-f0-9]{24}$/);
         });
     });
 
@@ -432,6 +436,50 @@ describe('SessionOccurrenceService authority methods (M3.3)', () => {
             expect(mockTx.set).toHaveBeenCalledWith(
                 expect.anything(),
                 expect.objectContaining({ state: 'completed', updatedAt: '2026-08-18T11:00:00Z' }),
+            );
+        });
+
+        it('transitions scheduled occurrence to completed (production state before PR 3 claims)', async () => {
+            const scheduled = occurrenceDoc({ occurrenceId: 'occ-1', state: 'scheduled' });
+            const mockTx = {
+                get: vi.fn().mockResolvedValue({
+                    exists: () => true,
+                    data: () => scheduled,
+                }),
+                set: vi.fn(),
+            };
+            firestore.runTransaction.mockImplementation(async (_db, cb) => cb(mockTx));
+
+            const service = new SessionOccurrenceService();
+            const result = await service.transitionOccurrenceState('u1', 'occ-1', 'completed', '2026-08-18T11:00:00Z');
+
+            expect(result.state).toBe('completed');
+            expect(result.updatedAt).toBe('2026-08-18T11:00:00Z');
+            expect(mockTx.set).toHaveBeenCalledWith(
+                expect.anything(),
+                expect.objectContaining({ state: 'completed', updatedAt: '2026-08-18T11:00:00Z' }),
+            );
+        });
+
+        it('transitions scheduled occurrence to abandoned', async () => {
+            const scheduled = occurrenceDoc({ occurrenceId: 'occ-1', state: 'scheduled' });
+            const mockTx = {
+                get: vi.fn().mockResolvedValue({
+                    exists: () => true,
+                    data: () => scheduled,
+                }),
+                set: vi.fn(),
+            };
+            firestore.runTransaction.mockImplementation(async (_db, cb) => cb(mockTx));
+
+            const service = new SessionOccurrenceService();
+            const result = await service.transitionOccurrenceState('u1', 'occ-1', 'abandoned', '2026-08-18T11:00:00Z');
+
+            expect(result.state).toBe('abandoned');
+            expect(result.updatedAt).toBe('2026-08-18T11:00:00Z');
+            expect(mockTx.set).toHaveBeenCalledWith(
+                expect.anything(),
+                expect.objectContaining({ state: 'abandoned', updatedAt: '2026-08-18T11:00:00Z' }),
             );
         });
 
@@ -474,24 +522,15 @@ describe('SessionOccurrenceService authority methods (M3.3)', () => {
             expect(mockTx.set).not.toHaveBeenCalled();
         });
 
-        it('throws when attempting an illegal transition (e.g. scheduled to completed, active to scheduled)', async () => {
-            const scheduled = occurrenceDoc({ occurrenceId: 'occ-1', state: 'scheduled' });
+        it('throws when attempting an illegal transition (e.g. active to scheduled, completed to active)', async () => {
+            const active = occurrenceDoc({ occurrenceId: 'occ-2', state: 'active' });
             const mockTx = {
-                get: vi.fn().mockResolvedValue({
-                    exists: () => true,
-                    data: () => scheduled,
-                }),
+                get: vi.fn().mockResolvedValue({ exists: () => true, data: () => active }),
                 set: vi.fn(),
             };
             firestore.runTransaction.mockImplementation(async (_db, cb) => cb(mockTx));
 
             const service = new SessionOccurrenceService();
-            await expect(
-                service.transitionOccurrenceState('u1', 'occ-1', 'completed'),
-            ).rejects.toThrow("Cannot transition occurrence occ-1 from 'scheduled' to 'completed'.");
-
-            const active = occurrenceDoc({ occurrenceId: 'occ-2', state: 'active' });
-            mockTx.get.mockResolvedValue({ exists: () => true, data: () => active });
             await expect(
                 service.transitionOccurrenceState('u1', 'occ-2', 'scheduled'),
             ).rejects.toThrow("Cannot transition occurrence occ-2 from 'active' to 'scheduled'.");
@@ -516,18 +555,24 @@ describe('SessionOccurrenceService authority methods (M3.3)', () => {
             expect(mockTx.set).not.toHaveBeenCalled();
         });
 
-        it('queueOccurrenceTransition queues state change into batch', async () => {
-            const active = occurrenceDoc({ occurrenceId: 'occ-1', state: 'active' });
+        it('queueOccurrenceTransition queues state change into batch starting from scheduled to completed', async () => {
+            const scheduled = occurrenceDoc({ occurrenceId: 'occ-1', state: 'scheduled' });
             firestore.getDoc.mockResolvedValue({
                 exists: () => true,
-                data: () => active,
+                data: () => scheduled,
             });
             const mockBatch = {
                 set: vi.fn(),
             };
 
             const service = new SessionOccurrenceService();
-            const result = await service.queueOccurrenceTransition('u1', 'occ-1', 'completed', '2026-08-18T12:00:00Z', mockBatch as unknown as WriteBatch);
+            const result = await service.queueOccurrenceTransition(
+                'u1',
+                'occ-1',
+                'completed',
+                mockBatch as unknown as WriteBatch,
+                '2026-08-18T12:00:00Z',
+            );
 
             expect(result.state).toBe('completed');
             expect(mockBatch.set).toHaveBeenCalledWith(

--- a/app/src/services/sessionOccurrenceService.ts
+++ b/app/src/services/sessionOccurrenceService.ts
@@ -14,9 +14,9 @@ import {
 import { getDb } from '../firebase';
 import type { DataState } from '../engine/dataState';
 import {
-    type OccurrenceAuthority,
     type OccurrenceState,
     type SessionOccurrence,
+    type ManualOccurrenceAuthority,
     type ManualOccurrenceRef,
     type ExternalPlanOccurrenceRef,
     type ExternalPlanSessionOccurrence,
@@ -28,9 +28,10 @@ const ACTIVE_OCCURRENCE_STATES: ReadonlySet<SessionOccurrence['state']> = new Se
 
 /**
  * Valid occurrence lifecycle transitions.
- * Scheduled occurrences may be claimed (active), skipped, superseded, or marked missed.
- * Active occurrences may be completed, abandoned, or superseded.
- * Terminal states (completed, abandoned, missed, skipped, superseded) cannot transition to any other state.
+ * Until the PR 3 launch-claim path is wired for every occurrence-backed execution,
+ * a scheduled occurrence may finish directly as completed/abandoned as well as being
+ * claimed (active), skipped, superseded, or marked missed. Once claimed, active
+ * occurrences may be completed, abandoned, or superseded. Terminal states cannot move.
  */
 export const VALID_OCCURRENCE_TRANSITIONS: Record<OccurrenceState, readonly OccurrenceState[]> = {
     scheduled: ['active', 'completed', 'abandoned', 'skipped', 'superseded', 'missed'],
@@ -135,7 +136,7 @@ export class SessionOccurrenceService {
     private async createOccurrence(
         userId: string,
         date: string,
-        authority: OccurrenceAuthority,
+        authority: ManualOccurrenceAuthority,
         definitionRef: ManualOccurrenceRef,
         placementOrder?: number,
         now = new Date().toISOString(),

--- a/app/src/services/sessionOccurrenceService.ts
+++ b/app/src/services/sessionOccurrenceService.ts
@@ -9,6 +9,7 @@ import {
     runTransaction,
     type Firestore,
     type Transaction,
+    type WriteBatch,
 } from 'firebase/firestore';
 import { getDb } from '../firebase';
 import type { DataState } from '../engine/dataState';
@@ -26,14 +27,36 @@ import { parseSessionOccurrenceDocument } from '../persistence/parsers/sessionDe
 /** ACTIVE_OCCURRENCE_STATES excludes terminal/superseded states from "what governs today". */
 const ACTIVE_OCCURRENCE_STATES: ReadonlySet<SessionOccurrence['state']> = new Set(['scheduled', 'active']);
 
-/** TERMINAL_OCCURRENCE_STATES cannot transition to any subsequent state. */
-const TERMINAL_OCCURRENCE_STATES: ReadonlySet<OccurrenceState> = new Set([
-    'completed',
-    'abandoned',
-    'missed',
-    'skipped',
-    'superseded',
-]);
+/**
+ * Valid occurrence lifecycle transitions.
+ * Scheduled occurrences may be claimed (active), skipped, superseded, or marked missed.
+ * Active occurrences may be completed, abandoned, or superseded.
+ * Terminal states (completed, abandoned, missed, skipped, superseded) cannot transition to any other state.
+ */
+export const VALID_OCCURRENCE_TRANSITIONS: Record<OccurrenceState, readonly OccurrenceState[]> = {
+    scheduled: ['active', 'skipped', 'superseded', 'missed'],
+    active: ['completed', 'abandoned', 'superseded'],
+    completed: [],
+    abandoned: [],
+    missed: [],
+    skipped: [],
+    superseded: [],
+};
+
+export function isValidOccurrenceTransition(from: OccurrenceState, to: OccurrenceState): boolean {
+    if (from === to) return true;
+    const allowed = VALID_OCCURRENCE_TRANSITIONS[from];
+    return allowed !== undefined && allowed.includes(to);
+}
+
+/**
+ * Computes a deterministic Firestore document ID for an external-plan occurrence.
+ * Ensures concurrent getOrCreate operations resolve to the exact same document ID.
+ */
+export function deterministicExternalPlanOccurrenceId(date: string, ref: ExternalPlanOccurrenceRef): string {
+    const raw = `ext_${date}_${ref.planId}_${ref.sessionId}_r${ref.revision}_${ref.contentHash.slice(0, 16)}`;
+    return raw.replace(/[^a-zA-Z0-9_.-]/g, '_');
+}
 
 export interface ClaimOccurrenceLaunchOptions {
     now?: string;
@@ -153,10 +176,11 @@ export class SessionOccurrenceService {
         externalPlanRef: ExternalPlanOccurrenceRef,
         placementOrder?: number,
         now = new Date().toISOString(),
+        customOccurrenceId?: string,
     ): Promise<ExternalPlanSessionOccurrence> {
         const occurrence: ExternalPlanSessionOccurrence = {
             userId,
-            occurrenceId: this.newOccurrenceId(),
+            occurrenceId: customOccurrenceId ?? this.newOccurrenceId(),
             date,
             authority: 'external_plan',
             externalPlanRef,
@@ -170,8 +194,8 @@ export class SessionOccurrenceService {
     }
 
     /**
-     * Idempotently retrieves an existing external-plan occurrence for (userId, date, planId, sessionId),
-     * or schedules a new one if not yet present.
+     * Idempotently retrieves an existing external-plan occurrence for (userId, date, planId, sessionId, revision, contentHash),
+     * or schedules a new one with a deterministic occurrenceId if not yet present.
      */
     async getOrCreateExternalPlanOccurrence(
         userId: string,
@@ -184,12 +208,15 @@ export class SessionOccurrenceService {
         const existing = occurrences.find(occ =>
             isExternalPlanOccurrence(occ) &&
             occ.externalPlanRef.planId === externalPlanRef.planId &&
-            occ.externalPlanRef.sessionId === externalPlanRef.sessionId,
+            occ.externalPlanRef.sessionId === externalPlanRef.sessionId &&
+            occ.externalPlanRef.revision === externalPlanRef.revision &&
+            occ.externalPlanRef.contentHash === externalPlanRef.contentHash,
         );
         if (existing) {
             return existing;
         }
-        return this.scheduleExternalPlanOccurrence(userId, date, externalPlanRef, placementOrder, now);
+        const deterministicId = deterministicExternalPlanOccurrenceId(date, externalPlanRef);
+        return this.scheduleExternalPlanOccurrence(userId, date, externalPlanRef, placementOrder, now, deterministicId);
     }
 
     /** The occurrence, if any, currently claiming to replace `date`'s recommendation.
@@ -261,7 +288,7 @@ export class SessionOccurrenceService {
 
     /**
      * Transitions an occurrence state across its lifecycle (e.g. active -> completed, active -> abandoned, scheduled -> skipped).
-     * Prevents invalid transitions from terminal states.
+     * Prevents invalid transitions using the explicit occurrence lifecycle table.
      */
     async transitionOccurrenceState(
         userId: string,
@@ -285,9 +312,9 @@ export class SessionOccurrenceService {
                 transitioned = current;
                 return;
             }
-            if (TERMINAL_OCCURRENCE_STATES.has(current.state)) {
+            if (!isValidOccurrenceTransition(current.state, nextState)) {
                 throw new Error(
-                    `Cannot transition occurrence ${occurrenceId} from terminal state '${current.state}' to '${nextState}'.`,
+                    `Cannot transition occurrence ${occurrenceId} from '${current.state}' to '${nextState}'.`,
                 );
             }
             transitioned = {
@@ -298,6 +325,44 @@ export class SessionOccurrenceService {
             transaction.set(ref, transitioned);
         });
         return transitioned!;
+    }
+
+    /**
+     * Reads the occurrence document, validates the state transition, and queues the state update
+     * into the caller's WriteBatch so that occurrence and execution updates commit atomically.
+     */
+    async queueOccurrenceTransition(
+        userId: string,
+        occurrenceId: string,
+        nextState: OccurrenceState,
+        now = new Date().toISOString(),
+        batch: WriteBatch,
+    ): Promise<SessionOccurrence> {
+        const ref = this.occurrenceRef(userId, occurrenceId);
+        const snap = await getDoc(ref);
+        if (!snap.exists()) {
+            throw new Error(`Occurrence ${occurrenceId} not found.`);
+        }
+        const parsed = parseSessionOccurrenceDocument(snap.data(), ref.path);
+        if (parsed.status !== 'AVAILABLE') {
+            throw new Error(`Occurrence ${occurrenceId} could not be parsed (${parsed.status}).`);
+        }
+        const current = parsed.data;
+        if (current.state === nextState) {
+            return current;
+        }
+        if (!isValidOccurrenceTransition(current.state, nextState)) {
+            throw new Error(
+                `Cannot transition occurrence ${occurrenceId} from '${current.state}' to '${nextState}'.`,
+            );
+        }
+        const transitioned: SessionOccurrence = {
+            ...current,
+            state: nextState,
+            updatedAt: now,
+        } as SessionOccurrence;
+        batch.set(ref, transitioned);
+        return transitioned;
     }
 }
 

--- a/app/src/services/sessionOccurrenceService.ts
+++ b/app/src/services/sessionOccurrenceService.ts
@@ -12,11 +12,28 @@ import {
 } from 'firebase/firestore';
 import { getDb } from '../firebase';
 import type { DataState } from '../engine/dataState';
-import type { OccurrenceAuthority, SessionOccurrence } from '../sessions/models';
+import {
+    type OccurrenceAuthority,
+    type OccurrenceState,
+    type SessionOccurrence,
+    type ManualOccurrenceRef,
+    type ExternalPlanOccurrenceRef,
+    type ExternalPlanSessionOccurrence,
+    isExternalPlanOccurrence,
+} from '../sessions/models';
 import { parseSessionOccurrenceDocument } from '../persistence/parsers/sessionDefinition';
 
 /** ACTIVE_OCCURRENCE_STATES excludes terminal/superseded states from "what governs today". */
 const ACTIVE_OCCURRENCE_STATES: ReadonlySet<SessionOccurrence['state']> = new Set(['scheduled', 'active']);
+
+/** TERMINAL_OCCURRENCE_STATES cannot transition to any subsequent state. */
+const TERMINAL_OCCURRENCE_STATES: ReadonlySet<OccurrenceState> = new Set([
+    'completed',
+    'abandoned',
+    'missed',
+    'skipped',
+    'superseded',
+]);
 
 export interface ClaimOccurrenceLaunchOptions {
     now?: string;
@@ -82,7 +99,7 @@ export class SessionOccurrenceService {
         userId: string,
         date: string,
         authority: OccurrenceAuthority,
-        definitionRef: SessionOccurrence['definitionRef'],
+        definitionRef: ManualOccurrenceRef,
         placementOrder?: number,
         now = new Date().toISOString(),
     ): Promise<SessionOccurrence> {
@@ -101,7 +118,7 @@ export class SessionOccurrenceService {
     async scheduleOccurrence(
         userId: string,
         date: string,
-        definitionRef: SessionOccurrence['definitionRef'],
+        definitionRef: ManualOccurrenceRef,
     ): Promise<SessionOccurrence> {
         return this.createOccurrence(userId, date, 'schedule', definitionRef);
     }
@@ -111,7 +128,7 @@ export class SessionOccurrenceService {
     async replaceRecommendationOccurrence(
         userId: string,
         date: string,
-        definitionRef: SessionOccurrence['definitionRef'],
+        definitionRef: ManualOccurrenceRef,
     ): Promise<SessionOccurrence> {
         return this.createOccurrence(userId, date, 'replace_recommendation', definitionRef);
     }
@@ -121,10 +138,58 @@ export class SessionOccurrenceService {
     async addAdditionalSessionOccurrence(
         userId: string,
         date: string,
-        definitionRef: SessionOccurrence['definitionRef'],
+        definitionRef: ManualOccurrenceRef,
         placementOrder?: number,
     ): Promise<SessionOccurrence> {
         return this.createOccurrence(userId, date, 'additional_session', definitionRef, placementOrder);
+    }
+
+    /**
+     * Schedules an external-plan session occurrence with 'external_plan' authority.
+     */
+    async scheduleExternalPlanOccurrence(
+        userId: string,
+        date: string,
+        externalPlanRef: ExternalPlanOccurrenceRef,
+        placementOrder?: number,
+        now = new Date().toISOString(),
+    ): Promise<ExternalPlanSessionOccurrence> {
+        const occurrence: ExternalPlanSessionOccurrence = {
+            userId,
+            occurrenceId: this.newOccurrenceId(),
+            date,
+            authority: 'external_plan',
+            externalPlanRef,
+            state: 'scheduled',
+            ...(placementOrder !== undefined ? { placementOrder } : {}),
+            createdAt: now,
+            updatedAt: now,
+        };
+        await this.saveOccurrence(occurrence);
+        return occurrence;
+    }
+
+    /**
+     * Idempotently retrieves an existing external-plan occurrence for (userId, date, planId, sessionId),
+     * or schedules a new one if not yet present.
+     */
+    async getOrCreateExternalPlanOccurrence(
+        userId: string,
+        date: string,
+        externalPlanRef: ExternalPlanOccurrenceRef,
+        placementOrder?: number,
+        now = new Date().toISOString(),
+    ): Promise<SessionOccurrence> {
+        const occurrences = await this.getOccurrencesForDate(userId, date);
+        const existing = occurrences.find(occ =>
+            isExternalPlanOccurrence(occ) &&
+            occ.externalPlanRef.planId === externalPlanRef.planId &&
+            occ.externalPlanRef.sessionId === externalPlanRef.sessionId,
+        );
+        if (existing) {
+            return existing;
+        }
+        return this.scheduleExternalPlanOccurrence(userId, date, externalPlanRef, placementOrder, now);
     }
 
     /** The occurrence, if any, currently claiming to replace `date`'s recommendation.
@@ -180,14 +245,56 @@ export class SessionOccurrenceService {
             if (options.onBeforeClaim) {
                 await options.onBeforeClaim(transaction, {
                     ...current,
-                    definitionRef: { ...current.definitionRef },
-                });
+                    ...(current.definitionRef ? { definitionRef: { ...current.definitionRef } } : {}),
+                    ...(current.externalPlanRef ? { externalPlanRef: { ...current.externalPlanRef } } : {}),
+                } as SessionOccurrence);
             }
             transitioned = {
                 ...current,
                 state: 'active',
                 updatedAt: now,
-            };
+            } as SessionOccurrence;
+            transaction.set(ref, transitioned);
+        });
+        return transitioned!;
+    }
+
+    /**
+     * Transitions an occurrence state across its lifecycle (e.g. active -> completed, active -> abandoned, scheduled -> skipped).
+     * Prevents invalid transitions from terminal states.
+     */
+    async transitionOccurrenceState(
+        userId: string,
+        occurrenceId: string,
+        nextState: OccurrenceState,
+        now = new Date().toISOString(),
+    ): Promise<SessionOccurrence> {
+        const ref = this.occurrenceRef(userId, occurrenceId);
+        let transitioned: SessionOccurrence | null = null;
+        await runTransaction(this.db, async transaction => {
+            const snap = await transaction.get(ref);
+            if (!snap.exists()) {
+                throw new Error(`Occurrence ${occurrenceId} not found.`);
+            }
+            const parsed = parseSessionOccurrenceDocument(snap.data(), ref.path);
+            if (parsed.status !== 'AVAILABLE') {
+                throw new Error(`Occurrence ${occurrenceId} could not be parsed (${parsed.status}).`);
+            }
+            const current = parsed.data;
+            if (current.state === nextState) {
+                transitioned = current;
+                return;
+            }
+            if (TERMINAL_OCCURRENCE_STATES.has(current.state)) {
+                throw new Error(
+                    `Cannot transition occurrence ${occurrenceId} from terminal state '${current.state}' to '${nextState}'.`,
+                );
+            }
+            transitioned = {
+                ...current,
+                state: nextState,
+                updatedAt: now,
+            } as SessionOccurrence;
             transaction.set(ref, transitioned);
         });
         return transitioned!;

--- a/app/src/services/sessionOccurrenceService.ts
+++ b/app/src/services/sessionOccurrenceService.ts
@@ -57,7 +57,13 @@ export async function deterministicExternalPlanOccurrenceId(
     date: string,
     ref: ExternalPlanOccurrenceRef,
 ): Promise<string> {
-    const raw = `${date}:${ref.planId}:${ref.sessionId}:${ref.revision}:${ref.contentHash}`;
+    const raw = JSON.stringify([
+        date,
+        ref.planId,
+        ref.sessionId,
+        ref.revision,
+        ref.contentHash,
+    ]);
     const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(raw));
     const hash = Array.from(new Uint8Array(digest))
         .map(byte => byte.toString(16).padStart(2, '0'))
@@ -204,6 +210,7 @@ export class SessionOccurrenceService {
     /**
      * Idempotently retrieves an existing external-plan occurrence for (userId, date, planId, sessionId, revision, contentHash),
      * or schedules a new one with a deterministic occurrenceId if not yet present.
+     * Transactionally reads and creates to prevent concurrent double-creations and permission errors on Firestore updates.
      */
     async getOrCreateExternalPlanOccurrence(
         userId: string,
@@ -214,15 +221,32 @@ export class SessionOccurrenceService {
     ): Promise<SessionOccurrence> {
         const deterministicId = await deterministicExternalPlanOccurrenceId(date, externalPlanRef);
         const ref = this.occurrenceRef(userId, deterministicId);
-        const snap = await getDoc(ref);
-        if (snap.exists()) {
-            const parsed = parseSessionOccurrenceDocument(snap.data(), ref.path);
-            if (parsed.status !== 'AVAILABLE') {
-                throw new Error(`External plan occurrence ${deterministicId} exists but could not be parsed (${parsed.status}).`);
+        let result: SessionOccurrence | null = null;
+        await runTransaction(this.db, async transaction => {
+            const snap = await transaction.get(ref);
+            if (snap.exists()) {
+                const parsed = parseSessionOccurrenceDocument(snap.data(), ref.path);
+                if (parsed.status !== 'AVAILABLE') {
+                    throw new Error(`External plan occurrence ${deterministicId} exists but could not be parsed (${parsed.status}).`);
+                }
+                result = parsed.data;
+                return;
             }
-            return parsed.data;
-        }
-        return this.scheduleExternalPlanOccurrence(userId, date, externalPlanRef, placementOrder, now, deterministicId);
+            const occurrence: ExternalPlanSessionOccurrence = {
+                userId,
+                occurrenceId: deterministicId,
+                date,
+                authority: 'external_plan',
+                externalPlanRef,
+                state: 'scheduled',
+                ...(placementOrder !== undefined ? { placementOrder } : {}),
+                createdAt: now,
+                updatedAt: now,
+            };
+            transaction.set(ref, occurrence);
+            result = occurrence;
+        });
+        return result!;
     }
 
     /** The occurrence, if any, currently claiming to replace `date`'s recommendation.

--- a/app/src/services/sessionOccurrenceService.ts
+++ b/app/src/services/sessionOccurrenceService.ts
@@ -20,7 +20,6 @@ import {
     type ManualOccurrenceRef,
     type ExternalPlanOccurrenceRef,
     type ExternalPlanSessionOccurrence,
-    isExternalPlanOccurrence,
 } from '../sessions/models';
 import { parseSessionOccurrenceDocument } from '../persistence/parsers/sessionDefinition';
 
@@ -34,7 +33,7 @@ const ACTIVE_OCCURRENCE_STATES: ReadonlySet<SessionOccurrence['state']> = new Se
  * Terminal states (completed, abandoned, missed, skipped, superseded) cannot transition to any other state.
  */
 export const VALID_OCCURRENCE_TRANSITIONS: Record<OccurrenceState, readonly OccurrenceState[]> = {
-    scheduled: ['active', 'skipped', 'superseded', 'missed'],
+    scheduled: ['active', 'completed', 'abandoned', 'skipped', 'superseded', 'missed'],
     active: ['completed', 'abandoned', 'superseded'],
     completed: [],
     abandoned: [],
@@ -50,12 +49,21 @@ export function isValidOccurrenceTransition(from: OccurrenceState, to: Occurrenc
 }
 
 /**
- * Computes a deterministic Firestore document ID for an external-plan occurrence.
- * Ensures concurrent getOrCreate operations resolve to the exact same document ID.
+ * Computes a deterministic Firestore document ID for an external-plan occurrence using SHA-256.
+ * Ensures concurrent getOrCreate operations resolve to the exact same document ID without
+ * character replacement collisions or reserved Firestore identifier issues.
  */
-export function deterministicExternalPlanOccurrenceId(date: string, ref: ExternalPlanOccurrenceRef): string {
-    const raw = `ext_${date}_${ref.planId}_${ref.sessionId}_r${ref.revision}_${ref.contentHash.slice(0, 16)}`;
-    return raw.replace(/[^a-zA-Z0-9_.-]/g, '_');
+export async function deterministicExternalPlanOccurrenceId(
+    date: string,
+    ref: ExternalPlanOccurrenceRef,
+): Promise<string> {
+    const raw = `${date}:${ref.planId}:${ref.sessionId}:${ref.revision}:${ref.contentHash}`;
+    const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(raw));
+    const hash = Array.from(new Uint8Array(digest))
+        .map(byte => byte.toString(16).padStart(2, '0'))
+        .join('')
+        .slice(0, 24);
+    return `ext_${date}_${hash}`;
 }
 
 export interface ClaimOccurrenceLaunchOptions {
@@ -204,18 +212,16 @@ export class SessionOccurrenceService {
         placementOrder?: number,
         now = new Date().toISOString(),
     ): Promise<SessionOccurrence> {
-        const occurrences = await this.getOccurrencesForDate(userId, date);
-        const existing = occurrences.find(occ =>
-            isExternalPlanOccurrence(occ) &&
-            occ.externalPlanRef.planId === externalPlanRef.planId &&
-            occ.externalPlanRef.sessionId === externalPlanRef.sessionId &&
-            occ.externalPlanRef.revision === externalPlanRef.revision &&
-            occ.externalPlanRef.contentHash === externalPlanRef.contentHash,
-        );
-        if (existing) {
-            return existing;
+        const deterministicId = await deterministicExternalPlanOccurrenceId(date, externalPlanRef);
+        const ref = this.occurrenceRef(userId, deterministicId);
+        const snap = await getDoc(ref);
+        if (snap.exists()) {
+            const parsed = parseSessionOccurrenceDocument(snap.data(), ref.path);
+            if (parsed.status !== 'AVAILABLE') {
+                throw new Error(`External plan occurrence ${deterministicId} exists but could not be parsed (${parsed.status}).`);
+            }
+            return parsed.data;
         }
-        const deterministicId = deterministicExternalPlanOccurrenceId(date, externalPlanRef);
         return this.scheduleExternalPlanOccurrence(userId, date, externalPlanRef, placementOrder, now, deterministicId);
     }
 
@@ -287,7 +293,7 @@ export class SessionOccurrenceService {
     }
 
     /**
-     * Transitions an occurrence state across its lifecycle (e.g. active -> completed, active -> abandoned, scheduled -> skipped).
+     * Transitions an occurrence state across its lifecycle (e.g. scheduled -> completed, active -> completed, active -> abandoned, scheduled -> skipped).
      * Prevents invalid transitions using the explicit occurrence lifecycle table.
      */
     async transitionOccurrenceState(
@@ -335,8 +341,8 @@ export class SessionOccurrenceService {
         userId: string,
         occurrenceId: string,
         nextState: OccurrenceState,
-        now = new Date().toISOString(),
         batch: WriteBatch,
+        now = new Date().toISOString(),
     ): Promise<SessionOccurrence> {
         const ref = this.occurrenceRef(userId, occurrenceId);
         const snap = await getDoc(ref);

--- a/app/src/sessions/models.ts
+++ b/app/src/sessions/models.ts
@@ -216,7 +216,8 @@ export type OccurrenceAuthority =
     | 'unplanned_log'
     | 'schedule'
     | 'replace_recommendation'
-    | 'additional_session';
+    | 'additional_session'
+    | 'external_plan';
 
 export type OccurrenceState =
     | 'scheduled'
@@ -224,22 +225,51 @@ export type OccurrenceState =
     | 'superseded'
     | 'completed'
     | 'abandoned'
-    | 'missed';
+    | 'missed'
+    | 'skipped';
 
-export interface SessionOccurrence {
+export interface ManualOccurrenceRef {
+    definitionId: string;
+    revision: number;
+    contentHash: string;
+}
+
+export interface ExternalPlanOccurrenceRef {
+    planId: string;
+    revision: number;
+    sessionId: string;
+    contentHash: string;
+}
+
+export interface BaseSessionOccurrence {
     userId: string;
     occurrenceId: string;
     date: string;
     authority: OccurrenceAuthority;
-    definitionRef: {
-        definitionId: string;
-        revision: number;
-        contentHash: string;
-    };
     state: OccurrenceState;
     placementOrder?: number;
     createdAt: string;
     updatedAt: string;
+}
+
+export interface ManualSessionOccurrence extends BaseSessionOccurrence {
+    definitionRef: ManualOccurrenceRef;
+    externalPlanRef?: never;
+}
+
+export interface ExternalPlanSessionOccurrence extends BaseSessionOccurrence {
+    externalPlanRef: ExternalPlanOccurrenceRef;
+    definitionRef?: never;
+}
+
+export type SessionOccurrence = ManualSessionOccurrence | ExternalPlanSessionOccurrence;
+
+export function isManualOccurrence(occurrence: SessionOccurrence): occurrence is ManualSessionOccurrence {
+    return 'definitionRef' in occurrence && occurrence.definitionRef !== undefined;
+}
+
+export function isExternalPlanOccurrence(occurrence: SessionOccurrence): occurrence is ExternalPlanSessionOccurrence {
+    return 'externalPlanRef' in occurrence && occurrence.externalPlanRef !== undefined;
 }
 
 /**

--- a/app/src/sessions/models.ts
+++ b/app/src/sessions/models.ts
@@ -265,11 +265,15 @@ export interface ExternalPlanSessionOccurrence extends BaseSessionOccurrence {
 export type SessionOccurrence = ManualSessionOccurrence | ExternalPlanSessionOccurrence;
 
 export function isManualOccurrence(occurrence: SessionOccurrence): occurrence is ManualSessionOccurrence {
-    return 'definitionRef' in occurrence && occurrence.definitionRef !== undefined;
+    return 'definitionRef' in occurrence
+        && occurrence.definitionRef !== null
+        && typeof occurrence.definitionRef === 'object';
 }
 
 export function isExternalPlanOccurrence(occurrence: SessionOccurrence): occurrence is ExternalPlanSessionOccurrence {
-    return 'externalPlanRef' in occurrence && occurrence.externalPlanRef !== undefined;
+    return 'externalPlanRef' in occurrence
+        && occurrence.externalPlanRef !== null
+        && typeof occurrence.externalPlanRef === 'object';
 }
 
 /**

--- a/app/src/sessions/models.ts
+++ b/app/src/sessions/models.ts
@@ -219,6 +219,8 @@ export type OccurrenceAuthority =
     | 'additional_session'
     | 'external_plan';
 
+export type ManualOccurrenceAuthority = Exclude<OccurrenceAuthority, 'external_plan'>;
+
 export type OccurrenceState =
     | 'scheduled'
     | 'active'
@@ -253,11 +255,13 @@ export interface BaseSessionOccurrence {
 }
 
 export interface ManualSessionOccurrence extends BaseSessionOccurrence {
+    authority: ManualOccurrenceAuthority;
     definitionRef: ManualOccurrenceRef;
     externalPlanRef?: never;
 }
 
 export interface ExternalPlanSessionOccurrence extends BaseSessionOccurrence {
+    authority: 'external_plan';
     externalPlanRef: ExternalPlanOccurrenceRef;
     definitionRef?: never;
 }
@@ -265,13 +269,15 @@ export interface ExternalPlanSessionOccurrence extends BaseSessionOccurrence {
 export type SessionOccurrence = ManualSessionOccurrence | ExternalPlanSessionOccurrence;
 
 export function isManualOccurrence(occurrence: SessionOccurrence): occurrence is ManualSessionOccurrence {
-    return 'definitionRef' in occurrence
+    return occurrence.authority !== 'external_plan'
+        && 'definitionRef' in occurrence
         && occurrence.definitionRef !== null
         && typeof occurrence.definitionRef === 'object';
 }
 
 export function isExternalPlanOccurrence(occurrence: SessionOccurrence): occurrence is ExternalPlanSessionOccurrence {
-    return 'externalPlanRef' in occurrence
+    return occurrence.authority === 'external_plan'
+        && 'externalPlanRef' in occurrence
         && occurrence.externalPlanRef !== null
         && typeof occurrence.externalPlanRef === 'object';
 }

--- a/app/src/sessions/validation.test.ts
+++ b/app/src/sessions/validation.test.ts
@@ -9,6 +9,7 @@ import {
     validateSessionEntry,
     validateSessionRestEvent,
 } from './validation';
+import { isManualOccurrence, isExternalPlanOccurrence, type SessionOccurrence } from './models';
 
 const FIXTURES_DIR = join(dirname(fileURLToPath(import.meta.url)), 'fixtures');
 const INVALID_CASES_PATH = join(FIXTURES_DIR, 'invalid', 'invalid-cases.json');
@@ -167,6 +168,94 @@ describe('Session Validation (M2.1 / ADR-0023)', () => {
             expect(result.ok).toBe(false);
             if (result.ok) throw new Error('Expected invalid occurrence');
             expect(result.issues.map(issue => issue.path)).toContain('externalPlanRef');
+        });
+
+        it('rejects null definitionRef or externalPlanRef', () => {
+            const nullDef = {
+                userId: 'user-1',
+                occurrenceId: 'occ-1',
+                date: '2026-08-18',
+                authority: 'schedule',
+                state: 'scheduled',
+                definitionRef: null,
+                createdAt: '2026-08-18T10:00:00Z',
+                updatedAt: '2026-08-18T10:00:00Z',
+            };
+            expect(validateSessionOccurrence(nullDef).ok).toBe(false);
+
+            const nullExt = {
+                userId: 'user-1',
+                occurrenceId: 'occ-1',
+                date: '2026-08-18',
+                authority: 'external_plan',
+                state: 'scheduled',
+                externalPlanRef: null,
+                createdAt: '2026-08-18T10:00:00Z',
+                updatedAt: '2026-08-18T10:00:00Z',
+            };
+            expect(validateSessionOccurrence(nullExt).ok).toBe(false);
+        });
+
+        it('enforces authority and reference pairing', () => {
+            // externalPlanRef with non-external_plan authority is rejected
+            const extWithReplace = {
+                userId: 'user-1',
+                occurrenceId: 'occ-1',
+                date: '2026-08-18',
+                authority: 'replace_recommendation',
+                state: 'scheduled',
+                externalPlanRef: { planId: 'p-1', revision: 1, sessionId: 's-1', contentHash: 'c'.repeat(64) },
+                createdAt: '2026-08-18T10:00:00Z',
+                updatedAt: '2026-08-18T10:00:00Z',
+            };
+            const res1 = validateSessionOccurrence(extWithReplace);
+            expect(res1.ok).toBe(false);
+            if (!res1.ok) {
+                expect(res1.issues.map(i => i.path)).toContain('authority');
+            }
+
+            // definitionRef with external_plan authority is rejected
+            const defWithExtPlan = {
+                userId: 'user-1',
+                occurrenceId: 'occ-1',
+                date: '2026-08-18',
+                authority: 'external_plan',
+                state: 'scheduled',
+                definitionRef: { definitionId: 'def-1', revision: 1, contentHash: 'c'.repeat(64) },
+                createdAt: '2026-08-18T10:00:00Z',
+                updatedAt: '2026-08-18T10:00:00Z',
+            };
+            const res2 = validateSessionOccurrence(defWithExtPlan);
+            expect(res2.ok).toBe(false);
+            if (!res2.ok) {
+                expect(res2.issues.map(i => i.path)).toContain('authority');
+            }
+        });
+
+        it('isManualOccurrence and isExternalPlanOccurrence type guards reject null references', () => {
+            const malformedDef = {
+                userId: 'user-1',
+                occurrenceId: 'occ-1',
+                date: '2026-08-18',
+                authority: 'schedule' as const,
+                state: 'scheduled' as const,
+                definitionRef: null,
+                createdAt: '2026-08-18T10:00:00Z',
+                updatedAt: '2026-08-18T10:00:00Z',
+            } as unknown as SessionOccurrence;
+            expect(isManualOccurrence(malformedDef)).toBe(false);
+
+            const malformedExt = {
+                userId: 'user-1',
+                occurrenceId: 'occ-1',
+                date: '2026-08-18',
+                authority: 'external_plan' as const,
+                state: 'scheduled' as const,
+                externalPlanRef: null,
+                createdAt: '2026-08-18T10:00:00Z',
+                updatedAt: '2026-08-18T10:00:00Z',
+            } as unknown as SessionOccurrence;
+            expect(isExternalPlanOccurrence(malformedExt)).toBe(false);
         });
     });
 

--- a/app/src/sessions/validation.test.ts
+++ b/app/src/sessions/validation.test.ts
@@ -93,15 +93,80 @@ describe('Session Validation (M2.1 / ADR-0023)', () => {
             expect(result.ok).toBe(false);
         });
 
-        it('rejects impossible calendar dates and incomplete definition references', () => {
+        it('accepts valid external_plan occurrence with externalPlanRef and authority', () => {
+            const valid = {
+                userId: 'user-1',
+                occurrenceId: 'occ-ext-1',
+                date: '2026-08-18',
+                authority: 'external_plan',
+                externalPlanRef: {
+                    planId: 'plan-1',
+                    revision: 1,
+                    sessionId: 'session-1',
+                    contentHash: 'a'.repeat(64),
+                },
+                state: 'scheduled',
+                createdAt: '2026-08-18T10:00:00Z',
+                updatedAt: '2026-08-18T10:00:00Z',
+            };
+            const result = validateSessionOccurrence(valid);
+            expect(result.ok).toBe(true);
+        });
+
+        it('accepts occurrence with skipped state', () => {
+            const valid = {
+                userId: 'user-1',
+                occurrenceId: 'occ-ext-1',
+                date: '2026-08-18',
+                authority: 'external_plan',
+                externalPlanRef: {
+                    planId: 'plan-1',
+                    revision: 1,
+                    sessionId: 'session-1',
+                    contentHash: 'a'.repeat(64),
+                },
+                state: 'skipped',
+                createdAt: '2026-08-18T10:00:00Z',
+                updatedAt: '2026-08-18T10:00:00Z',
+            };
+            const result = validateSessionOccurrence(valid);
+            expect(result.ok).toBe(true);
+        });
+
+        it('rejects occurrence when neither or both definitionRef and externalPlanRef are provided', () => {
+            const neither = {
+                userId: 'user-1',
+                occurrenceId: 'occ-1',
+                date: '2026-08-18',
+                authority: 'schedule',
+                state: 'scheduled',
+                createdAt: '2026-08-18T10:00:00Z',
+                updatedAt: '2026-08-18T10:00:00Z',
+            };
+            expect(validateSessionOccurrence(neither).ok).toBe(false);
+
+            const both = {
+                ...neither,
+                definitionRef: { definitionId: 'def-1', revision: 1, contentHash: 'a'.repeat(64) },
+                externalPlanRef: { planId: 'plan-1', revision: 1, sessionId: 's-1', contentHash: 'b'.repeat(64) },
+            };
+            expect(validateSessionOccurrence(both).ok).toBe(false);
+        });
+
+        it('rejects invalid externalPlanRef fields', () => {
             const result = validateSessionOccurrence({
-                userId: 'user-1', occurrenceId: 'occ-1', date: '2026-02-30',
-                authority: 'unplanned_log', state: 'scheduled',
-                definitionRef: { definitionId: 'def-1', revision: 0, contentHash: '' },
+                userId: 'user-1',
+                occurrenceId: 'occ-1',
+                date: '2026-08-18',
+                authority: 'external_plan',
+                state: 'scheduled',
+                externalPlanRef: { planId: '', revision: 0, sessionId: '', contentHash: '' },
+                createdAt: '2026-08-18T10:00:00Z',
+                updatedAt: '2026-08-18T10:00:00Z',
             });
             expect(result.ok).toBe(false);
             if (result.ok) throw new Error('Expected invalid occurrence');
-            expect(result.issues.map(issue => issue.path)).toEqual(expect.arrayContaining(['date', 'definitionRef']));
+            expect(result.issues.map(issue => issue.path)).toContain('externalPlanRef');
         });
     });
 

--- a/app/src/sessions/validation.ts
+++ b/app/src/sessions/validation.ts
@@ -438,17 +438,39 @@ export function validateSessionOccurrence(raw: unknown): ValidationResult<Sessio
     if (!isValidWarsawCalendarDate(raw.date)) {
         issues.push({ path: 'date', message: 'date must be Warsaw YYYY-MM-DD string' });
     }
-    if (!['unplanned_log', 'schedule', 'replace_recommendation', 'additional_session'].includes(String(raw.authority))) {
+    if (!['unplanned_log', 'schedule', 'replace_recommendation', 'additional_session', 'external_plan'].includes(String(raw.authority))) {
         issues.push({ path: 'authority', message: `Invalid authority: ${String(raw.authority)}` });
     }
-    if (!['scheduled', 'active', 'superseded', 'completed', 'abandoned', 'missed'].includes(String(raw.state))) {
+    if (!['scheduled', 'active', 'superseded', 'completed', 'abandoned', 'missed', 'skipped'].includes(String(raw.state))) {
         issues.push({ path: 'state', message: `Invalid state: ${String(raw.state)}` });
     }
-    if (!isObject(raw.definitionRef)
-        || typeof raw.definitionRef.definitionId !== 'string' || raw.definitionRef.definitionId.length === 0
-        || typeof raw.definitionRef.revision !== 'number' || !Number.isInteger(raw.definitionRef.revision) || raw.definitionRef.revision < 1
-        || typeof raw.definitionRef.contentHash !== 'string' || raw.definitionRef.contentHash.length === 0) {
-        issues.push({ path: 'definitionRef', message: 'Invalid definitionRef' });
+
+    const hasDefinitionRef = isObject(raw.definitionRef);
+    const hasExternalPlanRef = isObject(raw.externalPlanRef);
+
+    if (!hasDefinitionRef && !hasExternalPlanRef) {
+        issues.push({ path: 'ref', message: 'Session occurrence must have either definitionRef or externalPlanRef' });
+    } else if (hasDefinitionRef && hasExternalPlanRef) {
+        issues.push({ path: 'ref', message: 'Session occurrence cannot have both definitionRef and externalPlanRef' });
+    } else if (hasDefinitionRef) {
+        const def = raw.definitionRef as Record<string, unknown>;
+        if (
+            typeof def.definitionId !== 'string' || def.definitionId.length === 0
+            || typeof def.revision !== 'number' || !Number.isInteger(def.revision) || def.revision < 1
+            || typeof def.contentHash !== 'string' || def.contentHash.length === 0
+        ) {
+            issues.push({ path: 'definitionRef', message: 'Invalid definitionRef' });
+        }
+    } else if (hasExternalPlanRef) {
+        const ext = raw.externalPlanRef as Record<string, unknown>;
+        if (
+            typeof ext.planId !== 'string' || ext.planId.length === 0
+            || typeof ext.revision !== 'number' || !Number.isInteger(ext.revision) || ext.revision < 1
+            || typeof ext.sessionId !== 'string' || ext.sessionId.length === 0
+            || typeof ext.contentHash !== 'string' || ext.contentHash.length === 0
+        ) {
+            issues.push({ path: 'externalPlanRef', message: 'Invalid externalPlanRef' });
+        }
     }
 
     if (issues.length > 0) return { ok: false, issues };

--- a/app/src/sessions/validation.ts
+++ b/app/src/sessions/validation.ts
@@ -445,6 +445,13 @@ export function validateSessionOccurrence(raw: unknown): ValidationResult<Sessio
         issues.push({ path: 'state', message: `Invalid state: ${String(raw.state)}` });
     }
 
+    if ('definitionRef' in raw && raw.definitionRef !== undefined && !isObject(raw.definitionRef)) {
+        issues.push({ path: 'definitionRef', message: 'Invalid definitionRef' });
+    }
+    if ('externalPlanRef' in raw && raw.externalPlanRef !== undefined && !isObject(raw.externalPlanRef)) {
+        issues.push({ path: 'externalPlanRef', message: 'Invalid externalPlanRef' });
+    }
+
     const hasDefinitionRef = isObject(raw.definitionRef);
     const hasExternalPlanRef = isObject(raw.externalPlanRef);
 
@@ -453,6 +460,9 @@ export function validateSessionOccurrence(raw: unknown): ValidationResult<Sessio
     } else if (hasDefinitionRef && hasExternalPlanRef) {
         issues.push({ path: 'ref', message: 'Session occurrence cannot have both definitionRef and externalPlanRef' });
     } else if (hasDefinitionRef) {
+        if (raw.authority === 'external_plan') {
+            issues.push({ path: 'authority', message: 'definitionRef cannot have authority external_plan' });
+        }
         const def = raw.definitionRef as Record<string, unknown>;
         if (
             typeof def.definitionId !== 'string' || def.definitionId.length === 0
@@ -462,6 +472,9 @@ export function validateSessionOccurrence(raw: unknown): ValidationResult<Sessio
             issues.push({ path: 'definitionRef', message: 'Invalid definitionRef' });
         }
     } else if (hasExternalPlanRef) {
+        if (raw.authority !== 'external_plan') {
+            issues.push({ path: 'authority', message: 'externalPlanRef requires authority external_plan' });
+        }
         const ext = raw.externalPlanRef as Record<string, unknown>;
         if (
             typeof ext.planId !== 'string' || ext.planId.length === 0

--- a/docs/plans/h4-external-plan-execution-binding-pipeline.md
+++ b/docs/plans/h4-external-plan-execution-binding-pipeline.md
@@ -1,8 +1,8 @@
-# H4: external-plan execution-binding pipeline — PR-1 implementation and follow-up roadmap
+# H4: external-plan execution-binding pipeline — PR-1/PR-2 implementation and follow-up roadmap
 
-**Status:** PR 1 implemented in [PR #440](https://github.com/Szczepanov/adaptive-training-recommender/pull/440).
-This document records the original gap, the invariants enforced by PR 1, and the remaining
-follow-up work.
+**Status:** PR 1 implemented in [PR #440](https://github.com/Szczepanov/adaptive-training-recommender/pull/440); PR 2 implemented in [PR #445](https://github.com/Szczepanov/adaptive-training-recommender/pull/445).
+This document records the original gap, the invariants established by the first two PRs, and the
+remaining follow-up work.
 
 **Tracks:** [GitHub issue #434](https://github.com/Szczepanov/adaptive-training-recommender/issues/434).
 
@@ -244,16 +244,43 @@ A future implementation may transform external `SessionDefinition.blocks` accord
 accepted scale verdict, then hash and persist the transformed execution snapshot. Until that
 exists, `scale` remains display/advice only and cannot launch.
 
+## PR-2 lifecycle boundary
+
+PR 2 introduces source-appropriate external-plan occurrence identity and the
+`claimOccurrenceLaunch` transaction primitive, but it deliberately does **not** wire the H4
+ledger/reassessment claim into every live occurrence-backed start. Existing M3.3 manual
+occurrences and the new external-plan occurrence path can therefore still be in `scheduled`
+when their execution completes or is abandoned.
+
+Until PR 3 moves launch through the atomic claim/ledger boundary, `scheduled -> completed` and
+`scheduled -> abandoned` remain valid transitions in both service policy and Firestore rules.
+The runner commits the athlete's execution first and performs occurrence completion/abandonment
+as non-blocking bookkeeping afterward; an occurrence-sync failure must not prevent the athlete
+from finishing a recorded session. This is a transitional compatibility rule, not the final
+D-REASSESS launch protocol.
+
+PR 3 should wire the existing claim primitive at the actual launch boundary together with the
+ledger/input-revision checks required by ADR-0036. At that point the live path becomes
+`scheduled -> active -> completed/abandoned`, and the temporary direct terminal transitions can
+be reconsidered/tightened in the same change.
+
+PR 2 also treats an explicitly supplied occurrence id as evidence, not as a trusted string:
+`prepareExternalPlanSessionLaunch` resolves it and verifies user/date (when supplied) plus the
+full `(planId, revision, sessionId, contentHash)` source identity before binding it to a
+prescription.
+
 ## Follow-up roadmap
 
 1. **PR 1 — implemented in PR #440:** prescription-only v4 primary-session launch binding, no
    occurrence record.
-2. **PR 2 — implemented here:** introduce source-appropriate `SessionOccurrence` tracking for
-   `external_plan` (`scheduled → active → completed / skipped / abandoned`), adding an
-   `externalPlanRef` union branch on `SessionOccurrence`, `'external_plan'` authority, and
-   `'skipped'` state, allowing atomic claiming via `claimOccurrenceLaunch`.
+2. **PR 2 — implemented in PR #445:** introduce source-appropriate `SessionOccurrence`
+   tracking for `external_plan`, including a statically discriminated `externalPlanRef` branch,
+   `'external_plan'` authority, `'skipped'` state, deterministic/idempotent occurrence identity,
+   replay validation, lifecycle transitions, and the atomic `claimOccurrenceLaunch` primitive.
+   Live claim/ledger wiring is intentionally deferred as described above.
 3. **PR 3 — bundle member execution:** use resolved intraday placement to adjudicate and
-   surface non-primary v4 members as independently launchable `additionalSessions` entries.
+   surface non-primary v4 members as independently launchable `additionalSessions` entries,
+   wiring launch through the occurrence claim/ledger boundary.
 4. **PR 4 — D-REASSESS:** before a dependent/later member starts, reconcile real predecessor
    completion and elapsed separation against execution evidence, then re-adjudicate using
    current readiness/safety/availability state.

--- a/docs/plans/h4-external-plan-execution-binding-pipeline.md
+++ b/docs/plans/h4-external-plan-execution-binding-pipeline.md
@@ -246,12 +246,12 @@ exists, `scale` remains display/advice only and cannot launch.
 
 ## Follow-up roadmap
 
-1. **PR 1 — implemented here:** prescription-only v4 primary-session launch binding, no
+1. **PR 1 — implemented in PR #440:** prescription-only v4 primary-session launch binding, no
    occurrence record.
-2. **PR 2 — occurrence tracking:** introduce a source-appropriate external-plan occurrence
-   identity/lifecycle without overloading manual `definitionRef` semantics. Evaluate whether
-   this is best represented by an `externalPlanRef` branch/union rather than forcing
-   `planId`/`sessionId` into manual-definition fields.
+2. **PR 2 — implemented here:** introduce source-appropriate `SessionOccurrence` tracking for
+   `external_plan` (`scheduled → active → completed / skipped / abandoned`), adding an
+   `externalPlanRef` union branch on `SessionOccurrence`, `'external_plan'` authority, and
+   `'skipped'` state, allowing atomic claiming via `claimOccurrenceLaunch`.
 3. **PR 3 — bundle member execution:** use resolved intraday placement to adjudicate and
    surface non-primary v4 members as independently launchable `additionalSessions` entries.
 4. **PR 4 — D-REASSESS:** before a dependent/later member starts, reconcile real predecessor


### PR DESCRIPTION
## Summary

- Implements **PR 2 (External-Plan Occurrence Tracking)** of the [H4 External-Plan Execution & Binding Pipeline](docs/plans/h4-external-plan-execution-binding-pipeline.md), advancing **Issue #434** without closing the multi-PR parent issue.
- Adds source-appropriate external-plan occurrence identity, deterministic/transactional get-or-create, replay verification, lifecycle transitions, and the atomic `claimOccurrenceLaunch` primitive needed by later bundle-launch/ledger wiring.
- Makes `SessionOccurrence` genuinely discriminate manual vs external-plan authority at the type level and validates an explicitly supplied external occurrence against user/date plus the exact `(planId, revision, sessionId, contentHash)` source before binding it to a prescription.
- Preserves the current execution safety boundary: until PR 3 wires claim into every live occurrence-backed start, occurrences may remain `scheduled` through execution and transition directly to `completed`/`abandoned` as non-blocking bookkeeping.

## Changes

### Domain models, validation, and rules
- Added `'external_plan'` to `OccurrenceAuthority` and `'skipped'` to `OccurrenceState`.
- Added complete `ManualOccurrenceRef` (`definitionId`, `revision`, `contentHash`) and `ExternalPlanOccurrenceRef` (`planId`, `revision`, `sessionId`, `contentHash`) shapes.
- `ManualSessionOccurrence` now requires a non-external authority + `definitionRef`; `ExternalPlanSessionOccurrence` requires authority `'external_plan'` + `externalPlanRef`.
- Runtime validators and Firestore rules enforce reference shape, authority/reference pairing, mutual exclusivity, immutable identity, and explicit lifecycle transitions.

### Occurrence service and launch binding
- `getOrCreateExternalPlanOccurrence(...)` uses an unambiguous tuple-encoded SHA-256 identity and a Firestore transaction, so concurrent callers converge on one occurrence.
- `claimOccurrenceLaunch(...)` provides atomic `scheduled -> active` claiming with an optional transaction-scoped pre-claim hook for later ledger/input-revision checks.
- `prepareExternalPlanSessionLaunch(...)` gets/creates a dated occurrence when needed. If an explicit `occurrenceId` is supplied, it resolves the record first and rejects unavailable, wrong-source, wrong-user, or wrong-date evidence before persisting/binding the prescription.
- `Home.tsx` supplies the recommendation date and guards manual occurrence references with `isManualOccurrence`.
- `useSessionRunner.ts` updates linked occurrence state after execution completion/abandonment without making occurrence bookkeeping capable of blocking the athlete's recorded execution.

### Reassessment, replay, and docs
- A `'skipped'` predecessor is terminal for dependent intraday reassessment.
- Replay verifies the exact manual/external occurrence source identity and recommendation date.
- The H4 roadmap now documents PR 2, the temporary pre-claim lifecycle compatibility rule, and the remaining PR 3/PR 4 scope.

## Validation

- [x] `uv run pytest` (backend changes) — **pass on final head** via CI Pipeline #2597 (`pytest` with coverage).
- [x] `uv run ruff check .` and `uv run mypy src/garmin_sync` (backend changes) — **pass on final head** via CI Pipeline #2597; `ruff format --check .` also passed.
- [x] `cd app && npm run check` (frontend changes) — an earlier branch run passed; the **final head** passed the equivalent CI gates `npm run typecheck`, `npm run lint`, `npm run test:coverage`, knowledge/workout validators, policy-drift check, and frontend bundle build in CI Pipeline #2597.
- [x] `cd app && npm run test:rules` (Firestore rules changes) — **pass on final head** in CI Pipeline #2597.
- [x] `cd app && npm run simulate:scenarios` (recommendation-engine changes) — **pass on final head** in CI Pipeline #2597; aggregate baseline diff gate, deterministic plan judge, persona corpus build, and semantic diff also ran successfully/non-blocking as configured.
- [ ] `cd app && npm run visual:refresh` — **not applicable**; no material UI/layout change.

Additional final-head validation from CI Pipeline #2597:
- Docker build + Compose full-stack smoke: **pass**.
- Node/Python dependency audits and repository hygiene gates: **pass**.
- Focused tests added for explicit external occurrence binding, wrong source identity, and wrong recommendation date.

Manual review:
- PR is mergeable against current `main` with no branch conflict.
- All existing inline review threads are resolved; follow-up replies document the deliberate PR-2 lifecycle correction where earlier thread replies described a stricter pre-claim state machine.

## Risk and reviewer guidance

**Primary review focus:**
1. `app/src/services/sessionAuthoringService.ts` — explicit occurrence IDs are evidence, not trusted strings; verify exact source/date checks happen before prescription persistence.
2. `app/src/sessions/models.ts` + validation/rules — manual and external occurrence authority/reference pairing must stay consistent across TypeScript, runtime parsing, and Firestore.
3. `app/src/services/sessionOccurrenceService.ts` + `useSessionRunner.ts` — distinguish the **claim primitive that exists now** from the **live claim/ledger wiring intentionally deferred to PR 3**.

**Known transitional behavior:** `scheduled -> completed/abandoned` is temporarily allowed because current manual/external occurrence-backed starts are not all claimed first. Occurrence synchronization after execution is deliberately non-blocking so a bookkeeping failure cannot prevent an athlete from finishing a recorded session. If occurrence synchronization fails, later D-REASSESS lacks trustworthy completion evidence and therefore remains conservative/fail-closed rather than inventing capacity.

**Compatibility/migration:** no data migration is required. Existing manual occurrence documents remain valid; external-plan occurrences add a source-appropriate union branch and rules validation. Legacy v1-v3 external-plan execution behavior is not widened.

**Deployment/rollback:** no special deployment step beyond normal app/rules deployment. The PR can be rolled back as one feature set; there is no irreversible schema migration.

## Domain invariants

- [x] Firestore writes remain user-scoped under `users/{APP_USER_ID}/...`; external occurrences remain under `users/{userId}/session_occurrences/{occurrenceId}` and cross-user rules coverage remains in the emulator suite.
- [x] Calendar-date ownership remains explicit; this PR propagates the recommendation date and does not introduce new local-time conversion semantics. ADR-0036 continues to own `Europe/Warsaw` intraday timing for later window work.
- [x] No credentials, tokens, service-account files, or raw health payloads are included; repository/security hygiene passed on final-head CI.
- [x] Recommendation/reassessment behavior was evaluated against `POLICY_VERSION`; the final-head policy-drift gate passed and the H4 roadmap/ADR boundary is documented. No unrelated policy-version change was introduced.

## Screenshots or recordings

Not applicable — this PR changes occurrence identity, persistence, rules, replay, and execution bookkeeping; it does not materially change rendered UI states.

## Issue scope

This is **PR 2 of the multi-PR Issue #434 roadmap**. It intentionally does **not** close #434. Bundle-member execution and full D-REASSESS claim/ledger wiring remain follow-up work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for launching and tracking sessions from external plans.
  - External-plan launches can link to recommendation dates and specific occurrences.
  - Added occurrence lifecycle states and valid scheduled-to-terminal transitions.
  - External-plan occurrences retain plan, revision, session, and content details for validation.

- **Bug Fixes**
  - Prevented invalid or ambiguous occurrence references from being accepted.
  - Prevented dependent sessions from proceeding after skipped predecessors.
  - Improved replay validation for manual and external-plan sessions.
  - Improved reliability of occurrence creation, claiming, and state updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->