### PR TITLE
docs(plans): correct stale H4 status in the plans status board

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -57,10 +57,23 @@ specificity plus an anchor-date coverage-ordering fix (H2/H2b), an H3 investigat
 verified existing authored-block/replacement contracts, and explicit rest-day authoring
 under [ADR-0035](../adr/0035-explicit-rest-day-authoring.md) (H3-rest, delivered). H4
 intraday windows/reassessment is accepted in
-[ADR-0036](../adr/0036-intraday-training-windows-and-reassessment.md) and H5 block intent
-and controlled progression is accepted in
-[ADR-0037](../adr/0037-block-intent-and-controlled-progression.md); both implementations
-are unstarted. H4 runtime release needs verification of same-day canonical performed
+[ADR-0036](../adr/0036-intraday-training-windows-and-reassessment.md) and **In progress**:
+D-TIME (`localInstant.ts`), D-LEDGER's pure engine (`dailyLedger.ts`), D-PLACEMENT's
+bundle-placement engine, D-REASSESS's pure `reassessDependentBundleMember`
+(`intradayReassessment.ts`, #442) and D-AUDIT's decision store (`intradayDecision.ts`,
+#443) are all delivered; #434 PR 1 bound the v4 primary session to the source-neutral
+launch path (#440), PR 2 added external-plan occurrence tracking (#445), and PR 3
+Phases 1-2 (#448) added D-WINDOW's real per-window exclusivity, atomic re-import
+supersession, and D-LEDGER's persisted date-level reservation aggregate. None of
+`claimOccurrenceLaunch`, `reassessDependentBundleMember`, or the decision store yet has a
+live caller: a non-primary bundle member is placed but not launchable, and no runtime path
+exercises reassessment or replay end-to-end. The
+[bundle-launch plan](./h4-434-pr3-bundle-second-member-launch.md) tracks #434 PR 3's
+remaining phases (surfacing `additionalSessions`, the atomic claim, post-AM
+`SessionResponse` capture, and the `POLICY_VERSION` bump) as the path to a live H4 release.
+H5 block intent and controlled progression is accepted in
+[ADR-0037](../adr/0037-block-intent-and-controlled-progression.md); its implementation
+is unstarted. H4 runtime release needs verification of same-day canonical performed
 facts; H5 runtime needs validated intent mappings and linked response evidence. H5
 delivers intent authoring, report-only review, then confirmed bounded revisions. The work
 does not replace the reviewed active persona-judge baseline. The


### PR DESCRIPTION
## Summary

- `docs/plans/README.md` said H4's implementation was "unstarted", which predates six merged PRs (#440, #442, #443, #445, #446, #448). Corrects the status paragraph to name what has actually landed and what hasn't.
- Links [`h4-434-pr3-bundle-second-member-launch.md`](docs/plans/h4-434-pr3-bundle-second-member-launch.md) as the tracker for #434 PR 3's remaining phases, per CLAUDE.md's note that this README is the authoritative status board.
- No code change. No user-visible change.

## Validation

- [ ] `uv run pytest` / ruff / mypy: not applicable — no Python files changed.
- [ ] `cd app && npm run check` / `test:rules` / `simulate:scenarios`: not applicable — no frontend files changed.
- [x] Manual check: read the six PRs cited (#440, #442, #443, #445, #446, #448) and every symbol named (`claimOccurrenceLaunch`, `reassessDependentBundleMember`, `intradayDecision.ts`) against current `main` to confirm each claim in the new paragraph — in particular, that none of those three has a production caller yet, which is the reason the paragraph still says H4 is "In progress" rather than closer to done.

## Risk and reviewer guidance

Low risk: a documentation correction, no code touched. Worth a glance only to confirm the status claims match your own understanding of what's shipped versus what #434 PR 3's remaining phases (3-6) still need to build.

## Domain invariants

Not applicable — documentation-only change.

## Screenshots or recordings

Not applicable — no UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated implementation status for H4 to reflect work in progress and delivered components.
  * Clarified remaining H4 launch work.
  * Confirmed H5 remains accepted but has not started.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->