### PR TITLE
docs(plans): reconcile H4 status across the evaluation, handoff, README and PR 3 plans

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -62,23 +62,36 @@ D-TIME (`localInstant.ts`), D-LEDGER's pure engine (`dailyLedger.ts`), D-PLACEME
 bundle-placement engine, D-REASSESS's pure `reassessDependentBundleMember`
 (`intradayReassessment.ts`, #442) and D-AUDIT's decision store (`intradayDecision.ts`,
 #443) are all delivered; #434 PR 1 bound the v4 primary session to the source-neutral
-launch path (#440), PR 2 added external-plan occurrence tracking (#445), and PR 3
+launch path (#440), PR 2 added external-plan occurrence tracking (#445), PR 3
 Phases 1-2 (#448) added D-WINDOW's real per-window exclusivity, atomic re-import
-supersession, and D-LEDGER's persisted date-level reservation aggregate. None of
-`claimOccurrenceLaunch`, `reassessDependentBundleMember`, or the decision store yet has a
-live caller: a non-primary bundle member is placed but not launchable, and no runtime path
-exercises reassessment or replay end-to-end. The
+supersession, and D-LEDGER's persisted date-level reservation aggregate, and PR 3 Phase 3
+(#450, #451, #454) added the bundle-member adjudication loop
+(`services/intradayBundleMemberAdjudication.ts`) and its `Home.tsx` wiring -- giving
+`reassessDependentBundleMember` and the decision store their first live caller, so a
+non-primary member is now reassessed, reserved and emitted as an `additionalSessions`
+binding. It is still **not launchable**: no component renders `additionalSessions`,
+`claimOccurrenceLaunch` still has no production caller, and completing the AM session does
+not yet write the `immediate` `SessionResponse` a dependent PM member reads, so such a
+member stays `pending`. The
 [bundle-launch plan](./h4-434-pr3-bundle-second-member-launch.md) tracks #434 PR 3's
-remaining phases (surfacing `additionalSessions`, the atomic claim, post-AM
-`SessionResponse` capture, and the `POLICY_VERSION` bump) as the path to a live H4 release.
+remaining Phases 4-6 (the launch affordance and atomic claim, post-AM `SessionResponse`
+capture, and the `POLICY_VERSION` bump) as the path to a live H4 release. Beyond PR 3, H4
+also still needs ledger remainder/admission as a real ranking input in `planner.ts`, and a
+bundle's resolved placement persisted for display (blocked on `firestore.rules`' audit
+shape at Firestore's per-request rule-evaluation ceiling).
 H5 block intent and controlled progression is accepted in
-[ADR-0037](../adr/0037-block-intent-and-controlled-progression.md); its implementation
-is unstarted. H4 runtime release needs verification of same-day canonical performed
-facts; H5 runtime needs validated intent mappings and linked response evidence. H5
+[ADR-0037](../adr/0037-block-intent-and-controlled-progression.md) and is **In progress**:
+H5a intent contracts and canonical replay (`engine/blockIntent.ts`,
+`engine/blockIntentReplay.ts`) and H5b report-only progression review
+(`engine/progressionReview.ts`) are delivered, neither wired into daily recommendation
+selection; H5c confirmed bounded revisions and cumulative `external-plan@5` are unstarted
+and independently startable. H4's same-day canonical performed-fact boundary is verified;
+H5 runtime needs validated intent mappings and linked response evidence. H5
 delivers intent authoring, report-only review, then confirmed bounded revisions. The work
 does not replace the reviewed active persona-judge baseline. The
-[implementation handoff](./cycling-primary-hybrid-implementation-handoff.md) provides
-sequenced work orders, dependency gates and acceptance requirements.
+[implementation handoff](./cycling-primary-hybrid-implementation-handoff.md) supplies
+work orders for H2/H2b/H3/H3-rest and the H5 sequence; **its H4 work order is superseded**
+by the bundle-launch plan linked above.
 
 These implement the way forward in
 [`docs/analysis/2026-08-08-architecture-review.md`](../analysis/2026-08-08-architecture-review.md)

--- a/docs/plans/cycling-primary-hybrid-evaluation.md
+++ b/docs/plans/cycling-primary-hybrid-evaluation.md
@@ -1,22 +1,27 @@
 # Cycling-primary hybrid evaluation and recommendation improvements
 
 **Status:** In progress — H1, H2, H2b, H3 and H3-rest (ADR-0035) all delivered; H4 design
-accepted as ADR-0036 with D-SCHEMA/D-LEDGER/D-TIME/D-WINDOW delivered, D-PLACEMENT's
-bundle-placement engine delivered as a pure module, and that engine's placement-
-correctness wired into `activeExternalPlanService.ts`'s primary-session selection for v4
-intraday bundles (real `POLICY_VERSION` bump) -- the same-day canonical performed-fact
-boundary is verified and the fixed-activity cost-reduce duplication is unified -- (broader
-ledger-based ranking/admission unification, a bundle's resolved placement surfaced for
-display/persistence, and D-REASSESS/D-AUDIT, unstarted); H5 design accepted as ADR-0037
-with H5a/H5b delivered (H5c and cumulative `external-plan@5` unstarted)
+accepted as ADR-0036 with every design slice now delivered as code
+(D-SCHEMA/D-LEDGER/D-TIME/D-WINDOW, D-PLACEMENT's engine plus its placement-correctness
+wiring, D-REASSESS's `intradayReassessment.ts` (#442) and D-AUDIT's `intradayDecision.ts`
+decision store (#443)) and issue #434's execution-binding pipeline delivered through PR 3
+Phase 3 (#440, #445, #448, #450, #451, #454) -- so a non-primary bundle member is now
+adjudicated, reserved and surfaced as an `additionalSessions` binding, but is **not yet
+launchable**: PR 3 Phases 4-6 (launch affordance and atomic claim, post-AM
+`SessionResponse` capture, `POLICY_VERSION` bump) remain, as do the broader ledger-based
+ranking/admission unification and persisting a bundle's resolved placement for display;
+H5 design accepted as ADR-0037 with H5a/H5b delivered (H5c and cumulative
+`external-plan@5` unstarted)
 **Blocked by:** Personal M00/M01 prescription requires current workload/restriction
-confirmation; H4's remaining work (unifying `planner.ts`'s three ad hoc dedup mechanisms
-onto the ledger's remainder/admission semantics as a real ranking input; persisting a
-bundle's resolved placement for display, currently blocked on `firestore.rules`' audit
-shape already sitting at Firestore's per-request rule-evaluation ceiling -- see the H4
-section below; then D-REASSESS/D-AUDIT) needs its own decision-affecting PR(s); H5c needs
-the athlete-scoped singleton progression-claim transaction design, and cumulative
-`external-plan@5` acceptance is unblocked now that H4's v4 contract has landed.
+confirmation; H4's live release is gated on PR 3 Phases 4-6, tracked in
+[the PR 3 plan](./h4-434-pr3-bundle-second-member-launch.md); H4's remaining non-gating
+work (unifying `planner.ts`'s three ad hoc dedup mechanisms onto the ledger's
+remainder/admission semantics as a real ranking input; persisting a bundle's resolved
+placement for display, currently blocked on `firestore.rules`' audit shape already sitting
+at Firestore's per-request rule-evaluation ceiling -- see the H4 section below) needs its
+own decision-affecting PR(s); H5c needs the athlete-scoped singleton progression-claim
+transaction design, and cumulative `external-plan@5` acceptance is unblocked now that H4's
+v4 contract has landed.
 **Unlocks:** Reproducible acceptance cases for equipment specificity, block authority and hybrid plan quality.
 
 ## Decision
@@ -24,6 +29,12 @@ the athlete-scoped singleton progression-claim transaction design, and cumulativ
 For implementation, start with the bounded work orders and ready-to-use task prompt in
 [the implementation handoff](./cycling-primary-hybrid-implementation-handoff.md).
 This document remains the status and evidence record.
+
+**Routing note for H4.** The handoff's H4 work order predates issue #434's execution-binding
+pipeline and is retained for its H2/H2b/H3/H3-rest record and its still-accurate inventory of
+the un-unified dedup mechanisms. For current H4 implementation work, read
+[the PR 3 plan](./h4-434-pr3-bundle-second-member-launch.md) instead -- it is the
+authoritative spec for the remaining Phases 4-6.
 
 Reuse the existing `cycling_primary_hybrid_advanced` persona. Add scenarios that exercise
 distinct decisions and group them into focused judge families. Retain the existing seven
@@ -260,9 +271,16 @@ performed-fact boundary verified**; **D-PLACEMENT's bundle-placement engine deli
 as a pure module, and its **placement-correctness wired** into
 `activeExternalPlanService.ts`'s primary-session selection for v4 intraday bundles (real
 `POLICY_VERSION` bump -- see the "D-PLACEMENT wiring" subsection below for exactly what
-this does and does not activate). Still unstarted: the `dailyLedger.ts` refactor into
-`resolveAvailability`'s existing deductions and `planner.ts`'s three ad hoc dedup
-mechanisms, persisting a bundle's resolved placement for display, and D-REASSESS/D-AUDIT.
+this does and does not activate). **D-REASSESS and D-AUDIT are also delivered** as pure
+modules -- `engine/intradayReassessment.ts`'s `reassessDependentBundleMember` (#442) and
+`engine/intradayDecision.ts`'s append-only decision store (#443) -- and issue #434's
+execution-binding pipeline has since given them a live caller, through PR 3 Phase 3 (see
+"Issue #434 execution-binding pipeline" below).
+
+Still unstarted: the `dailyLedger.ts` refactor into `resolveAvailability`'s existing
+deductions and `planner.ts`'s three ad hoc dedup mechanisms, persisting a bundle's
+resolved placement for display, and PR 3 Phases 4-6 -- the last of which is what actually
+gates a live H4 release.
 **Dependencies:** ADR-0035 rest support (delivered). The `external-plan@4`/`dailyLedger.ts`
 D-SCHEMA/D-LEDGER slice itself left `POLICY_VERSION` unchanged (neither module is
 consumed by any decision path); the fixed-activity cost-reduce dedup slice bumped it
@@ -555,12 +573,46 @@ in `unrepresentedFixedActivityProjection`) are **not yet unified** onto the ledg
 `occurrenceId`/`revision` model, and none of these call sites yet consult
 `computeDailyLedger`'s remainder or `admitsCandidate` when ranking or admitting a
 candidate. D-PLACEMENT's own placement-correctness wiring is delivered (see the
-"D-PLACEMENT wiring" subsection above). The remaining H4 tasks are (1) using the ledger's
-remainder/admission semantics as a real ranking/admission input across these three sites,
-(2) building the external-plan `SessionReferenceBinding` execution-binding pipeline (a
-separate multi-PR foundational project) before a bundle's second member can be
-independently launchable, and (3) D-REASSESS/D-AUDIT -- each decision-affecting and
-scoped as its own PR.
+"D-PLACEMENT wiring" subsection above). Of the three tasks this subsection originally
+listed as remaining, (2) the execution-binding pipeline and (3) D-REASSESS/D-AUDIT have
+since been delivered (see the next subsection); (1) using the ledger's remainder/admission
+semantics as a real ranking/admission input across these three call sites is still
+outstanding and is still decision-affecting, so it remains its own PR.
+
+### Issue #434 execution-binding pipeline (delivered through PR 3 Phase 3)
+
+The external-plan `SessionReferenceBinding` execution-binding pipeline -- identified above
+as a separate multi-PR foundational project -- has been built as
+[issue #434](https://github.com/Szczepanov/adaptive-training-recommender/issues/434):
+
+| PR | Commit | Delivered |
+|---|---|---|
+| [#440](https://github.com/Szczepanov/adaptive-training-recommender/pull/440) | `c9cc402f` | PR 1 -- v4 primary session bound to the source-neutral launch path |
+| [#445](https://github.com/Szczepanov/adaptive-training-recommender/pull/445) | `99a7638f` | PR 2 -- external-plan occurrence tracking |
+| [#448](https://github.com/Szczepanov/adaptive-training-recommender/pull/448) | `ee6d132b` | PR 3 Phases 1-2 -- D-WINDOW per-window exclusivity, atomic re-import supersession, `intradayLedgerInputs.ts`, the persisted `daily_ledgers` reservation aggregate |
+| [#450](https://github.com/Szczepanov/adaptive-training-recommender/pull/450) | `eddacc09` | PR 3 Phase 3 foundations -- unified `ReassessmentInputRevision`, decision-record predecessor identity, transaction-composable decision writes |
+| [#451](https://github.com/Szczepanov/adaptive-training-recommender/pull/451) | `7399ec31` | PR 3 step 8 item 2a -- reject/recovery generation counters |
+| [#454](https://github.com/Szczepanov/adaptive-training-recommender/pull/454) | `9f42db1e` | PR 3 Phase 3 -- `services/intradayBundleMemberAdjudication.ts` and its `Home.tsx` wiring |
+
+**What this activates:** a placed v4 bundle's non-primary member is now reassessed per
+D-REASSESS, has its verdict persisted per D-AUDIT, holds (or releases) a real reservation
+against the day's ledger aggregate, and is emitted as an `additionalSessions` binding from
+`Home.tsx`.
+
+**What it does not yet activate:** the member is still not launchable. No component renders
+`additionalSessions`, and `claimOccurrenceLaunch` still has no production caller, so no
+Start control can appear. Completing the AM session also does not yet write the `immediate`
+`SessionResponse` that a dependent PM member's reassessment reads, so a dependent member
+stays `pending` indefinitely. `POLICY_VERSION` is correspondingly still
+`2026-09-h4-intraday-reassessment-v1`.
+
+**What remains:** PR 3 Phases 4-6 --
+[the PR 3 plan](./h4-434-pr3-bundle-second-member-launch.md) is the authoritative spec.
+Phase 4 adds the `AdditionalSessionsCard` and the atomic claim in `onStartSession`;
+Phase 5 records the post-AM `immediate` `SessionResponse`, extends the completion sheet
+with `completedFraction`/`unexpectedFatigue`, and populates
+`postPredecessorConfirmationRevision`; Phase 6 bumps `POLICY_VERSION` and archives the
+previous value. This is the gate on a live H4 release.
 
 ## H5 — Explicit develop/maintain intent and progression
 

--- a/docs/plans/cycling-primary-hybrid-implementation-handoff.md
+++ b/docs/plans/cycling-primary-hybrid-implementation-handoff.md
@@ -1,7 +1,23 @@
 # Cycling-primary hybrid: implementation handoff
 
-**Status:** H1, H2, H2b, H3 and H3-rest (ADR-0035) all delivered; H4 design accepted as ADR-0036 with D-SCHEMA/D-LEDGER delivered, the same-day canonical performed-fact boundary verified, and the fixed-activity cost-reduce duplication unified (D-TIME/D-REASSESS/D-PLACEMENT/D-AUDIT and ledger-based admission unstarted); H5 design accepted as ADR-0037 with H5a (intent contracts, canonical replay) and H5b (report-only progression review) delivered (H5c confirmed revisions and cumulative `external-plan@5` unstarted)
-**Blocked by:** H4's remaining runtime wiring (using `computeDailyLedger`/`admitsCandidate` as an actual ranking/admission input, then D-TIME/D-REASSESS/D-PLACEMENT/D-AUDIT) needs its own decision-affecting PR(s); nothing left blocks starting it. H5c (confirmed bounded revisions, with the athlete-scoped singleton progression claim) and cumulative `external-plan@5` with `intentBlocks` are both ready to start now that H4's v4 artifact has landed. Personal M00/M01 prescription needs current athlete inputs.
+**Scope note:** This document supplies **bounded implementation work orders**; the
+[evaluation plan](./cycling-primary-hybrid-evaluation.md) owns H1-H5 status. For current H4
+implementation work, read [the PR 3 plan](./h4-434-pr3-bundle-second-member-launch.md) --
+the H4 work order below predates issue #434's execution-binding pipeline and is retained for
+its record of what was investigated, not as a task list.
+**Status:** H1, H2, H2b, H3 and H3-rest (ADR-0035) all delivered; H4 design accepted as
+ADR-0036 with every design slice (D-SCHEMA, D-LEDGER, D-TIME, D-WINDOW, D-PLACEMENT,
+D-REASSESS, D-AUDIT) delivered as code and issue #434's execution-binding pipeline delivered
+through PR 3 Phase 3 -- PR 3 Phases 4-6 (launch affordance and atomic claim, post-AM
+`SessionResponse` capture, `POLICY_VERSION` bump) remain, and ledger-based
+ranking/admission is still not a decision input anywhere; H5 design accepted as ADR-0037
+with H5a (intent contracts, canonical replay) and H5b (report-only progression review)
+delivered (H5c confirmed revisions and cumulative `external-plan@5` unstarted)
+**Blocked by:** Nothing blocks starting any remaining item. H4's live release is gated on
+PR 3 Phases 4-6. H5c (confirmed bounded revisions, with the athlete-scoped singleton
+progression claim) and cumulative `external-plan@5` with `intentBlocks` are both ready to
+start, and are independent of H4's remaining phases. Personal M00/M01 prescription needs
+current athlete inputs.
 **Unlocks:** A cycling-first recommendation path that preserves feasible strength, respects equipment and time, and supports authored blocks without inventing capacity.
 
 ## Start here
@@ -24,12 +40,11 @@ when an earlier exposure already satisfied that role's weekly minimum. On unclai
 the ordinary coverage ordering is unchanged, so an already-met hard role does not force
 unnecessary repeats.
 
-The current decision policy version is
-`2026-09-fixed-activity-cost-dedup-v1` (bumped mechanically by the fixed-activity
-cost-reduce dedup slice, not by an actual decision-behavior change -- see `app/src/engine/policy.ts`
-for the authoritative current value, since this line will otherwise go stale again).
-See the evaluation plan for the root cause, focused regression tests and required
-PR-head validation.
+The current decision policy version is `2026-09-h4-intraday-reassessment-v1`. This line
+has gone stale before and will again -- read `app/src/engine/policy.ts` for the
+authoritative value rather than trusting it. PR 3 Phase 6 bumps it again when the
+bundle-member launch path lands. See the evaluation plan for the root cause, focused
+regression tests and required PR-head validation.
 
 H3 was investigated and its executable contracts are delivered (see the work orders below
 and the evaluation plan). The unplanned-date fallback, missed-session replacement,
@@ -50,13 +65,13 @@ verdict.
 
 H4's authority/schema design is the accepted ADR-0036 proposal
 (`docs/adr/0036-intraday-training-windows-and-reassessment.md`). Read that artifact rather
-than reconstructing its v4 contract from discussion context. H5 may proceed with
-manual/report-only intent groundwork now, but cumulative `external-plan@5` import
-acceptance must be based on ADR-0036's actual v4 artifact.
+than reconstructing its v4 contract from discussion context. Its v4 artifact has landed, so
+cumulative `external-plan@5` import acceptance now has a real contract to build against.
 
-Suggested next step: start ADR-0036 (H4) schema/pure-ledger implementation work, or start
-ADR-0037 (H5) intent-contract work instead -- both designs are accepted and ready. Keep
-that work separate from personal
+Suggested next step: **H4 PR 3 Phase 4** (the launch affordance and atomic claim), per
+[the PR 3 plan](./h4-434-pr3-bundle-second-member-launch.md) -- this is what turns six
+merged PRs of primitives into something an athlete can start. H5c (ADR-0037 confirmed
+bounded revisions) is independently startable in parallel. Keep both separate from personal
 M00/M01 prescription until current workload/restriction inputs are confirmed.
 
 ## Stable product intent
@@ -227,23 +242,36 @@ Useful synthetic software work can proceed without those personal answers.
 
 ## Work order H4 — Intraday windows and post-AM response
 
+> **Superseded for implementation.** This work order was written before issue #434's
+> execution-binding pipeline existed and its numbered steps below no longer describe the
+> work that remains. Read
+> [`h4-434-pr3-bundle-second-member-launch.md`](./h4-434-pr3-bundle-second-member-launch.md)
+> for the authoritative current spec (Phases 4-6). What is still worth reading here: step 2's
+> **inventory of the three un-unified ad hoc dedup mechanisms**, which remains accurate and
+> is still an open H4 task.
+
 **Status:** Design accepted in [ADR-0036](../adr/0036-intraday-training-windows-and-reassessment.md).
-By capability (not the numbered sequence below, which tracks a different granularity --
-see the note after the numbered list): D-SCHEMA, D-LEDGER (pure module), D-TIME and
-D-WINDOW are delivered; the same-day canonical performed-fact boundary is verified;
-D-PLACEMENT's bundle-placement engine (`engine/intradayBundlePlacement.ts`) is delivered
-and its placement-correctness is wired into `activeExternalPlanService.ts`'s
-primary-session selection (real `POLICY_VERSION` bump). Still unstarted: unifying
-`planner.ts`'s three ad hoc dedup mechanisms onto the ledger's remainder/admission
-semantics as a real ranking/admission input; building the external-plan
-`SessionReferenceBinding` execution-binding pipeline (discovered missing even for today's
-single primary session -- a separate multi-PR foundational project, required before a
-bundle's second member can be independently launchable or its placement persisted for
-display); and D-REASSESS/D-AUDIT.
+By capability, **every ADR-0036 design slice is now delivered as code**: D-SCHEMA,
+D-LEDGER (pure module), D-TIME, D-WINDOW, D-PLACEMENT's engine
+(`engine/intradayBundlePlacement.ts`) plus its placement-correctness wiring into
+`activeExternalPlanService.ts`'s primary-session selection, D-REASSESS
+(`engine/intradayReassessment.ts`, #442) and D-AUDIT (`engine/intradayDecision.ts`, #443);
+the same-day canonical performed-fact boundary is verified. The external-plan
+`SessionReferenceBinding` execution-binding pipeline -- called out below as a separate
+multi-PR foundational project -- became issue #434 and is delivered through PR 3 Phase 3
+(#440, #445, #448, #450, #451, #454), giving D-REASSESS/D-AUDIT their first live caller in
+`services/intradayBundleMemberAdjudication.ts`.
+
+Still outstanding: **PR 3 Phases 4-6** (the launch affordance and atomic claim, post-AM
+`SessionResponse` capture, and the `POLICY_VERSION` bump) -- the release gate, since a
+non-primary member is currently adjudicated and reserved but has no Start control; unifying
+`planner.ts`'s three ad hoc dedup mechanisms onto the ledger's remainder/admission semantics
+as a real ranking/admission input; and persisting a bundle's resolved placement for display
+(blocked on `firestore.rules`' audit shape already at Firestore's per-request
+rule-evaluation ceiling).
 **Dependencies:** ADR-0035 rest support (delivered). Same-day canonical performed
-identity/revision/timing inputs are now verified (see below), D-TIME's instant resolution
-is delivered, D-WINDOW's availability model is delivered, and D-PLACEMENT's engine and its
-placement-correctness wiring are delivered.
+identity/revision/timing inputs are verified (see below); D-TIME, D-WINDOW, D-PLACEMENT and
+the #434 pipeline through PR 3 Phase 3 are all delivered. Nothing blocks Phase 4.
 **Deliverable:** Authored intraday placement and reassessed execution, followed separately
 by automatic multi-window packing after the initial acceptance bar passes.
 

--- a/docs/plans/h4-434-pr3-bundle-second-member-launch.md
+++ b/docs/plans/h4-434-pr3-bundle-second-member-launch.md
@@ -1,13 +1,17 @@
 # H4 / issue #434 PR 3 — Intraday bundle second-member launch & athlete confirmation capture
 
-**Status:** Draft (design not yet agreed).
+**Status:** In progress — **Phases 1-3 delivered and merged** (#448, #450, #451, #454);
+**Phases 4-6 remain** and are the gate on a live H4 release.
 **Tracks:** [GitHub issue #434](https://github.com/Szczepanov/adaptive-training-recommender/issues/434), PR 3.
-**Blocked by:** nothing — [PR #445](https://github.com/Szczepanov/adaptive-training-recommender/pull/445)
-(#434 PR 2, external-plan occurrence tracking) merged to `main` as `99a7638f`. Phase 1
-below is now a short adopt-and-verify pass, not new construction.
-**Unlocks:** live wiring of ADR-0036 D-REASSESS (`reassessDependentBundleMember`, issue #436)
-and D-AUDIT (`intradayDecisionService`, issue #437), both of which currently exist as
-unwired engine/service code.
+**Blocked by:** nothing. Phase 4 is startable now: every primitive it composes
+(`claimOccurrenceLaunch`, the adjudication loop's emitted `additionalSessions` bindings, the
+`daily_ledgers` aggregate, the decision store's transaction-composable writes) is merged and
+tested on `main`.
+**Unlocks:** a launchable non-primary bundle member. ADR-0036 D-REASSESS
+(`reassessDependentBundleMember`, issue #436) and D-AUDIT (`intradayDecisionService`,
+issue #437) already have their first live caller as of Phase 3
+(`services/intradayBundleMemberAdjudication.ts`); Phases 4-5 give the athlete a Start
+control and the post-AM evidence that lets a dependent member leave `pending`.
 **Governs:** [ADR-0036](../adr/0036-intraday-training-windows-and-reassessment.md)
 D-WINDOW / D-LEDGER / D-REASSESS / D-PLACEMENT.
 **Builds on:** [`h4-external-plan-execution-binding-pipeline.md`](./h4-external-plan-execution-binding-pipeline.md),
@@ -376,10 +380,14 @@ parameter order on `queueOccurrenceTransition`. What remains:
 
 ### Phase 3 — Surface non-primary members as `additionalSessions`
 
-> **Handover:** steps 1-4a-4b-6-6a-7 and step 8's item 2a are delivered and merged on `main` (#448, #450, #451).
-> See [`h4-434-pr3-phase3-handover.md`](./h4-434-pr3-phase3-handover.md) for exactly what
-> remains in steps 8/9, the current signature of every primitive to compose, and the traps
-> already found and fixed along the way.
+> **Delivered.** Steps 8, 8/2a and 9 are merged on `main`: #448, #450 and #451 landed the
+> primitives, and [#454](https://github.com/Szczepanov/adaptive-training-recommender/pull/454)
+> (`9f42db1e`) landed the adjudication loop itself as
+> `app/src/services/intradayBundleMemberAdjudication.ts` plus its `Home.tsx` wiring. A placed
+> bundle's non-primary member is now reassessed, reserved, recorded in the decision store and
+> emitted as an `additionalSessions` binding. The steps below are retained as the delivered
+> contract. [`h4-434-pr3-phase3-handover.md`](./h4-434-pr3-phase3-handover.md) is superseded;
+> **Phase 4 is the next unit of work.**
 
 8. **Adjudicate bundle members** (`app/src/components/Home.tsx`, after `resolveIntradayBundlePlacement`)
    - Action: for a `placed` proposal, take every binding after `bindings[0]` (the primary,

--- a/docs/plans/h4-434-pr3-phase3-handover.md
+++ b/docs/plans/h4-434-pr3-phase3-handover.md
@@ -1,8 +1,17 @@
 # H4 #434 PR 3 — Phase 3 handover: the adjudication loop and `Home.tsx` wiring
 
-**Status:** Handover document for the next implementing agent. Not itself part of the plan's
-numbered steps; superseded by whichever PR actually builds the pieces described below (update
-or delete this file once that PR merges).
+**Status:** **Superseded — Phase 3 is delivered.**
+[PR #454](https://github.com/Szczepanov/adaptive-training-recommender/pull/454) (`9f42db1e`)
+built the adjudication loop and its `Home.tsx` wiring as
+`app/src/services/intradayBundleMemberAdjudication.ts`, closing everything this document was
+written to hand over. It is retained as a historical record of the primitives inventory and
+the traps found along the way -- **it is not a task list**, and its "What genuinely remains"
+section below is stale. For the work that actually remains, read
+[`h4-434-pr3-bundle-second-member-launch.md`](./h4-434-pr3-bundle-second-member-launch.md)
+Phases 4-6.
+
+Original status: handover document for the next implementing agent. Not itself part of the
+plan's numbered steps.
 
 **Read first:** [`h4-434-pr3-bundle-second-member-launch.md`](./h4-434-pr3-bundle-second-member-launch.md)
 Phase 3 (steps 8, 8/2a, 9) is the authoritative spec. This document is a map of what already


### PR DESCRIPTION
## Why

Four plan documents disagreed with each other and with `main`, in three different directions. The two most-linked ones — the evaluation plan and the implementation handoff — would have started the next agent from a false picture of H4: both still described D-REASSESS/D-AUDIT as unstarted and made no mention of issue #434's execution-binding pipeline, which is six merged PRs of work (#440, #445, #448, #450, #451, #454).

Docs-only. No decision behavior changes, no `POLICY_VERSION` movement.

## What changed

**[`cycling-primary-hybrid-evaluation.md`](docs/plans/cycling-primary-hybrid-evaluation.md)** — header, H4 status block and the "remaining H4 tasks" list corrected; new **"Issue #434 execution-binding pipeline"** subsection with a PR/commit table, plus explicit *what this activates* / *what it does not yet activate* / *what remains* paragraphs. A routing note in the Decision section sends H4 implementers to the PR 3 plan rather than the handoff.

**[`cycling-primary-hybrid-implementation-handoff.md`](docs/plans/cycling-primary-hybrid-implementation-handoff.md)** — the stalest of the four. Its header contradicted its own H4 section on D-TIME/D-PLACEMENT; it named `2026-09-fixed-activity-cost-dedup-v1` as the current policy version (actual: `2026-09-h4-intraday-reassessment-v1`); it described #434's pipeline as an unstarted "separate multi-PR foundational project"; and its suggested next step was to start H4 schema/pure-ledger work completed long ago. Its H4 work order now carries an explicit **superseded** banner pointing at the PR 3 plan — while calling out the one part still accurate and open: step 2's inventory of the three un-unified ad hoc dedup mechanisms.

**[`docs/plans/README.md`](docs/plans/README.md)** — H4 paragraph brought up to #454; the separate claim that H5's implementation is "unstarted" corrected (H5a/H5b are delivered, H5c is not); the stale "H4 runtime release needs verification of same-day canonical performed facts" dropped (verified).

**[`h4-434-pr3-bundle-second-member-launch.md`](docs/plans/h4-434-pr3-bundle-second-member-launch.md)** — still read "Draft (design not yet agreed)" with Phases 1–3 merged. Status corrected to Phases 1–3 delivered / Phases 4–6 remaining; the Phase 3 banner records delivery and points at Phase 4.

**[`h4-434-pr3-phase3-handover.md`](docs/plans/h4-434-pr3-phase3-handover.md)** — asked in its own status line to be updated or deleted once the PR it handed over merged. #454 merged; marked superseded, retained as a historical record, with its now-stale "What genuinely remains" section flagged.

## Verification

Every status assertion was checked against code on `main`, not inferred from the docs:

- `POLICY_VERSION` read from `app/src/engine/policy.ts`
- `AdditionalSessionsCard` confirmed absent from `app/src/components/session/`
- `claimOccurrenceLaunch` confirmed to have zero production callers (only its own definition)
- `recordResponse` confirmed absent from `useSessionRunner.ts`'s completion path
- `adjudicateIntradayBundleMembers` / `additionalSessions` confirmed wired in `Home.tsx`

All relative links in the five files resolve. `pre-commit` passes on all five.

## Net picture after this PR

H4's remaining work is: **PR 3 Phases 4–6** (release gate), ledger remainder/admission as a real ranking input in `planner.ts`, and persisting a bundle's resolved placement for display (blocked on the `firestore.rules` evaluation ceiling). H5c and cumulative `external-plan@5` are unstarted and independently startable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)