### PR TITLE
docs: route agents to the sports knowledge registry from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,7 @@ Quick guide for building, testing, and working on `adaptive-training-recommender
 - **User Scoping**: Ingestion output path MUST be `users/{APP_USER_ID}/daily_recovery_snapshots/{YYYY-MM-DD}`. Never write `"default_user"` documents.
 - **Timezone**: Dates MUST be computed in `Europe/Warsaw` timezone (`local_today()` in Python, `getLocalDateString()` in TS). Avoid UTC `.toISOString().split('T')[0]` for calendar dates.
 - **Step Semantics**: `totalSteps` represents previous completed day (`D - 1`). Baselines and activity-deducted ambient surges feed `fatigue.ts`.
+- **Knowledge Lineage**: Before proposing or changing any engine threshold, weight, cadence or policy constant, check `app/src/knowledge/knowledgeCoverage.ts` for an existing coverage item and `sportsKnowledgeRegistry.ts` for existing claims — the answer, or an explicit statement that the evidence does not support one, is often already registered. New decision-authority rules require a claim, a coverage item and a policy-alignment test (ADR-0033). The registry is invisible exactly when it matters most: you are reading a bare `0.40` in `optimizer.ts`, and nothing there says an alignment-tested claim owns it.
 - **Security**: Never commit credentials, `.garth` token directories, `.env` files, or raw health JSON logs.
 
 ## Essential Development Commands
@@ -59,6 +60,8 @@ Quick guide for building, testing, and working on `adaptive-training-recommender
 ---
 
 ## Key Code Locations
+- `AGENTS.md`: **Authoritative package map** — the file-by-file index for everything not listed below. This section is a shortlist, not an inventory; check `AGENTS.md` before concluding a capability does not exist.
+- `app/src/knowledge/`: Sports knowledge registry (ADR-0033) — scientific claims, product-policy claims and their evidence lineage. `knowledgeCoverage.ts` inventories every decision-authority rule in the engine with its classification, coverage state and research priority; `*PolicyAlignment.test.ts` assert registered claims match implemented constants.
 - `src/garmin_sync/`: Core Python Garmin ingestion package.
 - `scripts/bootstrap_garmin_tokens.py`: Garmin OAuth token bootstrap utility.
 - `app/src/engine/`: Core adaptive engine modules (`rules.ts`, `schedule.ts`, `periodization.ts`, `microcycle.ts`, `fatigue.ts`, `optimizer.ts`).


### PR DESCRIPTION
Independent of #453 and #455; based on `main`.

## Problem

`CLAUDE.md` is the auto-loaded context file. It never mentioned `app/src/knowledge/`, `knowledgeCoverage.ts`, or ADR-0033.

`AGENTS.md` documents them properly ([AGENTS.md:259-269](https://github.com/Szczepanov/adaptive-training-recommender/blob/main/AGENTS.md#L259-L269)), including `knowledgeCoverage.ts` as the engine coverage inventory. But the only pointer to `AGENTS.md` was a sub-clause on the sessions/responses bullet — it reads as "more detail on *those* packages", not "this is the index for everything else".

## What it cost

Concretely, in this session: while reviewing #453 I wrote "answered against the knowledge registry (ADR-0033)" into a draft ADR and deferred a weekly-recovery-cadence question to it — without opening it. The registry already carried the relevant material:

- `recovery.training.stress_recovery_balance` records that the evidence "supports monitoring and individualization, not a universal fixed 24-, 48- or 72-hour spacing rule" — so the cadence *cannot* be registered as a scientific claim at all;
- `health.adults.strength.default_upper_target` establishes the product-policy-claim pattern such a cadence should use instead;
- `optimizer.recovery_streak_heuristics` turned out to be an existing, alignment-tested recovery mechanism whose `systemicCost >= 0.40` input #453 silently changes.

None of that needed new research. It needed one grep.

## Changes

**A `Knowledge Lineage` rule under Core Guidelines**, attached to the *action* (changing a threshold, weight, cadence or policy constant) rather than to a location. The registry is least visible exactly when it matters most: you are reading a bare `0.40` in `optimizer.ts`, and nothing there indicates an alignment-tested claim owns it. A location entry alone gets skimmed.

**`AGENTS.md` promoted to its own Key Code Locations entry**, stated as the authoritative package map, with the shortlist framed as a shortlist.

**An `app/src/knowledge/` entry**, naming `knowledgeCoverage.ts` and the `*PolicyAlignment.test.ts` pattern.

## Scope

Documentation, not enforcement. Alignment tests only check claims that already exist — nothing forces a *new* constant to acquire one, so an agent adding an unregistered threshold still fails no test. Closing that would mean an inventory completeness check, which is a separate piece of work, not a doc edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for reviewing knowledge lineage before changing engine policy constants.
  * Documented registry coverage, claims, and alignment checks.
  * Updated key code location references for contributor guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->