### PR TITLE
feat(planner): admit candidates through daily ledger

### DIFF
--- a/app/src/engine/dailyLedger.ts
+++ b/app/src/engine/dailyLedger.ts
@@ -2,10 +2,9 @@
  * ADR-0036 (H4) D-LEDGER: one pure, as-of daily accounting boundary for the shared minute
  * and systemic-cost ceiling a date's windows draw from. This module has no dependency on
  * wall-clock/timezone resolution (D-TIME), Firestore, or any existing schedule module --
- * every input (ceilings, reservations, actuals) is already resolved by the caller. It is
- * not wired into `schedule.ts`'s `resolveAvailability`, `planner.ts`'s fixed-activity cost
- * reduces, or any recommendation decision yet; see the H4 status notes in
- * `docs/plans/cycling-primary-hybrid-evaluation.md` for the deferred wiring step.
+ * every input (ceilings, reservations, actuals) is already resolved by the caller. The
+ * rolling planner adapts pending fixed activities to this boundary before candidate ranking;
+ * direct same-day readiness selection remains outside this module's scope.
  *
  * Keep the current common cost/eligibility authorities: this file does not invent another
  * fatigue-fusion formula or a second systemic-cost scale. `dailySystemicCostCeiling` and

--- a/app/src/engine/fixedActivityLedger.test.ts
+++ b/app/src/engine/fixedActivityLedger.test.ts
@@ -32,9 +32,28 @@ describe('fixed activity D-LEDGER adapter', () => {
         expect(resolveAvailability('2026-09-10', null, [stale, current], context).maxTimeMinutes).toBe(60);
     });
 
+    it('reconciles an occurrence before date filtering when a newer revision moves it', () => {
+        const stale = activity({
+            id: 'football', date: '2026-09-10', durationMin: 30,
+            expectedCost: { systemic: 0.2 }, updatedAt: '2026-09-01T00:00:00Z',
+        });
+        const current = activity({
+            id: 'football', date: '2026-09-11', durationMin: 30,
+            expectedCost: { systemic: 0.2 }, updatedAt: '2026-09-02T00:00:00Z',
+        });
+
+        const oldDate = resolveAvailability('2026-09-10', null, [stale, current], context);
+        const newDate = resolveAvailability('2026-09-11', null, [stale, current], context);
+
+        expect(oldDate.fixedActivities).toEqual([]);
+        expect(oldDate.maxTimeMinutes).toBe(90);
+        expect(newDate.fixedActivities).toEqual([current]);
+        expect(newDate.maxTimeMinutes).toBe(60);
+    });
+
     it('fails closed when equal revisions disagree on decision-bearing fields', () => {
-        const left = activity({ id: 'football', durationMin: 30, expectedCost: { systemic: 0.2 } });
-        const right = activity({ id: 'football', durationMin: 45, expectedCost: { systemic: 0.2 } });
+        const left = activity({ id: 'football', startTime: '08:00', durationMin: 30, expectedCost: { systemic: 0.2 } });
+        const right = activity({ id: 'football', startTime: '18:00', durationMin: 30, expectedCost: { systemic: 0.2 } });
 
         expect(() => dedupeFixedActivitiesByLedgerIdentity([left, right]))
             .toThrow("Conflicting fixed-activity revisions for occurrence 'fixed:football'");

--- a/app/src/engine/fixedActivityLedger.test.ts
+++ b/app/src/engine/fixedActivityLedger.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import type { FixedActivity, UserContext } from './models';
+import { dedupeFixedActivitiesByLedgerIdentity, pendingFixedActivityLedgerEntries } from './fixedActivityLedger';
+import { resolveAvailability } from './schedule';
+
+function activity({ id, ...overrides }: Partial<FixedActivity> & Pick<FixedActivity, 'id'>): FixedActivity {
+    return {
+        id,
+        userId: 'u1', title: 'Fixed activity', date: '2026-09-10', durationMin: 30,
+        fixed: true, environment: 'either', equipment: [], isCompleted: false,
+        createdAt: '2026-09-01T00:00:00Z', updatedAt: '2026-09-01T00:00:00Z',
+        ...overrides,
+    };
+}
+
+const context: UserContext = {
+    goals: { shortTerm: '', midTerm: '', longTerm: '' },
+    constraints: { hasCableMachine: false, hasFreeWeights: false, hasTreadmill: false, hasIndoorBike: false, maxTimeMinutes: 90 },
+    preferences: { avoidedModalities: [], deprioritizedModalities: [], preferredModalities: [], conservativeBias: false },
+};
+
+describe('fixed activity D-LEDGER adapter', () => {
+    it('uses the newest occurrence revision once across schedule time and ledger cost', () => {
+        const stale = activity({ id: 'football', durationMin: 60, expectedCost: { systemic: 0.6 }, updatedAt: '2026-09-01T00:00:00Z' });
+        const current = activity({ id: 'football', durationMin: 30, expectedCost: { systemic: 0.2 }, updatedAt: '2026-09-02T00:00:00Z' });
+
+        expect(dedupeFixedActivitiesByLedgerIdentity([stale, current])).toEqual([current]);
+        expect(pendingFixedActivityLedgerEntries([stale, current])).toEqual([{
+            occurrenceId: 'fixed:football', revision: Date.parse(current.updatedAt),
+            reservedMinutes: 30, reservedSystemicCost: 0.2, state: 'reserved',
+        }]);
+        expect(resolveAvailability('2026-09-10', null, [stale, current], context).maxTimeMinutes).toBe(60);
+    });
+
+    it('fails closed when equal revisions disagree on decision-bearing fields', () => {
+        const left = activity({ id: 'football', durationMin: 30, expectedCost: { systemic: 0.2 } });
+        const right = activity({ id: 'football', durationMin: 45, expectedCost: { systemic: 0.2 } });
+
+        expect(() => dedupeFixedActivitiesByLedgerIdentity([left, right]))
+            .toThrow("Conflicting fixed-activity revisions for occurrence 'fixed:football'");
+    });
+});

--- a/app/src/engine/fixedActivityLedger.test.ts
+++ b/app/src/engine/fixedActivityLedger.test.ts
@@ -51,6 +51,23 @@ describe('fixed activity D-LEDGER adapter', () => {
         expect(newDate.maxTimeMinutes).toBe(60);
     });
 
+    it('canonicalizes occurrence order and ignores representation-only ordering differences', () => {
+        const zeta = activity({ id: 'zeta', equipment: ['bike', 'trainer'] });
+        const alpha = activity({
+            id: 'alpha', equipment: ['trainer', 'bike'],
+            expectedCost: { lowerBody: 0.3, systemic: 0.2 },
+        });
+        const alphaEquivalent = activity({
+            id: 'alpha', equipment: ['bike', 'trainer'],
+            expectedCost: { systemic: 0.2, lowerBody: 0.3 },
+        });
+
+        expect(dedupeFixedActivitiesByLedgerIdentity([zeta, alphaEquivalent, alpha]))
+            .toEqual([alphaEquivalent, zeta]);
+        expect(dedupeFixedActivitiesByLedgerIdentity([alpha, zeta, alphaEquivalent]))
+            .toEqual([alpha, zeta]);
+    });
+
     it('fails closed when equal revisions disagree on decision-bearing fields', () => {
         const left = activity({ id: 'football', startTime: '08:00', durationMin: 30, expectedCost: { systemic: 0.2 } });
         const right = activity({ id: 'football', startTime: '18:00', durationMin: 30, expectedCost: { systemic: 0.2 } });

--- a/app/src/engine/fixedActivityLedger.ts
+++ b/app/src/engine/fixedActivityLedger.ts
@@ -60,8 +60,10 @@ function decisionFingerprint(activity: FixedActivity): string {
 /**
  * Keeps the newest revision of each fixed-activity occurrence. Equal revisions must
  * describe the same decision-bearing activity; otherwise planning fails closed instead of
- * depending on Firestore/query order. This mirrors `computeDailyLedger`'s identity rule
- * while retaining the full activity for schedule and stimulus consumers.
+ * depending on Firestore/query order. The output is canonicalized by occurrence id so
+ * downstream stimulus/diagnostic consumers are deterministic even when query order varies.
+ * This mirrors `computeDailyLedger`'s identity rule while retaining the full activity for
+ * schedule and stimulus consumers.
  */
 export function dedupeFixedActivitiesByLedgerIdentity(
     activities: readonly FixedActivity[],
@@ -85,7 +87,9 @@ export function dedupeFixedActivitiesByLedgerIdentity(
             throw new Error(`Conflicting fixed-activity revisions for occurrence '${entry.occurrenceId}' at revision ${entry.revision}`);
         }
     }
-    return [...latest.values()];
+    return [...latest.entries()]
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([, activity]) => activity);
 }
 
 /** Entries for the planner's still-pending fixed commitments. Completed activities are

--- a/app/src/engine/fixedActivityLedger.ts
+++ b/app/src/engine/fixedActivityLedger.ts
@@ -19,18 +19,41 @@ export function fixedActivityLedgerEntry(activity: FixedActivity): LedgerEntry {
     };
 }
 
+function sortedRecordEntries(record: object | undefined): [string, unknown][] | null {
+    return record
+        ? Object.entries(record).sort(([left], [right]) => left.localeCompare(right))
+        : null;
+}
+
 function decisionFingerprint(activity: FixedActivity): string {
     return JSON.stringify({
         date: activity.date,
+        startTime: activity.startTime ?? null,
         durationMin: activity.durationMin,
-        expectedCost: activity.expectedCost ?? null,
-        expectedStimulus: activity.expectedStimulus ?? null,
+        expectedCost: sortedRecordEntries(activity.expectedCost),
+        expectedStimulus: sortedRecordEntries(activity.expectedStimulus),
         fixed: activity.fixed,
         environment: activity.environment,
-        equipment: activity.equipment,
+        equipment: [...activity.equipment].sort(),
         availabilityOverride: activity.availabilityOverride ?? null,
-        availabilityContextOverride: activity.availabilityContextOverride ?? null,
+        availabilityContextOverride: activity.availabilityContextOverride
+            ? {
+                environment: activity.availabilityContextOverride.environment ?? null,
+                equipment: activity.availabilityContextOverride.equipment
+                    ? [...activity.availabilityContextOverride.equipment].sort()
+                    : null,
+            }
+            : null,
         isCompleted: activity.isCompleted,
+        templateId: activity.templateId ?? null,
+        workoutId: activity.workoutId ?? null,
+        externalAuthoredIdentity: activity.externalAuthoredIdentity
+            ? {
+                modality: activity.externalAuthoredIdentity.modality,
+                category: activity.externalAuthoredIdentity.category,
+                stimulusConfidence: activity.externalAuthoredIdentity.stimulusConfidence,
+            }
+            : null,
     });
 }
 

--- a/app/src/engine/fixedActivityLedger.ts
+++ b/app/src/engine/fixedActivityLedger.ts
@@ -1,0 +1,76 @@
+import type { LedgerEntry } from './dailyLedger';
+import { fixedActivityOccurrenceKey } from './fixedActivityIdentity';
+import type { FixedActivity } from './models';
+
+/**
+ * Adapts a persisted fixed activity to ADR-0036's occurrence/revision accounting
+ * boundary. A fixed activity is a scheduled commitment, so it remains a reservation
+ * until a richer performed-occurrence source supersedes it; `isCompleted` is handled by
+ * the caller that decides whether this planned-capacity path still applies.
+ */
+export function fixedActivityLedgerEntry(activity: FixedActivity): LedgerEntry {
+    const updatedAt = Date.parse(activity.updatedAt);
+    return {
+        occurrenceId: fixedActivityOccurrenceKey(activity),
+        revision: Number.isSafeInteger(updatedAt) && updatedAt >= 0 ? updatedAt : 0,
+        reservedMinutes: activity.durationMin,
+        reservedSystemicCost: activity.expectedCost?.systemic ?? 0,
+        state: 'reserved',
+    };
+}
+
+function decisionFingerprint(activity: FixedActivity): string {
+    return JSON.stringify({
+        date: activity.date,
+        durationMin: activity.durationMin,
+        expectedCost: activity.expectedCost ?? null,
+        expectedStimulus: activity.expectedStimulus ?? null,
+        fixed: activity.fixed,
+        environment: activity.environment,
+        equipment: activity.equipment,
+        availabilityOverride: activity.availabilityOverride ?? null,
+        availabilityContextOverride: activity.availabilityContextOverride ?? null,
+        isCompleted: activity.isCompleted,
+    });
+}
+
+/**
+ * Keeps the newest revision of each fixed-activity occurrence. Equal revisions must
+ * describe the same decision-bearing activity; otherwise planning fails closed instead of
+ * depending on Firestore/query order. This mirrors `computeDailyLedger`'s identity rule
+ * while retaining the full activity for schedule and stimulus consumers.
+ */
+export function dedupeFixedActivitiesByLedgerIdentity(
+    activities: readonly FixedActivity[],
+): FixedActivity[] {
+    const latest = new Map<string, FixedActivity>();
+    for (const activity of activities) {
+        const entry = fixedActivityLedgerEntry(activity);
+        const current = latest.get(entry.occurrenceId);
+        if (!current) {
+            latest.set(entry.occurrenceId, activity);
+            continue;
+        }
+
+        const currentEntry = fixedActivityLedgerEntry(current);
+        if (entry.revision > currentEntry.revision) {
+            latest.set(entry.occurrenceId, activity);
+            continue;
+        }
+        if (entry.revision === currentEntry.revision
+            && decisionFingerprint(activity) !== decisionFingerprint(current)) {
+            throw new Error(`Conflicting fixed-activity revisions for occurrence '${entry.occurrenceId}' at revision ${entry.revision}`);
+        }
+    }
+    return [...latest.values()];
+}
+
+/** Entries for the planner's still-pending fixed commitments. Completed activities are
+ * reconstructed through completed-history authority rather than re-reserved here. */
+export function pendingFixedActivityLedgerEntries(
+    activities: readonly FixedActivity[],
+): LedgerEntry[] {
+    return dedupeFixedActivitiesByLedgerIdentity(activities)
+        .filter(activity => !activity.isCompleted)
+        .map(fixedActivityLedgerEntry);
+}

--- a/app/src/engine/planner.test.ts
+++ b/app/src/engine/planner.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { evaluateNextDayPlan, evaluateNextDayPlanWithIntent, evaluateTraining, evaluateTrainingWithIntent } from './rules';
 import { mapContextFromGoalsAndTrainingSettings } from './adapters';
-import { generateWeekAheadPlan, generateWeekAheadPlanWithIntent, prepareWeekAheadPlanSeed, projectTrailingHistory, reconcileObjectivesForDate, resolveWeeklyAnchors, type ProjectionExposure } from './planner';
+import { evaluateProjectedDate, generateWeekAheadPlan, generateWeekAheadPlanWithIntent, prepareWeekAheadPlanSeed, projectTrailingHistory, reconcileObjectivesForDate, resolveWeeklyAnchors, type ProjectionExposure } from './planner';
+import { createEmptyFatigue } from './fatigue';
 import { resolveTrainingIntent } from './trainingIntent';
 import type { AuthoredPlanBlock, DailyReadiness, EngineObjectiveInput, FatigueState, FixedActivity, SubjectiveInput, TrainingSettings, UserContext, UserEvent, UserPreferences } from './models';
 import type { CompletedExposure, TrainingHistoryProvider } from './trainingHistory';
@@ -1123,5 +1124,52 @@ describe('Phase 6.2b -- fixed activities as projected exposures', () => {
             expect(day3?.template.category).not.toBe('Race-Specific Endurance');
             expect(day3?.template.systemicCost ?? 0).toBeLessThanOrEqual(0.65);
         });
+    });
+});
+
+describe('D-LEDGER planner admission', () => {
+    const fixedActivity = (overrides: Partial<FixedActivity> & Pick<FixedActivity, 'id' | 'date'>): FixedActivity => ({
+        userId: 'u1', title: 'Fixed activity', durationMin: 30, isCompleted: false, fixed: true,
+        environment: 'either', equipment: [], createdAt: '2026-09-01T00:00:00Z', updatedAt: '2026-09-01T00:00:00Z',
+        ...overrides,
+    });
+
+    it('excludes ranking candidates that do not fit the shared remaining systemic capacity', () => {
+        const context = baseContext();
+        const readiness: DailyReadiness = { subjective: neutralSubjective(), objective: quietObjective() };
+        const seed = prepareWeekAheadPlanSeed(readiness, [], '2026-09-09', []);
+        const committed = fixedActivity({
+            id: 'morning-session', date: '2026-09-10', durationMin: 30,
+            expectedCost: { systemic: 0.9 },
+        });
+        const evaluation = evaluateProjectedDate('2026-09-10', {
+            microcycle: seed.microcycle,
+            externalFatigue: createEmptyFatigue('2026-09-09'),
+            projectedHistory: [],
+        }, {
+            context,
+            preferences: {
+                userId: 'u1', preferredRecoveryStyle: 'passive',
+                defaultWeekdayTimeMin: 90, defaultWeekendTimeMin: 90, preferredTimeOfDay: 'flexible',
+                preferredModalities: [], deprioritizedModalities: [], avoidedModalities: [],
+                explanationVerbosity: 'brief', conservativeBias: false,
+                preferredUnits: { distance: 'km', weight: 'kg', temperature: 'celsius' },
+                schemaVersion: 1, createdAt: '', updatedAt: '',
+            },
+            events: [], fixedActivities: [committed], authoredPlanBlocks: [], scheduleOverlays: [],
+            anchors: { eventSpecificAnchorDate: null, qualityAnchorDate: null },
+            internalStrain: { systemic: 0, cardiovascular: 0, lowerBody: 0, upperBody: 0, impactTissue: 0, neuromuscular: 0 },
+            internalStrainAsOf: '2026-09-09', todayDate: '2026-09-09',
+        });
+
+        expect(evaluation.dailyLedger.remainingMinutes).toBe(60);
+        expect(evaluation.dailyLedger.remainingSystemicCost).toBeCloseTo(0.1);
+        const excluded = evaluation.eligible.filter(template =>
+            evaluation.ledgerExcludedTemplateIds.includes(template.id),
+        );
+        expect(excluded.some(template => template.systemicCost > 0.1)).toBe(true);
+        expect(evaluation.fatigueGated.some(template =>
+            evaluation.ledgerExcludedTemplateIds.includes(template.id),
+        )).toBe(false);
     });
 });

--- a/app/src/engine/planner.ts
+++ b/app/src/engine/planner.ts
@@ -92,7 +92,7 @@ import type { TrainingHistorySnapshot } from './trainingHistorySnapshot';
 import { resolveFixedActivityIdentity } from './fixedActivityIdentity';
 import { sumFixedActivityCostProfiles } from './fixedActivityCostProfile';
 import { admitsCandidate, computeDailyLedger, type DailyLedgerResult } from './dailyLedger';
-import { pendingFixedActivityLedgerEntries } from './fixedActivityLedger';
+import { dedupeFixedActivitiesByLedgerIdentity, pendingFixedActivityLedgerEntries } from './fixedActivityLedger';
 
 export interface WeekAheadDay {
     date: string;
@@ -672,6 +672,7 @@ export function projectedDateOutcomeFrom(evaluation: ProjectedDateEvaluation): P
     const ranking = evaluation.rank(evaluation.fatigueGated);
     const eligibleIds = new Set(evaluation.eligible.map(template => template.id));
     const gatedIds = new Set(evaluation.fatigueGated.map(template => template.id));
+    const ledgerExcludedIds = new Set(evaluation.ledgerExcludedTemplateIds);
     const exclusionReasons = new Map<string, readonly string[]>();
     ranking.rejected.forEach(candidate => exclusionReasons.set(candidate.template.id, candidate.excludedReasons));
     evaluation.ledgerExcludedTemplateIds.forEach(templateId => exclusionReasons.set(templateId, [DAILY_LEDGER_CAPACITY]));
@@ -683,7 +684,7 @@ export function projectedDateOutcomeFrom(evaluation: ProjectedDateEvaluation): P
         fatigueTier: evaluation.fatigueTier,
         acceptedTemplateIds: ranking.accepted.map(candidate => candidate.template.id),
         fatigueExcludedTemplateIds: evaluation.eligible
-            .filter(template => !gatedIds.has(template.id))
+            .filter(template => !ledgerExcludedIds.has(template.id) && !gatedIds.has(template.id))
             .map(template => template.id),
         exclusionReasons,
     };
@@ -1051,7 +1052,11 @@ export function generateWeekAheadPlan(
 
     const totalDays = Math.max(1, options.days ?? 7);
     const events = options.events ?? [];
-    const fixedActivities = options.fixedActivities ?? [];
+    // Reconcile revisions once at the planner boundary so every downstream consumer --
+    // date grouping, stimulus credit, fatigue carry-forward and diagnostics -- sees the
+    // same newest occurrence fact. A stale pre-reschedule revision cannot claim the id
+    // before the current revision's date is evaluated.
+    const fixedActivities = dedupeFixedActivitiesByLedgerIdentity(options.fixedActivities ?? []);
     const fixedActivitiesByDate = groupFixedActivitiesByDate(fixedActivities);
     const unsetDateFixedActivities = fixedActivities.filter(a => !a.date);
     const getFixedActivitiesForDate = (targetDate: string): FixedActivity[] => {

--- a/app/src/engine/planner.ts
+++ b/app/src/engine/planner.ts
@@ -91,6 +91,8 @@ import type { CompletedExposure, TrainingHistoryProvider } from './trainingHisto
 import type { TrainingHistorySnapshot } from './trainingHistorySnapshot';
 import { resolveFixedActivityIdentity } from './fixedActivityIdentity';
 import { sumFixedActivityCostProfiles } from './fixedActivityCostProfile';
+import { admitsCandidate, computeDailyLedger, type DailyLedgerResult } from './dailyLedger';
+import { pendingFixedActivityLedgerEntries } from './fixedActivityLedger';
 
 export interface WeekAheadDay {
     date: string;
@@ -516,7 +518,11 @@ export interface ProjectedDateEvaluation {
     fatigueTier: 'train' | 'modify' | 'recover';
     anchorRole: 'event-specific' | 'quality' | null;
     adjacentToAnchor: boolean;
+    /** Shared day remainder after pending fixed commitments have been reconciled. */
+    dailyLedger: DailyLedgerResult;
     eligible: SessionTemplate[];
+    /** Candidates excluded by the date-wide D-LEDGER capacity remainder before ranking. */
+    ledgerExcludedTemplateIds: readonly string[];
     fatigueGated: SessionTemplate[];
     optimizationContext: OptimizationContext;
     rank(candidates: readonly SessionTemplate[]): RankCandidatesResult;
@@ -529,6 +535,17 @@ export function evaluateProjectedDate(
 ): ProjectedDateEvaluation {
     const periodization = evaluatePeriodizationPhase(shared.events, date, shared.todayDate);
     const availability = resolveAvailability(date, null, shared.fixedActivities, shared.context, shared.scheduleOverlays ?? []);
+    const fixedLedgerEntries = pendingFixedActivityLedgerEntries(availability.fixedActivities);
+    const fixedReservedMinutes = fixedLedgerEntries.reduce((sum, entry) => sum + entry.reservedMinutes, 0);
+    const overlaySystemicCost = scheduleOverlayCostProfileForDate(shared.scheduleOverlays ?? [], date).systemic;
+    // `resolveAvailability` has already reduced the time window by pending fixed activities.
+    // Reconstruct its pre-pending-fixed daily ceiling, then let D-LEDGER subtract each unique
+    // occurrence exactly once. Overlays remain a separate date-level reservation, so their
+    // systemic cost narrows the ceiling rather than being fabricated as an occurrence.
+    const dailyLedger: DailyLedgerResult = computeDailyLedger({
+        dailyMinuteCeiling: availability.maxTimeMinutes + fixedReservedMinutes,
+        dailySystemicCostCeiling: Math.max(0, 1 - overlaySystemicCost),
+    }, fixedLedgerEntries);
 
     const rankingFatigue = applyCompletedSessionLoad(
         projectFatigueForRankingDate(state.externalFatigue, shared.internalStrain, shared.internalStrainAsOf, date, shared.fatigueFusionPolicy ?? 'max'),
@@ -541,12 +558,28 @@ export function evaluateProjectedDate(
     const eligible = eligibleTemplates(ENRICHED_TEMPLATES, shared.context, availability.maxTimeMinutes, date)
         .filter(template => templateFitsResolvedAvailability(template, availability))
         .filter(t => isTemplatePhaseEligible(t, periodization));
+    const isLedgerAdmitted = (template: SessionTemplate): boolean => {
+        // Rest has no exercise occurrence or capacity debit. Keep it available as the safe
+        // fallback when every training candidate is correctly denied by the shared day.
+        if (template.category === 'Rest') return true;
+        const effective = effectiveTemplateForProjection(template);
+        return admitsCandidate(
+            dailyLedger,
+            availability.maxTimeMinutes,
+            effective.durationMin,
+            effective.costProfile?.systemic ?? effective.systemicCost,
+        ).admitted;
+    };
+    const ledgerAdmitted = eligible.filter(isLedgerAdmitted);
+    const ledgerExcludedTemplateIds = eligible
+        .filter(template => !isLedgerAdmitted(template))
+        .map(template => template.id);
 
     const isConservative = shared.preferences?.conservativeBias ?? false;
     const fatigueThresholds = projectedFatigueThresholds(isConservative);
     const fatigueTier = fatigueTierFor(peakFatigue, fatigueThresholds);
 
-    const fatigueGated = eligible.filter(t => {
+    const fatigueGated = ledgerAdmitted.filter(t => {
         if (peakFatigue >= fatigueThresholds.recover) {
             return t.category === 'Rest' || t.category === 'Mobility/Recovery';
         }
@@ -605,7 +638,9 @@ export function evaluateProjectedDate(
         fatigueTier,
         anchorRole,
         adjacentToAnchor,
+        dailyLedger,
         eligible,
+        ledgerExcludedTemplateIds,
         fatigueGated,
         optimizationContext,
         rank: (candidates: readonly SessionTemplate[]) => {
@@ -628,6 +663,7 @@ export function evaluateProjectedDate(
 }
 
 const NOT_ELIGIBLE_ON_DATE = 'NOT_ELIGIBLE_ON_DATE';
+const DAILY_LEDGER_CAPACITY = 'DAILY_LEDGER_CAPACITY';
 const PROJECTED_DATE_OUTCOMES = new WeakMap<ProjectedDateEvaluation, ProjectedDateOutcome>();
 
 export function projectedDateOutcomeFrom(evaluation: ProjectedDateEvaluation): ProjectedDateOutcome {
@@ -638,6 +674,7 @@ export function projectedDateOutcomeFrom(evaluation: ProjectedDateEvaluation): P
     const gatedIds = new Set(evaluation.fatigueGated.map(template => template.id));
     const exclusionReasons = new Map<string, readonly string[]>();
     ranking.rejected.forEach(candidate => exclusionReasons.set(candidate.template.id, candidate.excludedReasons));
+    evaluation.ledgerExcludedTemplateIds.forEach(templateId => exclusionReasons.set(templateId, [DAILY_LEDGER_CAPACITY]));
     ENRICHED_TEMPLATES.forEach(template => {
         if (!eligibleIds.has(template.id)) exclusionReasons.set(template.id, [NOT_ELIGIBLE_ON_DATE]);
     });

--- a/app/src/engine/planner.ts
+++ b/app/src/engine/planner.ts
@@ -269,7 +269,7 @@ export interface ProjectedFatigueThresholds {
 export function projectedFatigueThresholds(conservativeBias = false): ProjectedFatigueThresholds {
     return conservativeBias
         ? { recover: PROJECTED_FATIGUE_RECOVER_THRESHOLD * 0.88, modify: PROJECTED_FATIGUE_MODIFY_THRESHOLD * 0.88, modifyMaxSystemicCost: PROJECTED_MODIFY_MAX_SYSTEMIC_COST * 0.85 }
-        : { recover: PROJECTED_FATIGUE_RECOVER_THRESHOLD, modify: PROJECTED_FATIGUE_MODIFY_THRESHOLD, modifyMaxSystemicCost: PROJECTED_MODIFY_MAX_SYSTEMIC_COST };
+        : { recover: PROJECTED_FATIGUE_RECOVER_THRESHOLD, modify: PROJECTED_MODIFY_MAX_SYSTEMIC_COST, modifyMaxSystemicCost: PROJECTED_MODIFY_MAX_SYSTEMIC_COST };
 }
 
 export function maxFatigueDimension(fatigue: DimensionalFatigue): number {
@@ -365,7 +365,7 @@ export function applyProjectedObjectiveCredits(
         allocations.push({ objectiveId: objective.id, earnedCredit: allocated });
         const nextProjectedCredit = projectedCredit + allocated;
         return {
-            ...definition,
+            ...objective,
             completedCredit,
             projectedCredit: nextProjectedCredit,
             completedExposures: projectCompatibilityExposures(

--- a/app/src/engine/planner.ts
+++ b/app/src/engine/planner.ts
@@ -616,6 +616,7 @@ export function evaluateProjectedDate(
         {
             anchorRole, adjacentToAnchor, resolveMinimumDaysAfterHardLowerBody, resolveRecoveryHours: resolveRecoveryHoursForTemplate, fatigueTier,
             authoredPlanBlocks: shared.authoredPlanBlocks,
+            resolvedAvailability: availability,
             ...(planDefinition ? {
                 coverageState: buildCoverageState(
                     planDefinition,

--- a/app/src/engine/planner.ts
+++ b/app/src/engine/planner.ts
@@ -269,7 +269,7 @@ export interface ProjectedFatigueThresholds {
 export function projectedFatigueThresholds(conservativeBias = false): ProjectedFatigueThresholds {
     return conservativeBias
         ? { recover: PROJECTED_FATIGUE_RECOVER_THRESHOLD * 0.88, modify: PROJECTED_FATIGUE_MODIFY_THRESHOLD * 0.88, modifyMaxSystemicCost: PROJECTED_MODIFY_MAX_SYSTEMIC_COST * 0.85 }
-        : { recover: PROJECTED_FATIGUE_RECOVER_THRESHOLD, modify: PROJECTED_MODIFY_MAX_SYSTEMIC_COST, modifyMaxSystemicCost: PROJECTED_MODIFY_MAX_SYSTEMIC_COST };
+        : { recover: PROJECTED_FATIGUE_RECOVER_THRESHOLD, modify: PROJECTED_FATIGUE_MODIFY_THRESHOLD, modifyMaxSystemicCost: PROJECTED_MODIFY_MAX_SYSTEMIC_COST };
 }
 
 export function maxFatigueDimension(fatigue: DimensionalFatigue): number {

--- a/app/src/engine/planner.ts
+++ b/app/src/engine/planner.ts
@@ -365,7 +365,7 @@ export function applyProjectedObjectiveCredits(
         allocations.push({ objectiveId: objective.id, earnedCredit: allocated });
         const nextProjectedCredit = projectedCredit + allocated;
         return {
-            ...objective,
+            ...definition,
             completedCredit,
             projectedCredit: nextProjectedCredit,
             completedExposures: projectCompatibilityExposures(

--- a/app/src/engine/plannerLedgerOutcome.test.ts
+++ b/app/src/engine/plannerLedgerOutcome.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { projectedDateOutcomeFrom, type ProjectedDateEvaluation } from './planner';
+import { ENRICHED_TEMPLATES } from './templates';
+
+describe('projected D-LEDGER outcome classification', () => {
+    it('does not relabel a ledger-capacity rejection as projected fatigue', () => {
+        const rest = ENRICHED_TEMPLATES.find(template => template.category === 'Rest');
+        const ledgerBlocked = ENRICHED_TEMPLATES.find(template => template.category !== 'Rest');
+        expect(rest).toBeDefined();
+        expect(ledgerBlocked).toBeDefined();
+        if (!rest || !ledgerBlocked) return;
+
+        const evaluation = {
+            date: '2026-09-10',
+            fatigueTier: 'train',
+            eligible: [ledgerBlocked, rest],
+            ledgerExcludedTemplateIds: [ledgerBlocked.id],
+            fatigueGated: [rest],
+            rank: () => ({
+                accepted: [{ template: rest }],
+                rejected: [],
+            }),
+        } as unknown as ProjectedDateEvaluation;
+
+        const outcome = projectedDateOutcomeFrom(evaluation);
+
+        expect(outcome.acceptedTemplateIds).toContain(rest.id);
+        expect(outcome.exclusionReasons.get(ledgerBlocked.id)).toEqual(['DAILY_LEDGER_CAPACITY']);
+        expect(outcome.fatigueExcludedTemplateIds).not.toContain(ledgerBlocked.id);
+    });
+});

--- a/app/src/engine/plannerResolvedAvailability.test.ts
+++ b/app/src/engine/plannerResolvedAvailability.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { createEmptyFatigue } from './fatigue';
+import type { ScheduleOverlay, UserContext } from './models';
+import { generateWeeklyObjectives } from './microcycle';
+import { evaluatePeriodizationPhase } from './periodization';
+import { evaluateProjectedDate, NEUTRAL_PREFERENCES } from './planner';
+
+describe('projected availability authority', () => {
+    it('passes the exact overlay-aware resolved availability into optimization', () => {
+        const date = '2026-09-10';
+        const context: UserContext = {
+            goals: { shortTerm: '', midTerm: '', longTerm: '' },
+            constraints: {
+                hasCableMachine: false,
+                hasFreeWeights: true,
+                hasTreadmill: false,
+                hasIndoorBike: true,
+                restrictedModalities: [],
+                maxTimeMinutes: 90,
+            },
+            preferences: {
+                avoidedModalities: [],
+                deprioritizedModalities: [],
+                preferredModalities: [],
+                conservativeBias: false,
+            },
+        };
+        const overlay: ScheduleOverlay = {
+            id: 'limited-window',
+            userId: 'u1',
+            title: 'Limited training window',
+            category: 'limited_availability',
+            startDate: date,
+            endDate: date,
+            dailyAvailabilityMinutes: 30,
+            volumeScale: 1,
+            intensityScale: 1,
+            expectedCost: {
+                systemic: 0,
+                cardiovascular: 0,
+                lowerBody: 0,
+                upperBody: 0,
+                impactTissue: 0,
+                neuromuscular: 0,
+            },
+            createdAt: '2026-09-01T00:00:00Z',
+            updatedAt: '2026-09-01T00:00:00Z',
+        };
+        const phase = evaluatePeriodizationPhase([], date, date).phase;
+        const evaluation = evaluateProjectedDate(
+            date,
+            {
+                microcycle: generateWeeklyObjectives(phase, date, null),
+                externalFatigue: createEmptyFatigue(date),
+                projectedHistory: [],
+            },
+            {
+                context,
+                preferences: NEUTRAL_PREFERENCES,
+                events: [],
+                fixedActivities: [],
+                authoredPlanBlocks: [],
+                scheduleOverlays: [overlay],
+                anchors: { eventSpecificAnchorDate: null, qualityAnchorDate: null },
+                internalStrain: {
+                    systemic: 0,
+                    cardiovascular: 0,
+                    lowerBody: 0,
+                    upperBody: 0,
+                    impactTissue: 0,
+                    neuromuscular: 0,
+                },
+                internalStrainAsOf: date,
+                todayDate: date,
+            },
+        );
+
+        expect(evaluation.availability.maxTimeMinutes).toBe(30);
+        expect(evaluation.optimizationContext.availability).toBe(evaluation.availability);
+    });
+});

--- a/app/src/engine/policy.test.ts
+++ b/app/src/engine/policy.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, it } from 'vitest';
 import { isHistoricalPolicyVersion, HISTORICAL_POLICY_VERSIONS, POLICY_VERSION } from './policy';
 
 describe('isHistoricalPolicyVersion', () => {
-    it('records the exact H4 dependent-member launch policy transition once', () => {
-        expect(POLICY_VERSION).toBe('2026-09-h4-intraday-bundle-member-launch-v1');
+    it('records the exact D-LEDGER planner-admission transition once', () => {
+        expect(POLICY_VERSION).toBe('2026-09-h4-d-ledger-planner-admission-v1');
         expect(
             HISTORICAL_POLICY_VERSIONS.filter(
-                (version) => version === '2026-09-simulation-sequence-occupational-context-v2',
+                (version) => version === '2026-09-h4-intraday-bundle-member-launch-v1',
             ),
         ).toHaveLength(1);
     });

--- a/app/src/engine/policy.ts
+++ b/app/src/engine/policy.ts
@@ -1,11 +1,12 @@
 /** Increment whenever a change can alter a persisted recommendation decision. (Refactoring does not require a bump) */
 
-export const POLICY_VERSION = '2026-09-h4-intraday-bundle-member-launch-v1';
+export const POLICY_VERSION = '2026-09-h4-d-ledger-planner-admission-v1';
 
 /** Historical versions are intentionally not re-executed by this build. Their compact
  * audits remain readable evidence, but replay is rejected explicitly because the old
  * decision function is not bundled alongside the current policy. */
 export const HISTORICAL_POLICY_VERSIONS = [
+    '2026-09-h4-intraday-bundle-member-launch-v1',
     '2026-09-simulation-sequence-occupational-context-v2',
     '2026-09-simulation-sequence-occupational-context-v1',
     '2026-09-recommender-recovery-calibration-v1',

--- a/app/src/engine/schedule.ts
+++ b/app/src/engine/schedule.ts
@@ -9,6 +9,7 @@ import type {
 } from './models';
 import { resolveMaximumSessionMinutes } from './eligibility';
 import { sumFixedActivityCostProfiles } from './fixedActivityCostProfile';
+import { dedupeFixedActivitiesByLedgerIdentity } from './fixedActivityLedger';
 
 export interface ResolvedAvailability {
     date: string;
@@ -173,7 +174,12 @@ export function resolveAvailability(
         ? resolveMaximumSessionMinutes(userContext, checkinMinutes, dateStr)
         : (Number.isFinite(checkinMinutes) ? checkinMinutes : NO_CONTEXT_FALLBACK_MINUTES);
 
-    const daysFixed = fixedActivities.filter(activity => activity.date === dateStr);
+    // D-LEDGER is the occurrence/revision authority for a fixed commitment. Resolve it
+    // before every schedule-side consumer so duplicate query/replay rows cannot subtract
+    // time twice while the planner's ledger charges them once.
+    const daysFixed = dedupeFixedActivitiesByLedgerIdentity(
+        fixedActivities.filter(activity => activity.date === dateStr),
+    );
     const activeOverlays = activeScheduleOverlaysForDate(scheduleOverlays, dateStr);
 
     const fixedOverrides = daysFixed

--- a/app/src/engine/schedule.ts
+++ b/app/src/engine/schedule.ts
@@ -174,12 +174,11 @@ export function resolveAvailability(
         ? resolveMaximumSessionMinutes(userContext, checkinMinutes, dateStr)
         : (Number.isFinite(checkinMinutes) ? checkinMinutes : NO_CONTEXT_FALLBACK_MINUTES);
 
-    // D-LEDGER is the occurrence/revision authority for a fixed commitment. Resolve it
-    // before every schedule-side consumer so duplicate query/replay rows cannot subtract
-    // time twice while the planner's ledger charges them once.
-    const daysFixed = dedupeFixedActivitiesByLedgerIdentity(
-        fixedActivities.filter(activity => activity.date === dateStr),
-    );
+    // D-LEDGER occurrence identity spans revisions, including a move to another date.
+    // Reconcile the whole input set first, then select the requested day, so a stale
+    // pre-reschedule row cannot continue consuming capacity on its former date.
+    const daysFixed = dedupeFixedActivitiesByLedgerIdentity(fixedActivities)
+        .filter(activity => activity.date === dateStr);
     const activeOverlays = activeScheduleOverlaysForDate(scheduleOverlays, dateStr);
 
     const fixedOverrides = daysFixed

--- a/app/src/engine/weeklyAllocation.ts
+++ b/app/src/engine/weeklyAllocation.ts
@@ -33,7 +33,7 @@ export interface RequiredRoleOccurrence {
 }
 
 export type WeeklyRoleAllocationStatus = 'reserved' | 'fulfilled' | 'missed' | 'unresolved_search_budget';
-export type WeeklyRoleMissReason = 'no_exact_candidate' | 'hard_safety_or_recovery' | 'projected_fatigue' | 'fixed_seed' | 'no_conflict_free_date';
+export type WeeklyRoleMissReason = 'no_exact_candidate' | 'hard_safety_or_recovery' | 'daily_ledger_capacity' | 'projected_fatigue' | 'fixed_seed' | 'no_conflict_free_date';
 
 export interface RoleReservation {
     occurrenceId: string;
@@ -87,7 +87,7 @@ export interface ProjectedDateOutcome {
     acceptedTemplateIds: readonly string[];
     /** Template ids removed by the projected fatigue ceiling before ranking. */
     fatigueExcludedTemplateIds: readonly string[];
-    /** `rankCandidates` exclusion reasons, keyed by rejected template id. */
+    /** Production hard-gate exclusion reasons, keyed by rejected template id. */
     exclusionReasons: ReadonlyMap<string, readonly string[]>;
 }
 
@@ -120,6 +120,7 @@ const SAFETY_EXCLUSION_REASONS = new Set([
 ]);
 
 const FATIGUE_CEILING_BLOCKER = 'PROJECTED_FATIGUE_CEILING';
+export const DAILY_LEDGER_CAPACITY_BLOCKER = 'DAILY_LEDGER_CAPACITY';
 
 function canonicalOccurrenceId(parts: readonly string[]): string {
     return parts.map(part => encodeURIComponent(part)).join('|');
@@ -247,6 +248,7 @@ interface OccurrenceSearchState {
     sawDateConflict: boolean;
     sawFatigueExclusion: boolean;
     sawSafetyExclusion: boolean;
+    sawLedgerCapacityExclusion: boolean;
 }
 
 function assignmentSignature(assignments: readonly AllocationAssignment[]): string {
@@ -259,11 +261,13 @@ function assignmentSignature(assignments: readonly AllocationAssignment[]): stri
 function missReasonFor(state: OccurrenceSearchState): WeeklyRoleMissReason {
     if (state.candidates.length === 0) {
         if (state.sawSafetyExclusion) return 'hard_safety_or_recovery';
+        if (state.sawLedgerCapacityExclusion) return 'daily_ledger_capacity';
         if (state.sawFatigueExclusion) return 'projected_fatigue';
         return 'no_exact_candidate';
     }
     if (state.sawDateConflict) return 'no_conflict_free_date';
     if (state.sawSafetyExclusion) return 'hard_safety_or_recovery';
+    if (state.sawLedgerCapacityExclusion) return 'daily_ledger_capacity';
     if (state.sawFatigueExclusion) return 'projected_fatigue';
     return 'no_conflict_free_date';
 }
@@ -321,6 +325,7 @@ export function resolveWeeklyRoleReservations(
         const blockers = new Set<string>();
         let sawFatigueExclusion = false;
         let sawSafetyExclusion = false;
+        let sawLedgerCapacityExclusion = false;
         for (const date of dates) {
             const outcome = rootOutcomes.get(date)!;
             for (const templateId of occurrence.eligibleTemplateIds) {
@@ -333,6 +338,7 @@ export function resolveWeeklyRoleReservations(
                     for (const reason of outcome.exclusionReasons.get(templateId) ?? []) {
                         blockers.add(`${date}:${reason}`);
                         if (SAFETY_EXCLUSION_REASONS.has(reason)) sawSafetyExclusion = true;
+                        if (reason === DAILY_LEDGER_CAPACITY_BLOCKER) sawLedgerCapacityExclusion = true;
                     }
                 }
             }
@@ -346,6 +352,7 @@ export function resolveWeeklyRoleReservations(
             sawDateConflict: false,
             sawFatigueExclusion,
             sawSafetyExclusion,
+            sawLedgerCapacityExclusion,
         };
     });
 
@@ -399,6 +406,7 @@ export function resolveWeeklyRoleReservations(
                     for (const reason of outcome.exclusionReasons.get(candidate.templateId) ?? []) {
                         next.blockers.add(`${candidate.date}:${reason}`);
                         if (SAFETY_EXCLUSION_REASONS.has(reason)) next.sawSafetyExclusion = true;
+                        if (reason === DAILY_LEDGER_CAPACITY_BLOCKER) next.sawLedgerCapacityExclusion = true;
                     }
                 }
                 continue;

--- a/app/src/engine/weeklyAllocationLedgerCapacity.test.ts
+++ b/app/src/engine/weeklyAllocationLedgerCapacity.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import {
+    DAILY_LEDGER_CAPACITY_BLOCKER,
+    resolveWeeklyRoleReservations,
+    type AllocationDateEvaluator,
+    type RequiredRoleOccurrence,
+} from './weeklyAllocation';
+
+const occurrence: RequiredRoleOccurrence = {
+    id: 'september_cycling_event|2026-08-03|2026-09-01|build|sustained_quality|september_cycling_event:sustained_quality|0',
+    coverageSetId: 'september_cycling_event',
+    coverageKey: 'sustained_quality',
+    authoredSessionIdentity: 'september_cycling_event:sustained_quality',
+    phase: 'build',
+    windowStart: '2026-08-03',
+    windowEnd: '2026-09-01',
+    ordinal: 0,
+    label: 'Sustained quality',
+    eligibleTemplateIds: ['threshold'],
+    eligibleWorkoutIds: [],
+};
+
+describe('weekly allocation D-LEDGER diagnostics', () => {
+    it('does not report a ledger-blocked exact candidate as no_exact_candidate', () => {
+        const date = '2026-08-11';
+        const evaluator: AllocationDateEvaluator = {
+            forecastDates: [date],
+            evaluate: () => ({
+                date,
+                fatigueTier: 'train',
+                acceptedTemplateIds: [],
+                fatigueExcludedTemplateIds: [],
+                exclusionReasons: new Map([
+                    ['threshold', [DAILY_LEDGER_CAPACITY_BLOCKER]],
+                ]),
+            }),
+        };
+
+        const result = resolveWeeklyRoleReservations([occurrence], evaluator);
+
+        expect(result.outcomes[0]).toMatchObject({
+            status: 'missed',
+            reason: 'daily_ledger_capacity',
+        });
+        expect(result.outcomes[0].observedBlockers).toContain(`${date}:${DAILY_LEDGER_CAPACITY_BLOCKER}`);
+    });
+});

--- a/docs/architecture/recommendation-engine.md
+++ b/docs/architecture/recommendation-engine.md
@@ -604,6 +604,16 @@ this so their load is never projected a second time. See
 [docs/plans/phase-5-sequence-planning.md](../plans/phase-5-sequence-planning.md) 5.3 for
 the original storage/validation contract.
 
+**D-LEDGER admission in the rolling planner.** Before each projected date is ranked,
+`fixedActivityLedger.ts` reconciles pending fixed commitments by their stable occurrence key and
+newest `updatedAt` revision. `resolveAvailability` consumes that same deduplicated set. The
+planner passes the resulting entries to `computeDailyLedger`, keeps overlay load as a date-level
+ceiling reservation, and uses `admitsCandidate` to exclude any non-Rest candidate that cannot
+fit both remaining minutes and systemic cost. Conflicting equal-revision fixed-activity facts
+fail closed; Rest stays available as the safe non-training fallback. This is pure forecast
+accounting, not a Firestore read or a replacement for the transactional intraday
+`daily_ledgers/{date}` launch aggregate.
+
 ### Bounded sequence search prototype (Phase 5.1, `sequenceSearch.ts`) -- not live
 
 The "projected" tier above is a greedy walk: each day takes `rankCandidates`' rank-0 pick

--- a/docs/plans/cycling-primary-hybrid-evaluation.md
+++ b/docs/plans/cycling-primary-hybrid-evaluation.md
@@ -268,7 +268,8 @@ also remains blocked on current-workload/restriction confirmation.
 
 ## H4 — Intraday capacity and post-AM reassessment
 
-**Status:** Design accepted in [ADR-0036](../adr/0036-intraday-training-windows-and-reassessment.md).
+**Status:** Implemented — the H4 release and the planner-admission follow-up are delivered under
+[ADR-0036](../adr/0036-intraday-training-windows-and-reassessment.md).
 **D-SCHEMA, D-LEDGER, D-TIME and D-WINDOW delivered**; **same-day canonical
 performed-fact boundary verified**; **D-PLACEMENT's bundle-placement engine delivered**
 as a pure module, and its **placement-correctness wired** into
@@ -280,12 +281,11 @@ modules -- `engine/intradayReassessment.ts`'s `reassessDependentBundleMember` (#
 execution-binding pipeline has since given them a live caller, through PR 3 Phase 4 (see
 "Issue #434 execution-binding pipeline" below).
 
-Still unstarted: the `dailyLedger.ts` refactor into `resolveAvailability`'s existing
-deductions and `planner.ts`'s three ad hoc dedup mechanisms, recommendation-audit
-persistence of a bundle's resolved placement for display, and the H4-specific Phase 6 policy
-transition -- the last of which is what actually gates a live H4 release. Placement persistence was previously
-blocked by the recommendation-audit rules-expression ceiling; #468 closed #435 by reducing
-that evaluation cost, so it is now unblocked but not implemented.
+The rolling planner now uses D-LEDGER occurrence/revision identity for pending fixed activities
+and filters candidates through `computeDailyLedger` / `admitsCandidate` before ranking. The
+H4-specific Phase 6 policy transition is also delivered. Persisting a bundle's resolved
+placement for display in the recommendation audit remains separately unimplemented; #468 closed
+the earlier rules-expression blocker (#435), so that work is unblocked but non-gating.
 **Dependencies:** ADR-0035 rest support (delivered). The `external-plan@4`/`dailyLedger.ts`
 D-SCHEMA/D-LEDGER slice itself left `POLICY_VERSION` unchanged (neither module is
 consumed by any decision path); the fixed-activity cost-reduce dedup slice bumped it
@@ -610,7 +610,7 @@ mechanical requirement, while `h4-intraday-bundle-placement-v1` was H4's first r
 change. PR 3 Phase 5 added the post-AM evidence path, and Phase 6 completed the cumulative
 H4 transition by archiving the then-current
 `2026-09-simulation-sequence-occupational-context-v2` policy and activating
-`2026-09-h4-intraday-bundle-member-launch-v1`. H4's ledger-based ranking/admission wiring
-and H5c will each require normal policy
-review when they actually change decision behavior. Do not enable experimental
+`2026-09-h4-intraday-bundle-member-launch-v1`. The planner's D-LEDGER admission wiring then
+archived that version and activated `2026-09-h4-d-ledger-planner-admission-v1`. H5c will
+require normal policy review when it changes decision behavior. Do not enable experimental
 personalization simply to improve a judge score.

--- a/docs/plans/h4-434-pr3-bundle-second-member-launch.md
+++ b/docs/plans/h4-434-pr3-bundle-second-member-launch.md
@@ -333,10 +333,19 @@ into the completion-response PR merely because they are nearby.
 
 ### Ledger remainder/admission in the broader planner
 
-`planner.ts` / `rules.ts` still have separate dedup/accounting mechanisms outside the intraday
-bundle path. Unifying those onto D-LEDGER's occurrence/revision identity and using
-`computeDailyLedger` remainder / `admitsCandidate` as a real ranking/admission input remains a
-separate decision-affecting change.
+**Delivered in the follow-up D-LEDGER planner-admission change.** The rolling projection now
+adapts pending `FixedActivity` commitments to D-LEDGER occurrence/revision entries before
+ranking. `resolveAvailability` and the projection share the newest-revision identity, so a
+replayed fixed activity cannot consume time twice in one path and once in the other; an
+equal-revision disagreement fails closed. `computeDailyLedger` supplies the date remainder and
+`admitsCandidate` excludes a projected training candidate that cannot fit both the remaining
+minutes and systemic-cost capacity. Canonical Rest remains available as the non-training
+fallback.
+
+This does not make the pure rolling forecast a Firestore reader or replace the persisted
+`daily_ledgers/{date}` transaction used by intraday launch. Direct same-day readiness selection
+also remains on its existing authority path; wiring a persisted intraday aggregate into that
+separate entry point needs its own input/replay contract.
 
 ### Persist resolved bundle placement for display
 


### PR DESCRIPTION
## Summary
- reconcile pending fixed activities once by D-LEDGER occurrence/revision identity before schedule date filtering and rolling planner projection
- gate projected candidates with the shared daily minute and systemic-cost remainder while keeping ledger-capacity and projected-fatigue audit reasons distinct
- fail closed on equal-revision decision conflicts and canonicalize equivalent/reordered fixed-activity facts for deterministic replay
- cover rescheduled occurrences, deterministic occurrence ordering, and ledger-vs-fatigue diagnostics with focused regression tests
- document the delivered H4 planner-admission follow-up and advance `POLICY_VERSION`

## Review fixes added
- fix a rescheduled fixed activity being charged on both its stale/original date and its current date
- reconcile revisions at the rolling planner boundary so stale revisions cannot claim stimulus/fatigue identity before the current revision is reached
- include start time/catalog identity/external authored identity in equal-revision conflict detection while normalizing representation-only ordering differences
- canonicalize fixed-activity occurrence ordering so downstream objective-credit behavior cannot depend on Firestore/query order
- keep `DAILY_LEDGER_CAPACITY` exclusions separate from `PROJECTED_FATIGUE_GATE` evidence in weekly-allocation diagnostics

## Scope boundary
- this remains rolling-forecast/planner admission; direct same-day readiness selection and the persisted intraday transaction/launch ledger keep their existing authorities
- the existing D6-C forecast contract for a fixed activity with no `expectedCost` is unchanged; this PR does not invent a cost heuristic
- accepted ADR-0036 wording is preserved; living implementation/architecture docs record delivery status

## Verification
- GitHub Actions **CI Pipeline #2767 passed on final head `2d289b6`**, including the overall CI Gate
- Engine Simulations & AI Gates passed, including simulation scenarios, deterministic AI/persona corpora, and semantic diff
- frontend TypeScript typecheck, ESLint/static gates, knowledge/workout validators, build, full unit-test coverage run, and Firestore security-rule emulator suite passed
- Python repository hygiene, Ruff, formatting, mypy, pytest/coverage, and dependency audit passed
- Docker build, compose startup/healthchecks, and full-stack smoke test passed

## Review state
- branch is based directly on current `main`; no base drift or merge conflict was found during the review
- no inline review threads are open
- a manual CodeRabbit review was requested, but CodeRabbit reported that the request was rate-limited and produced no actionable review findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Rolling plans now account for pending fixed commitments when evaluating recommendations.
  - Recommendations are filtered by remaining daily time and systemic capacity.
  - Updated activity revisions are reconciled automatically, including activities moved to another date.
  - Conflicting revisions fail safely instead of producing inconsistent recommendations.
  - Rest remains available when other recommendations exceed daily capacity.

- **Bug Fixes**
  - Capacity-blocked items are now reported accurately instead of being misclassified as fatigue exclusions.
  - Weekly planning now preserves the correct reason when an item cannot fit within daily capacity.

- **Documentation**
  - Updated planning documentation to describe the new capacity-aware recommendation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->