### PR TITLE
feat(services): H4 #434 PR 3 Phase 3 -- bundle member adjudication loop and Home.tsx wiring

### DIFF
--- a/app/firestore.rules
+++ b/app/firestore.rules
@@ -1663,9 +1663,17 @@ service cloud.firestore {
         'predecessorOccurrenceId', 'reassessmentInputRevision',
         'bundlePlacement', 'ledgerSnapshot', 'verdict'
       ];
+      let allowedKeys = [
+        'id', 'userId', 'date', 'asOf', 'policyVersion', 'schemaVersion',
+        'status', 'supersededDecisionId', 'occurrenceId', 'sessionId',
+        'windowId', 'bundleId', 'orderInBundle', 'predecessorExecutionId',
+        'predecessorOccurrenceId', 'reassessmentInputRevision',
+        'bundlePlacement', 'ledgerSnapshot', 'verdict',
+        'postReservationLedgerRevision'
+      ];
       return hasOwnedUserId(userId)
         && data.keys().hasAll(requiredKeys)
-        && data.keys().hasOnly(requiredKeys)
+        && data.keys().hasOnly(allowedKeys)
         && data.id == decisionId
         && data.id is string && data.id.size() > 0 && data.id.size() <= 128
         && data.date is string && data.date.matches('^[0-9]{4}-[0-9]{2}-[0-9]{2}$')
@@ -1697,7 +1705,8 @@ service cloud.firestore {
         && data.ledgerSnapshot.entries is list
         && data.verdict is map
         && data.verdict.decision in ['proceed', 'scale', 'defer', 'skip', 'pending']
-        && data.verdict.reasons is list;
+        && data.verdict.reasons is list
+        && (!('postReservationLedgerRevision' in data) || (data.postReservationLedgerRevision is string && data.postReservationLedgerRevision.size() > 0 && data.postReservationLedgerRevision.size() <= 128));
     }
 
     match /users/{userId}/intraday_decisions/{decisionId} {

--- a/app/src/components/Home.tsx
+++ b/app/src/components/Home.tsx
@@ -38,9 +38,15 @@ import {
   buildIntradayMemberState,
   externalPlanContextForDate,
   externalRestContextForDate,
+  resolveIntradayBundlePlacement,
   type ActiveExternalPlan,
   type IntradayBundlePlacementContext,
 } from '../services/activeExternalPlanService';
+import {
+  adjudicateIntradayBundleMembers,
+  type IntradayBundleMemberStatus,
+} from '../services/intradayBundleMemberAdjudication';
+import type { LedgerCeilings } from '../engine/dailyLedger';
 import { checkinService } from '../services/checkinService';
 import { sessionExecutionService } from '../services/sessionExecutionService';
 import { sessionResponseService } from '../services/sessionResponseService';
@@ -114,6 +120,7 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
   const [reclassifyModalOpen, setReclassifyModalOpen] = useState(false);
   const [recentActivities, setRecentActivities] = useState<NormalizedGarminActivity[]>([]);
   const [, setActiveExternalPlan] = useState<ActiveExternalPlan | null>(null);
+  const [, setBundleMemberStatuses] = useState<IntradayBundleMemberStatus[]>([]);
   const [hasPendingSessionResponse, setHasPendingSessionResponse] = useState(false);
   const pendingAdherenceRef = useRef(pendingAdherence);
   useEffect(() => { pendingAdherenceRef.current = pendingAdherence; }, [pendingAdherence]);
@@ -482,6 +489,9 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
               memberState: todaysExternalPlanMemberState,
             }
           : undefined;
+        const bundlePlacement = (activeExternal && bundleContext && isV4Plan(activeExternal.plan))
+          ? resolveIntradayBundlePlacement(activeExternal, input.date, bundleContext)
+          : null;
         const externalContext = activeExternal ? externalPlanContextForDate(activeExternal, input.date, bundleContext) : null;
         const externalRestContext = activeExternal ? externalRestContextForDate(activeExternal, input.date) : null;
 
@@ -662,6 +672,40 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
             additionalBindings.push(launch.binding);
             acceptedSameDaySystemicCost += verdict.acceptedSystemicCost ?? estimateAuthoredSessionSystemicCost(targetDef);
             acceptedSameDayMinutes += targetDef.duration?.min ?? 45;
+          }
+
+          if (activeExternal && isV4Plan(activeExternal.plan) && bundlePlacement?.outcome === 'placed') {
+            const ceilings: LedgerCeilings = {
+              dailyMinuteCeiling: availability.maxTimeMinutes,
+              dailySystemicCostCeiling: Math.max(0, 1 - availability.reservedCapacityCost),
+            };
+            const memberResult = await adjudicateIntradayBundleMembers({
+              userId,
+              date: input.date,
+              activePlan: activeExternal,
+              bundlePlacement,
+              subjective,
+              objective,
+              subjectiveBaseline: input.subjectiveBaseline,
+              userContext: context,
+              availability,
+              ceilings,
+              inputRevision: {
+                availabilityRevision: `${input.date}:${availability.maxTimeMinutes}`,
+                completedFactsRevision: preparedSnapshot.performedTrainingFacts?.revision ?? preparedSnapshot.revision,
+                checkinRevision: (input.sourceStates?.subjectiveCheckin?.status === 'AVAILABLE' && input.sourceStates.subjectiveCheckin.revision)
+                  ? input.sourceStates.subjectiveCheckin.revision
+                  : (input.subjectiveCheckin ? 'checkin-present' : 'checkin-missing'),
+                placementRevision: `${activeExternal.plan.planId}:${activeExternal.plan.revision}`,
+              },
+              existingAdditionalBindingsCount: additionalBindings.length,
+            });
+            if (!isCurrent()) return;
+            setBundleMemberStatuses(memberResult.statuses);
+            additionalBindings.push(...memberResult.bindings);
+            additionalNotices.push(...memberResult.notices);
+          } else {
+            setBundleMemberStatuses([]);
           }
 
           if (additionalBindings.length > 0 || additionalNotices.length > 0) {

--- a/app/src/components/Home.tsx
+++ b/app/src/components/Home.tsx
@@ -691,7 +691,7 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
               availability,
               ceilings,
               inputRevision: {
-                availabilityRevision: `${input.date}:${availability.maxTimeMinutes}`,
+                availabilityRevision: `${input.date}:${availability.maxTimeMinutes}:${availability.reservedCapacityCost}`,
                 completedFactsRevision: preparedSnapshot.performedTrainingFacts?.revision ?? preparedSnapshot.revision,
                 checkinRevision: (input.sourceStates?.subjectiveCheckin?.status === 'AVAILABLE' && input.sourceStates.subjectiveCheckin.revision)
                   ? input.sourceStates.subjectiveCheckin.revision

--- a/app/src/emulator/sessionOccurrenceService.emulator.test.ts
+++ b/app/src/emulator/sessionOccurrenceService.emulator.test.ts
@@ -89,7 +89,7 @@ emulatorDescribe('getOrCreateExternalPlanOccurrence (real transaction, real rule
         expect(reservationSnap.data()?.occurrenceId).toBe(second.occurrenceId);
     });
 
-    it('refuses handoff and rejects re-import when prior occurrence transitioned to active or completed', async () => {
+    it('refuses handoff and rejects re-import when prior occurrence transitioned to active', async () => {
         const ownerId = 'athlete-b';
         const db = testEnvironment.authenticatedContext(ownerId).firestore() as unknown as Firestore;
         const service = new SessionOccurrenceService(db);
@@ -119,6 +119,41 @@ emulatorDescribe('getOrCreateExternalPlanOccurrence (real transaction, real rule
         expect(activeSnap.status === 'AVAILABLE' && activeSnap.data.state).toBe('active');
 
         const reservationRef = doc(db, 'users', ownerId, 'session_occurrence_windows', windowReservationId('2026-08-18', 'window-2'));
+        const reservationSnap = await getDoc(reservationRef);
+        expect(reservationSnap.exists()).toBe(true);
+        expect(reservationSnap.data()?.occurrenceId).toBe(first.occurrenceId);
+    });
+
+    it('refuses handoff and rejects re-import when prior occurrence transitioned to completed', async () => {
+        const ownerId = 'athlete-c';
+        const db = testEnvironment.authenticatedContext(ownerId).firestore() as unknown as Firestore;
+        const service = new SessionOccurrenceService(db);
+
+        const windowBinding = {
+            windowId: 'window-3', bundleId: 'bundle-3', order: 0,
+            boundStartLocal: '07:00', boundEndLocal: '08:00',
+            startInstant: '2026-08-18T05:00:00Z', endInstant: '2026-08-18T06:00:00Z',
+        };
+        const refV1 = { planId: 'plan-3', revision: 1, sessionId: 'session-3', contentHash: 'e'.repeat(64) };
+        const refV2 = { ...refV1, revision: 2, contentHash: 'f'.repeat(64) };
+
+        const first = await service.getOrCreateExternalPlanOccurrence(ownerId, '2026-08-18', refV1, { windowBinding });
+        expect(first.state).toBe('scheduled');
+
+        // Transition first occurrence to completed
+        await service.transitionOccurrenceState(ownerId, first.occurrenceId, 'completed');
+
+        // Attempting to re-import (new revision requesting the same window) must fail
+        // because the window reservation owner is completed and cannot be handed off or overwritten.
+        await expect(
+            service.getOrCreateExternalPlanOccurrence(ownerId, '2026-08-18', refV2, { windowBinding }),
+        ).rejects.toThrow(`Window 'window-3' on 2026-08-18 is already bound to occurrence '${first.occurrenceId}'.`);
+
+        // The completed occurrence must remain completed and its window reservation must be intact.
+        const completedSnap = await service.getOccurrence(ownerId, first.occurrenceId);
+        expect(completedSnap.status === 'AVAILABLE' && completedSnap.data.state).toBe('completed');
+
+        const reservationRef = doc(db, 'users', ownerId, 'session_occurrence_windows', windowReservationId('2026-08-18', 'window-3'));
         const reservationSnap = await getDoc(reservationRef);
         expect(reservationSnap.exists()).toBe(true);
         expect(reservationSnap.data()?.occurrenceId).toBe(first.occurrenceId);

--- a/app/src/emulator/sessionOccurrenceService.emulator.test.ts
+++ b/app/src/emulator/sessionOccurrenceService.emulator.test.ts
@@ -88,4 +88,39 @@ emulatorDescribe('getOrCreateExternalPlanOccurrence (real transaction, real rule
         expect(reservationSnap.exists()).toBe(true);
         expect(reservationSnap.data()?.occurrenceId).toBe(second.occurrenceId);
     });
+
+    it('refuses handoff and rejects re-import when prior occurrence transitioned to active or completed', async () => {
+        const ownerId = 'athlete-b';
+        const db = testEnvironment.authenticatedContext(ownerId).firestore() as unknown as Firestore;
+        const service = new SessionOccurrenceService(db);
+
+        const windowBinding = {
+            windowId: 'window-2', bundleId: 'bundle-2', order: 0,
+            boundStartLocal: '07:00', boundEndLocal: '08:00',
+            startInstant: '2026-08-18T05:00:00Z', endInstant: '2026-08-18T06:00:00Z',
+        };
+        const refV1 = { planId: 'plan-2', revision: 1, sessionId: 'session-2', contentHash: 'c'.repeat(64) };
+        const refV2 = { ...refV1, revision: 2, contentHash: 'd'.repeat(64) };
+
+        const first = await service.getOrCreateExternalPlanOccurrence(ownerId, '2026-08-18', refV1, { windowBinding });
+        expect(first.state).toBe('scheduled');
+
+        // Transition first occurrence to active
+        await service.claimOccurrenceLaunch(ownerId, first.occurrenceId);
+
+        // Attempting to re-import (new revision requesting the same window) must fail
+        // because the window reservation owner is active and cannot be handed off or overwritten.
+        await expect(
+            service.getOrCreateExternalPlanOccurrence(ownerId, '2026-08-18', refV2, { windowBinding }),
+        ).rejects.toThrow(`Window 'window-2' on 2026-08-18 is already bound to occurrence '${first.occurrenceId}'.`);
+
+        // The active occurrence must remain active and its window reservation must be intact.
+        const activeSnap = await service.getOccurrence(ownerId, first.occurrenceId);
+        expect(activeSnap.status === 'AVAILABLE' && activeSnap.data.state).toBe('active');
+
+        const reservationRef = doc(db, 'users', ownerId, 'session_occurrence_windows', windowReservationId('2026-08-18', 'window-2'));
+        const reservationSnap = await getDoc(reservationRef);
+        expect(reservationSnap.exists()).toBe(true);
+        expect(reservationSnap.data()?.occurrenceId).toBe(first.occurrenceId);
+    });
 });

--- a/app/src/engine/intradayDecision.ts
+++ b/app/src/engine/intradayDecision.ts
@@ -78,6 +78,9 @@ export interface IntradayDecisionRecord {
 
     /** Decision outcome and reasons */
     verdict: IntradayDecisionVerdict;
+
+    /** The transaction-produced post-reservation ledger revision, captured for Phase 4 claim staleness validation */
+    postReservationLedgerRevision?: string;
 }
 
 const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
@@ -252,6 +255,11 @@ export function validateIntradayDecisionRecord(raw: unknown): IntradayDecisionRe
         reasons: vd.reasons.map((r, i) => assertString(r, `verdict.reasons[${i}]`, 1, 256)),
     };
 
+    let postReservationLedgerRevision: string | undefined;
+    if ('postReservationLedgerRevision' in data && data.postReservationLedgerRevision !== undefined) {
+        postReservationLedgerRevision = assertString(data.postReservationLedgerRevision, 'postReservationLedgerRevision', 1, 128);
+    }
+
     return {
         id,
         userId,
@@ -272,6 +280,7 @@ export function validateIntradayDecisionRecord(raw: unknown): IntradayDecisionRe
         bundlePlacement,
         ledgerSnapshot,
         verdict,
+        ...(postReservationLedgerRevision !== undefined ? { postReservationLedgerRevision } : {}),
     };
 }
 

--- a/app/src/services/dailyLedgerAggregateService.ts
+++ b/app/src/services/dailyLedgerAggregateService.ts
@@ -48,6 +48,7 @@ export interface DailyLedgerReservation {
     actualMinutes?: number;
     actualSystemicCost?: number;
     decisionId?: string;
+    postReservationLedgerRevision?: string;
 }
 
 /**

--- a/app/src/services/intradayBundleMemberAdjudication.test.ts
+++ b/app/src/services/intradayBundleMemberAdjudication.test.ts
@@ -800,6 +800,8 @@ describe('adjudicateIntradayBundleMembers', () => {
             planId: 'p-v4', revision: 1, sessionId: 'pm-strength', contentHash: 'hash-bundle-v4',
         });
         expect(store.get(`users/${USER_ID}/session_occurrences/${targetOccId}`)).toBeUndefined();
+        const agg = store.get(`users/${USER_ID}/daily_ledgers/${DATE}`) as DailyLedgerAggregate | undefined;
+        expect(agg?.reservations?.[targetOccId]).toBeUndefined();
     });
 
     it('admits session at boundary of additional sessions cap (3 existing bindings -> 4th allowed)', async () => {
@@ -894,5 +896,78 @@ describe('adjudicateIntradayBundleMembers', () => {
         expect(second.bindings[0].sessionSource).toEqual(first.bindings[0].sessionSource);
         const secondAgg = store.get(`users/${USER_ID}/daily_ledgers/${DATE}`) as DailyLedgerAggregate;
         expect(Object.keys(secondAgg.reservations).length).toBe(Object.keys(firstAgg.reservations).length);
+    });
+
+    it('re-reads aggregate atomically with decision and uses current ledger revision when an intervening reservation advances aggregate', async () => {
+        const active = createPlan();
+        const bundlePlacement = createBundlePlacement();
+
+        const amOccId = 'occ-am-1';
+        const amOcc: ExternalPlanSessionOccurrence = {
+            userId: USER_ID,
+            occurrenceId: amOccId,
+            date: DATE,
+            authority: 'external_plan',
+            externalPlanRef: { planId: 'p-v4', revision: 1, sessionId: 'am-run', contentHash: 'hash-bundle-v4' },
+            state: 'completed',
+            placementOrder: 0,
+            createdAt: '2026-09-07T05:00:00.000Z',
+            updatedAt: '2026-09-07T06:00:00.000Z',
+        };
+        const amExec = createMockExecution(amOccId);
+        const amResp = createMockSessionResponse(amOccId);
+
+        vi.spyOn(sessionOccurrenceService, 'getOccurrencesForDate').mockResolvedValue([amOcc]);
+        vi.spyOn(sessionExecutionService, 'getExecutionsInRange').mockResolvedValue({ executions: [amExec], invalidRecords: 0 });
+        vi.spyOn(sessionResponseService, 'getResponseForWindow').mockResolvedValue(amResp);
+
+        const params: AdjudicateIntradayBundleMembersParams = {
+            userId: USER_ID,
+            date: DATE,
+            activePlan: active,
+            bundlePlacement,
+            subjective: mockSubjective,
+            objective: mockObjective,
+            userContext: mockUserContext,
+            availability: mockAvailability,
+            ceilings,
+            evaluationInstant: '2026-09-07T12:00:00.000Z',
+        };
+
+        // Run once to create first occurrence, reservation, and decision
+        const first = await adjudicateIntradayBundleMembers(params);
+        expect(first.statuses[0].status).toBe('proceed');
+        const firstAgg = store.get(`users/${USER_ID}/daily_ledgers/${DATE}`) as DailyLedgerAggregate;
+        // seedIfAbsent (rev 1) + applyReservation (rev 2)
+        expect(firstAgg.revision).toBe(2);
+
+        // Simulate an intervening reservation advancing the aggregate in Firestore to revision 3
+        const advancedAgg: DailyLedgerAggregate = {
+            ...firstAgg,
+            revision: 3,
+            reservations: {
+                ...firstAgg.reservations,
+                'intervening-occ': {
+                    minutes: 30,
+                    systemicCost: 0.2,
+                    state: 'reserved',
+                    postReservationLedgerRevision: '3',
+                },
+            },
+        };
+        store.set(`users/${USER_ID}/daily_ledgers/${DATE}`, advancedAgg);
+
+        // Run adjudication again: atomic read detects fresh aggregate revision 3,
+        // so postReservationLedgerRevision "2" does not match revision 3, and the decision
+        // is evaluated against current ledger revision "3".
+        const second = await adjudicateIntradayBundleMembers(params);
+        expect(second.statuses[0].status).toBe('proceed');
+        const secondAgg = store.get(`users/${USER_ID}/daily_ledgers/${DATE}`) as DailyLedgerAggregate;
+        const targetOccId = second.statuses[0].occurrenceId!;
+        const decisionId = secondAgg.reservations[targetOccId].decisionId!;
+        const secondDecisionDoc = store.get(
+            `users/${USER_ID}/intraday_decisions/${decisionId}`,
+        ) as IntradayDecisionRecord;
+        expect(secondDecisionDoc.reassessmentInputRevision.ledgerRevision).toBe('3');
     });
 });

--- a/app/src/services/intradayBundleMemberAdjudication.test.ts
+++ b/app/src/services/intradayBundleMemberAdjudication.test.ts
@@ -8,7 +8,8 @@ import type {
 } from '../engine/models';
 import type { BundlePlacementProposal } from '../engine/intradayBundlePlacement';
 import type { LedgerCeilings } from '../engine/dailyLedger';
-import { EXTERNAL_PLAN_SCHEMA_V4 } from '../sessions/externalPlanV4';
+import { EXTERNAL_PLAN_SCHEMA_V4, type ExternalPlanSessionV4, type ExternalTrainingPlanV4 } from '../sessions/externalPlanV4';
+import type { SessionDefinition } from '../sessions/models';
 import fixture01 from '../sessions/fixtures/01-full-body-maintenance.json';
 import type { ActiveExternalPlan } from './activeExternalPlanService';
 import { resolvePlacement } from '../engine/externalPlacement';
@@ -166,31 +167,31 @@ const mockUserContext: UserContext = {
 const mockAvailability: import('../engine/schedule').ResolvedAvailability = {
     date: DATE,
     maxTimeMinutes: 120,
-    availableEquipment: ['barbell', 'dumbbell'],
+    availableEquipment: ['free_weights', 'barbell', 'dumbbell'],
     fixedActivities: [],
     reservedCapacityCost: 0,
     reservedCapacityCostProfile: { systemic: 0, cardiovascular: 0, lowerBody: 0, upperBody: 0, impactTissue: 0, neuromuscular: 0 },
     environmentOverride: null,
 };
 
-function createPlan(amSessionOverrides = {}, pmSessionOverrides = {}): ActiveExternalPlan {
-    const am = {
+function createPlan(amSessionOverrides: Partial<ExternalPlanSessionV4> = {}, pmSessionOverrides: Partial<ExternalPlanSessionV4> = {}): ActiveExternalPlan {
+    const am: ExternalPlanSessionV4 = {
         id: 'am-run',
         title: 'Morning Easy Run',
-        priority: 'key' as const,
-        placement: { week: 1, preferredDay: 'monday' as const, flexibility: 'preferred' as const, ifMissed: 'drop' as const },
-        gating: { modality: 'running' as const, intensity: 'low' as const, durationMin: 45, durationMax: 50, environment: 'either' as const, equipment: [] },
-        definition: fixture01,
+        priority: 'key',
+        placement: { week: 1, preferredDay: 'monday', flexibility: 'preferred', ifMissed: 'drop' },
+        gating: { modality: 'running', intensity: 'easy', durationMin: 45, durationMax: 50, environment: 'either', equipment: [] },
+        definition: fixture01 as unknown as SessionDefinition,
         intraday: { window: { startLocal: '07:00', endLocal: '08:00' }, bundleId: 'b-double', order: 0 },
         ...amSessionOverrides,
     };
-    const pm = {
+    const pm: ExternalPlanSessionV4 = {
         id: 'pm-strength',
         title: 'Afternoon Strength',
-        priority: 'secondary' as const,
-        placement: { week: 1, preferredDay: 'monday' as const, flexibility: 'preferred' as const, ifMissed: 'drop' as const },
-        gating: { modality: 'strength' as const, intensity: 'moderate' as const, durationMin: 45, durationMax: 55, environment: 'either' as const, equipment: ['barbell'] },
-        definition: fixture01,
+        priority: 'supporting',
+        placement: { week: 1, preferredDay: 'monday', flexibility: 'preferred', ifMissed: 'drop' },
+        gating: { modality: 'strength', intensity: 'moderate', durationMin: 45, durationMax: 55, environment: 'either', equipment: ['free_weights'] },
+        definition: fixture01 as unknown as SessionDefinition,
         intraday: {
             window: { startLocal: '16:00', endLocal: '17:00' },
             bundleId: 'b-double',
@@ -200,7 +201,7 @@ function createPlan(amSessionOverrides = {}, pmSessionOverrides = {}): ActiveExt
         },
         ...pmSessionOverrides,
     };
-    const plan = {
+    const plan: ExternalTrainingPlanV4 = {
         schema: EXTERNAL_PLAN_SCHEMA_V4,
         planId: 'p-v4',
         revision: 1,
@@ -224,9 +225,9 @@ function createPlan(amSessionOverrides = {}, pmSessionOverrides = {}): ActiveExt
     };
     return {
         header,
-        plan: plan as unknown as ActiveExternalPlan['plan'],
+        plan,
         placement: null,
-        placed: resolvePlacement(plan as unknown as Parameters<typeof resolvePlacement>[0], null, {}),
+        placed: resolvePlacement(plan, null, {}),
     };
 }
 
@@ -793,6 +794,56 @@ describe('adjudicateIntradayBundleMembers', () => {
         expect(result.notices[0]).toContain('maximum 4 additional sessions cap reached');
         expect(result.statuses[0].status).toBe('proceed');
         expect(result.statuses[0].binding).toBeUndefined();
+
+        // Ensure no occurrence or reservation was committed for the capped member
+        const targetOccId = await deterministicExternalPlanOccurrenceId(DATE, {
+            planId: 'p-v4', revision: 1, sessionId: 'pm-strength', contentHash: 'hash-bundle-v4',
+        });
+        expect(store.get(`users/${USER_ID}/session_occurrences/${targetOccId}`)).toBeUndefined();
+    });
+
+    it('admits session at boundary of additional sessions cap (3 existing bindings -> 4th allowed)', async () => {
+        const active = createPlan();
+        const bundlePlacement = createBundlePlacement();
+
+        const amOccId = 'occ-am-1';
+        const amOcc: ExternalPlanSessionOccurrence = {
+            userId: USER_ID,
+            occurrenceId: amOccId,
+            date: DATE,
+            authority: 'external_plan',
+            externalPlanRef: { planId: 'p-v4', revision: 1, sessionId: 'am-run', contentHash: 'hash-bundle-v4' },
+            state: 'completed',
+            placementOrder: 0,
+            createdAt: '2026-09-07T05:00:00.000Z',
+            updatedAt: '2026-09-07T06:00:00.000Z',
+        };
+        const amExec = createMockExecution(amOccId);
+        const amResp = createMockSessionResponse(amOccId);
+
+        vi.spyOn(sessionOccurrenceService, 'getOccurrencesForDate').mockResolvedValue([amOcc]);
+        vi.spyOn(sessionExecutionService, 'getExecutionsInRange').mockResolvedValue({ executions: [amExec], invalidRecords: 0 });
+        vi.spyOn(sessionResponseService, 'getResponseForWindow').mockResolvedValue(amResp);
+
+        // existingAdditionalBindingsCount is 3, allowing the 4th session
+        const result = await adjudicateIntradayBundleMembers({
+            userId: USER_ID,
+            date: DATE,
+            activePlan: active,
+            bundlePlacement,
+            subjective: mockSubjective,
+            objective: mockObjective,
+            userContext: mockUserContext,
+            availability: mockAvailability,
+            ceilings,
+            existingAdditionalBindingsCount: 3,
+            evaluationInstant: '2026-09-07T12:00:00.000Z',
+        });
+
+        expect(result.bindings).toHaveLength(1);
+        expect(result.notices).toHaveLength(0);
+        expect(result.statuses[0].status).toBe('proceed');
+        expect(result.statuses[0].binding).toBeDefined();
     });
 
     it('converges idempotently on ambiguous retry without error', async () => {
@@ -834,10 +885,14 @@ describe('adjudicateIntradayBundleMembers', () => {
         // Run once
         const first = await adjudicateIntradayBundleMembers(params);
         expect(first.statuses[0].status).toBe('proceed');
+        const firstAgg = store.get(`users/${USER_ID}/daily_ledgers/${DATE}`) as DailyLedgerAggregate;
 
         // Run second time with identical inputs (simulates retry)
         const second = await adjudicateIntradayBundleMembers(params);
         expect(second.statuses[0].status).toBe('proceed');
+        expect(second.statuses[0].occurrenceId).toBe(first.statuses[0].occurrenceId);
         expect(second.bindings[0].sessionSource).toEqual(first.bindings[0].sessionSource);
+        const secondAgg = store.get(`users/${USER_ID}/daily_ledgers/${DATE}`) as DailyLedgerAggregate;
+        expect(Object.keys(secondAgg.reservations).length).toBe(Object.keys(firstAgg.reservations).length);
     });
 });

--- a/app/src/services/intradayBundleMemberAdjudication.test.ts
+++ b/app/src/services/intradayBundleMemberAdjudication.test.ts
@@ -948,18 +948,27 @@ describe('adjudicateIntradayBundleMembers', () => {
             reservations: {
                 ...firstAgg.reservations,
                 'intervening-occ': {
-                    minutes: 30,
-                    systemicCost: 0.2,
+                    minutes: 10,
+                    systemicCost: 0.05,
                     state: 'reserved',
                     postReservationLedgerRevision: '3',
                 },
             },
         };
-        store.set(`users/${USER_ID}/daily_ledgers/${DATE}`, advancedAgg);
 
-        // Run adjudication again: atomic read detects fresh aggregate revision 3,
-        // so postReservationLedgerRevision "2" does not match revision 3, and the decision
-        // is evaluated against current ledger revision "3".
+        // Advance aggregate in Firestore immediately after the initial aggregateService.get call (line 173)
+        // so that the initial read receives stale revision 2, but the member's atomic transaction observes revision 3.
+        const originalGet = dailyLedgerAggregateService.get.bind(dailyLedgerAggregateService);
+        vi.spyOn(dailyLedgerAggregateService, 'get').mockImplementationOnce(async (userId, date) => {
+            const initial = await originalGet(userId, date);
+            store.set(`users/${USER_ID}/daily_ledgers/${DATE}`, advancedAgg);
+            return initial;
+        });
+
+        // Run adjudication again: initial read receives revision 2,
+        // but member adjudication's atomic transaction re-reads fresh aggregate revision 3,
+        // reconciles 'intervening-occ' into the candidate ledger, evaluates capacity,
+        // and commits the decision with ledgerRevision '3'.
         const second = await adjudicateIntradayBundleMembers(params);
         expect(second.statuses[0].status).toBe('proceed');
         const secondAgg = store.get(`users/${USER_ID}/daily_ledgers/${DATE}`) as DailyLedgerAggregate;
@@ -969,5 +978,6 @@ describe('adjudicateIntradayBundleMembers', () => {
             `users/${USER_ID}/intraday_decisions/${decisionId}`,
         ) as IntradayDecisionRecord;
         expect(secondDecisionDoc.reassessmentInputRevision.ledgerRevision).toBe('3');
+        expect(secondDecisionDoc.ledgerSnapshot.entries.some(e => e.occurrenceId === 'intervening-occ')).toBe(true);
     });
 });

--- a/app/src/services/intradayBundleMemberAdjudication.test.ts
+++ b/app/src/services/intradayBundleMemberAdjudication.test.ts
@@ -1,0 +1,843 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Firestore } from 'firebase/firestore';
+import type {
+    SubjectiveInput,
+    EngineObjectiveInput,
+    UserContext,
+    ExternalPlanHeader,
+} from '../engine/models';
+import type { BundlePlacementProposal } from '../engine/intradayBundlePlacement';
+import type { LedgerCeilings } from '../engine/dailyLedger';
+import { EXTERNAL_PLAN_SCHEMA_V4 } from '../sessions/externalPlanV4';
+import fixture01 from '../sessions/fixtures/01-full-body-maintenance.json';
+import type { ActiveExternalPlan } from './activeExternalPlanService';
+import { resolvePlacement } from '../engine/externalPlacement';
+import {
+    sessionOccurrenceService,
+    windowReservationId,
+    deterministicExternalPlanOccurrenceId,
+} from './sessionOccurrenceService';
+import {
+    dailyLedgerAggregateService,
+    type DailyLedgerAggregate,
+} from './dailyLedgerAggregateService';
+import { sessionResponseService } from './sessionResponseService';
+import { sessionExecutionService } from './sessionExecutionService';
+import type { NormalizedExecutionRecord } from '../sessions/legacyStrengthAdapter';
+import {
+    getIntradayDecisionDocPath,
+} from './intradayDecisionService';
+import {
+    adjudicateIntradayBundleMembers,
+    type AdjudicateIntradayBundleMembersParams,
+} from './intradayBundleMemberAdjudication';
+import type {
+    ExternalPlanSessionOccurrence,
+} from '../sessions/models';
+import type { SessionResponse } from '../responses/models';
+import type { IntradayDecisionRecord } from '../engine/intradayDecision';
+
+const store = new Map<string, unknown>();
+
+function mockDocRef(path: string) {
+    return { path };
+}
+
+vi.mock('firebase/firestore', () => {
+    return {
+        doc: vi.fn((_db: unknown, ...parts: string[]) => {
+            const path = parts.filter(p => typeof p === 'string').join('/');
+            return mockDocRef(path);
+        }),
+        collection: vi.fn((_db: unknown, ...parts: string[]) => {
+            const path = parts.filter(p => typeof p === 'string').join('/');
+            return { path };
+        }),
+        query: vi.fn((c: unknown) => c),
+        where: vi.fn(() => ({})),
+        orderBy: vi.fn(() => ({})),
+        limit: vi.fn(() => ({})),
+        getDocs: vi.fn(async () => ({ docs: [] })),
+        getDoc: vi.fn(async (ref: { path: string }) => {
+            const val = store.get(ref.path);
+            return {
+                ref,
+                exists: () => val !== undefined,
+                data: () => (val !== undefined ? JSON.parse(JSON.stringify(val)) : undefined),
+            };
+        }),
+        runTransaction: vi.fn(async (_db: unknown, callback: (t: {
+            get: (ref: { path: string }) => Promise<{ ref: { path: string }; exists: () => boolean; data: () => unknown }>;
+            set: (ref: { path: string }, data: unknown) => void;
+            delete: (ref: { path: string }) => void;
+        }) => Promise<unknown>) => {
+            const fakeTransaction = {
+                get: vi.fn(async (ref: { path: string }) => {
+                    const val = store.get(ref.path);
+                    return {
+                        ref,
+                        exists: () => val !== undefined,
+                        data: () => (val !== undefined ? JSON.parse(JSON.stringify(val)) : undefined),
+                    };
+                }),
+                set: vi.fn((ref: { path: string }, data: unknown) => {
+                    store.set(ref.path, JSON.parse(JSON.stringify(data)));
+                }),
+                delete: vi.fn((ref: { path: string }) => {
+                    store.delete(ref.path);
+                }),
+            };
+            return callback(fakeTransaction);
+        }),
+    };
+});
+
+vi.mock('../firebase', () => ({
+    getDb: vi.fn(() => ({} as Firestore)),
+}));
+
+const DATE = '2026-09-07';
+const USER_ID = 'user-bundle-test';
+
+const ceilings: LedgerCeilings = {
+    dailyMinuteCeiling: 120,
+    dailySystemicCostCeiling: 1.0,
+};
+
+const mockSubjective: SubjectiveInput = {
+    readiness: 4,
+    sleepQuality: 4,
+    fatigue: 2,
+    soreness: 2,
+    stress: 2,
+    motivation: 4,
+    timeAvailable: 120,
+    painFlag: false,
+    alreadyTrainedToday: false,
+    preferredModalityToday: null,
+};
+
+const mockObjective: EngineObjectiveInput = {
+    sleep_score: 80,
+    sleep_duration_min: 480,
+    rhr: 50,
+    rhr_7d_avg: 50,
+    rhr_delta: 0,
+    hrv_weekly_avg: 55,
+    hrv_last_night: 55,
+    hrv_delta: 0,
+    hrv_stdev_28d: null,
+    rhr_stdev_28d: null,
+    sleep_score_stdev_28d: null,
+    respiration: 14,
+    respiration_delta: 0,
+    respiration_delta_28d: 0,
+    respiration_mad_28d: null,
+    body_battery_wake: 80,
+    last_3_days_hard_sessions_count: 0,
+    yesterday_training: null,
+    today_training: null,
+    sleep_score_delta_7d: 0,
+    rhr_delta_28d: 0,
+    hrv_delta_28d: 0,
+    sleep_score_delta_28d: 0,
+    total_steps: 8000,
+    steps_7d_avg: 8000,
+};
+
+const mockUserContext: UserContext = {
+    goals: { shortTerm: 'general_fitness', midTerm: 'strength', longTerm: 'endurance' },
+    constraints: {
+        hasCableMachine: true,
+        hasFreeWeights: true,
+        hasTreadmill: true,
+        hasIndoorBike: true,
+        maxTimeMinutes: 120,
+        restrictedModalities: [],
+    },
+    preferences: {
+        avoidedModalities: [],
+        deprioritizedModalities: [],
+        preferredModalities: ['Strength', 'Running'],
+        conservativeBias: false,
+    },
+};
+
+const mockAvailability: import('../engine/schedule').ResolvedAvailability = {
+    date: DATE,
+    maxTimeMinutes: 120,
+    availableEquipment: ['barbell', 'dumbbell'],
+    fixedActivities: [],
+    reservedCapacityCost: 0,
+    reservedCapacityCostProfile: { systemic: 0, cardiovascular: 0, lowerBody: 0, upperBody: 0, impactTissue: 0, neuromuscular: 0 },
+    environmentOverride: null,
+};
+
+function createPlan(amSessionOverrides = {}, pmSessionOverrides = {}): ActiveExternalPlan {
+    const am = {
+        id: 'am-run',
+        title: 'Morning Easy Run',
+        priority: 'key' as const,
+        placement: { week: 1, preferredDay: 'monday' as const, flexibility: 'preferred' as const, ifMissed: 'drop' as const },
+        gating: { modality: 'running' as const, intensity: 'low' as const, durationMin: 45, durationMax: 50, environment: 'either' as const, equipment: [] },
+        definition: fixture01,
+        intraday: { window: { startLocal: '07:00', endLocal: '08:00' }, bundleId: 'b-double', order: 0 },
+        ...amSessionOverrides,
+    };
+    const pm = {
+        id: 'pm-strength',
+        title: 'Afternoon Strength',
+        priority: 'secondary' as const,
+        placement: { week: 1, preferredDay: 'monday' as const, flexibility: 'preferred' as const, ifMissed: 'drop' as const },
+        gating: { modality: 'strength' as const, intensity: 'moderate' as const, durationMin: 45, durationMax: 55, environment: 'either' as const, equipment: ['barbell'] },
+        definition: fixture01,
+        intraday: {
+            window: { startLocal: '16:00', endLocal: '17:00' },
+            bundleId: 'b-double',
+            order: 1,
+            afterSessionId: 'am-run',
+            minimumSeparationMinutes: 240,
+        },
+        ...pmSessionOverrides,
+    };
+    const plan = {
+        schema: EXTERNAL_PLAN_SCHEMA_V4,
+        planId: 'p-v4',
+        revision: 1,
+        title: 'Intraday Double Plan',
+        startDate: DATE,
+        weekCount: 1,
+        sessions: [am, pm],
+        restDays: [],
+    };
+    const header: ExternalPlanHeader = {
+        userId: USER_ID,
+        planId: 'p-v4',
+        revision: 1,
+        title: 'Intraday Double Plan',
+        startDate: DATE,
+        weekCount: 1,
+        contentHash: 'hash-bundle-v4',
+        importedAt: '2026-09-01T00:00:00Z',
+        supersededFrom: null,
+        updatedAt: '2026-09-01T00:00:00Z',
+    };
+    return {
+        header,
+        plan: plan as unknown as ActiveExternalPlan['plan'],
+        placement: null,
+        placed: resolvePlacement(plan as unknown as Parameters<typeof resolvePlacement>[0], null, {}),
+    };
+}
+
+function createBundlePlacement(): BundlePlacementProposal {
+    return {
+        bundleId: 'b-double',
+        outcome: 'placed',
+        bindings: [
+            {
+                sessionId: 'am-run',
+                windowId: 'w-am',
+                boundStartLocal: '07:00',
+                boundEndLocal: '08:00',
+                startInstant: '2026-09-07T05:00:00.000Z',
+                endInstant: '2026-09-07T06:00:00.000Z',
+            },
+            {
+                sessionId: 'pm-strength',
+                windowId: 'w-pm',
+                boundStartLocal: '16:00',
+                boundEndLocal: '17:00',
+                startInstant: '2026-09-07T14:00:00.000Z',
+                endInstant: '2026-09-07T15:00:00.000Z',
+            },
+        ],
+    };
+}
+
+function createMockSessionResponse(amOccId: string): SessionResponse {
+    return {
+        userId: USER_ID,
+        responseId: 'resp-am-1',
+        sourceSession: { kind: 'execution', id: 'exec-am-1', date: DATE },
+        occurrenceId: amOccId,
+        window: 'immediate',
+        date: DATE,
+        checkinRef: { date: DATE },
+        sessionRpe: 3,
+        note: 'felt great',
+        createdAt: '2026-09-07T06:05:00.000Z',
+        updatedAt: '2026-09-07T06:05:00.000Z',
+    };
+}
+
+function createMockExecution(amOccId: string): NormalizedExecutionRecord {
+    return {
+        execution: {
+            executionId: 'exec-am-1',
+            userId: USER_ID,
+            sessionSource: { kind: 'external_plan', planId: 'p-v4', revision: 1, sessionId: 'am-run', contentHash: 'hash-bundle-v4' },
+            occurrenceId: amOccId,
+            date: DATE,
+            state: 'completed',
+            startedAt: '2026-09-07T05:00:00.000Z',
+            completedAt: '2026-09-07T06:00:00.000Z',
+            updatedAt: '2026-09-07T06:00:00.000Z',
+            schemaVersion: 1,
+        },
+        entries: [],
+    };
+}
+
+describe('adjudicateIntradayBundleMembers', () => {
+    beforeEach(() => {
+        store.clear();
+        vi.restoreAllMocks();
+    });
+
+    it('adjudicates an admitted member with completed predecessor & immediate response (proceed + binding + decision record)', async () => {
+        const active = createPlan();
+        const bundlePlacement = createBundlePlacement();
+
+        // Setup AM predecessor occurrence and completed execution
+        const amOccId = 'occ-am-123';
+        const amOcc: ExternalPlanSessionOccurrence = {
+            userId: USER_ID,
+            occurrenceId: amOccId,
+            date: DATE,
+            authority: 'external_plan',
+            externalPlanRef: {
+                planId: 'p-v4',
+                revision: 1,
+                sessionId: 'am-run',
+                contentHash: 'hash-bundle-v4',
+            },
+            state: 'completed',
+            placementOrder: 0,
+            windowBinding: {
+                windowId: 'w-am',
+                bundleId: 'b-double',
+                order: 0,
+                boundStartLocal: '07:00',
+                boundEndLocal: '08:00',
+                startInstant: '2026-09-07T05:00:00.000Z',
+                endInstant: '2026-09-07T06:00:00.000Z',
+            },
+            createdAt: '2026-09-07T05:00:00.000Z',
+            updatedAt: '2026-09-07T06:00:00.000Z',
+        };
+
+        const amExec = createMockExecution(amOccId);
+
+        const amResp = createMockSessionResponse(amOccId);
+
+        vi.spyOn(sessionOccurrenceService, 'getOccurrencesForDate').mockResolvedValue([amOcc]);
+        vi.spyOn(sessionExecutionService, 'getExecutionsInRange').mockResolvedValue({
+            executions: [amExec],
+            invalidRecords: 0,
+        });
+        vi.spyOn(sessionResponseService, 'getResponseForWindow').mockResolvedValue(amResp);
+
+        const result = await adjudicateIntradayBundleMembers({
+            userId: USER_ID,
+            date: DATE,
+            activePlan: active,
+            bundlePlacement,
+            subjective: mockSubjective,
+            objective: mockObjective,
+            userContext: mockUserContext,
+            availability: mockAvailability,
+            ceilings,
+            evaluationInstant: '2026-09-07T12:00:00.000Z', // 6 hours after AM completion (min separation 4h)
+        });
+
+        expect(result.bindings).toHaveLength(1);
+        expect(result.statuses).toHaveLength(1);
+        expect(result.statuses[0].status).toBe('proceed');
+        expect(result.statuses[0].sessionId).toBe('pm-strength');
+        expect(result.bindings[0].sessionSource.kind).toBe('external_plan');
+
+        // Verify occurrence document was written in transaction
+        const pmOccId = result.statuses[0].occurrenceId!;
+        const occPath = `users/${USER_ID}/session_occurrences/${pmOccId}`;
+        const occData = store.get(occPath) as ExternalPlanSessionOccurrence;
+        expect(occData).toBeDefined();
+        expect(occData.state).toBe('scheduled');
+        expect(occData.windowBinding?.windowId).toBe('w-pm');
+
+        // Verify window reservation document was written
+        const winPath = `users/${USER_ID}/session_occurrence_windows/${windowReservationId(DATE, 'w-pm')}`;
+        const winData = store.get(winPath) as { occurrenceId: string };
+        expect(winData).toBeDefined();
+        expect(winData.occurrenceId).toBe(pmOccId);
+
+        // Verify daily ledger aggregate document was updated
+        const aggPath = `users/${USER_ID}/daily_ledgers/${DATE}`;
+        const aggData = store.get(aggPath) as DailyLedgerAggregate;
+        expect(aggData).toBeDefined();
+        expect(aggData.reservations[pmOccId]).toBeDefined();
+        expect(aggData.reservations[pmOccId].state).toBe('reserved');
+
+        // Verify intraday decision record was written
+        const decisionId = aggData.reservations[pmOccId].decisionId!;
+        const decPath = getIntradayDecisionDocPath(USER_ID, decisionId);
+        const decData = store.get(decPath) as IntradayDecisionRecord;
+        expect(decData).toBeDefined();
+        expect(decData.status).toBe('provisional');
+        expect(decData.verdict.decision).toBe('proceed');
+        expect(decData.postReservationLedgerRevision).toBe(String(aggData.revision));
+        expect(decData.predecessorExecutionId).toBe('exec-am-1');
+        expect(decData.predecessorOccurrenceId).toBe(amOccId);
+    });
+
+    it('handles uncompleted predecessor (pending status, occurrence and reservation created, no binding)', async () => {
+        const active = createPlan();
+        const bundlePlacement = createBundlePlacement();
+
+        // AM predecessor occurrence is only scheduled
+        const amOccId = 'occ-am-1';
+        const amOcc: ExternalPlanSessionOccurrence = {
+            userId: USER_ID,
+            occurrenceId: amOccId,
+            date: DATE,
+            authority: 'external_plan',
+            externalPlanRef: { planId: 'p-v4', revision: 1, sessionId: 'am-run', contentHash: 'hash-bundle-v4' },
+            state: 'scheduled',
+            placementOrder: 0,
+            createdAt: '2026-09-07T05:00:00.000Z',
+            updatedAt: '2026-09-07T05:00:00.000Z',
+        };
+
+        vi.spyOn(sessionOccurrenceService, 'getOccurrencesForDate').mockResolvedValue([amOcc]);
+        vi.spyOn(sessionExecutionService, 'getExecutionsInRange').mockResolvedValue({ executions: [], invalidRecords: 0 });
+        vi.spyOn(sessionResponseService, 'getResponseForWindow').mockResolvedValue(null);
+
+        const result = await adjudicateIntradayBundleMembers({
+            userId: USER_ID,
+            date: DATE,
+            activePlan: active,
+            bundlePlacement,
+            subjective: mockSubjective,
+            objective: mockObjective,
+            userContext: mockUserContext,
+            availability: mockAvailability,
+            ceilings,
+            evaluationInstant: '2026-09-07T06:00:00.000Z',
+        });
+
+        expect(result.bindings).toHaveLength(0); // No binding on pending
+        expect(result.statuses).toHaveLength(1);
+        expect(result.statuses[0].status).toBe('pending');
+        expect(result.statuses[0].reason).toContain('has not completed');
+
+        // Occurrence and reservation were still created atomically
+        const pmOccId = result.statuses[0].occurrenceId!;
+        const occPath = `users/${USER_ID}/session_occurrences/${pmOccId}`;
+        expect(store.get(occPath)).toBeDefined();
+
+        const aggPath = `users/${USER_ID}/daily_ledgers/${DATE}`;
+        const aggData = store.get(aggPath) as DailyLedgerAggregate;
+        expect(aggData.reservations[pmOccId]).toBeDefined();
+        expect(aggData.reservations[pmOccId].state).toBe('reserved');
+    });
+
+    it('handles predecessor awaiting immediate confirmation (pending status, no binding)', async () => {
+        const active = createPlan();
+        const bundlePlacement = createBundlePlacement();
+
+        // AM completed, but NO immediate response yet
+        const amOccId = 'occ-am-1';
+        const amOcc: ExternalPlanSessionOccurrence = {
+            userId: USER_ID,
+            occurrenceId: amOccId,
+            date: DATE,
+            authority: 'external_plan',
+            externalPlanRef: { planId: 'p-v4', revision: 1, sessionId: 'am-run', contentHash: 'hash-bundle-v4' },
+            state: 'completed',
+            placementOrder: 0,
+            createdAt: '2026-09-07T05:00:00.000Z',
+            updatedAt: '2026-09-07T06:00:00.000Z',
+        };
+
+        const amExec = createMockExecution(amOccId);
+
+        vi.spyOn(sessionOccurrenceService, 'getOccurrencesForDate').mockResolvedValue([amOcc]);
+        vi.spyOn(sessionExecutionService, 'getExecutionsInRange').mockResolvedValue({ executions: [amExec], invalidRecords: 0 });
+        vi.spyOn(sessionResponseService, 'getResponseForWindow').mockResolvedValue(null);
+
+        const result = await adjudicateIntradayBundleMembers({
+            userId: USER_ID,
+            date: DATE,
+            activePlan: active,
+            bundlePlacement,
+            subjective: mockSubjective,
+            objective: mockObjective,
+            userContext: mockUserContext,
+            availability: mockAvailability,
+            ceilings,
+            evaluationInstant: '2026-09-07T12:00:00.000Z',
+        });
+
+        expect(result.bindings).toHaveLength(0);
+        expect(result.statuses).toHaveLength(1);
+        expect(result.statuses[0].status).toBe('pending');
+        expect(result.statuses[0].reason).toContain('Awaiting explicit post-predecessor');
+    });
+
+    it('excludes target member reservation to prevent self-consumption on consecutive reloads', async () => {
+        const active = createPlan();
+        const bundlePlacement = createBundlePlacement();
+
+        const amOccId = 'occ-am-1';
+        const amOcc: ExternalPlanSessionOccurrence = {
+            userId: USER_ID,
+            occurrenceId: amOccId,
+            date: DATE,
+            authority: 'external_plan',
+            externalPlanRef: { planId: 'p-v4', revision: 1, sessionId: 'am-run', contentHash: 'hash-bundle-v4' },
+            state: 'completed',
+            placementOrder: 0,
+            createdAt: '2026-09-07T05:00:00.000Z',
+            updatedAt: '2026-09-07T06:00:00.000Z',
+        };
+        const amExec = createMockExecution(amOccId);
+        const amResp = createMockSessionResponse(amOccId);
+
+        const targetOccId = await deterministicExternalPlanOccurrenceId(DATE, {
+            planId: 'p-v4', revision: 1, sessionId: 'pm-strength', contentHash: 'hash-bundle-v4',
+        });
+
+        // First pass: creates PM occurrence and reservation
+        vi.spyOn(sessionOccurrenceService, 'getOccurrencesForDate').mockResolvedValue([amOcc]);
+        vi.spyOn(sessionExecutionService, 'getExecutionsInRange').mockResolvedValue({ executions: [amExec], invalidRecords: 0 });
+        vi.spyOn(sessionResponseService, 'getResponseForWindow').mockResolvedValue(amResp);
+
+        const firstResult = await adjudicateIntradayBundleMembers({
+            userId: USER_ID,
+            date: DATE,
+            activePlan: active,
+            bundlePlacement,
+            subjective: mockSubjective,
+            objective: mockObjective,
+            userContext: mockUserContext,
+            availability: mockAvailability,
+            ceilings,
+            evaluationInstant: '2026-09-07T12:00:00.000Z',
+        });
+        expect(firstResult.statuses[0].status).toBe('proceed');
+
+        // Now PM occurrence exists in DB
+        const pmOcc = store.get(`users/${USER_ID}/session_occurrences/${targetOccId}`) as ExternalPlanSessionOccurrence;
+        expect(pmOcc).toBeDefined();
+
+        // Second pass: mock returns BOTH AM and PM occurrences
+        vi.spyOn(sessionOccurrenceService, 'getOccurrencesForDate').mockResolvedValue([amOcc, pmOcc]);
+
+        const secondResult = await adjudicateIntradayBundleMembers({
+            userId: USER_ID,
+            date: DATE,
+            activePlan: active,
+            bundlePlacement,
+            subjective: mockSubjective,
+            objective: mockObjective,
+            userContext: mockUserContext,
+            availability: mockAvailability,
+            ceilings,
+            evaluationInstant: '2026-09-07T12:00:00.000Z',
+        });
+
+        // Target does NOT reject itself by self-consuming capacity
+        expect(secondResult.statuses[0].status).toBe('proceed');
+        expect(secondResult.bindings).toHaveLength(1);
+    });
+
+    it('rejects candidate and atomically transitions scheduled occurrence to skipped and drops reservation', async () => {
+        const active = createPlan();
+        const bundlePlacement = createBundlePlacement();
+
+        const targetOccId = await deterministicExternalPlanOccurrenceId(DATE, {
+            planId: 'p-v4', revision: 1, sessionId: 'pm-strength', contentHash: 'hash-bundle-v4',
+        });
+
+        // Pre-seed an existing scheduled occurrence and reservation
+        const existingOcc: ExternalPlanSessionOccurrence = {
+            userId: USER_ID,
+            occurrenceId: targetOccId,
+            date: DATE,
+            authority: 'external_plan',
+            externalPlanRef: { planId: 'p-v4', revision: 1, sessionId: 'pm-strength', contentHash: 'hash-bundle-v4' },
+            state: 'scheduled',
+            placementOrder: 1,
+            windowBinding: {
+                windowId: 'w-pm',
+                bundleId: 'b-double',
+                order: 1,
+                boundStartLocal: '16:00',
+                boundEndLocal: '17:00',
+                startInstant: '2026-09-07T14:00:00.000Z',
+                endInstant: '2026-09-07T15:00:00.000Z',
+            },
+            createdAt: '2026-09-07T05:00:00.000Z',
+            updatedAt: '2026-09-07T05:00:00.000Z',
+        };
+        store.set(`users/${USER_ID}/session_occurrences/${targetOccId}`, existingOcc);
+        store.set(`users/${USER_ID}/session_occurrence_windows/${windowReservationId(DATE, 'w-pm')}`, {
+            userId: USER_ID,
+            date: DATE,
+            windowId: 'w-pm',
+            occurrenceId: targetOccId,
+            createdAt: '2026-09-07T05:00:00.000Z',
+        });
+
+        const initialAgg: DailyLedgerAggregate = {
+            userId: USER_ID,
+            date: DATE,
+            revision: 1,
+            ceilings,
+            reservations: {
+                [targetOccId]: { minutes: 50, systemicCost: 0.5, state: 'reserved', decisionId: 'dec-prior' },
+            },
+            seededAt: '2026-09-07T05:00:00.000Z',
+            createdAt: '2026-09-07T05:00:00.000Z',
+            updatedAt: '2026-09-07T05:00:00.000Z',
+        };
+        store.set(`users/${USER_ID}/daily_ledgers/${DATE}`, initialAgg);
+
+        // Make ceilings zero to force rejection (capacity exhausted)
+        const zeroCeilings: LedgerCeilings = {
+            dailyMinuteCeiling: 0,
+            dailySystemicCostCeiling: 0,
+        };
+
+        const amOccId = 'occ-am-1';
+        const amOcc: ExternalPlanSessionOccurrence = {
+            userId: USER_ID,
+            occurrenceId: amOccId,
+            date: DATE,
+            authority: 'external_plan',
+            externalPlanRef: { planId: 'p-v4', revision: 1, sessionId: 'am-run', contentHash: 'hash-bundle-v4' },
+            state: 'completed',
+            placementOrder: 0,
+            createdAt: '2026-09-07T05:00:00.000Z',
+            updatedAt: '2026-09-07T06:00:00.000Z',
+        };
+        const amExec = createMockExecution(amOccId);
+        const amResp = createMockSessionResponse(amOccId);
+
+        vi.spyOn(sessionOccurrenceService, 'getOccurrencesForDate').mockResolvedValue([amOcc, existingOcc]);
+        vi.spyOn(sessionExecutionService, 'getExecutionsInRange').mockResolvedValue({ executions: [amExec], invalidRecords: 0 });
+        vi.spyOn(sessionResponseService, 'getResponseForWindow').mockResolvedValue(amResp);
+
+        const result = await adjudicateIntradayBundleMembers({
+            userId: USER_ID,
+            date: DATE,
+            activePlan: active,
+            bundlePlacement,
+            subjective: mockSubjective,
+            objective: mockObjective,
+            userContext: mockUserContext,
+            availability: { ...mockAvailability, maxTimeMinutes: 0 },
+            ceilings: zeroCeilings,
+            evaluationInstant: '2026-09-07T12:00:00.000Z',
+        });
+
+        expect(result.statuses[0].status).toBe('reject');
+        expect(result.bindings).toHaveLength(0);
+
+        // Occurrence must be atomically transitioned to skipped
+        const updatedOcc = store.get(`users/${USER_ID}/session_occurrences/${targetOccId}`) as ExternalPlanSessionOccurrence;
+        expect(updatedOcc.state).toBe('skipped');
+
+        // Window reservation must be deleted
+        expect(store.get(`users/${USER_ID}/session_occurrence_windows/${windowReservationId(DATE, 'w-pm')}`)).toBeUndefined();
+
+        // Aggregate reservation dropped and generation bumped
+        const updatedAgg = store.get(`users/${USER_ID}/daily_ledgers/${DATE}`) as DailyLedgerAggregate;
+        expect(updatedAgg.reservations[targetOccId]).toBeUndefined();
+        expect(dailyLedgerAggregateService.currentGeneration(updatedAgg, 'pm-strength')).toBe(1);
+    });
+
+    it('recovers from reject with fresh occurrence identity minted at generation 1', async () => {
+        const active = createPlan();
+        const bundlePlacement = createBundlePlacement();
+
+        const gen0OccId = await deterministicExternalPlanOccurrenceId(DATE, {
+            planId: 'p-v4', revision: 1, sessionId: 'pm-strength', contentHash: 'hash-bundle-v4',
+        }, 0);
+
+        const gen1OccId = await deterministicExternalPlanOccurrenceId(DATE, {
+            planId: 'p-v4', revision: 1, sessionId: 'pm-strength', contentHash: 'hash-bundle-v4',
+        }, 1);
+
+        expect(gen1OccId).not.toBe(gen0OccId);
+
+        // Gen 0 occurrence is skipped
+        const skippedOcc: ExternalPlanSessionOccurrence = {
+            userId: USER_ID,
+            occurrenceId: gen0OccId,
+            date: DATE,
+            authority: 'external_plan',
+            externalPlanRef: { planId: 'p-v4', revision: 1, sessionId: 'pm-strength', contentHash: 'hash-bundle-v4' },
+            state: 'skipped',
+            placementOrder: 1,
+            createdAt: '2026-09-07T05:00:00.000Z',
+            updatedAt: '2026-09-07T06:00:00.000Z',
+        };
+        store.set(`users/${USER_ID}/session_occurrences/${gen0OccId}`, skippedOcc);
+
+        // Aggregate has generation: 1 for pm-strength
+        const initialAgg: DailyLedgerAggregate = {
+            userId: USER_ID,
+            date: DATE,
+            revision: 2,
+            ceilings,
+            reservations: {},
+            generations: { 'pm-strength': 1 },
+            seededAt: '2026-09-07T05:00:00.000Z',
+            createdAt: '2026-09-07T05:00:00.000Z',
+            updatedAt: '2026-09-07T06:00:00.000Z',
+        };
+        store.set(`users/${USER_ID}/daily_ledgers/${DATE}`, initialAgg);
+
+        // Predecessor is completed & healthy
+        const amOccId = 'occ-am-1';
+        const amOcc: ExternalPlanSessionOccurrence = {
+            userId: USER_ID,
+            occurrenceId: amOccId,
+            date: DATE,
+            authority: 'external_plan',
+            externalPlanRef: { planId: 'p-v4', revision: 1, sessionId: 'am-run', contentHash: 'hash-bundle-v4' },
+            state: 'completed',
+            placementOrder: 0,
+            createdAt: '2026-09-07T05:00:00.000Z',
+            updatedAt: '2026-09-07T06:00:00.000Z',
+        };
+        const amExec = createMockExecution(amOccId);
+        const amResp = createMockSessionResponse(amOccId);
+
+        vi.spyOn(sessionOccurrenceService, 'getOccurrencesForDate').mockResolvedValue([amOcc, skippedOcc]);
+        vi.spyOn(sessionExecutionService, 'getExecutionsInRange').mockResolvedValue({ executions: [amExec], invalidRecords: 0 });
+        vi.spyOn(sessionResponseService, 'getResponseForWindow').mockResolvedValue(amResp);
+
+        const result = await adjudicateIntradayBundleMembers({
+            userId: USER_ID,
+            date: DATE,
+            activePlan: active,
+            bundlePlacement,
+            subjective: mockSubjective,
+            objective: mockObjective,
+            userContext: mockUserContext,
+            availability: mockAvailability,
+            ceilings,
+            evaluationInstant: '2026-09-07T12:00:00.000Z',
+        });
+
+        expect(result.statuses[0].status).toBe('proceed');
+        expect(result.statuses[0].occurrenceId).toBe(gen1OccId);
+        expect(result.bindings).toHaveLength(1);
+
+        // Skipped occurrence document was NOT touched
+        expect((store.get(`users/${USER_ID}/session_occurrences/${gen0OccId}`) as ExternalPlanSessionOccurrence).state).toBe('skipped');
+
+        // New generation-1 occurrence was created
+        const gen1Occ = store.get(`users/${USER_ID}/session_occurrences/${gen1OccId}`) as ExternalPlanSessionOccurrence;
+        expect(gen1Occ).toBeDefined();
+        expect(gen1Occ.state).toBe('scheduled');
+
+        // Aggregate reservation is registered under gen1OccId
+        const updatedAgg = store.get(`users/${USER_ID}/daily_ledgers/${DATE}`) as DailyLedgerAggregate;
+        expect(updatedAgg.reservations[gen1OccId]).toBeDefined();
+        expect(updatedAgg.reservations[gen1OccId].state).toBe('reserved');
+    });
+
+    it('enforces maximum 4 additional sessions cap by omitting binding and emitting notice', async () => {
+        const active = createPlan();
+        const bundlePlacement = createBundlePlacement();
+
+        const amOccId = 'occ-am-1';
+        const amOcc: ExternalPlanSessionOccurrence = {
+            userId: USER_ID,
+            occurrenceId: amOccId,
+            date: DATE,
+            authority: 'external_plan',
+            externalPlanRef: { planId: 'p-v4', revision: 1, sessionId: 'am-run', contentHash: 'hash-bundle-v4' },
+            state: 'completed',
+            placementOrder: 0,
+            createdAt: '2026-09-07T05:00:00.000Z',
+            updatedAt: '2026-09-07T06:00:00.000Z',
+        };
+        const amExec = createMockExecution(amOccId);
+        const amResp = createMockSessionResponse(amOccId);
+
+        vi.spyOn(sessionOccurrenceService, 'getOccurrencesForDate').mockResolvedValue([amOcc]);
+        vi.spyOn(sessionExecutionService, 'getExecutionsInRange').mockResolvedValue({ executions: [amExec], invalidRecords: 0 });
+        vi.spyOn(sessionResponseService, 'getResponseForWindow').mockResolvedValue(amResp);
+
+        // existingAdditionalBindingsCount is already 4
+        const result = await adjudicateIntradayBundleMembers({
+            userId: USER_ID,
+            date: DATE,
+            activePlan: active,
+            bundlePlacement,
+            subjective: mockSubjective,
+            objective: mockObjective,
+            userContext: mockUserContext,
+            availability: mockAvailability,
+            ceilings,
+            existingAdditionalBindingsCount: 4,
+            evaluationInstant: '2026-09-07T12:00:00.000Z',
+        });
+
+        expect(result.bindings).toHaveLength(0);
+        expect(result.notices).toHaveLength(1);
+        expect(result.notices[0]).toContain('maximum 4 additional sessions cap reached');
+        expect(result.statuses[0].status).toBe('proceed');
+        expect(result.statuses[0].binding).toBeUndefined();
+    });
+
+    it('converges idempotently on ambiguous retry without error', async () => {
+        const active = createPlan();
+        const bundlePlacement = createBundlePlacement();
+
+        const amOccId = 'occ-am-1';
+        const amOcc: ExternalPlanSessionOccurrence = {
+            userId: USER_ID,
+            occurrenceId: amOccId,
+            date: DATE,
+            authority: 'external_plan',
+            externalPlanRef: { planId: 'p-v4', revision: 1, sessionId: 'am-run', contentHash: 'hash-bundle-v4' },
+            state: 'completed',
+            placementOrder: 0,
+            createdAt: '2026-09-07T05:00:00.000Z',
+            updatedAt: '2026-09-07T06:00:00.000Z',
+        };
+        const amExec = createMockExecution(amOccId);
+        const amResp = createMockSessionResponse(amOccId);
+
+        vi.spyOn(sessionOccurrenceService, 'getOccurrencesForDate').mockResolvedValue([amOcc]);
+        vi.spyOn(sessionExecutionService, 'getExecutionsInRange').mockResolvedValue({ executions: [amExec], invalidRecords: 0 });
+        vi.spyOn(sessionResponseService, 'getResponseForWindow').mockResolvedValue(amResp);
+
+        const params: AdjudicateIntradayBundleMembersParams = {
+            userId: USER_ID,
+            date: DATE,
+            activePlan: active,
+            bundlePlacement,
+            subjective: mockSubjective,
+            objective: mockObjective,
+            userContext: mockUserContext,
+            availability: mockAvailability,
+            ceilings,
+            evaluationInstant: '2026-09-07T12:00:00.000Z',
+        };
+
+        // Run once
+        const first = await adjudicateIntradayBundleMembers(params);
+        expect(first.statuses[0].status).toBe('proceed');
+
+        // Run second time with identical inputs (simulates retry)
+        const second = await adjudicateIntradayBundleMembers(params);
+        expect(second.statuses[0].status).toBe('proceed');
+        expect(second.bindings[0].sessionSource).toEqual(first.bindings[0].sessionSource);
+    });
+});

--- a/app/src/services/intradayBundleMemberAdjudication.ts
+++ b/app/src/services/intradayBundleMemberAdjudication.ts
@@ -9,6 +9,7 @@
 
 import {
     doc,
+    getDoc,
     runTransaction,
     type Firestore,
 } from 'firebase/firestore';
@@ -313,7 +314,7 @@ export async function adjudicateIntradayBundleMembers(
             // Target already held a reservation from this load or earlier
             const existingDecisionId = aggregate.reservations[targetScheduledOccurrence.occurrenceId].decisionId!;
             const existingDecDoc = doc(db, getIntradayDecisionDocPath(userId, existingDecisionId));
-            const existingDecSnap = await runTransaction(db, async t => t.get(existingDecDoc));
+            const existingDecSnap = await getDoc(existingDecDoc);
             if (existingDecSnap.exists()) {
                 const decData = existingDecSnap.data() as IntradayDecisionRecord;
                 if (decData.postReservationLedgerRevision && String(aggregate.revision) === decData.postReservationLedgerRevision) {
@@ -415,6 +416,16 @@ export async function adjudicateIntradayBundleMembers(
 
                 targetScheduledOccurrence.state = 'skipped';
                 targetScheduledOccurrence.updatedAt = now;
+
+                // The reject transaction removed this occurrence's ledger reservation.
+                // Drop it locally too, so later bundle members are evaluated against the
+                // capacity that was just released.
+                const releasedIndex = currentLedgerInputs.findIndex(
+                    inp => inp.occurrenceId === targetScheduledOccurrence.occurrenceId,
+                );
+                if (releasedIndex >= 0) {
+                    currentLedgerInputs.splice(releasedIndex, 1);
+                }
             }
 
             statuses.push({
@@ -523,6 +534,17 @@ export async function adjudicateIntradayBundleMembers(
                 status: verdict.decision,
                 reason: verdict.reason,
                 occurrenceId: deterministicOccId,
+            });
+            continue;
+        }
+
+        // Enforce 4 additional sessions cap before writing any transaction state
+        if (existingAdditionalBindingsCount + bindings.length >= 4) {
+            notices.push(`Bundle member '${targetSession.id}' omitted: maximum 4 additional sessions cap reached.`);
+            statuses.push({
+                sessionId: targetSession.id,
+                status: 'proceed',
+                reason: 'Maximum 4 additional sessions cap reached',
             });
             continue;
         }
@@ -643,18 +665,6 @@ export async function adjudicateIntradayBundleMembers(
 
             writeProvisionalDecisionInTransaction(transaction, userId, existingDec, decisionRecord);
         });
-
-        // Enforce 4 additional sessions cap
-        if (existingAdditionalBindingsCount + bindings.length >= 4) {
-            notices.push(`Bundle member '${targetSession.id}' omitted: maximum 4 additional sessions cap reached.`);
-            statuses.push({
-                sessionId: targetSession.id,
-                status: 'proceed',
-                reason: 'Maximum 4 additional sessions cap reached',
-                occurrenceId: deterministicOccId,
-            });
-            continue;
-        }
 
         // Prepare launch binding
         const launch = await prepareExternalPlanSessionLaunch(

--- a/app/src/services/intradayBundleMemberAdjudication.ts
+++ b/app/src/services/intradayBundleMemberAdjudication.ts
@@ -9,7 +9,6 @@
 
 import {
     doc,
-    getDoc,
     runTransaction,
     type Firestore,
 } from 'firebase/firestore';
@@ -311,15 +310,27 @@ export async function adjudicateIntradayBundleMembers(
         // Derive pre-reservation ledgerRevision
         let preReservationLedgerRevision = String(aggregate?.revision ?? 0);
         if (targetScheduledOccurrence && aggregate?.reservations[targetScheduledOccurrence.occurrenceId]?.decisionId) {
-            // Target already held a reservation from this load or earlier
+            // Target already held a reservation from this load or earlier:
+            // Read aggregate and decision atomically in one transaction so stale aggregate revision
+            // can never falsely match postReservationLedgerRevision if another reservation advanced the aggregate.
             const existingDecisionId = aggregate.reservations[targetScheduledOccurrence.occurrenceId].decisionId!;
             const existingDecDoc = doc(db, getIntradayDecisionDocPath(userId, existingDecisionId));
-            const existingDecSnap = await getDoc(existingDecDoc);
-            if (existingDecSnap.exists()) {
-                const decData = existingDecSnap.data() as IntradayDecisionRecord;
-                if (decData.postReservationLedgerRevision && String(aggregate.revision) === decData.postReservationLedgerRevision) {
-                    preReservationLedgerRevision = decData.reassessmentInputRevision.ledgerRevision;
-                }
+            const aggRef = aggregateService.ref(userId, date);
+
+            const { freshAgg, decData } = await runTransaction(db, async transaction => {
+                const aggSnap = await transaction.get(aggRef);
+                const decSnap = await transaction.get(existingDecDoc);
+                return {
+                    freshAgg: aggSnap.exists() ? (aggSnap.data() as DailyLedgerAggregate) : null,
+                    decData: decSnap.exists() ? (decSnap.data() as IntradayDecisionRecord) : null,
+                };
+            });
+
+            if (freshAgg) {
+                aggregate = freshAgg;
+            }
+            if (decData && decData.postReservationLedgerRevision && String(aggregate?.revision) === decData.postReservationLedgerRevision) {
+                preReservationLedgerRevision = decData.reassessmentInputRevision.ledgerRevision;
             }
         }
 

--- a/app/src/services/intradayBundleMemberAdjudication.ts
+++ b/app/src/services/intradayBundleMemberAdjudication.ts
@@ -1,0 +1,697 @@
+/**
+ * ADR-0036 (H4) D-REASSESS / D-AUDIT: Intraday bundle member adjudication loop and transaction wiring.
+ * (docs/plans/h4-434-pr3-bundle-second-member-launch.md, Phase 3 steps 8, 8/2a, 9).
+ *
+ * Surfaces non-primary members of a placed v4 intraday bundle as launchable `additionalSessions`
+ * entries on Home.tsx, evaluates D-REASSESS per member, manages atomic multi-document
+ * occurrence/ledger/decision transactions, and handles rejection/recovery cycles.
+ */
+
+import {
+    doc,
+    runTransaction,
+    type Firestore,
+} from 'firebase/firestore';
+import { getDb } from '../firebase';
+import type {
+    DailyReadiness,
+    SubjectiveInput,
+    EngineObjectiveInput,
+    UserContext,
+    PlannedDose,
+    RegionTissueResponse,
+} from '../engine/models';
+import type {
+    SessionReferenceBinding,
+    OccurrenceWindowBinding,
+    ExternalPlanOccurrenceRef,
+    ExternalPlanSessionOccurrence,
+} from '../sessions/models';
+import { isExternalPlanOccurrence } from '../sessions/models';
+import { parseSessionOccurrenceDocument } from '../persistence/parsers/sessionDefinition';
+import type { BundlePlacementProposal } from '../engine/intradayBundlePlacement';
+import type { LedgerCeilings } from '../engine/dailyLedger';
+import { computeDailyLedger } from '../engine/dailyLedger';
+import { buildLedgerEntries, type OccurrenceLedgerInput } from '../engine/intradayLedgerInputs';
+import {
+    reassessDependentBundleMember,
+    computeReassessmentInputRevision,
+    type DependentBundleMemberTarget,
+    type PredecessorEvidence,
+    type ReassessmentInputRevision,
+} from '../engine/intradayReassessment';
+import {
+    type IntradayDecisionRecord,
+    validateIntradayDecisionRecord,
+} from '../engine/intradayDecision';
+import {
+    deterministicIntradayDecisionId,
+    writeProvisionalDecisionInTransaction,
+    getIntradayDecisionDocPath,
+} from './intradayDecisionService';
+import {
+    SessionOccurrenceService,
+    sessionOccurrenceService,
+    deterministicExternalPlanOccurrenceId,
+} from './sessionOccurrenceService';
+import {
+    DailyLedgerAggregateService,
+    dailyLedgerAggregateService,
+    type DailyLedgerAggregate,
+} from './dailyLedgerAggregateService';
+import {
+    prepareExternalPlanSessionLaunch,
+} from './sessionAuthoringService';
+import {
+    SessionResponseService,
+    sessionResponseService,
+} from './sessionResponseService';
+import {
+    SessionExecutionService,
+    sessionExecutionService,
+} from './sessionExecutionService';
+import type { ActiveExternalPlan } from './activeExternalPlanService';
+import { isV4Plan, type ExternalPlanSessionV4 } from '../sessions/externalPlanV4';
+import { estimateAuthoredSessionSystemicCost } from '../engine/authoredSessionGates';
+import { POLICY_VERSION } from '../engine/policy';
+
+export interface IntradayBundleMemberStatus {
+    sessionId: string;
+    status: 'proceed' | 'scale' | 'reject' | 'pending';
+    reason: string;
+    occurrenceId?: string;
+    binding?: SessionReferenceBinding;
+}
+
+export interface IntradayBundleMemberAdjudicationResult {
+    bindings: SessionReferenceBinding[];
+    statuses: IntradayBundleMemberStatus[];
+    notices: string[];
+}
+
+export interface AdjudicateIntradayBundleMembersParams {
+    userId: string;
+    date: string;
+    activePlan: ActiveExternalPlan;
+    bundlePlacement: BundlePlacementProposal;
+    subjective: SubjectiveInput;
+    objective: EngineObjectiveInput;
+    subjectiveBaseline?: DailyReadiness['subjectiveBaseline'];
+    userContext: UserContext;
+    availability: import('../engine/schedule').ResolvedAvailability;
+    ceilings: LedgerCeilings;
+    inputRevision?: Partial<Omit<ReassessmentInputRevision, 'ledgerRevision' | 'postPredecessorConfirmationRevision'>>;
+    plannedDose?: PlannedDose;
+    tissueResponses?: RegionTissueResponse[];
+    existingAdditionalBindingsCount?: number;
+    now?: string;
+    evaluationInstant?: string;
+    db?: Firestore;
+    services?: {
+        occurrenceService?: SessionOccurrenceService;
+        aggregateService?: DailyLedgerAggregateService;
+        responseService?: SessionResponseService;
+        executionService?: SessionExecutionService;
+    };
+}
+
+function windowDurationMinutes(boundStartLocal: string, boundEndLocal: string, fallback = 60): number {
+    const [sH, sM] = boundStartLocal.split(':').map(Number);
+    const [eH, eM] = boundEndLocal.split(':').map(Number);
+    if (!Number.isFinite(sH) || !Number.isFinite(sM) || !Number.isFinite(eH) || !Number.isFinite(eM)) {
+        return fallback;
+    }
+    const diff = (eH * 60 + eM) - (sH * 60 + sM);
+    return diff > 0 ? diff : fallback;
+}
+
+/**
+ * Adjudicates non-primary intraday bundle members for today, managing occurrence lifecycle,
+ * shared ledger reservations, provisional audit records, and launch bindings.
+ */
+export async function adjudicateIntradayBundleMembers(
+    params: AdjudicateIntradayBundleMembersParams,
+): Promise<IntradayBundleMemberAdjudicationResult> {
+    const {
+        userId,
+        date,
+        activePlan,
+        bundlePlacement,
+        subjective,
+        objective,
+        subjectiveBaseline,
+        userContext,
+        availability,
+        ceilings,
+        inputRevision: baseInputRevision,
+        plannedDose,
+        tissueResponses = [],
+        existingAdditionalBindingsCount = 0,
+        now = new Date().toISOString(),
+        evaluationInstant = now,
+        db = getDb(),
+    } = params;
+
+    if (!isV4Plan(activePlan.plan) || bundlePlacement.outcome !== 'placed' || !bundlePlacement.bindings) {
+        return { bindings: [], statuses: [], notices: [] };
+    }
+
+    const v4Plan = activePlan.plan;
+    const contentHash = activePlan.header.contentHash;
+
+    const occurrenceService = params.services?.occurrenceService ?? (params.db ? new SessionOccurrenceService(params.db) : sessionOccurrenceService);
+    const aggregateService = params.services?.aggregateService ?? (params.db ? new DailyLedgerAggregateService(params.db) : dailyLedgerAggregateService);
+    const responseService = params.services?.responseService ?? (params.db ? new SessionResponseService(params.db) : sessionResponseService);
+    const executionService = params.services?.executionService ?? (params.db ? new SessionExecutionService(params.db) : sessionExecutionService);
+
+    const readiness: DailyReadiness = { subjective, objective, subjectiveBaseline };
+
+    // 1. Gather existing day state (occurrences, executions, aggregate)
+    const allOccurrences = await occurrenceService.getOccurrencesForDate(userId, date);
+    const { executions } = await executionService.getExecutionsInRange(userId, date, date);
+    let aggregate = await aggregateService.get(userId, date);
+
+    // Build initial ledger inputs from today's occurrences & executions
+    const currentLedgerInputs: OccurrenceLedgerInput[] = allOccurrences.map(occ => {
+        let estimatedMinutes = 45;
+        let estimatedSystemicCost = 0.3;
+        if (isExternalPlanOccurrence(occ)) {
+            const sess = v4Plan.sessions.find(s => s.id === occ.externalPlanRef.sessionId);
+            if (sess) {
+                estimatedMinutes = sess.definition.duration?.min ?? 45;
+                estimatedSystemicCost = estimateAuthoredSessionSystemicCost(sess.definition);
+            }
+        }
+        const linkedExec = executions.find(e => e.execution.occurrenceId === occ.occurrenceId);
+        return {
+            occurrenceId: occ.occurrenceId,
+            occurrenceState: occ.state,
+            estimatedMinutes,
+            estimatedSystemicCost,
+            revision: Date.parse(occ.updatedAt ?? occ.createdAt) || 0,
+            ...(linkedExec ? {
+                execution: {
+                    state: linkedExec.execution.state,
+                    startedAt: linkedExec.execution.startedAt,
+                    completedAt: linkedExec.execution.completedAt,
+                },
+            } : {}),
+        };
+    });
+
+    const bindings: SessionReferenceBinding[] = [];
+    const statuses: IntradayBundleMemberStatus[] = [];
+    const notices: string[] = [];
+
+    // The non-primary members are all bindings after bindings[0] (primary)
+    const nonPrimaryBindings = bundlePlacement.bindings.slice(1);
+
+    for (const binding of nonPrimaryBindings) {
+        const targetSession = v4Plan.sessions.find(s => s.id === binding.sessionId);
+        if (!targetSession) {
+            notices.push(`Session '${binding.sessionId}' not found in active plan.`);
+            continue;
+        }
+
+        // Guard rails
+        if (targetSession.isEvent) {
+            statuses.push({
+                sessionId: targetSession.id,
+                status: 'reject',
+                reason: 'Target event cannot be an executable intraday bundle session.',
+            });
+            continue;
+        }
+        if (targetSession.definition.id === 'rest_01') {
+            statuses.push({
+                sessionId: targetSession.id,
+                status: 'reject',
+                reason: 'Rest sessions cannot be bound as intraday bundle members.',
+            });
+            continue;
+        }
+        if (!targetSession.intraday) {
+            statuses.push({
+                sessionId: targetSession.id,
+                status: 'reject',
+                reason: 'Session lacks intraday specification.',
+            });
+            continue;
+        }
+        const intraday = targetSession.intraday;
+
+        const externalPlanRef: ExternalPlanOccurrenceRef = {
+            planId: v4Plan.planId,
+            revision: v4Plan.revision,
+            sessionId: targetSession.id,
+            contentHash,
+        };
+
+        const targetExistingOccurrences = allOccurrences.filter(
+            (occ): occ is ExternalPlanSessionOccurrence =>
+                isExternalPlanOccurrence(occ)
+                && occ.externalPlanRef.planId === v4Plan.planId
+                && occ.externalPlanRef.sessionId === targetSession.id,
+        );
+        const targetScheduledOccurrence = targetExistingOccurrences.find(occ => occ.state === 'scheduled');
+        const targetSkippedOccurrence = targetExistingOccurrences.find(occ => occ.state === 'skipped');
+        const targetActiveOrCompleted = targetExistingOccurrences.find(occ => occ.state === 'active' || occ.state === 'completed');
+
+        // Resolve predecessor evidence if required
+        let predecessor: PredecessorEvidence | undefined;
+        let predecessorExecutionId: string | null = null;
+        let predecessorOccurrenceId: string | null = null;
+
+        if (targetSession.intraday.afterSessionId) {
+            const predSessionId = targetSession.intraday.afterSessionId;
+            const predOccurrence = allOccurrences.find(
+                (occ): occ is ExternalPlanSessionOccurrence =>
+                    isExternalPlanOccurrence(occ)
+                    && occ.externalPlanRef.planId === v4Plan.planId
+                    && occ.externalPlanRef.sessionId === predSessionId
+                    && occ.state !== 'superseded',
+            );
+
+            if (predOccurrence) {
+                predecessorOccurrenceId = predOccurrence.occurrenceId;
+                const predExec = executions.find(e => e.execution.occurrenceId === predOccurrence.occurrenceId);
+                let immediateResponse = null;
+                if (predExec) {
+                    predecessorExecutionId = predExec.execution.executionId;
+                    immediateResponse = await responseService.getResponseForWindow(
+                        userId,
+                        { kind: 'execution', id: predExec.execution.executionId },
+                        'immediate',
+                    );
+                }
+                predecessor = {
+                    sessionId: predSessionId,
+                    occurrenceId: predOccurrence.occurrenceId,
+                    state: predOccurrence.state,
+                    completedAt: predExec?.execution.completedAt ?? null,
+                    response: immediateResponse,
+                    tissueResponses,
+                };
+            }
+        }
+
+        // 8.1 Exclude target's own reservation from its candidate ledger
+        const targetIdsToExclude = new Set(targetExistingOccurrences.map(o => o.occurrenceId));
+        const inputsExcludingTarget = currentLedgerInputs.filter(inp => !targetIdsToExclude.has(inp.occurrenceId));
+        const entriesExcludingTarget = buildLedgerEntries(inputsExcludingTarget);
+        const targetLedger = computeDailyLedger(ceilings, entriesExcludingTarget);
+
+        const candidateWindowMinutes = windowDurationMinutes(
+            binding.boundStartLocal,
+            binding.boundEndLocal,
+            targetSession.definition.duration?.min ?? 60,
+        );
+
+        // Derive pre-reservation ledgerRevision
+        let preReservationLedgerRevision = String(aggregate?.revision ?? 0);
+        if (targetScheduledOccurrence && aggregate?.reservations[targetScheduledOccurrence.occurrenceId]?.decisionId) {
+            // Target already held a reservation from this load or earlier
+            const existingDecisionId = aggregate.reservations[targetScheduledOccurrence.occurrenceId].decisionId!;
+            const existingDecDoc = doc(db, getIntradayDecisionDocPath(userId, existingDecisionId));
+            const existingDecSnap = await runTransaction(db, async t => t.get(existingDecDoc));
+            if (existingDecSnap.exists()) {
+                const decData = existingDecSnap.data() as IntradayDecisionRecord;
+                if (decData.postReservationLedgerRevision && String(aggregate.revision) === decData.postReservationLedgerRevision) {
+                    preReservationLedgerRevision = decData.reassessmentInputRevision.ledgerRevision;
+                }
+            }
+        }
+
+        const computedRevision = computeReassessmentInputRevision({
+            availabilityRevision: baseInputRevision?.availabilityRevision ?? `${date}:${availability.maxTimeMinutes}`,
+            completedFactsRevision: baseInputRevision?.completedFactsRevision ?? 'facts-0',
+            checkinRevision: baseInputRevision?.checkinRevision ?? 'checkin-0',
+            placementRevision: baseInputRevision?.placementRevision ?? `${v4Plan.planId}:${v4Plan.revision}`,
+            ledgerRevision: preReservationLedgerRevision,
+            ...(predecessor?.response ? {
+                postPredecessorConfirmationRevision: predecessor.response.updatedAt ?? predecessor.response.createdAt,
+            } : {}),
+        });
+
+        const targetTarget: DependentBundleMemberTarget = {
+            sessionId: targetSession.id,
+            definition: targetSession.definition,
+            requestedWindow: {
+                startLocal: binding.boundStartLocal,
+                endLocal: binding.boundEndLocal,
+            },
+            afterSessionId: intraday.afterSessionId,
+            minimumSeparationMinutes: intraday.minimumSeparationMinutes,
+        };
+
+        // Adjudicate verdict pure
+        const verdict = reassessDependentBundleMember({
+            target: targetTarget,
+            predecessor,
+            evaluationInstant,
+            readiness,
+            context: userContext,
+            date,
+            availability,
+            candidateWindowMinutes,
+            dailyLedger: targetLedger,
+            acceptedSameDaySystemicCost: 0,
+            inputRevision: computedRevision,
+            plannedDose,
+        });
+
+        const windowBinding: OccurrenceWindowBinding = {
+            windowId: binding.windowId,
+            bundleId: targetSession.intraday.bundleId,
+            order: targetSession.intraday.order,
+            boundStartLocal: binding.boundStartLocal,
+            boundEndLocal: binding.boundEndLocal,
+            startInstant: binding.startInstant,
+            endInstant: binding.endInstant,
+        };
+
+        const candidateMinutes = targetSession.definition.duration?.min ?? 45;
+        const candidateSystemicCost = estimateAuthoredSessionSystemicCost(targetSession.definition);
+
+        if (verdict.decision === 'reject') {
+            // 8.2 Reject: If a scheduled occurrence already exists, transition to skipped and drop reservation
+            if (targetScheduledOccurrence) {
+                const targetOccRef = occurrenceService.occurrenceRef(userId, targetScheduledOccurrence.occurrenceId);
+                const aggDocRef = aggregateService.ref(userId, date);
+                const winResRef = targetScheduledOccurrence.windowBinding
+                    ? occurrenceService.windowReservationRef(userId, date, targetScheduledOccurrence.windowBinding.windowId)
+                    : null;
+
+                await runTransaction(db, async transaction => {
+                    const occSnap = await transaction.get(targetOccRef);
+                    const aggSnap = await transaction.get(aggDocRef);
+                    const winSnap = winResRef ? await transaction.get(winResRef) : null;
+
+                    if (occSnap.exists()) {
+                        const parsed = parseSessionOccurrenceDocument(occSnap.data(), occSnap.ref.path);
+                        if (parsed.status === 'AVAILABLE' && parsed.data.state === 'scheduled') {
+                            transaction.set(targetOccRef, { ...parsed.data, state: 'skipped', updatedAt: now });
+                        }
+                    }
+
+                    if (winSnap?.exists() && winSnap.data()?.occurrenceId === targetScheduledOccurrence.occurrenceId) {
+                        transaction.delete(winResRef!);
+                    }
+
+                    if (aggSnap.exists()) {
+                        const currentAgg = aggSnap.data() as DailyLedgerAggregate;
+                        const { aggregate: nextAgg } = aggregateService.rejectReservationAndIncrementGeneration(
+                            transaction,
+                            userId,
+                            date,
+                            currentAgg,
+                            targetScheduledOccurrence.occurrenceId,
+                            targetSession.id,
+                            now,
+                        );
+                        aggregate = nextAgg;
+                    }
+                });
+
+                targetScheduledOccurrence.state = 'skipped';
+                targetScheduledOccurrence.updatedAt = now;
+            }
+
+            statuses.push({
+                sessionId: targetSession.id,
+                status: 'reject',
+                reason: verdict.reason,
+                occurrenceId: targetScheduledOccurrence?.occurrenceId ?? targetActiveOrCompleted?.occurrenceId,
+            });
+            continue;
+        }
+
+        // Recovery check: read current generation from aggregate for this session (defaults to 0 if absent)
+        const generation = aggregate ? aggregateService.currentGeneration(aggregate, targetSession.id) : 0;
+
+        const deterministicOccId = await deterministicExternalPlanOccurrenceId(date, externalPlanRef, generation);
+        const occRef = occurrenceService.occurrenceRef(userId, deterministicOccId);
+        const winRef = occurrenceService.windowReservationRef(userId, date, binding.windowId);
+        const aggRef = aggregateService.ref(userId, date);
+
+        if (verdict.decision === 'pending' || verdict.decision === 'scale') {
+            // 8.3 / 8.4: Create occurrence and reserve capacity; emit no binding
+            await runTransaction(db, async transaction => {
+                const occSnap = await transaction.get(occRef);
+                const winSnap = await transaction.get(winRef);
+                const aggSnap = await transaction.get(aggRef);
+
+                let currentAgg = aggSnap.exists()
+                    ? (aggSnap.data() as DailyLedgerAggregate)
+                    : null;
+
+                if (!currentAgg) {
+                    currentAgg = aggregateService.seedIfAbsent(
+                        transaction,
+                        userId,
+                        date,
+                        null,
+                        ceilings,
+                        currentLedgerInputs,
+                        now,
+                    );
+                }
+
+                if (!occSnap.exists()) {
+                    const newOcc: ExternalPlanSessionOccurrence = {
+                        userId,
+                        occurrenceId: deterministicOccId,
+                        date,
+                        authority: 'external_plan',
+                        externalPlanRef,
+                        state: 'scheduled',
+                        placementOrder: intraday.order,
+                        windowBinding,
+                        createdAt: now,
+                        updatedAt: now,
+                    };
+                    transaction.set(occRef, newOcc);
+
+                    if (winSnap.exists()) {
+                        const owner = winSnap.data()?.occurrenceId as string | undefined;
+                        const isOwnedBySkipped = generation > 0 && targetSkippedOccurrence && owner === targetSkippedOccurrence.occurrenceId;
+                        if (owner !== deterministicOccId && !isOwnedBySkipped) {
+                            throw new Error(`Window '${binding.windowId}' is already bound to '${owner}'.`);
+                        }
+                    }
+                    transaction.set(winRef, {
+                        userId,
+                        date,
+                        windowId: binding.windowId,
+                        occurrenceId: deterministicOccId,
+                        createdAt: now,
+                    });
+                }
+
+                // Check if already reserved in aggregate
+                const existingRes = currentAgg.reservations?.[deterministicOccId];
+                if (!existingRes || existingRes.state !== 'reserved') {
+                    const nextAgg = aggregateService.applyReservation(
+                        transaction,
+                        userId,
+                        date,
+                        currentAgg,
+                        deterministicOccId,
+                        {
+                            minutes: candidateMinutes,
+                            systemicCost: candidateSystemicCost,
+                            state: 'reserved',
+                            postReservationLedgerRevision: String(currentAgg.revision + 1),
+                        },
+                        now,
+                    );
+                    aggregate = nextAgg;
+                }
+            });
+
+            // Update local ledger inputs for subsequent members
+            currentLedgerInputs.push({
+                occurrenceId: deterministicOccId,
+                occurrenceState: 'scheduled',
+                estimatedMinutes: candidateMinutes,
+                estimatedSystemicCost: candidateSystemicCost,
+                revision: Date.parse(now),
+            });
+
+            statuses.push({
+                sessionId: targetSession.id,
+                status: verdict.decision,
+                reason: verdict.reason,
+                occurrenceId: deterministicOccId,
+            });
+            continue;
+        }
+
+        // 8.5 / Step 9: Proceed verdict -> create occurrence + aggregate reservation + provisional decision in ONE transaction
+        const decisionId = await deterministicIntradayDecisionId(deterministicOccId, computedRevision);
+        const decRef = doc(db, getIntradayDecisionDocPath(userId, decisionId));
+
+        let updatedAggregateRevision: number | null = null;
+
+        await runTransaction(db, async transaction => {
+            const occSnap = await transaction.get(occRef);
+            const winSnap = await transaction.get(winRef);
+            const aggSnap = await transaction.get(aggRef);
+            const decSnap = await transaction.get(decRef);
+
+            let currentAgg = aggSnap.exists()
+                ? (aggSnap.data() as DailyLedgerAggregate)
+                : null;
+
+            if (!currentAgg) {
+                currentAgg = aggregateService.seedIfAbsent(
+                    transaction,
+                    userId,
+                    date,
+                    null,
+                    ceilings,
+                    currentLedgerInputs,
+                    now,
+                );
+            }
+
+            if (!occSnap.exists()) {
+                const newOcc: ExternalPlanSessionOccurrence = {
+                    userId,
+                    occurrenceId: deterministicOccId,
+                    date,
+                    authority: 'external_plan',
+                    externalPlanRef,
+                    state: 'scheduled',
+                    placementOrder: intraday.order,
+                    windowBinding,
+                    createdAt: now,
+                    updatedAt: now,
+                };
+                transaction.set(occRef, newOcc);
+
+                if (winSnap.exists()) {
+                    const owner = winSnap.data()?.occurrenceId as string | undefined;
+                    const isOwnedBySkipped = generation > 0 && targetSkippedOccurrence && owner === targetSkippedOccurrence.occurrenceId;
+                    if (owner !== deterministicOccId && !isOwnedBySkipped) {
+                        throw new Error(`Window '${binding.windowId}' is already bound to '${owner}'.`);
+                    }
+                }
+                transaction.set(winRef, {
+                    userId,
+                    date,
+                    windowId: binding.windowId,
+                    occurrenceId: deterministicOccId,
+                    createdAt: now,
+                });
+            }
+
+            const existingRes = currentAgg.reservations?.[deterministicOccId];
+            if (!existingRes || existingRes.state !== 'reserved' || existingRes.decisionId !== decisionId) {
+                const nextAgg = aggregateService.applyReservation(
+                    transaction,
+                    userId,
+                    date,
+                    currentAgg,
+                    deterministicOccId,
+                    {
+                        minutes: candidateMinutes,
+                        systemicCost: candidateSystemicCost,
+                        state: 'reserved',
+                        decisionId,
+                        postReservationLedgerRevision: String(currentAgg.revision + 1),
+                    },
+                    now,
+                );
+                currentAgg = nextAgg;
+                aggregate = nextAgg;
+            }
+            updatedAggregateRevision = currentAgg.revision;
+
+            const existingDec = decSnap.exists()
+                ? validateIntradayDecisionRecord(decSnap.data())
+                : null;
+
+            const decisionRecord: IntradayDecisionRecord = {
+                id: decisionId,
+                userId,
+                date,
+                asOf: now,
+                policyVersion: POLICY_VERSION,
+                schemaVersion: 1,
+                status: 'provisional',
+                supersededDecisionId: null,
+                occurrenceId: deterministicOccId,
+                sessionId: targetSession.id,
+                windowId: binding.windowId,
+                bundleId: intraday.bundleId,
+                orderInBundle: intraday.order,
+                predecessorExecutionId,
+                predecessorOccurrenceId,
+                reassessmentInputRevision: computedRevision,
+                bundlePlacement,
+                ledgerSnapshot: {
+                    ceilings,
+                    entries: entriesExcludingTarget,
+                },
+                verdict: {
+                    decision: 'proceed',
+                    reasons: [verdict.reason],
+                },
+                postReservationLedgerRevision: String(updatedAggregateRevision),
+            };
+
+            writeProvisionalDecisionInTransaction(transaction, userId, existingDec, decisionRecord);
+        });
+
+        // Enforce 4 additional sessions cap
+        if (existingAdditionalBindingsCount + bindings.length >= 4) {
+            notices.push(`Bundle member '${targetSession.id}' omitted: maximum 4 additional sessions cap reached.`);
+            statuses.push({
+                sessionId: targetSession.id,
+                status: 'proceed',
+                reason: 'Maximum 4 additional sessions cap reached',
+                occurrenceId: deterministicOccId,
+            });
+            continue;
+        }
+
+        // Prepare launch binding
+        const launch = await prepareExternalPlanSessionLaunch(
+            userId,
+            {
+                planId: v4Plan.planId,
+                revision: v4Plan.revision,
+                contentHash,
+                session: targetSession as ExternalPlanSessionV4,
+            },
+            {
+                date,
+                occurrenceId: deterministicOccId,
+                placementOrder: intraday.order,
+                windowBinding,
+                now,
+            },
+        );
+
+        bindings.push(launch.binding);
+        statuses.push({
+            sessionId: targetSession.id,
+            status: 'proceed',
+            reason: verdict.reason,
+            occurrenceId: deterministicOccId,
+            binding: launch.binding,
+        });
+
+        // Add this member's reservation to local ledger inputs for subsequent bundle members
+        currentLedgerInputs.push({
+            occurrenceId: deterministicOccId,
+            occurrenceState: 'scheduled',
+            estimatedMinutes: candidateMinutes,
+            estimatedSystemicCost: candidateSystemicCost,
+            revision: Date.parse(now),
+        });
+    }
+
+    return { bindings, statuses, notices };
+}

--- a/app/src/services/intradayBundleMemberAdjudication.ts
+++ b/app/src/services/intradayBundleMemberAdjudication.ts
@@ -295,8 +295,62 @@ export async function adjudicateIntradayBundleMembers(
             }
         }
 
-        // 8.1 Exclude target's own reservation from its candidate ledger
-        const targetIdsToExclude = new Set(targetExistingOccurrences.map(o => o.occurrenceId));
+        // 8.1 Refresh aggregate and existing decision atomically before computing candidate capacity
+        let decData: IntradayDecisionRecord | null = null;
+        const aggRef = aggregateService.ref(userId, date);
+        if (targetScheduledOccurrence && aggregate?.reservations[targetScheduledOccurrence.occurrenceId]?.decisionId) {
+            // Target already held a reservation from this load or earlier:
+            // Read aggregate and decision atomically in one transaction so stale aggregate revision
+            // can never falsely match postReservationLedgerRevision if another reservation advanced the aggregate.
+            const existingDecisionId = aggregate.reservations[targetScheduledOccurrence.occurrenceId].decisionId!;
+            const existingDecDoc = doc(db, getIntradayDecisionDocPath(userId, existingDecisionId));
+
+            const res = await runTransaction(db, async transaction => {
+                const aggSnap = await transaction.get(aggRef);
+                const decSnap = await transaction.get(existingDecDoc);
+                return {
+                    freshAgg: aggSnap.exists() ? (aggSnap.data() as DailyLedgerAggregate) : null,
+                    decData: decSnap.exists() ? (decSnap.data() as IntradayDecisionRecord) : null,
+                };
+            });
+
+            if (res.freshAgg) {
+                aggregate = res.freshAgg;
+            }
+            decData = res.decData;
+        } else {
+            const freshAgg = await aggregateService.get(userId, date);
+            if (freshAgg) {
+                aggregate = freshAgg;
+            }
+        }
+
+        // Reconcile currentLedgerInputs against the refreshed aggregate reservations
+        // so capacity evaluation includes any reservations committed concurrently
+        if (aggregate?.reservations) {
+            for (const [resOccId, res] of Object.entries(aggregate.reservations)) {
+                const existingIdx = currentLedgerInputs.findIndex(inp => inp.occurrenceId === resOccId);
+                if (res.state === 'reserved' || res.state === 'in_progress') {
+                    if (existingIdx < 0) {
+                        currentLedgerInputs.push({
+                            occurrenceId: resOccId,
+                            occurrenceState: res.state === 'in_progress' ? 'active' : 'scheduled',
+                            estimatedMinutes: res.minutes,
+                            estimatedSystemicCost: res.systemicCost,
+                            revision: Date.now(),
+                        });
+                    }
+                }
+            }
+        }
+
+        // Exclude target's own reservation and occurrence from its candidate ledger
+        const generation = aggregate ? aggregateService.currentGeneration(aggregate, targetSession.id) : 0;
+        const deterministicOccId = await deterministicExternalPlanOccurrenceId(date, externalPlanRef, generation);
+        const targetIdsToExclude = new Set([
+            ...targetExistingOccurrences.map(o => o.occurrenceId),
+            deterministicOccId,
+        ]);
         const inputsExcludingTarget = currentLedgerInputs.filter(inp => !targetIdsToExclude.has(inp.occurrenceId));
         const entriesExcludingTarget = buildLedgerEntries(inputsExcludingTarget);
         const targetLedger = computeDailyLedger(ceilings, entriesExcludingTarget);
@@ -309,29 +363,8 @@ export async function adjudicateIntradayBundleMembers(
 
         // Derive pre-reservation ledgerRevision
         let preReservationLedgerRevision = String(aggregate?.revision ?? 0);
-        if (targetScheduledOccurrence && aggregate?.reservations[targetScheduledOccurrence.occurrenceId]?.decisionId) {
-            // Target already held a reservation from this load or earlier:
-            // Read aggregate and decision atomically in one transaction so stale aggregate revision
-            // can never falsely match postReservationLedgerRevision if another reservation advanced the aggregate.
-            const existingDecisionId = aggregate.reservations[targetScheduledOccurrence.occurrenceId].decisionId!;
-            const existingDecDoc = doc(db, getIntradayDecisionDocPath(userId, existingDecisionId));
-            const aggRef = aggregateService.ref(userId, date);
-
-            const { freshAgg, decData } = await runTransaction(db, async transaction => {
-                const aggSnap = await transaction.get(aggRef);
-                const decSnap = await transaction.get(existingDecDoc);
-                return {
-                    freshAgg: aggSnap.exists() ? (aggSnap.data() as DailyLedgerAggregate) : null,
-                    decData: decSnap.exists() ? (decSnap.data() as IntradayDecisionRecord) : null,
-                };
-            });
-
-            if (freshAgg) {
-                aggregate = freshAgg;
-            }
-            if (decData && decData.postReservationLedgerRevision && String(aggregate?.revision) === decData.postReservationLedgerRevision) {
-                preReservationLedgerRevision = decData.reassessmentInputRevision.ledgerRevision;
-            }
+        if (decData && decData.postReservationLedgerRevision && String(aggregate?.revision) === decData.postReservationLedgerRevision) {
+            preReservationLedgerRevision = decData.reassessmentInputRevision.ledgerRevision;
         }
 
         const computedRevision = computeReassessmentInputRevision({
@@ -448,13 +481,8 @@ export async function adjudicateIntradayBundleMembers(
             continue;
         }
 
-        // Recovery check: read current generation from aggregate for this session (defaults to 0 if absent)
-        const generation = aggregate ? aggregateService.currentGeneration(aggregate, targetSession.id) : 0;
-
-        const deterministicOccId = await deterministicExternalPlanOccurrenceId(date, externalPlanRef, generation);
         const occRef = occurrenceService.occurrenceRef(userId, deterministicOccId);
         const winRef = occurrenceService.windowReservationRef(userId, date, binding.windowId);
-        const aggRef = aggregateService.ref(userId, date);
 
         if (verdict.decision === 'pending' || verdict.decision === 'scale') {
             // 8.3 / 8.4: Create occurrence and reserve capacity; emit no binding

--- a/app/src/services/sessionOccurrenceService.ts
+++ b/app/src/services/sessionOccurrenceService.ts
@@ -133,11 +133,11 @@ export class SessionOccurrenceService {
         this.db = db;
     }
 
-    private occurrenceRef(userId: string, occurrenceId: string) {
+    occurrenceRef(userId: string, occurrenceId: string) {
         return doc(this.db, 'users', userId, 'session_occurrences', occurrenceId);
     }
 
-    private windowReservationRef(userId: string, date: string, windowId: string) {
+    windowReservationRef(userId: string, date: string, windowId: string) {
         return doc(this.db, 'users', userId, 'session_occurrence_windows', windowReservationId(date, windowId));
     }
 
@@ -287,11 +287,13 @@ export class SessionOccurrenceService {
         options: {
             placementOrder?: number;
             windowBinding?: OccurrenceWindowBinding;
+            generation?: number;
             now?: string;
         } = {},
     ): Promise<SessionOccurrence> {
         const now = options.now ?? new Date().toISOString();
-        const deterministicId = await deterministicExternalPlanOccurrenceId(date, externalPlanRef);
+        const generation = options.generation ?? 0;
+        const deterministicId = await deterministicExternalPlanOccurrenceId(date, externalPlanRef, generation);
         const ref = this.occurrenceRef(userId, deterministicId);
         const windowReservationRef = options.windowBinding
             ? this.windowReservationRef(userId, date, options.windowBinding.windowId)
@@ -326,7 +328,14 @@ export class SessionOccurrenceService {
 
             if (reservationSnap?.exists()) {
                 const owner = reservationSnap.data()?.occurrenceId as string | undefined;
-                if (owner !== priorRevision?.occurrenceId) {
+                const isOwnedByPrior = owner === priorRevision?.occurrenceId
+                    || (generation > 0 && sameDayOccurrences.some(
+                        occ => isExternalPlanOccurrence(occ)
+                            && occ.externalPlanRef.planId === externalPlanRef.planId
+                            && occ.externalPlanRef.sessionId === externalPlanRef.sessionId
+                            && occ.occurrenceId === owner,
+                    ));
+                if (!isOwnedByPrior) {
                     throw new Error(
                         `Window '${options.windowBinding!.windowId}' on ${date} is already bound to occurrence '${owner}'.`,
                     );

--- a/app/src/services/sessionOccurrenceService.ts
+++ b/app/src/services/sessionOccurrenceService.ts
@@ -333,7 +333,9 @@ export class SessionOccurrenceService {
                         occ => isExternalPlanOccurrence(occ)
                             && occ.externalPlanRef.planId === externalPlanRef.planId
                             && occ.externalPlanRef.sessionId === externalPlanRef.sessionId
-                            && occ.occurrenceId === owner,
+                            && occ.occurrenceId === owner
+                            && occ.state !== 'active'
+                            && occ.state !== 'completed',
                     ));
                 if (!isOwnedByPrior) {
                     throw new Error(

--- a/app/src/services/sessionOccurrenceService.ts
+++ b/app/src/services/sessionOccurrenceService.ts
@@ -328,19 +328,40 @@ export class SessionOccurrenceService {
 
             if (reservationSnap?.exists()) {
                 const owner = reservationSnap.data()?.occurrenceId as string | undefined;
-                const isOwnedByPrior = owner === priorRevision?.occurrenceId
-                    || (generation > 0 && sameDayOccurrences.some(
-                        occ => isExternalPlanOccurrence(occ)
-                            && occ.externalPlanRef.planId === externalPlanRef.planId
-                            && occ.externalPlanRef.sessionId === externalPlanRef.sessionId
-                            && occ.occurrenceId === owner
-                            && occ.state !== 'active'
-                            && occ.state !== 'completed',
-                    ));
-                if (!isOwnedByPrior) {
-                    throw new Error(
-                        `Window '${options.windowBinding!.windowId}' on ${date} is already bound to occurrence '${owner}'.`,
+                if (owner && owner !== deterministicId) {
+                    const ownerRef = (priorRef && owner === priorRevision?.occurrenceId)
+                        ? priorRef
+                        : this.occurrenceRef(userId, owner);
+                    const ownerSnap = (ownerRef === priorRef && priorSnap)
+                        ? priorSnap
+                        : await transaction.get(ownerRef);
+
+                    if (!ownerSnap || !ownerSnap.exists()) {
+                        throw new Error(
+                            `Window '${options.windowBinding!.windowId}' on ${date} is already bound to occurrence '${owner}'.`,
+                        );
+                    }
+
+                    const parsedOwner = parseSessionOccurrenceDocument(ownerSnap.data(), ownerRef.path);
+                    if (parsedOwner.status !== 'AVAILABLE' || !isExternalPlanOccurrence(parsedOwner.data)) {
+                        throw new Error(
+                            `Window '${options.windowBinding!.windowId}' on ${date} is already bound to occurrence '${owner}'.`,
+                        );
+                    }
+
+                    const ownerOcc = parsedOwner.data;
+                    const isMatchingSession = ownerOcc.externalPlanRef.planId === externalPlanRef.planId
+                        && ownerOcc.externalPlanRef.sessionId === externalPlanRef.sessionId;
+                    const isNotActiveOrCompleted = ownerOcc.state !== 'active' && ownerOcc.state !== 'completed';
+                    const isHandoffAllowed = isMatchingSession && isNotActiveOrCompleted && (
+                        ownerOcc.state === 'scheduled' || generation > 0
                     );
+
+                    if (!isHandoffAllowed) {
+                        throw new Error(
+                            `Window '${options.windowBinding!.windowId}' on ${date} is already bound to occurrence '${owner}'.`,
+                        );
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
Implements Phase 3 (steps 8, 8/2a, 9) of H4 #434 per \docs/plans/h4-434-pr3-phase3-handover.md\:
- Implements the non-primary intraday bundle member adjudication loop (\djudicateIntradayBundleMembers\).
- Implements predecessor completion and immediate session response checks before member admission.
- Implements atomic multi-document transaction committing session occurrence (\scheduled\), window reservation, daily ledger aggregate reservation, and provisional \IntradayDecisionRecord\ (ADR-0036 D-AUDIT).
- Stores \postReservationLedgerRevision\ in the decision record and daily ledger reservation for downstream Phase 4 claim staleness checks.
- Implements rejection handling: transitions occurrence \scheduled\ -> \skipped\, drops aggregate reservation, and increments generation in the aggregate.
- Implements recovery handling: queries \currentGeneration\ from the daily ledger aggregate and mints a generation-aware deterministic occurrence ID.
- Re-assesses readiness and eligibility with self-consumption exclusion for the admitted member's own planned minutes/cost.
- Enforces maximum 4 additional sessions cap with an advisory notice attached to the recommendation.
- Wires \esolveIntradayBundlePlacement\ and \djudicateIntradayBundleMembers\ into the \Home.tsx\ dashboard recommendation evaluation flow.

## Scope Boundaries
- **Strictly Phase 3 only**: Phase 4 (claim on start), Phase 5 (immediate response capture in runner), and Phase 6 (policy version bump) are intentionally deferred per the handover specification.
- Does not modify recommendation engine decision core or bump \POLICY_VERSION\.

## Changes
1. **\pp/firestore.rules\**:
   - Added \postReservationLedgerRevision\ to allowed keys in \hasValidIntradayDecision\ (string, size 1..128) alongside required keys.
2. **\pp/src/engine/intradayDecision.ts\**:
   - Added \postReservationLedgerRevision?: string\ to \IntradayDecisionRecord\ and parser validator \alidateIntradayDecisionRecord\.
3. **\pp/src/services/dailyLedgerAggregateService.ts\**:
   - Added \postReservationLedgerRevision?: string\ to \DailyLedgerReservation\.
4. **\pp/src/services/sessionOccurrenceService.ts\**:
   - Exposed \occurrenceRef\ and \windowReservationRef\ public helpers.
   - Added \generation?: number\ to \getOrCreateExternalPlanOccurrence\ options and allowed recovery window reservation handoff when \generation > 0\.
5. **\pp/src/services/intradayBundleMemberAdjudication.ts\** (NEW):
   - Exported \djudicateIntradayBundleMembers\ and supporting types.
   - Handles predecessor checks, immediate response lookups, self-consumption subtraction, atomic transaction commitment, rejection drops + generation increments, recovery occurrence generation, and the 4-session cap.
6. **\pp/src/components/Home.tsx\**:
   - Wired \esolveIntradayBundlePlacement\ and \djudicateIntradayBundleMembers\ into the dashboard recommendation pipeline.
   - Merged member bindings and notices into \dditionalSessions\ and \dditionalNotices\.
7. **\pp/src/services/intradayBundleMemberAdjudication.test.ts\** (NEW):
   - 8 comprehensive test scenarios covering:
     1. Admitted member with completed predecessor & immediate response (proceed + binding + decision record + atomic persistence)
     2. Uncompleted predecessor handling (pending status, no binding, atomic persistence)
     3. Predecessor awaiting immediate confirmation (pending status, no binding)
     4. Self-consumption exclusion (does not reject against its own reserved capacity on subsequent passes)
     5. Rejection atomicity (transitions occurrence to skipped, drops ledger reservation, increments generation)
     6. Recovery with generation 1 (mints generation-aware occurrence ID, leaves skipped occurrence untouched)
     7. Maximum 4 additional sessions cap (omits binding and emits advisory notice)
     8. Idempotent retry convergence (succeeds without error on duplicate evaluation)

## Verification
- \
pm run check\ (typecheck + eslint + vitest + sports-knowledge + knowledge-coverage + workouts): **PASSED** (0 errors, 402 test files passed, 3862 tests passed).
- Firestore emulator rules tests (\intradayDecisionRules.emulator.test.ts\ & \sessionOccurrenceService.emulator.test.ts\): **PASSED** (8 passed).
- Backend tests (\uv run pytest\): **PASSED** (816 passed).
- Backend typing & lint (\uv run ruff check .\ & \uv run mypy src/garmin_sync\): **PASSED** (0 issues).
- Engine simulation (\
pm run simulate:scenarios\): **PASSED** (39 scenarios, 0 diff against baseline).
- Policy drift check (\
ode scripts/check-policy-drift.mjs main\): **PASSED** (No decision-affecting engine files modified).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added intraday bundle placement and member adjudication for eligible active external plans.
  * Recommendations now include accepted member bindings and relevant notices.
  * Added recovery support for interrupted bundle placement while preserving reservation history.
  * Reservation availability now reflects capacity reserved for bundle members.
  * Decision records can retain the resulting ledger revision for reservation tracking.

* **Bug Fixes**
  * Improved handling of pending, rejected, scaled, and retried bundle members.
  * Added safeguards for session limits, duplicate processing, and conflicting active or completed reservations.

* **Tests**
  * Added coverage for placement, recovery, retries, rejection cleanup, session caps, and reservation conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->