### PR TITLE
✍️ Scribe: Update docs/README.md to include 2026-09-07 analysis files

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -184,6 +184,8 @@ Point-in-time assessments of the system as built, including gaps between documen
 * [**2026-09-03 PR 388 auth and wearable-free review**](./analysis/2026-09-03-pr-388-auth-wearable-free-review.md) — Review of PR 388 covering authentication and provider-link boundaries, recommendation composition, and 7-day planning.
 * [**2026-09-04 judge:e2e:quick drift diagnosis**](./analysis/2026-09-04-judge-e2e-quick-drift-diagnosis.md) — Diagnosis of a reported regression in the local 4B AI plan judge after PR #387 / #388, confirming it as sampling noise rather than an engine behavior change.
 * [**2026-09-05 Local AI-judge throughput tuning**](./analysis/2026-09-05-local-judge-vram-tuning.md) — Local GPU VRAM headroom analysis and adjustments to sample counts, context windows, and concurrency for AI-judge tools.
+* [**2026-09-07 ADR-0038 Recovery Placement Implementation Analysis**](./analysis/2026-09-07-adr-0038-recovery-placement-implementation-analysis.md) — Analysis of recovery placement options for external plans under ADR-0038.
+* [**2026-09-07 Recommender Optimization Analysis**](./analysis/2026-09-07-recommender-optimization-opportunities.md) — Investigation into potential optimization strategies for the core recommender engine.
 
 ---
 


### PR DESCRIPTION
* **📄 What:** Added two missing analysis files (from 2026-09-07) to the `docs/README.md` index.
* **⚠️ Problem:** Newly added files in `docs/analysis/` (`2026-09-07-adr-0038-recovery-placement-implementation-analysis.md` and `2026-09-07-recommender-optimization-opportunities.md`) were missing from the central documentation routing hub, making them hard to discover.
* **📚 Source of truth:** The contents of the `docs/analysis/` directory (checked via `ls -l`). The journal specifically indicates that newly added analysis files must be indexed in `docs/README.md`.
* **✅ Verification:** Used `cat docs/README.md | grep "2026-09-07"` to confirm the links were added, ran `make check` to ensure no build/lint regressions.
* **🎯 Impact:** Makes recent implementation and optimization analysis visible to future agents and developers via the standard documentation entry point.
* **🔒 Governance:** Purely a documentation index update; no product scope, authority, or operational limits were changed.

---
*PR created automatically by Jules for task [5397146263228885837](https://jules.google.com/task/5397146263228885837) started by @Szczepanov*