### PR TITLE
feat(policy): activate H4 bundle member launch

### DIFF
--- a/app/src/engine/policy.test.ts
+++ b/app/src/engine/policy.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, it } from 'vitest';
 import { isHistoricalPolicyVersion, HISTORICAL_POLICY_VERSIONS, POLICY_VERSION } from './policy';
 
 describe('isHistoricalPolicyVersion', () => {
+    it('retains the policy superseded by the H4 dependent-member launch contract', () => {
+        expect(HISTORICAL_POLICY_VERSIONS).toContain('2026-09-simulation-sequence-occupational-context-v2');
+    });
+
     it('returns true for all known historical versions', () => {
         for (const version of HISTORICAL_POLICY_VERSIONS) {
             expect(isHistoricalPolicyVersion(version)).toBe(true);

--- a/app/src/engine/policy.test.ts
+++ b/app/src/engine/policy.test.ts
@@ -2,8 +2,13 @@ import { describe, expect, it } from 'vitest';
 import { isHistoricalPolicyVersion, HISTORICAL_POLICY_VERSIONS, POLICY_VERSION } from './policy';
 
 describe('isHistoricalPolicyVersion', () => {
-    it('retains the policy superseded by the H4 dependent-member launch contract', () => {
-        expect(HISTORICAL_POLICY_VERSIONS).toContain('2026-09-simulation-sequence-occupational-context-v2');
+    it('records the exact H4 dependent-member launch policy transition once', () => {
+        expect(POLICY_VERSION).toBe('2026-09-h4-intraday-bundle-member-launch-v1');
+        expect(
+            HISTORICAL_POLICY_VERSIONS.filter(
+                (version) => version === '2026-09-simulation-sequence-occupational-context-v2',
+            ),
+        ).toHaveLength(1);
     });
 
     it('returns true for all known historical versions', () => {

--- a/app/src/engine/policy.ts
+++ b/app/src/engine/policy.ts
@@ -1,11 +1,12 @@
 /** Increment whenever a change can alter a persisted recommendation decision. (Refactoring does not require a bump) */
 
-export const POLICY_VERSION = '2026-09-simulation-sequence-occupational-context-v2';
+export const POLICY_VERSION = '2026-09-h4-intraday-bundle-member-launch-v1';
 
 /** Historical versions are intentionally not re-executed by this build. Their compact
  * audits remain readable evidence, but replay is rejected explicitly because the old
  * decision function is not bundled alongside the current policy. */
 export const HISTORICAL_POLICY_VERSIONS = [
+    '2026-09-simulation-sequence-occupational-context-v2',
     '2026-09-simulation-sequence-occupational-context-v1',
     '2026-09-recommender-recovery-calibration-v1',
     '2026-09-sequencing-ranking-diagnostics-v1',

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -62,7 +62,7 @@ specificity plus an anchor-date coverage-ordering fix (H2/H2b), an H3 investigat
 verified existing authored-block/replacement contracts, and explicit rest-day authoring
 under [ADR-0035](../adr/0035-explicit-rest-day-authoring.md) (H3-rest, delivered). H4
 intraday windows/reassessment is accepted in
-[ADR-0036](../adr/0036-intraday-training-windows-and-reassessment.md) and **In progress**:
+[ADR-0036](../adr/0036-intraday-training-windows-and-reassessment.md) and **Implemented**:
 D-TIME (`localInstant.ts`), D-LEDGER's pure engine (`dailyLedger.ts`), D-PLACEMENT's
 bundle-placement engine, D-REASSESS's pure `reassessDependentBundleMember`
 (`intradayReassessment.ts`, #442) and D-AUDIT's decision store (`intradayDecision.ts`,
@@ -78,10 +78,10 @@ binding. PR 3 Phase 4 (#465) now renders that binding and routes eligible starts
 the atomic occurrence/ledger claim with rollback on launch failure. PR 3 Phase 5 now
 captures the post-AM `immediate` `SessionResponse`, including completion fraction,
 unexpected fatigue, and notes; multi-region tissue feedback remains in the daily
-check-in as the canonical tissue authority. The
-[bundle-launch plan](./h4-434-pr3-bundle-second-member-launch.md) tracks #434 PR 3's
-remaining Phase 6 (the H4-specific `POLICY_VERSION` transition) as the path to a live H4
-release. Beyond PR 3, H4
+check-in as the canonical tissue authority. PR 3 Phase 6 applies the cumulative
+`2026-09-h4-intraday-bundle-member-launch-v1` policy contract, completing the live H4
+release. The [bundle-launch plan](./h4-434-pr3-bundle-second-member-launch.md) records the
+delivered phases. Beyond PR 3, H4
 also still needs ledger remainder/admission as a real ranking input in `planner.ts`, and a
 bundle's resolved placement persisted for display. The latter was previously blocked by
 Firestore's per-request rule-evaluation ceiling, but #468 reduced recommendation-audit

--- a/docs/plans/cycling-primary-hybrid-evaluation.md
+++ b/docs/plans/cycling-primary-hybrid-evaluation.md
@@ -9,13 +9,14 @@ Phase 3 (#440, #445, #448, #450, #451, #454) and Phase 4 (#465) -- so a non-prim
 member is now adjudicated, reserved, surfaced as an `additionalSessions` binding, and
 launchable when its verdict has a valid binding. Phase 5 now captures and persists the
 post-AM `SessionResponse` completion facts, while multi-region tissue feedback remains in
-the daily check-in as the canonical tissue authority. Only the
-H4-specific Phase 6 policy work remains; dependent members still require the response and
-separation checks before they become launchable. The broader ledger-based ranking/admission unification
+the daily check-in as the canonical tissue authority. Phase 6 applies the cumulative
+`2026-09-h4-intraday-bundle-member-launch-v1` policy transition, completing the H4 release;
+dependent members still require the response and separation checks before they become
+launchable. The broader ledger-based ranking/admission unification
 and persistence of a bundle's resolved placement for display also remain; H5 design is
 accepted as ADR-0037 with H5a/H5b delivered (H5c and cumulative `external-plan@5` unstarted).
 **Blocked by:** Personal M00/M01 prescription requires current workload/restriction
-confirmation; H4's live release is gated on PR 3 Phase 6, tracked in
+confirmation; H4's live release is delivered through PR 3 Phase 6, recorded in
 [the PR 3 plan](./h4-434-pr3-bundle-second-member-launch.md). H4's remaining non-gating
 work also needs its own decision-affecting PR(s): unifying `planner.ts`'s three ad hoc dedup
 mechanisms onto the ledger's remainder/admission semantics as a real ranking input, and
@@ -36,7 +37,7 @@ This document remains the status and evidence record.
 pipeline and is retained for its H2/H2b/H3/H3-rest record and its still-accurate inventory of
 the un-unified dedup mechanisms. For current H4 implementation work, read
 [the PR 3 plan](./h4-434-pr3-bundle-second-member-launch.md) instead -- it is the
-authoritative spec for the remaining Phase 6 policy transition.
+historical implementation record for the delivered H4 release.
 
 Reuse the existing `cycling_primary_hybrid_advanced` persona. Add scenarios that exercise
 distinct decisions and group them into focused judge families. Retain the existing seven
@@ -538,17 +539,14 @@ against the day's ledger aggregate, is emitted as an `additionalSessions` bindin
 launch path atomically validates the persisted decision and ledger state, claims the
 occurrence, and rolls both claims back if execution start fails.
 
-**What it does not yet activate:** the H4-specific Phase 6 policy transition is still open;
-the current global policy version has since advanced for ADR-0038/recovery-calibration work,
-but that does not constitute the H4 launch-policy bump.
+**Release activation:** Phase 6 sets `POLICY_VERSION` to
+`2026-09-h4-intraday-bundle-member-launch-v1` and archives the immediately preceding
+`2026-09-simulation-sequence-occupational-context-v2`, making the complete H4 launch
+contract the current decision policy.
 
-**What remains:** PR 3 Phase 6 --
-[the PR 3 plan](./h4-434-pr3-bundle-second-member-launch.md) is the authoritative spec.
-Phase 4 is delivered in #465 and Phase 5 in #470. Phase 5 records the post-AM
-`immediate` `SessionResponse`, extends the completion sheet with
-`completedFraction`/`unexpectedFatigue`, and preserves the confirmation evidence linkage;
-Phase 6 bumps `POLICY_VERSION` from the then-current
-global value and archives that value. This is the gate on a live H4 release.
+**What remains:** no PR 3 release-gating work. Phases 4-5 provide the launch and post-AM
+evidence path; Phase 6 activates their cumulative policy contract. The broader ledger
+ranking/admission and placement-persistence follow-ups remain separate H4 work.
 
 ## H5 — Explicit develop/maintain intent and progression
 
@@ -609,10 +607,10 @@ H1 did not change engine behavior and therefore required no policy bump. H2/H2b 
 decision-affecting. H3's new test was non-decision-affecting; explicit-rest behavior had
 its own policy transition. H4's fixed-activity dedup bump reflected the drift gate's
 mechanical requirement, while `h4-intraday-bundle-placement-v1` was H4's first real behavior
-change. PR 3 Phase 4 did not itself perform the final H4 policy transition because dependent
-members still lack the Phase-5 post-AM evidence. The remaining H4 policy change must start
-from the **then-current** global `POLICY_VERSION` (currently
-`2026-09-recommender-recovery-calibration-v1` on `main` at `78a2e11`), not from an obsolete
-H4 id. H4's ledger-based ranking/admission wiring and H5c will each require normal policy
+change. PR 3 Phase 5 added the post-AM evidence path, and Phase 6 completed the cumulative
+H4 transition by archiving the then-current
+`2026-09-simulation-sequence-occupational-context-v2` policy and activating
+`2026-09-h4-intraday-bundle-member-launch-v1`. H4's ledger-based ranking/admission wiring
+and H5c will each require normal policy
 review when they actually change decision behavior. Do not enable experimental
 personalization simply to improve a judge score.

--- a/docs/plans/cycling-primary-hybrid-implementation-handoff.md
+++ b/docs/plans/cycling-primary-hybrid-implementation-handoff.md
@@ -1,8 +1,8 @@
 # Cycling-primary hybrid: implementation handoff
 
 **Scope note:** This document supplies **bounded implementation work orders**; the
-[evaluation plan](./cycling-primary-hybrid-evaluation.md) owns H1-H5 status. For current H4
-implementation work, read [the PR 3 plan](./h4-434-pr3-bundle-second-member-launch.md) --
+[evaluation plan](./cycling-primary-hybrid-evaluation.md) owns H1-H5 status. For H4 release
+history and current follow-ups, read [the PR 3 plan](./h4-434-pr3-bundle-second-member-launch.md) --
 the H4 work order below predates issue #434's execution-binding pipeline and is retained for
 its record of what was investigated, not as a task list.
 **Status:** H1, H2, H2b, H3 and H3-rest (ADR-0035) all delivered; H4 design accepted as
@@ -15,7 +15,7 @@ delivered (H5c confirmed revisions and cumulative `external-plan@5` unstarted)
 **Blocked by:** Nothing blocks starting any remaining item. H4's live release is delivered.
 H5c (confirmed bounded revisions, with the athlete-scoped singleton
 progression claim) and cumulative `external-plan@5` with `intentBlocks` are both ready to
-start, and are independent of H4's remaining phases. Personal M00/M01 prescription needs
+start, and are independent of H4's non-gating follow-ups. Personal M00/M01 prescription needs
 current athlete inputs.
 **Unlocks:** A cycling-first recommendation path that preserves feasible strength, respects equipment and time, and supports authored blocks without inventing capacity.
 
@@ -67,13 +67,12 @@ H4's authority/schema design is the accepted ADR-0036 proposal
 than reconstructing its v4 contract from discussion context. Its v4 artifact has landed, so
 cumulative `external-plan@5` import acceptance now has a real contract to build against.
 
-Suggested next step: **H4 PR 3 Phase 5** (post-AM confirmation capture), per
-[the PR 3 plan](./h4-434-pr3-bundle-second-member-launch.md). Phase 4 already made eligible
-non-primary bundle members independently startable via the atomic claim path; Phase 5 supplies
-the real post-predecessor evidence required for a dependent member to leave `pending`.
-H5c (ADR-0037 confirmed bounded revisions) is independently startable in parallel. Keep both
-separate from personal M00/M01 prescription until current workload/restriction inputs are
-confirmed.
+H4 PR 3 is complete through Phase 6; see
+[the PR 3 plan](./h4-434-pr3-bundle-second-member-launch.md). The remaining H4 work is
+non-gating follow-up: planner-wide ledger remainder/admission unification and persistence of
+resolved bundle placement for display/audit. H5c (ADR-0037 confirmed bounded revisions) is
+independently startable. Keep all of those separate from personal M00/M01 prescription until
+current workload/restriction inputs are confirmed.
 
 ## Stable product intent
 
@@ -260,9 +259,10 @@ D-LEDGER (pure module), D-TIME, D-WINDOW, D-PLACEMENT's engine
 (`engine/intradayReassessment.ts`, #442) and D-AUDIT (`engine/intradayDecision.ts`, #443);
 the same-day canonical performed-fact boundary is verified. The external-plan
 `SessionReferenceBinding` execution-binding pipeline -- called out below as a separate
-multi-PR foundational project -- became issue #434 and is delivered through PR 3 Phase 5
-(#440, #445, #448, #450, #451, #454, #465), giving D-REASSESS/D-AUDIT a launchable
-non-primary member and post-AM response evidence through the source-neutral execution path.
+multi-PR foundational project -- became issue #434 and is delivered through PR 3 Phase 6
+(#440, #445, #448, #450, #451, #454, #465, #470, #472), giving D-REASSESS/D-AUDIT a
+launchable non-primary member, post-AM response evidence, and the cumulative H4 policy
+transition through the source-neutral execution path.
 
 Still outstanding: unifying `planner.ts`'s three ad hoc dedup mechanisms onto the ledger's
 remainder/admission semantics
@@ -397,16 +397,16 @@ its description has actually shipped.
 4. At PM launch, capture current symptoms/response, same-day work and availability, rerun
    common gates, and atomically validate the input/ledger revision before reserving.
    A morning PM approval is provisional; missing prerequisite evidence remains pending.
-   The launch/claim portion is delivered in PR 3 Phase 4; post-predecessor confirmation
-   capture remains Phase 5.
+   The launch/claim portion was delivered in PR 3 Phase 4; post-predecessor confirmation
+   capture was delivered in Phase 5 (#470).
 5. Persist independent immutable intraday decisions and replay snapshots, show provisional,
    pending, dropped and completed states, and implement the ADR's deterministic test matrix.
    D-AUDIT persistence and the Phase-4 launch snapshot are delivered; completion-response
-   evidence remains part of Phase 5.
+   evidence was delivered in Phase 5 (#470).
 6. Run focused tests, full frontend checks/build, Firestore rules, simulations/diff and
-   policy drift validation. Phase 6 must bump `POLICY_VERSION` from the then-current global
-   value when the remaining H4 behavior is activated. Introduce an execution scenario family
-   only when it can represent the required inputs and outputs.
+   policy drift validation. Phase 6 completed the required `POLICY_VERSION` transition from
+   the then-current global value in #472. Introduce an execution scenario family only when
+   it can represent the required inputs and outputs.
 
 Read ADR-0036 for the binding contract and full acceptance bar. This work does not add a
 universal recovery-hour threshold, automatically increase weekly dose, or authorize H5
@@ -434,10 +434,9 @@ pinning test confirming `getPerformedTrainingFactsInRange`'s existing behavior a
 `trainingIntent.ts`'s call site are unchanged.
 
 D-PLACEMENT's placement-correctness wiring and issue #434's execution-binding pipeline
-through Phase 4 are delivered. Current H4 work therefore separates into three independent
-tracks: (a) PR 3 Phases 5-6 for post-AM evidence and the cumulative policy transition (the
-live dependent-member release gate); (b) unifying `planner.ts`'s remaining ad hoc dedup /
-remainder-admission paths onto D-LEDGER as a real ranking input; and (c) recommendation-audit
+through Phase 6 are delivered. Remaining H4 work therefore separates into two independent,
+non-gating tracks: (a) unifying `planner.ts`'s remaining ad hoc dedup /
+remainder-admission paths onto D-LEDGER as a real ranking input; and (b) recommendation-audit
 persistence of resolved bundle placement for display, now unblocked by #468/#435 but still
 unimplemented. Do not resurrect the older roadmap that placed the execution-binding pipeline
 or D-REASSESS/D-AUDIT after D-PLACEMENT; those have already landed.

--- a/docs/plans/cycling-primary-hybrid-implementation-handoff.md
+++ b/docs/plans/cycling-primary-hybrid-implementation-handoff.md
@@ -8,13 +8,12 @@ its record of what was investigated, not as a task list.
 **Status:** H1, H2, H2b, H3 and H3-rest (ADR-0035) all delivered; H4 design accepted as
 ADR-0036 with every design slice (D-SCHEMA, D-LEDGER, D-TIME, D-WINDOW, D-PLACEMENT,
 D-REASSESS, D-AUDIT) delivered as code and issue #434's execution-binding pipeline delivered
-through PR 3 Phase 5 -- only the H4-specific `POLICY_VERSION` transition remains, and
-ledger-based
+through PR 3 Phase 6, including the cumulative H4 `POLICY_VERSION` transition; ledger-based
 ranking/admission is still not a decision input anywhere; H5 design accepted as ADR-0037
 with H5a (intent contracts, canonical replay) and H5b (report-only progression review)
 delivered (H5c confirmed revisions and cumulative `external-plan@5` unstarted)
-**Blocked by:** Nothing blocks starting any remaining item. H4's live release is gated on
-PR 3 Phase 6. H5c (confirmed bounded revisions, with the athlete-scoped singleton
+**Blocked by:** Nothing blocks starting any remaining item. H4's live release is delivered.
+H5c (confirmed bounded revisions, with the athlete-scoped singleton
 progression claim) and cumulative `external-plan@5` with `intentBlocks` are both ready to
 start, and are independent of H4's remaining phases. Personal M00/M01 prescription needs
 current athlete inputs.
@@ -40,12 +39,11 @@ when an earlier exposure already satisfied that role's weekly minimum. On unclai
 the ordinary coverage ordering is unchanged, so an already-met hard role does not force
 unnecessary repeats.
 
-As of `main` at `78a2e11` (#468), the current decision policy version is
-`2026-09-recommender-recovery-calibration-v1`. This line can go stale -- always read
-`app/src/engine/policy.ts` before changing policy. PR 3 Phase 6 must archive whatever value
-is **then current** before bumping to the cumulative H4 launch contract; it must not assume
-that an earlier H4 policy id is still the active one. See the evaluation plan for the root
-cause, focused regression tests and required PR-head validation.
+Phase 6 archived the then-current
+`2026-09-simulation-sequence-occupational-context-v2` policy and activated
+`2026-09-h4-intraday-bundle-member-launch-v1`. Future policy work must still read
+`app/src/engine/policy.ts` rather than assuming this value remains current. See the
+evaluation plan for the root cause, focused regression tests and required PR-head validation.
 
 H3 was investigated and its executable contracts are delivered (see the work orders below
 and the evaluation plan). The unplanned-date fallback, missed-session replacement,
@@ -266,16 +264,15 @@ multi-PR foundational project -- became issue #434 and is delivered through PR 3
 (#440, #445, #448, #450, #451, #454, #465), giving D-REASSESS/D-AUDIT a launchable
 non-primary member and post-AM response evidence through the source-neutral execution path.
 
-Still outstanding: **PR 3 Phase 6** (the H4-specific `POLICY_VERSION` transition) -- the
-release gate; unifying
-`planner.ts`'s three ad hoc dedup mechanisms onto the ledger's remainder/admission semantics
+Still outstanding: unifying `planner.ts`'s three ad hoc dedup mechanisms onto the ledger's
+remainder/admission semantics
 as a real ranking/admission input; and persisting a bundle's resolved placement for display.
 The placement-display work was previously blocked by Firestore's per-request rules-expression
 ceiling; #468 reduced recommendation-audit evaluation cost and closed #435, so that work is
 now unblocked but remains unimplemented and non-gating for PR 3.
 **Dependencies:** ADR-0035 rest support (delivered). Same-day canonical performed
 identity/revision/timing inputs are verified (see below); D-TIME, D-WINDOW, D-PLACEMENT and
-the #434 pipeline through PR 3 Phase 5 are all delivered. Nothing blocks Phase 6.
+the #434 pipeline through PR 3 Phase 6 are all delivered.
 **Deliverable:** Authored intraday placement and reassessed execution, followed separately
 by automatic multi-window packing after the initial acceptance bar passes.
 

--- a/docs/plans/h4-434-pr3-bundle-second-member-launch.md
+++ b/docs/plans/h4-434-pr3-bundle-second-member-launch.md
@@ -1,10 +1,11 @@
 # H4 / issue #434 PR 3 — Intraday bundle second-member launch & athlete confirmation capture
 
-**Status:** In progress — **Phases 1-5 delivered** (#448, #450, #451, #454, #465, #470);
-**Phase 6 remains** and is the final gate on a live dependent-member H4 release.
+**Status:** Implemented — **Phases 1-6 delivered** (#448, #450, #451, #454, #465, #470);
+Phase 6 activates the cumulative H4 dependent-member launch policy.
 **Tracks:** [GitHub issue #434](https://github.com/Szczepanov/adaptive-training-recommender/issues/434)
 (historical issue, now closed), PR 3.
-**Blocked by:** Phase 6 should branch only after #470 merges; no additional architecture blocker remains.
+**Blocked by:** none for the delivered H4 release; broader ledger and placement-persistence
+follow-ups remain separately scoped.
 **Unlocks:** dependent non-primary bundle members that can move from `pending` to a fresh
 launchable verdict after real post-predecessor evidence, followed by the cumulative H4
 policy transition.
@@ -16,7 +17,8 @@ D-WINDOW / D-LEDGER / D-REASSESS / D-PLACEMENT.
 
 > This is a mutable implementation plan. Delivered phases are summarized as outcomes rather
 > than left as a live work list; the merged PRs remain the detailed historical implementation
-> record. The executable work in this document is Phase 6.
+> record. No executable work remains in this document; the non-gating H4 follow-ups below
+> remain separately scoped.
 
 ---
 
@@ -38,10 +40,10 @@ A v4 intraday bundle's non-primary member is now:
 8. atomically claimed against the occurrence/ledger state before execution starts, with
    rollback if definition resolution or runner start fails.
 
-The remaining release gap is narrower: **the H4-specific Phase 6 policy transition is not yet
-applied.** Phase 5 now persists an `immediate` `SessionResponse` after completion, alongside
-completion facts and tissue feedback, so a dependent PM member has the evidence needed for a
-fresh reassessment rather than remaining pending solely because the response record is absent.
+The H4 release is complete. Phase 5 persists an `immediate` `SessionResponse` after
+completion, alongside completion facts and tissue feedback, so a dependent PM member has the
+evidence needed for a fresh reassessment. Phase 6 makes that complete H4 contract current
+under `2026-09-h4-intraday-bundle-member-launch-v1`.
 
 ### Current authoritative implementation map
 
@@ -61,7 +63,7 @@ fresh reassessment rather than remaining pending solely because the response rec
 | Atomic launch claim + rollback | `services/intradayLaunchClaim.ts`, `sessionOccurrenceService.releaseOccurrenceClaim`, `Home.tsx` | Delivered (#465) |
 | Post-AM immediate response | `useSessionRunner.completeSession` records/revises the deterministic response after commit | **Delivered — Phase 5** |
 | Confirmation revision from submitted evidence | Existing reassessment revision consumes response/tissue evidence | **Delivered — Phase 5** |
-| Cumulative H4 policy transition | `engine/policy.ts` | **Open — Phase 6** |
+| Cumulative H4 policy transition | `engine/policy.ts` | **Delivered — Phase 6** |
 
 ### Phase-4 implementation decisions that supersede older plan text
 
@@ -282,7 +284,7 @@ Add focused tests proving at least:
 
 ---
 
-## Phase 6 — policy and contract reconciliation
+## Phase 6 — policy and contract reconciliation — delivered
 
 ### 16. Reassessment revision type — already delivered
 
@@ -290,39 +292,36 @@ No work remains here. #450 made `engine/intradayReassessment.ts` the canonical
 `ReassessmentInputRevision` declaration and `intradayDecision.ts` imports it. Do not recreate
 an obsolete schema-unification task.
 
-### 17. Bump the cumulative policy version from the then-current value
+### 17. Bump the cumulative policy version from the then-current value — delivered
 
 **File:** `app/src/engine/policy.ts`.
 
 The old draft assumed `2026-09-h4-intraday-reassessment-v1` would still be active when Phase 6
-landed. That is false: as of `main` at `78a2e11`, the current value is
-`2026-09-recommender-recovery-calibration-v1`, and
-`2026-09-h4-intraday-reassessment-v1` is already present in
-`HISTORICAL_POLICY_VERSIONS`.
+landed. That was already false before Phase 5, and further decision work advanced the active
+version again. On the Phase 6 base, the current value was
+`2026-09-simulation-sequence-occupational-context-v2`; Phase 6 archives that value and
+activates `2026-09-h4-intraday-bundle-member-launch-v1`.
 
-When Phase 6 is implemented:
+Delivered contract:
 
 1. read the actual `POLICY_VERSION` on the Phase-6 base commit;
-2. append **that then-current value** to `HISTORICAL_POLICY_VERSIONS` if it is not already
-   present;
-3. set a new cumulative policy id representing the now-live H4 post-predecessor launch
-   contract;
-4. preserve every existing historical id; do not duplicate the already-historical H4
-   reassessment id;
+2. append that then-current value exactly once to `HISTORICAL_POLICY_VERSIONS`;
+3. set the cumulative H4 launch policy id;
+4. preserve every existing historical id, including the already-historical H4 reassessment
+   id; and
 5. run `node scripts/check-policy-drift.mjs <actual-phase6-base-sha>` plus the normal
    simulation/replay checks.
 
 The exact new string is an implementation naming choice, not an unresolved architecture
 decision. The required invariant is the ancestry/history transition above.
 
-### 18. Reconcile docs in the same change
+### 18. Reconcile docs in the same change — delivered
 
 PR #469 already reconciled the plan index, evaluation, implementation handoff, this PR 3 plan,
 and the older execution-binding roadmap. There is **no separate outstanding task** to reconcile
 that roadmap's historical PR-3 wording after #469.
 
-When Phase 6 lands, update these documents again from the implementation that actually
-merged rather than pre-declaring the final status.
+This change updates the current status from the implementation that delivered Phase 6.
 
 ---
 
@@ -364,7 +363,7 @@ For Phase 5 / PR #470, use the latest PR-head CI run as the authoritative reposi
 result. Unlike #469, this PR changes runtime completion/persistence behavior, so the focused
 completion-sheet and response-service tests must pass alongside the normal application checks.
 
-For the remaining Phase 6 implementation, the required validation set is:
+The Phase 6 implementation validation set is:
 
 ```bash
 cd app && npm run check
@@ -440,9 +439,9 @@ choices.
       `SessionResponse` with the missing completion facts and correct provenance.
 - [x] Post-predecessor response/tissue edits change the confirmation revision and invalidate a
       stale approval.
-- [ ] A dependent member can leave `pending` after valid evidence and required separation,
+- [x] A dependent member can leave `pending` after valid evidence and required separation,
       while adverse/missing evidence remains fail-closed.
-- [ ] The cumulative H4 policy version is bumped from the **then-current** global policy and
+- [x] The cumulative H4 policy version is bumped from the **then-current** global policy and
       that prior value is archived exactly once.
-- [ ] Full checks/rules/simulations/policy-drift verification pass on the Phase 6
+- [x] Full checks/rules/simulations/policy-drift verification pass on the Phase 6
       implementation head.

--- a/docs/plans/h4-434-pr3-bundle-second-member-launch.md
+++ b/docs/plans/h4-434-pr3-bundle-second-member-launch.md
@@ -1,7 +1,7 @@
 # H4 / issue #434 PR 3 — Intraday bundle second-member launch & athlete confirmation capture
 
-**Status:** Implemented — **Phases 1-6 delivered** (#448, #450, #451, #454, #465, #470);
-Phase 6 activates the cumulative H4 dependent-member launch policy.
+**Status:** Implemented — **Phases 1-6 delivered** (#448, #450, #451, #454, #465, #470, #472);
+Phase 6 is delivered in #472 and activates the cumulative H4 dependent-member launch policy.
 **Tracks:** [GitHub issue #434](https://github.com/Szczepanov/adaptive-training-recommender/issues/434)
 (historical issue, now closed), PR 3.
 **Blocked by:** none for the delivered H4 release; broader ledger and placement-persistence
@@ -26,7 +26,8 @@ D-WINDOW / D-LEDGER / D-REASSESS / D-PLACEMENT.
 
 `43c7ce74` (PR #469) is the **pre-Phase-5 `main` baseline**, re-verified after
 #465/#466/#467 and the rules-budget follow-up #468. Phase 5 is implemented in PR #470; its
-verification reference is the latest #470 head/check set, not `43c7ce74`.
+verification reference is the latest #470 head/check set, not `43c7ce74`. Phase 6 is
+implemented in PR #472; use the latest #472 head/check set for the cumulative policy transition.
 
 A v4 intraday bundle's non-primary member is now:
 
@@ -63,7 +64,7 @@ under `2026-09-h4-intraday-bundle-member-launch-v1`.
 | Atomic launch claim + rollback | `services/intradayLaunchClaim.ts`, `sessionOccurrenceService.releaseOccurrenceClaim`, `Home.tsx` | Delivered (#465) |
 | Post-AM immediate response | `useSessionRunner.completeSession` records/revises the deterministic response after commit | **Delivered — Phase 5** |
 | Confirmation revision from submitted evidence | Existing reassessment revision consumes response/tissue evidence | **Delivered — Phase 5** |
-| Cumulative H4 policy transition | `engine/policy.ts` | **Delivered — Phase 6** |
+| Cumulative H4 policy transition | `engine/policy.ts` | **Delivered — Phase 6 (#472)** |
 
 ### Phase-4 implementation decisions that supersede older plan text
 
@@ -284,7 +285,7 @@ Add focused tests proving at least:
 
 ---
 
-## Phase 6 — policy and contract reconciliation — delivered
+## Phase 6 — policy and contract reconciliation — delivered in #472
 
 ### 16. Reassessment revision type — already delivered
 
@@ -292,7 +293,7 @@ No work remains here. #450 made `engine/intradayReassessment.ts` the canonical
 `ReassessmentInputRevision` declaration and `intradayDecision.ts` imports it. Do not recreate
 an obsolete schema-unification task.
 
-### 17. Bump the cumulative policy version from the then-current value — delivered
+### 17. Bump the cumulative policy version from the then-current value — delivered in #472
 
 **File:** `app/src/engine/policy.ts`.
 

--- a/docs/plans/h4-external-plan-execution-binding-pipeline.md
+++ b/docs/plans/h4-external-plan-execution-binding-pipeline.md
@@ -1,7 +1,7 @@
 # H4: external-plan execution-binding pipeline — PR-1/PR-2 implementation and follow-up roadmap
 
 **Status:** PR 1 implemented in [PR #440](https://github.com/Szczepanov/adaptive-training-recommender/pull/440); PR 2 implemented in [PR #445](https://github.com/Szczepanov/adaptive-training-recommender/pull/445).
-PR 3 is delivered through Phase 6; the cumulative H4 policy transition completes the live release.
+PR 3 is delivered through Phase 6, completed by [PR #472](https://github.com/Szczepanov/adaptive-training-recommender/pull/472); the cumulative H4 policy transition completes the live release.
 This document records the original gap, the invariants established by the first two PRs, and the
 remaining follow-up work.
 
@@ -286,12 +286,12 @@ prescription.
    `'external_plan'` authority, `'skipped'` state, deterministic/idempotent occurrence identity,
    replay validation, lifecycle transitions, and the atomic `claimOccurrenceLaunch` primitive.
    Live claim/ledger wiring was intentionally deferred as described above.
-3. **PR 3 — delivered through Phase 6:** use resolved intraday placement to
+3. **PR 3 — delivered through Phase 6, completed by PR #472:** use resolved intraday placement to
    adjudicate and surface non-primary v4 members as independently launchable
    `additionalSessions` entries, wiring eligible launch through the occurrence claim/ledger
    boundary. Phase 5 captures post-AM `SessionResponse` evidence and Phase 6 activates the
    H4 policy transition.
-4. **Phase 6 — delivered:** archived the then-current
+4. **Phase 6 — delivered in PR #472:** archived the then-current
    `2026-09-simulation-sequence-occupational-context-v2` policy and activated
    `2026-09-h4-intraday-bundle-member-launch-v1`.
 5. **Optional later work — block scaling:** add a deterministic, testable external-definition

--- a/docs/plans/h4-external-plan-execution-binding-pipeline.md
+++ b/docs/plans/h4-external-plan-execution-binding-pipeline.md
@@ -1,7 +1,7 @@
 # H4: external-plan execution-binding pipeline — PR-1/PR-2 implementation and follow-up roadmap
 
 **Status:** PR 1 implemented in [PR #440](https://github.com/Szczepanov/adaptive-training-recommender/pull/440); PR 2 implemented in [PR #445](https://github.com/Szczepanov/adaptive-training-recommender/pull/445).
-PR 3 is delivered through Phase 5 in [PR #470](https://github.com/Szczepanov/adaptive-training-recommender/pull/470); Phase 6 remains.
+PR 3 is delivered through Phase 6; the cumulative H4 policy transition completes the live release.
 This document records the original gap, the invariants established by the first two PRs, and the
 remaining follow-up work.
 
@@ -286,13 +286,14 @@ prescription.
    `'external_plan'` authority, `'skipped'` state, deterministic/idempotent occurrence identity,
    replay validation, lifecycle transitions, and the atomic `claimOccurrenceLaunch` primitive.
    Live claim/ledger wiring was intentionally deferred as described above.
-3. **PR 3 — delivered through Phase 5 in PR #470:** use resolved intraday placement to
+3. **PR 3 — delivered through Phase 6:** use resolved intraday placement to
    adjudicate and surface non-primary v4 members as independently launchable
    `additionalSessions` entries, wiring eligible launch through the occurrence claim/ledger
-   boundary. Phase 5 now captures post-AM `SessionResponse` evidence; Phase 6 still needs
-   the H4-specific policy transition.
-4. **Remaining PR 3 work — Phase 6:** bump the cumulative policy version while archiving the
-   **then-current** `POLICY_VERSION` (not a hard-coded earlier H4 value).
+   boundary. Phase 5 captures post-AM `SessionResponse` evidence and Phase 6 activates the
+   H4 policy transition.
+4. **Phase 6 — delivered:** archived the then-current
+   `2026-09-simulation-sequence-occupational-context-v2` policy and activated
+   `2026-09-h4-intraday-bundle-member-launch-v1`.
 5. **Optional later work — block scaling:** add a deterministic, testable external-definition
    scaling transform before allowing `scale` verdicts to produce launch bindings.
 


### PR DESCRIPTION
## Summary

Completes H4 / ADR-0036 PR 3 Phase 6.

- activates `2026-09-h4-intraday-bundle-member-launch-v1` as the cumulative H4 release policy;
- archives the actual Phase 6 base policy, `2026-09-simulation-sequence-occupational-context-v2`, exactly once without altering prior policy history;
- hardens the policy-history regression test so both the active policy ID and exact-once superseded lineage are pinned;
- reconciles H4 living status documents through Phase 6 / PR #472;
- leaves planner-wide ledger admission and resolved-placement persistence as explicitly non-gating follow-ups;
- incorporates current `main` / #473 so the PR is not behind the base.

## Risk and reviewer guidance

**Risk:** Low. This PR is a policy-version activation plus regression/docs reconciliation; it does not change recommendation-selection logic. The main regression risks are corrupting policy ancestry/history or leaving contradictory H4 release status in the living plans.

**Reviewer focus:**
- `app/src/engine/policy.ts`: current policy should be `2026-09-h4-intraday-bundle-member-launch-v1`; the superseded `2026-09-simulation-sequence-occupational-context-v2` should appear exactly once in history.
- `app/src/engine/policy.test.ts`: the transition test must fail on either the wrong active ID or duplicate superseded history.
- `docs/plans/*`: H4 PR 3 / Phase 6 should be consistently complete, while planner-wide ledger admission and resolved-placement persistence remain non-gating follow-ups.
- ADR-0036 is intentionally not rewritten: accepted ADRs in this repo preserve decision-time implementation wording; the living plan docs own delivery status.

**Rollback:** revert the Phase-6 policy/docs changes together so the active policy and historical lineage stay coherent. Do not remove older historical IDs.

## Domain invariants

- Policy ancestry is append-only: the then-current policy is archived exactly once before changing `POLICY_VERSION`.
- Existing historical policy IDs remain intact.
- This activation must not alter selection/recommendation behavior; simulation semantic drift attributable to this PR should remain absent.
- Missing/post-predecessor evidence and H4 launch safety behavior remain fail-closed as delivered in earlier phases.
- Non-gating follow-ups are not presented as blockers for the completed H4 live release.

## Validation

- Targeted H4/policy tests: 54 passed.
- `npm run check`: 416 files passed; 3,998 tests passed, 19 skipped / 237 skipped.
- `npm run test:rules`: 19 files / 237 tests passed.
- `npm run simulate:scenarios` and `npm run simulate:diff` completed. The semantic diff reports baseline drift already introduced by merged #471; this PR changes no selection logic.
- `make check`: 816 backend tests passed; frontend checks and workout validation passed.
- `node scripts/check-policy-drift.mjs d33eb5bb`: expected policy-only version-change warning with the verified old-to-new transition.
- `git diff --check`: passed.
- GitHub Actions CI Pipeline #2752 passed on final head `46da444`, including frontend/rules, static gates, simulations/AI gates, Docker smoke, Python pre-commit/Ruff/mypy, 816 Python tests, coverage artifact upload, dependency audit, and the overall CI Gate. The first Python attempt failed only while finalizing the already-uploaded coverage artifact with a GitHub intermediary HTTP 403; the unchanged targeted rerun passed end-to-end.

## Screenshots or recordings

Not applicable — no UI or visual behavior changes.