### PR TITLE
feat(sessions): capture H4 post-AM response evidence

### DIFF
--- a/app/src/components/session/SessionCompletionSheet.test.tsx
+++ b/app/src/components/session/SessionCompletionSheet.test.tsx
@@ -1,12 +1,23 @@
 import { describe, expect, it, vi } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { SessionCompletionSheet } from './SessionCompletionSheet';
+import { SessionCompletionSheet, resolveSubmittedTissueFeedback } from './SessionCompletionSheet';
 import { COMPLETION_TISSUE_LEVEL_OPTIONS } from './sessionCompletionOptions';
 import type { SessionStepSummary } from '../../workouts/strengthSessionEntry';
 
 describe('SessionCompletionSheet', () => {
     it('uses the canonical tissue-response vocabulary for completion feedback', () => {
         expect(COMPLETION_TISSUE_LEVEL_OPTIONS.map(option => option.value)).toEqual(['mild', 'moderate', 'severe']);
+    });
+
+    it('includes the currently selected tissue region when Finish is used before Add region', () => {
+        expect(resolveSubmittedTissueFeedback([], 'knee', 'moderate')).toEqual([
+            { region: 'knee', painDuringTraining: 'moderate', afterTrainingState: 'moderate' },
+        ]);
+    });
+
+    it('does not duplicate a tissue region that was already added', () => {
+        const existing = [{ region: 'knee' as const, painDuringTraining: 'mild' as const, afterTrainingState: 'mild' as const }];
+        expect(resolveSubmittedTissueFeedback(existing, 'knee', 'severe')).toBe(existing);
     });
 
     it('renders summary metrics correctly including duration, total sets, and completed exercises count', () => {

--- a/app/src/components/session/SessionCompletionSheet.test.tsx
+++ b/app/src/components/session/SessionCompletionSheet.test.tsx
@@ -55,6 +55,8 @@ describe('SessionCompletionSheet', () => {
         expect(html).toContain('3');
         expect(html).toContain('Exercises');
         expect(html).toContain('1'); // Only 1 exercise has loggedSetsCount > 0
+        expect(html).toContain('How much of the planned session did you complete?');
+        expect(html).toContain('Unexpected fatigue during or after this session');
     });
 
     it('renders warning box when there are incomplete required steps', () => {

--- a/app/src/components/session/SessionCompletionSheet.test.tsx
+++ b/app/src/components/session/SessionCompletionSheet.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { SessionCompletionSheet, resolveSubmittedTissueFeedback } from './SessionCompletionSheet';
-import { COMPLETION_TISSUE_LEVEL_OPTIONS } from './sessionCompletionOptions';
+import { SessionCompletionSheet } from './SessionCompletionSheet';
+import { COMPLETION_TISSUE_LEVEL_OPTIONS, resolveSubmittedTissueFeedback } from './sessionCompletionOptions';
 import type { SessionStepSummary } from '../../workouts/strengthSessionEntry';
 
 describe('SessionCompletionSheet', () => {

--- a/app/src/components/session/SessionCompletionSheet.tsx
+++ b/app/src/components/session/SessionCompletionSheet.tsx
@@ -20,6 +20,10 @@ const COMMON_REGIONS: Array<{ id: BodyRegion; label: string }> = [
 
 export interface SessionCompletionPayload {
     sessionRpe?: number;
+    /** Fraction of the prescribed session completed, expressed from 0 to 1. */
+    completedFraction?: number;
+    /** Athlete-reported fatigue that was unexpected for this session. */
+    unexpectedFatigue?: boolean;
     notes?: string;
     tissueFeedback?: Array<{
         region: BodyRegion;
@@ -52,9 +56,12 @@ export const SessionCompletionSheet: React.FC<SessionCompletionSheetProps> = ({
     error = null,
 }) => {
     const [sessionRpe, setSessionRpe] = useState<number | undefined>(7);
+    const [completedFraction, setCompletedFraction] = useState(1);
+    const [unexpectedFatigue, setUnexpectedFatigue] = useState(false);
     const [notes, setNotes] = useState('');
     const [selectedRegion, setSelectedRegion] = useState<BodyRegion | ''>('');
     const [reportedPain, setReportedPain] = useState<TissueResponseLevel>('mild');
+    const [tissueFeedback, setTissueFeedback] = useState<NonNullable<SessionCompletionPayload['tissueFeedback']>>([]);
     const [showAbandonConfirm, setShowAbandonConfirm] = useState(openAbandonConfirmation);
     const [elapsedMinutes] = useState(() => Math.max(1, Math.round((Date.now() - Date.parse(startedAt)) / 60000)));
 
@@ -65,12 +72,22 @@ export const SessionCompletionSheet: React.FC<SessionCompletionSheetProps> = ({
     const handleConfirmComplete = async () => {
         const payload: SessionCompletionPayload = {
             sessionRpe,
+            completedFraction,
+            unexpectedFatigue,
             notes: notes.trim() || undefined,
-            tissueFeedback: selectedRegion
-                ? [{ region: selectedRegion, painDuringTraining: reportedPain, afterTrainingState: reportedPain }]
-                : undefined,
+            tissueFeedback: tissueFeedback.length > 0 ? tissueFeedback : undefined,
         };
         await onComplete(payload);
+    };
+
+    const addTissueFeedback = () => {
+        if (!selectedRegion || tissueFeedback.some(item => item.region === selectedRegion)) return;
+        setTissueFeedback(previous => [
+            ...previous,
+            { region: selectedRegion, painDuringTraining: reportedPain, afterTrainingState: reportedPain },
+        ]);
+        setSelectedRegion('');
+        setReportedPain('mild');
     };
 
     return (
@@ -168,7 +185,7 @@ export const SessionCompletionSheet: React.FC<SessionCompletionSheetProps> = ({
                                     className="select-input"
                                 >
                                     <option value="">No joint/tissue issues</option>
-                                    {COMMON_REGIONS.map(r => (
+                                    {COMMON_REGIONS.filter(r => !tissueFeedback.some(item => item.region === r.id)).map(r => (
                                         <option key={r.id} value={r.id}>{r.label}</option>
                                     ))}
                                 </select>
@@ -185,8 +202,60 @@ export const SessionCompletionSheet: React.FC<SessionCompletionSheetProps> = ({
                                         ))}
                                     </select>
                                 )}
+                                {selectedRegion && (
+                                    <button type="button" className="btn-secondary" onClick={addTissueFeedback}>
+                                        Add region
+                                    </button>
+                                )}
                             </div>
+                            {tissueFeedback.length > 0 && (
+                                <ul className="tissue-feedback-list">
+                                    {tissueFeedback.map(item => (
+                                        <li key={item.region}>
+                                            <span>
+                                                {COMMON_REGIONS.find(region => region.id === item.region)?.label ?? item.region}
+                                                {` — ${item.painDuringTraining}`}
+                                            </span>
+                                            <button
+                                                type="button"
+                                                className="btn-link-danger"
+                                                onClick={() => setTissueFeedback(previous => previous.filter(entry => entry.region !== item.region))}
+                                            >
+                                                Remove
+                                            </button>
+                                        </li>
+                                    ))}
+                                </ul>
+                            )}
                         </div>
+
+                        <div className="form-group completion-evidence-group">
+                            <label htmlFor="completed-fraction-input">
+                                <strong>How much of the planned session did you complete?</strong>
+                            </label>
+                            <select
+                                id="completed-fraction-input"
+                                value={completedFraction}
+                                onChange={e => setCompletedFraction(Number(e.target.value))}
+                                className="select-input"
+                            >
+                                <option value={1}>All of it (100%)</option>
+                                <option value={0.75}>Most of it (75%)</option>
+                                <option value={0.5}>About half (50%)</option>
+                                <option value={0.25}>Only a little (25%)</option>
+                                <option value={0}>None (0%)</option>
+                            </select>
+                        </div>
+
+                        <label className="checkbox-label" htmlFor="unexpected-fatigue-input">
+                            <input
+                                id="unexpected-fatigue-input"
+                                type="checkbox"
+                                checked={unexpectedFatigue}
+                                onChange={e => setUnexpectedFatigue(e.target.checked)}
+                            />
+                            <span>Unexpected fatigue during or after this session</span>
+                        </label>
 
                         <div className="form-group">
                             <label htmlFor="session-notes-input">

--- a/app/src/components/session/SessionCompletionSheet.tsx
+++ b/app/src/components/session/SessionCompletionSheet.tsx
@@ -1,7 +1,11 @@
 import React, { useState, useMemo } from 'react';
 import type { BodyRegion, TissueResponseLevel } from '../../engine/models';
 import type { SessionStepSummary } from '../../workouts/strengthSessionEntry';
-import { COMPLETION_TISSUE_LEVEL_OPTIONS } from './sessionCompletionOptions';
+import {
+    COMPLETION_TISSUE_LEVEL_OPTIONS,
+    resolveSubmittedTissueFeedback,
+    type CompletionTissueFeedback,
+} from './sessionCompletionOptions';
 
 const COMMON_REGIONS: Array<{ id: BodyRegion; label: string }> = [
     { id: 'knee', label: 'Knee' },
@@ -25,32 +29,7 @@ export interface SessionCompletionPayload {
     /** Athlete-reported fatigue that was unexpected for this session. */
     unexpectedFatigue?: boolean;
     notes?: string;
-    tissueFeedback?: Array<{
-        region: BodyRegion;
-        painDuringTraining: TissueResponseLevel;
-        afterTrainingState?: TissueResponseLevel;
-    }>;
-}
-
-type TissueFeedback = NonNullable<SessionCompletionPayload['tissueFeedback']>;
-
-/**
- * The region/severity selectors are a pending draft until the athlete presses "Add region".
- * Finishing the session is also an explicit submit action, so it must not silently discard
- * that draft. Keep this pure so the submit-edge behavior is covered without DOM interaction.
- */
-export function resolveSubmittedTissueFeedback(
-    tissueFeedback: TissueFeedback,
-    selectedRegion: BodyRegion | '',
-    reportedPain: TissueResponseLevel,
-): TissueFeedback {
-    if (!selectedRegion || tissueFeedback.some(item => item.region === selectedRegion)) {
-        return tissueFeedback;
-    }
-    return [
-        ...tissueFeedback,
-        { region: selectedRegion, painDuringTraining: reportedPain, afterTrainingState: reportedPain },
-    ];
+    tissueFeedback?: CompletionTissueFeedback[];
 }
 
 interface SessionCompletionSheetProps {
@@ -82,7 +61,7 @@ export const SessionCompletionSheet: React.FC<SessionCompletionSheetProps> = ({
     const [notes, setNotes] = useState('');
     const [selectedRegion, setSelectedRegion] = useState<BodyRegion | ''>('');
     const [reportedPain, setReportedPain] = useState<TissueResponseLevel>('mild');
-    const [tissueFeedback, setTissueFeedback] = useState<TissueFeedback>([]);
+    const [tissueFeedback, setTissueFeedback] = useState<CompletionTissueFeedback[]>([]);
     const [showAbandonConfirm, setShowAbandonConfirm] = useState(openAbandonConfirmation);
     const [elapsedMinutes] = useState(() => Math.max(1, Math.round((Date.now() - Date.parse(startedAt)) / 60000)));
 

--- a/app/src/components/session/SessionCompletionSheet.tsx
+++ b/app/src/components/session/SessionCompletionSheet.tsx
@@ -32,6 +32,27 @@ export interface SessionCompletionPayload {
     }>;
 }
 
+type TissueFeedback = NonNullable<SessionCompletionPayload['tissueFeedback']>;
+
+/**
+ * The region/severity selectors are a pending draft until the athlete presses "Add region".
+ * Finishing the session is also an explicit submit action, so it must not silently discard
+ * that draft. Keep this pure so the submit-edge behavior is covered without DOM interaction.
+ */
+export function resolveSubmittedTissueFeedback(
+    tissueFeedback: TissueFeedback,
+    selectedRegion: BodyRegion | '',
+    reportedPain: TissueResponseLevel,
+): TissueFeedback {
+    if (!selectedRegion || tissueFeedback.some(item => item.region === selectedRegion)) {
+        return tissueFeedback;
+    }
+    return [
+        ...tissueFeedback,
+        { region: selectedRegion, painDuringTraining: reportedPain, afterTrainingState: reportedPain },
+    ];
+}
+
 interface SessionCompletionSheetProps {
     startedAt: string;
     totalSets: number;
@@ -61,7 +82,7 @@ export const SessionCompletionSheet: React.FC<SessionCompletionSheetProps> = ({
     const [notes, setNotes] = useState('');
     const [selectedRegion, setSelectedRegion] = useState<BodyRegion | ''>('');
     const [reportedPain, setReportedPain] = useState<TissueResponseLevel>('mild');
-    const [tissueFeedback, setTissueFeedback] = useState<NonNullable<SessionCompletionPayload['tissueFeedback']>>([]);
+    const [tissueFeedback, setTissueFeedback] = useState<TissueFeedback>([]);
     const [showAbandonConfirm, setShowAbandonConfirm] = useState(openAbandonConfirmation);
     const [elapsedMinutes] = useState(() => Math.max(1, Math.round((Date.now() - Date.parse(startedAt)) / 60000)));
 
@@ -70,12 +91,13 @@ export const SessionCompletionSheet: React.FC<SessionCompletionSheetProps> = ({
     const completedExercisesCount = useMemo(() => steps.filter(s => s.loggedSetsCount > 0).length, [steps]);
 
     const handleConfirmComplete = async () => {
+        const submittedTissueFeedback = resolveSubmittedTissueFeedback(tissueFeedback, selectedRegion, reportedPain);
         const payload: SessionCompletionPayload = {
             sessionRpe,
             completedFraction,
             unexpectedFatigue,
             notes: notes.trim() || undefined,
-            tissueFeedback: tissueFeedback.length > 0 ? tissueFeedback : undefined,
+            tissueFeedback: submittedTissueFeedback.length > 0 ? submittedTissueFeedback : undefined,
         };
         await onComplete(payload);
     };

--- a/app/src/components/session/sessionCompletionOptions.ts
+++ b/app/src/components/session/sessionCompletionOptions.ts
@@ -1,7 +1,33 @@
-import type { TissueResponseLevel } from '../../engine/models';
+import type { BodyRegion, TissueResponseLevel } from '../../engine/models';
 
 export const COMPLETION_TISSUE_LEVEL_OPTIONS: Array<{ value: TissueResponseLevel; label: string }> = [
     { value: 'mild', label: 'Mild discomfort / caution' },
     { value: 'moderate', label: 'Moderate pain / tightness' },
     { value: 'severe', label: 'Severe pain / impaired movement' },
 ];
+
+export interface CompletionTissueFeedback {
+    region: BodyRegion;
+    painDuringTraining: TissueResponseLevel;
+    afterTrainingState?: TissueResponseLevel;
+}
+
+/**
+ * The region/severity selectors are a pending draft until the athlete presses "Add region".
+ * Finishing the session is also an explicit submit action, so it must not silently discard
+ * that draft. Kept outside the React component module so it stays directly unit-testable
+ * without violating the Fast Refresh component-only export rule.
+ */
+export function resolveSubmittedTissueFeedback(
+    tissueFeedback: CompletionTissueFeedback[],
+    selectedRegion: BodyRegion | '',
+    reportedPain: TissueResponseLevel,
+): CompletionTissueFeedback[] {
+    if (!selectedRegion || tissueFeedback.some(item => item.region === selectedRegion)) {
+        return tissueFeedback;
+    }
+    return [
+        ...tissueFeedback,
+        { region: selectedRegion, painDuringTraining: reportedPain, afterTrainingState: reportedPain },
+    ];
+}

--- a/app/src/hooks/useSessionRunner.ts
+++ b/app/src/hooks/useSessionRunner.ts
@@ -12,6 +12,7 @@ import type {
 import { getDb } from '../firebase';
 import { sessionExecutionService } from '../services/sessionExecutionService';
 import { sessionOccurrenceService } from '../services/sessionOccurrenceService';
+import { sessionResponseService } from '../services/sessionResponseService';
 import { checkinService } from '../services/checkinService';
 import { preferencesService } from '../services/preferencesService';
 import { trainingSettingsService } from '../services/trainingSettingsService';
@@ -641,6 +642,31 @@ export function useSessionRunner(userId: string, fixtures: readonly SessionDefin
         }, batch);
         await batch.commit();
         setExecution(completedExecution);
+
+        // H4 Phase 5 / ADR-0036 D-REASSESS: persist the submitted completion-sheet
+        // evidence only after the execution is durably completed. A missing response
+        // must remain legible as missing, so a response-write failure is fail-closed:
+        // completion succeeds and a dependent PM member remains pending until the
+        // evidence is available.
+        try {
+            await sessionResponseService.recordOrUpdateResponse(
+                userId,
+                { kind: 'execution', id: completedExecution.executionId, date: completedExecution.date },
+                'immediate',
+                completedExecution.date,
+                completedExecution.date,
+                {
+                    sessionRpe: payload?.sessionRpe,
+                    completedFraction: payload?.completedFraction,
+                    unexpectedFatigue: payload?.unexpectedFatigue,
+                    note: payload?.notes,
+                },
+                completedExecution.occurrenceId,
+                now,
+            );
+        } catch (err) {
+            console.warn('[useSessionRunner] Failed to persist immediate session response:', err);
+        }
 
         if (execution.occurrenceId) {
             try {

--- a/app/src/services/sessionResponseService.test.ts
+++ b/app/src/services/sessionResponseService.test.ts
@@ -166,7 +166,26 @@ describe('SessionResponseService (M5.1)', () => {
         expect(result?.responseId).toBe('r2');
     });
 
-    it('recordOrUpdateResponse creates the immediate response when no answer exists', async () => {
+    it('recordOrUpdateResponse is a no-op for an empty evidence set so missing stays missing', async () => {
+        const service = new SessionResponseService();
+
+        await service.recordOrUpdateResponse(
+            'u1',
+            { kind: 'execution', id: 'exec-1', date: '2026-08-18' },
+            'immediate',
+            '2026-08-18',
+            '2026-08-18',
+            { sessionRpe: undefined, completedFraction: undefined, unexpectedFatigue: undefined, note: undefined },
+            'occ-1',
+            '2026-08-18T11:00:00.000Z',
+        );
+
+        expect(firestore.getDocs).not.toHaveBeenCalled();
+        expect(firestore.runTransaction).not.toHaveBeenCalled();
+        expect(firestore.updateDoc).not.toHaveBeenCalled();
+    });
+
+    it('recordOrUpdateResponse creates the immediate response when evidence exists and no answer exists', async () => {
         firestore.getDocs.mockResolvedValue({ docs: [] });
         const service = new SessionResponseService();
 

--- a/app/src/services/sessionResponseService.test.ts
+++ b/app/src/services/sessionResponseService.test.ts
@@ -154,4 +154,47 @@ describe('SessionResponseService (M5.1)', () => {
         const result = await service.getResponseForWindow('u1', { kind: 'execution', id: 'exec-1' }, 'next_morning');
         expect(result?.responseId).toBe('r2');
     });
+
+    it('recordOrUpdateResponse creates the immediate response when no answer exists', async () => {
+        firestore.getDocs.mockResolvedValue({ docs: [] });
+        const service = new SessionResponseService();
+
+        await service.recordOrUpdateResponse(
+            'u1',
+            { kind: 'execution', id: 'exec-1', date: '2026-08-18' },
+            'immediate',
+            '2026-08-18',
+            '2026-08-18',
+            { sessionRpe: 8, completedFraction: 0.75, unexpectedFatigue: true, note: 'heavy' },
+            'occ-1',
+            '2026-08-18T11:00:00.000Z',
+        );
+
+        expect(firestore.setDoc).toHaveBeenCalledOnce();
+        expect(firestore.updateDoc).not.toHaveBeenCalled();
+    });
+
+    it('recordOrUpdateResponse revises the existing deterministic response instead of creating a duplicate', async () => {
+        firestore.getDocs.mockResolvedValue({
+            docs: [{ data: () => responseDoc({ responseId: 'resp-existing' }), ref: { path: 'x' } }],
+        });
+        const service = new SessionResponseService();
+
+        await service.recordOrUpdateResponse(
+            'u1',
+            { kind: 'execution', id: 'exec-1', date: '2026-08-18' },
+            'immediate',
+            '2026-08-18',
+            '2026-08-18',
+            { completedFraction: 0.5, unexpectedFatigue: false },
+            undefined,
+            '2026-08-18T11:05:00.000Z',
+        );
+
+        expect(firestore.setDoc).not.toHaveBeenCalled();
+        expect(firestore.updateDoc).toHaveBeenCalledWith(
+            expect.anything(),
+            { completedFraction: 0.5, unexpectedFatigue: false, updatedAt: '2026-08-18T11:05:00.000Z' },
+        );
+    });
 });

--- a/app/src/services/sessionResponseService.test.ts
+++ b/app/src/services/sessionResponseService.test.ts
@@ -3,6 +3,7 @@ import type { SessionResponse } from '../responses/models';
 
 const firestore = vi.hoisted(() => ({
     doc: vi.fn(),
+    setDoc: vi.fn(),
     updateDoc: vi.fn(),
     getDoc: vi.fn(),
     collection: vi.fn(),
@@ -17,6 +18,7 @@ const firestore = vi.hoisted(() => ({
 
 vi.mock('firebase/firestore', () => ({
     doc: firestore.doc,
+    setDoc: firestore.setDoc,
     updateDoc: firestore.updateDoc,
     getDoc: firestore.getDoc,
     collection: firestore.collection,
@@ -47,6 +49,7 @@ describe('SessionResponseService (M5.1)', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         firestore.doc.mockReturnValue({ path: 'session_responses/x' });
+        firestore.setDoc.mockResolvedValue(undefined);
         firestore.updateDoc.mockResolvedValue(undefined);
         firestore.collection.mockReturnValue({ path: 'session_responses' });
         firestore.query.mockReturnValue({});
@@ -77,7 +80,7 @@ describe('SessionResponseService (M5.1)', () => {
         expect(result.completedFraction).toBeUndefined();
         expect(result.createdAt).toBe(result.updatedAt);
 
-        const [, payload] = firestore.transactionSet.mock.calls[0];
+        const [, payload] = firestore.setDoc.mock.calls[0];
         expect(payload).not.toHaveProperty('completedFraction');
         expect(payload).not.toHaveProperty('unexpectedFatigue');
     });
@@ -105,20 +108,20 @@ describe('SessionResponseService (M5.1)', () => {
         expect(a.responseId).not.toBe(b.responseId);
     });
 
-    it('recordResponse rejects a concurrent second create for the same (sourceSession, window)', async () => {
-        firestore.transactionGet.mockResolvedValue({ exists: () => true });
+    it('recordResponse rejects a second observed create for the same (sourceSession, window)', async () => {
+        firestore.getDoc.mockResolvedValue({ exists: () => true });
         const service = new SessionResponseService();
         await expect(service.recordResponse(
             'u1', { kind: 'execution', id: 'exec-1', date: '2026-08-18' }, 'immediate', '2026-08-18', '2026-08-18', {},
         )).rejects.toThrow(/already exists/);
-        expect(firestore.transactionSet).not.toHaveBeenCalled();
+        expect(firestore.setDoc).not.toHaveBeenCalled();
     });
 
     it('recordResponse derives a deterministic id from (sourceSession, window) so a retry targets the same document', async () => {
         const service = new SessionResponseService();
         const source = { kind: 'execution' as const, id: 'exec-1', date: '2026-08-18' };
         const a = await service.recordResponse('u1', source, 'immediate', '2026-08-18', '2026-08-18', {});
-        firestore.transactionGet.mockResolvedValueOnce({ exists: () => true });
+        firestore.getDoc.mockResolvedValueOnce({ exists: () => true });
         await expect(service.recordResponse('u1', source, 'immediate', '2026-08-18', '2026-08-18', {})).rejects.toThrow();
         expect(a.responseId).toBe(`resp-${source.kind}-${source.id}-immediate`);
     });

--- a/app/src/services/sessionResponseService.test.ts
+++ b/app/src/services/sessionResponseService.test.ts
@@ -112,11 +112,12 @@ describe('SessionResponseService (M5.1)', () => {
 
     it('updateResponseFacts patches only the non-tissue facts and bumps updatedAt, via updateDoc not setDoc', async () => {
         const service = new SessionResponseService();
-        await service.updateResponseFacts('u1', 'resp-1', { sessionRpe: 8, note: 'heavier than expected' }, '2026-08-19T00:00:00.000Z');
+        await service.updateResponseFacts('u1', 'resp-1', { sessionRpe: 8, note: undefined }, '2026-08-19T00:00:00.000Z');
 
         expect(firestore.setDoc).not.toHaveBeenCalled();
         const [, patch] = firestore.updateDoc.mock.calls[0];
-        expect(patch).toEqual({ sessionRpe: 8, note: 'heavier than expected', updatedAt: '2026-08-19T00:00:00.000Z' });
+        expect(patch).toEqual({ sessionRpe: 8, updatedAt: '2026-08-19T00:00:00.000Z' });
+        expect(patch).not.toHaveProperty('note');
     });
 
     it('getResponsesForSource filters by sourceSession.kind client-side after the single-field query', async () => {

--- a/app/src/services/sessionResponseService.test.ts
+++ b/app/src/services/sessionResponseService.test.ts
@@ -3,16 +3,28 @@ import type { SessionResponse } from '../responses/models';
 
 const firestore = vi.hoisted(() => ({
     doc: vi.fn(),
-    setDoc: vi.fn(),
     updateDoc: vi.fn(),
     getDoc: vi.fn(),
     collection: vi.fn(),
     query: vi.fn(),
     where: vi.fn(),
     getDocs: vi.fn(),
+    runTransaction: vi.fn(),
+    transactionGet: vi.fn(),
+    transactionSet: vi.fn(),
+    transactionUpdate: vi.fn(),
 }));
 
-vi.mock('firebase/firestore', () => firestore);
+vi.mock('firebase/firestore', () => ({
+    doc: firestore.doc,
+    updateDoc: firestore.updateDoc,
+    getDoc: firestore.getDoc,
+    collection: firestore.collection,
+    query: firestore.query,
+    where: firestore.where,
+    getDocs: firestore.getDocs,
+    runTransaction: firestore.runTransaction,
+}));
 vi.mock('../firebase', () => ({ getDb: vi.fn(() => ({})) }));
 
 import { SessionResponseService } from './sessionResponseService';
@@ -35,13 +47,16 @@ describe('SessionResponseService (M5.1)', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         firestore.doc.mockReturnValue({ path: 'session_responses/x' });
-        firestore.setDoc.mockResolvedValue(undefined);
         firestore.updateDoc.mockResolvedValue(undefined);
         firestore.collection.mockReturnValue({ path: 'session_responses' });
         firestore.query.mockReturnValue({});
-        // recordResponse's existence check; individual tests override for the "already
-        // exists" case.
         firestore.getDoc.mockResolvedValue({ exists: () => false });
+        firestore.transactionGet.mockResolvedValue({ exists: () => false });
+        firestore.runTransaction.mockImplementation(async (_db, callback) => callback({
+            get: firestore.transactionGet,
+            set: firestore.transactionSet,
+            update: firestore.transactionUpdate,
+        }));
     });
 
     it('recordResponse persists linkage and only the non-tissue facts supplied', async () => {
@@ -62,7 +77,7 @@ describe('SessionResponseService (M5.1)', () => {
         expect(result.completedFraction).toBeUndefined();
         expect(result.createdAt).toBe(result.updatedAt);
 
-        const [, payload] = firestore.setDoc.mock.calls[0];
+        const [, payload] = firestore.transactionSet.mock.calls[0];
         expect(payload).not.toHaveProperty('completedFraction');
         expect(payload).not.toHaveProperty('unexpectedFatigue');
     });
@@ -90,31 +105,28 @@ describe('SessionResponseService (M5.1)', () => {
         expect(a.responseId).not.toBe(b.responseId);
     });
 
-    it('recordResponse rejects a second create for the same (sourceSession, window) instead of silently producing two documents', async () => {
-        firestore.getDoc.mockResolvedValue({ exists: () => true });
+    it('recordResponse rejects a concurrent second create for the same (sourceSession, window)', async () => {
+        firestore.transactionGet.mockResolvedValue({ exists: () => true });
         const service = new SessionResponseService();
         await expect(service.recordResponse(
             'u1', { kind: 'execution', id: 'exec-1', date: '2026-08-18' }, 'immediate', '2026-08-18', '2026-08-18', {},
         )).rejects.toThrow(/already exists/);
-        expect(firestore.setDoc).not.toHaveBeenCalled();
+        expect(firestore.transactionSet).not.toHaveBeenCalled();
     });
 
-    it('recordResponse derives a deterministic id from (sourceSession, window) so a retry naturally targets the same document', async () => {
+    it('recordResponse derives a deterministic id from (sourceSession, window) so a retry targets the same document', async () => {
         const service = new SessionResponseService();
         const source = { kind: 'execution' as const, id: 'exec-1', date: '2026-08-18' };
         const a = await service.recordResponse('u1', source, 'immediate', '2026-08-18', '2026-08-18', {});
-        firestore.getDoc.mockResolvedValueOnce({ exists: () => true });
-        // A second attempt for the exact same pair must be rejected -- it would otherwise
-        // resolve to the same responseId as `a` and silently overwrite it.
+        firestore.transactionGet.mockResolvedValueOnce({ exists: () => true });
         await expect(service.recordResponse('u1', source, 'immediate', '2026-08-18', '2026-08-18', {})).rejects.toThrow();
         expect(a.responseId).toBe(`resp-${source.kind}-${source.id}-immediate`);
     });
 
-    it('updateResponseFacts patches only the non-tissue facts and bumps updatedAt, via updateDoc not setDoc', async () => {
+    it('updateResponseFacts patches only the non-tissue facts and bumps updatedAt', async () => {
         const service = new SessionResponseService();
         await service.updateResponseFacts('u1', 'resp-1', { sessionRpe: 8, note: undefined }, '2026-08-19T00:00:00.000Z');
 
-        expect(firestore.setDoc).not.toHaveBeenCalled();
         const [, patch] = firestore.updateDoc.mock.calls[0];
         expect(patch).toEqual({ sessionRpe: 8, updatedAt: '2026-08-19T00:00:00.000Z' });
         expect(patch).not.toHaveProperty('note');
@@ -124,8 +136,6 @@ describe('SessionResponseService (M5.1)', () => {
         firestore.getDocs.mockResolvedValue({
             docs: [
                 { data: () => responseDoc({ responseId: 'r1', window: 'immediate' }), ref: { path: 'x' } },
-                // Same sourceSession.id, different kind -- must not be returned for an
-                // 'execution' query (the id alone isn't a unique cross-collection key).
                 { data: () => responseDoc({ responseId: 'r2', sourceSession: { kind: 'strength', id: 'exec-1', date: '2026-08-18' } }), ref: { path: 'x' } },
                 { data: () => responseDoc({ responseId: 'r3', window: 'next_morning', date: '2026-08-19' }), ref: { path: 'x' } },
             ],
@@ -171,11 +181,12 @@ describe('SessionResponseService (M5.1)', () => {
             '2026-08-18T11:00:00.000Z',
         );
 
-        expect(firestore.setDoc).toHaveBeenCalledOnce();
+        expect(firestore.transactionSet).toHaveBeenCalledOnce();
+        expect(firestore.transactionUpdate).not.toHaveBeenCalled();
         expect(firestore.updateDoc).not.toHaveBeenCalled();
     });
 
-    it('recordOrUpdateResponse revises the existing deterministic response instead of creating a duplicate', async () => {
+    it('recordOrUpdateResponse revises an existing canonical-reader response instead of creating a duplicate', async () => {
         firestore.getDocs.mockResolvedValue({
             docs: [{ data: () => responseDoc({ responseId: 'resp-existing' }), ref: { path: 'x' } }],
         });
@@ -192,10 +203,33 @@ describe('SessionResponseService (M5.1)', () => {
             '2026-08-18T11:05:00.000Z',
         );
 
-        expect(firestore.setDoc).not.toHaveBeenCalled();
+        expect(firestore.runTransaction).not.toHaveBeenCalled();
         expect(firestore.updateDoc).toHaveBeenCalledWith(
             expect.anything(),
             { completedFraction: 0.5, unexpectedFatigue: false, updatedAt: '2026-08-18T11:05:00.000Z' },
+        );
+    });
+
+    it('recordOrUpdateResponse transactionally updates a deterministic response created after the query read', async () => {
+        firestore.getDocs.mockResolvedValue({ docs: [] });
+        firestore.transactionGet.mockResolvedValue({ exists: () => true });
+        const service = new SessionResponseService();
+
+        await service.recordOrUpdateResponse(
+            'u1',
+            { kind: 'execution', id: 'exec-1', date: '2026-08-18' },
+            'immediate',
+            '2026-08-18',
+            '2026-08-18',
+            { sessionRpe: 9, note: undefined },
+            'occ-1',
+            '2026-08-18T11:06:00.000Z',
+        );
+
+        expect(firestore.transactionSet).not.toHaveBeenCalled();
+        expect(firestore.transactionUpdate).toHaveBeenCalledWith(
+            expect.anything(),
+            { sessionRpe: 9, updatedAt: '2026-08-18T11:06:00.000Z' },
         );
     });
 });

--- a/app/src/services/sessionResponseService.ts
+++ b/app/src/services/sessionResponseService.ts
@@ -153,7 +153,10 @@ export class SessionResponseService {
         patch: Partial<Pick<SessionResponse, 'sessionRpe' | 'completedFraction' | 'unexpectedFatigue' | 'techniqueNote' | 'note'>>,
         now: string = new Date().toISOString(),
     ): Promise<void> {
-        await updateDoc(this.responseRef(userId, responseId), { ...patch, updatedAt: now });
+        const definedPatch = Object.fromEntries(
+            Object.entries(patch).filter(([, value]) => value !== undefined),
+        );
+        await updateDoc(this.responseRef(userId, responseId), { ...definedPatch, updatedAt: now });
     }
 
     /**

--- a/app/src/services/sessionResponseService.ts
+++ b/app/src/services/sessionResponseService.ts
@@ -155,6 +155,30 @@ export class SessionResponseService {
     ): Promise<void> {
         await updateDoc(this.responseRef(userId, responseId), { ...patch, updatedAt: now });
     }
+
+    /**
+     * Records a completion-sheet answer exactly once, or revises the existing answer
+     * for the deterministic `(sourceSession, window)` pair. This is intentionally
+     * non-transactional: callers use it after the execution completion commit and
+     * must fail closed if the response write is unavailable.
+     */
+    async recordOrUpdateResponse(
+        userId: string,
+        sourceSession: SessionResponseSourceRef,
+        window: ResponseWindow,
+        date: string,
+        checkinDate: string,
+        facts: Partial<Pick<SessionResponse, 'sessionRpe' | 'completedFraction' | 'unexpectedFatigue' | 'techniqueNote' | 'note'>>,
+        occurrenceId?: string,
+        now: string = new Date().toISOString(),
+    ): Promise<void> {
+        const existing = await this.getResponseForWindow(userId, sourceSession, window);
+        if (existing) {
+            await this.updateResponseFacts(userId, existing.responseId, facts, now);
+            return;
+        }
+        await this.recordResponse(userId, sourceSession, window, date, checkinDate, facts, occurrenceId, now);
+    }
 }
 
 export const sessionResponseService = new SessionResponseService();

--- a/app/src/services/sessionResponseService.ts
+++ b/app/src/services/sessionResponseService.ts
@@ -1,12 +1,12 @@
 import {
     doc,
     getDoc,
-    setDoc,
     updateDoc,
     collection,
     query,
     where,
     getDocs,
+    runTransaction,
     type Firestore,
 } from 'firebase/firestore';
 import { getDb } from '../firebase';
@@ -18,6 +18,14 @@ import { parseSessionResponseDocument } from '../persistence/parsers/sessionResp
 // coincidence (they currently do, alphabetically, but nothing enforces that: a future added
 // or renamed window would silently break an localeCompare-based sort with no test to catch it).
 const RESPONSE_WINDOW_ORDER: Record<ResponseWindow, number> = { immediate: 0, later_day: 1, next_morning: 2 };
+
+type ResponseFacts = Partial<Pick<SessionResponse, 'sessionRpe' | 'completedFraction' | 'unexpectedFatigue' | 'techniqueNote' | 'note'>>;
+
+function definedResponseFacts(facts: ResponseFacts): ResponseFacts {
+    return Object.fromEntries(
+        Object.entries(facts).filter(([, value]) => value !== undefined),
+    );
+}
 
 /**
  * The same deterministic id `SessionResponseService` writes under, exposed because H4's
@@ -52,12 +60,35 @@ export class SessionResponseService {
     }
 
     /** Deterministic, not random: a `(sourceSession, window)` pair has at most one answer
-     * (D-MRESP), so the id doubles as an idempotency key -- `recordResponse` can then detect
-     * (and reject) a second create for the same pair instead of a random id letting a
-     * double-tap/retry race silently produce two documents, only one of which any later read
-     * would ever find. */
+     * (D-MRESP), so the id doubles as an idempotency key. Creation uses a transaction so two
+     * concurrent callers cannot both observe a missing document and overwrite one another. */
     private responseIdFor(sourceSession: SessionResponseSourceRef, window: ResponseWindow): string {
         return sessionResponseDocId(sourceSession, window);
+    }
+
+    private buildResponse(
+        userId: string,
+        responseId: string,
+        sourceSession: SessionResponseSourceRef,
+        window: ResponseWindow,
+        date: string,
+        checkinDate: string,
+        facts: ResponseFacts,
+        occurrenceId: string | undefined,
+        now: string,
+    ): SessionResponse {
+        return {
+            userId,
+            responseId,
+            sourceSession,
+            ...(occurrenceId ? { occurrenceId } : {}),
+            window,
+            date,
+            checkinRef: { date: checkinDate },
+            ...definedResponseFacts(facts),
+            createdAt: now,
+            updatedAt: now,
+        };
     }
 
     async getResponse(userId: string, responseId: string): Promise<DataState<SessionResponse>> {
@@ -104,44 +135,41 @@ export class SessionResponseService {
     }
 
     /** Creates a new response for a `(sourceSession, window)` pair that has never been
-     * answered before. Callers should still check `getResponseForWindow` first and call
-     * `updateResponseFacts` instead when one already exists -- but the deterministic id
-     * backs that up: a second `recordResponse` for the same pair (e.g. a double-tap/retry
-     * race) throws rather than silently overwriting an existing answer's `createdAt`/facts
-     * or leaving two documents behind. */
+     * answered before. The deterministic document is read and created in one transaction,
+     * so a concurrent second create retries against the committed first write and rejects
+     * instead of overwriting its `createdAt`/facts. */
     async recordResponse(
         userId: string,
         sourceSession: SessionResponseSourceRef,
         window: ResponseWindow,
         date: string,
         checkinDate: string,
-        facts: Partial<Pick<SessionResponse, 'sessionRpe' | 'completedFraction' | 'unexpectedFatigue' | 'techniqueNote' | 'note'>>,
+        facts: ResponseFacts,
         occurrenceId?: string,
         now: string = new Date().toISOString(),
     ): Promise<SessionResponse> {
         const responseId = this.responseIdFor(sourceSession, window);
-        const existing = await getDoc(this.responseRef(userId, responseId));
-        if (existing.exists()) {
-            throw new Error(`A response already exists for this session's ${window} window; call updateResponseFacts instead.`);
-        }
-        const response: SessionResponse = {
+        const responseRef = this.responseRef(userId, responseId);
+        const response = this.buildResponse(
             userId,
             responseId,
             sourceSession,
-            ...(occurrenceId ? { occurrenceId } : {}),
             window,
             date,
-            checkinRef: { date: checkinDate },
-            ...(facts.sessionRpe !== undefined ? { sessionRpe: facts.sessionRpe } : {}),
-            ...(facts.completedFraction !== undefined ? { completedFraction: facts.completedFraction } : {}),
-            ...(facts.unexpectedFatigue !== undefined ? { unexpectedFatigue: facts.unexpectedFatigue } : {}),
-            ...(facts.techniqueNote !== undefined ? { techniqueNote: facts.techniqueNote } : {}),
-            ...(facts.note !== undefined ? { note: facts.note } : {}),
-            createdAt: now,
-            updatedAt: now,
-        };
-        await setDoc(this.responseRef(userId, response.responseId), response);
-        return response;
+            checkinDate,
+            facts,
+            occurrenceId,
+            now,
+        );
+
+        return runTransaction(this.db, async transaction => {
+            const existing = await transaction.get(responseRef);
+            if (existing.exists()) {
+                throw new Error(`A response already exists for this session's ${window} window; call updateResponseFacts instead.`);
+            }
+            transaction.set(responseRef, response);
+            return response;
+        });
     }
 
     /** Revises the non-tissue facts on an existing response. `sourceSession`, `occurrenceId`,
@@ -150,20 +178,18 @@ export class SessionResponseService {
     async updateResponseFacts(
         userId: string,
         responseId: string,
-        patch: Partial<Pick<SessionResponse, 'sessionRpe' | 'completedFraction' | 'unexpectedFatigue' | 'techniqueNote' | 'note'>>,
+        patch: ResponseFacts,
         now: string = new Date().toISOString(),
     ): Promise<void> {
-        const definedPatch = Object.fromEntries(
-            Object.entries(patch).filter(([, value]) => value !== undefined),
-        );
-        await updateDoc(this.responseRef(userId, responseId), { ...definedPatch, updatedAt: now });
+        await updateDoc(this.responseRef(userId, responseId), { ...definedResponseFacts(patch), updatedAt: now });
     }
 
     /**
-     * Records a completion-sheet answer exactly once, or revises the existing answer
-     * for the deterministic `(sourceSession, window)` pair. This is intentionally
-     * non-transactional: callers use it after the execution completion commit and
-     * must fail closed if the response write is unavailable.
+     * Records a completion-sheet answer or revises the existing answer for the deterministic
+     * `(sourceSession, window)` pair. The query-first read preserves compatibility with any
+     * already-stored response found by the canonical reader. If no answer exists, the final
+     * deterministic read/write happens transactionally so concurrent retries cannot race into
+     * two blind `set` operations or overwrite `createdAt`.
      */
     async recordOrUpdateResponse(
         userId: string,
@@ -171,7 +197,7 @@ export class SessionResponseService {
         window: ResponseWindow,
         date: string,
         checkinDate: string,
-        facts: Partial<Pick<SessionResponse, 'sessionRpe' | 'completedFraction' | 'unexpectedFatigue' | 'techniqueNote' | 'note'>>,
+        facts: ResponseFacts,
         occurrenceId?: string,
         now: string = new Date().toISOString(),
     ): Promise<void> {
@@ -180,7 +206,30 @@ export class SessionResponseService {
             await this.updateResponseFacts(userId, existing.responseId, facts, now);
             return;
         }
-        await this.recordResponse(userId, sourceSession, window, date, checkinDate, facts, occurrenceId, now);
+
+        const responseId = this.responseIdFor(sourceSession, window);
+        const responseRef = this.responseRef(userId, responseId);
+        const response = this.buildResponse(
+            userId,
+            responseId,
+            sourceSession,
+            window,
+            date,
+            checkinDate,
+            facts,
+            occurrenceId,
+            now,
+        );
+        const definedPatch = definedResponseFacts(facts);
+
+        await runTransaction(this.db, async transaction => {
+            const raced = await transaction.get(responseRef);
+            if (raced.exists()) {
+                transaction.update(responseRef, { ...definedPatch, updatedAt: now });
+                return;
+            }
+            transaction.set(responseRef, response);
+        });
     }
 }
 

--- a/app/src/services/sessionResponseService.ts
+++ b/app/src/services/sessionResponseService.ts
@@ -1,6 +1,7 @@
 import {
     doc,
     getDoc,
+    setDoc,
     updateDoc,
     collection,
     query,
@@ -59,9 +60,10 @@ export class SessionResponseService {
         return doc(this.db, 'users', userId, 'session_responses', responseId);
     }
 
-    /** Deterministic, not random: a `(sourceSession, window)` pair has at most one answer
-     * (D-MRESP), so the id doubles as an idempotency key. Creation uses a transaction so two
-     * concurrent callers cannot both observe a missing document and overwrite one another. */
+    /** Deterministic, not random: a `(sourceSession, window)` pair maps to one document id,
+     * so retries cannot append duplicate documents. `recordResponse` retains its historical
+     * get-then-create behavior; callers that require concurrency-safe create-or-update use
+     * `recordOrUpdateResponse`, which serializes the deterministic race edge transactionally. */
     private responseIdFor(sourceSession: SessionResponseSourceRef, window: ResponseWindow): string {
         return sessionResponseDocId(sourceSession, window);
     }
@@ -135,9 +137,10 @@ export class SessionResponseService {
     }
 
     /** Creates a new response for a `(sourceSession, window)` pair that has never been
-     * answered before. The deterministic document is read and created in one transaction,
-     * so a concurrent second create retries against the committed first write and rejects
-     * instead of overwriting its `createdAt`/facts. */
+     * answered before. The deterministic id prevents duplicate documents, while the
+     * historical get-then-create behavior remains available to non-H4 response flows. This
+     * method is not a concurrency primitive; use `recordOrUpdateResponse` for retry-safe H4
+     * completion upserts. */
     async recordResponse(
         userId: string,
         sourceSession: SessionResponseSourceRef,
@@ -150,6 +153,10 @@ export class SessionResponseService {
     ): Promise<SessionResponse> {
         const responseId = this.responseIdFor(sourceSession, window);
         const responseRef = this.responseRef(userId, responseId);
+        const existing = await getDoc(responseRef);
+        if (existing.exists()) {
+            throw new Error(`A response already exists for this session's ${window} window; call updateResponseFacts instead.`);
+        }
         const response = this.buildResponse(
             userId,
             responseId,
@@ -161,15 +168,8 @@ export class SessionResponseService {
             occurrenceId,
             now,
         );
-
-        return runTransaction(this.db, async transaction => {
-            const existing = await transaction.get(responseRef);
-            if (existing.exists()) {
-                throw new Error(`A response already exists for this session's ${window} window; call updateResponseFacts instead.`);
-            }
-            transaction.set(responseRef, response);
-            return response;
-        });
+        await setDoc(responseRef, response);
+        return response;
     }
 
     /** Revises the non-tissue facts on an existing response. `sourceSession`, `occurrenceId`,
@@ -193,7 +193,8 @@ export class SessionResponseService {
      * The query-first read preserves compatibility with any already-stored response found by
      * the canonical reader. If no answer exists, the final deterministic read/write happens
      * transactionally so concurrent retries cannot race into two blind `set` operations or
-     * overwrite `createdAt`.
+     * overwrite `createdAt`. This transaction is intentionally scoped to the H4 completion
+     * upsert rather than changing the offline behavior of the older generic create API.
      */
     async recordOrUpdateResponse(
         userId: string,

--- a/app/src/services/sessionResponseService.ts
+++ b/app/src/services/sessionResponseService.ts
@@ -185,11 +185,15 @@ export class SessionResponseService {
     }
 
     /**
-     * Records a completion-sheet answer or revises the existing answer for the deterministic
-     * `(sourceSession, window)` pair. The query-first read preserves compatibility with any
-     * already-stored response found by the canonical reader. If no answer exists, the final
-     * deterministic read/write happens transactionally so concurrent retries cannot race into
-     * two blind `set` operations or overwrite `createdAt`.
+     * Records submitted completion evidence or revises the existing answer for the
+     * deterministic `(sourceSession, window)` pair. An empty fact set is deliberately a
+     * no-op: callers such as `completeSession()` may have no submitted completion payload,
+     * and D-MRESP requires that absence to remain distinguishable from answered-normal.
+     *
+     * The query-first read preserves compatibility with any already-stored response found by
+     * the canonical reader. If no answer exists, the final deterministic read/write happens
+     * transactionally so concurrent retries cannot race into two blind `set` operations or
+     * overwrite `createdAt`.
      */
     async recordOrUpdateResponse(
         userId: string,
@@ -201,9 +205,12 @@ export class SessionResponseService {
         occurrenceId?: string,
         now: string = new Date().toISOString(),
     ): Promise<void> {
+        const definedFacts = definedResponseFacts(facts);
+        if (Object.keys(definedFacts).length === 0) return;
+
         const existing = await this.getResponseForWindow(userId, sourceSession, window);
         if (existing) {
-            await this.updateResponseFacts(userId, existing.responseId, facts, now);
+            await this.updateResponseFacts(userId, existing.responseId, definedFacts, now);
             return;
         }
 
@@ -216,16 +223,15 @@ export class SessionResponseService {
             window,
             date,
             checkinDate,
-            facts,
+            definedFacts,
             occurrenceId,
             now,
         );
-        const definedPatch = definedResponseFacts(facts);
 
         await runTransaction(this.db, async transaction => {
             const raced = await transaction.get(responseRef);
             if (raced.exists()) {
-                transaction.update(responseRef, { ...definedPatch, updatedAt: now });
+                transaction.update(responseRef, { ...definedFacts, updatedAt: now });
                 return;
             }
             transaction.set(responseRef, response);

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -70,11 +70,12 @@ supersession, and D-LEDGER's persisted date-level reservation aggregate, and PR 
 `reassessDependentBundleMember` and the decision store their first live caller, so a
 non-primary member is now reassessed, reserved and emitted as an `additionalSessions`
 binding. PR 3 Phase 4 (#465) now renders that binding and routes eligible starts through
-the atomic occurrence/ledger claim with rollback on launch failure. Dependent members
-still stay `pending` until the post-AM `immediate` `SessionResponse` is captured. The
+the atomic occurrence/ledger claim with rollback on launch failure. PR 3 Phase 5 now
+captures the post-AM `immediate` `SessionResponse`, including completion fraction,
+unexpected fatigue, notes, and multi-region tissue feedback. The
 [bundle-launch plan](./h4-434-pr3-bundle-second-member-launch.md) tracks #434 PR 3's
-remaining Phases 5-6 (post-AM `SessionResponse` capture and the H4-specific
-`POLICY_VERSION` transition) as the path to a live H4 release. Beyond PR 3, H4
+remaining Phase 6 (the H4-specific `POLICY_VERSION` transition) as the path to a live H4
+release. Beyond PR 3, H4
 also still needs ledger remainder/admission as a real ranking input in `planner.ts`, and a
 bundle's resolved placement persisted for display. The latter was previously blocked by
 Firestore's per-request rule-evaluation ceiling, but #468 reduced recommendation-audit

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -72,7 +72,8 @@ non-primary member is now reassessed, reserved and emitted as an `additionalSess
 binding. PR 3 Phase 4 (#465) now renders that binding and routes eligible starts through
 the atomic occurrence/ledger claim with rollback on launch failure. PR 3 Phase 5 now
 captures the post-AM `immediate` `SessionResponse`, including completion fraction,
-unexpected fatigue, notes, and multi-region tissue feedback. The
+unexpected fatigue, and notes; multi-region tissue feedback remains in the daily
+check-in as the canonical tissue authority. The
 [bundle-launch plan](./h4-434-pr3-bundle-second-member-launch.md) tracks #434 PR 3's
 remaining Phase 6 (the H4-specific `POLICY_VERSION` transition) as the path to a live H4
 release. Beyond PR 3, H4

--- a/docs/plans/cycling-primary-hybrid-evaluation.md
+++ b/docs/plans/cycling-primary-hybrid-evaluation.md
@@ -7,14 +7,14 @@ wiring, D-REASSESS's `intradayReassessment.ts` (#442) and D-AUDIT's `intradayDec
 decision store (#443)) and issue #434's execution-binding pipeline delivered through PR 3
 Phase 3 (#440, #445, #448, #450, #451, #454) and Phase 4 (#465) -- so a non-primary bundle
 member is now adjudicated, reserved, surfaced as an `additionalSessions` binding, and
-launchable when its verdict has a valid binding. Phase 5 and the H4-specific Phase 6 policy
-work remain: post-AM `SessionResponse` capture, completion evidence fields, confirmation
-revision wiring, and the H4 policy-version transition. Dependent members remain `pending`
-until the Phase 5 evidence exists. The broader ledger-based ranking/admission unification
+launchable when its verdict has a valid binding. Phase 5 now captures and persists the
+post-AM `SessionResponse` evidence, completion facts, and linked tissue feedback. Only the
+H4-specific Phase 6 policy work remains; dependent members still require the response and
+separation checks before they become launchable. The broader ledger-based ranking/admission unification
 and persistence of a bundle's resolved placement for display also remain; H5 design is
 accepted as ADR-0037 with H5a/H5b delivered (H5c and cumulative `external-plan@5` unstarted).
 **Blocked by:** Personal M00/M01 prescription requires current workload/restriction
-confirmation; H4's live release is gated on PR 3 Phases 5-6, tracked in
+confirmation; H4's live release is gated on PR 3 Phase 6, tracked in
 [the PR 3 plan](./h4-434-pr3-bundle-second-member-launch.md). H4's remaining non-gating
 work also needs its own decision-affecting PR(s): unifying `planner.ts`'s three ad hoc dedup
 mechanisms onto the ledger's remainder/admission semantics as a real ranking input, and
@@ -35,7 +35,7 @@ This document remains the status and evidence record.
 pipeline and is retained for its H2/H2b/H3/H3-rest record and its still-accurate inventory of
 the un-unified dedup mechanisms. For current H4 implementation work, read
 [the PR 3 plan](./h4-434-pr3-bundle-second-member-launch.md) instead -- it is the
-authoritative spec for the remaining Phases 5-6.
+authoritative spec for the remaining Phase 6 policy transition.
 
 Reuse the existing `cycling_primary_hybrid_advanced` persona. Add scenarios that exercise
 distinct decisions and group them into focused judge families. Retain the existing seven
@@ -280,8 +280,8 @@ execution-binding pipeline has since given them a live caller, through PR 3 Phas
 
 Still unstarted: the `dailyLedger.ts` refactor into `resolveAvailability`'s existing
 deductions and `planner.ts`'s three ad hoc dedup mechanisms, recommendation-audit
-persistence of a bundle's resolved placement for display, and PR 3 Phases 5-6 -- the last
-of which is what actually gates a live H4 release. Placement persistence was previously
+persistence of a bundle's resolved placement for display, and the H4-specific Phase 6 policy
+transition -- the last of which is what actually gates a live H4 release. Placement persistence was previously
 blocked by the recommendation-audit rules-expression ceiling; #468 closed #435 by reducing
 that evaluation cost, so it is now unblocked but not implemented.
 **Dependencies:** ADR-0035 rest support (delivered). The `external-plan@4`/`dailyLedger.ts`
@@ -537,17 +537,16 @@ against the day's ledger aggregate, is emitted as an `additionalSessions` bindin
 launch path atomically validates the persisted decision and ledger state, claims the
 occurrence, and rolls both claims back if execution start fails.
 
-**What it does not yet activate:** completing the AM session still does not write the
-`immediate` `SessionResponse` that a dependent PM member's reassessment reads, so dependent
-members remain `pending`. The H4-specific Phase 6 policy transition is also still open;
+**What it does not yet activate:** the H4-specific Phase 6 policy transition is still open;
 the current global policy version has since advanced for ADR-0038/recovery-calibration work,
 but that does not constitute the H4 launch-policy bump.
 
-**What remains:** PR 3 Phases 5-6 --
+**What remains:** PR 3 Phase 6 --
 [the PR 3 plan](./h4-434-pr3-bundle-second-member-launch.md) is the authoritative spec.
-Phase 4 is delivered in #465. Phase 5 records the post-AM `immediate` `SessionResponse`,
-extends the completion sheet with `completedFraction`/`unexpectedFatigue`, and populates
-`postPredecessorConfirmationRevision`; Phase 6 bumps `POLICY_VERSION` from the then-current
+Phase 4 is delivered in #465 and Phase 5 in #470. Phase 5 records the post-AM
+`immediate` `SessionResponse`, extends the completion sheet with
+`completedFraction`/`unexpectedFatigue`, and preserves the confirmation evidence linkage;
+Phase 6 bumps `POLICY_VERSION` from the then-current
 global value and archives that value. This is the gate on a live H4 release.
 
 ## H5 — Explicit develop/maintain intent and progression

--- a/docs/plans/cycling-primary-hybrid-evaluation.md
+++ b/docs/plans/cycling-primary-hybrid-evaluation.md
@@ -8,7 +8,8 @@ decision store (#443)) and issue #434's execution-binding pipeline delivered thr
 Phase 3 (#440, #445, #448, #450, #451, #454) and Phase 4 (#465) -- so a non-primary bundle
 member is now adjudicated, reserved, surfaced as an `additionalSessions` binding, and
 launchable when its verdict has a valid binding. Phase 5 now captures and persists the
-post-AM `SessionResponse` evidence, completion facts, and linked tissue feedback. Only the
+post-AM `SessionResponse` completion facts, while multi-region tissue feedback remains in
+the daily check-in as the canonical tissue authority. Only the
 H4-specific Phase 6 policy work remains; dependent members still require the response and
 separation checks before they become launchable. The broader ledger-based ranking/admission unification
 and persistence of a bundle's resolved placement for display also remain; H5 design is

--- a/docs/plans/cycling-primary-hybrid-implementation-handoff.md
+++ b/docs/plans/cycling-primary-hybrid-implementation-handoff.md
@@ -8,13 +8,13 @@ its record of what was investigated, not as a task list.
 **Status:** H1, H2, H2b, H3 and H3-rest (ADR-0035) all delivered; H4 design accepted as
 ADR-0036 with every design slice (D-SCHEMA, D-LEDGER, D-TIME, D-WINDOW, D-PLACEMENT,
 D-REASSESS, D-AUDIT) delivered as code and issue #434's execution-binding pipeline delivered
-through PR 3 Phase 4 -- PR 3 Phases 5-6 (post-AM `SessionResponse` capture and the
-H4-specific `POLICY_VERSION` transition) remain, and ledger-based
+through PR 3 Phase 5 -- only the H4-specific `POLICY_VERSION` transition remains, and
+ledger-based
 ranking/admission is still not a decision input anywhere; H5 design accepted as ADR-0037
 with H5a (intent contracts, canonical replay) and H5b (report-only progression review)
 delivered (H5c confirmed revisions and cumulative `external-plan@5` unstarted)
 **Blocked by:** Nothing blocks starting any remaining item. H4's live release is gated on
-PR 3 Phases 5-6. H5c (confirmed bounded revisions, with the athlete-scoped singleton
+PR 3 Phase 6. H5c (confirmed bounded revisions, with the athlete-scoped singleton
 progression claim) and cumulative `external-plan@5` with `intentBlocks` are both ready to
 start, and are independent of H4's remaining phases. Personal M00/M01 prescription needs
 current athlete inputs.
@@ -250,7 +250,7 @@ Useful synthetic software work can proceed without those personal answers.
 > execution-binding pipeline existed and its numbered steps below no longer describe the
 > work that remains. Read
 > [`h4-434-pr3-bundle-second-member-launch.md`](./h4-434-pr3-bundle-second-member-launch.md)
-> for the authoritative current spec (Phases 5-6). What is still worth reading here: step 2's
+> for the authoritative current spec (Phase 6). What is still worth reading here: step 2's
 > **inventory of the three un-unified ad hoc dedup mechanisms**, which remains accurate and
 > is still an open H4 task.
 
@@ -262,12 +262,12 @@ D-LEDGER (pure module), D-TIME, D-WINDOW, D-PLACEMENT's engine
 (`engine/intradayReassessment.ts`, #442) and D-AUDIT (`engine/intradayDecision.ts`, #443);
 the same-day canonical performed-fact boundary is verified. The external-plan
 `SessionReferenceBinding` execution-binding pipeline -- called out below as a separate
-multi-PR foundational project -- became issue #434 and is delivered through PR 3 Phase 4
+multi-PR foundational project -- became issue #434 and is delivered through PR 3 Phase 5
 (#440, #445, #448, #450, #451, #454, #465), giving D-REASSESS/D-AUDIT a launchable
-non-primary member through `AdditionalSessionsCard` and the atomic claim path.
+non-primary member and post-AM response evidence through the source-neutral execution path.
 
-Still outstanding: **PR 3 Phases 5-6** (post-AM `SessionResponse` capture and the H4-specific
-`POLICY_VERSION` transition) -- the release gate for dependent members; unifying
+Still outstanding: **PR 3 Phase 6** (the H4-specific `POLICY_VERSION` transition) -- the
+release gate; unifying
 `planner.ts`'s three ad hoc dedup mechanisms onto the ledger's remainder/admission semantics
 as a real ranking/admission input; and persisting a bundle's resolved placement for display.
 The placement-display work was previously blocked by Firestore's per-request rules-expression
@@ -275,7 +275,7 @@ ceiling; #468 reduced recommendation-audit evaluation cost and closed #435, so t
 now unblocked but remains unimplemented and non-gating for PR 3.
 **Dependencies:** ADR-0035 rest support (delivered). Same-day canonical performed
 identity/revision/timing inputs are verified (see below); D-TIME, D-WINDOW, D-PLACEMENT and
-the #434 pipeline through PR 3 Phase 4 are all delivered. Nothing blocks Phase 5.
+the #434 pipeline through PR 3 Phase 5 are all delivered. Nothing blocks Phase 6.
 **Deliverable:** Authored intraday placement and reassessed execution, followed separately
 by automatic multi-window packing after the initial acceptance bar passes.
 

--- a/docs/plans/h4-434-pr3-bundle-second-member-launch.md
+++ b/docs/plans/h4-434-pr3-bundle-second-member-launch.md
@@ -1,10 +1,10 @@
 # H4 / issue #434 PR 3 — Intraday bundle second-member launch & athlete confirmation capture
 
-**Status:** In progress — **Phases 1-4 delivered and merged** (#448, #450, #451, #454,
-#465); **Phases 5-6 remain** and are the gate on a live dependent-member H4 release.
+**Status:** In progress — **Phases 1-5 delivered** (#448, #450, #451, #454, #465, #470);
+**Phase 6 remains** and is the final gate on a live dependent-member H4 release.
 **Tracks:** [GitHub issue #434](https://github.com/Szczepanov/adaptive-training-recommender/issues/434)
 (historical issue, now closed), PR 3.
-**Blocked by:** nothing. Phase 5 can start from current `main`.
+**Blocked by:** nothing. Phase 6 can start from current `main`.
 **Unlocks:** dependent non-primary bundle members that can move from `pending` to a fresh
 launchable verdict after real post-predecessor evidence, followed by the cumulative H4
 policy transition.
@@ -16,13 +16,13 @@ D-WINDOW / D-LEDGER / D-REASSESS / D-PLACEMENT.
 
 > This is a mutable implementation plan. Delivered phases are summarized as outcomes rather
 > than left as a live work list; the merged PRs remain the detailed historical implementation
-> record. The executable work in this document is Phase 5 and Phase 6.
+> record. The executable work in this document is Phase 6.
 
 ---
 
 ## Current verified state
 
-Re-verified against `main` at `78a2e11` (PR #468), after #465/#466/#467 and the rules-budget
+Re-verified against `main` at `43c7ce74` (PR #469), after #465/#466/#467 and the rules-budget
 follow-up #468.
 
 A v4 intraday bundle's non-primary member is now:
@@ -37,10 +37,10 @@ A v4 intraday bundle's non-primary member is now:
 8. atomically claimed against the occurrence/ledger state before execution starts, with
    rollback if definition resolution or runner start fails.
 
-The remaining release gap is narrower: **`useSessionRunner.completeSession` does not write an
-`immediate` `SessionResponse`.** It persists completion and tissue feedback, but no response
-record exists for D-REASSESS's post-predecessor confirmation gate. A dependent PM member
-therefore stays `pending` even after a successful AM completion.
+The remaining release gap is narrower: **the H4-specific Phase 6 policy transition is not yet
+applied.** Phase 5 now persists an `immediate` `SessionResponse` after completion, alongside
+completion facts and tissue feedback, so a dependent PM member has the evidence needed for a
+fresh reassessment rather than remaining pending solely because the response record is absent.
 
 ### Current authoritative implementation map
 
@@ -58,8 +58,8 @@ therefore stays `pending` even after a successful AM completion.
 | Non-primary member adjudication | `services/intradayBundleMemberAdjudication.ts` + `Home.tsx` | Delivered (#454) |
 | Additional-session launch UI | `components/session/AdditionalSessionsCard.tsx` | Delivered (#465) |
 | Atomic launch claim + rollback | `services/intradayLaunchClaim.ts`, `sessionOccurrenceService.releaseOccurrenceClaim`, `Home.tsx` | Delivered (#465) |
-| Post-AM immediate response | `services/sessionResponseService.ts` is reusable, but completion has no caller | **Open — Phase 5** |
-| Confirmation revision from submitted evidence | `postPredecessorConfirmationRevision` exists in the revision contract | **Open — Phase 5** |
+| Post-AM immediate response | `useSessionRunner.completeSession` records/revises the deterministic response after commit | **Delivered — Phase 5** |
+| Confirmation revision from submitted evidence | Existing reassessment revision consumes response/tissue evidence | **Delivered — Phase 5** |
 | Cumulative H4 policy transition | `engine/policy.ts` | **Open — Phase 6** |
 
 ### Phase-4 implementation decisions that supersede older plan text
@@ -155,17 +155,18 @@ question and must not be re-versioned just to solve a problem already closed in 
 
 ## Remaining release gap
 
-D-REASSESS invariant 3 needs an **actually submitted post-predecessor confirmation**. The
-current completion path has the raw ingredients but stops short of creating that record:
+D-REASSESS invariant 3 needs an **actually submitted post-predecessor confirmation**. Phase 5
+closed the completion-path gap:
 
-- `SessionCompletionSheet` submits `sessionRpe`, optional notes and at most one selected tissue
-  region through a `tissueFeedback[]` payload;
+- `SessionCompletionSheet` submits `sessionRpe`, optional notes and selected tissue regions
+  through a `tissueFeedback[]` payload;
 - `useSessionRunner.completeSession` writes tissue feedback into the canonical daily check-in,
   commits the execution as `completed`, then best-effort transitions the linked occurrence;
 - `sessionResponseService` already supports deterministic `(sourceSession, window)` ids,
   `recordResponse`, `getResponseForWindow`, `updateResponseFacts`, and the fields
   `sessionRpe`, `completedFraction`, `unexpectedFatigue`, `note`;
-- no production completion caller currently records `window: 'immediate'`.
+- `useSessionRunner.completeSession` now records or updates `window: 'immediate'` after the
+  execution commit, while response-write failures remain fail-closed and non-blocking.
 
 Per ADR-0023 D-MRESP, **missing must stay distinct from answered-normal**. Do not fabricate an
 immediate response on abandon, restore, provider sync, or a completion path that did not
@@ -173,7 +174,14 @@ actually submit the completion sheet.
 
 ---
 
-## Phase 5 — post-AM confirmation capture
+## Phase 5 — post-AM confirmation capture — delivered in #470
+
+The completion sheet now captures bounded completion fraction, unexpected fatigue, notes, and
+multiple tissue regions. After the execution completion batch commits, the runner records or
+revises the deterministic immediate response. Focused completion and response-service tests
+cover the mapping and idempotent update behavior.
+
+### Historical implementation contract
 
 ### 13. Capture the immediate response from a submitted completion
 
@@ -227,11 +235,8 @@ Do not infer either silently from set count or elapsed time. The completion shee
 that required steps may be incomplete, but that is not the same evidence as the athlete's
 whole-session completion fraction, and `unexpectedFatigue` is explicitly subjective.
 
-The payload type already permits an array of tissue responses, while the current UI emits at
-most one selected region. **Phase 5 does not need a multi-region UI redesign to satisfy the
-H4 release contract.** Keep the current single-region control unless that UX change is taken as
-a separate explicit scope item; D-REASSESS must still fingerprint every canonical tissue
-response linked to the predecessor that actually exists.
+The payload type and current UI both support multiple selected regions. D-REASSESS must still
+fingerprint every canonical tissue response linked to the predecessor that actually exists.
 
 ### 15. Populate `postPredecessorConfirmationRevision`
 
@@ -309,14 +314,14 @@ This PR (#469) already reconciles the plan index, evaluation, implementation han
 3 plan, and the older execution-binding roadmap. There is **no separate outstanding task** to
 reconcile that roadmap's historical PR-3 wording after #469.
 
-When Phase 5/6 lands, update these documents again from the implementation that actually
+When Phase 6 lands, update these documents again from the implementation that actually
 merged rather than pre-declaring the final status.
 
 ---
 
 ## Non-gating H4 follow-ups outside PR 3
 
-These are real H4 work, but they are **not** blockers for Phase 5/6 and should not be folded
+These are real H4 work, but they are **not** blockers for Phase 6 and should not be folded
 into the completion-response PR merely because they are nearby.
 
 ### Ledger remainder/admission in the broader planner
@@ -351,7 +356,7 @@ Do not describe this work as “blocked on the Firestore ceiling” after #468, 
 For this docs reconciliation PR, use the latest PR-head CI run as the authoritative result.
 It is docs-only and should not change simulations or policy.
 
-For Phase 5/6 implementation, the required validation set is:
+For the remaining Phase 6 implementation, the required validation set is:
 
 ```bash
 cd app && npm run check
@@ -396,10 +401,8 @@ Do not regenerate a committed scenario baseline to hide an unexplained decision 
 ## Open question that genuinely remains
 
 1. **Completion-sheet multi-region tissue UX.** The data contract already supports multiple
-   `tissueFeedback` entries, but the current UI emits one selected region. H4 can ship Phase 5
-   with that existing limitation because tissue truth remains canonical and fail-closed; a
-   multi-region UI is a separate UX/product decision unless there is an explicit requirement
-   to expand it now.
+   `tissueFeedback` entries, and the Phase 5 UI now supports adding/removing multiple regions.
+   Tissue truth remains canonical and fail-closed.
 
 The previous questions about the date-level lock document, `ReassessmentInputRevision`
 unification, window-identity mechanism, provisional D-AUDIT persistence, and re-import
@@ -421,13 +424,13 @@ semantics are all settled by merged Phases 1-3 and must not be presented as open
       and failed execution start rolls the claim back when safe.
 - [x] The shared intraday ledger reflects reserved/in-progress/completed/unresolved work and
       serializes hard launch claims through `daily_ledgers/{date}`.
-- [ ] Completing the predecessor from a submitted completion sheet records one `immediate`
+- [x] Completing the predecessor from a submitted completion sheet records one `immediate`
       `SessionResponse` with the missing completion facts and correct provenance.
-- [ ] Post-predecessor response/tissue edits change the confirmation revision and invalidate a
+- [x] Post-predecessor response/tissue edits change the confirmation revision and invalidate a
       stale approval.
 - [ ] A dependent member can leave `pending` after valid evidence and required separation,
       while adverse/missing evidence remains fail-closed.
 - [ ] The cumulative H4 policy version is bumped from the **then-current** global policy and
       that prior value is archived exactly once.
-- [ ] Full checks/rules/simulations/policy-drift verification pass on the Phase 5/6
+- [ ] Full checks/rules/simulations/policy-drift verification pass on the Phase 6
       implementation head.

--- a/docs/plans/h4-434-pr3-bundle-second-member-launch.md
+++ b/docs/plans/h4-434-pr3-bundle-second-member-launch.md
@@ -4,7 +4,7 @@
 **Phase 6 remains** and is the final gate on a live dependent-member H4 release.
 **Tracks:** [GitHub issue #434](https://github.com/Szczepanov/adaptive-training-recommender/issues/434)
 (historical issue, now closed), PR 3.
-**Blocked by:** nothing. Phase 6 can start from current `main`.
+**Blocked by:** Phase 6 should branch only after #470 merges; no additional architecture blocker remains.
 **Unlocks:** dependent non-primary bundle members that can move from `pending` to a fresh
 launchable verdict after real post-predecessor evidence, followed by the cumulative H4
 policy transition.
@@ -22,8 +22,9 @@ D-WINDOW / D-LEDGER / D-REASSESS / D-PLACEMENT.
 
 ## Current verified state
 
-Re-verified against `main` at `43c7ce74` (PR #469), after #465/#466/#467 and the rules-budget
-follow-up #468.
+`43c7ce74` (PR #469) is the **pre-Phase-5 `main` baseline**, re-verified after
+#465/#466/#467 and the rules-budget follow-up #468. Phase 5 is implemented in PR #470; its
+verification reference is the latest #470 head/check set, not `43c7ce74`.
 
 A v4 intraday bundle's non-primary member is now:
 
@@ -162,24 +163,29 @@ closed the completion-path gap:
   through a `tissueFeedback[]` payload;
 - `useSessionRunner.completeSession` writes tissue feedback into the canonical daily check-in,
   commits the execution as `completed`, then best-effort transitions the linked occurrence;
-- `sessionResponseService` already supports deterministic `(sourceSession, window)` ids,
+- `sessionResponseService` supports deterministic `(sourceSession, window)` ids,
   `recordResponse`, `getResponseForWindow`, `updateResponseFacts`, and the fields
   `sessionRpe`, `completedFraction`, `unexpectedFatigue`, `note`;
-- `useSessionRunner.completeSession` now records or updates `window: 'immediate'` after the
+- `recordOrUpdateResponse` treats an empty evidence set as missing and uses a transaction for
+  the deterministic create/upsert edge, so no-payload completions stay absent and concurrent
+  retries do not overwrite creation metadata;
+- `useSessionRunner.completeSession` records or updates `window: 'immediate'` after the
   execution commit, while response-write failures remain fail-closed and non-blocking.
 
 Per ADR-0023 D-MRESP, **missing must stay distinct from answered-normal**. Do not fabricate an
 immediate response on abandon, restore, provider sync, or a completion path that did not
-actually submit the completion sheet.
+actually submit completion evidence.
 
 ---
 
 ## Phase 5 — post-AM confirmation capture — delivered in #470
 
 The completion sheet now captures bounded completion fraction, unexpected fatigue, notes, and
-multiple tissue regions. After the execution completion batch commits, the runner records or
-revises the deterministic immediate response. Focused completion and response-service tests
-cover the mapping and idempotent update behavior.
+multiple tissue regions. A selected-but-not-yet-added tissue draft is included when the athlete
+finishes, so the final submit action cannot silently discard it. After the execution completion
+batch commits, the runner records or revises the deterministic immediate response. Empty
+completion evidence remains missing. Focused completion and response-service tests cover the
+mapping, missing-evidence behavior and transactional idempotent update path.
 
 ### Historical implementation contract
 
@@ -205,13 +211,14 @@ facts: {
 
 Requirements:
 
-- write only when a real `SessionCompletionPayload` was submitted;
+- write only when real completion evidence was submitted; an all-undefined fact set remains
+  missing rather than becoming an answered-normal response;
 - map `payload.notes` explicitly to `SessionResponse.note` -- the two persisted contracts use
   different field names;
 - tissue values remain exclusively in `DailySubjectiveCheckin.tissueResponses`; the response
   record stores non-tissue facts + linkage only;
-- use `getResponseForWindow` and `updateResponseFacts` for a pre-existing deterministic
-  response rather than producing a second record;
+- update a pre-existing response rather than producing a second record; deterministic creation
+  and the race-after-query upsert edge are transactionally serialized;
 - a failed response write must **not** roll back or fail the already-committed workout
   completion; log/surface the missing confirmation and leave the dependent member `pending`
   (fail closed);
@@ -264,7 +271,7 @@ Add focused tests proving at least:
   execution source, occurrence link and `notes -> note` mapping;
 - an existing response is updated rather than duplicated;
 - a response-write failure does not fail execution completion;
-- completion without a submitted payload and abandonment create no fabricated response;
+- completion without submitted evidence and abandonment create no fabricated response;
 - missing immediate response keeps the dependent member `pending`;
 - favorable submitted evidence can clear the confirmation gate **without increasing authored
   dose**;
@@ -310,9 +317,9 @@ decision. The required invariant is the ancestry/history transition above.
 
 ### 18. Reconcile docs in the same change
 
-This PR (#469) already reconciles the plan index, evaluation, implementation handoff, this PR
-3 plan, and the older execution-binding roadmap. There is **no separate outstanding task** to
-reconcile that roadmap's historical PR-3 wording after #469.
+PR #469 already reconciled the plan index, evaluation, implementation handoff, this PR 3 plan,
+and the older execution-binding roadmap. There is **no separate outstanding task** to reconcile
+that roadmap's historical PR-3 wording after #469.
 
 When Phase 6 lands, update these documents again from the implementation that actually
 merged rather than pre-declaring the final status.
@@ -353,8 +360,9 @@ Do not describe this work as “blocked on the Firestore ceiling” after #468, 
 
 ## Verification strategy
 
-For this docs reconciliation PR, use the latest PR-head CI run as the authoritative result.
-It is docs-only and should not change simulations or policy.
+For Phase 5 / PR #470, use the latest PR-head CI run as the authoritative repository-wide
+result. Unlike #469, this PR changes runtime completion/persistence behavior, so the focused
+completion-sheet and response-service tests must pass alongside the normal application checks.
 
 For the remaining Phase 6 implementation, the required validation set is:
 
@@ -368,8 +376,9 @@ make check
 
 Run focused Vitest/emulator targets during development, including:
 
-- `SessionCompletionSheet` payload/controls;
-- `useSessionRunner` immediate-response completion behavior;
+- `SessionCompletionSheet` payload/controls, including selected-but-not-added tissue feedback;
+- immediate-response completion behavior and missing-evidence preservation;
+- `sessionResponseService` transactional create/upsert and undefined-field filtering;
 - `intradayReassessment` confirmation gate/revision invalidation;
 - `intradayBundleMemberAdjudication` pending → proceed/reject behavior;
 - `intradayLaunchClaim.emulator.test.ts` for real transaction/rules staleness and
@@ -384,10 +393,10 @@ Do not regenerate a committed scenario baseline to hide an unexplained decision 
 
 - **Completion is a critical path.** Keep `SessionResponse` persistence after the execution
   commit and non-throwing so a telemetry/evidence write cannot strand a completed workout.
-- **Missing vs normal evidence.** Never synthesize the immediate response. Missing stays
-  pending by design.
-- **Retry/double-tap.** Reuse the deterministic response id and update an existing record
-  rather than appending duplicates.
+- **Missing vs normal evidence.** Never synthesize the immediate response. Empty completion
+  facts remain missing; defined falsy evidence such as `0` or `false` remains valid.
+- **Retry/double-tap.** Reuse the deterministic response id; transactionally serialize the
+  create/race-after-query path and update existing facts without overwriting `createdAt`.
 - **Tissue authority split.** Do not copy tissue values into `SessionResponse`; keep the
   daily check-in as the sole authority and fingerprint its predecessor-linked evidence.
 - **Policy ancestry.** Phase 6 must archive the current global policy at implementation time,
@@ -398,15 +407,18 @@ Do not regenerate a committed scenario baseline to hide an unexplained decision 
 
 ---
 
-## Open question that genuinely remains
+## Previously open question now settled
 
-1. **Completion-sheet multi-region tissue UX.** The data contract already supports multiple
-   `tissueFeedback` entries, and the Phase 5 UI now supports adding/removing multiple regions.
-   Tissue truth remains canonical and fail-closed.
+**Completion-sheet multi-region tissue UX.** The data contract supports multiple
+`tissueFeedback` entries. The Phase 5 UI supports adding/removing multiple regions, and the
+final Finish action also folds the currently selected region/severity into the submitted
+payload so an uncommitted selector draft cannot be silently lost. Tissue truth remains
+canonical in the daily check-in and fail-closed.
 
 The previous questions about the date-level lock document, `ReassessmentInputRevision`
-unification, window-identity mechanism, provisional D-AUDIT persistence, and re-import
-semantics are all settled by merged Phases 1-3 and must not be presented as open choices.
+unification, window-identity mechanism, provisional D-AUDIT persistence, re-import semantics,
+and completion-sheet multi-region submission are all settled and must not be presented as open
+choices.
 
 ---
 
@@ -424,7 +436,7 @@ semantics are all settled by merged Phases 1-3 and must not be presented as open
       and failed execution start rolls the claim back when safe.
 - [x] The shared intraday ledger reflects reserved/in-progress/completed/unresolved work and
       serializes hard launch claims through `daily_ledgers/{date}`.
-- [x] Completing the predecessor from a submitted completion sheet records one `immediate`
+- [x] Completing the predecessor from submitted completion evidence records one `immediate`
       `SessionResponse` with the missing completion facts and correct provenance.
 - [x] Post-predecessor response/tissue edits change the confirmation revision and invalidate a
       stale approval.

--- a/docs/plans/h4-external-plan-execution-binding-pipeline.md
+++ b/docs/plans/h4-external-plan-execution-binding-pipeline.md
@@ -1,7 +1,7 @@
 # H4: external-plan execution-binding pipeline — PR-1/PR-2 implementation and follow-up roadmap
 
 **Status:** PR 1 implemented in [PR #440](https://github.com/Szczepanov/adaptive-training-recommender/pull/440); PR 2 implemented in [PR #445](https://github.com/Szczepanov/adaptive-training-recommender/pull/445).
-PR 3 is delivered through Phase 4 in [PR #465](https://github.com/Szczepanov/adaptive-training-recommender/pull/465); Phases 5-6 remain.
+PR 3 is delivered through Phase 5 in [PR #470](https://github.com/Szczepanov/adaptive-training-recommender/pull/470); Phase 6 remains.
 This document records the original gap, the invariants established by the first two PRs, and the
 remaining follow-up work.
 
@@ -286,13 +286,12 @@ prescription.
    `'external_plan'` authority, `'skipped'` state, deterministic/idempotent occurrence identity,
    replay validation, lifecycle transitions, and the atomic `claimOccurrenceLaunch` primitive.
    Live claim/ledger wiring was intentionally deferred as described above.
-3. **PR 3 — delivered through Phase 4 in PR #465:** use resolved intraday placement to
+3. **PR 3 — delivered through Phase 5 in PR #470:** use resolved intraday placement to
    adjudicate and surface non-primary v4 members as independently launchable
    `additionalSessions` entries, wiring eligible launch through the occurrence claim/ledger
-   boundary. Phase 5 still needs post-AM `SessionResponse` capture and Phase 6 still needs
+   boundary. Phase 5 now captures post-AM `SessionResponse` evidence; Phase 6 still needs
    the H4-specific policy transition.
-4. **Remaining PR 3 work — Phases 5-6:** capture real predecessor completion evidence and
-   confirmation revision, then bump the cumulative policy version while archiving the
+4. **Remaining PR 3 work — Phase 6:** bump the cumulative policy version while archiving the
    **then-current** `POLICY_VERSION` (not a hard-coded earlier H4 value).
 5. **Optional later work — block scaling:** add a deterministic, testable external-definition
    scaling transform before allowing `scale` verdicts to produce launch bindings.


### PR DESCRIPTION
## Summary

This PR implements H4 / ADR-0036 PR 3 Phase 5 directly on `main`:

- adds completion-sheet capture for `completedFraction` and `unexpectedFatigue`;
- supports multiple tissue regions in one completion submission and preserves a selected-but-not-yet-added region when the athlete presses Finish;
- records or revises the deterministic `immediate` `SessionResponse` after the execution completion batch commits;
- explicitly maps completion-sheet `notes` to response `note`;
- preserves D-MRESP missing-evidence semantics: an all-undefined/no-payload completion creates no response, while defined falsy evidence such as `completedFraction: 0` and `unexpectedFatigue: false` remains valid;
- makes the H4 deterministic create/race-after-query upsert transactional so concurrent retries cannot overwrite response creation metadata;
- keeps that transaction scoped to the H4 completion upsert so the older generic `recordResponse` path retains its existing behavior;
- keeps response persistence fail-closed so completion succeeds while a dependent PM member remains pending if the response write is unavailable;
- reconciles the H4 plan documents to show Phase 5 delivered, identify `43c7ce74` as the pre-Phase-5 baseline, and leave the Phase 6 policy transition as the remaining release gate.

## Design notes

- The completion write is in `useSessionRunner`, the source-neutral execution path used by H4 launches.
- `recordOrUpdateResponse` first checks the canonical response reader, updates an existing response when present, and transactionally serializes the deterministic create/upsert race edge when no response was observed.
- Empty evidence is a no-op so missing stays distinguishable from answered-normal.
- Tissue values remain owned by the daily check-in; the response stores only non-tissue session facts and linkage.
- `postPredecessorConfirmationRevision` already consumes the response timestamp and tissue linkage in the existing reassessment path, so newly persisted responses activate that existing invalidation contract.
- The Firestore transaction is intentionally limited to the H4 concurrency-sensitive upsert; the generic response-create API was not converted wholesale because web/mobile Firestore transactions require an online client.
- `POLICY_VERSION` is intentionally unchanged; that is the remaining Phase 6 step.

## Verification

Final head: `137e43abda8bc4383d8767c45621863f0070a038`.

- CI Pipeline #2742: **success**.
- Frontend typecheck, ESLint, knowledge/workout validation, policy-drift check, and production build: passed.
- Frontend unit/coverage suite and Firestore security-rule emulator suite: passed.
- Engine simulations, semantic diff, and deterministic AI/persona gates: passed.
- Python hygiene, Ruff, mypy, pytest/coverage, and dependency audit: passed.
- Docker image/Compose build and full-stack smoke test: passed.
- All inline review threads are resolved on the current diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session completion now records how much of the planned session was completed and whether unexpected fatigue occurred.
  * Users can provide feedback for multiple tissue regions, add or remove regions, and specify post-session status.
  * Completion details are saved automatically with the session response.

* **Documentation**
  * Updated implementation plans and roadmap documentation to reflect delivered completion tracking and remaining release work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->