### PR TITLE
feat(sessions): H4 #434 PR 3 Phases 1-2 -- window exclusivity, re-import supersession, ledger-input builder, reservation aggregate

### DIFF
--- a/app/firestore.rules
+++ b/app/firestore.rules
@@ -1691,6 +1691,51 @@ service cloud.firestore {
       allow update, delete: if false;
     }
 
+    // H4 (#434) PR 3 / ADR-0036 D-LEDGER, Phase 2 step 6a: the persisted date-level
+    // reservation aggregate. Firestore's `Transaction.get()` accepts a `DocumentReference`
+    // only -- a transaction cannot query "every occurrence for this date" -- so this one
+    // named document is the serialization authority every reserving/releasing write must
+    // update atomically; `session_occurrences` alone cannot give a claim transaction that
+    // guarantee. `reservations` is keyed by occurrenceId (an unbounded, dynamic keyspace),
+    // which the rules language cannot iterate to validate each entry's shape -- the same
+    // accepted tradeoff this schema already makes elsewhere for dynamic-keyed maps (e.g.
+    // `tissueResponses`); per-entry validation is enforced by
+    // `dailyLedgerAggregateService.ts` and its own tests, not by these rules.
+    function hasValidDailyLedgerAggregate(userId, date) {
+      let data = request.resource.data;
+      return hasOwnedUserId(userId)
+        && data.keys().hasOnly(['userId', 'date', 'revision', 'ceilings', 'reservations', 'seededAt', 'createdAt', 'updatedAt'])
+        && data.keys().hasAll(['userId', 'date', 'revision', 'ceilings', 'reservations', 'seededAt', 'createdAt', 'updatedAt'])
+        && data.date == date
+        && isValidActivityDate(data.date)
+        && data.revision is int && data.revision >= 1
+        && data.ceilings is map
+        && data.ceilings.keys().hasOnly(['dailyMinuteCeiling', 'dailySystemicCostCeiling'])
+        && data.ceilings.keys().hasAll(['dailyMinuteCeiling', 'dailySystemicCostCeiling'])
+        && data.ceilings.dailyMinuteCeiling is number && data.ceilings.dailyMinuteCeiling >= 0
+        && data.ceilings.dailySystemicCostCeiling is number && data.ceilings.dailySystemicCostCeiling >= 0 && data.ceilings.dailySystemicCostCeiling <= 1
+        && data.reservations is map
+        && data.reservations.size() <= 50
+        && data.seededAt is string && data.seededAt.size() > 0
+        && data.createdAt is string && data.updatedAt is string;
+    }
+
+    match /users/{userId}/daily_ledgers/{date} {
+      allow read: if isOwner(userId);
+      allow create: if hasValidDailyLedgerAggregate(userId, date);
+      allow update: if hasValidDailyLedgerAggregate(userId, date)
+        && keepsOwnership(userId)
+        && request.resource.data.date == resource.data.date
+        && request.resource.data.ceilings == resource.data.ceilings
+        && request.resource.data.seededAt == resource.data.seededAt
+        && request.resource.data.createdAt == resource.data.createdAt
+        // Every mutating transition bumps revision by exactly one (plan step 6a): this is
+        // the same optimistic-sequencing property that makes a concurrent claim conflict
+        // and retry rather than silently overwrite another writer's reservation change.
+        && request.resource.data.revision == resource.data.revision + 1;
+      allow delete: if false;
+    }
+
     function hasKnownOutcomeMetric(metricId) {
       return metricId in [
         'cycling_tt_20m_mean_power_w',

--- a/app/firestore.rules
+++ b/app/firestore.rules
@@ -1146,11 +1146,29 @@ service cloud.firestore {
       }
     }
 
+    function hasValidOccurrenceWindowBinding(binding) {
+      return binding is map
+        && binding.keys().hasOnly(['windowId', 'bundleId', 'order', 'boundStartLocal', 'boundEndLocal', 'startInstant', 'endInstant'])
+        && binding.keys().hasAll(['windowId', 'bundleId', 'order', 'boundStartLocal', 'boundEndLocal', 'startInstant', 'endInstant'])
+        && binding.windowId is string && binding.windowId.size() > 0 && binding.windowId.size() <= 128
+        && binding.bundleId is string && binding.bundleId.size() > 0 && binding.bundleId.size() <= 128
+        && binding.order is int && binding.order >= 0
+        && binding.boundStartLocal is string && binding.boundStartLocal.size() > 0
+        && binding.boundEndLocal is string && binding.boundEndLocal.size() > 0
+        && binding.startInstant is string && binding.startInstant.size() > 0
+        && binding.endInstant is string && binding.endInstant.size() > 0;
+    }
+
+    // H4 (#434) PR 3 / ADR-0036 D-WINDOW: `windowBinding` on its own records the resolved
+    // window an intraday member sits in but enforces nothing across documents -- real
+    // exclusivity comes from `session_occurrence_windows` below, whose document id *is*
+    // `(date, windowId)`.
     function hasValidSessionOccurrence(userId, occurrenceId) {
       let data = request.resource.data;
       return hasOwnedUserId(userId)
-        && data.keys().hasOnly(['userId', 'occurrenceId', 'date', 'authority', 'definitionRef', 'externalPlanRef', 'state', 'placementOrder', 'createdAt', 'updatedAt'])
+        && data.keys().hasOnly(['userId', 'occurrenceId', 'date', 'authority', 'definitionRef', 'externalPlanRef', 'windowBinding', 'state', 'placementOrder', 'createdAt', 'updatedAt'])
         && data.keys().hasAll(['userId', 'occurrenceId', 'date', 'authority', 'state', 'createdAt', 'updatedAt'])
+        && (!('windowBinding' in data) || ('externalPlanRef' in data && hasValidOccurrenceWindowBinding(data.windowBinding)))
         && (('definitionRef' in data) != ('externalPlanRef' in data))
         && data.occurrenceId == occurrenceId
         && isValidActivityDate(data.date)
@@ -1196,6 +1214,32 @@ service cloud.firestore {
         && request.resource.data.authority == resource.data.authority
         && isValidOccurrenceStateTransition(resource.data.state, request.resource.data.state)
         && request.resource.data.diff(resource.data).affectedKeys().hasOnly(['state', 'updatedAt']);
+      allow delete: if isOwner(userId);
+    }
+
+    // H4 (#434) PR 3 / ADR-0036 D-WINDOW: transactional exclusivity for "at most one
+    // occurrence per resolved window". Document id is deterministic from (date, windowId)
+    // (see `windowReservationId` in `sessionOccurrenceService.ts`), so a create-if-absent
+    // write inside the same transaction that creates the occurrence is what makes a
+    // duplicate binding to one window impossible -- `windowBinding` on the occurrence
+    // itself is a snapshot, not an enforcement mechanism. Released (deleted) in the same
+    // transaction that supersedes/skips the occurrence holding it, freeing the window for
+    // a later generation.
+    function hasValidWindowReservation(userId) {
+      let data = request.resource.data;
+      return hasOwnedUserId(userId)
+        && data.keys().hasOnly(['userId', 'date', 'windowId', 'occurrenceId', 'createdAt'])
+        && data.keys().hasAll(['userId', 'date', 'windowId', 'occurrenceId', 'createdAt'])
+        && isValidActivityDate(data.date)
+        && data.windowId is string && data.windowId.size() > 0 && data.windowId.size() <= 128
+        && data.occurrenceId is string && data.occurrenceId.size() > 0 && data.occurrenceId.size() <= 128
+        && data.createdAt is string;
+    }
+
+    match /users/{userId}/session_occurrence_windows/{reservationId} {
+      allow read: if isOwner(userId);
+      allow create: if hasValidWindowReservation(userId);
+      allow update: if false;
       allow delete: if isOwner(userId);
     }
 

--- a/app/firestore.rules
+++ b/app/firestore.rules
@@ -1222,9 +1222,9 @@ service cloud.firestore {
     // (see `windowReservationId` in `sessionOccurrenceService.ts`), so a create-if-absent
     // write inside the same transaction that creates the occurrence is what makes a
     // duplicate binding to one window impossible -- `windowBinding` on the occurrence
-    // itself is a snapshot, not an enforcement mechanism. Released (deleted) in the same
-    // transaction that supersedes/skips the occurrence holding it, freeing the window for
-    // a later generation.
+    // itself is a snapshot, not an enforcement mechanism. Released by deletion in the same
+    // transaction that supersedes/skips the occurrence holding it and binds a *different*
+    // window, or handed to a same-window successor via the constrained update below.
     function hasValidWindowReservation(userId) {
       let data = request.resource.data;
       return hasOwnedUserId(userId)
@@ -1239,7 +1239,18 @@ service cloud.firestore {
     match /users/{userId}/session_occurrence_windows/{reservationId} {
       allow read: if isOwner(userId);
       allow create: if hasValidWindowReservation(userId);
-      allow update: if false;
+      // A re-import that keeps the same resolved window (`getOrCreateExternalPlanOccurrence`
+      // superseding a stale-revision predecessor) hands this reservation to the successor
+      // occurrence in place, rather than deleting and recreating it -- Firestore evaluates a
+      // `set()` on an existing document as `update`, so the reservation-claiming write for
+      // exactly that case needs an update rule, not just create. Everything the reservation's
+      // *identity* is keyed on (`date`, `windowId`, ownership) stays immutable; only the
+      // occurrence it points at (and the timestamp) may change.
+      allow update: if hasValidWindowReservation(userId)
+        && keepsOwnership(userId)
+        && request.resource.data.date == resource.data.date
+        && request.resource.data.windowId == resource.data.windowId
+        && request.resource.data.diff(resource.data).affectedKeys().hasOnly(['occurrenceId', 'createdAt']);
       allow delete: if isOwner(userId);
     }
 

--- a/app/src/components/Home.tsx
+++ b/app/src/components/Home.tsx
@@ -440,9 +440,20 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
         // member; `started` alone is already real and meaningful today.
         let todaysExternalPlanMemberState: IntradayBundlePlacementContext['memberState'];
         try {
-          const todaysExternalPlanOccurrences = await sessionOccurrenceService.getExternalPlanOccurrencesForDate(userId, input.date);
+          // `getExternalPlanOccurrencesForDate` returns every external-plan occurrence for
+          // the date regardless of plan/revision, and a v4 session's `sessionId` is
+          // plan-internal, not globally unique -- `buildIntradayMemberState` requires the
+          // active plan's identity so a stale or unrelated occurrence sharing a session id
+          // can never silently apply its started/existingBinding to the current plan's
+          // member. No active plan means no bundle to place against, so memberState stays
+          // unset entirely rather than built from an identity that doesn't exist.
+          const todaysExternalPlanOccurrences = activeExternal
+            ? await sessionOccurrenceService.getExternalPlanOccurrencesForDate(userId, input.date)
+            : [];
           if (!isCurrent()) return;
-          todaysExternalPlanMemberState = buildIntradayMemberState(todaysExternalPlanOccurrences);
+          todaysExternalPlanMemberState = activeExternal
+            ? buildIntradayMemberState(todaysExternalPlanOccurrences, { planId: activeExternal.plan.planId, revision: activeExternal.plan.revision })
+            : undefined;
         } catch (err) {
           // A failed read must not silently become "nothing has started" -- that would let
           // D-PLACEMENT re-resolve a member that has actually already launched. Omit

--- a/app/src/components/Home.tsx
+++ b/app/src/components/Home.tsx
@@ -35,9 +35,11 @@ function formatEventTiming(daysToEvent: number | null): string {
 }
 import {
   activeExternalPlanService,
+  buildIntradayMemberState,
   externalPlanContextForDate,
   externalRestContextForDate,
   type ActiveExternalPlan,
+  type IntradayBundlePlacementContext,
 } from '../services/activeExternalPlanService';
 import { checkinService } from '../services/checkinService';
 import { sessionExecutionService } from '../services/sessionExecutionService';
@@ -430,6 +432,24 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
           console.warn(`Schedule windows for today could not be read (${scheduleWindowsState.status}); intraday bundle placement falls back to the legacy single-slot case.`);
         }
         const todaysScheduleWindows = scheduleWindowsState.status === 'AVAILABLE' ? scheduleWindowsState.data : [];
+        // H4 (#434) PR 3 step 7: real per-member started/existingBinding state, so a
+        // member that has already launched keeps its window rather than being silently
+        // re-resolved (D-PLACEMENT). `windowBinding` is only ever set once a caller passes
+        // one into `getOrCreateExternalPlanOccurrence` -- until Phase 3 wires that for
+        // non-primary members, `existingBinding` stays absent here even for a started
+        // member; `started` alone is already real and meaningful today.
+        let todaysExternalPlanMemberState: IntradayBundlePlacementContext['memberState'];
+        try {
+          const todaysExternalPlanOccurrences = await sessionOccurrenceService.getExternalPlanOccurrencesForDate(userId, input.date);
+          if (!isCurrent()) return;
+          todaysExternalPlanMemberState = buildIntradayMemberState(todaysExternalPlanOccurrences);
+        } catch (err) {
+          // A failed read must not silently become "nothing has started" -- that would let
+          // D-PLACEMENT re-resolve a member that has actually already launched. Omit
+          // memberState entirely (the exact pre-wiring fallback, not a worse one).
+          console.warn('Failed to read today\'s external-plan occurrence state for bundle placement:', err);
+          todaysExternalPlanMemberState = undefined;
+        }
         const earlyAvailability = resolveAvailability(input.date, subjective, planWeekActivities, context, input.scheduleOverlays);
         const bundleLedger = computeDailyLedger(
           {
@@ -446,7 +466,10 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
         // `resolveIntradayBundlePlacement` already treats an empty list as the
         // intentional legacy single-slot fallback (D-WINDOW), not a data-loss signal.
         const bundleContext = planWeekActivitiesState.status === 'AVAILABLE'
-          ? { scheduleWindows: todaysScheduleWindows, fixedActivities: planWeekActivities, ledger: bundleLedger }
+          ? {
+              scheduleWindows: todaysScheduleWindows, fixedActivities: planWeekActivities, ledger: bundleLedger,
+              memberState: todaysExternalPlanMemberState,
+            }
           : undefined;
         const externalContext = activeExternal ? externalPlanContextForDate(activeExternal, input.date, bundleContext) : null;
         const externalRestContext = activeExternal ? externalRestContextForDate(activeExternal, input.date) : null;

--- a/app/src/emulator/firestoreRules.emulator.test.ts
+++ b/app/src/emulator/firestoreRules.emulator.test.ts
@@ -1739,6 +1739,59 @@ emulatorDescribe('Firestore security rules', () => {
         await expect(assertSucceeds(deleteDoc(doc(ownerDb, reservationPath)))).resolves.toBeUndefined();
     });
 
+    it('enforces the daily_ledgers reservation aggregate contract (H4 #434 PR 3, D-LEDGER step 6a)', async () => {
+        const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+        const otherDb = testEnvironment.authenticatedContext(otherUserId).firestore();
+        const aggregatePath = `users/${ownerId}/daily_ledgers/2026-08-18`;
+
+        function validAggregate() {
+            return {
+                userId: ownerId, date: '2026-08-18', revision: 1,
+                ceilings: { dailyMinuteCeiling: 90, dailySystemicCostCeiling: 1 },
+                reservations: { 'occ-1': { minutes: 60, systemicCost: 0.4, state: 'reserved' } },
+                seededAt: '2026-08-18T05:00:00Z',
+                createdAt: '2026-08-18T05:00:00Z', updatedAt: '2026-08-18T05:00:00Z',
+            };
+        }
+
+        // 1. Owner can seed a valid aggregate.
+        await expect(assertSucceeds(setDoc(doc(ownerDb, aggregatePath), validAggregate())))
+            .resolves.toBeUndefined();
+
+        // 2. Cross-user read is denied.
+        await assertFails(getDoc(doc(otherDb, aggregatePath)));
+
+        // 3. A revision jump greater than 1 is rejected -- every mutating transition must
+        // bump revision by exactly one.
+        await assertFails(setDoc(doc(ownerDb, aggregatePath), {
+            ...validAggregate(), revision: 3, updatedAt: '2026-08-18T06:00:00Z',
+        }));
+
+        // 4. A legitimate +1 update (adding a reservation) succeeds.
+        await expect(assertSucceeds(setDoc(doc(ownerDb, aggregatePath), {
+            ...validAggregate(),
+            revision: 2,
+            reservations: { ...validAggregate().reservations, 'occ-2': { minutes: 30, systemicCost: 0.2, state: 'reserved' } },
+            updatedAt: '2026-08-18T06:00:00Z',
+        }))).resolves.toBeUndefined();
+
+        // 5. ceilings/seededAt/createdAt/date are immutable once seeded.
+        await assertFails(setDoc(doc(ownerDb, aggregatePath), {
+            ...validAggregate(), revision: 3, ceilings: { dailyMinuteCeiling: 999, dailySystemicCostCeiling: 1 },
+        }));
+        await assertFails(setDoc(doc(ownerDb, aggregatePath), {
+            ...validAggregate(), revision: 3, seededAt: '2026-08-18T07:00:00Z',
+        }));
+
+        // 6. Deletes are never allowed -- the aggregate is an append/mutate-only ledger.
+        await assertFails(deleteDoc(doc(ownerDb, aggregatePath)));
+
+        // 7. Rejects a malformed shape (missing a required field).
+        const malformed = validAggregate() as Partial<ReturnType<typeof validAggregate>>;
+        delete malformed.ceilings;
+        await assertFails(setDoc(doc(ownerDb, `users/${ownerId}/daily_ledgers/2026-08-19`), malformed));
+    });
+
     it('allows recommendations with primarySession and additionalSessions bindings', async () => {
         const base = validRecommendation();
         const recWithBindings = {

--- a/app/src/emulator/firestoreRules.emulator.test.ts
+++ b/app/src/emulator/firestoreRules.emulator.test.ts
@@ -1726,16 +1726,30 @@ emulatorDescribe('Firestore security rules', () => {
         delete missingField.occurrenceId;
         await assertFails(setDoc(doc(ownerDb, missingFieldPath), missingField));
 
-        // 3. Updates are never allowed -- a reservation is claimed once and released by
-        // deletion, never silently repointed to a different occurrence.
+        // 3. A same-window handoff (occurrenceId repointed, date/windowId unchanged) is
+        // allowed -- this is exactly what getOrCreateExternalPlanOccurrence's re-import
+        // supersession does when the successor keeps the predecessor's resolved window:
+        // Firestore evaluates that `set()` on an existing document as `update`, so without
+        // this the whole occurrence-creation transaction would fail with permission-denied.
+        await expect(assertSucceeds(setDoc(doc(ownerDb, reservationPath), {
+            ...validReservation(), occurrenceId: 'occ-ext-2', createdAt: '2026-08-18T11:00:00Z',
+        }))).resolves.toBeUndefined();
+
+        // 4. The reservation's identity (date, windowId) stays immutable even though
+        // occurrenceId can change -- a reservation must never be silently moved to cover a
+        // different window or date.
         await assertFails(setDoc(doc(ownerDb, reservationPath), {
-            ...validReservation(), occurrenceId: 'occ-ext-2',
+            ...validReservation(), windowId: 'window-2',
+        }));
+        await assertFails(setDoc(doc(ownerDb, reservationPath), {
+            ...validReservation(), date: '2026-08-19',
         }));
 
-        // 4. The owner may delete their own reservation (releasing the window); a
-        // cross-user read/write is denied.
+        // 5. The owner may delete their own reservation (releasing the window); a
+        // cross-user read/write/update is denied.
         await assertFails(getDoc(doc(otherDb, reservationPath)));
         await assertFails(deleteDoc(doc(otherDb, reservationPath)));
+        await assertFails(setDoc(doc(otherDb, reservationPath), { ...validReservation(), occurrenceId: 'occ-hijacked' }));
         await expect(assertSucceeds(deleteDoc(doc(ownerDb, reservationPath)))).resolves.toBeUndefined();
     });
 

--- a/app/src/emulator/firestoreRules.emulator.test.ts
+++ b/app/src/emulator/firestoreRules.emulator.test.ts
@@ -1655,6 +1655,90 @@ emulatorDescribe('Firestore security rules', () => {
         }));
     });
 
+    it('validates windowBinding on external-plan occurrences (H4 #434 PR 3, D-WINDOW)', async () => {
+        const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+        function validWindowBinding() {
+            return {
+                windowId: 'window-1', bundleId: 'bundle-1', order: 0,
+                boundStartLocal: '07:00', boundEndLocal: '08:00',
+                startInstant: '2026-08-18T05:00:00Z', endInstant: '2026-08-18T06:00:00Z',
+            };
+        }
+
+        // 1. Accepts a valid windowBinding on an external-plan occurrence.
+        const boundPath = `users/${ownerId}/session_occurrences/occ-ext-bound`;
+        await expect(assertSucceeds(setDoc(doc(ownerDb, boundPath), {
+            ...validExternalPlanSessionOccurrence(),
+            occurrenceId: 'occ-ext-bound',
+            windowBinding: validWindowBinding(),
+        }))).resolves.toBeUndefined();
+
+        // 2. Rejects windowBinding on a manual (non-external-plan) occurrence.
+        const manualWithWindowPath = `users/${ownerId}/session_occurrences/occ-manual-window`;
+        await assertFails(setDoc(doc(ownerDb, manualWithWindowPath), {
+            ...validSessionOccurrence(),
+            occurrenceId: 'occ-manual-window',
+            windowBinding: validWindowBinding(),
+        }));
+
+        // 3. Rejects a windowBinding missing a required field.
+        const incompletePath = `users/${ownerId}/session_occurrences/occ-ext-incomplete-window`;
+        const incompleteBinding = validWindowBinding() as Partial<ReturnType<typeof validWindowBinding>>;
+        delete incompleteBinding.order;
+        await assertFails(setDoc(doc(ownerDb, incompletePath), {
+            ...validExternalPlanSessionOccurrence(),
+            occurrenceId: 'occ-ext-incomplete-window',
+            windowBinding: incompleteBinding,
+        }));
+
+        // 4. windowBinding is immutable once set (the update rule's diff().affectedKeys()
+        // already restricts updates to ['state', 'updatedAt'], so any windowBinding change
+        // on update is rejected the same way externalPlanRef changes are).
+        await assertFails(setDoc(doc(ownerDb, boundPath), {
+            ...validExternalPlanSessionOccurrence(),
+            occurrenceId: 'occ-ext-bound',
+            windowBinding: { ...validWindowBinding(), windowId: 'window-2' },
+            updatedAt: '2026-08-18T11:00:00Z',
+        }));
+    });
+
+    it('enforces session_occurrence_windows as the D-WINDOW exclusivity mechanism (H4 #434 PR 3)', async () => {
+        const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+        const otherDb = testEnvironment.authenticatedContext(otherUserId).firestore();
+        const reservationPath = `users/${ownerId}/session_occurrence_windows/win-2026-08-18-window-1`;
+
+        function validReservation() {
+            return {
+                userId: ownerId, date: '2026-08-18', windowId: 'window-1',
+                occurrenceId: 'occ-ext-1', createdAt: '2026-08-18T10:00:00Z',
+            };
+        }
+
+        // 1. Owner can create a valid reservation.
+        await expect(assertSucceeds(setDoc(doc(ownerDb, reservationPath), validReservation())))
+            .resolves.toBeUndefined();
+
+        // 2. Rejects a shape with an extra/missing field.
+        const malformedPath = `users/${ownerId}/session_occurrence_windows/win-2026-08-18-window-2`;
+        await assertFails(setDoc(doc(ownerDb, malformedPath), { ...validReservation(), extra: 'nope' }));
+        const missingFieldPath = `users/${ownerId}/session_occurrence_windows/win-2026-08-18-window-3`;
+        const missingField: Partial<ReturnType<typeof validReservation>> = validReservation();
+        delete missingField.occurrenceId;
+        await assertFails(setDoc(doc(ownerDb, missingFieldPath), missingField));
+
+        // 3. Updates are never allowed -- a reservation is claimed once and released by
+        // deletion, never silently repointed to a different occurrence.
+        await assertFails(setDoc(doc(ownerDb, reservationPath), {
+            ...validReservation(), occurrenceId: 'occ-ext-2',
+        }));
+
+        // 4. The owner may delete their own reservation (releasing the window); a
+        // cross-user read/write is denied.
+        await assertFails(getDoc(doc(otherDb, reservationPath)));
+        await assertFails(deleteDoc(doc(otherDb, reservationPath)));
+        await expect(assertSucceeds(deleteDoc(doc(ownerDb, reservationPath)))).resolves.toBeUndefined();
+    });
+
     it('allows recommendations with primarySession and additionalSessions bindings', async () => {
         const base = validRecommendation();
         const recWithBindings = {

--- a/app/src/emulator/sessionOccurrenceService.emulator.test.ts
+++ b/app/src/emulator/sessionOccurrenceService.emulator.test.ts
@@ -1,0 +1,73 @@
+/**
+ * H4 (#434) PR 3: runs the real `SessionOccurrenceService` (not mocked Firestore calls)
+ * against the emulator, for behavior that a rules-only or a mocked-transaction unit test
+ * cannot prove -- specifically, that `getOrCreateExternalPlanOccurrence`'s multi-document
+ * transaction actually commits under the real security rules. A prior version of
+ * `session_occurrence_windows`'s rules (`allow update: if false`) made the same-window
+ * re-import supersession path fail with permission-denied in production while every
+ * mocked unit test still passed, because the mock never evaluates real rules.
+ */
+import { readFileSync } from 'node:fs';
+import { afterAll, afterEach, beforeAll, expect, it } from 'vitest';
+import { initializeTestEnvironment, type RulesTestEnvironment } from '@firebase/rules-unit-testing';
+import type { Firestore } from 'firebase/firestore';
+import { SessionOccurrenceService } from '../services/sessionOccurrenceService';
+import { isExternalPlanOccurrence } from '../sessions/models';
+
+const emulatorDescribe = process.env.FIRESTORE_EMULATOR_HOST ? it : it.skip;
+let testEnvironment: RulesTestEnvironment;
+
+beforeAll(async () => {
+    testEnvironment = await initializeTestEnvironment({
+        // A distinct project id from firestoreRules.emulator.test.ts's 'demo-adaptive-training'
+        // -- separate projects are separate namespaces within the same emulator process, so
+        // this file's afterEach(clearFirestore()) can never race with or wipe data a
+        // concurrently-running sibling test file just wrote under the same ownerId.
+        projectId: 'demo-h4-pr3-occurrence-service',
+        firestore: { rules: readFileSync('firestore.rules', 'utf8') },
+    });
+});
+
+afterEach(async () => {
+    await testEnvironment.clearFirestore();
+});
+
+afterAll(async () => {
+    await testEnvironment.cleanup();
+});
+
+emulatorDescribe(
+    'getOrCreateExternalPlanOccurrence hands off a shared window on re-import supersession (real transaction, real rules)',
+    async () => {
+        const ownerId = 'athlete-a';
+        // `.firestore()` is declared to return the legacy compat type for interop, but its
+        // own doc comment confirms the returned instance actually is the modular Firebase
+        // JS Client SDK object -- the same instance every other emulator test in this repo
+        // passes straight into modular `doc()`/`getDoc()` calls without a cast. The cast is
+        // needed only because `SessionOccurrenceService`'s constructor is typed against the
+        // strict modular `Firestore` interface rather than accepting the same loose overload.
+        const db = testEnvironment.authenticatedContext(ownerId).firestore() as unknown as Firestore;
+        const service = new SessionOccurrenceService(db);
+
+        const windowBinding = {
+            windowId: 'window-1', bundleId: 'bundle-1', order: 0,
+            boundStartLocal: '07:00', boundEndLocal: '08:00',
+            startInstant: '2026-08-18T05:00:00Z', endInstant: '2026-08-18T06:00:00Z',
+        };
+        const refV1 = { planId: 'plan-1', revision: 1, sessionId: 'session-1', contentHash: 'a'.repeat(64) };
+        const refV2 = { ...refV1, revision: 2, contentHash: 'b'.repeat(64) };
+
+        const first = await service.getOrCreateExternalPlanOccurrence(ownerId, '2026-08-18', refV1, { windowBinding });
+        expect(first.state).toBe('scheduled');
+
+        // Re-importing the plan (a new revision, same window) must not throw -- this is
+        // the exact permission-denied regression: the window reservation already exists
+        // and must be handed off to the successor occurrence in the same transaction.
+        const second = await service.getOrCreateExternalPlanOccurrence(ownerId, '2026-08-18', refV2, { windowBinding });
+        expect(second.occurrenceId).not.toBe(first.occurrenceId);
+        expect(isExternalPlanOccurrence(second) && second.windowBinding?.windowId).toBe('window-1');
+
+        const supersededFirst = await service.getOccurrence(ownerId, first.occurrenceId);
+        expect(supersededFirst.status === 'AVAILABLE' && supersededFirst.data.state).toBe('superseded');
+    },
+);

--- a/app/src/emulator/sessionOccurrenceService.emulator.test.ts
+++ b/app/src/emulator/sessionOccurrenceService.emulator.test.ts
@@ -8,37 +8,44 @@
  * mocked unit test still passed, because the mock never evaluates real rules.
  */
 import { readFileSync } from 'node:fs';
-import { afterAll, afterEach, beforeAll, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import { initializeTestEnvironment, type RulesTestEnvironment } from '@firebase/rules-unit-testing';
-import type { Firestore } from 'firebase/firestore';
-import { SessionOccurrenceService } from '../services/sessionOccurrenceService';
+import { doc, getDoc, type Firestore } from 'firebase/firestore';
+import { SessionOccurrenceService, windowReservationId } from '../services/sessionOccurrenceService';
 import { isExternalPlanOccurrence } from '../sessions/models';
 
-const emulatorDescribe = process.env.FIRESTORE_EMULATOR_HOST ? it : it.skip;
-let testEnvironment: RulesTestEnvironment;
+// Guards the whole suite -- hooks included -- exactly like every sibling
+// `*.emulator.test.ts` file in this directory. Gating only the leaf `it()` (e.g. via
+// `it.skip`) while leaving `beforeAll`/`afterEach`/`afterAll` at module scope would let
+// those hooks attempt `initializeTestEnvironment`/`clearFirestore` against an emulator
+// that may not be running whenever this file is collected outside `firebase
+// emulators:exec` (a plain `npm run check` / `vitest run`, for instance).
+const emulatorDescribe = process.env.FIRESTORE_EMULATOR_HOST ? describe : describe.skip;
 
-beforeAll(async () => {
-    testEnvironment = await initializeTestEnvironment({
-        // A distinct project id from firestoreRules.emulator.test.ts's 'demo-adaptive-training'
-        // -- separate projects are separate namespaces within the same emulator process, so
-        // this file's afterEach(clearFirestore()) can never race with or wipe data a
-        // concurrently-running sibling test file just wrote under the same ownerId.
-        projectId: 'demo-h4-pr3-occurrence-service',
-        firestore: { rules: readFileSync('firestore.rules', 'utf8') },
+emulatorDescribe('getOrCreateExternalPlanOccurrence (real transaction, real rules)', () => {
+    let testEnvironment: RulesTestEnvironment;
+
+    beforeAll(async () => {
+        testEnvironment = await initializeTestEnvironment({
+            // A distinct project id from firestoreRules.emulator.test.ts's
+            // 'demo-adaptive-training' -- separate projects are separate namespaces within
+            // the same emulator process, so this file's afterEach(clearFirestore()) can
+            // never race with or wipe data a concurrently-running sibling test file just
+            // wrote under the same ownerId.
+            projectId: 'demo-h4-pr3-occurrence-service',
+            firestore: { rules: readFileSync('firestore.rules', 'utf8') },
+        });
     });
-});
 
-afterEach(async () => {
-    await testEnvironment.clearFirestore();
-});
+    afterEach(async () => {
+        await testEnvironment.clearFirestore();
+    });
 
-afterAll(async () => {
-    await testEnvironment.cleanup();
-});
+    afterAll(async () => {
+        await testEnvironment.cleanup();
+    });
 
-emulatorDescribe(
-    'getOrCreateExternalPlanOccurrence hands off a shared window on re-import supersession (real transaction, real rules)',
-    async () => {
+    it('hands off a shared window to the successor occurrence on re-import supersession', async () => {
         const ownerId = 'athlete-a';
         // `.firestore()` is declared to return the legacy compat type for interop, but its
         // own doc comment confirms the returned instance actually is the modular Firebase
@@ -69,5 +76,16 @@ emulatorDescribe(
 
         const supersededFirst = await service.getOccurrence(ownerId, first.occurrenceId);
         expect(supersededFirst.status === 'AVAILABLE' && supersededFirst.data.state).toBe('superseded');
-    },
-);
+
+        // Read the actual reservation document, not just the two occurrences' own state.
+        // Both occurrences agreeing the window "belongs" to `second` is necessary but not
+        // sufficient: a regression that left the persisted reservation still pointing at
+        // `first` would pass every assertion above yet incorrectly reject the *next*
+        // same-window re-import as a conflict against an occurrence that no longer governs
+        // anything.
+        const reservationRef = doc(db, 'users', ownerId, 'session_occurrence_windows', windowReservationId('2026-08-18', 'window-1'));
+        const reservationSnap = await getDoc(reservationRef);
+        expect(reservationSnap.exists()).toBe(true);
+        expect(reservationSnap.data()?.occurrenceId).toBe(second.occurrenceId);
+    });
+});

--- a/app/src/engine/intradayLedgerInputs.test.ts
+++ b/app/src/engine/intradayLedgerInputs.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest';
+import { buildLedgerEntries, toLedgerEntry, type OccurrenceLedgerInput } from './intradayLedgerInputs';
+import { computeDailyLedger } from './dailyLedger';
+
+function input(overrides: Partial<OccurrenceLedgerInput> = {}): OccurrenceLedgerInput {
+    return {
+        occurrenceId: 'occ-1',
+        occurrenceState: 'scheduled',
+        estimatedMinutes: 60,
+        estimatedSystemicCost: 0.4,
+        revision: 1,
+        ...overrides,
+    };
+}
+
+describe('toLedgerEntry', () => {
+    it('maps a scheduled occurrence with no execution to a reserved entry', () => {
+        const entry = toLedgerEntry(input());
+        expect(entry).toEqual({
+            occurrenceId: 'occ-1', revision: 1, reservedMinutes: 60, reservedSystemicCost: 0.4,
+            state: 'reserved',
+        });
+    });
+
+    it('maps an active occurrence with no execution yet to in_progress', () => {
+        const entry = toLedgerEntry(input({ occurrenceState: 'active' }));
+        expect(entry?.state).toBe('in_progress');
+    });
+
+    it('maps an in-progress execution to in_progress regardless of occurrence state', () => {
+        const entry = toLedgerEntry(input({
+            occurrenceState: 'active',
+            execution: { state: 'in_progress', startedAt: '2026-08-18T07:00:00Z' },
+        }));
+        expect(entry?.state).toBe('in_progress');
+        expect(entry?.actualMinutes).toBeUndefined();
+    });
+
+    it('maps a completed execution to completed with elapsed actual minutes and the reserved cost as actual', () => {
+        const entry = toLedgerEntry(input({
+            occurrenceState: 'active',
+            estimatedSystemicCost: 0.35,
+            execution: {
+                state: 'completed',
+                startedAt: '2026-08-18T07:00:00Z',
+                completedAt: '2026-08-18T08:00:00Z',
+            },
+        }));
+        expect(entry).toEqual({
+            occurrenceId: 'occ-1', revision: 1, reservedMinutes: 60, reservedSystemicCost: 0.35,
+            state: 'completed', actualMinutes: 60, actualSystemicCost: 0.35,
+        });
+    });
+
+    it('leaves a completed execution unresolved when completedAt is missing (evidence gap, not a formula guess)', () => {
+        const entry = toLedgerEntry(input({
+            execution: { state: 'completed', startedAt: '2026-08-18T07:00:00Z', completedAt: null },
+        }));
+        expect(entry?.state).toBe('unresolved');
+        expect(entry?.actualMinutes).toBeUndefined();
+        expect(entry?.actualSystemicCost).toBeUndefined();
+    });
+
+    it('bounds actual minutes for an abandoned execution but leaves systemic cost unresolved', () => {
+        const entry = toLedgerEntry(input({
+            estimatedMinutes: 60,
+            execution: {
+                state: 'abandoned',
+                startedAt: '2026-08-18T07:00:00Z',
+                completedAt: '2026-08-18T07:12:00Z',
+            },
+        }));
+        expect(entry).toEqual({
+            occurrenceId: 'occ-1', revision: 1, reservedMinutes: 60, reservedSystemicCost: 0.4,
+            state: 'abandoned', actualMinutes: 12,
+        });
+        expect(entry?.actualSystemicCost).toBeUndefined();
+    });
+
+    it('produces no entry for a superseded occurrence', () => {
+        expect(toLedgerEntry(input({ occurrenceState: 'superseded' }))).toBeNull();
+    });
+
+    it('produces no entry for a skipped occurrence', () => {
+        expect(toLedgerEntry(input({ occurrenceState: 'skipped' }))).toBeNull();
+    });
+
+    it('conservatively retains the reservation for a missed occurrence with no execution', () => {
+        const entry = toLedgerEntry(input({ occurrenceState: 'missed' }));
+        expect(entry?.state).toBe('unresolved');
+        expect(entry?.reservedMinutes).toBe(60);
+    });
+
+    it('conservatively retains the reservation for a terminal occurrence state with no linked execution', () => {
+        const entry = toLedgerEntry(input({ occurrenceState: 'completed' }));
+        expect(entry?.state).toBe('unresolved');
+    });
+});
+
+describe('buildLedgerEntries', () => {
+    it('drops superseded/skipped and keeps every other occurrence', () => {
+        const entries = buildLedgerEntries([
+            input({ occurrenceId: 'occ-a', occurrenceState: 'scheduled' }),
+            input({ occurrenceId: 'occ-b', occurrenceState: 'superseded' }),
+            input({ occurrenceId: 'occ-c', occurrenceState: 'skipped' }),
+            input({ occurrenceId: 'occ-d', occurrenceState: 'active' }),
+        ]);
+        expect(entries.map(e => e.occurrenceId)).toEqual(['occ-a', 'occ-d']);
+    });
+});
+
+describe('ADR-0036 D-LEDGER acceptance cases (via buildLedgerEntries -> computeDailyLedger)', () => {
+    it('a 90-minute daily ceiling with a 60-minute AM completion leaves at most 30 minutes for PM', () => {
+        const ceilings = { dailyMinuteCeiling: 90, dailySystemicCostCeiling: 1 };
+        const entries = buildLedgerEntries([
+            input({
+                occurrenceId: 'occ-am', occurrenceState: 'active', estimatedMinutes: 90, estimatedSystemicCost: 0.3,
+                execution: { state: 'completed', startedAt: '2026-08-18T06:00:00Z', completedAt: '2026-08-18T07:00:00Z' },
+            }),
+        ]);
+        const ledger = computeDailyLedger(ceilings, entries);
+        expect(ledger.remainingMinutes).toBe(30);
+    });
+
+    it('a candidate with spare minutes but exhausted systemic cost is not admitted', () => {
+        const ceilings = { dailyMinuteCeiling: 120, dailySystemicCostCeiling: 0.5 };
+        const entries = buildLedgerEntries([
+            input({
+                occurrenceId: 'occ-am', occurrenceState: 'active', estimatedMinutes: 40, estimatedSystemicCost: 0.5,
+                execution: { state: 'completed', startedAt: '2026-08-18T06:00:00Z', completedAt: '2026-08-18T06:40:00Z' },
+            }),
+        ]);
+        const ledger = computeDailyLedger(ceilings, entries);
+        expect(ledger.remainingMinutes).toBe(80);
+        expect(ledger.remainingSystemicCost).toBe(0);
+    });
+
+    it('a rejected member never reserves capacity (superseded/skipped excluded), unlike a pending reservation', () => {
+        const ceilings = { dailyMinuteCeiling: 90, dailySystemicCostCeiling: 1 };
+        const rejected = buildLedgerEntries([
+            input({ occurrenceId: 'occ-skipped', occurrenceState: 'skipped', estimatedMinutes: 45, estimatedSystemicCost: 0.3 }),
+        ]);
+        const pending = buildLedgerEntries([
+            input({ occurrenceId: 'occ-pending', occurrenceState: 'scheduled', estimatedMinutes: 45, estimatedSystemicCost: 0.3 }),
+        ]);
+        expect(computeDailyLedger(ceilings, rejected).remainingMinutes).toBe(90);
+        expect(computeDailyLedger(ceilings, pending).remainingMinutes).toBe(45);
+    });
+
+    it('a re-imported plan does not double-reserve: the superseded predecessor contributes nothing alongside its successor', () => {
+        const ceilings = { dailyMinuteCeiling: 90, dailySystemicCostCeiling: 1 };
+        const entries = buildLedgerEntries([
+            input({ occurrenceId: 'occ-old', occurrenceState: 'superseded', estimatedMinutes: 60, estimatedSystemicCost: 0.4 }),
+            input({ occurrenceId: 'occ-new', occurrenceState: 'scheduled', estimatedMinutes: 60, estimatedSystemicCost: 0.4 }),
+        ]);
+        expect(computeDailyLedger(ceilings, entries).remainingMinutes).toBe(30);
+    });
+
+    it('an abandoned session retains its known elapsed minutes but the full systemic-cost reservation until resolved', () => {
+        const ceilings = { dailyMinuteCeiling: 90, dailySystemicCostCeiling: 1 };
+        const entries = buildLedgerEntries([
+            input({
+                occurrenceId: 'occ-abandoned', occurrenceState: 'active', estimatedMinutes: 60, estimatedSystemicCost: 0.4,
+                execution: { state: 'abandoned', startedAt: '2026-08-18T06:00:00Z', completedAt: '2026-08-18T06:12:00Z' },
+            }),
+        ]);
+        const ledger = computeDailyLedger(ceilings, entries);
+        // Minutes: 90 - 12 (known elapsed) = 78. Cost: 1 - 0.4 (unresolved -> full reservation).
+        expect(ledger.remainingMinutes).toBe(78);
+        expect(ledger.remainingSystemicCost).toBeCloseTo(0.6, 10);
+        expect(ledger.unresolvedEntries).toContain('occ-abandoned');
+    });
+
+    it('missing/ambiguous evidence retains the full reservation rather than inferring spare capacity', () => {
+        const ceilings = { dailyMinuteCeiling: 90, dailySystemicCostCeiling: 1 };
+        const entries = buildLedgerEntries([
+            input({
+                occurrenceId: 'occ-ambiguous', occurrenceState: 'active', estimatedMinutes: 60, estimatedSystemicCost: 0.4,
+                execution: { state: 'completed', startedAt: '2026-08-18T06:00:00Z', completedAt: null },
+            }),
+        ]);
+        const ledger = computeDailyLedger(ceilings, entries);
+        expect(ledger.remainingMinutes).toBe(30);
+        expect(ledger.unresolvedEntries).toContain('occ-ambiguous');
+    });
+});

--- a/app/src/engine/intradayLedgerInputs.ts
+++ b/app/src/engine/intradayLedgerInputs.ts
@@ -1,0 +1,153 @@
+/**
+ * ADR-0036 (H4) D-LEDGER: builds today's `LedgerEntry[]` from already-resolved occurrence
+ * and execution facts (docs/plans/h4-434-pr3-bundle-second-member-launch.md, Phase 2 step
+ * 6). Pure -- no Firestore, no session-definition resolution, no wall-clock reads. The
+ * caller (`Home.tsx` / the Phase 2 seeding path in `sessionOccurrenceService.ts`) is
+ * responsible for resolving each occurrence's estimated minutes/systemic cost (the same
+ * estimator `activeExternalPlanService.ts`'s `toMembers` already uses) before calling this
+ * module; "engine pure, resolution in callers" is the same invariant PR 1 established for
+ * the launch-binding path.
+ *
+ * `superseded`/`skipped` occurrences produce no entry at all (not a zero-reservation
+ * entry): they never governed a decision and never consumed anything, and Phase 1's
+ * supersession (step 4b) / Phase 3's reject-handling (step 8) already made that the
+ * invariant an occurrence in those states holds. Counting them would double-reserve a
+ * re-imported plan, or charge the day for a member the gates just rejected.
+ *
+ * Deliberately not modeled here (documented rather than guessed at):
+ * - `ReconciliationState: 'partial'` is never emitted. `SessionExecution.state` has no
+ *   `'partial'` value, and the only partial-disposition signal the plan names
+ *   (`SessionResponse.completedFraction`, Phase 5) does not exist yet at this point in the
+ *   implementation sequence. Inventing a heuristic (e.g. from logged-entry counts) would be
+ *   exactly the kind of new formula this module's ADR forbids. When a real partial signal
+ *   is wired in, extend `toReconciliationState` -- do not guess here.
+ * - An occurrence's own `missed` state has no case in the plan's step 6 table. Mapped
+ *   conservatively to `'unresolved'` (reservation retained, evidence gap surfaced) per
+ *   D-LEDGER's "missing cost is uncertainty, never spare capacity" -- never silently
+ *   treated as freed capacity.
+ * - A completed execution's actual systemic cost is not independently estimable from
+ *   performed facts anywhere in this codebase (that estimator does not exist; building one
+ *   here would be the same forbidden new formula). Full completion is therefore modeled as
+ *   "the reserved estimate was, as far as anything can currently prove, actually spent" --
+ *   `actualSystemicCost` mirrors `reservedSystemicCost`. An `abandoned` execution's
+ *   systemic-cost dimension stays unresolved rather than assumed complete or scaled down.
+ */
+
+import type { LedgerEntry, ReconciliationState } from './dailyLedger';
+import type { OccurrenceState, SessionExecutionState } from '../sessions/models';
+
+/**
+ * One occurrence's already-resolved facts, as the caller has gathered them for today.
+ * `estimatedMinutes`/`estimatedSystemicCost` are the same authored/estimated figures used
+ * at reservation time (D-LEDGER: "keep the current common cost/eligibility authorities").
+ */
+export interface OccurrenceLedgerInput {
+    occurrenceId: string;
+    occurrenceState: OccurrenceState;
+    estimatedMinutes: number;
+    estimatedSystemicCost: number;
+    /** Orders competing/replayed evidence for this occurrence identity (D-LEDGER
+     * dedupe authority). A monotonic proxy such as `Date.parse(execution.updatedAt ??
+     * occurrence.updatedAt)` is sufficient -- this module does not require a real sequence
+     * number, only that later evidence carries a strictly higher value. */
+    revision: number;
+    /** The linked execution's own facts, when a `session_executions` document exists for
+     * this occurrence. Absent for a reservation with no execution yet. */
+    execution?: {
+        state: SessionExecutionState;
+        startedAt: string;
+        completedAt?: string | null;
+    };
+}
+
+const TERMINAL_OCCURRENCE_STATES_WITHOUT_ENTRY: ReadonlySet<OccurrenceState> = new Set(['superseded', 'skipped']);
+
+/** Elapsed minutes between two ISO instants, rounded to the nearest whole minute and
+ * floored at zero. A real timestamp fact, not an estimate -- safe to treat as a bounded
+ * actual regardless of completion disposition. */
+function elapsedMinutes(startedAt: string, completedAt: string): number | undefined {
+    const startMs = Date.parse(startedAt);
+    const endMs = Date.parse(completedAt);
+    if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs < startMs) return undefined;
+    return Math.round((endMs - startMs) / 60000);
+}
+
+/** Maps one occurrence's already-resolved facts onto D-LEDGER's `ReconciliationState` --
+ * see the module doc for the exact table and the deliberately-out-of-scope cases. Returns
+ * `null` for `superseded`/`skipped`, meaning "no entry", not a zero-cost entry. */
+export function toLedgerEntry(input: OccurrenceLedgerInput): LedgerEntry | null {
+    if (TERMINAL_OCCURRENCE_STATES_WITHOUT_ENTRY.has(input.occurrenceState)) return null;
+
+    const base = {
+        occurrenceId: input.occurrenceId,
+        revision: input.revision,
+        reservedMinutes: input.estimatedMinutes,
+        reservedSystemicCost: input.estimatedSystemicCost,
+    };
+
+    if (input.execution?.state === 'in_progress') {
+        return { ...base, state: 'in_progress' };
+    }
+    if (input.execution?.state === 'completed') {
+        const actualMinutes = input.execution.completedAt
+            ? elapsedMinutes(input.execution.startedAt, input.execution.completedAt)
+            : undefined;
+        const state: ReconciliationState = actualMinutes !== undefined ? 'completed' : 'unresolved';
+        return {
+            ...base,
+            state,
+            ...(actualMinutes !== undefined ? { actualMinutes } : {}),
+            // See module doc: no independent actual-cost estimator exists yet, so a full
+            // completion's actual is the reserved estimate -- never assumed for an
+            // unbounded-duration completion, since that would itself be an unverified guess.
+            ...(actualMinutes !== undefined ? { actualSystemicCost: input.estimatedSystemicCost } : {}),
+        };
+    }
+    if (input.execution?.state === 'abandoned') {
+        // Elapsed minutes are still a real, knowable fact for an abandoned session; actual
+        // systemic cost is not (see module doc) and stays unresolved, so
+        // computeDailyLedger's TERMINAL_STATES gate falls back to the full
+        // reservedSystemicCost rather than crediting an unproven partial discount.
+        const actualMinutes = input.execution.completedAt
+            ? elapsedMinutes(input.execution.startedAt, input.execution.completedAt)
+            : undefined;
+        return {
+            ...base,
+            state: 'abandoned',
+            ...(actualMinutes !== undefined ? { actualMinutes } : {}),
+        };
+    }
+
+    // No linked execution: the occurrence's own state governs.
+    switch (input.occurrenceState) {
+        case 'scheduled':
+            return { ...base, state: 'reserved' };
+        case 'active':
+            // Claimed but no execution record found yet -- still in progress against the
+            // reservation; no actual is knowable without an execution.
+            return { ...base, state: 'in_progress' };
+        case 'completed':
+        case 'abandoned':
+        case 'missed':
+            // The occurrence itself reached a terminal disposition with no linked
+            // execution to source a bounded actual from (e.g. the best-effort occurrence
+            // transition in useSessionRunner succeeded while an execution lookup failed,
+            // or a manually-marked 'missed' occurrence). Conservative fallback: retain the
+            // full reservation, surface the evidence gap.
+            return { ...base, state: 'unresolved' };
+        default:
+            return { ...base, state: 'unresolved' };
+    }
+}
+
+/** Builds today's full `LedgerEntry[]` from every occurrence's already-resolved facts,
+ * dropping `superseded`/`skipped` occurrences entirely. Pass the result straight to
+ * `computeDailyLedger` -- this function performs no aggregation of its own. */
+export function buildLedgerEntries(inputs: readonly OccurrenceLedgerInput[]): LedgerEntry[] {
+    const entries: LedgerEntry[] = [];
+    for (const input of inputs) {
+        const entry = toLedgerEntry(input);
+        if (entry) entries.push(entry);
+    }
+    return entries;
+}

--- a/app/src/services/activeExternalPlanService.intradayBundle.test.ts
+++ b/app/src/services/activeExternalPlanService.intradayBundle.test.ts
@@ -5,12 +5,14 @@ import type { ScheduleWindow, ExternalPlanHeader } from '../engine/models';
 import { EXTERNAL_PLAN_SCHEMA_V4 } from '../sessions/externalPlanV4';
 import fixture01 from '../sessions/fixtures/01-full-body-maintenance.json';
 import {
+    buildIntradayMemberState,
     externalPlanContextForDate,
     placedSessionForDate,
     resolveIntradayBundlePlacement,
     type ActiveExternalPlan,
     type IntradayBundlePlacementContext,
 } from './activeExternalPlanService';
+import type { ExternalPlanSessionOccurrence } from '../sessions/models';
 
 const DATE = '2026-08-17'; // the plan's Monday startDate
 
@@ -225,5 +227,79 @@ describe('externalPlanContextForDate with bundleContext', () => {
         expect(externalPlanContextForDate(active, DATE, context)?.session.id).toBe('s-am');
         // Omitting bundleContext keeps the exact pre-D-PLACEMENT priority-based pick.
         expect(externalPlanContextForDate(active, DATE)?.session.id).toBe('s-pm');
+    });
+});
+
+describe('buildIntradayMemberState (H4 #434 PR 3 step 7)', () => {
+    function externalOccurrence(overrides: Partial<ExternalPlanSessionOccurrence> = {}): ExternalPlanSessionOccurrence {
+        return {
+            userId: 'u1', occurrenceId: 'occ-1', date: DATE, authority: 'external_plan',
+            externalPlanRef: { planId: 'v4-bundle-1', revision: 1, sessionId: 's-am', contentHash: 'a'.repeat(64) },
+            state: 'scheduled',
+            createdAt: '2026-08-17T00:00:00Z', updatedAt: '2026-08-17T00:00:00Z',
+            ...overrides,
+        };
+    }
+
+    it('marks a scheduled occurrence as not started', () => {
+        const result = buildIntradayMemberState([externalOccurrence({ state: 'scheduled' })]);
+        expect(result.get('s-am')).toEqual({ started: false });
+    });
+
+    it.each(['active', 'completed', 'abandoned'] as const)('marks a %s occurrence as started', state => {
+        const result = buildIntradayMemberState([externalOccurrence({ state })]);
+        expect(result.get('s-am')?.started).toBe(true);
+    });
+
+    it.each(['missed', 'superseded', 'skipped'] as const)('never marks a %s occurrence as started', state => {
+        const result = buildIntradayMemberState([externalOccurrence({ state })]);
+        expect(result.get('s-am')?.started).toBe(false);
+    });
+
+    it('carries a started member\'s windowBinding through as existingBinding', () => {
+        const windowBinding = {
+            windowId: 'window-1', bundleId: 'double-monday', order: 0,
+            boundStartLocal: '06:00', boundEndLocal: '07:00',
+            startInstant: '2026-08-17T04:00:00Z', endInstant: '2026-08-17T05:00:00Z',
+        };
+        const result = buildIntradayMemberState([externalOccurrence({ state: 'active', windowBinding })]);
+        expect(result.get('s-am')).toEqual({
+            started: true,
+            existingBinding: {
+                sessionId: 's-am', windowId: 'window-1',
+                boundStartLocal: '06:00', boundEndLocal: '07:00',
+                startInstant: '2026-08-17T04:00:00Z', endInstant: '2026-08-17T05:00:00Z',
+            },
+        });
+    });
+
+    it('never carries a windowBinding for an unstarted member, even if one is somehow present', () => {
+        const windowBinding = {
+            windowId: 'window-1', bundleId: 'double-monday', order: 0,
+            boundStartLocal: '06:00', boundEndLocal: '07:00',
+            startInstant: '2026-08-17T04:00:00Z', endInstant: '2026-08-17T05:00:00Z',
+        };
+        const result = buildIntradayMemberState([externalOccurrence({ state: 'scheduled', windowBinding })]);
+        expect(result.get('s-am')).toEqual({ started: false });
+    });
+
+    it('keys by externalPlanRef.sessionId across multiple occurrences', () => {
+        const result = buildIntradayMemberState([
+            externalOccurrence({ occurrenceId: 'occ-am', externalPlanRef: { planId: 'p', revision: 1, sessionId: 's-am', contentHash: 'a'.repeat(64) }, state: 'active' }),
+            externalOccurrence({ occurrenceId: 'occ-pm', externalPlanRef: { planId: 'p', revision: 1, sessionId: 's-pm', contentHash: 'b'.repeat(64) }, state: 'scheduled' }),
+        ]);
+        expect([...result.keys()].sort()).toEqual(['s-am', 's-pm']);
+        expect(result.get('s-am')?.started).toBe(true);
+        expect(result.get('s-pm')?.started).toBe(false);
+    });
+
+    it('ignores manual (non-external-plan) occurrences', () => {
+        const manual = {
+            userId: 'u1', occurrenceId: 'occ-manual', date: DATE, authority: 'schedule' as const,
+            definitionRef: { definitionId: 'def-1', revision: 1, contentHash: 'a'.repeat(64) },
+            state: 'active' as const, createdAt: '2026-08-17T00:00:00Z', updatedAt: '2026-08-17T00:00:00Z',
+        };
+        const result = buildIntradayMemberState([manual]);
+        expect(result.size).toBe(0);
     });
 });

--- a/app/src/services/activeExternalPlanService.intradayBundle.test.ts
+++ b/app/src/services/activeExternalPlanService.intradayBundle.test.ts
@@ -231,6 +231,8 @@ describe('externalPlanContextForDate with bundleContext', () => {
 });
 
 describe('buildIntradayMemberState (H4 #434 PR 3 step 7)', () => {
+    const activePlanRef = { planId: 'v4-bundle-1', revision: 1 };
+
     function externalOccurrence(overrides: Partial<ExternalPlanSessionOccurrence> = {}): ExternalPlanSessionOccurrence {
         return {
             userId: 'u1', occurrenceId: 'occ-1', date: DATE, authority: 'external_plan',
@@ -242,17 +244,17 @@ describe('buildIntradayMemberState (H4 #434 PR 3 step 7)', () => {
     }
 
     it('marks a scheduled occurrence as not started', () => {
-        const result = buildIntradayMemberState([externalOccurrence({ state: 'scheduled' })]);
+        const result = buildIntradayMemberState([externalOccurrence({ state: 'scheduled' })], activePlanRef);
         expect(result.get('s-am')).toEqual({ started: false });
     });
 
     it.each(['active', 'completed', 'abandoned'] as const)('marks a %s occurrence as started', state => {
-        const result = buildIntradayMemberState([externalOccurrence({ state })]);
+        const result = buildIntradayMemberState([externalOccurrence({ state })], activePlanRef);
         expect(result.get('s-am')?.started).toBe(true);
     });
 
     it.each(['missed', 'superseded', 'skipped'] as const)('never marks a %s occurrence as started', state => {
-        const result = buildIntradayMemberState([externalOccurrence({ state })]);
+        const result = buildIntradayMemberState([externalOccurrence({ state })], activePlanRef);
         expect(result.get('s-am')?.started).toBe(false);
     });
 
@@ -262,7 +264,7 @@ describe('buildIntradayMemberState (H4 #434 PR 3 step 7)', () => {
             boundStartLocal: '06:00', boundEndLocal: '07:00',
             startInstant: '2026-08-17T04:00:00Z', endInstant: '2026-08-17T05:00:00Z',
         };
-        const result = buildIntradayMemberState([externalOccurrence({ state: 'active', windowBinding })]);
+        const result = buildIntradayMemberState([externalOccurrence({ state: 'active', windowBinding })], activePlanRef);
         expect(result.get('s-am')).toEqual({
             started: true,
             existingBinding: {
@@ -279,15 +281,15 @@ describe('buildIntradayMemberState (H4 #434 PR 3 step 7)', () => {
             boundStartLocal: '06:00', boundEndLocal: '07:00',
             startInstant: '2026-08-17T04:00:00Z', endInstant: '2026-08-17T05:00:00Z',
         };
-        const result = buildIntradayMemberState([externalOccurrence({ state: 'scheduled', windowBinding })]);
+        const result = buildIntradayMemberState([externalOccurrence({ state: 'scheduled', windowBinding })], activePlanRef);
         expect(result.get('s-am')).toEqual({ started: false });
     });
 
-    it('keys by externalPlanRef.sessionId across multiple occurrences', () => {
+    it('keys by externalPlanRef.sessionId across multiple occurrences of the active plan', () => {
         const result = buildIntradayMemberState([
-            externalOccurrence({ occurrenceId: 'occ-am', externalPlanRef: { planId: 'p', revision: 1, sessionId: 's-am', contentHash: 'a'.repeat(64) }, state: 'active' }),
-            externalOccurrence({ occurrenceId: 'occ-pm', externalPlanRef: { planId: 'p', revision: 1, sessionId: 's-pm', contentHash: 'b'.repeat(64) }, state: 'scheduled' }),
-        ]);
+            externalOccurrence({ occurrenceId: 'occ-am', externalPlanRef: { planId: 'v4-bundle-1', revision: 1, sessionId: 's-am', contentHash: 'a'.repeat(64) }, state: 'active' }),
+            externalOccurrence({ occurrenceId: 'occ-pm', externalPlanRef: { planId: 'v4-bundle-1', revision: 1, sessionId: 's-pm', contentHash: 'b'.repeat(64) }, state: 'scheduled' }),
+        ], activePlanRef);
         expect([...result.keys()].sort()).toEqual(['s-am', 's-pm']);
         expect(result.get('s-am')?.started).toBe(true);
         expect(result.get('s-pm')?.started).toBe(false);
@@ -299,7 +301,29 @@ describe('buildIntradayMemberState (H4 #434 PR 3 step 7)', () => {
             definitionRef: { definitionId: 'def-1', revision: 1, contentHash: 'a'.repeat(64) },
             state: 'active' as const, createdAt: '2026-08-17T00:00:00Z', updatedAt: '2026-08-17T00:00:00Z',
         };
-        const result = buildIntradayMemberState([manual]);
+        const result = buildIntradayMemberState([manual], activePlanRef);
         expect(result.size).toBe(0);
+    });
+
+    it('never lets a same-session-id occurrence from a different plan apply its state to the active plan\'s member', () => {
+        // getExternalPlanOccurrencesForDate returns every external-plan occurrence for the
+        // date across all plans; a v4 sessionId is plan-internal, not globally unique.
+        const unrelatedPlanOccurrence = externalOccurrence({
+            occurrenceId: 'occ-unrelated',
+            externalPlanRef: { planId: 'some-other-plan', revision: 1, sessionId: 's-am', contentHash: 'c'.repeat(64) },
+            state: 'active', // would incorrectly mark s-am as started if not filtered out
+        });
+        const result = buildIntradayMemberState([unrelatedPlanOccurrence], activePlanRef);
+        expect(result.has('s-am')).toBe(false);
+    });
+
+    it('never lets a stale (superseded/prior-revision) occurrence apply its state to the current revision\'s member', () => {
+        const priorRevisionOccurrence = externalOccurrence({
+            occurrenceId: 'occ-prior-revision',
+            externalPlanRef: { planId: 'v4-bundle-1', revision: 0, sessionId: 's-am', contentHash: 'd'.repeat(64) },
+            state: 'active',
+        });
+        const result = buildIntradayMemberState([priorRevisionOccurrence], activePlanRef);
+        expect(result.has('s-am')).toBe(false);
     });
 });

--- a/app/src/services/activeExternalPlanService.intradayBundle.test.ts
+++ b/app/src/services/activeExternalPlanService.intradayBundle.test.ts
@@ -88,6 +88,27 @@ describe('resolveIntradayBundlePlacement', () => {
         expect(result?.bindings?.map(b => b.sessionId)).toEqual(['s-am', 's-pm']);
     });
 
+    it('preserves a started member\'s history via memberState instead of hardcoding started: false (H4 #434 PR 3 step 7)', () => {
+        const active = activePlan([
+            intradaySession({ id: 's-am', intraday: { window: { startLocal: '06:00', endLocal: '07:00' }, bundleId: 'double-monday', order: 0 } }),
+            intradaySession({ id: 's-pm', title: 'PM', intraday: { window: { startLocal: '17:00', endLocal: '18:00' }, bundleId: 'double-monday', order: 1 } }),
+        ]);
+        const existingBinding = {
+            sessionId: 's-am', windowId: 'am',
+            boundStartLocal: '06:00', boundEndLocal: '07:00',
+            startInstant: '2026-08-17T04:00:00Z', endInstant: '2026-08-17T05:00:00Z',
+        };
+        const result = resolveIntradayBundlePlacement(active, DATE, bundleContext({
+            scheduleWindows: [scheduleWindow({ id: 'am', startLocal: '06:00', endLocal: '07:00' }), scheduleWindow({ id: 'pm', startLocal: '17:00', endLocal: '18:00' })],
+            memberState: new Map([['s-am', { started: true, existingBinding }]]),
+        }));
+        expect(result?.outcome).toBe('placed');
+        // The started member's binding is carried through unchanged, not re-derived --
+        // without memberState wired through, toMembers would hardcode started: false and
+        // this exact instant pair could silently move on a later dashboard load.
+        expect(result?.bindings?.find(b => b.sessionId === 's-am')).toEqual(existingBinding);
+    });
+
     it('does not merge two distinct bundle instances that land on the same date, and lets the first feasible one win', () => {
         // An athlete's explicit per-session overlay can move any single session --
         // including one bundle member independently of its siblings -- to an arbitrary

--- a/app/src/services/activeExternalPlanService.ts
+++ b/app/src/services/activeExternalPlanService.ts
@@ -10,7 +10,7 @@ import type {
 import type { ExternalPlanContext, ExternalRestContext } from '../engine/rules';
 import { estimateAuthoredSessionSystemicCost } from '../engine/authoredSessionGates';
 import type { DailyLedgerResult } from '../engine/dailyLedger';
-import { proposeBundlePlacement, type BundlePlacementProposal, type IntradayBundleMember } from '../engine/intradayBundlePlacement';
+import { proposeBundlePlacement, type BundlePlacementProposal, type IntradayBundleMember, type ResolvedWindowBinding } from '../engine/intradayBundlePlacement';
 import { externalPlanService, type ExternalPlanService } from './externalPlanService';
 // M3.6: an active plan may be any supported schema version -- resolvePlacement and most
 // downstream session handling read envelope fields shared by every version. ADR-0035 adds
@@ -75,11 +75,28 @@ export interface IntradayBundlePlacementContext {
     scheduleWindows: readonly ScheduleWindow[];
     fixedActivities: readonly FixedActivity[];
     ledger: DailyLedgerResult;
+    /**
+     * H4 (#434) PR 3, Phase 2 step 7: real per-member execution state, keyed by the v4
+     * session's own `sessionId` (`ExternalPlanSessionV4.id`), when the caller has already
+     * resolved today's occurrence/launch state for this bundle. Absent (or a member with
+     * no entry) falls back to `started: false` -- the exact pre-PR-3 behavior -- so a
+     * caller that has not yet wired occurrence lookups keeps working unchanged.
+     */
+    memberState?: ReadonlyMap<string, { started: boolean; existingBinding?: ResolvedWindowBinding }>;
 }
 
-function toMembers(bundleSessions: readonly (PlacedSession & { session: ExternalPlanSessionV4 & { intraday: ExternalIntradayPlacement } })[]): IntradayBundleMember[] {
+function toMembers(
+    bundleSessions: readonly (PlacedSession & { session: ExternalPlanSessionV4 & { intraday: ExternalIntradayPlacement } })[],
+    memberState?: IntradayBundlePlacementContext['memberState'],
+): IntradayBundleMember[] {
     return bundleSessions.map(placed => {
         const { intraday, definition, priority, id } = placed.session;
+        // ADR-0036 D-PLACEMENT: "once a member starts, do not move its history." Before
+        // PR 3 wired real occurrence state through, every member was evaluated as
+        // not-yet-started regardless of what actually happened -- a placed-but-launched
+        // member's window could be silently reassigned on the next dashboard load. The
+        // caller-supplied state is authoritative when present.
+        const state = memberState?.get(id);
         return {
             sessionId: id,
             order: intraday.order,
@@ -89,10 +106,8 @@ function toMembers(bundleSessions: readonly (PlacedSession & { session: External
             minimumSeparationMinutes: intraday.minimumSeparationMinutes,
             estimatedMinutes: definition.duration?.max ?? definition.duration?.min ?? 45,
             estimatedSystemicCost: estimateAuthoredSessionSystemicCost(definition),
-            // Placement-correctness resolution only: execution status is not wired in
-            // here. Every member is evaluated as not-yet-started; reconciling against
-            // actual launch/completion is D-REASSESS, not this PR.
-            started: false,
+            started: state?.started ?? false,
+            ...(state?.existingBinding !== undefined ? { existingBinding: state.existingBinding } : {}),
         };
     });
 }
@@ -135,7 +150,7 @@ export function resolveIntradayBundlePlacement(
     for (const key of [...groups.keys()].sort()) {
         const groupSessions = groups.get(key)!;
         const bundleId = groupSessions[0].session.intraday.bundleId;
-        const result = proposeBundlePlacement(bundleId, date, toMembers(groupSessions), context.scheduleWindows, context.fixedActivities, restDates, context.ledger);
+        const result = proposeBundlePlacement(bundleId, date, toMembers(groupSessions, context.memberState), context.scheduleWindows, context.fixedActivities, restDates, context.ledger);
         firstResult ??= result;
         if (result.outcome === 'placed') return result;
     }

--- a/app/src/services/activeExternalPlanService.ts
+++ b/app/src/services/activeExternalPlanService.ts
@@ -93,6 +93,15 @@ export interface IntradayBundlePlacementContext {
  * `Home.tsx` only needs to fetch the occurrences (`sessionOccurrenceService
  * .getExternalPlanOccurrencesForDate`) and pass the result through.
  *
+ * `activePlanRef` is required, not optional: `getExternalPlanOccurrencesForDate` returns
+ * every external-plan occurrence for the date regardless of which plan or revision it
+ * belongs to, and a v4 session's `sessionId` is plan-internal, not globally unique -- a
+ * stale occurrence from a superseded revision, or an unrelated imported plan that happens
+ * to reuse the same session id, could otherwise silently apply its `started`/
+ * `existingBinding` to the *current* plan's member of the same id. Only an occurrence
+ * whose `externalPlanRef` matches the active plan's `planId` **and** `revision` is
+ * considered; every other occurrence is skipped, not merged.
+ *
  * `started` is true once the occurrence's execution has actually begun --
  * `active`/`completed`/`abandoned` -- never for `scheduled` (not launched),
  * `missed` (never launched), or `superseded`/`skipped` (already excluded by
@@ -104,10 +113,13 @@ export interface IntradayBundlePlacementContext {
  */
 export function buildIntradayMemberState(
     occurrences: readonly SessionOccurrence[],
+    activePlanRef: { planId: string; revision: number },
 ): NonNullable<IntradayBundlePlacementContext['memberState']> {
     const memberState = new Map<string, { started: boolean; existingBinding?: ResolvedWindowBinding }>();
     for (const occurrence of occurrences) {
         if (!isExternalPlanOccurrence(occurrence)) continue;
+        if (occurrence.externalPlanRef.planId !== activePlanRef.planId
+            || occurrence.externalPlanRef.revision !== activePlanRef.revision) continue;
         const started = occurrence.state === 'active' || occurrence.state === 'completed' || occurrence.state === 'abandoned';
         const windowBinding = occurrence.windowBinding;
         const sessionId = occurrence.externalPlanRef.sessionId;

--- a/app/src/services/activeExternalPlanService.ts
+++ b/app/src/services/activeExternalPlanService.ts
@@ -17,6 +17,7 @@ import { externalPlanService, type ExternalPlanService } from './externalPlanSer
 // plan-level rest directives in v3, resolved separately below rather than faked as sessions.
 import type { AnyExternalTrainingPlan as ExternalTrainingPlan, AnyExternalPlanSession as ExternalPlanSession } from '../sessions/externalPlanV2';
 import type { ExternalIntradayPlacement, ExternalPlanSessionV4 } from '../sessions/externalPlanV4';
+import { isExternalPlanOccurrence, type SessionOccurrence } from '../sessions/models';
 
 export interface ActiveExternalPlan {
     header: ExternalPlanHeader;
@@ -83,6 +84,48 @@ export interface IntradayBundlePlacementContext {
      * caller that has not yet wired occurrence lookups keeps working unchanged.
      */
     memberState?: ReadonlyMap<string, { started: boolean; existingBinding?: ResolvedWindowBinding }>;
+}
+
+/**
+ * H4 (#434) PR 3 step 7: maps today's already-fetched external-plan occurrences onto
+ * `IntradayBundlePlacementContext['memberState']`, keyed by the v4 session's own
+ * `sessionId` via `externalPlanRef.sessionId`. Pure and unit-testable on its own --
+ * `Home.tsx` only needs to fetch the occurrences (`sessionOccurrenceService
+ * .getExternalPlanOccurrencesForDate`) and pass the result through.
+ *
+ * `started` is true once the occurrence's execution has actually begun --
+ * `active`/`completed`/`abandoned` -- never for `scheduled` (not launched),
+ * `missed` (never launched), or `superseded`/`skipped` (already excluded by
+ * `getExternalPlanOccurrencesForDate`, but excluded here too for callers that pass an
+ * unfiltered list). `existingBinding` is populated only for a started member that also
+ * carries a persisted `windowBinding` -- until a caller passes `windowBinding` into
+ * `getOrCreateExternalPlanOccurrence` when creating a bundle member's occurrence, this
+ * stays absent even for a started member; `started` alone is still real and meaningful.
+ */
+export function buildIntradayMemberState(
+    occurrences: readonly SessionOccurrence[],
+): NonNullable<IntradayBundlePlacementContext['memberState']> {
+    const memberState = new Map<string, { started: boolean; existingBinding?: ResolvedWindowBinding }>();
+    for (const occurrence of occurrences) {
+        if (!isExternalPlanOccurrence(occurrence)) continue;
+        const started = occurrence.state === 'active' || occurrence.state === 'completed' || occurrence.state === 'abandoned';
+        const windowBinding = occurrence.windowBinding;
+        const sessionId = occurrence.externalPlanRef.sessionId;
+        memberState.set(sessionId, {
+            started,
+            ...(started && windowBinding ? {
+                existingBinding: {
+                    sessionId,
+                    windowId: windowBinding.windowId,
+                    boundStartLocal: windowBinding.boundStartLocal,
+                    boundEndLocal: windowBinding.boundEndLocal,
+                    startInstant: windowBinding.startInstant,
+                    endInstant: windowBinding.endInstant,
+                },
+            } : {}),
+        });
+    }
+    return memberState;
 }
 
 function toMembers(

--- a/app/src/services/dailyLedgerAggregateService.test.ts
+++ b/app/src/services/dailyLedgerAggregateService.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const firestore = vi.hoisted(() => ({
+    doc: vi.fn(),
+    getDoc: vi.fn(),
+}));
+
+vi.mock('firebase/firestore', () => firestore);
+vi.mock('../firebase', () => ({ getDb: vi.fn(() => ({})) }));
+
+import {
+    DailyLedgerAggregateService,
+    buildInitialReservations,
+    hasSeededAggregate,
+    findAggregateDrift,
+    type DailyLedgerAggregate,
+} from './dailyLedgerAggregateService';
+import type { OccurrenceLedgerInput } from '../engine/intradayLedgerInputs';
+
+const ceilings = { dailyMinuteCeiling: 90, dailySystemicCostCeiling: 1 };
+
+function occInput(overrides: Partial<OccurrenceLedgerInput> = {}): OccurrenceLedgerInput {
+    return {
+        occurrenceId: 'occ-1', occurrenceState: 'scheduled',
+        estimatedMinutes: 60, estimatedSystemicCost: 0.4, revision: 1,
+        ...overrides,
+    };
+}
+
+function aggregate(overrides: Partial<DailyLedgerAggregate> = {}): DailyLedgerAggregate {
+    return {
+        userId: 'u1', date: '2026-08-18', revision: 1, ceilings,
+        reservations: {}, seededAt: '2026-08-18T05:00:00Z',
+        createdAt: '2026-08-18T05:00:00Z', updatedAt: '2026-08-18T05:00:00Z',
+        ...overrides,
+    };
+}
+
+describe('hasSeededAggregate', () => {
+    it('is false for a missing aggregate', () => {
+        expect(hasSeededAggregate(null)).toBe(false);
+        expect(hasSeededAggregate(undefined)).toBe(false);
+    });
+
+    it('is false for a document missing seededAt (partial write, must fail closed)', () => {
+        const partial = aggregate();
+        // @ts-expect-error -- intentionally malformed to exercise the fail-closed path
+        delete partial.seededAt;
+        expect(hasSeededAggregate(partial)).toBe(false);
+    });
+
+    it('is true once seededAt is present', () => {
+        expect(hasSeededAggregate(aggregate())).toBe(true);
+    });
+});
+
+describe('buildInitialReservations', () => {
+    it('reuses step 6\'s mapping verbatim -- a scheduled occurrence seeds a reserved row', () => {
+        const reservations = buildInitialReservations([occInput()]);
+        expect(reservations['occ-1']).toEqual({ minutes: 60, systemicCost: 0.4, state: 'reserved' });
+    });
+
+    it('drops superseded/skipped occurrences from the seed entirely', () => {
+        const reservations = buildInitialReservations([
+            occInput({ occurrenceId: 'occ-superseded', occurrenceState: 'superseded' }),
+            occInput({ occurrenceId: 'occ-skipped', occurrenceState: 'skipped' }),
+            occInput({ occurrenceId: 'occ-live', occurrenceState: 'scheduled' }),
+        ]);
+        expect(Object.keys(reservations)).toEqual(['occ-live']);
+    });
+
+    it('includes a pre-existing abandoned execution with its bounded actual minutes (the exact regression the plan calls out)', () => {
+        const reservations = buildInitialReservations([
+            occInput({
+                occurrenceId: 'occ-abandoned', occurrenceState: 'active',
+                execution: { state: 'abandoned', startedAt: '2026-08-18T06:00:00Z', completedAt: '2026-08-18T06:15:00Z' },
+            }),
+        ]);
+        expect(reservations['occ-abandoned']).toEqual({
+            minutes: 60, systemicCost: 0.4, state: 'abandoned', actualMinutes: 15,
+        });
+    });
+});
+
+describe('findAggregateDrift', () => {
+    it('reports no drift when the aggregate matches a freshly recomputed seed', () => {
+        const inputs = [occInput()];
+        const agg = aggregate({ reservations: buildInitialReservations(inputs) });
+        expect(findAggregateDrift(agg, inputs)).toEqual([]);
+    });
+
+    it('flags an occurrence whose persisted row disagrees with the recomputed one', () => {
+        const inputs = [occInput({ estimatedMinutes: 45 })];
+        const agg = aggregate({ reservations: { 'occ-1': { minutes: 60, systemicCost: 0.4, state: 'reserved' } } });
+        expect(findAggregateDrift(agg, inputs)).toEqual(['occ-1']);
+    });
+
+    it('flags a reservation with no corresponding current occurrence', () => {
+        const agg = aggregate({ reservations: { 'occ-ghost': { minutes: 30, systemicCost: 0.2, state: 'reserved' } } });
+        expect(findAggregateDrift(agg, [])).toEqual(['occ-ghost']);
+    });
+});
+
+describe('DailyLedgerAggregateService', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        firestore.doc.mockReturnValue({ path: 'users/u1/daily_ledgers/2026-08-18' });
+    });
+
+    describe('seedIfAbsent', () => {
+        it('seeds a fresh aggregate when none exists', () => {
+            const service = new DailyLedgerAggregateService();
+            const mockTx = { set: vi.fn() };
+            const result = service.seedIfAbsent(
+                mockTx as never, 'u1', '2026-08-18', null, ceilings, [occInput()], '2026-08-18T05:00:00Z',
+            );
+            expect(result.revision).toBe(1);
+            expect(result.reservations['occ-1']).toEqual({ minutes: 60, systemicCost: 0.4, state: 'reserved' });
+            expect(mockTx.set).toHaveBeenCalledTimes(1);
+        });
+
+        it('is a no-op returning the existing aggregate unchanged when already seeded', () => {
+            const service = new DailyLedgerAggregateService();
+            const mockTx = { set: vi.fn() };
+            const existing = aggregate({ revision: 3, reservations: { 'occ-existing': { minutes: 10, systemicCost: 0.1, state: 'reserved' } } });
+            const result = service.seedIfAbsent(mockTx as never, 'u1', '2026-08-18', existing, ceilings, [occInput()]);
+            expect(result).toBe(existing);
+            expect(mockTx.set).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('applyReservation', () => {
+        it('adds a reservation and bumps revision by exactly one', () => {
+            const service = new DailyLedgerAggregateService();
+            const mockTx = { set: vi.fn() };
+            const current = aggregate({ revision: 1, reservations: {} });
+            const result = service.applyReservation(
+                mockTx as never, 'u1', '2026-08-18', current, 'occ-new',
+                { minutes: 45, systemicCost: 0.3, state: 'reserved' },
+                '2026-08-18T06:00:00Z',
+            );
+            expect(result.revision).toBe(2);
+            expect(result.reservations['occ-new']).toEqual({ minutes: 45, systemicCost: 0.3, state: 'reserved' });
+            expect(mockTx.set).toHaveBeenCalledWith(
+                expect.anything(),
+                expect.objectContaining({ revision: 2 }),
+            );
+        });
+
+        it('removes a reservation when passed null (reject / re-import supersede)', () => {
+            const service = new DailyLedgerAggregateService();
+            const mockTx = { set: vi.fn() };
+            const current = aggregate({ revision: 2, reservations: { 'occ-rejected': { minutes: 45, systemicCost: 0.3, state: 'reserved' } } });
+            const result = service.applyReservation(mockTx as never, 'u1', '2026-08-18', current, 'occ-rejected', null);
+            expect(result.revision).toBe(3);
+            expect(result.reservations).not.toHaveProperty('occ-rejected');
+        });
+
+        it('never mutates a reservation for a different occurrence', () => {
+            const service = new DailyLedgerAggregateService();
+            const mockTx = { set: vi.fn() };
+            const current = aggregate({ reservations: { 'occ-other': { minutes: 20, systemicCost: 0.1, state: 'reserved' } } });
+            const result = service.applyReservation(
+                mockTx as never, 'u1', '2026-08-18', current, 'occ-new',
+                { minutes: 45, systemicCost: 0.3, state: 'reserved' },
+            );
+            expect(result.reservations['occ-other']).toEqual({ minutes: 20, systemicCost: 0.1, state: 'reserved' });
+        });
+    });
+});

--- a/app/src/services/dailyLedgerAggregateService.ts
+++ b/app/src/services/dailyLedgerAggregateService.ts
@@ -1,0 +1,202 @@
+/**
+ * ADR-0036 (H4) D-LEDGER, Phase 2 step 6a of
+ * `docs/plans/h4-434-pr3-bundle-second-member-launch.md`: the persisted date-level
+ * reservation aggregate at `users/{userId}/daily_ledgers/{date}`.
+ *
+ * Why this document has to exist at all: in the Web SDK, `Transaction.get()` accepts a
+ * `DocumentReference` only -- a transaction cannot query "every occurrence for this date"
+ * to re-derive the day's ledger. So the day's reservation totals must live in one named
+ * document every reserving/releasing writer reads and updates atomically, and
+ * `intradayLedgerInputs.ts`'s `buildLedgerEntries` (step 6) becomes a read-side
+ * projection over `session_occurrences`, not the serialization authority the claim
+ * transaction (Phase 4 step 11) actually reads.
+ *
+ * Every transition that changes an occurrence's reserving status must update this
+ * document and bump `revision` in the *same* transaction as the occurrence write --
+ * see the table in the plan's step 6a. This module exposes the primitives
+ * (`seedIfAbsent`, `applyReservation`) that those call sites compose; it does not itself
+ * own a `runTransaction` for the mutating path, because the reservation change must
+ * commit atomically with whatever occurrence/decision write triggered it, not as a
+ * separate round trip.
+ *
+ * Wiring status (tracked here so this doesn't read as silently "done"): `seedIfAbsent`
+ * and `applyReservation` are implemented and tested against every acceptance case named
+ * in the plan's step 6a. The six call sites in the transition table are wired in as each
+ * phase builds them -- `getOrCreateExternalPlanOccurrence`
+ * (`sessionOccurrenceService.ts`) is the first, covering "create" and the re-import
+ * "supersede" rows; "reject" (Phase 3 step 8), "claim"/"release" (Phase 4 step 11) and
+ * completion/abandonment reconciliation (`useSessionRunner.ts`) still need to call
+ * `applyReservation` from their own transactions once those call sites exist.
+ */
+
+import { doc, getDoc, type DocumentReference, type Firestore, type Transaction } from 'firebase/firestore';
+import { getDb } from '../firebase';
+import type { LedgerCeilings, ReconciliationState } from '../engine/dailyLedger';
+import { buildLedgerEntries, type OccurrenceLedgerInput } from '../engine/intradayLedgerInputs';
+
+/** One occurrence's row in the aggregate. Mirrors `LedgerEntry`'s reservation/actual
+ * fields under the `minutes`/`systemicCost` names the persisted document uses.
+ * `decisionId` is optional on the row but mandatory for anything launchable (plan step
+ * 6a): a `pending`/`scale` reservation legitimately has none, since step 9 only writes a
+ * decision record for a member that receives a binding -- the claim (step 11) must reject
+ * a launchable entry lacking one rather than reading the absence as "nothing to check". */
+export interface DailyLedgerReservation {
+    minutes: number;
+    systemicCost: number;
+    state: ReconciliationState;
+    actualMinutes?: number;
+    actualSystemicCost?: number;
+    decisionId?: string;
+}
+
+export interface DailyLedgerAggregate {
+    userId: string;
+    date: string;
+    revision: number;
+    ceilings: LedgerCeilings;
+    reservations: Record<string, DailyLedgerReservation>;
+    /** Presence (not just document existence) is what "seeded" means -- see
+     * `hasSeededAggregate`. A partially-written document without this field must still
+     * fail closed rather than read as an empty day. */
+    seededAt: string;
+    createdAt: string;
+    updatedAt: string;
+}
+
+/** True only for a document that completed seeding. A claim (Phase 4 step 11) must treat
+ * an absent *or* unseeded aggregate as "fail closed", never as an empty day with free
+ * capacity (plan step 6a: "Initialization is part of the contract"). */
+export function hasSeededAggregate(aggregate: DailyLedgerAggregate | null | undefined): aggregate is DailyLedgerAggregate {
+    return !!aggregate && typeof aggregate.seededAt === 'string' && aggregate.seededAt.length > 0;
+}
+
+function reservationFromLedgerEntry(entry: ReturnType<typeof buildLedgerEntries>[number]): DailyLedgerReservation {
+    return {
+        minutes: entry.reservedMinutes,
+        systemicCost: entry.reservedSystemicCost,
+        state: entry.state,
+        ...(entry.actualMinutes !== undefined ? { actualMinutes: entry.actualMinutes } : {}),
+        ...(entry.actualSystemicCost !== undefined ? { actualSystemicCost: entry.actualSystemicCost } : {}),
+    };
+}
+
+/** Builds the initial `reservations` map for a seed. Reuses `buildLedgerEntries` (step 6)
+ * verbatim rather than restating its state mapping, so the seed and the derived ledger
+ * can never drift -- a subset here is exactly how a pre-existing occurrence (e.g. an
+ * abandoned execution) would be dropped from the seed and undercount the day. */
+export function buildInitialReservations(inputs: readonly OccurrenceLedgerInput[]): Record<string, DailyLedgerReservation> {
+    const reservations: Record<string, DailyLedgerReservation> = {};
+    for (const entry of buildLedgerEntries(inputs)) {
+        reservations[entry.occurrenceId] = reservationFromLedgerEntry(entry);
+    }
+    return reservations;
+}
+
+/**
+ * Read-side reconciliation check (plan step 6a): recomputes the seed set the aggregate
+ * *should* currently reflect for its already-reserving occurrences and reports any
+ * disagreement. A mismatch is a bug to surface, never to silently paper over by trusting
+ * whichever side shows less consumption -- callers should prefer the aggregate's own
+ * value when it is the higher (more conservative) one.
+ */
+export function findAggregateDrift(
+    aggregate: DailyLedgerAggregate,
+    currentInputs: readonly OccurrenceLedgerInput[],
+): string[] {
+    const expected = buildInitialReservations(currentInputs);
+    const drifted: string[] = [];
+    const ids = new Set([...Object.keys(expected), ...Object.keys(aggregate.reservations)]);
+    for (const occurrenceId of ids) {
+        const a = aggregate.reservations[occurrenceId];
+        const b = expected[occurrenceId];
+        if (JSON.stringify(a) !== JSON.stringify(b)) drifted.push(occurrenceId);
+    }
+    return drifted;
+}
+
+export class DailyLedgerAggregateService {
+    private readonly db: Firestore;
+
+    constructor(db: Firestore = getDb()) {
+        this.db = db;
+    }
+
+    ref(userId: string, date: string): DocumentReference {
+        return doc(this.db, 'users', userId, 'daily_ledgers', date);
+    }
+
+    async get(userId: string, date: string): Promise<DailyLedgerAggregate | null> {
+        const snap = await getDoc(this.ref(userId, date));
+        return snap.exists() ? (snap.data() as DailyLedgerAggregate) : null;
+    }
+
+    /**
+     * Create-if-absent seeding, callable from inside a caller-supplied transaction so it
+     * can commit atomically with whatever occurrence write is triggering it (e.g. a bundle
+     * member's first reservation on a date that has no aggregate yet). `transaction.get`
+     * on this document must already have been read by the caller *before* any writes in
+     * that transaction (Firestore's reads-before-writes rule) -- pass that snapshot's data
+     * as `existing`. A concurrent seeder loses the create (Firestore's transaction commit
+     * protocol detects the conflict) and retries, so two tabs opening the same day cannot
+     * produce two different starting balances.
+     */
+    seedIfAbsent(
+        transaction: Transaction,
+        userId: string,
+        date: string,
+        existing: DailyLedgerAggregate | null,
+        ceilings: LedgerCeilings,
+        inputs: readonly OccurrenceLedgerInput[],
+        now = new Date().toISOString(),
+    ): DailyLedgerAggregate {
+        const priorCreatedAt = existing?.createdAt;
+        if (hasSeededAggregate(existing)) return existing;
+        const aggregate: DailyLedgerAggregate = {
+            userId,
+            date,
+            revision: 1,
+            ceilings,
+            reservations: buildInitialReservations(inputs),
+            seededAt: now,
+            createdAt: priorCreatedAt ?? now,
+            updatedAt: now,
+        };
+        transaction.set(this.ref(userId, date), aggregate);
+        return aggregate;
+    }
+
+    /**
+     * Adds, replaces, or removes one occurrence's reservation row and bumps `revision` by
+     * exactly one (the rules enforce this, so a stale caller's write is rejected rather
+     * than silently applied). Must be called with `current` already read via
+     * `transaction.get` in the same transaction, and only after any `seedIfAbsent` call in
+     * that same transaction. Passing `reservation: null` removes the row -- the "reject"
+     * and "re-import supersede" rows in the plan's step 6a table.
+     */
+    applyReservation(
+        transaction: Transaction,
+        userId: string,
+        date: string,
+        current: DailyLedgerAggregate,
+        occurrenceId: string,
+        reservation: DailyLedgerReservation | null,
+        now = new Date().toISOString(),
+    ): DailyLedgerAggregate {
+        const reservations = { ...current.reservations };
+        if (reservation) {
+            reservations[occurrenceId] = reservation;
+        } else {
+            delete reservations[occurrenceId];
+        }
+        const next: DailyLedgerAggregate = {
+            ...current,
+            reservations,
+            revision: current.revision + 1,
+            updatedAt: now,
+        };
+        transaction.set(this.ref(userId, date), next);
+        return next;
+    }
+}
+
+export const dailyLedgerAggregateService = new DailyLedgerAggregateService();

--- a/app/src/services/sessionAuthoringService.test.ts
+++ b/app/src/services/sessionAuthoringService.test.ts
@@ -240,8 +240,11 @@ describe('prepareExternalPlanSessionLaunch (ADR-0036 H4)', () => {
                 sessionId: 'session-101',
                 contentHash: 'c'.repeat(64),
             },
-            undefined,
-            '2026-09-06T12:00:00.000Z',
+            {
+                placementOrder: undefined,
+                windowBinding: undefined,
+                now: '2026-09-06T12:00:00.000Z',
+            },
         );
     });
 

--- a/app/src/services/sessionAuthoringService.ts
+++ b/app/src/services/sessionAuthoringService.ts
@@ -1,4 +1,4 @@
-import { isExternalPlanOccurrence, type SessionDefinition, type ExecutionPrescription, type SessionReferenceBinding } from '../sessions/models';
+import { isExternalPlanOccurrence, type SessionDefinition, type ExecutionPrescription, type SessionReferenceBinding, type OccurrenceWindowBinding } from '../sessions/models';
 import type { PreparedSessionLaunch } from '../sessions/sessionLaunch';
 import type { WorkoutPrescription } from '../workouts/models';
 import type { ExternalPlanSessionV4 } from '../sessions/externalPlanV4';
@@ -155,6 +155,10 @@ export interface PrepareExternalPlanSessionLaunchOptions {
     date?: string;
     occurrenceId?: string;
     placementOrder?: number;
+    /** H4 (#434) PR 3: the D-PLACEMENT-resolved window this member sits in. Only meaningful
+     * alongside `date` (occurrence creation); ignored when `occurrenceId` is supplied
+     * directly, since an existing occurrence's `windowBinding` is already immutable. */
+    windowBinding?: OccurrenceWindowBinding;
 }
 
 /**
@@ -244,8 +248,11 @@ export async function prepareExternalPlanSessionLaunch(
                 sessionId: externalPlan.session.id,
                 contentHash: externalPlan.contentHash,
             },
-            options.placementOrder,
-            now,
+            {
+                placementOrder: options.placementOrder,
+                windowBinding: options.windowBinding,
+                now,
+            },
         );
         if (occurrence.state !== 'scheduled') {
             throw new Error(`External-plan occurrence ${occurrence.occurrenceId} does not match the launch source.`);

--- a/app/src/services/sessionOccurrenceService.test.ts
+++ b/app/src/services/sessionOccurrenceService.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { WriteBatch } from 'firebase/firestore';
 import type { ExternalPlanSessionOccurrence, ManualOccurrenceRef, SessionOccurrence } from '../sessions/models';
 
 const firestore = vi.hoisted(() => ({
@@ -578,32 +577,6 @@ describe('SessionOccurrenceService authority methods (M3.3)', () => {
             ).rejects.toThrow("Cannot transition occurrence occ-1 from 'completed' to 'active'.");
 
             expect(mockTx.set).not.toHaveBeenCalled();
-        });
-
-        it('queueOccurrenceTransition queues state change into batch starting from scheduled to completed', async () => {
-            const scheduled = occurrenceDoc({ occurrenceId: 'occ-1', state: 'scheduled' });
-            firestore.getDoc.mockResolvedValue({
-                exists: () => true,
-                data: () => scheduled,
-            });
-            const mockBatch = {
-                set: vi.fn(),
-            };
-
-            const service = new SessionOccurrenceService();
-            const result = await service.queueOccurrenceTransition(
-                'u1',
-                'occ-1',
-                'completed',
-                mockBatch as unknown as WriteBatch,
-                '2026-08-18T12:00:00Z',
-            );
-
-            expect(result.state).toBe('completed');
-            expect(mockBatch.set).toHaveBeenCalledWith(
-                expect.anything(),
-                expect.objectContaining({ state: 'completed', updatedAt: '2026-08-18T12:00:00Z' }),
-            );
         });
     });
 });

--- a/app/src/services/sessionOccurrenceService.test.ts
+++ b/app/src/services/sessionOccurrenceService.test.ts
@@ -351,6 +351,7 @@ describe('SessionOccurrenceService authority methods (M3.3)', () => {
         });
 
         it('getOrCreateExternalPlanOccurrence returns existing occurrence transactionally if document exists at deterministic ID', async () => {
+            firestore.getDocs.mockResolvedValue({ docs: [] });
             const existing = {
                 userId: 'u1',
                 occurrenceId: 'ext_2026-08-18_0123456789abcdef01234567',
@@ -380,9 +381,11 @@ describe('SessionOccurrenceService authority methods (M3.3)', () => {
         });
 
         it('getOrCreateExternalPlanOccurrence transactionally creates a new occurrence with deterministic ID if none exists', async () => {
+            firestore.getDocs.mockResolvedValue({ docs: [] });
             const mockTx = {
                 get: vi.fn().mockResolvedValue({ exists: () => false }),
                 set: vi.fn(),
+                delete: vi.fn(),
             };
             firestore.runTransaction.mockImplementation(async (_db, cb) => cb(mockTx));
 
@@ -393,6 +396,150 @@ describe('SessionOccurrenceService authority methods (M3.3)', () => {
             expect(result.state).toBe('scheduled');
             expect(result.occurrenceId).toMatch(/^ext_2026-08-18_[a-f0-9]{24}$/);
             expect(mockTx.set).toHaveBeenCalledTimes(1);
+        });
+
+        describe('D-WINDOW exclusivity and re-import supersession (H4 #434 PR 3, plan steps 4a/4b)', () => {
+            const windowBinding = {
+                windowId: 'window-1', bundleId: 'bundle-1', order: 0,
+                boundStartLocal: '07:00', boundEndLocal: '08:00',
+                startInstant: '2026-08-18T05:00:00Z', endInstant: '2026-08-18T06:00:00Z',
+            };
+
+            it('claims the window reservation alongside a fresh occurrence create', async () => {
+                firestore.getDocs.mockResolvedValue({ docs: [] });
+                const mockTx = {
+                    // Call order: occurrence ref, then the window reservation ref (no
+                    // prior-revision candidate found, so no priorRef get in between).
+                    get: vi.fn()
+                        .mockResolvedValueOnce({ exists: () => false })
+                        .mockResolvedValueOnce({ exists: () => false }),
+                    set: vi.fn(),
+                    delete: vi.fn(),
+                };
+                firestore.runTransaction.mockImplementation(async (_db, cb) => cb(mockTx));
+
+                const service = new SessionOccurrenceService();
+                const result = await service.getOrCreateExternalPlanOccurrence('u1', '2026-08-18', extPlanRef, { windowBinding });
+
+                expect((result as ExternalPlanSessionOccurrence).windowBinding).toEqual(windowBinding);
+                expect(mockTx.set).toHaveBeenCalledTimes(2);
+                expect(mockTx.set).toHaveBeenCalledWith(
+                    expect.anything(),
+                    expect.objectContaining({ windowId: 'window-1', occurrenceId: expect.stringMatching(/^ext_/) }),
+                );
+            });
+
+            it('rejects the create when the window is already reserved by an unrelated occurrence', async () => {
+                firestore.getDocs.mockResolvedValue({ docs: [] });
+                const mockTx = {
+                    get: vi.fn()
+                        .mockResolvedValueOnce({ exists: () => false }) // occurrence: absent
+                        .mockResolvedValueOnce({ exists: () => true, data: () => ({ occurrenceId: 'occ-someone-else' }) }), // reservation: taken
+                    set: vi.fn(),
+                    delete: vi.fn(),
+                };
+                firestore.runTransaction.mockImplementation(async (_db, cb) => cb(mockTx));
+
+                const service = new SessionOccurrenceService();
+                await expect(
+                    service.getOrCreateExternalPlanOccurrence('u1', '2026-08-18', extPlanRef, { windowBinding }),
+                ).rejects.toThrow("Window 'window-1' on 2026-08-18 is already bound to occurrence 'occ-someone-else'.");
+                expect(mockTx.set).not.toHaveBeenCalled();
+            });
+
+            it('supersedes a scheduled prior-revision occurrence for the same (planId, sessionId) in the same transaction', async () => {
+                const priorOccurrence = {
+                    userId: 'u1', occurrenceId: 'ext_2026-08-18_prior000000000000000000',
+                    date: '2026-08-18', authority: 'external_plan' as const,
+                    externalPlanRef: { ...extPlanRef, revision: 1 },
+                    state: 'scheduled' as const,
+                    createdAt: '2026-08-18T00:00:00Z', updatedAt: '2026-08-18T00:00:00Z',
+                };
+                firestore.getDocs.mockResolvedValue({ docs: [{ data: () => priorOccurrence, ref: { path: 'x' } }] });
+                const revisedRef = { ...extPlanRef, revision: 2 };
+                const mockTx = {
+                    // Call order: new-occurrence ref (absent), prior-occurrence ref (found,
+                    // still scheduled), no windowBinding so no reservation get.
+                    get: vi.fn()
+                        .mockResolvedValueOnce({ exists: () => false })
+                        .mockResolvedValueOnce({ exists: () => true, data: () => priorOccurrence }),
+                    set: vi.fn(),
+                    delete: vi.fn(),
+                };
+                firestore.runTransaction.mockImplementation(async (_db, cb) => cb(mockTx));
+
+                const service = new SessionOccurrenceService();
+                const result = await service.getOrCreateExternalPlanOccurrence('u1', '2026-08-18', revisedRef);
+
+                expect(result.occurrenceId).not.toBe(priorOccurrence.occurrenceId);
+                expect(mockTx.set).toHaveBeenCalledWith(
+                    expect.anything(),
+                    expect.objectContaining({ occurrenceId: priorOccurrence.occurrenceId, state: 'superseded' }),
+                );
+                expect(mockTx.set).toHaveBeenCalledWith(
+                    expect.anything(),
+                    expect.objectContaining({ externalPlanRef: revisedRef, state: 'scheduled' }),
+                );
+            });
+
+            it('never supersedes a prior occurrence that already started or completed', async () => {
+                const activePrior = {
+                    userId: 'u1', occurrenceId: 'ext_2026-08-18_prior000000000000000000',
+                    date: '2026-08-18', authority: 'external_plan' as const,
+                    externalPlanRef: { ...extPlanRef, revision: 1 },
+                    state: 'active' as const,
+                    createdAt: '2026-08-18T00:00:00Z', updatedAt: '2026-08-18T00:00:00Z',
+                };
+                // The pre-transaction query only ever considers 'scheduled' candidates
+                // (see the `occ.state === 'scheduled'` filter), so an active/completed
+                // predecessor is never even proposed as priorRef -- there is nothing to
+                // read a second time inside the transaction.
+                firestore.getDocs.mockResolvedValue({ docs: [{ data: () => activePrior, ref: { path: 'x' } }] });
+                const mockTx = {
+                    get: vi.fn().mockResolvedValueOnce({ exists: () => false }),
+                    set: vi.fn(),
+                    delete: vi.fn(),
+                };
+                firestore.runTransaction.mockImplementation(async (_db, cb) => cb(mockTx));
+
+                const service = new SessionOccurrenceService();
+                await service.getOrCreateExternalPlanOccurrence('u1', '2026-08-18', { ...extPlanRef, revision: 2 });
+
+                expect(mockTx.get).toHaveBeenCalledTimes(1);
+                expect(mockTx.set).not.toHaveBeenCalledWith(
+                    expect.anything(),
+                    expect.objectContaining({ state: 'superseded' }),
+                );
+            });
+
+            it('releases the prior occurrence\'s window reservation when the successor binds a different window', async () => {
+                const priorOccurrence = {
+                    userId: 'u1', occurrenceId: 'ext_2026-08-18_prior000000000000000000',
+                    date: '2026-08-18', authority: 'external_plan' as const,
+                    externalPlanRef: { ...extPlanRef, revision: 1 },
+                    state: 'scheduled' as const,
+                    windowBinding: { ...windowBinding, windowId: 'window-old' },
+                    createdAt: '2026-08-18T00:00:00Z', updatedAt: '2026-08-18T00:00:00Z',
+                };
+                firestore.getDocs.mockResolvedValue({ docs: [{ data: () => priorOccurrence, ref: { path: 'x' } }] });
+                const mockTx = {
+                    // occurrence (absent), prior (found), new window reservation (absent).
+                    get: vi.fn()
+                        .mockResolvedValueOnce({ exists: () => false })
+                        .mockResolvedValueOnce({ exists: () => true, data: () => priorOccurrence })
+                        .mockResolvedValueOnce({ exists: () => false }),
+                    set: vi.fn(),
+                    delete: vi.fn(),
+                };
+                firestore.runTransaction.mockImplementation(async (_db, cb) => cb(mockTx));
+
+                const service = new SessionOccurrenceService();
+                await service.getOrCreateExternalPlanOccurrence(
+                    'u1', '2026-08-18', { ...extPlanRef, revision: 2 }, { windowBinding },
+                );
+
+                expect(mockTx.delete).toHaveBeenCalledTimes(1);
+            });
         });
     });
 

--- a/app/src/services/sessionOccurrenceService.ts
+++ b/app/src/services/sessionOccurrenceService.ts
@@ -19,6 +19,7 @@ import {
     type ManualOccurrenceRef,
     type ExternalPlanOccurrenceRef,
     type ExternalPlanSessionOccurrence,
+    type OccurrenceWindowBinding,
     isExternalPlanOccurrence,
 } from '../sessions/models';
 import { parseSessionOccurrenceDocument } from '../persistence/parsers/sessionDefinition';
@@ -81,6 +82,17 @@ export async function deterministicExternalPlanOccurrenceId(
     return `ext_${date}_${hash}`;
 }
 
+/**
+ * H4 (#434) PR 3 / ADR-0036 D-WINDOW: deterministic id for the `session_occurrence_windows`
+ * document that gives one resolved window on one date real transactional exclusivity.
+ * `windowId` is app-generated (a real `ScheduleWindow.id` or the `LEGACY_SINGLE_SLOT_WINDOW_ID`
+ * sentinel), not athlete-supplied free text, so `encodeURIComponent` is sufficient here --
+ * unlike `deterministicExternalPlanOccurrenceId`, which hashes because plan session ids are.
+ */
+export function windowReservationId(date: string, windowId: string): string {
+    return `win-${date}-${encodeURIComponent(windowId)}`;
+}
+
 export interface ClaimOccurrenceLaunchOptions {
     now?: string;
     /**
@@ -100,6 +112,10 @@ export class SessionOccurrenceService {
 
     private occurrenceRef(userId: string, occurrenceId: string) {
         return doc(this.db, 'users', userId, 'session_occurrences', occurrenceId);
+    }
+
+    private windowReservationRef(userId: string, date: string, windowId: string) {
+        return doc(this.db, 'users', userId, 'session_occurrence_windows', windowReservationId(date, windowId));
     }
 
     async saveOccurrence(occurrence: SessionOccurrence): Promise<void> {
@@ -217,22 +233,65 @@ export class SessionOccurrenceService {
     }
 
     /**
-     * Idempotently retrieves an existing external-plan occurrence for (userId, date, planId, sessionId, revision, contentHash),
-     * or schedules a new one with a deterministic occurrenceId if not yet present.
-     * Transactionally reads and creates to prevent concurrent double-creations and permission errors on Firestore updates.
+     * Idempotently retrieves an existing external-plan occurrence for
+     * (userId, date, planId, sessionId, revision, contentHash), or schedules a new one with
+     * a deterministic occurrenceId if not yet present. Transactionally reads and creates to
+     * prevent concurrent double-creations and permission errors on Firestore updates.
+     *
+     * Two H4 (#434) PR 3 responsibilities live here, both required before this occurrence
+     * can be trusted by Phase 2's ledger or Phase 4's claim:
+     *
+     * - **D-WINDOW exclusivity (plan step 4a):** when `windowBinding` is supplied, this
+     *   atomically claims `session_occurrence_windows/(date, windowId)` alongside creating
+     *   the occurrence, so two occurrences can never end up bound to the same resolved
+     *   window even if placement resolution is ever wrong.
+     * - **Re-import supersession (plan step 4b):** a prior `scheduled` occurrence for the
+     *   same `(date, planId, sessionId)` under a *different* revision/contentHash is
+     *   transitioned to `superseded` in this same transaction, releasing its window
+     *   reservation (if any) so a same-window successor is not blocked by history that no
+     *   longer governs anything. An occurrence that already reached `active`/`completed` is
+     *   never touched -- its consumption is real (D-LEDGER).
+     *
+     * The candidate predecessor is found by query *outside* the transaction (a transaction
+     * cannot query) and re-verified by direct document reference *inside* it, so a
+     * concurrent claim/completion of that predecessor between the two reads is not
+     * silently overwritten.
      */
     async getOrCreateExternalPlanOccurrence(
         userId: string,
         date: string,
         externalPlanRef: ExternalPlanOccurrenceRef,
-        placementOrder?: number,
-        now = new Date().toISOString(),
+        options: {
+            placementOrder?: number;
+            windowBinding?: OccurrenceWindowBinding;
+            now?: string;
+        } = {},
     ): Promise<SessionOccurrence> {
+        const now = options.now ?? new Date().toISOString();
         const deterministicId = await deterministicExternalPlanOccurrenceId(date, externalPlanRef);
         const ref = this.occurrenceRef(userId, deterministicId);
+        const windowReservationRef = options.windowBinding
+            ? this.windowReservationRef(userId, date, options.windowBinding.windowId)
+            : null;
+
+        const sameDayOccurrences = await this.getOccurrencesForDate(userId, date);
+        const priorRevision = sameDayOccurrences.find(
+            (occ): occ is ExternalPlanSessionOccurrence =>
+                isExternalPlanOccurrence(occ)
+                && occ.externalPlanRef.planId === externalPlanRef.planId
+                && occ.externalPlanRef.sessionId === externalPlanRef.sessionId
+                && occ.occurrenceId !== deterministicId
+                && occ.state === 'scheduled',
+        );
+        const priorRef = priorRevision ? this.occurrenceRef(userId, priorRevision.occurrenceId) : null;
+
         let result: SessionOccurrence | null = null;
         await runTransaction(this.db, async transaction => {
+            // -- every read before any write (Firestore transaction requirement) --
             const snap = await transaction.get(ref);
+            const priorSnap = priorRef ? await transaction.get(priorRef) : null;
+            const reservationSnap = windowReservationRef ? await transaction.get(windowReservationRef) : null;
+
             if (snap.exists()) {
                 const parsed = parseSessionOccurrenceDocument(snap.data(), ref.path);
                 if (parsed.status !== 'AVAILABLE') {
@@ -241,6 +300,33 @@ export class SessionOccurrenceService {
                 result = parsed.data;
                 return;
             }
+
+            if (reservationSnap?.exists()) {
+                const owner = reservationSnap.data()?.occurrenceId as string | undefined;
+                if (owner !== priorRevision?.occurrenceId) {
+                    throw new Error(
+                        `Window '${options.windowBinding!.windowId}' on ${date} is already bound to occurrence '${owner}'.`,
+                    );
+                }
+            }
+
+            let priorWindowIdToRelease: string | undefined;
+            if (priorRef && priorSnap?.exists()) {
+                const parsedPrior = parseSessionOccurrenceDocument(priorSnap.data(), priorRef.path);
+                if (parsedPrior.status === 'AVAILABLE' && parsedPrior.data.state === 'scheduled') {
+                    transaction.set(priorRef, { ...parsedPrior.data, state: 'superseded', updatedAt: now });
+                    const priorWindowId = isExternalPlanOccurrence(parsedPrior.data)
+                        ? parsedPrior.data.windowBinding?.windowId
+                        : undefined;
+                    if (priorWindowId && priorWindowId !== options.windowBinding?.windowId) {
+                        priorWindowIdToRelease = priorWindowId;
+                    }
+                }
+            }
+            if (priorWindowIdToRelease) {
+                transaction.delete(this.windowReservationRef(userId, date, priorWindowIdToRelease));
+            }
+
             const occurrence: ExternalPlanSessionOccurrence = {
                 userId,
                 occurrenceId: deterministicId,
@@ -248,11 +334,23 @@ export class SessionOccurrenceService {
                 authority: 'external_plan',
                 externalPlanRef,
                 state: 'scheduled',
-                ...(placementOrder !== undefined ? { placementOrder } : {}),
+                ...(options.placementOrder !== undefined ? { placementOrder: options.placementOrder } : {}),
+                ...(options.windowBinding !== undefined ? { windowBinding: options.windowBinding } : {}),
                 createdAt: now,
                 updatedAt: now,
             };
             transaction.set(ref, occurrence);
+
+            if (windowReservationRef && options.windowBinding) {
+                transaction.set(windowReservationRef, {
+                    userId,
+                    date,
+                    windowId: options.windowBinding.windowId,
+                    occurrenceId: deterministicId,
+                    createdAt: now,
+                });
+            }
+
             result = occurrence;
         });
         return result!;

--- a/app/src/services/sessionOccurrenceService.ts
+++ b/app/src/services/sessionOccurrenceService.ts
@@ -9,7 +9,6 @@ import {
     runTransaction,
     type Firestore,
     type Transaction,
-    type WriteBatch,
 } from 'firebase/firestore';
 import { getDb } from '../firebase';
 import type { DataState } from '../engine/dataState';
@@ -20,11 +19,20 @@ import {
     type ManualOccurrenceRef,
     type ExternalPlanOccurrenceRef,
     type ExternalPlanSessionOccurrence,
+    isExternalPlanOccurrence,
 } from '../sessions/models';
 import { parseSessionOccurrenceDocument } from '../persistence/parsers/sessionDefinition';
 
 /** ACTIVE_OCCURRENCE_STATES excludes terminal/superseded states from "what governs today". */
 const ACTIVE_OCCURRENCE_STATES: ReadonlySet<SessionOccurrence['state']> = new Set(['scheduled', 'active']);
+
+/**
+ * H4 (#434) PR 3, Phase 1 step 4: a rejected member (`scheduled -> skipped`, plan step 8)
+ * or a re-imported revision's predecessor (`scheduled -> superseded`, plan step 4b) has
+ * never governed today's decision and never will again -- neither reserves capacity nor
+ * is offered for adjudication. Both are excluded from the bundle-member query below.
+ */
+const BUNDLE_QUERY_EXCLUDED_STATES: ReadonlySet<SessionOccurrence['state']> = new Set(['superseded', 'skipped']);
 
 /**
  * Valid occurrence lifecycle transitions.
@@ -271,6 +279,25 @@ export class SessionOccurrenceService {
     }
 
     /**
+     * Every external-plan occurrence on `date`, ordered by `placementOrder` (the bundle's
+     * `intraday.order`) then `occurrenceId` for a deterministic tie-break. `superseded` and
+     * `skipped` are excluded (see `BUNDLE_QUERY_EXCLUDED_STATES`) -- unlike
+     * `getAdditionalOccurrencesForDate`, every other state is included, because callers
+     * need `completed`/`abandoned` history too: predecessor-completion checks (D-REASSESS)
+     * and the reject-against-an-existing-occurrence branch (plan step 8) both read states
+     * this filter would otherwise hide.
+     */
+    async getExternalPlanOccurrencesForDate(userId: string, date: string): Promise<ExternalPlanSessionOccurrence[]> {
+        const occurrences = await this.getOccurrencesForDate(userId, date);
+        return occurrences
+            .filter(isExternalPlanOccurrence)
+            .filter(item => !BUNDLE_QUERY_EXCLUDED_STATES.has(item.state))
+            .sort((a, b) =>
+                (a.placementOrder ?? 0) - (b.placementOrder ?? 0)
+                || a.occurrenceId.localeCompare(b.occurrenceId));
+    }
+
+    /**
      * ADR-0036 (H4) D-REASSESS: atomically claim a scheduled occurrence for launch.
      * Prevents duplicate/concurrent requests from launching the same occurrence twice
      * or claiming an occurrence that has already transitioned to active/terminal.
@@ -356,44 +383,6 @@ export class SessionOccurrenceService {
             transaction.set(ref, transitioned);
         });
         return transitioned!;
-    }
-
-    /**
-     * Reads the occurrence document, validates the state transition, and queues the state update
-     * into the caller's WriteBatch so that occurrence and execution updates commit atomically.
-     */
-    async queueOccurrenceTransition(
-        userId: string,
-        occurrenceId: string,
-        nextState: OccurrenceState,
-        batch: WriteBatch,
-        now = new Date().toISOString(),
-    ): Promise<SessionOccurrence> {
-        const ref = this.occurrenceRef(userId, occurrenceId);
-        const snap = await getDoc(ref);
-        if (!snap.exists()) {
-            throw new Error(`Occurrence ${occurrenceId} not found.`);
-        }
-        const parsed = parseSessionOccurrenceDocument(snap.data(), ref.path);
-        if (parsed.status !== 'AVAILABLE') {
-            throw new Error(`Occurrence ${occurrenceId} could not be parsed (${parsed.status}).`);
-        }
-        const current = parsed.data;
-        if (current.state === nextState) {
-            return current;
-        }
-        if (!isValidOccurrenceTransition(current.state, nextState)) {
-            throw new Error(
-                `Cannot transition occurrence ${occurrenceId} from '${current.state}' to '${nextState}'.`,
-            );
-        }
-        const transitioned: SessionOccurrence = {
-            ...current,
-            state: nextState,
-            updatedAt: now,
-        } as SessionOccurrence;
-        batch.set(ref, transitioned);
-        return transitioned;
     }
 }
 

--- a/app/src/sessions/models.ts
+++ b/app/src/sessions/models.ts
@@ -243,6 +243,29 @@ export interface ExternalPlanOccurrenceRef {
     contentHash: string;
 }
 
+/**
+ * H4 (#434) PR 3 / ADR-0036 D-WINDOW: the real dated window an intraday bundle member is
+ * bound to. A deliberate snapshot, not a reference to the live `ResolvedWindowBinding`
+ * engine type (`intradayBundlePlacement.ts`) or `ScheduleWindow` -- the same reasoning as
+ * `SessionDisplayMetadata` above: a persisted occurrence must remain readable if the
+ * engine's placement shape evolves, and replay must bind to the window an athlete actually
+ * saw, not one re-derived from live (and possibly since-edited) availability.
+ *
+ * Immutable once set, exactly like `externalPlanRef` (see `hasValidOccurrenceUpdate` in
+ * `firestore.rules`): D-WINDOW's "at most one occurrence per resolved window" is enforced
+ * by this field being part of the occurrence's identity for the life of that occurrence,
+ * not by re-validating it on every update.
+ */
+export interface OccurrenceWindowBinding {
+    windowId: string;
+    bundleId: string;
+    order: number;
+    boundStartLocal: string;
+    boundEndLocal: string;
+    startInstant: string;
+    endInstant: string;
+}
+
 export interface BaseSessionOccurrence {
     userId: string;
     occurrenceId: string;
@@ -264,6 +287,11 @@ export interface ExternalPlanSessionOccurrence extends BaseSessionOccurrence {
     authority: 'external_plan';
     externalPlanRef: ExternalPlanOccurrenceRef;
     definitionRef?: never;
+    /** Present once D-PLACEMENT has resolved this member to a real (or legacy-sentinel)
+     * window. Absent for a v4 primary session, which is not part of a bundle. Recording
+     * the fact does not by itself enforce D-WINDOW's one-occurrence-per-window rule --
+     * that is `session_occurrence_windows`' job (`sessionOccurrenceService.ts`). */
+    windowBinding?: OccurrenceWindowBinding;
 }
 
 export type SessionOccurrence = ManualSessionOccurrence | ExternalPlanSessionOccurrence;

--- a/app/src/sessions/validation.test.ts
+++ b/app/src/sessions/validation.test.ts
@@ -134,6 +134,81 @@ describe('Session Validation (M2.1 / ADR-0023)', () => {
             expect(result.ok).toBe(true);
         });
 
+        describe('windowBinding (H4 #434 PR 3, D-WINDOW)', () => {
+            function externalPlanOccurrence(windowBinding?: unknown) {
+                return {
+                    userId: 'user-1',
+                    occurrenceId: 'occ-ext-1',
+                    date: '2026-08-18',
+                    authority: 'external_plan',
+                    externalPlanRef: {
+                        planId: 'plan-1', revision: 1, sessionId: 'session-1', contentHash: 'a'.repeat(64),
+                    },
+                    state: 'scheduled',
+                    createdAt: '2026-08-18T10:00:00Z',
+                    updatedAt: '2026-08-18T10:00:00Z',
+                    ...(windowBinding !== undefined ? { windowBinding } : {}),
+                };
+            }
+
+            function validWindowBinding(overrides: Record<string, unknown> = {}) {
+                return {
+                    windowId: 'window-1', bundleId: 'bundle-1', order: 0,
+                    boundStartLocal: '07:00', boundEndLocal: '08:00',
+                    startInstant: '2026-08-18T05:00:00Z', endInstant: '2026-08-18T06:00:00Z',
+                    ...overrides,
+                };
+            }
+
+            it('accepts a valid windowBinding', () => {
+                const result = validateSessionOccurrence(externalPlanOccurrence(validWindowBinding()));
+                expect(result.ok).toBe(true);
+            });
+
+            it('rejects windowBinding on a manual (non-external_plan) occurrence', () => {
+                const manual = {
+                    userId: 'user-1', occurrenceId: 'occ-1', date: '2026-08-18',
+                    authority: 'schedule', definitionRef: { definitionId: 'def-1', revision: 1, contentHash: 'a'.repeat(64) },
+                    state: 'scheduled', createdAt: '2026-08-18T10:00:00Z', updatedAt: '2026-08-18T10:00:00Z',
+                    windowBinding: validWindowBinding(),
+                };
+                const result = validateSessionOccurrence(manual);
+                expect(result.ok).toBe(false);
+            });
+
+            it('rejects a resolved interval where endInstant does not come after startInstant (the exact bug: reversed but individually-valid ISO timestamps must not pass)', () => {
+                const reversed = validateSessionOccurrence(externalPlanOccurrence(validWindowBinding({
+                    startInstant: '2026-08-18T06:00:00Z', endInstant: '2026-08-18T05:00:00Z',
+                })));
+                expect(reversed.ok).toBe(false);
+
+                const zeroWidth = validateSessionOccurrence(externalPlanOccurrence(validWindowBinding({
+                    startInstant: '2026-08-18T05:00:00Z', endInstant: '2026-08-18T05:00:00Z',
+                })));
+                expect(zeroWidth.ok).toBe(false);
+            });
+
+            it('rejects local bounds that are not valid HH:mm values', () => {
+                expect(validateSessionOccurrence(externalPlanOccurrence(validWindowBinding({ boundStartLocal: '25:00' }))).ok).toBe(false);
+                expect(validateSessionOccurrence(externalPlanOccurrence(validWindowBinding({ boundEndLocal: 'not-a-time' }))).ok).toBe(false);
+                expect(validateSessionOccurrence(externalPlanOccurrence(validWindowBinding({ boundStartLocal: '7:00' }))).ok).toBe(false);
+            });
+
+            it('rejects reversed local bounds even when both are individually valid HH:mm', () => {
+                const result = validateSessionOccurrence(externalPlanOccurrence(validWindowBinding({
+                    boundStartLocal: '08:00', boundEndLocal: '07:00',
+                })));
+                expect(result.ok).toBe(false);
+            });
+
+            it('rejects a windowBinding missing a required field', () => {
+                const missingOrder = validWindowBinding() as Partial<ReturnType<typeof validWindowBinding>>;
+                delete missingOrder.order;
+                const result = validateSessionOccurrence(externalPlanOccurrence(missingOrder));
+                expect(result.ok).toBe(false);
+            });
+        });
+
         it('rejects occurrence when neither or both definitionRef and externalPlanRef are provided', () => {
             const neither = {
                 userId: 'user-1',

--- a/app/src/sessions/validation.ts
+++ b/app/src/sessions/validation.ts
@@ -493,14 +493,23 @@ export function validateSessionOccurrence(raw: unknown): ValidationResult<Sessio
             issues.push({ path: 'windowBinding', message: 'Invalid windowBinding' });
         } else {
             const wb = raw.windowBinding as Record<string, unknown>;
+            // HH:mm, mirroring localInstant.ts's HHMM_PATTERN -- a non-empty string alone
+            // (the prior check) accepted reversed or malformed intervals, which
+            // parseSessionOccurrenceDocument would then expose as an available occurrence.
+            const isValidHHmm = (value: unknown): value is string =>
+                typeof value === 'string' && /^([01]\d|2[0-3]):([0-5]\d)$/.test(value);
+            const validLocalBounds = isValidHHmm(wb.boundStartLocal) && isValidHHmm(wb.boundEndLocal)
+                && wb.boundEndLocal > wb.boundStartLocal;
+            const startInstantMs = typeof wb.startInstant === 'string' ? Date.parse(wb.startInstant) : NaN;
+            const endInstantMs = typeof wb.endInstant === 'string' ? Date.parse(wb.endInstant) : NaN;
+            const validInstantInterval = Number.isFinite(startInstantMs) && Number.isFinite(endInstantMs)
+                && endInstantMs > startInstantMs;
             if (
                 typeof wb.windowId !== 'string' || wb.windowId.length === 0
                 || typeof wb.bundleId !== 'string' || wb.bundleId.length === 0
                 || typeof wb.order !== 'number' || !Number.isInteger(wb.order) || wb.order < 0
-                || typeof wb.boundStartLocal !== 'string' || wb.boundStartLocal.length === 0
-                || typeof wb.boundEndLocal !== 'string' || wb.boundEndLocal.length === 0
-                || typeof wb.startInstant !== 'string' || Number.isNaN(Date.parse(wb.startInstant))
-                || typeof wb.endInstant !== 'string' || Number.isNaN(Date.parse(wb.endInstant))
+                || !validLocalBounds
+                || !validInstantInterval
             ) {
                 issues.push({ path: 'windowBinding', message: 'Invalid windowBinding' });
             }

--- a/app/src/sessions/validation.ts
+++ b/app/src/sessions/validation.ts
@@ -486,6 +486,27 @@ export function validateSessionOccurrence(raw: unknown): ValidationResult<Sessio
         }
     }
 
+    if ('windowBinding' in raw && raw.windowBinding !== undefined) {
+        if (!hasExternalPlanRef) {
+            issues.push({ path: 'windowBinding', message: 'windowBinding requires externalPlanRef' });
+        } else if (!isObject(raw.windowBinding)) {
+            issues.push({ path: 'windowBinding', message: 'Invalid windowBinding' });
+        } else {
+            const wb = raw.windowBinding as Record<string, unknown>;
+            if (
+                typeof wb.windowId !== 'string' || wb.windowId.length === 0
+                || typeof wb.bundleId !== 'string' || wb.bundleId.length === 0
+                || typeof wb.order !== 'number' || !Number.isInteger(wb.order) || wb.order < 0
+                || typeof wb.boundStartLocal !== 'string' || wb.boundStartLocal.length === 0
+                || typeof wb.boundEndLocal !== 'string' || wb.boundEndLocal.length === 0
+                || typeof wb.startInstant !== 'string' || Number.isNaN(Date.parse(wb.startInstant))
+                || typeof wb.endInstant !== 'string' || Number.isNaN(Date.parse(wb.endInstant))
+            ) {
+                issues.push({ path: 'windowBinding', message: 'Invalid windowBinding' });
+            }
+        }
+    }
+
     if (issues.length > 0) return { ok: false, issues };
     return { ok: true, value: raw as unknown as SessionOccurrence };
 }


### PR DESCRIPTION
## Summary

- Implements Phase 1 and Phase 2 of the [H4 #434 PR 3 plan](docs/plans/h4-434-pr3-bundle-second-member-launch.md) (bundle second-member launch and confirmation capture), against [PR #445](https://github.com/Szczepanov/adaptive-training-recommender/pull/445) (external-plan occurrence tracking) as merged to `main`.
- **Phase 1** (steps 1-4, 4a, 4b): adopts #445's occurrence contract; adds `getExternalPlanOccurrencesForDate`; removes the dead `queueOccurrenceTransition` API; adds ADR-0036 D-WINDOW exclusivity (`session_occurrence_windows`, a real per-`(date, windowId)` reservation document — a `windowBinding` field on the occurrence alone enforces nothing across documents) and atomic re-import supersession, both inside `getOrCreateExternalPlanOccurrence`'s existing transaction.
- **Phase 2** (steps 6, 6a, 7): a new pure `intradayLedgerInputs.ts` maps occurrence/execution facts onto D-LEDGER's `LedgerEntry` state machine, tested against every acceptance case ADR-0036 names; the new `daily_ledgers/{date}` reservation aggregate (`dailyLedgerAggregateService.ts`) is the document Phase 4's atomic claim will serialize on, since a Firestore transaction can only read named documents, never a query; `activeExternalPlanService.ts` now threads real per-member `started`/`existingBinding` state instead of hardcoding `started: false`.
- No user-visible change and no recommendation-decision change: `POLICY_VERSION` was evaluated and does not need a bump (see Validation).
- Phases 3-6 (surfacing `additionalSessions` in `Home.tsx`, the atomic launch claim wired to the new aggregate, `SessionResponse` capture on AM completion, and the policy bump) are **not** in this PR — see Risk and reviewer guidance.

## Validation

- [x] `cd app && npm run check`: pass. Typecheck, ESLint, and the full Vitest suite (`3805 passed`) all clean.
- [x] `cd app && npm run test:rules`: pass. `114 passed`, including new emulator tests for `windowBinding` validation, `session_occurrence_windows` exclusivity, and the `daily_ledgers` aggregate's revision-increment/immutability/shape rules.
- [x] `cd app && npm run simulate:scenarios`: pass — `39 scenarios simulated, committed simulation baseline left unchanged`, confirming no live recommendation output changed.
- [x] `cd app && node scripts/check-policy-drift.mjs origin/main`: pass — `No decision-affecting engine files were modified`, confirming `POLICY_VERSION` correctly does not need a bump for this PR.
- [ ] `uv run pytest` / `uv run ruff check .` / `uv run mypy src/garmin_sync`: not applicable — no Python files changed.
- [ ] `cd app && npm run visual:refresh`: not applicable — no UI changes in this PR.

## Risk and reviewer guidance

This PR intentionally stops at a phase boundary rather than delivering the full plan in one PR, given the plan's own design went through six rounds of adversarial review before merging (#446) and each round found a genuine subtle bug in the round before — the remaining phases deserve the same unhurried, test-first treatment rather than being compressed alongside this one.

What to look at most closely:
- `getOrCreateExternalPlanOccurrence` in [`sessionOccurrenceService.ts`](app/src/services/sessionOccurrenceService.ts) now does three things atomically in one transaction: create-or-return the occurrence, claim/release the window reservation, and supersede a stale-revision predecessor. All reads happen before any write (Firestore's requirement), and no single document is written twice within the transaction (verified by construction, not just by test — see the module comment on why the prior-window release and the new-window claim never collide on one ref).
- `dailyLedgerAggregateService.ts`'s `seedIfAbsent`/`applyReservation` are **not yet wired into any real claim/reject/completion path** — that wiring is Phase 3/4's job, once those call sites exist. The module's own doc comment tracks exactly which of the plan's six transition-table rows are covered today (two: create, and re-import supersede) versus still pending a caller.
- `intradayLedgerInputs.ts` deliberately does not model `ReconciliationState: 'partial'` (no signal exists yet — `SessionExecution` has no such state, and the plan's own `completedFraction` signal is Phase 5, not built here) and treats an occurrence's `missed` state conservatively (`unresolved`, retaining the reservation) since the plan's own table doesn't cover it. Both choices are documented inline as deliberate scope, not oversights.
- The `daily_ledgers` Firestore rule cannot validate individual `reservations` map entries (Firestore rules cannot iterate a dynamic-keyed map) — the same accepted tradeoff this schema already makes elsewhere (e.g. `tissueResponses`). Per-entry shape is enforced by `dailyLedgerAggregateService.ts` and its own tests, not by rules.

Rollback: every change here is additive (new module, new optional fields, new collections) except the removal of `queueOccurrenceTransition`, which had no production caller.

## Domain invariants

- [x] Firestore writes remain user-scoped under `users/{APP_USER_ID}/...`: the new `session_occurrence_windows` and `daily_ledgers` collections are both under `users/{userId}/...`, ownership-checked in rules exactly like existing sibling collections.
- [x] Calendar-date logic uses `Europe/Warsaw`: no new date computation was introduced; `windowReservationId`/aggregate documents key on the already-resolved Warsaw-local date string passed in by the caller.
- [x] No credentials, tokens, service-account files, or raw health payloads are included.
- [x] Recommendation decision logic: evaluated via `check-policy-drift.mjs` (see Validation) — no decision-affecting engine file was modified, so `POLICY_VERSION` is correctly unchanged.

## Screenshots or recordings

Not applicable — no UI changes in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - External-plan sessions now preserve validated intraday window assignments.
  - Conflicting window reservations are rejected, while superseded reservations are released automatically.
  - Added daily ledger tracking with capacity limits, reservation metadata, and revision-safe updates.
  - Ledger entries reflect execution progress, completion, abandonment, unresolved evidence, and reserved costs.
  - Added date-level retrieval of external-plan occurrences.

- **Bug Fixes**
  - Started bundle members retain their original window assignments during placement.
  - Occurrences are now filtered to the active plan and revision.
  - Improved filtering of superseded and skipped occurrences.
  - Invalid, inconsistent, or malformed window assignments are rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->