### PR TITLE
feat(engine): add auditable ADR-0038 recovery history facts (RP2)

### DIFF
--- a/app/src/engine/models.ts
+++ b/app/src/engine/models.ts
@@ -1503,6 +1503,8 @@ export interface TrainingSettings {
         legacyReviewed: boolean;
         migratedAt: string | null;
     };
+    /** ADR-0038: durable recovery-policy enrollment epoch B. Never slides once established. */
+    recoveryBootstrapDate?: string | null;
     createdAt: string;
     updatedAt: string;
 }

--- a/app/src/engine/recoveryFacts.test.ts
+++ b/app/src/engine/recoveryFacts.test.ts
@@ -1,0 +1,476 @@
+import { describe, expect, it } from 'vitest';
+import {
+    buildRecoveryHistorySnapshot,
+    deriveRecoveryFactFromAuthoredRest,
+    deriveRecoveryFactFromCoverageCreditFact,
+    deriveRecoveryFactFromPerformedOccurrence,
+    reconcileGeneratedRestOutcome,
+    resolveBootstrapDate,
+    validatePerformedRecoveryFact,
+    type RecoveryPlacementFact,
+} from './recoveryFacts';
+import {
+    resolveRecoveryAuthority,
+    resolveRecoveryPlacementState,
+} from './recoveryPlacement';
+import type { PerformedTrainingOccurrence } from '../training-occurrence/models';
+import type { CoverageCreditFact, PerformedExposureFact } from './performedTrainingFacts';
+import type { ExternalRestProvenance } from './models';
+import type { ExternalRestDecisionProvenance } from './externalRestProvenance';
+
+function mockOccurrence(overrides: Partial<PerformedTrainingOccurrence> = {}): PerformedTrainingOccurrence {
+    return {
+        performedOccurrenceId: 'occ_rec_01',
+        userId: 'u1',
+        schemaVersion: 1,
+        status: 'active',
+        sourceRefs: [{ kind: 'structured_execution', executionId: 'exec_01' }],
+        localDate: '2026-09-08',
+        startedAt: '2026-09-08T09:00:00.000Z',
+        endedAt: '2026-09-08T09:30:00.000Z',
+        modality: 'Mobility',
+        reconciliation: { state: 'single_source' },
+        createdAt: '2026-09-08T09:30:00.000Z',
+        updatedAt: '2026-09-08T09:30:00.000Z',
+        ...overrides,
+    };
+}
+
+describe('ADR-0038 historical recovery truth (RP2)', () => {
+    describe('Work A: performed active recovery facts', () => {
+        it('derives a RecoveryPlacementFact for exact active recovery with workoutId and qualification authority', () => {
+            const occurrence = mockOccurrence();
+            const hydrated = {
+                structured: {
+                    executionId: 'exec_01',
+                    workoutId: 'recovery_mobility_tissue_01',
+                    templateId: 'mobility_recovery',
+                    modality: 'Mobility' as const,
+                },
+            };
+            const authority = resolveRecoveryAuthority(null);
+
+            const fact = deriveRecoveryFactFromPerformedOccurrence(occurrence, hydrated, authority);
+            expect(fact).not.toBeNull();
+            expect(fact?.date).toBe('2026-09-08');
+            expect(fact?.source.kind).toBe('performed_recovery');
+            if (fact?.source.kind === 'performed_recovery') {
+                expect(fact.source.performedOccurrenceId).toBe('occ_rec_01');
+                expect(fact.source.workoutId).toBe('recovery_mobility_tissue_01');
+                expect(fact.source.qualification).toEqual({
+                    coverageSetId: 'evergreen_general',
+                    phase: 'general',
+                    coverageKey: 'recovery_or_rest',
+                });
+                expect(fact.source.templateId).toBe('mobility_recovery');
+            }
+        });
+
+        it('derives a fact for cycling recovery spin and breathwork under active recovery identities', () => {
+            const spinOccurrence = mockOccurrence({ performedOccurrenceId: 'occ_spin' });
+            const spinHydrated = {
+                structured: {
+                    executionId: 'exec_spin',
+                    workoutId: 'cycling_recovery_spin_01',
+                    modality: 'Cycling' as const,
+                },
+            };
+            const breathOccurrence = mockOccurrence({ performedOccurrenceId: 'occ_breath' });
+            const breathHydrated = {
+                structured: {
+                    executionId: 'exec_breath',
+                    workoutId: 'recovery_breathwork_01',
+                    modality: 'Mobility' as const,
+                },
+            };
+            const authority = resolveRecoveryAuthority(null);
+
+            const spinFact = deriveRecoveryFactFromPerformedOccurrence(spinOccurrence, spinHydrated, authority);
+            expect(spinFact).not.toBeNull();
+            expect(spinFact?.source.kind).toBe('performed_recovery');
+            if (spinFact?.source.kind === 'performed_recovery') {
+                expect(spinFact.source.workoutId).toBe('cycling_recovery_spin_01');
+            }
+
+            const breathFact = deriveRecoveryFactFromPerformedOccurrence(breathOccurrence, breathHydrated, authority);
+            expect(breathFact).not.toBeNull();
+            expect(breathFact?.source.kind).toBe('performed_recovery');
+            if (breathFact?.source.kind === 'performed_recovery') {
+                expect(breathFact.source.workoutId).toBe('recovery_breathwork_01');
+            }
+        });
+
+        it('fails closed when modality is generic mobility without exact catalog workout identity', () => {
+            const occurrence = mockOccurrence();
+            const hydrated = {
+                provider: {
+                    activityId: 'garmin_act_01',
+                    provider: 'garmin',
+                    modality: 'Mobility' as const,
+                },
+            };
+            const authority = resolveRecoveryAuthority(null);
+
+            const fact = deriveRecoveryFactFromPerformedOccurrence(occurrence, hydrated, authority);
+            expect(fact).toBeNull();
+        });
+
+        it('fails closed when workoutId is legacy_strength or non-recovery workout', () => {
+            const occurrence = mockOccurrence();
+            const hydratedStrength = {
+                structured: {
+                    executionId: 'exec_legacy',
+                    workoutId: 'legacy_strength',
+                    modality: 'Strength' as const,
+                },
+            };
+            const hydratedNonRecovery = {
+                structured: {
+                    executionId: 'exec_run',
+                    workoutId: 'running_aerobic_base_01',
+                    modality: 'Running' as const,
+                },
+            };
+            const authority = resolveRecoveryAuthority(null);
+
+            expect(deriveRecoveryFactFromPerformedOccurrence(occurrence, hydratedStrength, authority)).toBeNull();
+            expect(deriveRecoveryFactFromPerformedOccurrence(occurrence, hydratedNonRecovery, authority)).toBeNull();
+        });
+
+        it('derives a fact from CoverageCreditFact when coverageKey is recovery_or_rest and creditKind is exact', () => {
+            const credit: CoverageCreditFact = {
+                performedOccurrenceId: 'occ_credit_01',
+                coverageSetId: 'evergreen_general',
+                coverageKey: 'recovery_or_rest',
+                workoutId: 'recovery_mobility_tissue_01',
+                creditKind: 'exact',
+                confidence: 1.0,
+                reasonCode: 'exact_workout_identity',
+                sourceKinds: ['structured_execution'],
+            };
+            const exposure: PerformedExposureFact = {
+                performedOccurrenceId: 'occ_credit_01',
+                localDate: '2026-09-08',
+                modality: 'Mobility',
+                confidence: 'exact',
+                sourceKinds: ['structured_execution'],
+                evidenceTier: 'completedStructuredWorkout',
+                workoutId: 'recovery_mobility_tissue_01',
+            };
+            const authority = resolveRecoveryAuthority(null);
+
+            const fact = deriveRecoveryFactFromCoverageCreditFact(credit, exposure, authority);
+            expect(fact).not.toBeNull();
+            expect(fact?.source.kind).toBe('performed_recovery');
+            if (fact?.source.kind === 'performed_recovery') {
+                expect(fact.source.workoutId).toBe('recovery_mobility_tissue_01');
+                expect(fact.source.qualification.coverageKey).toBe('recovery_or_rest');
+            }
+        });
+
+        it('pure validator confirms qualifying workoutId under authority and rejects altered/unmapped workoutId', () => {
+            const authority = resolveRecoveryAuthority(null);
+            const validFact: RecoveryPlacementFact = {
+                date: '2026-09-08',
+                source: {
+                    kind: 'performed_recovery',
+                    performedOccurrenceId: 'occ_01',
+                    workoutId: 'recovery_mobility_tissue_01',
+                    qualification: {
+                        coverageSetId: 'evergreen_general',
+                        phase: 'general',
+                        coverageKey: 'recovery_or_rest',
+                    },
+                },
+            };
+            expect(validatePerformedRecoveryFact(validFact, authority)).toBe(true);
+
+            // Mutated workoutId that does not qualify under authority
+            const invalidFact: RecoveryPlacementFact = {
+                date: '2026-09-08',
+                source: {
+                    kind: 'performed_recovery',
+                    performedOccurrenceId: 'occ_01',
+                    workoutId: 'cycling_vo2_intervals_01',
+                    qualification: {
+                        coverageSetId: 'evergreen_general',
+                        phase: 'general',
+                        coverageKey: 'recovery_or_rest',
+                    },
+                },
+            };
+            expect(validatePerformedRecoveryFact(invalidFact, authority)).toBe(false);
+
+            // Mismatched phase/coverageSetId
+            const mismatchedAuthorityFact: RecoveryPlacementFact = {
+                date: '2026-09-08',
+                source: {
+                    kind: 'performed_recovery',
+                    performedOccurrenceId: 'occ_01',
+                    workoutId: 'recovery_mobility_tissue_01',
+                    qualification: {
+                        coverageSetId: 'september_cycling_event',
+                        phase: 'taper',
+                        coverageKey: 'recovery_or_rest',
+                    },
+                },
+            };
+            expect(validatePerformedRecoveryFact(mismatchedAuthorityFact, authority)).toBe(false);
+        });
+    });
+
+    describe('Work B: ADR-0035 authored Rest bridge', () => {
+        const baseProvenance: ExternalRestProvenance = {
+            planId: 'plan_ext_01',
+            revision: 2,
+            contentHash: 'hash_abc123',
+            restDirectiveId: 'directive_rest_01',
+            date: '2026-09-08',
+        };
+
+        it('credits valid authored Rest with canonical ExternalRestProvenance', () => {
+            const result = deriveRecoveryFactFromAuthoredRest(baseProvenance);
+            expect(result.reason).toBeUndefined();
+            expect(result.fact).not.toBeNull();
+            expect(result.fact?.date).toBe('2026-09-08');
+            expect(result.fact?.source.kind).toBe('authored_rest');
+            if (result.fact?.source.kind === 'authored_rest') {
+                expect(result.fact.source.planId).toBe('plan_ext_01');
+                expect(result.fact.source.restDirectiveId).toBe('directive_rest_01');
+                expect(result.fact.source.contentHash).toBe('hash_abc123');
+            }
+        });
+
+        it('suppresses recovery credit when provenance reports overridden: true while preserving base fields', () => {
+            const overriddenProvenance: ExternalRestDecisionProvenance = {
+                ...baseProvenance,
+                overridden: true,
+            };
+
+            const result = deriveRecoveryFactFromAuthoredRest(overriddenProvenance);
+            expect(result.fact).toBeNull();
+            expect(result.reason).toBe('overridden');
+        });
+
+        it('decision gate: suppresses recovery credit when unrecorded contradictory training occurred on that date', () => {
+            const result = deriveRecoveryFactFromAuthoredRest(baseProvenance, {
+                hasContradictoryTraining: true,
+            });
+            expect(result.fact).toBeNull();
+            expect(result.reason).toBe('contradictory_training');
+        });
+
+        it('rejects invalid or malformed provenance without minting fake facts', () => {
+            const invalidProvenance: ExternalRestProvenance = {
+                planId: '',
+                revision: 0,
+                contentHash: '',
+                restDirectiveId: '',
+                date: 'not-a-date',
+            };
+            const result = deriveRecoveryFactFromAuthoredRest(invalidProvenance);
+            expect(result.fact).toBeNull();
+            expect(result.reason).toBe('invalid_provenance');
+        });
+    });
+
+    describe('Work C: generated complete-Rest day outcome reconciliation', () => {
+        const baseRecommendation = {
+            date: '2026-09-08',
+            category: 'Rest' as const,
+            templateId: 'rest_day',
+            recommendationAudit: {
+                policyVersion: '2026-09-adr-0038-recovery-identity-v1',
+                decisionContextRevision: 'audit_rev_123',
+            },
+        };
+
+        it('refuses to mint a historical fact from recommendation alone when day reconciliation is incomplete', () => {
+            const result = reconcileGeneratedRestOutcome({
+                recommendation: baseRecommendation,
+                closureState: { status: 'incomplete' },
+            });
+            expect(result.status).toBe('unreconciled');
+            expect(result.fact).toBeNull();
+        });
+
+        it('explicitly refuses "provider returned nothing" as day closure', () => {
+            const result = reconcileGeneratedRestOutcome({
+                recommendation: baseRecommendation,
+                closureState: { status: 'provider_empty_unverified' },
+            });
+            expect(result.status).toBe('unreconciled');
+            expect(result.fact).toBeNull();
+        });
+
+        it('mints an engine_rest_day_outcome fact when day reconciliation has authoritative clean closure and no contradictions', () => {
+            const result = reconcileGeneratedRestOutcome({
+                recommendation: baseRecommendation,
+                closureState: { status: 'authoritative_clean_closure', closedAt: '2026-09-09T03:00:00.000Z' },
+                contradictoryOccurrences: [],
+            });
+            expect(result.status).toBe('credited');
+            expect(result.fact).not.toBeNull();
+            expect(result.fact?.date).toBe('2026-09-08');
+            expect(result.fact?.source.kind).toBe('engine_rest_day_outcome');
+            if (result.fact?.source.kind === 'engine_rest_day_outcome') {
+                expect(result.fact.source.recommendationAuditId).toBe('audit_rev_123');
+                expect(result.fact.source.policyVersion).toBe('2026-09-adr-0038-recovery-identity-v1');
+                expect(result.fact.source.reconciliationStatus).toBe('authoritative_clean_closure');
+            }
+        });
+
+        it('mints an engine_rest_day_outcome fact when athlete confirmed adherence to rest', () => {
+            const result = reconcileGeneratedRestOutcome({
+                recommendation: {
+                    ...baseRecommendation,
+                    adherence: {
+                        respondedAt: '2026-09-08T20:00:00.000Z',
+                        followed: true,
+                        actualModality: null,
+                        actualDurationMin: null,
+                        skipped: false,
+                        notes: null,
+                    },
+                },
+                closureState: { status: 'adherence_confirmed' },
+            });
+            expect(result.status).toBe('credited');
+            expect(result.fact?.source.kind).toBe('engine_rest_day_outcome');
+        });
+
+        it('suppresses fact when contradictory performed training occurred on the rest date', () => {
+            const result = reconcileGeneratedRestOutcome({
+                recommendation: baseRecommendation,
+                closureState: { status: 'authoritative_clean_closure', closedAt: '2026-09-09T03:00:00.000Z' },
+                contradictoryOccurrences: [
+                    {
+                        performedOccurrenceId: 'occ_contra_01',
+                        localDate: '2026-09-08',
+                        modality: 'Running',
+                    },
+                ],
+            });
+            expect(result.status).toBe('contradicted');
+            expect(result.fact).toBeNull();
+        });
+
+        it('rejects non-rest recommendations and un-audited recommendations', () => {
+            const nonRestResult = reconcileGeneratedRestOutcome({
+                recommendation: {
+                    ...baseRecommendation,
+                    category: 'Hard Endurance',
+                    templateId: 'tempo_run',
+                },
+                closureState: { status: 'authoritative_clean_closure', closedAt: '2026-09-09T03:00:00.000Z' },
+            });
+            expect(nonRestResult.status).toBe('not_rest');
+            expect(nonRestResult.fact).toBeNull();
+
+            const unAuditedResult = reconcileGeneratedRestOutcome({
+                recommendation: {
+                    ...baseRecommendation,
+                    recommendationAudit: undefined,
+                },
+                closureState: { status: 'authoritative_clean_closure', closedAt: '2026-09-09T03:00:00.000Z' },
+            });
+            expect(unAuditedResult.status).toBe('unreconciled');
+            expect(unAuditedResult.fact).toBeNull();
+        });
+    });
+
+    describe('Work D: durable bootstrap resolver and recovery history snapshot', () => {
+        it('reuses stored bootstrap date B on repeated daily planning without sliding', () => {
+            const storedB = '2026-09-01';
+
+            const day1 = resolveBootstrapDate({
+                storedBootstrapDate: storedB,
+                asOfDate: '2026-09-02',
+            });
+            const day2 = resolveBootstrapDate({
+                storedBootstrapDate: storedB,
+                asOfDate: '2026-09-03',
+            });
+            const day8 = resolveBootstrapDate({
+                storedBootstrapDate: storedB,
+                asOfDate: '2026-09-08',
+            });
+
+            expect(day1.bootstrapDate).toBe('2026-09-01');
+            expect(day1.isNewlyGenerated).toBe(false);
+            expect(day2.bootstrapDate).toBe('2026-09-01');
+            expect(day2.isNewlyGenerated).toBe(false);
+            expect(day8.bootstrapDate).toBe('2026-09-01');
+            expect(day8.isNewlyGenerated).toBe(false);
+        });
+
+        it('initializes bootstrap date once when no stored date exists', () => {
+            const init = resolveBootstrapDate({
+                asOfDate: '2026-09-01',
+            });
+            expect(init.bootstrapDate).toBe('2026-09-01');
+            expect(init.isNewlyGenerated).toBe(true);
+        });
+
+        it('builds a RecoveryHistorySnapshot deduplicating dates and resolving latestQualifyingRecoveryDate', () => {
+            const facts: RecoveryPlacementFact[] = [
+                {
+                    date: '2026-09-03',
+                    source: {
+                        kind: 'authored_rest',
+                        planId: 'p1',
+                        revision: 1,
+                        contentHash: 'h1',
+                        restDirectiveId: 'd1',
+                        date: '2026-09-03',
+                    },
+                },
+                {
+                    date: '2026-09-06',
+                    source: {
+                        kind: 'performed_recovery',
+                        performedOccurrenceId: 'occ_1',
+                        workoutId: 'recovery_mobility_tissue_01',
+                        qualification: {
+                            coverageSetId: 'evergreen_general',
+                            phase: 'general',
+                            coverageKey: 'recovery_or_rest',
+                        },
+                    },
+                },
+                {
+                    date: '2026-09-06', // duplicate date
+                    source: {
+                        kind: 'engine_rest_day_outcome',
+                        recommendationAuditId: 'audit_1',
+                        policyVersion: 'v1',
+                        reconciliationStatus: 'authoritative_clean_closure',
+                    },
+                },
+            ];
+
+            const snapshot = buildRecoveryHistorySnapshot({
+                asOfDate: '2026-09-08',
+                facts,
+                bootstrapDate: '2026-09-01',
+            });
+
+            expect(snapshot.asOfDate).toBe('2026-09-08');
+            expect(snapshot.qualifyingRecoveryDates).toEqual(['2026-09-03', '2026-09-06']);
+            expect(snapshot.latestQualifyingRecoveryDate).toBe('2026-09-06');
+            expect(snapshot.bootstrapDate).toBe('2026-09-01');
+
+            // Resolving placement state with snapshot output gives R + 7 = 2026-09-13
+            const state = resolveRecoveryPlacementState({
+                asOfDate: snapshot.asOfDate,
+                latestQualifyingRecoveryDate: snapshot.latestQualifyingRecoveryDate,
+                bootstrapDate: snapshot.bootstrapDate,
+            });
+            expect(state.historicalState).toBe('known');
+            expect(state.referenceDate).toBe('2026-09-06');
+            expect(state.dueByDate).toBe('2026-09-13');
+            expect(state.isDueToday).toBe(false);
+            expect(state.daysUntilDue).toBe(5);
+        });
+    });
+});

--- a/app/src/engine/recoveryFacts.test.ts
+++ b/app/src/engine/recoveryFacts.test.ts
@@ -9,14 +9,12 @@ import {
     validatePerformedRecoveryFact,
     type RecoveryPlacementFact,
 } from './recoveryFacts';
-import {
-    resolveRecoveryAuthority,
-    resolveRecoveryPlacementState,
-} from './recoveryPlacement';
+import { resolveRecoveryAuthority, resolveRecoveryPlacementState } from './recoveryPlacement';
+import { computeContentHash } from './externalPlanHash';
+import { POLICY_VERSION } from './policy';
 import type { PerformedTrainingOccurrence } from '../training-occurrence/models';
 import type { CoverageCreditFact, PerformedExposureFact } from './performedTrainingFacts';
-import type { ExternalRestProvenance } from './models';
-import type { ExternalRestDecisionProvenance } from './externalRestProvenance';
+import { EXTERNAL_PLAN_SCHEMA, type DailyRecommendation, type ExternalTrainingPlan } from './models';
 
 function mockOccurrence(overrides: Partial<PerformedTrainingOccurrence> = {}): PerformedTrainingOccurrence {
     return {
@@ -36,10 +34,91 @@ function mockOccurrence(overrides: Partial<PerformedTrainingOccurrence> = {}): P
     };
 }
 
+function coveragePair(): { credit: CoverageCreditFact; exposure: PerformedExposureFact } {
+    return {
+        credit: {
+            performedOccurrenceId: 'occ_credit_01',
+            coverageSetId: 'evergreen_general',
+            coverageKey: 'recovery_or_rest',
+            workoutId: 'recovery_mobility_tissue_01',
+            creditKind: 'exact',
+            confidence: 1,
+            reasonCode: 'exact_workout_identity',
+            sourceKinds: ['structured_execution'],
+        },
+        exposure: {
+            performedOccurrenceId: 'occ_credit_01',
+            localDate: '2026-09-08',
+            modality: 'Mobility',
+            confidence: 'exact',
+            sourceKinds: ['structured_execution'],
+            evidenceTier: 'completedStructuredWorkout',
+            workoutId: 'recovery_mobility_tissue_01',
+        },
+    };
+}
+
+const PLAN_ID = 'autumn-block';
+const DIRECTIVE_ID = 'w1-tue-rest';
+
+function restPlan(overrides: Partial<ExternalTrainingPlan> = {}): ExternalTrainingPlan {
+    return {
+        schema: EXTERNAL_PLAN_SCHEMA,
+        planId: PLAN_ID,
+        revision: 1,
+        title: '4-week block',
+        startDate: '2026-08-17',
+        weekCount: 4,
+        sessions: [{
+            id: 'w1-threshold',
+            title: 'Threshold 3x12',
+            priority: 'key',
+            placement: { week: 1, preferredDay: 'monday', flexibility: 'preferred', ifMissed: 'drop' },
+            gating: { modality: 'cycling', intensity: 'hard', durationMin: 60, durationMax: 75, environment: 'either', equipment: [] },
+            prescription: { summary: '3x12 at threshold.' },
+        }],
+        restDays: [{ id: DIRECTIVE_ID, week: 1, day: 'tuesday' }],
+        ...overrides,
+    } as ExternalTrainingPlan;
+}
+
+async function authoredRestRecommendation(plan: ExternalTrainingPlan): Promise<DailyRecommendation> {
+    return {
+        userId: 'u1',
+        date: '2026-08-18',
+        templateId: 'rest_01',
+        templateTitle: 'Rest',
+        category: 'Rest',
+        modality: 'None',
+        mode: 'recover',
+        rationale: 'protected rest',
+        schemaVersion: 3,
+        createdAt: '',
+        updatedAt: '',
+        adherence: { respondedAt: null, followed: null, actualModality: null, actualDurationMin: null, skipped: false, notes: null },
+        recommendationAudit: {
+            policyVersion: POLICY_VERSION,
+            evaluatedAt: '2026-08-18T08:00:00Z',
+            decisionContextRevision: 'history-v1:2026-08-18:7:none:none',
+            safetyStatus: 'complete',
+            history: { completedEventCount: 1, unmatchedEventCount: 0, sourceStatuses: { activities: 'AVAILABLE', recommendations: 'AVAILABLE', manualTraining: 'MISSING' } },
+            envelope: { safetyRestrictedModalityCount: 0, planMaxAllowableTier: 'Rest' },
+            candidateScores: [],
+            droppedContributorObjectives: [],
+            externalRest: {
+                planId: PLAN_ID,
+                revision: 1,
+                contentHash: await computeContentHash(plan),
+                restDirectiveId: DIRECTIVE_ID,
+                date: '2026-08-18',
+            },
+        },
+    };
+}
+
 describe('ADR-0038 historical recovery truth (RP2)', () => {
-    describe('Work A: performed active recovery facts', () => {
-        it('derives a RecoveryPlacementFact for exact active recovery with workoutId and qualification authority', () => {
-            const occurrence = mockOccurrence();
+    describe('performed recovery facts', () => {
+        it('derives exact recovery only from an active canonical occurrence', () => {
             const hydrated = {
                 structured: {
                     executionId: 'exec_01',
@@ -50,426 +129,238 @@ describe('ADR-0038 historical recovery truth (RP2)', () => {
             };
             const authority = resolveRecoveryAuthority(null);
 
-            const fact = deriveRecoveryFactFromPerformedOccurrence(occurrence, hydrated, authority);
-            expect(fact).not.toBeNull();
-            expect(fact?.date).toBe('2026-09-08');
-            expect(fact?.source.kind).toBe('performed_recovery');
-            if (fact?.source.kind === 'performed_recovery') {
-                expect(fact.source.performedOccurrenceId).toBe('occ_rec_01');
-                expect(fact.source.workoutId).toBe('recovery_mobility_tissue_01');
-                expect(fact.source.qualification).toEqual({
-                    coverageSetId: 'evergreen_general',
-                    phase: 'general',
-                    coverageKey: 'recovery_or_rest',
-                });
-                expect(fact.source.templateId).toBe('mobility_recovery');
-            }
+            expect(deriveRecoveryFactFromPerformedOccurrence(mockOccurrence(), hydrated, authority)?.source.kind)
+                .toBe('performed_recovery');
+            expect(deriveRecoveryFactFromPerformedOccurrence(mockOccurrence({ status: 'merged', mergedIntoOccurrenceId: 'survivor' }), hydrated, authority))
+                .toBeNull();
         });
 
-        it('derives a fact for cycling recovery spin and breathwork under active recovery identities', () => {
-            const spinOccurrence = mockOccurrence({ performedOccurrenceId: 'occ_spin' });
-            const spinHydrated = {
-                structured: {
-                    executionId: 'exec_spin',
-                    workoutId: 'cycling_recovery_spin_01',
-                    modality: 'Cycling' as const,
-                },
-            };
-            const breathOccurrence = mockOccurrence({ performedOccurrenceId: 'occ_breath' });
-            const breathHydrated = {
-                structured: {
-                    executionId: 'exec_breath',
-                    workoutId: 'recovery_breathwork_01',
-                    modality: 'Mobility' as const,
-                },
-            };
+        it('fails closed on generic modality and non-recovery workout identity', () => {
             const authority = resolveRecoveryAuthority(null);
-
-            const spinFact = deriveRecoveryFactFromPerformedOccurrence(spinOccurrence, spinHydrated, authority);
-            expect(spinFact).not.toBeNull();
-            expect(spinFact?.source.kind).toBe('performed_recovery');
-            if (spinFact?.source.kind === 'performed_recovery') {
-                expect(spinFact.source.workoutId).toBe('cycling_recovery_spin_01');
-            }
-
-            const breathFact = deriveRecoveryFactFromPerformedOccurrence(breathOccurrence, breathHydrated, authority);
-            expect(breathFact).not.toBeNull();
-            expect(breathFact?.source.kind).toBe('performed_recovery');
-            if (breathFact?.source.kind === 'performed_recovery') {
-                expect(breathFact.source.workoutId).toBe('recovery_breathwork_01');
-            }
+            expect(deriveRecoveryFactFromPerformedOccurrence(mockOccurrence(), {
+                provider: { activityId: 'g1', provider: 'garmin', modality: 'Mobility' as const },
+            }, authority)).toBeNull();
+            expect(deriveRecoveryFactFromPerformedOccurrence(mockOccurrence(), {
+                structured: { executionId: 'e2', workoutId: 'running_aerobic_base_01', modality: 'Running' as const },
+            }, authority)).toBeNull();
         });
 
-        it('fails closed when modality is generic mobility without exact catalog workout identity', () => {
-            const occurrence = mockOccurrence();
-            const hydrated = {
-                provider: {
-                    activityId: 'garmin_act_01',
-                    provider: 'garmin',
-                    modality: 'Mobility' as const,
-                },
-            };
+        it('requires coverage credit and exposure to describe the same occurrence/workout/authority', () => {
             const authority = resolveRecoveryAuthority(null);
-
-            const fact = deriveRecoveryFactFromPerformedOccurrence(occurrence, hydrated, authority);
-            expect(fact).toBeNull();
+            const { credit, exposure } = coveragePair();
+            expect(deriveRecoveryFactFromCoverageCreditFact(credit, exposure, authority)?.date).toBe('2026-09-08');
+            expect(deriveRecoveryFactFromCoverageCreditFact(
+                { ...credit, performedOccurrenceId: 'other' }, exposure, authority,
+            )).toBeNull();
+            expect(deriveRecoveryFactFromCoverageCreditFact(
+                credit, { ...exposure, workoutId: 'cycling_recovery_spin_01' }, authority,
+            )).toBeNull();
+            expect(deriveRecoveryFactFromCoverageCreditFact(
+                { ...credit, coverageSetId: 'september_cycling_event' }, exposure, authority,
+            )).toBeNull();
+            expect(deriveRecoveryFactFromCoverageCreditFact(
+                { ...credit, workoutId: undefined }, exposure, authority,
+            )).toBeNull();
         });
 
-        it('fails closed when workoutId is legacy_strength or non-recovery workout', () => {
-            const occurrence = mockOccurrence();
-            const hydratedStrength = {
-                structured: {
-                    executionId: 'exec_legacy',
-                    workoutId: 'legacy_strength',
-                    modality: 'Strength' as const,
-                },
-            };
-            const hydratedNonRecovery = {
-                structured: {
-                    executionId: 'exec_run',
-                    workoutId: 'running_aerobic_base_01',
-                    modality: 'Running' as const,
-                },
-            };
+        it('revalidates persisted exact identity and qualification authority', () => {
             const authority = resolveRecoveryAuthority(null);
-
-            expect(deriveRecoveryFactFromPerformedOccurrence(occurrence, hydratedStrength, authority)).toBeNull();
-            expect(deriveRecoveryFactFromPerformedOccurrence(occurrence, hydratedNonRecovery, authority)).toBeNull();
-        });
-
-        it('derives a fact from CoverageCreditFact when coverageKey is recovery_or_rest and creditKind is exact', () => {
-            const credit: CoverageCreditFact = {
-                performedOccurrenceId: 'occ_credit_01',
-                coverageSetId: 'evergreen_general',
-                coverageKey: 'recovery_or_rest',
-                workoutId: 'recovery_mobility_tissue_01',
-                creditKind: 'exact',
-                confidence: 1.0,
-                reasonCode: 'exact_workout_identity',
-                sourceKinds: ['structured_execution'],
-            };
-            const exposure: PerformedExposureFact = {
-                performedOccurrenceId: 'occ_credit_01',
-                localDate: '2026-09-08',
-                modality: 'Mobility',
-                confidence: 'exact',
-                sourceKinds: ['structured_execution'],
-                evidenceTier: 'completedStructuredWorkout',
-                workoutId: 'recovery_mobility_tissue_01',
-            };
-            const authority = resolveRecoveryAuthority(null);
-
-            const fact = deriveRecoveryFactFromCoverageCreditFact(credit, exposure, authority);
-            expect(fact).not.toBeNull();
-            expect(fact?.source.kind).toBe('performed_recovery');
-            if (fact?.source.kind === 'performed_recovery') {
-                expect(fact.source.workoutId).toBe('recovery_mobility_tissue_01');
-                expect(fact.source.qualification.coverageKey).toBe('recovery_or_rest');
-            }
-        });
-
-        it('pure validator confirms qualifying workoutId under authority and rejects altered/unmapped workoutId', () => {
-            const authority = resolveRecoveryAuthority(null);
-            const validFact: RecoveryPlacementFact = {
+            const fact: RecoveryPlacementFact = {
                 date: '2026-09-08',
                 source: {
                     kind: 'performed_recovery',
-                    performedOccurrenceId: 'occ_01',
+                    performedOccurrenceId: 'occ_1',
                     workoutId: 'recovery_mobility_tissue_01',
-                    qualification: {
-                        coverageSetId: 'evergreen_general',
-                        phase: 'general',
-                        coverageKey: 'recovery_or_rest',
-                    },
+                    qualification: { coverageSetId: 'evergreen_general', phase: 'general', coverageKey: 'recovery_or_rest' },
                 },
             };
-            expect(validatePerformedRecoveryFact(validFact, authority)).toBe(true);
-
-            // Mutated workoutId that does not qualify under authority
-            const invalidFact: RecoveryPlacementFact = {
-                date: '2026-09-08',
-                source: {
-                    kind: 'performed_recovery',
-                    performedOccurrenceId: 'occ_01',
-                    workoutId: 'cycling_vo2_intervals_01',
-                    qualification: {
-                        coverageSetId: 'evergreen_general',
-                        phase: 'general',
-                        coverageKey: 'recovery_or_rest',
-                    },
-                },
-            };
-            expect(validatePerformedRecoveryFact(invalidFact, authority)).toBe(false);
-
-            // Mismatched phase/coverageSetId
-            const mismatchedAuthorityFact: RecoveryPlacementFact = {
-                date: '2026-09-08',
-                source: {
-                    kind: 'performed_recovery',
-                    performedOccurrenceId: 'occ_01',
-                    workoutId: 'recovery_mobility_tissue_01',
-                    qualification: {
-                        coverageSetId: 'september_cycling_event',
-                        phase: 'taper',
-                        coverageKey: 'recovery_or_rest',
-                    },
-                },
-            };
-            expect(validatePerformedRecoveryFact(mismatchedAuthorityFact, authority)).toBe(false);
+            expect(validatePerformedRecoveryFact(fact, authority)).toBe(true);
+            expect(validatePerformedRecoveryFact({ ...fact, date: 'bad-date' }, authority)).toBe(false);
+            if (fact.source.kind === 'performed_recovery') {
+                expect(validatePerformedRecoveryFact({
+                    ...fact,
+                    source: { ...fact.source, workoutId: 'cycling_vo2_intervals_01' },
+                }, authority)).toBe(false);
+            }
         });
     });
 
-    describe('Work B: ADR-0035 authored Rest bridge', () => {
-        const baseProvenance: ExternalRestProvenance = {
-            planId: 'plan_ext_01',
-            revision: 2,
-            contentHash: 'hash_abc123',
-            restDirectiveId: 'directive_rest_01',
-            date: '2026-09-08',
-        };
+    describe('ADR-0035 authored Rest bridge', () => {
+        it('credits only a recommendation that passes the existing revision replay path', async () => {
+            const plan = restPlan();
+            const recommendation = await authoredRestRecommendation(plan);
+            const result = await deriveRecoveryFactFromAuthoredRest(recommendation, plan);
 
-        it('credits valid authored Rest with canonical ExternalRestProvenance', () => {
-            const result = deriveRecoveryFactFromAuthoredRest(baseProvenance);
             expect(result.reason).toBeUndefined();
-            expect(result.fact).not.toBeNull();
-            expect(result.fact?.date).toBe('2026-09-08');
-            expect(result.fact?.source.kind).toBe('authored_rest');
-            if (result.fact?.source.kind === 'authored_rest') {
-                expect(result.fact.source.planId).toBe('plan_ext_01');
-                expect(result.fact.source.restDirectiveId).toBe('directive_rest_01');
-                expect(result.fact.source.contentHash).toBe('hash_abc123');
-            }
-        });
-
-        it('suppresses recovery credit when provenance reports overridden: true while preserving base fields', () => {
-            const overriddenProvenance: ExternalRestDecisionProvenance = {
-                ...baseProvenance,
-                overridden: true,
-            };
-
-            const result = deriveRecoveryFactFromAuthoredRest(overriddenProvenance);
-            expect(result.fact).toBeNull();
-            expect(result.reason).toBe('overridden');
-        });
-
-        it('decision gate: suppresses recovery credit when unrecorded contradictory training occurred on that date', () => {
-            const result = deriveRecoveryFactFromAuthoredRest(baseProvenance, {
-                hasContradictoryTraining: true,
+            expect(result.fact).toMatchObject({
+                date: '2026-08-18',
+                source: { kind: 'authored_rest', planId: PLAN_ID, revision: 1, restDirectiveId: DIRECTIVE_ID },
             });
-            expect(result.fact).toBeNull();
-            expect(result.reason).toBe('contradictory_training');
         });
 
-        it('rejects invalid or malformed provenance without minting fake facts', () => {
-            const invalidProvenance: ExternalRestProvenance = {
-                planId: '',
-                revision: 0,
-                contentHash: '',
-                restDirectiveId: '',
-                date: 'not-a-date',
-            };
-            const result = deriveRecoveryFactFromAuthoredRest(invalidProvenance);
+        it('fails closed when the supplied immutable revision no longer matches the audit hash', async () => {
+            const original = restPlan();
+            const recommendation = await authoredRestRecommendation(original);
+            const mutated = restPlan({ title: 'mutated revision' });
+            const result = await deriveRecoveryFactFromAuthoredRest(recommendation, mutated);
+
             expect(result.fact).toBeNull();
             expect(result.reason).toBe('invalid_provenance');
+            expect(result.replayErrors?.join(' ')).toMatch(/content hash mismatch/i);
+        });
+
+        it('suppresses explicit override and contradictory canonical training', async () => {
+            const plan = restPlan();
+            const overridden = await authoredRestRecommendation(plan);
+            (overridden.recommendationAudit!.externalRest as typeof overridden.recommendationAudit.externalRest & { overridden?: true }).overridden = true;
+            expect((await deriveRecoveryFactFromAuthoredRest(overridden, plan)).reason).toBe('overridden');
+
+            const recommendation = await authoredRestRecommendation(plan);
+            const contradicted = await deriveRecoveryFactFromAuthoredRest(recommendation, plan, { hasContradictoryTraining: true });
+            expect(contradicted.fact).toBeNull();
+            expect(contradicted.reason).toBe('contradictory_training');
         });
     });
 
-    describe('Work C: generated complete-Rest day outcome reconciliation', () => {
+    describe('generated complete-Rest reconciliation', () => {
         const baseRecommendation = {
             date: '2026-09-08',
             category: 'Rest' as const,
             templateId: 'rest_day',
             recommendationAudit: {
-                policyVersion: '2026-09-adr-0038-recovery-identity-v1',
-                decisionContextRevision: 'audit_rev_123',
+                policyVersion: POLICY_VERSION,
+                decisionContextRevision: 'history-v1:2026-09-08:7:none:none',
             },
         };
 
-        it('refuses to mint a historical fact from recommendation alone when day reconciliation is incomplete', () => {
-            const result = reconcileGeneratedRestOutcome({
-                recommendation: baseRecommendation,
-                closureState: { status: 'incomplete' },
-            });
-            expect(result.status).toBe('unreconciled');
-            expect(result.fact).toBeNull();
-        });
-
-        it('explicitly refuses "provider returned nothing" as day closure', () => {
-            const result = reconcileGeneratedRestOutcome({
-                recommendation: baseRecommendation,
-                closureState: { status: 'provider_empty_unverified' },
-            });
-            expect(result.status).toBe('unreconciled');
-            expect(result.fact).toBeNull();
-        });
-
-        it('mints an engine_rest_day_outcome fact when day reconciliation has authoritative clean closure and no contradictions', () => {
-            const result = reconcileGeneratedRestOutcome({
-                recommendation: baseRecommendation,
+        it('requires an exact authority-pinned Rest identity and replay identity', () => {
+            expect(reconcileGeneratedRestOutcome({
+                recommendation: { ...baseRecommendation, templateId: 'easy_01' },
                 closureState: { status: 'authoritative_clean_closure', closedAt: '2026-09-09T03:00:00.000Z' },
-                contradictoryOccurrences: [],
-            });
-            expect(result.status).toBe('credited');
-            expect(result.fact).not.toBeNull();
-            expect(result.fact?.date).toBe('2026-09-08');
-            expect(result.fact?.source.kind).toBe('engine_rest_day_outcome');
-            if (result.fact?.source.kind === 'engine_rest_day_outcome') {
-                expect(result.fact.source.recommendationAuditId).toBe('audit_rev_123');
-                expect(result.fact.source.policyVersion).toBe('2026-09-adr-0038-recovery-identity-v1');
-                expect(result.fact.source.reconciliationStatus).toBe('authoritative_clean_closure');
-            }
+            }).status).toBe('not_rest');
+
+            expect(reconcileGeneratedRestOutcome({
+                recommendation: { ...baseRecommendation, recommendationAudit: { ...baseRecommendation.recommendationAudit, decisionContextRevision: 'synthetic-id' } },
+                closureState: { status: 'authoritative_clean_closure', closedAt: '2026-09-09T03:00:00.000Z' },
+            }).status).toBe('unreconciled');
         });
 
-        it('mints an engine_rest_day_outcome fact when athlete confirmed adherence to rest', () => {
-            const result = reconcileGeneratedRestOutcome({
+        it('requires positive Rest adherence for adherence_confirmed closure', () => {
+            expect(reconcileGeneratedRestOutcome({
+                recommendation: baseRecommendation,
+                closureState: { status: 'adherence_confirmed' },
+            }).status).toBe('unreconciled');
+
+            expect(reconcileGeneratedRestOutcome({
                 recommendation: {
                     ...baseRecommendation,
-                    adherence: {
-                        respondedAt: '2026-09-08T20:00:00.000Z',
-                        followed: true,
-                        actualModality: null,
-                        actualDurationMin: null,
-                        skipped: false,
-                        notes: null,
-                    },
+                    adherence: { respondedAt: '2026-09-08T20:00:00.000Z', followed: false, actualModality: null, actualDurationMin: null, skipped: true, notes: null },
+                },
+                closureState: { status: 'adherence_confirmed' },
+            }).status).toBe('unreconciled');
+
+            const credited = reconcileGeneratedRestOutcome({
+                recommendation: {
+                    ...baseRecommendation,
+                    adherence: { respondedAt: '2026-09-08T20:00:00.000Z', followed: true, actualModality: null, actualDurationMin: null, skipped: false, notes: null },
                 },
                 closureState: { status: 'adherence_confirmed' },
             });
-            expect(result.status).toBe('credited');
-            expect(result.fact?.source.kind).toBe('engine_rest_day_outcome');
+            expect(credited.status).toBe('credited');
+            expect(credited.fact?.source).toMatchObject({
+                kind: 'engine_rest_day_outcome',
+                decisionContextRevision: 'history-v1:2026-09-08:7:none:none',
+                reconciliationEvidenceAt: '2026-09-08T20:00:00.000Z',
+            });
         });
 
-        it('suppresses fact when contradictory performed training occurred on the rest date', () => {
-            const result = reconcileGeneratedRestOutcome({
+        it('requires parseable authoritative clean closure evidence', () => {
+            expect(reconcileGeneratedRestOutcome({
+                recommendation: baseRecommendation,
+                closureState: { status: 'authoritative_clean_closure', closedAt: 'invalid' },
+            }).status).toBe('unreconciled');
+
+            expect(reconcileGeneratedRestOutcome({
                 recommendation: baseRecommendation,
                 closureState: { status: 'authoritative_clean_closure', closedAt: '2026-09-09T03:00:00.000Z' },
-                contradictoryOccurrences: [
-                    {
-                        performedOccurrenceId: 'occ_contra_01',
-                        localDate: '2026-09-08',
-                        modality: 'Running',
-                    },
-                ],
-            });
-            expect(result.status).toBe('contradicted');
-            expect(result.fact).toBeNull();
+            }).status).toBe('credited');
         });
 
-        it('rejects non-rest recommendations and un-audited recommendations', () => {
-            const nonRestResult = reconcileGeneratedRestOutcome({
-                recommendation: {
-                    ...baseRecommendation,
-                    category: 'Hard Endurance',
-                    templateId: 'tempo_run',
-                },
-                closureState: { status: 'authoritative_clean_closure', closedAt: '2026-09-09T03:00:00.000Z' },
-            });
-            expect(nonRestResult.status).toBe('not_rest');
-            expect(nonRestResult.fact).toBeNull();
+        it('blocks active contradictory training but ignores merged occurrence tombstones', () => {
+            const closureState = { status: 'authoritative_clean_closure' as const, closedAt: '2026-09-09T03:00:00.000Z' };
+            expect(reconcileGeneratedRestOutcome({
+                recommendation: baseRecommendation,
+                closureState,
+                contradictoryOccurrences: [{ performedOccurrenceId: 'active', localDate: '2026-09-08', modality: 'Running', status: 'active' }],
+            }).status).toBe('contradicted');
 
-            const unAuditedResult = reconcileGeneratedRestOutcome({
-                recommendation: {
-                    ...baseRecommendation,
-                    recommendationAudit: undefined,
-                },
-                closureState: { status: 'authoritative_clean_closure', closedAt: '2026-09-09T03:00:00.000Z' },
-            });
-            expect(unAuditedResult.status).toBe('unreconciled');
-            expect(unAuditedResult.fact).toBeNull();
+            expect(reconcileGeneratedRestOutcome({
+                recommendation: baseRecommendation,
+                closureState,
+                contradictoryOccurrences: [{ performedOccurrenceId: 'merged', localDate: '2026-09-08', modality: 'Running', status: 'merged' }],
+            }).status).toBe('credited');
+        });
+
+        it('never treats provider-empty state as Rest closure', () => {
+            expect(reconcileGeneratedRestOutcome({
+                recommendation: baseRecommendation,
+                closureState: { status: 'provider_empty_unverified' },
+            }).status).toBe('unreconciled');
         });
     });
 
-    describe('Work D: durable bootstrap resolver and recovery history snapshot', () => {
-        it('reuses stored bootstrap date B on repeated daily planning without sliding', () => {
-            const storedB = '2026-09-01';
+    describe('stable bootstrap and historical snapshot', () => {
+        it('reuses a valid stored B and fails closed on malformed persisted B', () => {
+            expect(resolveBootstrapDate({ storedBootstrapDate: '2026-09-01', asOfDate: '2026-09-08' }))
+                .toEqual({ bootstrapDate: '2026-09-01', isNewlyGenerated: false });
+            expect(() => resolveBootstrapDate({ storedBootstrapDate: 'bad-date', asOfDate: '2026-09-08' }))
+                .toThrow(/storedBootstrapDate is invalid/);
+        });
 
-            const day1 = resolveBootstrapDate({
-                storedBootstrapDate: storedB,
-                asOfDate: '2026-09-02',
+        it('excludes the unknown prefix through B plus same-day/future facts, while retaining older post-B history', () => {
+            const authoredFact = (date: string, id: string): RecoveryPlacementFact => ({
+                date,
+                source: { kind: 'authored_rest', planId: 'p', revision: 1, contentHash: 'h', restDirectiveId: id, date },
             });
-            const day2 = resolveBootstrapDate({
-                storedBootstrapDate: storedB,
-                asOfDate: '2026-09-03',
+            const snapshot = buildRecoveryHistorySnapshot({
+                asOfDate: '2026-09-12',
+                bootstrapDate: '2026-09-01',
+                facts: [
+                    authoredFact('2026-08-30', 'pre'),
+                    authoredFact('2026-09-01', 'bootstrap-day'),
+                    authoredFact('2026-09-03', 'old-post-bootstrap'),
+                    authoredFact('2026-09-10', 'latest'),
+                    authoredFact('2026-09-12', 'same-day'),
+                    authoredFact('2026-09-13', 'future'),
+                ],
             });
-            const day8 = resolveBootstrapDate({
-                storedBootstrapDate: storedB,
+
+            expect(snapshot.qualifyingRecoveryDates).toEqual(['2026-09-03', '2026-09-10']);
+            expect(snapshot.latestQualifyingRecoveryDate).toBe('2026-09-10');
+            expect(snapshot.facts.map(fact => fact.date)).toEqual(['2026-09-03', '2026-09-10']);
+        });
+
+        it('feeds the latest trustworthy historical fact into the normal R + 7 deadline', () => {
+            const snapshot = buildRecoveryHistorySnapshot({
                 asOfDate: '2026-09-08',
-            });
-
-            expect(day1.bootstrapDate).toBe('2026-09-01');
-            expect(day1.isNewlyGenerated).toBe(false);
-            expect(day2.bootstrapDate).toBe('2026-09-01');
-            expect(day2.isNewlyGenerated).toBe(false);
-            expect(day8.bootstrapDate).toBe('2026-09-01');
-            expect(day8.isNewlyGenerated).toBe(false);
-        });
-
-        it('initializes bootstrap date once when no stored date exists', () => {
-            const init = resolveBootstrapDate({
-                asOfDate: '2026-09-01',
-            });
-            expect(init.bootstrapDate).toBe('2026-09-01');
-            expect(init.isNewlyGenerated).toBe(true);
-        });
-
-        it('builds a RecoveryHistorySnapshot deduplicating dates and resolving latestQualifyingRecoveryDate', () => {
-            const facts: RecoveryPlacementFact[] = [
-                {
-                    date: '2026-09-03',
-                    source: {
-                        kind: 'authored_rest',
-                        planId: 'p1',
-                        revision: 1,
-                        contentHash: 'h1',
-                        restDirectiveId: 'd1',
-                        date: '2026-09-03',
-                    },
-                },
-                {
+                bootstrapDate: '2026-09-01',
+                facts: [{
                     date: '2026-09-06',
                     source: {
                         kind: 'performed_recovery',
                         performedOccurrenceId: 'occ_1',
                         workoutId: 'recovery_mobility_tissue_01',
-                        qualification: {
-                            coverageSetId: 'evergreen_general',
-                            phase: 'general',
-                            coverageKey: 'recovery_or_rest',
-                        },
+                        qualification: { coverageSetId: 'evergreen_general', phase: 'general', coverageKey: 'recovery_or_rest' },
                     },
-                },
-                {
-                    date: '2026-09-06', // duplicate date
-                    source: {
-                        kind: 'engine_rest_day_outcome',
-                        recommendationAuditId: 'audit_1',
-                        policyVersion: 'v1',
-                        reconciliationStatus: 'authoritative_clean_closure',
-                    },
-                },
-            ];
-
-            const snapshot = buildRecoveryHistorySnapshot({
-                asOfDate: '2026-09-08',
-                facts,
-                bootstrapDate: '2026-09-01',
+                }],
             });
-
-            expect(snapshot.asOfDate).toBe('2026-09-08');
-            expect(snapshot.qualifyingRecoveryDates).toEqual(['2026-09-03', '2026-09-06']);
-            expect(snapshot.latestQualifyingRecoveryDate).toBe('2026-09-06');
-            expect(snapshot.bootstrapDate).toBe('2026-09-01');
-
-            // Resolving placement state with snapshot output gives R + 7 = 2026-09-13
             const state = resolveRecoveryPlacementState({
                 asOfDate: snapshot.asOfDate,
                 latestQualifyingRecoveryDate: snapshot.latestQualifyingRecoveryDate,
                 bootstrapDate: snapshot.bootstrapDate,
             });
-            expect(state.historicalState).toBe('known');
             expect(state.referenceDate).toBe('2026-09-06');
             expect(state.dueByDate).toBe('2026-09-13');
-            expect(state.isDueToday).toBe(false);
             expect(state.daysUntilDue).toBe(5);
         });
     });

--- a/app/src/engine/recoveryFacts.test.ts
+++ b/app/src/engine/recoveryFacts.test.ts
@@ -212,7 +212,9 @@ describe('ADR-0038 historical recovery truth (RP2)', () => {
         it('suppresses explicit override and contradictory canonical training', async () => {
             const plan = restPlan();
             const overridden = await authoredRestRecommendation(plan);
-            (overridden.recommendationAudit!.externalRest as typeof overridden.recommendationAudit.externalRest & { overridden?: true }).overridden = true;
+            const externalRest = overridden.recommendationAudit!.externalRest;
+            expect(externalRest).toBeDefined();
+            (externalRest as { overridden?: true }).overridden = true;
             expect((await deriveRecoveryFactFromAuthoredRest(overridden, plan)).reason).toBe('overridden');
 
             const recommendation = await authoredRestRecommendation(plan);

--- a/app/src/engine/recoveryFacts.test.ts
+++ b/app/src/engine/recoveryFacts.test.ts
@@ -228,7 +228,7 @@ describe('ADR-0038 historical recovery truth (RP2)', () => {
         const baseRecommendation = {
             date: '2026-09-08',
             category: 'Rest' as const,
-            templateId: 'rest_day',
+            templateId: 'rest_01',
             recommendationAudit: {
                 policyVersion: POLICY_VERSION,
                 decisionContextRevision: 'history-v1:2026-09-08:7:none:none',

--- a/app/src/engine/recoveryFacts.ts
+++ b/app/src/engine/recoveryFacts.ts
@@ -402,14 +402,17 @@ export function reconcileGeneratedRestOutcome(input: ReconcileGeneratedRestInput
         return { fact: null, status: 'contradicted' };
     }
 
+    let reconciliationStatus: 'adherence_confirmed' | 'authoritative_clean_closure' | null = null;
     let reconciliationEvidenceAt: string | null = null;
     if (closureState.status === 'adherence_confirmed') {
+        reconciliationStatus = 'adherence_confirmed';
         reconciliationEvidenceAt = positiveRestAdherenceEvidence(recommendation.adherence);
     } else if (closureState.status === 'authoritative_clean_closure') {
+        reconciliationStatus = 'authoritative_clean_closure';
         reconciliationEvidenceAt = isValidInstant(closureState.closedAt) ? closureState.closedAt : null;
     }
 
-    if (!reconciliationEvidenceAt) {
+    if (!reconciliationStatus || !reconciliationEvidenceAt) {
         return { fact: null, status: 'unreconciled' };
     }
 
@@ -420,7 +423,7 @@ export function reconcileGeneratedRestOutcome(input: ReconcileGeneratedRestInput
                 kind: 'engine_rest_day_outcome',
                 decisionContextRevision,
                 policyVersion,
-                reconciliationStatus: closureState.status,
+                reconciliationStatus,
                 reconciliationEvidenceAt,
             },
         },

--- a/app/src/engine/recoveryFacts.ts
+++ b/app/src/engine/recoveryFacts.ts
@@ -1,0 +1,438 @@
+/**
+ * Pure recovery fact models and derivation boundaries (ADR-0038 Work Package RP2).
+ *
+ * Implements historical recovery truth:
+ * - Work A: Performed active recovery facts with exact workout identity and qualification authority;
+ * - Work B: ADR-0035 authored Rest bridge with override suppression and adherence contradiction checks;
+ * - Work C: Generated complete-Rest outcome reconciliation requiring authoritative closure;
+ * - Work D: Durable bootstrap epoch resolution and historical recovery snapshot derivation.
+ *
+ * Fails closed: non-training is never treated as a performed workout, missing telemetry is
+ * never interpreted as Rest, and generic modality/category without exact catalog identity
+ * never mints recovery credit.
+ */
+
+import type { CoverageSetId, PlanPhase } from '../workouts/event-plan';
+import {
+    isQualifyingRecoveryIdentity,
+    resolveRecoveryAuthority,
+    type RecoveryAuthorityResolution,
+} from './recoveryPlacement';
+import {
+    isExternalRestOverride,
+    type ExternalRestDecisionProvenance,
+} from './externalRestProvenance';
+import type {
+    DailyRecommendation,
+    ExternalRestProvenance,
+    RecommendationAudit,
+    SessionTemplate,
+} from './models';
+import {
+    templateIdForWorkoutId,
+    type CoverageCreditFact,
+    type HydratedOccurrenceContext,
+    type PerformedExposureFact,
+} from './performedTrainingFacts';
+import type { PerformedTrainingOccurrence } from '../training-occurrence/models';
+import { getLocalDateString } from '../utils/localDate';
+
+export interface PerformedRecoveryQualification {
+    coverageSetId: CoverageSetId;
+    phase: PlanPhase;
+    coverageKey: 'recovery_or_rest';
+}
+
+export type RecoveryFactSource =
+    | {
+          kind: 'performed_recovery';
+          performedOccurrenceId: string;
+          workoutId: string;
+          qualification: PerformedRecoveryQualification;
+          templateId?: string;
+      }
+    | {
+          kind: 'authored_rest';
+          planId: string;
+          revision: number;
+          contentHash: string;
+          restDirectiveId: string;
+          date: string;
+          overridden?: true;
+      }
+    | {
+          kind: 'engine_rest_day_outcome';
+          recommendationAuditId: string;
+          policyVersion: string;
+          reconciliationStatus: 'adherence_confirmed' | 'authoritative_clean_closure';
+      };
+
+export interface RecoveryPlacementFact {
+    date: string;
+    source: RecoveryFactSource;
+}
+
+export interface RecoveryHistorySnapshot {
+    asOfDate: string;
+    facts: RecoveryPlacementFact[];
+    qualifyingRecoveryDates: string[];
+    latestQualifyingRecoveryDate: string | null;
+    bootstrapDate: string | null;
+}
+
+function isValidCalendarDate(value: string): boolean {
+    const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+    if (!match) return false;
+    const year = Number(match[1]);
+    const month = Number(match[2]);
+    const day = Number(match[3]);
+    const candidate = new Date(Date.UTC(year, month - 1, day));
+    return candidate.getUTCFullYear() === year
+        && candidate.getUTCMonth() === month - 1
+        && candidate.getUTCDate() === day;
+}
+
+function requirePerformedLocalDate(
+    occurrence: PerformedTrainingOccurrence,
+    startedAt: string | undefined,
+    hydrated: HydratedOccurrenceContext,
+): string {
+    let localDate: string | undefined;
+    if (occurrence.localDate !== undefined) {
+        localDate = occurrence.localDate;
+    } else if (startedAt) {
+        const startedInstant = new Date(startedAt);
+        if (!Number.isNaN(startedInstant.getTime())) {
+            localDate = getLocalDateString(startedInstant);
+        }
+    } else if (hydrated.provider?.garminActivity?.date !== undefined) {
+        localDate = hydrated.provider.garminActivity.date;
+    }
+
+    if (!localDate || !isValidCalendarDate(localDate)) {
+        throw new Error(`Performed training occurrence ${occurrence.performedOccurrenceId} has invalid or missing local date.`);
+    }
+    return localDate;
+}
+
+// ---------------------------------------------------------------------------
+// Work A: Performed active recovery facts
+// ---------------------------------------------------------------------------
+
+/**
+ * Derives a RecoveryPlacementFact from a canonical performed occurrence and its hydrated sources.
+ * Refuses generic modality or unmapped sessions: an exact canonical workoutId must be present
+ * and qualify under the resolved authority descriptor and phase.
+ */
+export function deriveRecoveryFactFromPerformedOccurrence(
+    occurrence: PerformedTrainingOccurrence,
+    hydrated: HydratedOccurrenceContext,
+    authority: RecoveryAuthorityResolution = resolveRecoveryAuthority(null),
+): RecoveryPlacementFact | null {
+    const workoutId = hydrated.structured?.workoutId;
+    if (!workoutId || workoutId === 'legacy_strength') {
+        return null;
+    }
+
+    if (!isQualifyingRecoveryIdentity(workoutId, authority)) {
+        return null;
+    }
+
+    const startedAt = hydrated.structured?.startedAt ?? occurrence.startedAt ?? hydrated.provider?.startedAt;
+    const localDate = requirePerformedLocalDate(occurrence, startedAt, hydrated);
+    const templateId = hydrated.structured?.templateId ?? templateIdForWorkoutId(workoutId);
+
+    return {
+        date: localDate,
+        source: {
+            kind: 'performed_recovery',
+            performedOccurrenceId: occurrence.performedOccurrenceId,
+            workoutId,
+            qualification: {
+                coverageSetId: authority.coverageSetId,
+                phase: authority.phase,
+                coverageKey: 'recovery_or_rest',
+            },
+            ...(templateId ? { templateId } : {}),
+        },
+    };
+}
+
+/**
+ * Derives a RecoveryPlacementFact from an already-derived CoverageCreditFact and PerformedExposureFact.
+ */
+export function deriveRecoveryFactFromCoverageCreditFact(
+    coverageCredit: CoverageCreditFact,
+    exposure: PerformedExposureFact,
+    authority: RecoveryAuthorityResolution = resolveRecoveryAuthority(null),
+): RecoveryPlacementFact | null {
+    if (coverageCredit.coverageKey !== 'recovery_or_rest' || coverageCredit.creditKind !== 'exact') {
+        return null;
+    }
+    const workoutId = coverageCredit.workoutId ?? exposure.workoutId;
+    if (!workoutId || !isQualifyingRecoveryIdentity(workoutId, authority)) {
+        return null;
+    }
+
+    const templateId = exposure.templateId ?? templateIdForWorkoutId(workoutId);
+
+    return {
+        date: exposure.localDate,
+        source: {
+            kind: 'performed_recovery',
+            performedOccurrenceId: exposure.performedOccurrenceId,
+            workoutId,
+            qualification: {
+                coverageSetId: authority.coverageSetId,
+                phase: authority.phase,
+                coverageKey: 'recovery_or_rest',
+            },
+            ...(templateId ? { templateId } : {}),
+        },
+    };
+}
+
+/**
+ * Pure replay validator for performed recovery facts.
+ * Revalidates the persisted workoutId against the recorded qualification authority.
+ * Returns false if the stored identity does not qualify under the authority descriptor & phase.
+ */
+export function validatePerformedRecoveryFact(
+    fact: RecoveryPlacementFact,
+    authority: RecoveryAuthorityResolution,
+): boolean {
+    if (fact.source.kind !== 'performed_recovery') {
+        return false;
+    }
+    const { qualification, workoutId } = fact.source;
+    if (qualification.coverageKey !== 'recovery_or_rest') {
+        return false;
+    }
+    if (qualification.coverageSetId !== authority.coverageSetId || qualification.phase !== authority.phase) {
+        return false;
+    }
+    return isQualifyingRecoveryIdentity(workoutId, authority);
+}
+
+// ---------------------------------------------------------------------------
+// Work B: ADR-0035 Authored Rest bridge
+// ---------------------------------------------------------------------------
+
+export interface DeriveAuthoredRestFactOptions {
+    /**
+     * Set when contradictory canonical training occurred on the resolved date
+     * without an explicit in-app override. Suppresses recovery credit while preserving
+     * original intent in audit.
+     */
+    hasContradictoryTraining?: boolean;
+}
+
+export interface DeriveAuthoredRestFactResult {
+    fact: RecoveryPlacementFact | null;
+    reason?: 'overridden' | 'contradictory_training' | 'invalid_provenance';
+}
+
+function isValidBaseRestProvenance(provenance: ExternalRestProvenance): boolean {
+    return Boolean(
+        provenance.planId && provenance.planId.trim().length > 0
+        && typeof provenance.revision === 'number' && provenance.revision >= 1
+        && provenance.contentHash && provenance.contentHash.trim().length > 0
+        && provenance.restDirectiveId && provenance.restDirectiveId.trim().length > 0
+        && provenance.date && isValidCalendarDate(provenance.date),
+    );
+}
+
+/**
+ * Validates authored Rest provenance and bridges it into an auditable recovery fact.
+ * - Suppresses credit when decision-time provenance reports `overridden: true`.
+ * - Suppresses credit when unrecorded contradictory performed training appears on the date.
+ * - Preserves original base provenance in audit.
+ */
+export function deriveRecoveryFactFromAuthoredRest(
+    provenance: ExternalRestProvenance | ExternalRestDecisionProvenance,
+    options: DeriveAuthoredRestFactOptions = {},
+): DeriveAuthoredRestFactResult {
+    if (!isValidBaseRestProvenance(provenance)) {
+        return { fact: null, reason: 'invalid_provenance' };
+    }
+
+    if (isExternalRestOverride(provenance) || (provenance as ExternalRestDecisionProvenance).overridden === true) {
+        return { fact: null, reason: 'overridden' };
+    }
+
+    if (options.hasContradictoryTraining) {
+        return { fact: null, reason: 'contradictory_training' };
+    }
+
+    return {
+        fact: {
+            date: provenance.date,
+            source: {
+                kind: 'authored_rest',
+                planId: provenance.planId,
+                revision: provenance.revision,
+                contentHash: provenance.contentHash,
+                restDirectiveId: provenance.restDirectiveId,
+                date: provenance.date,
+            },
+        },
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Work C: Generated complete-Rest day outcome reconciliation
+// ---------------------------------------------------------------------------
+
+export type DayReconciliationClosure =
+    | { status: 'adherence_confirmed' }
+    | { status: 'authoritative_clean_closure'; closedAt: string }
+    | { status: 'incomplete' | 'unreconciled' | 'provider_empty_unverified' };
+
+export interface ContradictoryOccurrenceCandidate {
+    performedOccurrenceId?: string;
+    date?: string;
+    localDate?: string;
+    modality?: SessionTemplate['modality'] | 'Unknown';
+}
+
+export interface ReconcileGeneratedRestInput {
+    recommendation: {
+        date: string;
+        category: SessionTemplate['category'];
+        templateId: string;
+        recommendationAudit?: Pick<RecommendationAudit, 'policyVersion' | 'decisionContextRevision'>;
+        adherence?: DailyRecommendation['adherence'];
+    };
+    closureState: DayReconciliationClosure;
+    contradictoryOccurrences?: ContradictoryOccurrenceCandidate[];
+    authority?: RecoveryAuthorityResolution;
+}
+
+export interface ReconcileGeneratedRestResult {
+    fact: RecoveryPlacementFact | null;
+    status: 'credited' | 'contradicted' | 'unreconciled' | 'not_rest';
+}
+
+/**
+ * Pure post-day reconciliation step for generated complete-Rest recommendations.
+ * Emits a historical Rest fact only when:
+ * 1. Persisted recommendation proves canonical Rest was selected with valid policy version;
+ * 2. Reconciliation closure state is authoritative enough to close the day;
+ * 3. No contradictory performed training replaced Rest.
+ *
+ * Missing provider telemetry ("provider returned nothing") is explicitly rejected as closure.
+ */
+export function reconcileGeneratedRestOutcome(input: ReconcileGeneratedRestInput): ReconcileGeneratedRestResult {
+    const { recommendation, closureState, contradictoryOccurrences = [], authority = resolveRecoveryAuthority(null) } = input;
+
+    const isRestRecommendation =
+        recommendation.category === 'Rest'
+        || recommendation.templateId === 'rest_day'
+        || isQualifyingRecoveryIdentity(recommendation.templateId, authority);
+
+    if (!isRestRecommendation) {
+        return { fact: null, status: 'not_rest' };
+    }
+
+    const policyVersion = recommendation.recommendationAudit?.policyVersion;
+    if (!policyVersion) {
+        return { fact: null, status: 'unreconciled' };
+    }
+
+    const hasContradiction = contradictoryOccurrences.some(occ => {
+        const occDate = occ.localDate ?? occ.date;
+        if (occDate !== recommendation.date) return false;
+        // Non-rest activity performed on the rest date is contradictory training
+        return occ.modality !== 'None';
+    });
+
+    if (hasContradiction) {
+        return { fact: null, status: 'contradicted' };
+    }
+
+    if (closureState.status === 'incomplete'
+        || closureState.status === 'unreconciled'
+        || closureState.status === 'provider_empty_unverified') {
+        return { fact: null, status: 'unreconciled' };
+    }
+
+    const recommendationAuditId = recommendation.recommendationAudit?.decisionContextRevision
+        ?? `recommendation_rest:${recommendation.date}`;
+
+    return {
+        fact: {
+            date: recommendation.date,
+            source: {
+                kind: 'engine_rest_day_outcome',
+                recommendationAuditId,
+                policyVersion,
+                reconciliationStatus: closureState.status,
+            },
+        },
+        status: 'credited',
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Work D: Durable bootstrap resolution and recovery history snapshot
+// ---------------------------------------------------------------------------
+
+export interface ResolveBootstrapDateInput {
+    storedBootstrapDate?: string | null;
+    firstEvaluationDate?: string | null;
+    asOfDate?: string;
+}
+
+export interface ResolveBootstrapDateResult {
+    bootstrapDate: string;
+    isNewlyGenerated: boolean;
+}
+
+/**
+ * Pure resolver for the durable recovery-policy bootstrap epoch B.
+ * Reuses the stored epoch when present so repeated recomputation never slides the reference date.
+ */
+export function resolveBootstrapDate(input: ResolveBootstrapDateInput): ResolveBootstrapDateResult {
+    if (input.storedBootstrapDate && isValidCalendarDate(input.storedBootstrapDate)) {
+        return { bootstrapDate: input.storedBootstrapDate, isNewlyGenerated: false };
+    }
+    const candidate = input.firstEvaluationDate ?? input.asOfDate;
+    if (!candidate || !isValidCalendarDate(candidate)) {
+        throw new Error('Cannot resolve bootstrap date: valid storedBootstrapDate, firstEvaluationDate, or asOfDate is required.');
+    }
+    return { bootstrapDate: candidate, isNewlyGenerated: true };
+}
+
+export interface BuildRecoveryHistorySnapshotInput {
+    asOfDate: string;
+    facts: RecoveryPlacementFact[];
+    bootstrapDate?: string | null;
+}
+
+/**
+ * Pure constructor assembling a bounded RecoveryHistorySnapshot from derived facts.
+ * Deduplicates and sorts qualifying recovery dates, resolving the latest qualifying recovery date.
+ */
+export function buildRecoveryHistorySnapshot(input: BuildRecoveryHistorySnapshotInput): RecoveryHistorySnapshot {
+    const { asOfDate, facts, bootstrapDate } = input;
+    const qualifyingDatesSet = new Set<string>();
+
+    for (const fact of facts) {
+        if (isValidCalendarDate(fact.date) && fact.date <= asOfDate) {
+            qualifyingDatesSet.add(fact.date);
+        }
+    }
+
+    const qualifyingRecoveryDates = [...qualifyingDatesSet].sort();
+    const latestQualifyingRecoveryDate = qualifyingRecoveryDates.length > 0
+        ? qualifyingRecoveryDates[qualifyingRecoveryDates.length - 1]
+        : null;
+
+    return {
+        asOfDate,
+        facts: [...facts].sort((a, b) => a.date.localeCompare(b.date)),
+        qualifyingRecoveryDates,
+        latestQualifyingRecoveryDate,
+        bootstrapDate: bootstrapDate ?? null,
+    };
+}

--- a/app/src/engine/recoveryFacts.ts
+++ b/app/src/engine/recoveryFacts.ts
@@ -3,7 +3,7 @@
  *
  * Implements historical recovery truth:
  * - Work A: Performed active recovery facts with exact workout identity and qualification authority;
- * - Work B: ADR-0035 authored Rest bridge with override suppression and adherence contradiction checks;
+ * - Work B: ADR-0035 authored Rest bridge validated through the existing replay path;
  * - Work C: Generated complete-Rest outcome reconciliation requiring authoritative closure;
  * - Work D: Durable bootstrap epoch resolution and historical recovery snapshot derivation.
  *
@@ -25,6 +25,7 @@ import {
 import type {
     DailyRecommendation,
     ExternalRestProvenance,
+    ExternalTrainingPlan,
     RecommendationAudit,
     SessionTemplate,
 } from './models';
@@ -34,8 +35,9 @@ import {
     type HydratedOccurrenceContext,
     type PerformedExposureFact,
 } from './performedTrainingFacts';
-import type { PerformedTrainingOccurrence } from '../training-occurrence/models';
+import type { PerformedTrainingOccurrence, PerformedOccurrenceStatus } from '../training-occurrence/models';
 import { getLocalDateString } from '../utils/localDate';
+import { replayRecommendationAuditAgainstRevision } from './replay';
 
 export interface PerformedRecoveryQualification {
     coverageSetId: CoverageSetId;
@@ -62,9 +64,10 @@ export type RecoveryFactSource =
       }
     | {
           kind: 'engine_rest_day_outcome';
-          recommendationAuditId: string;
+          decisionContextRevision: string;
           policyVersion: string;
           reconciliationStatus: 'adherence_confirmed' | 'authoritative_clean_closure';
+          reconciliationEvidenceAt: string;
       };
 
 export interface RecoveryPlacementFact {
@@ -90,6 +93,12 @@ function isValidCalendarDate(value: string): boolean {
     return candidate.getUTCFullYear() === year
         && candidate.getUTCMonth() === month - 1
         && candidate.getUTCDate() === day;
+}
+
+function isValidInstant(value: unknown): value is string {
+    return typeof value === 'string'
+        && value.trim().length > 0
+        && !Number.isNaN(new Date(value).getTime());
 }
 
 function requirePerformedLocalDate(
@@ -121,14 +130,18 @@ function requirePerformedLocalDate(
 
 /**
  * Derives a RecoveryPlacementFact from a canonical performed occurrence and its hydrated sources.
- * Refuses generic modality or unmapped sessions: an exact canonical workoutId must be present
- * and qualify under the resolved authority descriptor and phase.
+ * Refuses merged/superseded canonical occurrences, generic modality and unmapped sessions: an exact
+ * canonical workoutId must be present and qualify under the resolved authority descriptor and phase.
  */
 export function deriveRecoveryFactFromPerformedOccurrence(
     occurrence: PerformedTrainingOccurrence,
     hydrated: HydratedOccurrenceContext,
     authority: RecoveryAuthorityResolution = resolveRecoveryAuthority(null),
 ): RecoveryPlacementFact | null {
+    if (occurrence.status !== 'active') {
+        return null;
+    }
+
     const workoutId = hydrated.structured?.workoutId;
     if (!workoutId || workoutId === 'legacy_strength') {
         return null;
@@ -159,18 +172,33 @@ export function deriveRecoveryFactFromPerformedOccurrence(
 }
 
 /**
- * Derives a RecoveryPlacementFact from an already-derived CoverageCreditFact and PerformedExposureFact.
+ * Derives a RecoveryPlacementFact from an already-derived CoverageCreditFact and
+ * PerformedExposureFact. Both facts must describe the same canonical occurrence; exact coverage
+ * from one occurrence must never be paired with the date/exposure of another occurrence.
  */
 export function deriveRecoveryFactFromCoverageCreditFact(
     coverageCredit: CoverageCreditFact,
     exposure: PerformedExposureFact,
     authority: RecoveryAuthorityResolution = resolveRecoveryAuthority(null),
 ): RecoveryPlacementFact | null {
+    if (coverageCredit.performedOccurrenceId !== exposure.performedOccurrenceId) {
+        return null;
+    }
+    if (coverageCredit.coverageSetId !== authority.coverageSetId) {
+        return null;
+    }
     if (coverageCredit.coverageKey !== 'recovery_or_rest' || coverageCredit.creditKind !== 'exact') {
         return null;
     }
-    const workoutId = coverageCredit.workoutId ?? exposure.workoutId;
+    if (!isValidCalendarDate(exposure.localDate)) {
+        return null;
+    }
+
+    const workoutId = coverageCredit.workoutId;
     if (!workoutId || !isQualifyingRecoveryIdentity(workoutId, authority)) {
+        return null;
+    }
+    if (exposure.workoutId !== undefined && exposure.workoutId !== workoutId) {
         return null;
     }
 
@@ -195,7 +223,7 @@ export function deriveRecoveryFactFromCoverageCreditFact(
 /**
  * Pure replay validator for performed recovery facts.
  * Revalidates the persisted workoutId against the recorded qualification authority.
- * Returns false if the stored identity does not qualify under the authority descriptor & phase.
+ * Returns false if the stored identity/date/provenance cannot be trusted under the authority.
  */
 export function validatePerformedRecoveryFact(
     fact: RecoveryPlacementFact,
@@ -204,7 +232,10 @@ export function validatePerformedRecoveryFact(
     if (fact.source.kind !== 'performed_recovery') {
         return false;
     }
-    const { qualification, workoutId } = fact.source;
+    const { qualification, workoutId, performedOccurrenceId } = fact.source;
+    if (!isValidCalendarDate(fact.date) || performedOccurrenceId.trim().length === 0 || workoutId.trim().length === 0) {
+        return false;
+    }
     if (qualification.coverageKey !== 'recovery_or_rest') {
         return false;
     }
@@ -230,12 +261,14 @@ export interface DeriveAuthoredRestFactOptions {
 export interface DeriveAuthoredRestFactResult {
     fact: RecoveryPlacementFact | null;
     reason?: 'overridden' | 'contradictory_training' | 'invalid_provenance';
+    /** Existing replay diagnostics when provenance/revision/decision validation fails. */
+    replayErrors?: string[];
 }
 
 function isValidBaseRestProvenance(provenance: ExternalRestProvenance): boolean {
     return Boolean(
         provenance.planId && provenance.planId.trim().length > 0
-        && typeof provenance.revision === 'number' && provenance.revision >= 1
+        && typeof provenance.revision === 'number' && Number.isInteger(provenance.revision) && provenance.revision >= 1
         && provenance.contentHash && provenance.contentHash.trim().length > 0
         && provenance.restDirectiveId && provenance.restDirectiveId.trim().length > 0
         && provenance.date && isValidCalendarDate(provenance.date),
@@ -243,21 +276,28 @@ function isValidBaseRestProvenance(provenance: ExternalRestProvenance): boolean 
 }
 
 /**
- * Validates authored Rest provenance and bridges it into an auditable recovery fact.
- * - Suppresses credit when decision-time provenance reports `overridden: true`.
- * - Suppresses credit when unrecorded contradictory performed training appears on the date.
- * - Preserves original base provenance in audit.
+ * Validates an authored Rest decision through ADR-0035's existing recommendation replay path before
+ * bridging it into historical recovery truth. This proves the immutable revision hash, directive id,
+ * resolved date, canonical Rest selection and the recommendation's normal replay invariants instead
+ * of trusting a shape-valid provenance object in isolation.
  */
-export function deriveRecoveryFactFromAuthoredRest(
-    provenance: ExternalRestProvenance | ExternalRestDecisionProvenance,
+export async function deriveRecoveryFactFromAuthoredRest(
+    recommendation: DailyRecommendation,
+    planRevision: ExternalTrainingPlan,
     options: DeriveAuthoredRestFactOptions = {},
-): DeriveAuthoredRestFactResult {
-    if (!isValidBaseRestProvenance(provenance)) {
+): Promise<DeriveAuthoredRestFactResult> {
+    const provenance = recommendation.recommendationAudit?.externalRest;
+    if (!provenance || !isValidBaseRestProvenance(provenance)) {
         return { fact: null, reason: 'invalid_provenance' };
     }
 
     if (isExternalRestOverride(provenance) || (provenance as ExternalRestDecisionProvenance).overridden === true) {
         return { fact: null, reason: 'overridden' };
+    }
+
+    const replay = await replayRecommendationAuditAgainstRevision(recommendation, planRevision);
+    if (!replay.reproducible) {
+        return { fact: null, reason: 'invalid_provenance', replayErrors: replay.errors };
     }
 
     if (options.hasContradictoryTraining) {
@@ -293,6 +333,7 @@ export interface ContradictoryOccurrenceCandidate {
     date?: string;
     localDate?: string;
     modality?: SessionTemplate['modality'] | 'Unknown';
+    status?: PerformedOccurrenceStatus;
 }
 
 export interface ReconcileGeneratedRestInput {
@@ -313,36 +354,47 @@ export interface ReconcileGeneratedRestResult {
     status: 'credited' | 'contradicted' | 'unreconciled' | 'not_rest';
 }
 
+function positiveRestAdherenceEvidence(adherence: DailyRecommendation['adherence'] | undefined): string | null {
+    if (!adherence || adherence.followed !== true || adherence.skipped === true) {
+        return null;
+    }
+    if (adherence.actualModality !== null && adherence.actualModality !== undefined && adherence.actualModality !== 'None') {
+        return null;
+    }
+    if (typeof adherence.actualDurationMin === 'number' && adherence.actualDurationMin > 0) {
+        return null;
+    }
+    return isValidInstant(adherence.respondedAt) ? adherence.respondedAt : null;
+}
+
 /**
  * Pure post-day reconciliation step for generated complete-Rest recommendations.
  * Emits a historical Rest fact only when:
- * 1. Persisted recommendation proves canonical Rest was selected with valid policy version;
- * 2. Reconciliation closure state is authoritative enough to close the day;
- * 3. No contradictory performed training replaced Rest.
+ * 1. Persisted recommendation proves an exact authority-pinned Rest identity and replay identity;
+ * 2. Reconciliation closure has positive Rest adherence or an authoritative clean closure;
+ * 3. No active contradictory performed training replaced Rest.
  *
  * Missing provider telemetry ("provider returned nothing") is explicitly rejected as closure.
  */
 export function reconcileGeneratedRestOutcome(input: ReconcileGeneratedRestInput): ReconcileGeneratedRestResult {
     const { recommendation, closureState, contradictoryOccurrences = [], authority = resolveRecoveryAuthority(null) } = input;
 
-    const isRestRecommendation =
-        recommendation.category === 'Rest'
-        || recommendation.templateId === 'rest_day'
-        || isQualifyingRecoveryIdentity(recommendation.templateId, authority);
-
-    if (!isRestRecommendation) {
+    if (!isValidCalendarDate(recommendation.date)
+        || !isQualifyingRecoveryIdentity(recommendation.templateId, authority)) {
         return { fact: null, status: 'not_rest' };
     }
 
-    const policyVersion = recommendation.recommendationAudit?.policyVersion;
-    if (!policyVersion) {
+    const policyVersion = recommendation.recommendationAudit?.policyVersion?.trim();
+    const decisionContextRevision = recommendation.recommendationAudit?.decisionContextRevision?.trim();
+    if (!policyVersion || !decisionContextRevision || !decisionContextRevision.startsWith('history-v1:')) {
         return { fact: null, status: 'unreconciled' };
     }
 
     const hasContradiction = contradictoryOccurrences.some(occ => {
+        if (occ.status !== undefined && occ.status !== 'active') return false;
         const occDate = occ.localDate ?? occ.date;
         if (occDate !== recommendation.date) return false;
-        // Non-rest activity performed on the rest date is contradictory training
+        // Any active performed occurrence other than explicit non-training contradicts a Rest day.
         return occ.modality !== 'None';
     });
 
@@ -350,23 +402,26 @@ export function reconcileGeneratedRestOutcome(input: ReconcileGeneratedRestInput
         return { fact: null, status: 'contradicted' };
     }
 
-    if (closureState.status === 'incomplete'
-        || closureState.status === 'unreconciled'
-        || closureState.status === 'provider_empty_unverified') {
-        return { fact: null, status: 'unreconciled' };
+    let reconciliationEvidenceAt: string | null = null;
+    if (closureState.status === 'adherence_confirmed') {
+        reconciliationEvidenceAt = positiveRestAdherenceEvidence(recommendation.adherence);
+    } else if (closureState.status === 'authoritative_clean_closure') {
+        reconciliationEvidenceAt = isValidInstant(closureState.closedAt) ? closureState.closedAt : null;
     }
 
-    const recommendationAuditId = recommendation.recommendationAudit?.decisionContextRevision
-        ?? `recommendation_rest:${recommendation.date}`;
+    if (!reconciliationEvidenceAt) {
+        return { fact: null, status: 'unreconciled' };
+    }
 
     return {
         fact: {
             date: recommendation.date,
             source: {
                 kind: 'engine_rest_day_outcome',
-                recommendationAuditId,
+                decisionContextRevision,
                 policyVersion,
                 reconciliationStatus: closureState.status,
+                reconciliationEvidenceAt,
             },
         },
         status: 'credited',
@@ -391,9 +446,13 @@ export interface ResolveBootstrapDateResult {
 /**
  * Pure resolver for the durable recovery-policy bootstrap epoch B.
  * Reuses the stored epoch when present so repeated recomputation never slides the reference date.
+ * A malformed persisted epoch fails closed rather than silently replacing it with today's date.
  */
 export function resolveBootstrapDate(input: ResolveBootstrapDateInput): ResolveBootstrapDateResult {
-    if (input.storedBootstrapDate && isValidCalendarDate(input.storedBootstrapDate)) {
+    if (input.storedBootstrapDate !== undefined && input.storedBootstrapDate !== null) {
+        if (!isValidCalendarDate(input.storedBootstrapDate)) {
+            throw new Error('Cannot resolve bootstrap date: storedBootstrapDate is invalid.');
+        }
         return { bootstrapDate: input.storedBootstrapDate, isNewlyGenerated: false };
     }
     const candidate = input.firstEvaluationDate ?? input.asOfDate;
@@ -410,29 +469,37 @@ export interface BuildRecoveryHistorySnapshotInput {
 }
 
 /**
- * Pure constructor assembling a bounded RecoveryHistorySnapshot from derived facts.
- * Deduplicates and sorts qualifying recovery dates, resolving the latest qualifying recovery date.
+ * Pure constructor assembling a trustworthy historical RecoveryHistorySnapshot.
+ * Only dates strictly before the evaluation date are historical. When a bootstrap epoch exists,
+ * the unknown-history prefix through B is excluded; a real qualifying fact must occur after B.
+ * Older post-bootstrap facts are retained because the deadline calculation needs the latest known
+ * recovery even when it is more than one seven-day window old (overdue state).
  */
 export function buildRecoveryHistorySnapshot(input: BuildRecoveryHistorySnapshotInput): RecoveryHistorySnapshot {
-    const { asOfDate, facts, bootstrapDate } = input;
-    const qualifyingDatesSet = new Set<string>();
-
-    for (const fact of facts) {
-        if (isValidCalendarDate(fact.date) && fact.date <= asOfDate) {
-            qualifyingDatesSet.add(fact.date);
-        }
+    const { asOfDate, facts, bootstrapDate = null } = input;
+    if (!isValidCalendarDate(asOfDate)) {
+        throw new Error('Cannot build recovery history: asOfDate is invalid.');
+    }
+    if (bootstrapDate !== null && !isValidCalendarDate(bootstrapDate)) {
+        throw new Error('Cannot build recovery history: bootstrapDate is invalid.');
     }
 
-    const qualifyingRecoveryDates = [...qualifyingDatesSet].sort();
+    const historicalFacts = facts
+        .filter(fact => isValidCalendarDate(fact.date)
+            && fact.date < asOfDate
+            && (bootstrapDate === null || fact.date > bootstrapDate))
+        .sort((a, b) => a.date.localeCompare(b.date));
+
+    const qualifyingRecoveryDates = [...new Set(historicalFacts.map(fact => fact.date))].sort();
     const latestQualifyingRecoveryDate = qualifyingRecoveryDates.length > 0
         ? qualifyingRecoveryDates[qualifyingRecoveryDates.length - 1]
         : null;
 
     return {
         asOfDate,
-        facts: [...facts].sort((a, b) => a.date.localeCompare(b.date)),
+        facts: historicalFacts,
         qualifyingRecoveryDates,
         latestQualifyingRecoveryDate,
-        bootstrapDate: bootstrapDate ?? null,
+        bootstrapDate,
     };
 }

--- a/app/src/engine/recoveryPlacement.ts
+++ b/app/src/engine/recoveryPlacement.ts
@@ -338,3 +338,5 @@ export function checkRollingRecoveryInvariant(
         violations,
     };
 }
+
+export * from './recoveryFacts';

--- a/app/src/services/trainingSettingsService.recoveryBootstrap.test.ts
+++ b/app/src/services/trainingSettingsService.recoveryBootstrap.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const firestore = vi.hoisted(() => ({
+    getDoc: vi.fn(),
+    setDoc: vi.fn(),
+    runTransaction: vi.fn(),
+    transactionGet: vi.fn(),
+    transactionSet: vi.fn(),
+}));
+
+vi.mock('firebase/firestore', () => ({
+    doc: vi.fn((_db: unknown, ...segments: string[]) => ({ path: segments.join('/') })),
+    getDoc: firestore.getDoc,
+    setDoc: firestore.setDoc,
+    runTransaction: firestore.runTransaction,
+}));
+
+vi.mock('../firebase', () => ({ getDb: () => ({}) }));
+vi.mock('./constraintService', () => ({
+    constraintService: { listConstraints: vi.fn().mockResolvedValue([]) },
+}));
+
+import { createDefaultTrainingSettings, TrainingSettingsService } from './trainingSettingsService';
+
+function snapshot(data: ReturnType<typeof createDefaultTrainingSettings>) {
+    return { exists: () => true, data: () => data };
+}
+
+describe('ADR-0038 recovery bootstrap persistence', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        firestore.runTransaction.mockImplementation(async (
+            _db: unknown,
+            handler: (transaction: { get: typeof firestore.transactionGet; set: typeof firestore.transactionSet }) => Promise<unknown>,
+        ) => handler({ get: firestore.transactionGet, set: firestore.transactionSet }));
+    });
+
+    it('re-reads inside the transaction so a concurrent first writer wins', async () => {
+        const before = createDefaultTrainingSettings('athlete', '2026-09-01T00:00:00.000Z');
+        const concurrentlyInitialized = { ...before, recoveryBootstrapDate: '2026-09-01' };
+        firestore.getDoc.mockResolvedValue(snapshot(before));
+        firestore.transactionGet.mockResolvedValue(snapshot(concurrentlyInitialized));
+
+        const result = await new TrainingSettingsService().ensureRecoveryBootstrapDate('athlete', '2026-09-03');
+
+        expect(result).toBe('2026-09-01');
+        expect(firestore.transactionSet).not.toHaveBeenCalled();
+    });
+
+    it('initializes B exactly once when the transactional read still has no epoch', async () => {
+        const before = createDefaultTrainingSettings('athlete', '2026-09-01T00:00:00.000Z');
+        firestore.getDoc.mockResolvedValue(snapshot(before));
+        firestore.transactionGet.mockResolvedValue(snapshot(before));
+
+        const result = await new TrainingSettingsService().ensureRecoveryBootstrapDate('athlete', '2026-09-03');
+
+        expect(result).toBe('2026-09-03');
+        expect(firestore.transactionSet).toHaveBeenCalledTimes(1);
+        expect(firestore.transactionSet.mock.calls[0]?.[1]).toMatchObject({
+            userId: 'athlete',
+            recoveryBootstrapDate: '2026-09-03',
+        });
+    });
+
+    it('rejects an invalid candidate date before reading or writing settings', async () => {
+        await expect(new TrainingSettingsService().ensureRecoveryBootstrapDate('athlete', 'not-a-date'))
+            .rejects.toThrow(/asOfDate is invalid/);
+        expect(firestore.getDoc).not.toHaveBeenCalled();
+        expect(firestore.runTransaction).not.toHaveBeenCalled();
+    });
+});

--- a/app/src/services/trainingSettingsService.recoveryBootstrap.test.ts
+++ b/app/src/services/trainingSettingsService.recoveryBootstrap.test.ts
@@ -68,4 +68,37 @@ describe('ADR-0038 recovery bootstrap persistence', () => {
         expect(firestore.getDoc).not.toHaveBeenCalled();
         expect(firestore.runTransaction).not.toHaveBeenCalled();
     });
+
+    it('initializes missing profile and bootstrap date atomically within the transaction', async () => {
+        firestore.transactionGet.mockResolvedValue({ exists: () => false, data: () => null });
+
+        const result = await new TrainingSettingsService().ensureRecoveryBootstrapDate('athlete', '2026-09-03');
+
+        expect(result).toBe('2026-09-03');
+        expect(firestore.transactionSet).toHaveBeenCalledTimes(1);
+        expect(firestore.transactionSet.mock.calls[0]?.[1]).toMatchObject({
+            userId: 'athlete',
+            recoveryBootstrapDate: '2026-09-03',
+        });
+    });
+
+    it('preserves recoveryBootstrapDate in updateTrainingSettings even when settings update starts before bootstrap commits', async () => {
+        const initial = createDefaultTrainingSettings('athlete', '2026-09-01T00:00:00.000Z');
+        const concurrentlyBootstrapped = { ...initial, recoveryBootstrapDate: '2026-09-02' };
+        // Transaction reads the latest committed state which includes recoveryBootstrapDate
+        firestore.transactionGet.mockResolvedValue(snapshot(concurrentlyBootstrapped));
+
+        const updated = await new TrainingSettingsService().updateTrainingSettings('athlete', {
+            defaults: { weekdayMaxMinutes: 45 },
+        });
+
+        expect(updated.recoveryBootstrapDate).toBe('2026-09-02');
+        expect(updated.defaults.weekdayMaxMinutes).toBe(45);
+        expect(firestore.transactionSet).toHaveBeenCalledTimes(1);
+        expect(firestore.transactionSet.mock.calls[0]?.[1]).toMatchObject({
+            userId: 'athlete',
+            recoveryBootstrapDate: '2026-09-02',
+            defaults: expect.objectContaining({ weekdayMaxMinutes: 45 }),
+        });
+    });
 });

--- a/app/src/services/trainingSettingsService.test.ts
+++ b/app/src/services/trainingSettingsService.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createDefaultTrainingSettings, migrateLegacyConstraints, parseTrainingSettings } from './trainingSettingsService';
+import { createDefaultTrainingSettings, mergeSettings, migrateLegacyConstraints, parseTrainingSettings } from './trainingSettingsService';
 import type { UserConstraint } from '../engine/models';
 
 function legacy(key: string, value: UserConstraint['value'], isActive = true): UserConstraint {
@@ -67,5 +67,18 @@ describe('training settings storage parsing', () => {
         const base = createDefaultTrainingSettings('athlete', '2026-08-07T10:00:00.000Z');
         expect(parseTrainingSettings({ ...base, recoveryBootstrapDate: 'invalid-date' }, 'athlete')).toBeNull();
         expect(parseTrainingSettings({ ...base, recoveryBootstrapDate: 12345 }, 'athlete')).toBeNull();
+    });
+
+    it('ensures recoveryBootstrapDate is preserved and cannot be cleared by ordinary settings update', () => {
+        const base = createDefaultTrainingSettings('athlete', '2026-08-07T10:00:00.000Z');
+        const withBootstrap = { ...base, recoveryBootstrapDate: '2026-09-01' };
+        // Even if an update object attempts to inject recoveryBootstrapDate (e.g. from untyped caller)
+        const untypedUpdate = { defaults: { weekdayMaxMinutes: 45 }, recoveryBootstrapDate: '2026-09-05' } as unknown as Parameters<typeof mergeSettings>[1];
+        const updated = mergeSettings(withBootstrap, untypedUpdate);
+        expect(updated.recoveryBootstrapDate).toBe('2026-09-01');
+
+        const clearingUpdate = { defaults: { weekdayMaxMinutes: 30 }, recoveryBootstrapDate: null } as unknown as Parameters<typeof mergeSettings>[1];
+        const clearedAttempt = mergeSettings(withBootstrap, clearingUpdate);
+        expect(clearedAttempt.recoveryBootstrapDate).toBe('2026-09-01');
     });
 });

--- a/app/src/services/trainingSettingsService.test.ts
+++ b/app/src/services/trainingSettingsService.test.ts
@@ -53,4 +53,19 @@ describe('training settings storage parsing', () => {
         }, 'athlete');
         expect(parsed?.injuries?.[0].restrictedModalities).toEqual(['Walking', 'Swimming']);
     });
+
+    it('accepts valid recoveryBootstrapDate and preserves it', () => {
+        const base = createDefaultTrainingSettings('athlete', '2026-08-07T10:00:00.000Z');
+        const parsed = parseTrainingSettings({
+            ...base,
+            recoveryBootstrapDate: '2026-09-01',
+        }, 'athlete');
+        expect(parsed?.recoveryBootstrapDate).toBe('2026-09-01');
+    });
+
+    it('rejects malformed recoveryBootstrapDate', () => {
+        const base = createDefaultTrainingSettings('athlete', '2026-08-07T10:00:00.000Z');
+        expect(parseTrainingSettings({ ...base, recoveryBootstrapDate: 'invalid-date' }, 'athlete')).toBeNull();
+        expect(parseTrainingSettings({ ...base, recoveryBootstrapDate: 12345 }, 'athlete')).toBeNull();
+    });
 });

--- a/app/src/services/trainingSettingsService.ts
+++ b/app/src/services/trainingSettingsService.ts
@@ -1,4 +1,4 @@
-import { doc, getDoc, setDoc } from 'firebase/firestore';
+import { doc, getDoc, runTransaction, setDoc } from 'firebase/firestore';
 import { getDb } from '../firebase';
 import type { BodyRegion, SessionTemplate, TrainingSettings, UserConstraint } from '../engine/models';
 import type { DataState } from '../engine/dataState';
@@ -208,15 +208,35 @@ export class TrainingSettingsService {
 
     /**
      * Reads existing recovery-policy bootstrap date B or initializes it once to `asOfDate`.
-     * Never slides on subsequent calls once established (ADR-0038 Work D).
+     * The transaction re-reads the latest profile and makes initialization first-writer-wins,
+     * so two devices/sessions cannot race and slide the durable epoch (ADR-0038 Work D).
      */
     async ensureRecoveryBootstrapDate(userId: string, asOfDate: string): Promise<string> {
-        const current = await this.getTrainingSettings(userId);
-        if (current.recoveryBootstrapDate) {
-            return current.recoveryBootstrapDate;
+        if (!isValidDate(asOfDate)) {
+            throw new Error('Cannot initialize recovery bootstrap date: asOfDate is invalid.');
         }
-        const updated = await this.updateTrainingSettings(userId, { recoveryBootstrapDate: asOfDate });
-        return updated.recoveryBootstrapDate ?? asOfDate;
+
+        // Preserve the documented first-run settings migration before entering the transaction.
+        await this.getTrainingSettings(userId);
+        const ref = this.ref(userId);
+
+        return runTransaction(getDb(), async transaction => {
+            const snapshot = await transaction.get(ref);
+            if (!snapshot.exists()) {
+                throw new Error('Training settings disappeared while initializing recovery bootstrap date.');
+            }
+            const current = parseTrainingSettings(snapshot.data(), userId);
+            if (!current) {
+                throw new Error('Training settings are invalid. Please review and save them again.');
+            }
+            if (current.recoveryBootstrapDate) {
+                return current.recoveryBootstrapDate;
+            }
+
+            const updated = mergeSettings(current, { recoveryBootstrapDate: asOfDate });
+            transaction.set(ref, updated);
+            return updated.recoveryBootstrapDate ?? asOfDate;
+        });
     }
 }
 

--- a/app/src/services/trainingSettingsService.ts
+++ b/app/src/services/trainingSettingsService.ts
@@ -14,7 +14,6 @@ export type TrainingSettingsUpdate = {
     defaults?: Partial<TrainingSettings['defaults']>;
     preferences?: Partial<TrainingSettings['preferences']>;
     migration?: Partial<TrainingSettings['migration']>;
-    recoveryBootstrapDate?: string | null;
 };
 
 const COLLECTION = 'trainingSettings';
@@ -125,7 +124,7 @@ export function migrateLegacyConstraints(userId: string, constraints: UserConstr
     return result;
 }
 
-function mergeSettings(current: TrainingSettings, update: TrainingSettingsUpdate): TrainingSettings {
+export function mergeSettings(current: TrainingSettings, update: TrainingSettingsUpdate): TrainingSettings {
     const next: TrainingSettings = {
         ...current,
         schemaVersion: CURRENT_TRAINING_SETTINGS_SCHEMA_VERSION,
@@ -135,11 +134,7 @@ function mergeSettings(current: TrainingSettings, update: TrainingSettingsUpdate
         defaults: { ...current.defaults, ...update.defaults },
         preferences: { ...current.preferences, ...update.preferences },
         migration: { ...current.migration, ...update.migration },
-        ...(update.recoveryBootstrapDate !== undefined
-            ? { recoveryBootstrapDate: update.recoveryBootstrapDate }
-            : current.recoveryBootstrapDate !== undefined
-                ? { recoveryBootstrapDate: current.recoveryBootstrapDate }
-                : {}),
+        ...(current.recoveryBootstrapDate !== undefined ? { recoveryBootstrapDate: current.recoveryBootstrapDate } : {}),
         updatedAt: timestamp(),
     };
     if (!parseTrainingSettings(next, current.userId)) throw new Error('Invalid training settings update');
@@ -201,41 +196,67 @@ export class TrainingSettingsService {
     }
 
     async updateTrainingSettings(userId: string, update: TrainingSettingsUpdate): Promise<TrainingSettings> {
-        const updated = mergeSettings(await this.getTrainingSettings(userId), update);
-        await setDoc(this.ref(userId), updated);
-        return updated;
+        const ref = this.ref(userId);
+        return runTransaction(getDb(), async transaction => {
+            const snapshot = await transaction.get(ref);
+            let current: TrainingSettings;
+            if (!snapshot.exists()) {
+                const legacy = await constraintService.listConstraints(userId);
+                current = migrateLegacyConstraints(userId, legacy);
+            } else {
+                const parsed = parseTrainingSettings(snapshot.data(), userId);
+                if (!parsed) {
+                    throw new Error('Training settings are invalid. Please review and save them again.');
+                }
+                current = parsed;
+            }
+
+            const updated = mergeSettings(current, update);
+            transaction.set(ref, updated);
+            return updated;
+        });
     }
 
     /**
      * Reads existing recovery-policy bootstrap date B or initializes it once to `asOfDate`.
      * The transaction re-reads the latest profile and makes initialization first-writer-wins,
      * so two devices/sessions cannot race and slide the durable epoch (ADR-0038 Work D).
+     * Missing profile migration/creation is also handled within the transaction so a delayed
+     * initial migration write cannot clobber a committed bootstrap epoch.
      */
     async ensureRecoveryBootstrapDate(userId: string, asOfDate: string): Promise<string> {
         if (!isValidDate(asOfDate)) {
             throw new Error('Cannot initialize recovery bootstrap date: asOfDate is invalid.');
         }
 
-        // Preserve the documented first-run settings migration before entering the transaction.
-        await this.getTrainingSettings(userId);
         const ref = this.ref(userId);
 
         return runTransaction(getDb(), async transaction => {
             const snapshot = await transaction.get(ref);
+            let current: TrainingSettings;
+
             if (!snapshot.exists()) {
-                throw new Error('Training settings disappeared while initializing recovery bootstrap date.');
+                const legacy = await constraintService.listConstraints(userId);
+                current = migrateLegacyConstraints(userId, legacy);
+            } else {
+                const parsed = parseTrainingSettings(snapshot.data(), userId);
+                if (!parsed) {
+                    throw new Error('Training settings are invalid. Please review and save them again.');
+                }
+                current = parsed;
             }
-            const current = parseTrainingSettings(snapshot.data(), userId);
-            if (!current) {
-                throw new Error('Training settings are invalid. Please review and save them again.');
-            }
+
             if (current.recoveryBootstrapDate) {
                 return current.recoveryBootstrapDate;
             }
 
-            const updated = mergeSettings(current, { recoveryBootstrapDate: asOfDate });
+            const updated: TrainingSettings = {
+                ...current,
+                recoveryBootstrapDate: asOfDate,
+                updatedAt: timestamp(),
+            };
             transaction.set(ref, updated);
-            return updated.recoveryBootstrapDate ?? asOfDate;
+            return asOfDate;
         });
     }
 }

--- a/app/src/services/trainingSettingsService.ts
+++ b/app/src/services/trainingSettingsService.ts
@@ -14,6 +14,7 @@ export type TrainingSettingsUpdate = {
     defaults?: Partial<TrainingSettings['defaults']>;
     preferences?: Partial<TrainingSettings['preferences']>;
     migration?: Partial<TrainingSettings['migration']>;
+    recoveryBootstrapDate?: string | null;
 };
 
 const COLLECTION = 'trainingSettings';
@@ -82,6 +83,10 @@ export function parseTrainingSettings(raw: unknown, userId: string): TrainingSet
         }
     }
 
+    if (data.recoveryBootstrapDate !== undefined && data.recoveryBootstrapDate !== null) {
+        if (typeof data.recoveryBootstrapDate !== 'string' || !isValidDate(data.recoveryBootstrapDate)) return null;
+    }
+
     return {
         ...(data as unknown as TrainingSettings),
         schemaVersion: CURRENT_TRAINING_SETTINGS_SCHEMA_VERSION,
@@ -97,6 +102,7 @@ export function parseTrainingSettings(raw: unknown, userId: string): TrainingSet
             swim_access: typeof equipment.swim_access === 'boolean' ? equipment.swim_access : false,
         },
         injuries: (data.injuries as TrainingSettings['injuries']) ?? [],
+        ...(data.recoveryBootstrapDate !== undefined ? { recoveryBootstrapDate: data.recoveryBootstrapDate as string | null } : {}),
     };
 }
 
@@ -129,6 +135,11 @@ function mergeSettings(current: TrainingSettings, update: TrainingSettingsUpdate
         defaults: { ...current.defaults, ...update.defaults },
         preferences: { ...current.preferences, ...update.preferences },
         migration: { ...current.migration, ...update.migration },
+        ...(update.recoveryBootstrapDate !== undefined
+            ? { recoveryBootstrapDate: update.recoveryBootstrapDate }
+            : current.recoveryBootstrapDate !== undefined
+                ? { recoveryBootstrapDate: current.recoveryBootstrapDate }
+                : {}),
         updatedAt: timestamp(),
     };
     if (!parseTrainingSettings(next, current.userId)) throw new Error('Invalid training settings update');
@@ -193,6 +204,19 @@ export class TrainingSettingsService {
         const updated = mergeSettings(await this.getTrainingSettings(userId), update);
         await setDoc(this.ref(userId), updated);
         return updated;
+    }
+
+    /**
+     * Reads existing recovery-policy bootstrap date B or initializes it once to `asOfDate`.
+     * Never slides on subsequent calls once established (ADR-0038 Work D).
+     */
+    async ensureRecoveryBootstrapDate(userId: string, asOfDate: string): Promise<string> {
+        const current = await this.getTrainingSettings(userId);
+        if (current.recoveryBootstrapDate) {
+            return current.recoveryBootstrapDate;
+        }
+        const updated = await this.updateTrainingSettings(userId, { recoveryBootstrapDate: asOfDate });
+        return updated.recoveryBootstrapDate ?? asOfDate;
     }
 }
 

--- a/docs/plans/adr-0038-recovery-placement.md
+++ b/docs/plans/adr-0038-recovery-placement.md
@@ -294,7 +294,7 @@ Exact identity is deterministic and complete enough for ADR-0038. No broad categ
 
 ## RP2 — Historical recovery facts, authored-rest bridge and bootstrap persistence
 
-**Status:** planned
+**Status:** implemented (PR B)
 **Depends on:** RP0, RP1
 **Behavior change:** historical recovery state becomes available, but ranking activation remains off
 


### PR DESCRIPTION
## Summary

Implements **Work Package RP2** (Historical Recovery Truth) of **ADR-0038** ("Engine-Generated Recovery Placement").

This establishes an auditable historical recovery truth boundary without treating non-training as a performed workout, without interpreting missing telemetry as Rest, and without relying on mutable lookup to recover exact performed-recovery identity.

Ranking activation remains off in this PR; this package focuses exclusively on data trust, provenance, and historical fact derivation.

### Key Changes

1. **Work A — Performed Active Recovery Facts**:
   - `deriveRecoveryFactFromPerformedOccurrence` & `deriveRecoveryFactFromCoverageCreditFact`: Extract exact canonical `workoutId` from structured execution or coverage facts. Validates against `RecoveryAuthorityResolution` (`coverageSetId`, `phase`, `recovery_or_rest`). Fails closed on generic mobility/strength without exact catalog identity.
   - `validatePerformedRecoveryFact`: Pure validator for replay to re-verify persisted `workoutId` against recorded qualification authority.
2. **Work B — ADR-0035 Authored Rest Bridge**:
   - `deriveRecoveryFactFromAuthoredRest`: Consumes `ExternalRestProvenance` / `ExternalRestDecisionProvenance`.
   - Suppresses credit if `overridden: true`.
   - Suppresses credit if unrecorded contradictory training occurred on that date (decision gate for adherence contradiction), while preserving base provenance in audit.
3. **Work C — Generated Complete-Rest Day Outcome Reconciliation**:
   - `reconcileGeneratedRestOutcome`: Requires:
     1. Persisted recommendation proves canonical Rest was selected with valid policy version;
     2. Reconciliation closure state is authoritative (`adherence_confirmed` or `authoritative_clean_closure`);
     3. Absence of contradictory performed training occurrences on that date.
   - Explicitly rejects "provider returned nothing" as day closure.
4. **Work D — Durable Bootstrap Epoch & Snapshot**:
   - Durably stores `recoveryBootstrapDate?: string | null` in `TrainingSettings` (`users/{userId}/trainingSettings/profile`).
   - `resolveBootstrapDate`: Never slides on repeated daily recomputations once established.
   - `buildRecoveryHistorySnapshot`: Deduplicates qualifying recovery dates across performed, authored, and engine rest sources to identify `latestQualifyingRecoveryDate`.

### Verification

- Unit tests: Added 19 comprehensive tests in `app/src/engine/recoveryFacts.test.ts` covering all RP2 acceptance criteria.
- Full check: `npm run check` passed (3,961 tests across 410 test files, typecheck, lint, knowledge validation, and workout catalog validation).
- Policy drift check: `node scripts/check-policy-drift.mjs origin/main` passed (no decision-affecting engine files modified).
- Backend tests: `uv run pytest` passed (816 tests).
- Pre-push hooks passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added historical recovery tracking from completed training, confirmed rest days, eligible recovery activity, and authored rest recommendations.
  - Recovery history now preserves a stable starting date and remains consistent across updates.
  - Added safeguards to prevent recovery credit when activity data is incomplete, invalid, overridden, or contradictory.

- **Documentation**
  - Updated recovery-placement documentation to reflect implemented historical tracking.
  - Recovery ranking activation remains unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->