### PR TITLE
feat(engine): H4 #434 PR 3 Phase 3 foundations -- decision-record predecessor identity, unified ReassessmentInputRevision

### DIFF
--- a/app/firestore.rules
+++ b/app/firestore.rules
@@ -1659,7 +1659,8 @@ service cloud.firestore {
       let requiredKeys = [
         'id', 'userId', 'date', 'asOf', 'policyVersion', 'schemaVersion',
         'status', 'supersededDecisionId', 'occurrenceId', 'sessionId',
-        'windowId', 'bundleId', 'orderInBundle', 'reassessmentInputRevision',
+        'windowId', 'bundleId', 'orderInBundle', 'predecessorExecutionId',
+        'predecessorOccurrenceId', 'reassessmentInputRevision',
         'bundlePlacement', 'ledgerSnapshot', 'verdict'
       ];
       return hasOwnedUserId(userId)
@@ -1678,6 +1679,9 @@ service cloud.firestore {
         && data.windowId is string && data.windowId.size() > 0 && data.windowId.size() <= 128
         && data.bundleId is string && data.bundleId.size() > 0 && data.bundleId.size() <= 128
         && data.orderInBundle is int && data.orderInBundle >= 0
+        && (data.predecessorExecutionId == null || (data.predecessorExecutionId is string && data.predecessorExecutionId.size() > 0 && data.predecessorExecutionId.size() <= 128))
+        && (data.predecessorOccurrenceId == null || (data.predecessorOccurrenceId is string && data.predecessorOccurrenceId.size() > 0 && data.predecessorOccurrenceId.size() <= 128))
+        && (data.predecessorExecutionId == null) == (data.predecessorOccurrenceId == null)
         && data.reassessmentInputRevision is map
         && data.reassessmentInputRevision.keys().hasAll(['availabilityRevision', 'completedFactsRevision', 'checkinRevision', 'ledgerRevision', 'placementRevision'])
         && data.bundlePlacement is map

--- a/app/src/emulator/intradayDecisionRules.emulator.test.ts
+++ b/app/src/emulator/intradayDecisionRules.emulator.test.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'node:fs';
-import { afterAll, afterEach, beforeAll, describe, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import {
     assertFails,
     assertSucceeds,
@@ -32,6 +32,8 @@ function validRecord() {
         windowId: 'win-am-1',
         bundleId: 'bundle-sunday-1',
         orderInBundle: 0,
+        predecessorExecutionId: null,
+        predecessorOccurrenceId: null,
         reassessmentInputRevision: {
             availabilityRevision: 'avail-rev-1',
             completedFactsRevision: 'facts-rev-1',
@@ -109,6 +111,26 @@ emulatorDescribe('Intraday decision security rules (ADR-0036 D-AUDIT)', () => {
         const db = testEnvironment.authenticatedContext(ownerId).firestore();
         const mismatchedPath = `users/${ownerId}/intraday_decisions/different-id`;
         await assertFails(setDoc(doc(db, mismatchedPath), validRecord()));
+    });
+
+    it('accepts a non-null predecessor pair, and rejects a mismatched one (H4 #434 PR 3)', async () => {
+        const db = testEnvironment.authenticatedContext(ownerId).firestore();
+        const withPredecessorPath = `users/${ownerId}/intraday_decisions/${decisionId}-with-predecessor`;
+        await expect(assertSucceeds(setDoc(doc(db, withPredecessorPath), {
+            ...validRecord(), id: `${decisionId}-with-predecessor`,
+            predecessorExecutionId: 'exec-am-1', predecessorOccurrenceId: 'occ-am-1',
+        }))).resolves.toBeUndefined();
+
+        const mismatchedPath = `users/${ownerId}/intraday_decisions/${decisionId}-mismatched`;
+        await assertFails(setDoc(doc(db, mismatchedPath), {
+            ...validRecord(), id: `${decisionId}-mismatched`,
+            predecessorExecutionId: 'exec-am-1', predecessorOccurrenceId: null,
+        }));
+
+        const missingPath = `users/${ownerId}/intraday_decisions/${decisionId}-missing-predecessor`;
+        const missing = { ...validRecord(), id: `${decisionId}-missing-predecessor` } as Partial<ReturnType<typeof validRecord>>;
+        delete missing.predecessorExecutionId;
+        await assertFails(setDoc(doc(db, missingPath), missing));
     });
 
     it('rejects malformed payloads and invalid enums', async () => {

--- a/app/src/engine/intradayDecision.test.ts
+++ b/app/src/engine/intradayDecision.test.ts
@@ -25,6 +25,8 @@ function sampleRecord(overrides: Partial<IntradayDecisionRecord> = {}): Intraday
         windowId: 'window-morning',
         bundleId: 'bundle-sunday',
         orderInBundle: 0,
+        predecessorExecutionId: null,
+        predecessorOccurrenceId: null,
         reassessmentInputRevision: {
             availabilityRevision: 'avail-rev-1',
             completedFactsRevision: 'facts-rev-1',
@@ -137,6 +139,44 @@ describe('intradayDecision validation and replay', () => {
             ...sampleRecord(),
             bundlePlacement: { bundleId: 'b1', outcome: 'infeasible', reason: '' },
         })).toThrow(TypeError);
+    });
+
+    it('accepts a non-null predecessor pair (a dependent bundle member)', () => {
+        const record = sampleRecord({ predecessorExecutionId: 'exec-am-1', predecessorOccurrenceId: 'occ-am-1' });
+        const validated = validateIntradayDecisionRecord(record);
+        expect(validated.predecessorExecutionId).toBe('exec-am-1');
+        expect(validated.predecessorOccurrenceId).toBe('occ-am-1');
+    });
+
+    it('rejects a record missing predecessorExecutionId/predecessorOccurrenceId entirely', () => {
+        const record = sampleRecord() as unknown as Record<string, unknown>;
+        delete record.predecessorExecutionId;
+        delete record.predecessorOccurrenceId;
+        expect(() => validateIntradayDecisionRecord(record)).toThrow(TypeError);
+    });
+
+    it('rejects a mismatched predecessor pair -- one null, one set', () => {
+        expect(() => validateIntradayDecisionRecord(sampleRecord({
+            predecessorExecutionId: 'exec-am-1', predecessorOccurrenceId: null,
+        }))).toThrow(TypeError);
+        expect(() => validateIntradayDecisionRecord(sampleRecord({
+            predecessorExecutionId: null, predecessorOccurrenceId: 'occ-am-1',
+        }))).toThrow(TypeError);
+    });
+
+    it('accepts an optional postPredecessorConfirmationRevision on reassessmentInputRevision', () => {
+        const record = sampleRecord({
+            reassessmentInputRevision: {
+                availabilityRevision: 'avail-rev-1',
+                completedFactsRevision: 'facts-rev-1',
+                checkinRevision: 'checkin-rev-1',
+                ledgerRevision: 'ledger-rev-1',
+                placementRevision: 'placement-rev-1',
+                postPredecessorConfirmationRevision: 'confirmation-rev-1',
+            },
+        });
+        const validated = validateIntradayDecisionRecord(record);
+        expect(validated.reassessmentInputRevision.postPredecessorConfirmationRevision).toBe('confirmation-rev-1');
     });
 
     it('validates an infeasible proposal with a non-empty reason', () => {

--- a/app/src/engine/intradayDecision.ts
+++ b/app/src/engine/intradayDecision.ts
@@ -14,18 +14,13 @@ import type { LedgerCeilings, LedgerEntry } from './dailyLedger';
 import type { ExternalRevisionEvidence } from './replay';
 import { POLICY_VERSION } from './policy';
 import { isV4Plan, type ExternalTrainingPlanV4 } from '../sessions/externalPlanV4';
+import type { ReassessmentInputRevision } from './intradayReassessment';
+
+export type { ReassessmentInputRevision };
 
 export type IntradayDecisionStatus = 'provisional' | 'confirmed' | 'superseded' | 'dropped';
 
 export type IntradayDecisionVerdictOutcome = 'proceed' | 'scale' | 'defer' | 'skip' | 'pending';
-
-export interface ReassessmentInputRevision {
-    availabilityRevision: string;
-    completedFactsRevision: string;
-    checkinRevision: string;
-    ledgerRevision: string;
-    placementRevision: string;
-}
 
 export interface IntradayDecisionLedgerSnapshot {
     ceilings: LedgerCeilings;
@@ -59,6 +54,20 @@ export interface IntradayDecisionRecord {
     windowId: string;
     bundleId: string;
     orderInBundle: number;
+
+    /**
+     * The predecessor this decision was reassessed against, or `null` for an order-0
+     * bundle member with no `afterSessionId` (nothing to confirm). Required as a pair,
+     * not optional, because the claim (Phase 4 step 11) must be able to read the
+     * predecessor's `immediate` `SessionResponse` at the deterministic id
+     * `resp-execution-{predecessorExecutionId}-immediate` inside its own transaction --
+     * without a durable pointer to *which* execution, that read would have to fall back to
+     * a non-transactional lookup, reintroducing the exact race the transaction exists to
+     * close. No production caller has ever written to this store (`saveIntradayDecision`
+     * has no caller as of #448), so there is no legacy-record migration concern here.
+     */
+    predecessorExecutionId: string | null;
+    predecessorOccurrenceId: string | null;
 
     /** Saved input revision fingerprints for change detection */
     reassessmentInputRevision: ReassessmentInputRevision;
@@ -128,6 +137,21 @@ export function validateIntradayDecisionRecord(raw: unknown): IntradayDecisionRe
     const bundleId = assertString(data.bundleId, 'bundleId', 1, 128);
     const orderInBundle = assertInteger(data.orderInBundle, 'orderInBundle', 0);
 
+    if (!('predecessorExecutionId' in data) || !('predecessorOccurrenceId' in data)) {
+        throw new TypeError('predecessorExecutionId and predecessorOccurrenceId are required (null for an order-0 member with no predecessor)');
+    }
+    let predecessorExecutionId: string | null = null;
+    if (data.predecessorExecutionId !== null) {
+        predecessorExecutionId = assertString(data.predecessorExecutionId, 'predecessorExecutionId', 1, 128);
+    }
+    let predecessorOccurrenceId: string | null = null;
+    if (data.predecessorOccurrenceId !== null) {
+        predecessorOccurrenceId = assertString(data.predecessorOccurrenceId, 'predecessorOccurrenceId', 1, 128);
+    }
+    if ((predecessorExecutionId === null) !== (predecessorOccurrenceId === null)) {
+        throw new TypeError('predecessorExecutionId and predecessorOccurrenceId must both be null or both be set');
+    }
+
     if (!data.reassessmentInputRevision || typeof data.reassessmentInputRevision !== 'object') {
         throw new TypeError('reassessmentInputRevision must be a non-null object');
     }
@@ -138,6 +162,9 @@ export function validateIntradayDecisionRecord(raw: unknown): IntradayDecisionRe
         checkinRevision: assertString(rev.checkinRevision, 'reassessmentInputRevision.checkinRevision', 1, 128),
         ledgerRevision: assertString(rev.ledgerRevision, 'reassessmentInputRevision.ledgerRevision', 1, 128),
         placementRevision: assertString(rev.placementRevision, 'reassessmentInputRevision.placementRevision', 1, 128),
+        ...(rev.postPredecessorConfirmationRevision !== undefined
+            ? { postPredecessorConfirmationRevision: assertString(rev.postPredecessorConfirmationRevision, 'reassessmentInputRevision.postPredecessorConfirmationRevision', 1, 128) }
+            : {}),
     };
 
     if (!data.bundlePlacement || typeof data.bundlePlacement !== 'object') {
@@ -239,6 +266,8 @@ export function validateIntradayDecisionRecord(raw: unknown): IntradayDecisionRe
         windowId,
         bundleId,
         orderInBundle,
+        predecessorExecutionId,
+        predecessorOccurrenceId,
         reassessmentInputRevision,
         bundlePlacement,
         ledgerSnapshot,

--- a/app/src/engine/intradayReassessment.test.ts
+++ b/app/src/engine/intradayReassessment.test.ts
@@ -117,7 +117,7 @@ const mockInputRevision: ReassessmentInputRevision = {
     availabilityRevision: 'avail-rev-1',
     completedFactsRevision: 'facts-rev-1',
     checkinRevision: 'checkin-rev-1',
-    ledgerRevision: 2,
+    ledgerRevision: 'ledger-rev-2',
     placementRevision: 'placement-rev-1',
     postPredecessorConfirmationRevision: 'resp-rev-1',
 };

--- a/app/src/engine/intradayReassessment.ts
+++ b/app/src/engine/intradayReassessment.ts
@@ -41,11 +41,21 @@ import {
 import { evaluateReadinessAndSafetyEnvelope } from './rules';
 import { deriveTissueSeverity } from './injuryPolicy';
 
+/**
+ * The canonical shape -- also used, unimported, by `intradayDecision.ts`'s persisted
+ * `IntradayDecisionRecord` until this change. That copy declared `ledgerRevision: string`
+ * (it stringifies `DailyLedgerAggregate.revision`, matching every other field's
+ * fingerprint-string convention) while this one declared `number`; this module's own
+ * `ledgerRevision` is never used arithmetically, so unifying on `string` -- the shape the
+ * shipped, rules-validated persisted record already committed to -- and having
+ * `intradayDecision.ts` import this type instead of re-declaring it is a pure
+ * consolidation, not a behavior change.
+ */
 export interface ReassessmentInputRevision {
     availabilityRevision: string;
     completedFactsRevision: string;
     checkinRevision: string;
-    ledgerRevision: number;
+    ledgerRevision: string;
     placementRevision: string;
     postPredecessorConfirmationRevision?: string;
 }
@@ -54,7 +64,7 @@ export function computeReassessmentInputRevision(params: {
     availabilityRevision: string;
     completedFactsRevision: string;
     checkinRevision: string;
-    ledgerRevision: number;
+    ledgerRevision: string;
     placementRevision: string;
     postPredecessorConfirmationRevision?: string;
 }): ReassessmentInputRevision {

--- a/app/src/services/intradayDecisionService.test.ts
+++ b/app/src/services/intradayDecisionService.test.ts
@@ -8,6 +8,9 @@ import {
     listIntradayDecisionsForDate,
     getActiveIntradayDecisionsForDate,
     getActiveIntradayDecisionForOccurrence,
+    deterministicIntradayDecisionId,
+    decisionRecordsMatch,
+    writeProvisionalDecisionInTransaction,
 } from './intradayDecisionService';
 
 const mockSetDoc = vi.fn();
@@ -43,6 +46,8 @@ function sampleRecord(id = 'dec-1', overrides: Partial<IntradayDecisionRecord> =
         windowId: 'win-1',
         bundleId: 'bundle-1',
         orderInBundle: 0,
+        predecessorExecutionId: null,
+        predecessorOccurrenceId: null,
         reassessmentInputRevision: {
             availabilityRevision: 'a1',
             completedFactsRevision: 'c1',
@@ -175,5 +180,91 @@ describe('intradayDecisionService', () => {
 
         const active = await getActiveIntradayDecisionsForDate('u1', '2026-09-06');
         expect(active.map(r => r.id).sort()).toEqual(['dec-occ1', 'dec-occ2']);
+    });
+});
+
+describe('deterministicIntradayDecisionId (H4 #434 PR 3 step 9)', () => {
+    const revision = {
+        availabilityRevision: 'a1', completedFactsRevision: 'c1',
+        checkinRevision: 'ch1', ledgerRevision: 'l1', placementRevision: 'p1',
+    };
+
+    it('is deterministic for the same occurrence and revision', async () => {
+        const id1 = await deterministicIntradayDecisionId('occ-1', revision);
+        const id2 = await deterministicIntradayDecisionId('occ-1', revision);
+        expect(id1).toBe(id2);
+    });
+
+    it('differs when the occurrence differs', async () => {
+        const id1 = await deterministicIntradayDecisionId('occ-1', revision);
+        const id2 = await deterministicIntradayDecisionId('occ-2', revision);
+        expect(id1).not.toBe(id2);
+    });
+
+    it('differs when the revision differs', async () => {
+        const id1 = await deterministicIntradayDecisionId('occ-1', revision);
+        const id2 = await deterministicIntradayDecisionId('occ-1', { ...revision, ledgerRevision: 'l2' });
+        expect(id1).not.toBe(id2);
+    });
+});
+
+describe('decisionRecordsMatch (H4 #434 PR 3 step 9)', () => {
+    it('matches two records identical on every immutable field', () => {
+        const a = sampleRecord('dec-1', { predecessorExecutionId: 'exec-1', predecessorOccurrenceId: 'occ-am' });
+        const b = sampleRecord('dec-1', { predecessorExecutionId: 'exec-1', predecessorOccurrenceId: 'occ-am' });
+        expect(decisionRecordsMatch(a, b)).toBe(true);
+    });
+
+    it('does not match when the verdict differs', () => {
+        const a = sampleRecord('dec-1');
+        const b = sampleRecord('dec-1', { verdict: { decision: 'defer', reasons: ['different'] } });
+        expect(decisionRecordsMatch(a, b)).toBe(false);
+    });
+
+    it('does not match when only the predecessor differs -- two decisions colliding on one id are not the same decision', () => {
+        const a = sampleRecord('dec-1', { predecessorExecutionId: 'exec-1', predecessorOccurrenceId: 'occ-am' });
+        const b = sampleRecord('dec-1', { predecessorExecutionId: 'exec-2', predecessorOccurrenceId: 'occ-am-2' });
+        expect(decisionRecordsMatch(a, b)).toBe(false);
+    });
+
+    it('does not match when the input revision differs', () => {
+        const a = sampleRecord('dec-1');
+        const b = sampleRecord('dec-1', {
+            reassessmentInputRevision: { ...sampleRecord().reassessmentInputRevision, ledgerRevision: 'l2' },
+        });
+        expect(decisionRecordsMatch(a, b)).toBe(false);
+    });
+});
+
+describe('writeProvisionalDecisionInTransaction (H4 #434 PR 3 step 9)', () => {
+    function mockTransaction() {
+        return { set: vi.fn() } as unknown as import('firebase/firestore').Transaction;
+    }
+
+    it('creates the record when none exists', () => {
+        const tx = mockTransaction();
+        const record = sampleRecord('dec-1');
+        const result = writeProvisionalDecisionInTransaction(tx, 'u1', null, record);
+        expect(result).toEqual(record);
+        expect((tx as unknown as { set: ReturnType<typeof vi.fn> }).set).toHaveBeenCalledTimes(1);
+    });
+
+    it('is a no-op returning the existing record on a matching retry', () => {
+        const tx = mockTransaction();
+        const existing = sampleRecord('dec-1');
+        const retry = sampleRecord('dec-1');
+        const result = writeProvisionalDecisionInTransaction(tx, 'u1', existing, retry);
+        expect(result).toBe(existing);
+        expect((tx as unknown as { set: ReturnType<typeof vi.fn> }).set).not.toHaveBeenCalled();
+    });
+
+    it('throws on a conflicting record at the same id rather than overwriting', () => {
+        const tx = mockTransaction();
+        const existing = sampleRecord('dec-1', { occurrenceId: 'occ-1' });
+        const conflicting = sampleRecord('dec-1', { occurrenceId: 'occ-2' });
+        expect(() => writeProvisionalDecisionInTransaction(tx, 'u1', existing, conflicting)).toThrow(
+            /already holds a different decision/,
+        );
+        expect((tx as unknown as { set: ReturnType<typeof vi.fn> }).set).not.toHaveBeenCalled();
     });
 });

--- a/app/src/services/intradayDecisionService.test.ts
+++ b/app/src/services/intradayDecisionService.test.ts
@@ -267,4 +267,28 @@ describe('writeProvisionalDecisionInTransaction (H4 #434 PR 3 step 9)', () => {
         );
         expect((tx as unknown as { set: ReturnType<typeof vi.fn> }).set).not.toHaveBeenCalled();
     });
+
+    it('rejects records with non-provisional status', () => {
+        const tx = mockTransaction();
+        const nonProvisional = sampleRecord('dec-1', { status: 'confirmed' });
+        expect(() => writeProvisionalDecisionInTransaction(tx, 'u1', null, nonProvisional)).toThrow(
+            TypeError,
+        );
+        expect(() => writeProvisionalDecisionInTransaction(tx, 'u1', null, nonProvisional)).toThrow(
+            /requires status "provisional"/,
+        );
+        expect((tx as unknown as { set: ReturnType<typeof vi.fn> }).set).not.toHaveBeenCalled();
+    });
+
+    it('rejects records where userId does not match the path userId', () => {
+        const tx = mockTransaction();
+        const mismatchedUser = sampleRecord('dec-1', { userId: 'u2' });
+        expect(() => writeProvisionalDecisionInTransaction(tx, 'u1', null, mismatchedUser)).toThrow(
+            TypeError,
+        );
+        expect(() => writeProvisionalDecisionInTransaction(tx, 'u1', null, mismatchedUser)).toThrow(
+            /userId must match record\.userId/,
+        );
+        expect((tx as unknown as { set: ReturnType<typeof vi.fn> }).set).not.toHaveBeenCalled();
+    });
 });

--- a/app/src/services/intradayDecisionService.ts
+++ b/app/src/services/intradayDecisionService.ts
@@ -7,11 +7,12 @@
  * to previous records.
  */
 
-import { collection, doc, getDoc, getDocs, query, setDoc, where } from 'firebase/firestore';
+import { collection, doc, getDoc, getDocs, query, setDoc, where, type Transaction } from 'firebase/firestore';
 import { getDb } from '../firebase';
 import {
     validateIntradayDecisionRecord,
     type IntradayDecisionRecord,
+    type ReassessmentInputRevision,
 } from '../engine/intradayDecision';
 
 export function getIntradayDecisionDocPath(userId: string, decisionId: string): string {
@@ -38,6 +39,78 @@ export async function saveIntradayDecision(record: IntradayDecisionRecord): Prom
     const db = getDb();
     const docRef = doc(db, getIntradayDecisionDocPath(validated.userId, validated.id));
     await setDoc(docRef, validated);
+}
+
+/**
+ * H4 (#434) PR 3 step 9: deterministic id for a *provisional* decision, derived from the
+ * occurrence it decides for and the exact input revision the verdict was computed
+ * against. A deterministic id alone is not an idempotency rule -- see
+ * `decisionRecordsMatch` and `writeProvisionalDecisionInTransaction` below, which define
+ * what "the same decision" means on a retry after an ambiguous acknowledgement.
+ */
+export async function deterministicIntradayDecisionId(
+    occurrenceId: string,
+    reassessmentInputRevision: ReassessmentInputRevision,
+): Promise<string> {
+    const raw = JSON.stringify([occurrenceId, reassessmentInputRevision]);
+    const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(raw));
+    const hash = Array.from(new Uint8Array(digest))
+        .map(byte => byte.toString(16).padStart(2, '0'))
+        .join('')
+        .slice(0, 24);
+    return `dec_${occurrenceId.replace(/[^a-zA-Z0-9_.-]/g, '_').slice(0, 64)}_${hash}`;
+}
+
+/**
+ * Whether two candidate decision records represent *the same decision* -- an ambiguous
+ * retry should converge on this, not append a second record. Compares only the fields
+ * the plan names as immutable identity: the target occurrence, the predecessor identity,
+ * the verdict, and the input revision it was computed against. Two decisions differing
+ * only in which predecessor they depend on are different decisions -- omitting
+ * `predecessorOccurrenceId`/`predecessorExecutionId` here would accept one as an
+ * idempotent retry of the other.
+ */
+export function decisionRecordsMatch(a: IntradayDecisionRecord, b: IntradayDecisionRecord): boolean {
+    return a.occurrenceId === b.occurrenceId
+        && a.predecessorOccurrenceId === b.predecessorOccurrenceId
+        && a.predecessorExecutionId === b.predecessorExecutionId
+        && a.verdict.decision === b.verdict.decision
+        && JSON.stringify(a.reassessmentInputRevision) === JSON.stringify(b.reassessmentInputRevision);
+}
+
+/**
+ * Writes a provisional decision record inside a caller-supplied transaction, so it can
+ * commit atomically with whatever occurrence/aggregate write the decision authorizes
+ * (plan step 9: "steps 8 and 9 must not be able to half-succeed"). `existing` must already
+ * have been read via `transaction.get` in the same transaction (Firestore's
+ * reads-before-writes rule), typically alongside the occurrence/aggregate reads the same
+ * transaction needs.
+ *
+ * - Absent: creates the record and returns it.
+ * - Present and matching (`decisionRecordsMatch`): the first attempt already committed --
+ *   an ambiguous-acknowledgement retry converges on it without writing again.
+ * - Present and *not* matching: a different decision is colliding on this deterministic
+ *   id, not a retry of this one. Throws rather than silently overwriting an append-only
+ *   audit record -- a silent overwrite would break the replay guarantee the store exists
+ *   for.
+ */
+export function writeProvisionalDecisionInTransaction(
+    transaction: Transaction,
+    userId: string,
+    existing: IntradayDecisionRecord | null,
+    record: IntradayDecisionRecord,
+): IntradayDecisionRecord {
+    const validated = validateIntradayDecisionRecord(record);
+    if (existing) {
+        if (!decisionRecordsMatch(existing, validated)) {
+            throw new Error(
+                `Decision id ${validated.id} already holds a different decision for occurrence ${existing.occurrenceId}; refusing to overwrite an append-only record.`,
+            );
+        }
+        return existing;
+    }
+    transaction.set(doc(getDb(), getIntradayDecisionDocPath(userId, validated.id)), validated);
+    return validated;
 }
 
 /**

--- a/app/src/services/intradayDecisionService.ts
+++ b/app/src/services/intradayDecisionService.ts
@@ -101,6 +101,12 @@ export function writeProvisionalDecisionInTransaction(
     record: IntradayDecisionRecord,
 ): IntradayDecisionRecord {
     const validated = validateIntradayDecisionRecord(record);
+    if (validated.status !== 'provisional') {
+        throw new TypeError('writeProvisionalDecisionInTransaction requires status "provisional"');
+    }
+    if (validated.userId !== userId) {
+        throw new TypeError('userId must match record.userId');
+    }
     if (existing) {
         if (!decisionRecordsMatch(existing, validated)) {
             throw new Error(


### PR DESCRIPTION
## Summary

- First of Phase 3's foundational pieces from the [H4 #434 PR 3 plan](docs/plans/h4-434-pr3-bundle-second-member-launch.md), steps 8/9, ahead of the `Home.tsx` adjudication loop and the atomic create+reserve+decide transaction that will consume them.
- Unifies `ReassessmentInputRevision`, previously declared independently in `intradayDecision.ts` (`ledgerRevision: string`) and `intradayReassessment.ts` (`ledgerRevision: number`) — the exact contract inconsistency the plan's own review rounds flagged as open question 2. `intradayReassessment.ts` is now the canonical, exported declaration; `intradayDecision.ts` imports and re-exports it instead of re-declaring.
- `IntradayDecisionRecord` gains required (but nullable-as-a-pair) `predecessorExecutionId`/`predecessorOccurrenceId` fields, so the future atomic claim can read the predecessor's `SessionResponse` inside its own transaction rather than falling back to a non-transactional lookup. No `schemaVersion` bump: `saveIntradayDecision` has had zero production callers through #448, so there is no legacy-record migration concern.
- Adds `deterministicIntradayDecisionId`, `decisionRecordsMatch`, and `writeProvisionalDecisionInTransaction` to `intradayDecisionService.ts` — the transaction-composable write primitive step 9 requires, mirroring `dailyLedgerAggregateService.ts`'s `seedIfAbsent`/`applyReservation` pattern.
- No user-visible change and no recommendation-decision change (see Validation).

## Validation

- [x] `cd app && npm run check`: pass. Typecheck, ESLint, full Vitest suite (`3838 passed`).
- [x] `cd app && npm run test:rules`: scoped run — `intradayDecisionRules.emulator.test.ts` + `firestoreRules.emulator.test.ts`, `121 passed`. (The full 14-file emulator suite has shown session-level resource-contention flakiness unrelated to any specific PR in this session's environment; a scoped run of the two files this PR actually touches is clean and an order of magnitude faster.)
- [x] `cd app && node scripts/simulate-scenarios.mjs`: pass — `39 scenarios simulated, committed simulation baseline left unchanged`.
- [x] `cd app && node scripts/check-policy-drift.mjs origin/main`: pass — `No decision-affecting engine files were modified`, confirming `POLICY_VERSION` correctly needs no bump.
- [ ] `uv run pytest` / ruff / mypy: not applicable — no Python files changed.
- [ ] `cd app && npm run visual:refresh`: not applicable — no UI changes.

## Risk and reviewer guidance

Low-to-medium risk: schema/service additions with no live caller yet (same posture as #448's `dailyLedgerAggregateService.ts`). What's worth a close look:

- The `predecessorExecutionId`/`predecessorOccurrenceId` paired-null constraint, enforced in both the TypeScript validator (`intradayDecision.ts`) and Firestore rules (`hasValidIntradayDecision`) — an order-0 bundle member (no `afterSessionId`) has no predecessor, so both must be `null` together, never one set without the other.
- `decisionRecordsMatch`'s exact-match set: target `occurrenceId`, predecessor identity, `verdict.decision`, and the full `reassessmentInputRevision`. Omitting the predecessor fields here would let two decisions that differ only in which predecessor they depend on collide as a false "retry".

Not yet built, and flagged in the plan as the highest-risk remaining pieces: the reject→recovery generation-counter mechanism (step 8, item 2a), the composite transaction combining occurrence-create + aggregate-reservation + decision-write in one atomic unit (step 9's "Medium risk" atomicity requirement), and the `Home.tsx` adjudication loop itself ("High risk — blast radius in a 1,400-line component"). These are intentionally separate follow-up work, not rushed into this PR.

## Domain invariants

- [x] Firestore writes remain user-scoped under `users/{APP_USER_ID}/...`: `intraday_decisions` is unchanged in that respect; no new top-level or `default_user` paths.
- [x] Calendar-date logic uses `Europe/Warsaw`: no new date computation introduced.
- [x] No credentials, tokens, service-account files, or raw health payloads are included.
- [x] Recommendation decision logic: evaluated via `check-policy-drift.mjs` (see Validation) — no decision-affecting engine file was modified, so `POLICY_VERSION` is correctly unchanged.

## Screenshots or recordings

Not applicable — no UI changes in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deterministic provisional decision IDs and safe transactional writes.
  * Retry attempts now return matching existing records, while conflicting records are rejected to preserve data integrity.
  * Intraday decisions now track paired predecessor execution and occurrence references.
  * Reassessment ledger revisions now use string values consistently.

* **Tests**
  * Expanded coverage for validation, retries, record matching, predecessor references, and transactional writes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->