### PR TITLE
test(ci): remove flaky concurrent launch ordering assertion

### DIFF
--- a/app/src/services/sessionAuthoringService.test.ts
+++ b/app/src/services/sessionAuthoringService.test.ts
@@ -425,20 +425,23 @@ describe('prepareExternalPlanSessionLaunch (ADR-0036 H4)', () => {
         expect(stored?.createdAt).toBe('2026-09-06T10:00:00.000Z');
     });
 
-    it('preserves the first committed write when concurrent launches share a prescriptionHash with different timestamps', async () => {
+    it('produces the same content-addressed binding for concurrent launches with different timestamps', async () => {
         const externalPlan = makeV4ExternalPlan();
-        const earliestTime = '2026-09-06T10:00:00.000Z';
-        const laterTime = '2026-09-06T10:05:00.000Z';
+        const firstTime = '2026-09-06T10:00:00.000Z';
+        const secondTime = '2026-09-06T10:05:00.000Z';
 
         const [first, second] = await Promise.all([
-            prepareExternalPlanSessionLaunch('u1', externalPlan, undefined, earliestTime),
-            prepareExternalPlanSessionLaunch('u1', externalPlan, undefined, laterTime),
+            prepareExternalPlanSessionLaunch('u1', externalPlan, undefined, firstTime),
+            prepareExternalPlanSessionLaunch('u1', externalPlan, undefined, secondTime),
         ]);
 
         expect(first.binding.prescriptionHash).toBe(second.binding.prescriptionHash);
-        const stored = services.store.get(first.binding.prescriptionHash);
-        expect(stored).toBeDefined();
-        expect(stored?.createdAt).toBe(earliestTime);
+        expect(services.prescription.savePrescription).toHaveBeenCalledTimes(2);
+
+        // Content hashing is asynchronous, so concurrent callers have no invocation-order
+        // guarantee. First-commit persistence is covered by ExecutionPrescriptionService's
+        // transaction tests; this launch-layer test only owns binding determinism.
+        expect(services.store.size).toBe(1);
     });
 
     it('omits volatile createdAt from the prescription hash payload', async () => {


### PR DESCRIPTION
## Summary

Fixes the failed production release gate from GitHub Actions run 34245584313.

`prepareExternalPlanSessionLaunch` performs asynchronous content hashing before it delegates persistence. The launch-layer unit test used `Promise.all` with an in-memory write-once `Map`, then assumed the first array element must reach that mock first. That order is not guaranteed: the later-timestamp call can finish hashing first, which caused the CI-only assertion failure.

This PR keeps the production contract unchanged:

- `ExecutionPrescriptionService.savePrescription` remains responsible for first-commit immutability through its Firestore transaction.
- The launch-layer test now asserts its actual responsibility: concurrent preparations of equivalent execution content generate the same content-addressed prescription binding and result in one write-once mock record.
- Existing `executionPrescriptionService.test.ts` transaction tests continue to cover commit ordering, contention retries, and immutable persisted `createdAt` values.

No runtime, Firestore rule, workflow, or deployment configuration changes are included.

## Validation

- `npm test -- --run src/services/sessionAuthoringService.test.ts src/services/executionPrescriptionService.test.ts`
  - 27 passed
- `npm run typecheck`
- `npm run lint -- --quiet`
- `npm test`
  - 416 files passed, 19 skipped; 3,997 tests passed, 237 skipped
- Repository pre-commit/pre-push validation passed, including frontend typecheck, lint, tests, and workout validation.

## Deployment impact

Merging this PR should allow the previously blocked `Deploy Production E2E` workflow to pass its frontend unit-test gate. The Node 20 deprecation and missing coverage-artifact messages in the failed run are warnings, not release blockers.