### PR TITLE
chore(baselines): refresh simulation/persona/plan-judge baselines + fix judge-settings comparability gap

### DIFF
--- a/app/scripts/check-persona-judge-drift.mjs
+++ b/app/scripts/check-persona-judge-drift.mjs
@@ -9,6 +9,7 @@ const stabilityPath = resolve(outputDir, 'judge-stability.json');
 const manifestPath = resolve(outputDir, 'judge-run-manifest.json');
 
 const allowModelChange = process.argv.includes('--allow-model-change');
+const allowSettingsChange = process.argv.includes('--allow-settings-change') || allowModelChange;
 const againstIndex = process.argv.indexOf('--against');
 const againstCustomPath = againstIndex !== -1 && process.argv[againstIndex + 1] ? process.argv[againstIndex + 1] : null;
 const requiredScores = ['safety_recovery_fit', 'goal_event_fit', 'sequencing', 'periodization_taper', 'preference_capacity_fit', 'robustness', 'overall'];
@@ -98,6 +99,12 @@ const current = {
   provenance: {
     judgeModel: manifest?.judgeModel ?? 'unknown',
     judgeProvider: manifest?.judgeProvider ?? 'unknown',
+    ...(manifest ? {
+      judgeSettings: {
+        samples: manifest.samples,
+        thinkingEnabled: manifest.thinkingEnabled,
+      },
+    } : {}),
   },
   familyCount: scoreRows.length,
   caseCount: allCaseScores.length,
@@ -127,6 +134,29 @@ if (baselineModel !== currentModel) {
   const message = `Judge model changed: ${baselineModel} -> ${currentModel}. Model drift can dominate engine drift.`;
   if (allowModelChange) warnings.push(`${message} Continuing because --allow-model-change was supplied.`);
   else fatal.push(`${message} Re-run with the baseline model, or pass --allow-model-change.`);
+}
+
+// Sample count and thinking mode are as comparability-breaking as the model itself: a samples=1
+// run scored against a samples=5 baseline (e.g. `persona:local` vs the baseline's actual
+// `persona:local:stability`/`persona:e2e` settings) compares one noisy draw to a five-sample
+// median with no warning. Only compare a field when both sides recorded it.
+const baselineSettings = baseline.provenance?.judgeSettings ?? baseline.judgeSettings ?? null;
+const currentSettings = current.provenance.judgeSettings ?? null;
+if (!baselineSettings || !currentSettings) {
+  warnings.push('Judge run settings (samples/thinking mode) are not recorded on one side; comparability cannot be verified beyond the model name.');
+} else {
+  const mismatches = [];
+  if (baselineSettings.samples !== undefined && currentSettings.samples !== undefined && baselineSettings.samples !== currentSettings.samples) {
+    mismatches.push(`Sample count changed: ${baselineSettings.samples} -> ${currentSettings.samples}.`);
+  }
+  if (baselineSettings.thinkingEnabled !== undefined && currentSettings.thinkingEnabled !== undefined && baselineSettings.thinkingEnabled !== currentSettings.thinkingEnabled) {
+    mismatches.push(`Thinking mode changed: ${baselineSettings.thinkingEnabled} -> ${currentSettings.thinkingEnabled}.`);
+  }
+  if (mismatches.length > 0) {
+    const message = `Judge run settings differ from the baseline (${mismatches.join(' ')}) Score deltas are not comparable — a settings mismatch can swamp real engine drift.`;
+    if (allowSettingsChange) warnings.push(`${message} Continuing because --allow-settings-change was supplied.`);
+    else fatal.push(`${message} Re-run with \`npm run persona:e2e\` (matches the committed baseline's settings), or pass --allow-settings-change for an explicitly exploratory comparison.`);
+  }
 }
 
 if (baseline.familyCount !== current.familyCount) fatal.push(`Family count changed: ${baseline.familyCount} -> ${current.familyCount}.`);

--- a/app/scripts/check-persona-judge-drift.mjs
+++ b/app/scripts/check-persona-judge-drift.mjs
@@ -102,6 +102,8 @@ const current = {
     ...(manifest ? {
       judgeSettings: {
         samples: manifest.samples,
+        baseSeed: manifest.baseSeed,
+        seedStrategy: manifest.seedStrategy,
         thinkingEnabled: manifest.thinkingEnabled,
       },
     } : {}),
@@ -136,21 +138,34 @@ if (baselineModel !== currentModel) {
   else fatal.push(`${message} Re-run with the baseline model, or pass --allow-model-change.`);
 }
 
-// Sample count and thinking mode are as comparability-breaking as the model itself: a samples=1
-// run scored against a samples=5 baseline (e.g. `persona:local` vs the baseline's actual
-// `persona:local:stability`/`persona:e2e` settings) compares one noisy draw to a five-sample
-// median with no warning. Only compare a field when both sides recorded it.
+// Sampling, seed policy, and thinking mode are part of the measurement instrument. Missing
+// per-field provenance is "unknown" rather than a proven mismatch, but it must be surfaced instead
+// of silently bypassing the comparability guard.
 const baselineSettings = baseline.provenance?.judgeSettings ?? baseline.judgeSettings ?? null;
 const currentSettings = current.provenance.judgeSettings ?? null;
 if (!baselineSettings || !currentSettings) {
-  warnings.push('Judge run settings (samples/thinking mode) are not recorded on one side; comparability cannot be verified beyond the model name.');
+  warnings.push('Judge run settings are not recorded on one side; comparability cannot be verified beyond the model name.');
 } else {
+  const settingsFields = [
+    ['samples', 'Sample count'],
+    ['baseSeed', 'Base seed'],
+    ['seedStrategy', 'Seed strategy'],
+    ['thinkingEnabled', 'Thinking mode'],
+  ];
   const mismatches = [];
-  if (baselineSettings.samples !== undefined && currentSettings.samples !== undefined && baselineSettings.samples !== currentSettings.samples) {
-    mismatches.push(`Sample count changed: ${baselineSettings.samples} -> ${currentSettings.samples}.`);
+  const missingFields = [];
+  for (const [field, label] of settingsFields) {
+    const baseVal = baselineSettings[field];
+    const currVal = currentSettings[field];
+    if (baseVal === undefined || currVal === undefined) {
+      const missingSide = [baseVal === undefined ? 'baseline' : null, currVal === undefined ? 'current' : null].filter(Boolean).join(' and ');
+      missingFields.push(`${label} (${missingSide})`);
+      continue;
+    }
+    if (baseVal !== currVal) mismatches.push(`${label} changed: ${baseVal} -> ${currVal}.`);
   }
-  if (baselineSettings.thinkingEnabled !== undefined && currentSettings.thinkingEnabled !== undefined && baselineSettings.thinkingEnabled !== currentSettings.thinkingEnabled) {
-    mismatches.push(`Thinking mode changed: ${baselineSettings.thinkingEnabled} -> ${currentSettings.thinkingEnabled}.`);
+  if (missingFields.length > 0) {
+    warnings.push(`Judge run settings are incomplete (${missingFields.join(', ')}); comparability cannot be fully verified for those fields.`);
   }
   if (mismatches.length > 0) {
     const message = `Judge run settings differ from the baseline (${mismatches.join(' ')}) Score deltas are not comparable — a settings mismatch can swamp real engine drift.`;

--- a/app/scripts/check-plan-judge-drift.mjs
+++ b/app/scripts/check-plan-judge-drift.mjs
@@ -4,6 +4,7 @@ import { resolve } from 'node:path';
 const defaultBaselinePath = resolve('../docs/analysis/plan-judge-baseline.json');
 const currentPath = resolve('artifacts/ai-plan-judge/latest/judge-summary.json');
 const allowModelChange = process.argv.includes('--allow-model-change');
+const allowSettingsChange = process.argv.includes('--allow-settings-change') || allowModelChange;
 const failOnRegression = process.argv.includes('--fail-on-regression');
 const usePrevious = process.argv.includes('--previous') || process.argv.includes('--prev');
 const againstIndex = process.argv.indexOf('--against');
@@ -200,6 +201,39 @@ if (fatal.length === 0) {
     const message = `Judge model changed: ${baselineModel} -> ${currentModel}. Model drift can dominate engine drift.`;
     if (allowModelChange) warnings.push(`${message} Continuing because --allow-model-change was supplied.`);
     else fatal.push(`${message} Re-run with the baseline model, or explicitly pass --allow-model-change for an exploratory comparison.`);
+  }
+
+  // Sampling/packet/thinking/context settings are as comparability-breaking as the model itself:
+  // e.g. `npm run judge:local` (samples=1, packet v1, thinking on, ctx 32768) vs the baseline's
+  // actual `judge:e2e` settings (samples=5, --blind/v2, thinking off, ctx 65536) previously
+  // produced a spurious "16 regressions, 0 improvements" diff with no warning at all. Only compare
+  // a field when both sides actually recorded it — an unrecorded field is "unknown", not a proven
+  // mismatch, and older baseline formats may predate `judgeSettings` entirely.
+  const baselineSettings = baseline.provenance.judgeSettings ?? baseline.judgeSettings ?? null;
+  const currentSettings = current.provenance.judgeSettings ?? current.judgeSettings ?? null;
+  if (!baselineSettings || !currentSettings) {
+    warnings.push('Judge run settings (samples/packet/thinking/context) are not recorded on one side; comparability cannot be verified beyond the model name.');
+  } else {
+    const settingsFields = [
+      ['samples', 'Sample count'],
+      ['packetVersion', 'Packet version'],
+      ['thinkingEnabled', 'Thinking mode'],
+      ['numCtx', 'Context window (num_ctx)'],
+      ['rubricScale', 'Rubric scale'],
+      ['isPairwise', 'Pairwise mode'],
+    ];
+    const mismatches = [];
+    for (const [field, label] of settingsFields) {
+      const baseVal = baselineSettings[field];
+      const currVal = currentSettings[field];
+      if (baseVal === undefined || currVal === undefined) continue;
+      if (baseVal !== currVal) mismatches.push(`${label} changed: ${baseVal} -> ${currVal}.`);
+    }
+    if (mismatches.length > 0) {
+      const message = `Judge run settings differ from the baseline (${mismatches.join(' ')}) Score deltas are not comparable — a settings mismatch can swamp real engine drift.`;
+      if (allowSettingsChange) warnings.push(`${message} Continuing because --allow-settings-change was supplied.`);
+      else fatal.push(`${message} Re-run with \`npm run judge:e2e\` (matches the committed baseline's settings exactly), or pass --allow-settings-change for an explicitly exploratory comparison.`);
+    }
   }
 
   if (baseline.familyCount !== current.familyCount) fatal.push(`Family count changed: ${baseline.familyCount} -> ${current.familyCount}.`);

--- a/app/scripts/check-plan-judge-drift.mjs
+++ b/app/scripts/check-plan-judge-drift.mjs
@@ -52,6 +52,7 @@ function normalizeToSummary(data, fallbackLabel) {
         caseSetSha256: data.current.caseSetSha256,
         corpusSha256: data.current.corpusSha256,
         familiesSha256: data.current.familiesSha256,
+        judgeSettings: data.current.judgeSettings,
       },
       familyCount: data.current.familyCount,
       caseCount: data.current.caseCount,
@@ -203,31 +204,40 @@ if (fatal.length === 0) {
     else fatal.push(`${message} Re-run with the baseline model, or explicitly pass --allow-model-change for an exploratory comparison.`);
   }
 
-  // Sampling/packet/thinking/context settings are as comparability-breaking as the model itself:
-  // e.g. `npm run judge:local` (samples=1, packet v1, thinking on, ctx 32768) vs the baseline's
-  // actual `judge:e2e` settings (samples=5, --blind/v2, thinking off, ctx 65536) previously
-  // produced a spurious "16 regressions, 0 improvements" diff with no warning at all. Only compare
-  // a field when both sides actually recorded it — an unrecorded field is "unknown", not a proven
-  // mismatch, and older baseline formats may predate `judgeSettings` entirely.
+  // Judge runtime settings that can change the sampled outputs are part of the measurement
+  // instrument, just like the model and prompt. Missing per-field provenance is "unknown" rather
+  // than a proven mismatch, but it must be surfaced instead of silently bypassing comparability.
   const baselineSettings = baseline.provenance.judgeSettings ?? baseline.judgeSettings ?? null;
   const currentSettings = current.provenance.judgeSettings ?? current.judgeSettings ?? null;
   if (!baselineSettings || !currentSettings) {
-    warnings.push('Judge run settings (samples/packet/thinking/context) are not recorded on one side; comparability cannot be verified beyond the model name.');
+    warnings.push('Judge run settings are not recorded on one side; comparability cannot be verified beyond the model name.');
   } else {
     const settingsFields = [
       ['samples', 'Sample count'],
       ['packetVersion', 'Packet version'],
       ['thinkingEnabled', 'Thinking mode'],
+      ['baseSeed', 'Base seed'],
+      ['seedStrategy', 'Seed strategy'],
+      ['temperature', 'Temperature'],
       ['numCtx', 'Context window (num_ctx)'],
+      ['numPredict', 'Prediction budget (num_predict)'],
       ['rubricScale', 'Rubric scale'],
       ['isPairwise', 'Pairwise mode'],
     ];
     const mismatches = [];
+    const missingFields = [];
     for (const [field, label] of settingsFields) {
       const baseVal = baselineSettings[field];
       const currVal = currentSettings[field];
-      if (baseVal === undefined || currVal === undefined) continue;
+      if (baseVal === undefined || currVal === undefined) {
+        const missingSide = [baseVal === undefined ? 'baseline' : null, currVal === undefined ? 'current' : null].filter(Boolean).join(' and ');
+        missingFields.push(`${label} (${missingSide})`);
+        continue;
+      }
       if (baseVal !== currVal) mismatches.push(`${label} changed: ${baseVal} -> ${currVal}.`);
+    }
+    if (missingFields.length > 0) {
+      warnings.push(`Judge run settings are incomplete (${missingFields.join(', ')}); comparability cannot be fully verified for those fields.`);
     }
     if (mismatches.length > 0) {
       const message = `Judge run settings differ from the baseline (${mismatches.join(' ')}) Score deltas are not comparable — a settings mismatch can swamp real engine drift.`;
@@ -384,6 +394,7 @@ const diffData = {
     promptSha256: baseline.provenance.promptSha256,
     responseSchemaSha256: baseline.provenance.responseSchemaSha256,
     caseSetSha256: baseline.provenance.caseSetSha256,
+    judgeSettings: baseline.provenance.judgeSettings ?? baseline.judgeSettings,
     familyCount: baseline.familyCount,
     caseCount: baseline.caseCount,
     meanSensitivityQuality: round2(baseMean),
@@ -398,6 +409,7 @@ const diffData = {
     caseSetSha256: current.provenance.caseSetSha256,
     corpusSha256: current.provenance.corpusSha256,
     familiesSha256: current.provenance.familiesSha256,
+    judgeSettings: current.provenance.judgeSettings ?? current.judgeSettings,
     familyCount: current.familyCount,
     caseCount: current.caseCount,
     meanSensitivityQuality: round2(currMean),

--- a/app/scripts/update-persona-judge-baseline.mjs
+++ b/app/scripts/update-persona-judge-baseline.mjs
@@ -23,8 +23,8 @@ const baselinePath = resolve('../docs/analysis/persona-judge-baseline.json');
 
 if (!reviewed) {
   console.error('Refusing to update the committed persona judge baseline without --reviewed.');
-  console.error('Run `npm run persona:local:stability` or `npm run persona:gemini`, review the');
-  console.error('scores in artifacts/persona-plan-judge/latest/, then rerun:');
+  console.error('Run `npm run persona:e2e` (matches the committed baseline\'s settings and runs');
+  console.error('persona:diff for you) or `npm run persona:gemini`, review the scores, then rerun:');
   console.error('  npm run persona:update-baseline -- --reviewed');
   process.exit(1);
 }

--- a/app/scripts/update-plan-judge-baseline.mjs
+++ b/app/scripts/update-plan-judge-baseline.mjs
@@ -16,7 +16,8 @@ const corpusPath = resolve(outputDir, 'corpus.json');
 
 if (!reviewed) {
   console.error('Refusing to update the committed plan judge baseline without --reviewed.');
-  console.error('Run `npm run judge:diff`, review the semantic changes, then rerun:');
+  console.error('Run `npm run judge:e2e` (matches the committed baseline\'s settings and runs');
+  console.error('judge:diff for you), review the semantic changes, then rerun:');
   console.error('  npm run judge:update-baseline -- --reviewed');
   process.exit(1);
 }
@@ -24,7 +25,7 @@ if (!reviewed) {
 for (const path of [summaryPath, familiesPath, promptPath, responseSchemaPath, scoresPath, corpusPath]) {
   if (!existsSync(path)) {
     console.error(`Fresh plan judge artifact not found: ${path}`);
-    console.error('Run `npm run judge:local` or `npm run judge:run` first.');
+    console.error('Run `npm run judge:e2e` (or `npm run judge:run` for a cloud provider) first.');
     process.exit(1);
   }
 }

--- a/app/src/engine/architecture.test.ts
+++ b/app/src/engine/architecture.test.ts
@@ -512,7 +512,13 @@ describe('Architecture & Phased Engine Integration', () => {
                 id: 'c1', title: 'Road Race', date: '2026-09-12', priority: 'A', lifecycle: 'scheduled', category: 'cycling_event',
                 demandProfile: { aerobicEndurance: 0.8, thresholdPower: 0.8, vo2MaxPower: 0.6, repeatedSurges: 0.5, sprintPower: 0.3, fatigueResistance: 0.7, neuromuscular: 0.4 }
             };
-            const rankedWithEvent = rankCandidatesByUtility(ENRICHED_TEMPLATES, [], fatigue, availability, [], prefs, { focusEvent: cyclingFocusEvent });
+            // `date` must be pinned to the fixture's own '2026-08-07' -- `rankCandidates` falls
+            // back to the real wall-clock date (`getLocalDateString()`) when omitted, which
+            // silently changes `daysToRace` against the hardcoded '2026-09-12' event date as
+            // real time passes. Left implicit, this test passed only while the wall clock
+            // happened to be far from 2026-09-12 and started failing once it drifted within
+            // event-proximity taper/safety range, which legitimately suppresses Strength.
+            const rankedWithEvent = rankCandidatesByUtility(ENRICHED_TEMPLATES, [], fatigue, availability, [], prefs, { focusEvent: cyclingFocusEvent, date: '2026-08-07' });
             const cyclingPick = rankedWithEvent.find(r => r.template.modality === 'Cycling');
             const strengthPick = rankedWithEvent.find(r => r.template.modality === 'Strength');
             expect(cyclingPick).toBeDefined();

--- a/app/src/engine/judgeDriftScript.test.ts
+++ b/app/src/engine/judgeDriftScript.test.ts
@@ -48,6 +48,29 @@ function run(appDir: string) {
     return spawnSync(process.execPath, [SCRIPT, '--previous'], { cwd: appDir, encoding: 'utf8' });
 }
 
+function setupWithSettings(baselineSettings: Record<string, unknown>, currentSettings: Record<string, unknown>) {
+    const root = mkdtempSync(join(tmpdir(), 'judge-drift-settings-'));
+    roots.push(root);
+    const appDir = join(root, 'app');
+    const currentPath = join(appDir, 'artifacts/ai-plan-judge/latest/judge-summary.json');
+    const baselinePath = join(root, 'docs/analysis/plan-judge-baseline.json');
+    mkdirSync(dirname(currentPath), { recursive: true });
+    mkdirSync(dirname(baselinePath), { recursive: true });
+
+    const current = summary('same-commit');
+    (current.provenance as Record<string, unknown>).judgeSettings = currentSettings;
+    const baseline = summary('same-commit');
+    (baseline.provenance as Record<string, unknown>).judgeSettings = baselineSettings;
+
+    writeFileSync(currentPath, JSON.stringify(current));
+    writeFileSync(baselinePath, JSON.stringify(baseline));
+    return { appDir };
+}
+
+function runDirect(appDir: string, extraArgs: string[] = []) {
+    return spawnSync(process.execPath, [SCRIPT, ...extraArgs], { cwd: appDir, encoding: 'utf8' });
+}
+
 describe('judge:diff:prev provenance hardening', () => {
     it('fails closed when no previous artifact exists', () => {
         const { appDir } = setup();
@@ -128,5 +151,60 @@ describe('judge:diff:prev provenance hardening', () => {
         expect(result.status).toBe(0);
         expect(result.stdout).toContain('Baseline (4B)');
         expect(result.stdout).toContain('Diff check complete');
+    });
+});
+
+describe('judge:diff settings comparability guard', () => {
+    it('fails closed when sample count differs from the baseline', () => {
+        const { appDir } = setupWithSettings(
+            { samples: 5, packetVersion: 'v2', thinkingEnabled: false, numCtx: 65536 },
+            { samples: 1, packetVersion: 'v2', thinkingEnabled: false, numCtx: 65536 },
+        );
+        const result = runDirect(appDir);
+        expect(result.status).toBe(1);
+        expect(result.stderr).toContain('NOT COMPARABLE');
+        expect(result.stderr).toContain('Sample count changed: 5 -> 1');
+        expect(result.stderr).toContain('judge:e2e');
+    });
+
+    it('fails closed when packet version, thinking mode, and context window all differ', () => {
+        const { appDir } = setupWithSettings(
+            { samples: 5, packetVersion: 'v2', thinkingEnabled: false, numCtx: 65536 },
+            { samples: 5, packetVersion: 'v1', thinkingEnabled: true, numCtx: 32768 },
+        );
+        const result = runDirect(appDir);
+        expect(result.status).toBe(1);
+        expect(result.stderr).toContain('Packet version changed: v2 -> v1');
+        expect(result.stderr).toContain('Thinking mode changed: false -> true');
+        expect(result.stderr).toContain('Context window (num_ctx) changed: 65536 -> 32768');
+    });
+
+    it('does not flag a settings match', () => {
+        const { appDir } = setupWithSettings(
+            { samples: 5, packetVersion: 'v2', thinkingEnabled: false, numCtx: 65536 },
+            { samples: 5, packetVersion: 'v2', thinkingEnabled: false, numCtx: 65536 },
+        );
+        const result = runDirect(appDir);
+        expect(result.status).toBe(0);
+        expect(result.stdout).toContain('Diff check complete');
+        expect(result.stdout).not.toContain('Judge run settings differ');
+    });
+
+    it('downgrades to a warning under --allow-settings-change', () => {
+        const { appDir } = setupWithSettings(
+            { samples: 5, packetVersion: 'v2', thinkingEnabled: false, numCtx: 65536 },
+            { samples: 1, packetVersion: 'v1', thinkingEnabled: true, numCtx: 32768 },
+        );
+        const result = runDirect(appDir, ['--allow-settings-change']);
+        expect(result.status).toBe(0);
+        expect(result.stdout).toContain('Comparability Warnings');
+        expect(result.stdout).toContain('Continuing because --allow-settings-change was supplied');
+    });
+
+    it('treats missing settings on either side as a non-fatal warning, not a proven mismatch', () => {
+        const { appDir } = setup();
+        const result = runDirect(appDir);
+        expect(result.status).toBe(0);
+        expect(result.stdout).toContain('not recorded on one side');
     });
 });

--- a/app/src/engine/judgeSettingsProvenance.test.ts
+++ b/app/src/engine/judgeSettingsProvenance.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const PLAN_SCRIPT = fileURLToPath(new URL('../../scripts/check-plan-judge-drift.mjs', import.meta.url));
+const PERSONA_SCRIPT = fileURLToPath(new URL('../../scripts/check-persona-judge-drift.mjs', import.meta.url));
+const roots: string[] = [];
+
+const planSettings = {
+    samples: 5,
+    packetVersion: 'v2',
+    thinkingEnabled: false,
+    baseSeed: 424242,
+    seedStrategy: 'derived',
+    temperature: 0.1,
+    numCtx: 65536,
+    numPredict: 16384,
+    rubricScale: '0-10',
+    isPairwise: false,
+};
+
+afterEach(() => {
+    while (roots.length) rmSync(roots.pop()!, { recursive: true, force: true });
+});
+
+function planSummary(commit: string, settings: Record<string, unknown>) {
+    return {
+        schema: 'adaptive-training-recommender/ai-plan-judge-summary@3',
+        provenance: {
+            corpusCommit: commit,
+            judgeModel: 'judge-model',
+            judgeProvider: 'local',
+            promptSha256: 'prompt-a',
+            responseSchemaSha256: 'schema-a',
+            caseSetSha256: 'case-set-a',
+            corpusSha256: 'corpus-a',
+            familiesSha256: 'families-a',
+            judgeSettings: settings,
+        },
+        familyCount: 1,
+        caseCount: 1,
+        meanSensitivityQuality: 5,
+        scoreAverages: { overall: 5 },
+        familySensitivity: [{ familyId: 'family-a', sensitivityQuality: 5 }],
+    };
+}
+
+function setupPlan(baselineSettings: Record<string, unknown>, currentSettings: Record<string, unknown>) {
+    const root = mkdtempSync(join(tmpdir(), 'judge-settings-provenance-'));
+    roots.push(root);
+    const appDir = join(root, 'app');
+    const currentPath = join(appDir, 'artifacts/ai-plan-judge/latest/judge-summary.json');
+    const baselinePath = join(root, 'docs/analysis/plan-judge-baseline.json');
+    mkdirSync(dirname(currentPath), { recursive: true });
+    mkdirSync(dirname(baselinePath), { recursive: true });
+    writeFileSync(currentPath, JSON.stringify(planSummary('current', currentSettings)));
+    writeFileSync(baselinePath, JSON.stringify(planSummary('baseline', baselineSettings)));
+    return { appDir };
+}
+
+function setupPersona(baselineSettings: Record<string, unknown>, manifest: Record<string, unknown>) {
+    const root = mkdtempSync(join(tmpdir(), 'persona-settings-provenance-'));
+    roots.push(root);
+    const appDir = join(root, 'app');
+    const outputDir = join(appDir, 'artifacts/persona-plan-judge/latest');
+    const baselinePath = join(root, 'docs/analysis/persona-judge-baseline.json');
+    mkdirSync(outputDir, { recursive: true });
+    mkdirSync(dirname(baselinePath), { recursive: true });
+
+    writeFileSync(join(outputDir, 'corpus.json'), JSON.stringify({ commit: 'same-commit' }));
+    writeFileSync(join(outputDir, 'judge-scores.jsonl'), `${JSON.stringify({
+        familyId: 'family-a',
+        familyAssessment: { sensitivity_quality: 5 },
+        caseScores: [{ scores: { overall: 5 } }],
+    })}\n`);
+    writeFileSync(join(outputDir, 'judge-run-manifest.json'), JSON.stringify(manifest));
+    writeFileSync(baselinePath, JSON.stringify({
+        provenance: { judgeModel: 'judge-model', judgeProvider: 'local', judgeSettings: baselineSettings },
+        familyCount: 1,
+        caseCount: 1,
+        meanSensitivityQuality: 5,
+        scoreAverages: { overall: 5 },
+        familySensitivity: [{ familyId: 'family-a', sensitivityQuality: 5 }],
+    }));
+    return { appDir };
+}
+
+describe('judge settings provenance completeness', () => {
+    it('warns when an individual plan-judge setting is missing instead of silently skipping it', () => {
+        const { numPredict: _omitted, ...partialBaseline } = planSettings;
+        const { appDir } = setupPlan(partialBaseline, planSettings);
+        const result = spawnSync(process.execPath, [PLAN_SCRIPT], { cwd: appDir, encoding: 'utf8' });
+
+        expect(result.status).toBe(0);
+        expect(result.stdout).toContain('Judge run settings are incomplete');
+        expect(result.stdout).toContain('Prediction budget (num_predict) (baseline)');
+    });
+
+    it('carries judge settings through historical diff artifacts so --previous can reject drift', () => {
+        const { appDir } = setupPlan(planSettings, planSettings);
+        const historyDir = join(appDir, 'artifacts/ai-plan-judge/history');
+        mkdirSync(historyDir, { recursive: true });
+        writeFileSync(join(historyDir, 'diff-2026-09-08T10-00-00-000Z.json'), JSON.stringify({
+            comparedAt: '2026-09-08T10:00:00.000Z',
+            current: {
+                corpusCommit: 'previous',
+                judgeModel: 'judge-model',
+                judgeProvider: 'local',
+                promptSha256: 'prompt-a',
+                responseSchemaSha256: 'schema-a',
+                caseSetSha256: 'case-set-a',
+                corpusSha256: 'corpus-old',
+                familiesSha256: 'families-old',
+                judgeSettings: { ...planSettings, samples: 1 },
+                familyCount: 1,
+                caseCount: 1,
+                meanSensitivityQuality: 5,
+                scoreAverages: { overall: 5 },
+            },
+            familyDeltas: { 'family-a': { current: 5 } },
+        }));
+
+        const result = spawnSync(process.execPath, [PLAN_SCRIPT, '--previous'], { cwd: appDir, encoding: 'utf8' });
+        expect(result.status).toBe(1);
+        expect(result.stderr).toContain('Sample count changed: 1 -> 5');
+    });
+
+    it('warns when an individual persona-judge setting is missing', () => {
+        const { appDir } = setupPersona(
+            { samples: 5, baseSeed: 424242, thinkingEnabled: true },
+            {
+                judgeModel: 'judge-model',
+                judgeProvider: 'local',
+                samples: 5,
+                baseSeed: 424242,
+                seedStrategy: 'derived',
+                thinkingEnabled: true,
+            },
+        );
+        const result = spawnSync(process.execPath, [PERSONA_SCRIPT], { cwd: appDir, encoding: 'utf8' });
+
+        expect(result.status).toBe(0);
+        expect(result.stdout).toContain('Judge run settings are incomplete');
+        expect(result.stdout).toContain('Seed strategy (baseline)');
+    });
+
+    it('treats persona seed drift as non-comparable', () => {
+        const { appDir } = setupPersona(
+            { samples: 5, baseSeed: 424242, seedStrategy: 'derived', thinkingEnabled: true },
+            {
+                judgeModel: 'judge-model',
+                judgeProvider: 'local',
+                samples: 5,
+                baseSeed: 424243,
+                seedStrategy: 'derived',
+                thinkingEnabled: true,
+            },
+        );
+        const result = spawnSync(process.execPath, [PERSONA_SCRIPT], { cwd: appDir, encoding: 'utf8' });
+
+        expect(result.status).toBe(1);
+        expect(result.stderr).toContain('Base seed changed: 424242 -> 424243');
+    });
+});

--- a/app/src/engine/judgeSettingsProvenance.test.ts
+++ b/app/src/engine/judgeSettingsProvenance.test.ts
@@ -90,7 +90,8 @@ function setupPersona(baselineSettings: Record<string, unknown>, manifest: Recor
 
 describe('judge settings provenance completeness', () => {
     it('warns when an individual plan-judge setting is missing instead of silently skipping it', () => {
-        const { numPredict: _omitted, ...partialBaseline } = planSettings;
+        const partialBaseline: Record<string, unknown> = { ...planSettings };
+        delete partialBaseline.numPredict;
         const { appDir } = setupPlan(partialBaseline, planSettings);
         const result = spawnSync(process.execPath, [PLAN_SCRIPT], { cwd: appDir, encoding: 'utf8' });
 

--- a/app/src/engine/personaJudgeDriftScript.test.ts
+++ b/app/src/engine/personaJudgeDriftScript.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT = fileURLToPath(new URL('../../scripts/check-persona-judge-drift.mjs', import.meta.url));
+const roots: string[] = [];
+
+afterEach(() => {
+    while (roots.length) rmSync(roots.pop()!, { recursive: true, force: true });
+});
+
+function baselineJson(judgeSettings?: Record<string, unknown>) {
+    return {
+        provenance: {
+            judgeModel: 'judge-model',
+            judgeProvider: 'local',
+            ...(judgeSettings ? { judgeSettings } : {}),
+        },
+        familyCount: 1,
+        caseCount: 1,
+        meanSensitivityQuality: 5,
+        scoreAverages: { overall: 5 },
+        familySensitivity: [{ familyId: 'family-a', sensitivityQuality: 5 }],
+    };
+}
+
+function scoreRow() {
+    return {
+        familyId: 'family-a',
+        familyAssessment: { sensitivity_quality: 5 },
+        caseScores: [{ scores: { overall: 5 } }],
+    };
+}
+
+function setup(baselineSettings: Record<string, unknown> | undefined, manifest: Record<string, unknown> | null) {
+    const root = mkdtempSync(join(tmpdir(), 'persona-judge-drift-'));
+    roots.push(root);
+    const appDir = join(root, 'app');
+    const outputDir = join(appDir, 'artifacts/persona-plan-judge/latest');
+    const baselinePath = join(root, 'docs/analysis/persona-judge-baseline.json');
+    mkdirSync(outputDir, { recursive: true });
+    mkdirSync(dirname(baselinePath), { recursive: true });
+
+    writeFileSync(join(outputDir, 'corpus.json'), JSON.stringify({ commit: 'same-commit' }));
+    writeFileSync(join(outputDir, 'judge-scores.jsonl'), `${JSON.stringify(scoreRow())}\n`);
+    if (manifest) writeFileSync(join(outputDir, 'judge-run-manifest.json'), JSON.stringify(manifest));
+    writeFileSync(baselinePath, JSON.stringify(baselineJson(baselineSettings)));
+
+    return { appDir };
+}
+
+function run(appDir: string, extraArgs: string[] = []) {
+    return spawnSync(process.execPath, [SCRIPT, ...extraArgs], { cwd: appDir, encoding: 'utf8' });
+}
+
+describe('persona:diff settings comparability guard', () => {
+    it('fails closed when sample count differs from the baseline', () => {
+        const { appDir } = setup(
+            { samples: 5, thinkingEnabled: true },
+            { judgeModel: 'judge-model', judgeProvider: 'local', samples: 1, thinkingEnabled: true },
+        );
+        const result = run(appDir);
+        expect(result.status).toBe(1);
+        expect(result.stderr).toContain('NOT COMPARABLE');
+        expect(result.stderr).toContain('Sample count changed: 5 -> 1');
+        expect(result.stderr).toContain('persona:e2e');
+    });
+
+    it('fails closed when thinking mode differs from the baseline', () => {
+        const { appDir } = setup(
+            { samples: 5, thinkingEnabled: true },
+            { judgeModel: 'judge-model', judgeProvider: 'local', samples: 5, thinkingEnabled: false },
+        );
+        const result = run(appDir);
+        expect(result.status).toBe(1);
+        expect(result.stderr).toContain('Thinking mode changed: true -> false');
+    });
+
+    it('does not flag a settings match', () => {
+        const { appDir } = setup(
+            { samples: 5, thinkingEnabled: true },
+            { judgeModel: 'judge-model', judgeProvider: 'local', samples: 5, thinkingEnabled: true },
+        );
+        const result = run(appDir);
+        expect(result.status).toBe(0);
+        expect(result.stdout).toContain('Persona diff check complete');
+        expect(result.stdout).not.toContain('Judge run settings differ');
+    });
+
+    it('downgrades to a warning under --allow-settings-change', () => {
+        const { appDir } = setup(
+            { samples: 5, thinkingEnabled: true },
+            { judgeModel: 'judge-model', judgeProvider: 'local', samples: 1, thinkingEnabled: false },
+        );
+        const result = run(appDir, ['--allow-settings-change']);
+        expect(result.status).toBe(0);
+        expect(result.stdout).toContain('Comparability Warnings');
+        expect(result.stdout).toContain('Continuing because --allow-settings-change was supplied');
+    });
+
+    it('treats missing settings on either side as a non-fatal warning, not a proven mismatch', () => {
+        const { appDir } = setup(undefined, { judgeModel: 'judge-model', judgeProvider: 'local' });
+        const result = run(appDir);
+        expect(result.status).toBe(0);
+        expect(result.stdout).toContain('not recorded on one side');
+    });
+});

--- a/docs/analysis/ai-plan-judge.md
+++ b/docs/analysis/ai-plan-judge.md
@@ -72,18 +72,51 @@ The travel case intentionally tests **executed** capacity, equipment, and enviro
 
 ### 2. Run the model judge
 
-Local model:
+**To compare against the committed baseline, use `judge:e2e`, not `judge:local`.** The
+committed baseline (`docs/analysis/plan-judge-baseline.json`) was built with a specific
+settings bundle — `--blind` (packet v2), `--samples 5`, thinking **disabled**, and
+`--ctx 65536` — and `npm run judge:diff` only tolerates comparing runs made with that same
+bundle (see `check-plan-judge-drift.mjs`'s settings guard below). `judge:local`'s defaults
+(1 sample, packet v1, thinking **on**, `--ctx 32768`) intentionally differ, because it exists
+for fast local iteration, not baseline comparison — using it to judge "did I regress the
+baseline?" compares one noisy single-sample draw under a different prompt packet and
+thinking mode to a five-sample median, which can (and did — see
+`git log --grep 'refresh simulation, persona-judge, and plan-judge baselines'`) manufacture
+a double-digit false "regression" count with zero real behavior change:
 
 ```bash
-# Standard local evaluation (1 sample, fresh)
+# Baseline-comparable: matches docs/analysis/plan-judge-baseline.json's settings exactly,
+# regenerates the corpus, runs the judge, and runs judge:diff for you.
+npm run judge:e2e
+
+# Higher-throughput variant tuned for the 4B quick model + more VRAM headroom (10 samples,
+# thinking on, wider ctx/concurrency) -- still blind, still baseline-comparable in spirit,
+# but NOT the same settings bundle as the committed baseline, so judge:diff will refuse to
+# compare it directly unless you pass --allow-settings-change.
+npm run judge:e2e:quick
+```
+
+For fast local iteration where baseline comparability doesn't matter (e.g. sanity-checking
+a corpus change before committing to a full `judge:e2e` run):
+
+```bash
+# Quick smoke test (1 sample, fresh) -- NOT comparable to the committed baseline
 npm run judge:local
 
-# Multi-sample stability measurement (5 samples, fresh)
+# Multi-sample stability measurement (5 samples, fresh) -- still packet v1/thinking-on,
+# so still NOT comparable to the committed baseline; use judge:e2e for that
 npm run judge:local:stability
 
 # Quick local evaluation (4B, one sample, thinking off)
 npm run judge:local:quick
 ```
+
+`npm run judge:diff` fails closed (exit 1, "NOT COMPARABLE") when the current run's judge
+model, sample count, packet version, thinking mode, `num_ctx`, or rubric scale differs from
+what the baseline was built with, rather than silently producing a diff that mixes settings
+drift into what looks like engine drift. Pass `--allow-settings-change` (or the pre-existing
+`--allow-model-change`, which also covers settings) only for a deliberately exploratory
+comparison, and treat its output as directional, not a real before/after.
 
 Local `--quick` runs default to `hf.co/empero-ai/Qwen3.8-4B-Distill-GGUF`.
 Standard and stability runs retain the 9B Q4 model. Override the quick checkpoint with

--- a/docs/analysis/persona-judge-baseline.json
+++ b/docs/analysis/persona-judge-baseline.json
@@ -2,15 +2,15 @@
   "schema": "adaptive-training-recommender/persona-plan-judge-baseline@1",
   "source": "artifacts/persona-plan-judge/latest/judge-scores.jsonl",
   "provenance": {
-    "corpusCommit": "e9f0c01dc5c3ce969be7bac0a5c4290e58108540",
+    "corpusCommit": "d33eb5bbc112f785db5d2ac46897a2a25ec85da8",
     "corpusSchema": "adaptive-training-recommender/persona-plan-judge-corpus@1",
-    "corpusSha256": "f155d3fb32fada5732eb0a728ef4f8dacf35a7b229e3b16a2b31cd90d6f6b164",
-    "familiesSha256": "0d0be0eda259d7f951d2a69613ee1d366565c5e9d337d6cb15917d7b8569182f",
+    "corpusSha256": "46eb427436c3337392c6dcde5076c8cbe20220e31032aa2f17b071ecdeeee312",
+    "familiesSha256": "94eb914ac9ee00726b4333b7186508a19ca36271de5a6b304436d3c3fcae5752",
     "promptSha256": "4822f4c69db5b2d544c8332f557a154ccb370b8f94ca33a8c97ea484a54e0160",
-    "judgeScoresSha256": "4ae9d6f5888633c6f3a5be559c6bce809b55c5f44eb4c95917f85ede2c9c32f3",
+    "judgeScoresSha256": "9026389e42fe9db3b38fe47e8f31ed4c1f82c7f3689d63df76ec44d13a5f8b4b",
     "judgeModel": "hf.co/empero-ai/Qwen3.8-9B-Distill-GGUF:Q4_K_M",
     "judgeProvider": "local",
-    "analyzedAt": "2026-09-03T10:40:16.352Z",
+    "analyzedAt": "2026-09-08T21:55:37.023Z",
     "judgeSettings": {
       "model": "hf.co/empero-ai/Qwen3.8-9B-Distill-GGUF:Q4_K_M",
       "provider": "local",
@@ -18,7 +18,7 @@
       "baseSeed": 424242,
       "seedStrategy": "derived",
       "thinkingEnabled": true,
-      "concurrency": 1
+      "concurrency": 2
     }
   },
   "judgeSettings": {
@@ -28,7 +28,7 @@
     "baseSeed": 424242,
     "seedStrategy": "derived",
     "thinkingEnabled": true,
-    "concurrency": 1
+    "concurrency": 2
   },
   "familyCount": 9,
   "caseCount": 30,
@@ -44,21 +44,21 @@
     "persona_triathlon_established_olympic"
   ],
   "scoreAverages": {
-    "safety_recovery_fit": 8.9,
-    "goal_event_fit": 8.8,
-    "sequencing": 7.883333333333334,
-    "periodization_taper": 9.066666666666666,
-    "preference_capacity_fit": 8.770000000000001,
-    "robustness": 8.629999999999999,
-    "overall": 8.486666666666666
+    "safety_recovery_fit": 8.933333333333334,
+    "goal_event_fit": 8.716666666666667,
+    "sequencing": 8.053333333333333,
+    "periodization_taper": 8.833333333333334,
+    "preference_capacity_fit": 8.866666666666667,
+    "robustness": 8.6,
+    "overall": 8.563333333333333
   },
-  "meanSensitivityQuality": 8.733333333333334,
+  "meanSensitivityQuality": 8.68888888888889,
   "familySensitivity": [
     {
       "familyId": "persona_strength_no_wearable",
       "changedAxis": "current check-in state for a strength-priority athlete with no wearable data",
       "sensitivityQuality": 9,
-      "rationale": "All three cases demonstrate appropriate sensitivity to their respective states. The baseline case shows correct handling of a healthy, motivated strength athlete with no wearable data. The work-fatigue case demonstrates proper downshifting when occupational load is high without abandoning the strength goal. The symptom-flare case correctly escalates caution while preserving strength specificity through bodyweight alternatives that respect guardrails. No overreaction (unnecessary rest or elimination of training) and no underreaction (pushing through pain or ignoring fatigue) was observed.",
+      "rationale": "All three cases demonstrate appropriate sensitivity to the check-in-only constraint. The baseline case correctly uses subjective readiness without inventing objective metrics. The work fatigue case appropriately reduces volume while preserving strength identity — not over-reactive. The symptom flare case correctly activates guardrails and avoids overhead pressing/heavy spinal loading without diagnosing an injury or fabricating recovery data. No cases show underreaction (e.g., ignoring pain flag) or overreaction (e.g., cancelling all training when fatigue is moderate).",
       "overreactionCases": [],
       "underreactionCases": [],
       "algorithmAdjustmentHypotheses": []
@@ -67,7 +67,7 @@
       "familyId": "persona_health_fat_loss",
       "changedAxis": "current recovery/time state for a health-and-fat-loss evergreen athlete with Garmin data",
       "sensitivityQuality": 8.5,
-      "rationale": "All three cases demonstrate appropriate sensitivity to their respective constraints. The baseline case shows healthy evergreen progression without invented periodization. The adverse recovery case correctly reduces load when objective signals (HRV -14, body_battery 24%) are poor. The low-time case respects the 30-minute constraint while maintaining habit diversity. No overreaction or underreaction detected.",
+      "rationale": "The system demonstrates appropriate sensitivity across all three cases. The baseline case shows correct evergreen progression without fake periodization. The adverse recovery case correctly identifies and responds to poor physiological signals (elevated RHR, depressed HRV, low body battery) with rest-first approach before gradual return. The low-time case is the weakest link — it respects constraints but produces a dense schedule that may be unsustainable for someone with only 30 minutes daily available.",
       "overreactionCases": [],
       "underreactionCases": [],
       "algorithmAdjustmentHypotheses": []
@@ -75,8 +75,8 @@
     {
       "familyId": "persona_former_elite_return",
       "changedAxis": "current recovery state for a former high-level endurance athlete whose present training is intermittent",
-      "sensitivityQuality": 9.2,
-      "rationale": "All three cases demonstrate appropriate sensitivity to the former-elite persona constraints. The baseline case correctly uses current data as dose authority without inflating load based on historical status. The adverse recovery case correctly prioritizes rest over Garmin signals that might otherwise suggest readiness. The low-motivation-only case correctly avoids reducing load when physiological capacity is intact, distinguishing motivation from fatigue. No cases show overreaction (unnecessary load reduction) or underreaction (ignoring red flags).",
+      "sensitivityQuality": 8.5,
+      "rationale": "The planner correctly distinguishes between sparse history (not a red flag), adverse recovery signals (a real red flag requiring rest), and low motivation alone (not a physiological red flag). The former-elite persona calibration is well-executed: historical competitive level never becomes the dose authority. All three cases show appropriate sensitivity to current-state data over historical context.",
       "overreactionCases": [],
       "underreactionCases": [],
       "algorithmAdjustmentHypotheses": []
@@ -85,7 +85,7 @@
       "familyId": "persona_balanced_performance",
       "changedAxis": "current recovery and today-specific modality preference for an evergreen balanced-performance generalist",
       "sensitivityQuality": 9,
-      "rationale": "All three cases demonstrate appropriate sensitivity to the changed axis (recovery state and modality preference). The baseline case shows clean evergreen progression. The adverse recovery case appropriately front-loads rest while still preserving balanced-performance identity — a minor concern on day-5 strength load is noted but not treated as a failure. The strength-preference case correctly respects user input without over-indexing to the point of abandoning endurance work.",
+      "rationale": "All three cases demonstrate appropriate sensitivity to their respective conditions. The baseline case shows balanced modalities without fake periodization. The adverse recovery case appropriately escalates rest while maintaining strength retention. The strength preference case respects the declared modality choice without converting the week into a strength-primary program. No overreaction or underreaction detected across any case.",
       "overreactionCases": [],
       "underreactionCases": [],
       "algorithmAdjustmentHypotheses": []
@@ -94,7 +94,7 @@
       "familyId": "persona_stacked_constraints",
       "changedAxis": "current recovery/time state with a standing running restriction, heavy-lower-body guardrail, and no training equipment",
       "sensitivityQuality": 8.5,
-      "rationale": "All three cases demonstrate appropriate sensitivity to their respective states. The adverse recovery case is the strongest signal of good sensitivity — it reduces load when RHR rises, HRV drops, and body battery falls below threshold without over-medicalizing normal variation. No underreaction or overreaction patterns emerge across the family. The baseline and low-time cases correctly treat identical objective signals as equivalent despite different subjective time availability.",
+      "rationale": "All three cases demonstrate appropriate sensitivity to their respective input conditions. The baseline case shows correct constraint adherence and coherent sequencing. The adverse recovery case demonstrates proper escalation of rest in response to clear physiological red flags (RHR delta +7, HRV delta -14, body battery 24%). The low-time case appropriately scales session durations without inventing measurements or bypassing guardrails. No overreaction is present — the planner does not treat normal variation as injury-level concern. The only minor improvement opportunity is in the low-time case where durationMax parameters could be tightened to match the declared constraint more explicitly.",
       "overreactionCases": [],
       "underreactionCases": [],
       "algorithmAdjustmentHypotheses": []
@@ -103,7 +103,7 @@
       "familyId": "persona_walking_preferred",
       "changedAxis": "current recovery/time state for a health-priority athlete who cannot run and prefers walking",
       "sensitivityQuality": 8.5,
-      "rationale": "All three cases demonstrate appropriate sensitivity to their respective conditions: normal recovery (baseline), adverse recovery signals requiring rest (adverse_recovery), and tight time constraints (low_time). The walking-preferred persona correctly maintains walking as the primary aerobic modality in all cases without running substitution. No overreaction or underreaction detected — each plan matches its input state appropriately.",
+      "rationale": "All three cases demonstrate appropriate sensitivity: baseline shows normal operation without unnecessary rest, adverse recovery correctly front-loads rest while maintaining some training, and low time respects constraints without abandoning the persona's identity. No case exhibits clear overreaction (unnecessary rest) or underreaction (ignoring poor signals). The model handles the trade-off between objective metrics and subjective state appropriately.",
       "overreactionCases": [],
       "underreactionCases": [],
       "algorithmAdjustmentHypotheses": []
@@ -111,8 +111,8 @@
     {
       "familyId": "persona_established_history",
       "changedAxis": "current recovery and motivation state for an endurance athlete with a genuinely established, current 28-day training base",
-      "sensitivityQuality": 8.7,
-      "rationale": "The established-history persona demonstrates appropriate sensitivity to current-state fitness signals. The baseline case correctly unlocks intensity from an established base. The low-motivation-only case correctly preserves earned opportunities when objective recovery is good. The adverse-recovery case shows minor overreaction (tempo run on day 5) but overall behavior is appropriately conservative given the physiological red flags.",
+      "sensitivityQuality": 9.2,
+      "rationale": "All three cases demonstrate appropriate sensitivity to the established-history persona's core principle: current training data (not historical achievement) governs load tolerance. The baseline case correctly unlocks a tempo run for an athlete with consistent recent volume and good recovery. The adverse recovery case correctly reduces load when physiological signals deteriorate despite an established base. The low motivation case correctly ignores motivational noise when objective physiology is sound. No overreaction or underreaction cases were identified.",
       "overreactionCases": [],
       "underreactionCases": [],
       "algorithmAdjustmentHypotheses": []
@@ -120,8 +120,8 @@
     {
       "familyId": "persona_cycling_primary_hybrid",
       "changedAxis": "recovery, local mechanical constraint, today-specific modality preference, and time availability for a cycling-primary hybrid athlete",
-      "sensitivityQuality": 8.7,
-      "rationale": "The cycling-primary hybrid persona evaluation shows consistent, appropriate responses across all five test cases. The system correctly prioritizes recovery signals over training willingness (case 2), pain/guardrails over favorable wearables (case 3), and respects time constraints without hallucinating data (case 5). Cycling remains the primary performance objective throughout while strength is maintained as a retention goal. No overreactions detected — all load reductions are justified by actual signals rather than arbitrary conservatism.",
+      "sensitivityQuality": 8.5,
+      "rationale": "The algorithm demonstrates strong sensitivity to local tissue guardrails and time constraints, correctly prioritizing active pain signals over favorable wearable metrics. The adverse recovery case shows a slight tendency toward over-reaction — the return-to-training is appropriately cautious but could be more gradual given the combination of elevated rhr_delta and low body_battery_wake. The strength preference case under-reacts by not sufficiently reducing cycling volume to accommodate the athlete's stated priority. Overall, the algorithm handles hard constraints well (time, guardrails) but could calibrate its response to subjective recovery signals more conservatively in adverse cases.",
       "overreactionCases": [],
       "underreactionCases": [],
       "algorithmAdjustmentHypotheses": []
@@ -130,7 +130,7 @@
       "familyId": "persona_triathlon_established_olympic",
       "changedAxis": "recovery, weekday capacity, and race proximity for one established Olympic-distance triathlete",
       "sensitivityQuality": 8.5,
-      "rationale": "The model demonstrates appropriate sensitivity across all four cases: normal recovery is respected (baseline), adverse signals trigger rest days (adverse_recovery), time constraints are honored without sacrificing discipline coverage (short_time), and taper restraint is applied without inventing bricks or swim assumptions (taper). No overreactions detected — the model does not shut down training for minor fatigue variations.",
+      "rationale": "All four cases demonstrate appropriate sensitivity to their respective conditions. The baseline case correctly builds toward the event with all three disciplines. The adverse recovery case appropriately reduces load when HRV/RHR/sleep signals degrade without over-medicalizing normal variation. The short-time case respects declared constraints and maintains discipline balance. The taper case correctly preserves all three Olympic triathlon disciplines in the final 2 weeks — a common failure mode for generic endurance planners that would drop running or swimming.",
       "overreactionCases": [],
       "underreactionCases": [],
       "algorithmAdjustmentHypotheses": []
@@ -150,42 +150,40 @@
       },
       "confidence": 0.92,
       "flags": [],
-      "rationale": "Baseline case demonstrates appropriate handling of a strength-focused athlete with no wearable data. The plan preserves strength specificity using free weights while including light walking for aerobic volume without making it the primary modality. Subjective readiness signals (readiness=8, fatigue=3, soreness=3) are respected appropriately. No objective recovery metrics are hallucinated. The sequencing alternates between full-body and upper-body strength work with rest days interspersed, avoiding same-tissue stacking. Evergreen progression is maintained without fake race periodization.",
+      "rationale": "Baseline case shows a coherent evergreen strength plan using free weights with appropriate rest/mobility spacing. Subjective readiness of 8/10 is respected without inventing wearable data. The walking sessions serve as easy active recovery rather than performance cardio. Strength specificity (bench/deadlift emphasis) is preserved through full-body push/pull templates. No pain flag means guardrails are not unnecessarily tightened.",
       "suggestedChanges": []
     },
     {
       "caseId": "persona_strength_no_wearable_work_fatigue",
       "scores": {
         "safety_recovery_fit": 9,
-        "goal_event_fit": 9,
+        "goal_event_fit": 8,
         "sequencing": 8,
         "periodization_taper": 9,
         "preference_capacity_fit": 9,
         "robustness": 9,
-        "overall": 8.5
+        "overall": 8.3
       },
       "confidence": 0.88,
       "flags": [],
-      "rationale": "The plan appropriately downshifts from full-load strength to 'Reduced Full-body Strength Maintenance' when fatigue (8/10) and soreness (7/10) are elevated. Rest days are inserted more frequently without abandoning the strength goal entirely. The system does not overreact by eliminating all training, nor underreact by pushing through high occupational load. It respects the no-wearable constraint and maintains strength specificity with free weights where available. This demonstrates proper handling of non-training load as decision-relevant information.",
+      "rationale": "The plan appropriately downshifts when subjective fatigue=8 and soreness=7 are reported alongside a physically demanding job. Rest is placed on day 1, reduced-volume maintenance follows, and walking provides low-impact aerobic support without inventing objective metrics. This demonstrates correct handling of non-training load as decision-relevant evidence.",
       "suggestedChanges": []
     },
     {
       "caseId": "persona_strength_no_wearable_symptom_flare",
       "scores": {
         "safety_recovery_fit": 9,
-        "goal_event_fit": 9,
-        "sequencing": 7,
+        "goal_event_fit": 8,
+        "sequencing": 8,
         "periodization_taper": 9,
         "preference_capacity_fit": 9,
         "robustness": 9,
-        "overall": 8.5
+        "overall": 8
       },
-      "confidence": 0.94,
+      "confidence": 0.9,
       "flags": [],
-      "rationale": "The plan correctly treats the pain flag as a hard constraint and enforces implied guardrails (avoid_overhead_pressing, avoid_heavy_spinal_loading) by switching to bodyweight-only full-body work. Multiple rest days are appropriate for an active symptom flare without over-medicalizing normal variation. The system does not invent objective recovery data or substitute swimming/cycling as silent substitutes. Strength specificity is preserved through bodyweight pressing/pulling patterns that respect the shoulder/back guardrails. This demonstrates proper escalation of caution when pain signals are present.",
-      "suggestedChanges": [
-        "Consider adding a brief mobility session on one of the rest days to maintain shoulder range of motion without provoking symptoms."
-      ]
+      "rationale": "Plan correctly tightens around active shoulder/back symptoms with painFlag=true and explicit guardrails (avoid_overhead_pressing, avoid_heavy_spinal_loading). Bodyweight full-body avoids heavy spinal loading; pull-up practice is shoulder-friendly compared to bench press. Rest days are appropriately increased without diagnosing an injury. No wearable hallucination. The plan respects the 'do not diagnose' rule while still tightening training appropriately.",
+      "suggestedChanges": []
     },
     {
       "caseId": "persona_health_fatloss_baseline",
@@ -200,89 +198,89 @@
       },
       "confidence": 0.92,
       "flags": [],
-      "rationale": "Baseline plan correctly aligns with health/fat-loss goals using free weights and walking as preferred modalities. Recovery signals are good (body_battery 72%, stable RHR/HRV), so a full-body strength session on day 1 is appropriate for habit-building. Sequencing alternates well between train/modify/recover modes without same-tissue stacking. No event means no fake tapering. The plan respects the 60-minute time constraint and available equipment (free weights only).",
+      "rationale": "Baseline case shows healthy Garmin signals (stable RHR at 58, HRV at 42, body battery 72%, good sleep). The plan appropriately balances strength, walking, running, mobility, and rest days for an evergreen health/fat-loss goal. No event means no taper needed. Equipment constraints are respected (free weights used when available, bodyweight alternatives provided). The sequencing avoids same-tissue stacking with adequate recovery spacing between sessions.",
       "suggestedChanges": []
     },
     {
       "caseId": "persona_health_fatloss_adverse_recovery",
       "scores": {
-        "safety_recovery_fit": 9,
+        "safety_recovery_fit": 10,
         "goal_event_fit": 9,
-        "sequencing": 7.5,
+        "sequencing": 8,
         "periodization_taper": 9,
         "preference_capacity_fit": 8,
-        "robustness": 9,
-        "overall": 8.5
-      },
-      "confidence": 0.88,
-      "flags": [],
-      "rationale": "Adverse recovery signals are clearly present: HRV delta -14, RHR delta +7, sleep score delta -24, body battery at 24%. The plan appropriately front-loads rest days before reintroducing load. This is correct evergreen behavior — no fake event peak is invented. Minor note: day-3 walk after only 2 rest days with such low body battery could be slightly more conservative, but for an evergreen health persona this is acceptable.",
-      "suggestedChanges": [
-        "Consider adding a third rest day before the first walk session given body battery at 24% and HRV delta of -14."
-      ]
-    },
-    {
-      "caseId": "persona_health_fatloss_low_time",
-      "scores": {
-        "safety_recovery_fit": 9,
-        "goal_event_fit": 9,
-        "sequencing": 8,
-        "periodization_taper": 9,
-        "preference_capacity_fit": 9,
-        "robustness": 8,
-        "overall": 8.5
-      },
-      "confidence": 0.9,
-      "flags": [],
-      "rationale": "Low-time constraint (30 min) is respected without hallucinating measurements or inventing data. Session durations are explicitly shortened to fit the window while maintaining habit-building frequency. Recovery signals remain healthy so no unnecessary rest escalation. The system correctly treats this as a capacity constraint rather than an adverse signal — distinct from case 2.",
-      "suggestedChanges": []
-    },
-    {
-      "caseId": "persona_former_elite_sparse_history_baseline",
-      "scores": {
-        "safety_recovery_fit": 9,
-        "goal_event_fit": 9,
-        "sequencing": 8,
-        "periodization_taper": 10,
-        "preference_capacity_fit": 9.8,
         "robustness": 9,
         "overall": 9
       },
       "confidence": 0.95,
       "flags": [],
-      "rationale": "Plan correctly treats sparse history as the dose authority rather than historical elite status. The good Garmin day (HRV 42, RHR stable at 58, sleep score 80) combined with low subjective fatigue/soreness supports a moderate training load. Strength is preserved alongside easy aerobic work in an evergreen mode. No fake periodization or invented peaking. Respects free-weights-only constraint.",
+      "rationale": "Adverse recovery signals are correctly detected and acted upon: rhr delta +7 (elevated resting HR), hrv delta -14 (significant drop from 42 to 28), sleep_score dropped to 52 (-24 delta). The plan appropriately front-loads rest days, then gradually reintroduces walking before strength. This is a textbook example of respecting recovery signals without over-medicalizing — the athlete still gets movement but at reduced load. No fake race periodization is present.",
+      "suggestedChanges": []
+    },
+    {
+      "caseId": "persona_health_fatloss_low_time",
+      "scores": {
+        "safety_recovery_fit": 8.5,
+        "goal_event_fit": 9,
+        "sequencing": 8,
+        "periodization_taper": 9,
+        "preference_capacity_fit": 9,
+        "robustness": 8,
+        "overall": 8
+      },
+      "confidence": 0.88,
+      "flags": [],
+      "rationale": "Plan respects the 30-minute constraint while maintaining modalities (bodyweight strength + walking + running). No invented data or measurements. Evergreen progression without fake peaking. Minor sequencing note: mobility on day 4 after a run is fine but could be placed more flexibly.",
+      "suggestedChanges": [
+        "Mobility session on day 4 could be swapped with the run for better recovery spacing, but this is a minor preference call."
+      ]
+    },
+    {
+      "caseId": "persona_former_elite_sparse_history_baseline",
+      "scores": {
+        "safety_recovery_fit": 9,
+        "goal_event_fit": 8,
+        "sequencing": 8,
+        "periodization_taper": 8,
+        "preference_capacity_fit": 9,
+        "robustness": 8,
+        "overall": 8
+      },
+      "confidence": 0.92,
+      "flags": [],
+      "rationale": "Plan correctly treats sparse history as the dose authority rather than historical elite status. Strength on day 1 is appropriate given free weights available and no guardrails. Light running/walk alternation respects intermittent current training identity. No fake periodization or invented peaking.",
       "suggestedChanges": []
     },
     {
       "caseId": "persona_former_elite_adverse_recovery",
       "scores": {
-        "safety_recovery_fit": 9.7,
-        "goal_event_fit": 9,
+        "safety_recovery_fit": 9.5,
+        "goal_event_fit": 8.5,
         "sequencing": 8,
-        "periodization_taper": 10,
-        "preference_capacity_fit": 9.5,
-        "robustness": 9.5,
-        "overall": 8.8
+        "periodization_taper": 8,
+        "preference_capacity_fit": 8,
+        "robustness": 9,
+        "overall": 9
       },
-      "confidence": 0.92,
+      "confidence": 0.95,
       "flags": [],
-      "rationale": "Plan correctly identifies adverse recovery (HRV delta -14, RHR +7, sleep score down 24, body battery 24) and responds with rest days on 31/1/5/7/8. Light work is deferred until day 2 onward. This avoids the common error of overriding Garmin signals with historical fitness assumptions. Strength remains available but not forced into a hard session while recovery lags.",
+      "rationale": "Plan correctly responds to adverse recovery signals (RHR delta +7, HRV delta -14, body battery 24%) with rest days and reduced load. Historical elite status does not override current physiological state. The response is appropriately conservative without being excessive.",
       "suggestedChanges": []
     },
     {
       "caseId": "persona_former_elite_low_motivation_only",
       "scores": {
-        "safety_recovery_fit": 9.3,
-        "goal_event_fit": 9,
+        "safety_recovery_fit": 8,
+        "goal_event_fit": 8,
         "sequencing": 8,
-        "periodization_taper": 10,
-        "preference_capacity_fit": 9.8,
-        "robustness": 9.4,
-        "overall": 9
+        "periodization_taper": 8,
+        "preference_capacity_fit": 9,
+        "robustness": 8.5,
+        "overall": 8.1
       },
-      "confidence": 0.93,
+      "confidence": 0.88,
       "flags": [],
-      "rationale": "Plan correctly distinguishes low motivation (subjective only) from physiological red flags. All objective metrics are healthy (HRV 42, RHR stable at 58, sleep score 80, body battery 72). The plan maintains full training load because the data supports it — low motivation alone is not a physiological contraindication. This demonstrates proper calibration: subjective mood ≠ physiological readiness.",
+      "rationale": "Correctly treats low motivation (2/10) as a non-physiological factor and does not overreact by reducing load unnecessarily. Objective recovery signals are good (rhr delta 0, hrv delta 0, sleep score normal), so proceeding with training is appropriate. The plan follows the same coherent structure as case 1 but this is justified because low motivation alone is explicitly stated to NOT be a physiological red flag.",
       "suggestedChanges": []
     },
     {
@@ -294,11 +292,11 @@
         "periodization_taper": 9,
         "preference_capacity_fit": 9,
         "robustness": 8,
-        "overall": 8.7
+        "overall": 8.5
       },
       "confidence": 0.92,
       "flags": [],
-      "rationale": "Baseline plan correctly balances aerobic and strength work over the week with no event target. Three strength sessions (days 1,4,8) and four endurance sessions (days 2,3,7,10,13) provide balanced progression. Equipment constraints respected (free weights only). No fake periodization since no event exists.",
+      "rationale": "Baseline plan correctly balances strength and endurance across the week with no event target. Recovery signals are good (RHR stable at 58, HRV normal at 42, sleep score 80). The plan respects the 60-minute weekday constraint, uses only free weights as equipment is available, and avoids inventing event-specific periodization. Strength sessions on Aug 31 and Sep 4/8 provide retention while easy runs/walks maintain aerobic base.",
       "suggestedChanges": []
     },
     {
@@ -306,19 +304,17 @@
       "scores": {
         "safety_recovery_fit": 9,
         "goal_event_fit": 8,
-        "sequencing": 7,
-        "periodization_taper": 9,
+        "sequencing": 8.5,
+        "periodization_taper": 8,
         "preference_capacity_fit": 8,
         "robustness": 9,
-        "overall": 8.3
+        "overall": 8.5
       },
-      "confidence": 0.88,
-      "flags": [
-        "HRV delta of -14 is a significant red flag requiring rest"
-      ],
-      "rationale": "Adverse recovery case correctly responds with three rest days and reduced load. The planner recognizes elevated RHR (+7), poor sleep score (52), and HRV drop (-14) as legitimate signals warranting recovery. Strength work is preserved but scaled down to bodyweight on day 6, avoiding complete deconditioning while respecting the adverse state.",
+      "confidence": 0.92,
+      "flags": [],
+      "rationale": "Adverse recovery case correctly identifies poor objective signals (rhr_delta=+7, hrv_delta=-14, body_battery_wake=24) and responds with multiple rest days in the first half of the week before gradually reintroducing load. The plan maintains both endurance and strength modalities over the full period to preserve the balanced-performance identity without inventing event-specific preparation. Safety is prioritized appropriately without over-medicalizing normal variation.",
       "suggestedChanges": [
-        "Consider adding a brief mobility session on day 3 to maintain tissue quality during rest-heavy week"
+        "The plan is appropriately conservative for adverse recovery; no changes needed."
       ]
     },
     {
@@ -332,16 +328,16 @@
         "robustness": 8,
         "overall": 8.7
       },
-      "confidence": 0.92,
+      "confidence": 0.91,
       "flags": [],
-      "rationale": "Strength preference today is correctly honored with a full strength session on day 1. The planner does not over-index to strength at the expense of aerobic work—the remaining week still includes four endurance sessions. This respects both the user's stated preference and the balanced-performance goal without turning the plan into a strength-primary program.",
+      "rationale": "The strength preference for Aug 31 is correctly honored with a full-body push/pull session as the first training day. Endurance work remains present throughout the week (runs on Sep 1/7/10, walk on Sep 2, tempo run on Sep 12) so the plan does not silently become strength-primary. This respects both the preference signal and the balanced-performance identity.",
       "suggestedChanges": []
     },
     {
       "caseId": "persona_stacked_constraints_baseline",
       "scores": {
         "safety_recovery_fit": 9,
-        "goal_event_fit": 9,
+        "goal_event_fit": 8.5,
         "sequencing": 8,
         "periodization_taper": 9,
         "preference_capacity_fit": 9,
@@ -350,47 +346,41 @@
       },
       "confidence": 0.92,
       "flags": [],
-      "rationale": "Baseline case demonstrates solid constraint handling: running restriction respected via bodyweight strength + walking only; no equipment hallucinated (all sessions use zero equipment); health priority maintained with balanced strength/aerobic load; rest days appropriately interspersed. The plan avoids inventing cardio when none is needed and respects the 60-minute weekday cap. Sequencing alternates train/recover without same-tissue stacking. No fake periodization present.",
-      "suggestedChanges": [
-        "Consider adding a brief mobility note on strength days to reinforce the 'no equipment' constraint explicitly in user-facing copy.",
-        "Walking sessions could occasionally be labeled as 'easy aerobic' rather than generic walking to better communicate health-focused intent."
-      ]
+      "rationale": "Baseline plan correctly respects all stacked constraints: running restricted, no equipment available, max 60 min per session. Bodyweight strength preserves specificity while walking provides aerobic base without heavy lower-body loading. Rest days are distributed appropriately for a health-focused persona. Sequencing avoids same-tissue stacking (strength/walk/mobility/rest rotation). No hallucinated measurements or invented event periodization.",
+      "suggestedChanges": []
     },
     {
       "caseId": "persona_stacked_constraints_adverse_recovery",
       "scores": {
-        "safety_recovery_fit": 10,
-        "goal_event_fit": 9,
+        "safety_recovery_fit": 9,
+        "goal_event_fit": 8,
         "sequencing": 8,
         "periodization_taper": 9,
         "preference_capacity_fit": 9,
         "robustness": 9,
-        "overall": 9
+        "overall": 8.5
       },
       "confidence": 0.94,
       "flags": [],
-      "rationale": "Adverse recovery case shows excellent sensitivity: HRV delta of -14, RHR up +7, body battery at 24%, fatigue at 7/10 all trigger appropriate rest-day escalation. The plan shifts from train-heavy to recover-heavy (3 rest days vs 1 in baseline) without inventing a race taper or performance peaking. Strength remains available but deferred until recovery signals improve. This is the correct response to elevated physiological stress under stacked constraints.",
-      "suggestedChanges": [
-        "The transition back to training on 2026-09-04 (strength) after only one rest day could be slightly more conservative given the HRV delta of -14; consider adding a second recover day before returning to strength.",
-        "Walking sessions in the recovery phase should explicitly note 'easy aerobic' to reinforce health priority over performance."
-      ]
+      "rationale": "Plan appropriately escalates recovery in response to adverse signals: RHR delta +7, HRV delta -14, body battery at 24%, sleep score drop of 24 points. Rest days are increased and training load is reduced accordingly. This demonstrates correct sensitivity to physiological red flags without over-medicalizing normal variation. The shift from strength/walk mix toward more rest is a sensible response to elevated fatigue and low recovery capacity.",
+      "suggestedChanges": []
     },
     {
       "caseId": "persona_stacked_constraints_low_time",
       "scores": {
-        "safety_recovery_fit": 8,
+        "safety_recovery_fit": 9,
         "goal_event_fit": 8,
         "sequencing": 7,
         "periodization_taper": 9,
-        "preference_capacity_fit": 8,
+        "preference_capacity_fit": 9,
         "robustness": 8,
         "overall": 8
       },
-      "confidence": 0.88,
+      "confidence": 0.91,
       "flags": [],
-      "rationale": "Low-time case correctly adjusts session durations (strength to 15-25 min, walks capped at 30 min) while maintaining the health-focused structure. The plan respects both equipment constraints and the reduced time window. Sequencing remains coherent with rest days preserved. No fake event periodization is introduced. This demonstrates robust handling of a constraint change without compromising safety or goal alignment.",
+      "rationale": "The plan correctly shortens the strength session to 15-25 min when timeAvailable=30 without hallucinating measurements or inventing data. It respects all equipment and running constraints while maintaining health-focused activity. The system does not reward verbosity or complexity.",
       "suggestedChanges": [
-        "Consider adding a brief note that if motivation dips below threshold on any day, the user may swap to rest without penalty—this supports adherence under time pressure."
+        "Consider adding a note explaining why the strength session was shortened to fit within the 30-minute window"
       ]
     },
     {
@@ -402,32 +392,31 @@
         "periodization_taper": 9,
         "preference_capacity_fit": 9,
         "robustness": 8,
-        "overall": 9
+        "overall": 8.5
       },
       "confidence": 0.92,
       "flags": [],
-      "rationale": "Baseline case shows healthy Garmin signals (rhr_delta=0, hrv_delta=0, body_battery=72) with good subjective readiness. The plan correctly treats walking as genuine aerobic volume across multiple sessions rather than filler. Strength is appropriately sized for a health-focused persona without cable machines. No running is hallucinated despite the 'no running' constraint being absent from constraints — it's simply not offered because the persona identity states running isn't viable. Sequencing alternates strength/walking/mobility/rest coherently.",
-      "suggestedChanges": []
+      "rationale": "Baseline case with normal recovery signals (rhr=58, hrv=42, body_battery=72). Plan appropriately mixes walking and strength within the 60-minute window. Strength specificity is preserved without running substitution. Evergreen progression is appropriate for a health-focused athlete with no event. Minor concern: day 13 walks at 30-60min range which could be tighter capped, but overall sequencing is coherent.",
+      "suggestedChanges": [
+        "Cap walking sessions to a consistent 30-45 minute range for better predictability.",
+        "Consider adding one additional rest day mid-week for sustainability."
+      ]
     },
     {
       "caseId": "persona_walking_adverse_recovery",
       "scores": {
-        "safety_recovery_fit": 9,
+        "safety_recovery_fit": 8,
         "goal_event_fit": 9,
         "sequencing": 7,
         "periodization_taper": 8,
-        "preference_capacity_fit": 9,
+        "preference_capacity_fit": 8,
         "robustness": 9,
-        "overall": 8
+        "overall": 8.3
       },
       "confidence": 0.88,
-      "flags": [
-        "Adverse recovery signals (rhr_delta=+7, hrv_delta=-14, body_battery=24) warrant the two consecutive rest days at week start — this is appropriate restraint, not overreaction."
-      ],
-      "rationale": "The plan appropriately responds to adverse Garmin signals with initial rest days before gradually reintroducing walking and strength. Walking remains the primary aerobic modality (not replaced by running). The gradual re-introduction of load after two rest days is sensible for a health-focused persona. Strength is reintroduced at reduced volume on Sep 4, which is appropriate given the elevated fatigue/soreness signals.",
-      "suggestedChanges": [
-        "Consider adding a third rest day if fatigue continues to decline slowly; the current plan reintroduces load on Sep 4 which is acceptable but could be more conservative depending on how quickly body_battery recovers."
-      ]
+      "flags": [],
+      "rationale": "Plan appropriately responds to adverse recovery signals (HRV delta -14, RHR +7, sleep score 52) by front-loading rest days while still providing walking as the aerobic modality on subsequent days. This avoids over-medicalizing normal variation while respecting the health-first goal. Walking is not replaced with running or fabricated metrics.",
+      "suggestedChanges": []
     },
     {
       "caseId": "persona_walking_low_time",
@@ -435,119 +424,117 @@
         "safety_recovery_fit": 9,
         "goal_event_fit": 9,
         "sequencing": 8,
-        "periodization_taper": 8,
+        "periodization_taper": 9,
         "preference_capacity_fit": 9,
-        "robustness": 8,
-        "overall": 9
+        "robustness": 9,
+        "overall": 8.7
       },
-      "confidence": 0.93,
+      "confidence": 0.9,
       "flags": [],
-      "rationale": "Plan respects the 30-minute time constraint without hallucinating objective measurements or inventing data. Walking sessions are capped at 30 min matching available capacity. Strength is bodyweight-only on day 1 to fit within constraints. Walking remains the primary aerobic modality throughout — never silently replaced by running. Evergreen habit-building goal is preserved despite tight windows.",
+      "rationale": "The plan respects the 30-minute time constraint while maintaining walking as genuine aerobic volume and including strength for retention. No running substitution occurs. Sessions are shortened appropriately without abandoning the persona's core identity. This demonstrates good robustness under sparse time data.",
       "suggestedChanges": []
     },
     {
       "caseId": "persona_established_history_baseline",
       "scores": {
         "safety_recovery_fit": 9,
-        "goal_event_fit": 9,
+        "goal_event_fit": 8,
         "sequencing": 8,
         "periodization_taper": 8,
         "preference_capacity_fit": 9,
-        "robustness": 9,
-        "overall": 8.7
+        "robustness": 8.5,
+        "overall": 9
       },
       "confidence": 0.92,
       "flags": [],
-      "rationale": "Good recovery signals (rhr_delta=0, hrv_delta=0, body_battery_wake=72) combined with high subjective readiness/motivation justify a purposeful tempo run on top of established aerobic volume. The plan is coherent: easy runs interspersed with one quality session and rest days. No pain flag, no event to taper for. Respects running preference without requiring unavailable equipment.",
+      "rationale": "The baseline case demonstrates correct handling of a genuinely established current training base (12 consecutive days of easy running). The plan appropriately unlocks one purposeful higher-intensity session (tempo run) while maintaining an evergreen progression without fake event periodization. Objective signals are stable and respected; the runner's preference for running is honored within 75-minute constraints. No physiological red flags exist, so load is not unnecessarily suppressed.",
       "suggestedChanges": []
     },
     {
       "caseId": "persona_established_history_adverse_recovery",
       "scores": {
-        "safety_recovery_fit": 7,
-        "goal_event_fit": 7,
-        "sequencing": 7,
-        "periodization_taper": 8,
-        "preference_capacity_fit": 8,
-        "robustness": 8,
-        "overall": 7
-      },
-      "confidence": 0.92,
-      "flags": [
-        "tempo_run_on_day_5_may_be_aggressive_given_hrv_delta_minus_14"
-      ],
-      "rationale": "The plan correctly reduces load with rest days and walks given adverse recovery signals (rhr_delta=+7, hrv_delta=-14, body_battery_wake=24). However, the tempo run on 09-05 may be slightly aggressive given the significant HRV drop and elevated RHR. The system appropriately prioritizes recovery over motivation (motivation=7 is high but recovery signals are poor), which is correct behavior for an established athlete whose authority comes from current state, not history.",
-      "suggestedChanges": [
-        "Consider removing the tempo run on 09-05 and replacing with a moderate easy run or walk given hrv_delta=-14 and fatigue=7"
-      ]
-    },
-    {
-      "caseId": "persona_established_history_low_motivation_only",
-      "scores": {
         "safety_recovery_fit": 9,
-        "goal_event_fit": 9,
+        "goal_event_fit": 8,
         "sequencing": 8,
         "periodization_taper": 8,
         "preference_capacity_fit": 9,
         "robustness": 9,
-        "overall": 8.7
+        "overall": 8.5
+      },
+      "confidence": 0.92,
+      "flags": [],
+      "rationale": "Despite an established training base, the athlete shows clear adverse recovery signals: rhr_delta=+7 (elevated resting HR), hrv_delta=-14 (significant drop), body_battery_wake=24 (very low). The plan correctly responds by front-loading rest days and reducing session duration. This is not overreaction — it respects that current physiological state overrides historical fitness authority. The tempo run on day 5 is appropriately scaled to a shorter, lower-intensity effort.",
+      "suggestedChanges": []
+    },
+    {
+      "caseId": "persona_established_history_low_motivation_only",
+      "scores": {
+        "safety_recovery_fit": 9.5,
+        "goal_event_fit": 9,
+        "sequencing": 9,
+        "periodization_taper": 8,
+        "preference_capacity_fit": 9,
+        "robustness": 9.5,
+        "overall": 9.3
       },
       "confidence": 0.95,
       "flags": [],
-      "rationale": "Low motivation (2) alone is not a physiological red flag when objective signals are green (rhr_delta=0, hrv_delta=0, body_battery_wake=72). The plan correctly retains the tempo run — low motivation should not remove an otherwise-earned higher-intensity opportunity. This demonstrates proper robustness: distinguishing psychological state from physiological capacity.",
+      "rationale": "The plan correctly maintains the baseline workload despite low motivation (2/10) because all objective signals are excellent (HRV delta 0, RHR delta 0, body battery 72%, sleep score 80). This is a critical test: the system must not conflate subjective mood with physiological readiness. The established current training base earns its earned intensity — low motivation alone is not a red flag when objective data says otherwise.",
       "suggestedChanges": []
     },
     {
       "caseId": "persona_cycling_hybrid_baseline",
       "scores": {
         "safety_recovery_fit": 9,
-        "goal_event_fit": 9,
+        "goal_event_fit": 10,
         "sequencing": 9,
         "periodization_taper": 10,
-        "preference_capacity_fit": 9,
+        "preference_capacity_fit": 10,
         "robustness": 9,
-        "overall": 8.5
+        "overall": 9.5
       },
-      "confidence": 0.92,
+      "confidence": 0.95,
       "flags": [],
-      "rationale": "Baseline case shows a well-structured evergreen plan for a cycling-primary hybrid athlete with good recovery signals. Cycling remains the primary modality throughout the week while strength is included as a retention goal. The sequencing alternates between cycling, strength, and rest appropriately without same-tissue stacking. No event means no tapering needed. Minor suggestion: could slightly increase cycling volume on non-strength days to better reflect 'cycling-primary' identity.",
-      "suggestedChanges": [
-        "Consider adding one additional Zone 2 cycling session mid-week to better reflect cycling-primary identity while maintaining strength retention."
-      ]
+      "rationale": "Baseline case shows normal recovery signals (readiness 8, fatigue 2, hrv stable at +0 delta). The plan correctly prioritizes cycling as the primary modality while preserving strength retention through a full-body session on day 1 and day 7. Sequencing is coherent with alternating easy endurance days and no same-tissue stacking. No event means no tapering needed. Preference for cycling over running is respected. Equipment constraints are honored (free weights available, treadmill present).",
+      "suggestedChanges": []
     },
     {
       "caseId": "persona_cycling_hybrid_adverse_recovery",
       "scores": {
-        "safety_recovery_fit": 9,
+        "safety_recovery_fit": 8,
         "goal_event_fit": 9,
         "sequencing": 8,
-        "periodization_taper": 10,
-        "preference_capacity_fit": 9,
-        "robustness": 9.5,
-        "overall": 8.5
+        "periodization_taper": 9,
+        "preference_capacity_fit": 8,
+        "robustness": 8,
+        "overall": 8
       },
       "confidence": 0.92,
-      "flags": [],
-      "rationale": "Adverse recovery case correctly responds to elevated fatigue (7), reduced HRV (-14 delta), and elevated RHR (+7). The plan appropriately reduces load with rest days and lower-intensity cycling. Cycling remains the primary modality at reduced volume while strength is maintained as a retention goal. This demonstrates proper prioritization of recovery signals over training willingness.",
-      "suggestedChanges": []
+      "flags": [
+        "overreaction"
+      ],
+      "rationale": "Adverse recovery case shows clear physiological red flags: rhr delta +7 (elevated), hrv delta -14 (significant drop), body_battery_wake at 24 (severely depleted). The plan correctly responds with two full rest days followed by a gradual return. However, the response is somewhat aggressive — cycling resumes on day 3 with Zone 2 work while soreness is still elevated (5/10) and fatigue remains high (7/10). A more conservative approach would delay structured cycling until at least day 4-5. The plan also drops strength entirely during recovery, which risks muscle loss for a hybrid athlete; a very light bodyweight session could have been included.",
+      "suggestedChanges": [
+        "Delay first structured cycling session to day 4 or 5 given elevated rhr_delta (+7) and low body_battery_wake (24).",
+        "Consider adding a very light bodyweight strength session during recovery to preserve muscle retention.",
+        "Reduce Zone 2 intensity on the return-to-training days to account for lingering soreness (5/10)."
+      ]
     },
     {
       "caseId": "persona_cycling_hybrid_local_tissue_conflict",
       "scores": {
-        "safety_recovery_fit": 9,
-        "goal_event_fit": 9,
-        "sequencing": 8,
+        "safety_recovery_fit": 10,
+        "goal_event_fit": 10,
+        "sequencing": 8.6,
         "periodization_taper": 10,
         "preference_capacity_fit": 9,
-        "robustness": 9,
-        "overall": 8.5
+        "robustness": 9.5,
+        "overall": 9
       },
-      "confidence": 0.88,
+      "confidence": 0.94,
       "flags": [],
-      "rationale": "This is the critical test case: favorable wearable signals (HRV up, sleep good) conflict with active pain flag and implied guardrails for lower body. The plan correctly prioritizes the subjective pain/guardrail over favorable wearables by avoiding heavy lower-body work and using bodyweight strength instead of free weights. Cycling remains primary but respects the mechanical constraint. This demonstrates proper hierarchy: pain/guardrails > wearable signals.",
-      "suggestedChanges": [
-        "Consider explicitly noting in the plan explanation that bodyweight strength is substituted to respect lower-body guardrails while maintaining strength retention."
-      ]
+      "rationale": "This case presents a favorable wearable signal (hrv delta +9, body battery 88) but an active local-tissue guardrail (painFlag: true with impliedGuardrails for high impact and heavy lower body). The plan correctly responds by substituting the full-body strength session with a bodyweight-only version that avoids free weights (respecting the guardrail), while maintaining cycling as the primary modality. This is excellent handling of the wearable vs. subjective conflict — the algorithm does not override active pain flags with favorable objective data. The use of bodyweight instead of free weights shows appropriate constraint respect.",
+      "suggestedChanges": []
     },
     {
       "caseId": "persona_cycling_hybrid_strength_preference",
@@ -557,13 +544,18 @@
         "sequencing": 8,
         "periodization_taper": 10,
         "preference_capacity_fit": 9,
-        "robustness": 9,
-        "overall": 8.5
+        "robustness": 8,
+        "overall": 8.7
       },
       "confidence": 0.91,
-      "flags": [],
-      "rationale": "Strength preference case correctly schedules a full-body strength session first when the user prefers it today. Cycling remains primary throughout the week (not silently converted to strength-primary programming). The plan respects the declared preference without over-indexing on strength at the expense of cycling performance goals. This demonstrates proper handling of modality preferences within the cycling-primary framework.",
-      "suggestedChanges": []
+      "flags": [
+        "underreaction"
+      ],
+      "rationale": "The athlete prefers strength today and the plan correctly schedules a full-body strength session first. However, the cycling volume for the week remains unchanged from baseline despite the preference shift. This is acceptable since strength is a retention goal, not a primary performance objective. The underreaction flag applies because the plan does not explicitly reduce cycling volume to accommodate the strength priority — it simply adds strength without adjusting the overall load. A more nuanced approach would slightly reduce cycling duration or intensity on non-strength days to keep total systemic load in check.",
+      "suggestedChanges": [
+        "Consider reducing cycling duration by 5–10 minutes on non-strength days to keep total systemic load in check",
+        "Add a brief note explaining that strength is being prioritized today without compromising the weekly cycling goal"
+      ]
     },
     {
       "caseId": "persona_cycling_hybrid_low_time",
@@ -571,92 +563,81 @@
         "safety_recovery_fit": 9,
         "goal_event_fit": 9,
         "sequencing": 8,
-        "periodization_taper": 10,
+        "periodization_taper": 9,
         "preference_capacity_fit": 9,
         "robustness": 9,
         "overall": 8.5
       },
-      "confidence": 0.87,
+      "confidence": 0.91,
       "flags": [],
-      "rationale": "Low time case correctly respects the 35-minute constraint by reducing session durations across all modalities. Cycling remains the primary modality while strength is maintained as a retention goal within the reduced window. The plan avoids hallucinating measurements and works with sparse data (no wearable override). This demonstrates robust handling of capacity constraints.",
+      "rationale": "The athlete has only 35 minutes available per session (down from the default 90). The plan correctly adapts by shortening all sessions to fit within this constraint while maintaining cycling as the primary modality and preserving strength retention through bodyweight full-body sessions. Cycling-specific work is prioritized over running, which aligns with the persona's goal hierarchy. The sequencing remains coherent — no same-tissue stacking issues introduced by compression. This demonstrates good handling of a hard feasibility constraint without sacrificing the core identity of the cycling-primary hybrid athlete.",
       "suggestedChanges": [
-        "Consider explicitly noting in the plan that bodyweight strength is used to fit within the 35-minute window when free weights would require more setup time."
+        "Consider adding a brief mobility or activation block (5-7 min) at the start of sessions to maintain injury prevention habits despite time compression.",
+        "Monitor whether the reduced cycling volume over two weeks begins to erode aerobic base — if so, consider one slightly longer session on a weekend day."
       ]
     },
     {
       "caseId": "persona_triathlon_established_olympic_baseline",
       "scores": {
         "safety_recovery_fit": 9,
-        "goal_event_fit": 9,
-        "sequencing": 8,
+        "goal_event_fit": 9.5,
+        "sequencing": 8.5,
         "periodization_taper": 9,
-        "preference_capacity_fit": 8,
-        "robustness": 8,
-        "overall": 8.7
+        "preference_capacity_fit": 9,
+        "robustness": 8.5,
+        "overall": 9
       },
       "confidence": 0.92,
       "flags": [],
-      "rationale": "Baseline case shows a well-structured plan for an established Olympic-distance triathlete ~7 weeks from event. All three disciplines are present with appropriate progression. Strength is included as retention requirement. No taper yet which is correct for this phase. Equipment constraints (no cable machine, free weights available) are respected.",
+      "rationale": "Baseline plan correctly distributes all three disciplines (swim, cycle, run) across the week with one strength session that does not dominate programming. Event is ~7 weeks away so no taper restraint needed. No fabricated elements; equipment gates respected. Sequencing avoids same-tissue stacking.",
       "suggestedChanges": []
     },
     {
       "caseId": "persona_triathlon_established_olympic_adverse_recovery",
       "scores": {
-        "safety_recovery_fit": 7,
+        "safety_recovery_fit": 9,
         "goal_event_fit": 8,
         "sequencing": 8,
-        "periodization_taper": 8,
-        "preference_capacity_fit": 8,
-        "robustness": 8,
-        "overall": 7
+        "periodization_taper": 8.5,
+        "preference_capacity_fit": 9,
+        "robustness": 9.5,
+        "overall": 8.5
       },
       "confidence": 0.92,
-      "flags": [
-        "hrv_delta=-14 indicates significant autonomic stress",
-        "rhr_delta=+7 shows elevated resting heart rate",
-        "sleep_score dropped from baseline (80→52)",
-        "cycling session on Sep 12 at 50-90min may be slightly aggressive given recovery signals"
-      ],
-      "rationale": "Adverse recovery signals are correctly recognized and responded to with initial rest days. However, the cycling session on Sep 12 (50-90 min) is borderline aggressive given hrv_delta=-14 and rhr_delta=+7. The long lead time to race (Oct 12) provides some buffer, but a more conservative approach would cap all sessions at ≤45min for the first 3 days after adverse signals.",
-      "suggestedChanges": [
-        "Consider capping the Sep 12 cycling session at ≤45min given hrv_delta=-14 and rhr_delta=+7",
-        "Add a rest day between Sep 6 (swim) and Sep 9 (run) to provide additional recovery buffer"
-      ]
+      "flags": [],
+      "rationale": "Adverse recovery signals (HRV -14, RHR +7, sleep score -24) are properly respected with multiple rest days and reduced load. All three disciplines remain present without fabrication. Strength training is appropriately scaled down. The plan avoids over-medicalizing while still tightening guardrails around the adverse physiological state.",
+      "suggestedChanges": []
     },
     {
       "caseId": "persona_triathlon_established_olympic_short_time",
       "scores": {
-        "safety_recovery_fit": 9,
-        "goal_event_fit": 8,
+        "safety_recovery_fit": 8,
+        "goal_event_fit": 9,
         "sequencing": 8,
         "periodization_taper": 9,
-        "preference_capacity_fit": 7,
+        "preference_capacity_fit": 9,
         "robustness": 8,
-        "overall": 8
+        "overall": 8.5
       },
       "confidence": 0.88,
-      "flags": [
-        "weekday_cap_may_be_exceeded_in_some_sessions"
-      ],
-      "rationale": "Short time case (45-minute weekday cap) shows good adaptation but some swim sessions have durationMax:60 which could exceed the cap if set to maximum. The running session on 08-31 at 20-35 min fits well within constraints. Overall structure is sound for an established athlete with limited time.",
-      "suggestedChanges": [
-        "Consider reducing swim session durationMax to 45 min on weekdays to strictly honor the time cap"
-      ]
+      "flags": [],
+      "rationale": "45-minute weekday cap is respected across all sessions. All three disciplines are maintained without substitution or fabrication. Strength training fits within the time budget. The plan avoids inventing bricks or swim-specific anchors not present in input. Equipment constraints (no indoor bike) are honored with outdoor rides.",
+      "suggestedChanges": []
     },
     {
       "caseId": "persona_triathlon_established_olympic_taper",
       "scores": {
-        "safety_recovery_fit": 9,
+        "safety_recovery_fit": 8.5,
         "goal_event_fit": 9,
-        "sequencing": 9,
-        "periodization_taper": 9,
-        "preference_capacity_fit": 8,
-        "robustness": 8.5,
-        "overall": 9
+        "sequencing": 8,
+        "periodization_taper": 9.5,
+        "preference_capacity_fit": 9,
+        "robustness": 8,
+        "overall": 8.8
       },
-      "confidence": 0.93,
+      "confidence": 0.91,
       "flags": [],
-      "rationale": "Final 14-day taper window (Aug 31–Sep 13) before Sep 14 Olympic triathlon. Plan demonstrates excellent taper restraint: no hard sessions in final week, reduced volume across all disciplines, rest days strategically placed, strength reduced to maintenance only. All three race disciplines remain represented without inventing brick workouts or open-water assumptions. The plan respects the established persona's mixed-discipline base while appropriately reducing load for peak performance.",
+      "rationale": "Event is Sep 14; plan ends Sep 13 (day before race). Final window shows taper restraint: rest days on Sep 5, 10, 12 and light/moderate sessions only. All three disciplines remain present without a full build load in the final week. No invented swim pace/CSS or open-water assumptions.",
       "suggestedChanges": []
     }
   ],
@@ -669,12 +650,12 @@
       "familySensitivitySpread": 0.5,
       "dimensionMadAverages": {
         "safety_recovery_fit": 0,
-        "goal_event_fit": 0,
+        "goal_event_fit": 0.33,
         "sequencing": 0,
         "periodization_taper": 0,
-        "preference_capacity_fit": 0,
+        "preference_capacity_fit": 0.33,
         "robustness": 0,
-        "overall": 0
+        "overall": 0.07
       },
       "cases": {
         "persona_strength_no_wearable_baseline": {
@@ -701,44 +682,44 @@
         "persona_strength_no_wearable_work_fatigue": {
           "scoreMedians": {
             "safety_recovery_fit": 9,
-            "goal_event_fit": 9,
+            "goal_event_fit": 8,
             "sequencing": 8,
             "periodization_taper": 9,
             "preference_capacity_fit": 9,
             "robustness": 9,
-            "overall": 8.5
+            "overall": 8.3
           },
           "dimensionMads": {
             "safety_recovery_fit": 0,
             "goal_event_fit": 0,
             "sequencing": 0,
             "periodization_taper": 0,
-            "preference_capacity_fit": 0,
+            "preference_capacity_fit": 0.5,
             "robustness": 0,
-            "overall": 0
+            "overall": 0.1999999999999993
           },
-          "maxSpread": 1.5
+          "maxSpread": 2
         },
         "persona_strength_no_wearable_symptom_flare": {
           "scoreMedians": {
             "safety_recovery_fit": 9,
-            "goal_event_fit": 9,
-            "sequencing": 7,
+            "goal_event_fit": 8,
+            "sequencing": 8,
             "periodization_taper": 9,
             "preference_capacity_fit": 9,
             "robustness": 9,
-            "overall": 8.5
+            "overall": 8
           },
           "dimensionMads": {
             "safety_recovery_fit": 0,
-            "goal_event_fit": 0,
+            "goal_event_fit": 1,
             "sequencing": 0,
             "periodization_taper": 0,
-            "preference_capacity_fit": 0,
+            "preference_capacity_fit": 0.5,
             "robustness": 0,
             "overall": 0
           },
-          "maxSpread": 1.5
+          "maxSpread": 2.5
         }
       }
     },
@@ -746,16 +727,16 @@
       "familyId": "persona_health_fat_loss",
       "samples": 5,
       "familySensitivityMedian": 8.5,
-      "familySensitivityMad": 0.5,
-      "familySensitivitySpread": 3,
+      "familySensitivityMad": 0,
+      "familySensitivitySpread": 0.5,
       "dimensionMadAverages": {
-        "safety_recovery_fit": 0,
+        "safety_recovery_fit": 0.17,
         "goal_event_fit": 0,
         "sequencing": 0.17,
         "periodization_taper": 0,
-        "preference_capacity_fit": 0.17,
+        "preference_capacity_fit": 0,
         "robustness": 0,
-        "overall": 0.08
+        "overall": 0.33
       },
       "cases": {
         "persona_health_fatloss_baseline": {
@@ -775,40 +756,19 @@
             "periodization_taper": 0,
             "preference_capacity_fit": 0,
             "robustness": 0,
-            "overall": 0
+            "overall": 0.5
           },
-          "maxSpread": 4
+          "maxSpread": 1
         },
         "persona_health_fatloss_adverse_recovery": {
           "scoreMedians": {
-            "safety_recovery_fit": 9,
-            "goal_event_fit": 9,
-            "sequencing": 7.5,
-            "periodization_taper": 9,
-            "preference_capacity_fit": 8,
-            "robustness": 9,
-            "overall": 8.5
-          },
-          "dimensionMads": {
-            "safety_recovery_fit": 0,
-            "goal_event_fit": 0,
-            "sequencing": 0.5,
-            "periodization_taper": 0,
-            "preference_capacity_fit": 0.5,
-            "robustness": 0,
-            "overall": 0.25
-          },
-          "maxSpread": 5
-        },
-        "persona_health_fatloss_low_time": {
-          "scoreMedians": {
-            "safety_recovery_fit": 9,
+            "safety_recovery_fit": 10,
             "goal_event_fit": 9,
             "sequencing": 8,
             "periodization_taper": 9,
-            "preference_capacity_fit": 9,
-            "robustness": 8,
-            "overall": 8.5
+            "preference_capacity_fit": 8,
+            "robustness": 9,
+            "overall": 9
           },
           "dimensionMads": {
             "safety_recovery_fit": 0,
@@ -819,88 +779,109 @@
             "robustness": 0,
             "overall": 0
           },
-          "maxSpread": 4
+          "maxSpread": 1
+        },
+        "persona_health_fatloss_low_time": {
+          "scoreMedians": {
+            "safety_recovery_fit": 8.5,
+            "goal_event_fit": 9,
+            "sequencing": 8,
+            "periodization_taper": 9,
+            "preference_capacity_fit": 9,
+            "robustness": 8,
+            "overall": 8
+          },
+          "dimensionMads": {
+            "safety_recovery_fit": 0.5,
+            "goal_event_fit": 0,
+            "sequencing": 0.5,
+            "periodization_taper": 0,
+            "preference_capacity_fit": 0,
+            "robustness": 0,
+            "overall": 0.5
+          },
+          "maxSpread": 2
         }
       }
     },
     {
       "familyId": "persona_former_elite_return",
       "samples": 5,
-      "familySensitivityMedian": 9.2,
-      "familySensitivityMad": 0.1999999999999993,
-      "familySensitivitySpread": 0.5,
+      "familySensitivityMedian": 8.5,
+      "familySensitivityMad": 0.5,
+      "familySensitivitySpread": 1.5,
       "dimensionMadAverages": {
-        "safety_recovery_fit": 0.2,
-        "goal_event_fit": 0,
+        "safety_recovery_fit": 0.5,
+        "goal_event_fit": 0.33,
         "sequencing": 0.33,
-        "periodization_taper": 0,
-        "preference_capacity_fit": 0.3,
-        "robustness": 0.3,
+        "periodization_taper": 0.5,
+        "preference_capacity_fit": 0.33,
+        "robustness": 0.17,
         "overall": 0.23
       },
       "cases": {
         "persona_former_elite_sparse_history_baseline": {
           "scoreMedians": {
             "safety_recovery_fit": 9,
-            "goal_event_fit": 9,
+            "goal_event_fit": 8,
             "sequencing": 8,
-            "periodization_taper": 10,
-            "preference_capacity_fit": 9.8,
-            "robustness": 9,
-            "overall": 9
+            "periodization_taper": 8,
+            "preference_capacity_fit": 9,
+            "robustness": 8,
+            "overall": 8
           },
           "dimensionMads": {
             "safety_recovery_fit": 0,
             "goal_event_fit": 0,
             "sequencing": 0,
-            "periodization_taper": 0,
-            "preference_capacity_fit": 0.1999999999999993,
+            "periodization_taper": 0.5,
+            "preference_capacity_fit": 0,
             "robustness": 0,
-            "overall": 0.3000000000000007
+            "overall": 0.20000000000000018
           },
-          "maxSpread": 1.5
+          "maxSpread": 2
         },
         "persona_former_elite_adverse_recovery": {
           "scoreMedians": {
-            "safety_recovery_fit": 9.7,
-            "goal_event_fit": 9,
+            "safety_recovery_fit": 9.5,
+            "goal_event_fit": 8.5,
             "sequencing": 8,
-            "periodization_taper": 10,
-            "preference_capacity_fit": 9.5,
-            "robustness": 9.5,
-            "overall": 8.8
-          },
-          "dimensionMads": {
-            "safety_recovery_fit": 0.3000000000000007,
-            "goal_event_fit": 0,
-            "sequencing": 1,
-            "periodization_taper": 0,
-            "preference_capacity_fit": 0.5,
-            "robustness": 0.5,
-            "overall": 0.3000000000000007
-          },
-          "maxSpread": 2.5
-        },
-        "persona_former_elite_low_motivation_only": {
-          "scoreMedians": {
-            "safety_recovery_fit": 9.3,
-            "goal_event_fit": 9,
-            "sequencing": 8,
-            "periodization_taper": 10,
-            "preference_capacity_fit": 9.8,
-            "robustness": 9.4,
+            "periodization_taper": 8,
+            "preference_capacity_fit": 8,
+            "robustness": 9,
             "overall": 9
           },
           "dimensionMads": {
-            "safety_recovery_fit": 0.3000000000000007,
-            "goal_event_fit": 0,
-            "sequencing": 0,
+            "safety_recovery_fit": 0.5,
+            "goal_event_fit": 0.5,
+            "sequencing": 1,
             "periodization_taper": 0,
-            "preference_capacity_fit": 0.1999999999999993,
-            "robustness": 0.40000000000000036,
+            "preference_capacity_fit": 1,
+            "robustness": 0,
             "overall": 0.09999999999999964
           },
-          "maxSpread": 1.5
+          "maxSpread": 2
+        },
+        "persona_former_elite_low_motivation_only": {
+          "scoreMedians": {
+            "safety_recovery_fit": 8,
+            "goal_event_fit": 8,
+            "sequencing": 8,
+            "periodization_taper": 8,
+            "preference_capacity_fit": 9,
+            "robustness": 8.5,
+            "overall": 8.1
+          },
+          "dimensionMads": {
+            "safety_recovery_fit": 1,
+            "goal_event_fit": 0.5,
+            "sequencing": 0,
+            "periodization_taper": 1,
+            "preference_capacity_fit": 0,
+            "robustness": 0.5,
+            "overall": 0.40000000000000036
+          },
+          "maxSpread": 4
         }
       }
     },
@@ -909,15 +890,15 @@
       "samples": 5,
       "familySensitivityMedian": 9,
       "familySensitivityMad": 0,
-      "familySensitivitySpread": 2,
+      "familySensitivitySpread": 0.3,
       "dimensionMadAverages": {
         "safety_recovery_fit": 0,
         "goal_event_fit": 0,
-        "sequencing": 0.33,
-        "periodization_taper": 0.33,
-        "preference_capacity_fit": 0.33,
+        "sequencing": 0.17,
+        "periodization_taper": 0,
+        "preference_capacity_fit": 0,
         "robustness": 0,
-        "overall": 0.23
+        "overall": 0.1
       },
       "cases": {
         "persona_balanced_performance_baseline": {
@@ -928,7 +909,7 @@
             "periodization_taper": 9,
             "preference_capacity_fit": 9,
             "robustness": 8,
-            "overall": 8.7
+            "overall": 8.5
           },
           "dimensionMads": {
             "safety_recovery_fit": 0,
@@ -937,30 +918,30 @@
             "periodization_taper": 0,
             "preference_capacity_fit": 0,
             "robustness": 0,
-            "overall": 0.1999999999999993
+            "overall": 0
           },
-          "maxSpread": 2.5
+          "maxSpread": 2
         },
         "persona_balanced_performance_adverse_recovery": {
           "scoreMedians": {
             "safety_recovery_fit": 9,
             "goal_event_fit": 8,
-            "sequencing": 7,
-            "periodization_taper": 9,
+            "sequencing": 8.5,
+            "periodization_taper": 8,
             "preference_capacity_fit": 8,
             "robustness": 9,
-            "overall": 8.3
+            "overall": 8.5
           },
           "dimensionMads": {
             "safety_recovery_fit": 0,
             "goal_event_fit": 0,
-            "sequencing": 1,
-            "periodization_taper": 1,
-            "preference_capacity_fit": 1,
+            "sequencing": 0.5,
+            "periodization_taper": 0,
+            "preference_capacity_fit": 0,
             "robustness": 0,
-            "overall": 0.3000000000000007
+            "overall": 0.09999999999999964
           },
-          "maxSpread": 3
+          "maxSpread": 2
         },
         "persona_balanced_performance_strength_preference": {
           "scoreMedians": {
@@ -990,21 +971,21 @@
       "samples": 5,
       "familySensitivityMedian": 8.5,
       "familySensitivityMad": 0,
-      "familySensitivitySpread": 0.5,
+      "familySensitivitySpread": 2.2,
       "dimensionMadAverages": {
         "safety_recovery_fit": 0,
-        "goal_event_fit": 0,
-        "sequencing": 0,
-        "periodization_taper": 0.67,
-        "preference_capacity_fit": 0,
-        "robustness": 0,
-        "overall": 0.17
+        "goal_event_fit": 0.83,
+        "sequencing": 0.33,
+        "periodization_taper": 1,
+        "preference_capacity_fit": 0.17,
+        "robustness": 0.5,
+        "overall": 0.4
       },
       "cases": {
         "persona_stacked_constraints_baseline": {
           "scoreMedians": {
             "safety_recovery_fit": 9,
-            "goal_event_fit": 9,
+            "goal_event_fit": 8.5,
             "sequencing": 8,
             "periodization_taper": 9,
             "preference_capacity_fit": 9,
@@ -1013,56 +994,56 @@
           },
           "dimensionMads": {
             "safety_recovery_fit": 0,
-            "goal_event_fit": 0,
+            "goal_event_fit": 0.5,
+            "sequencing": 0.5,
+            "periodization_taper": 1,
+            "preference_capacity_fit": 0,
+            "robustness": 1,
+            "overall": 0.1999999999999993
+          },
+          "maxSpread": 3
+        },
+        "persona_stacked_constraints_adverse_recovery": {
+          "scoreMedians": {
+            "safety_recovery_fit": 9,
+            "goal_event_fit": 8,
+            "sequencing": 8,
+            "periodization_taper": 9,
+            "preference_capacity_fit": 9,
+            "robustness": 9,
+            "overall": 8.5
+          },
+          "dimensionMads": {
+            "safety_recovery_fit": 0,
+            "goal_event_fit": 1,
             "sequencing": 0,
             "periodization_taper": 1,
             "preference_capacity_fit": 0,
             "robustness": 0,
             "overall": 0.5
           },
-          "maxSpread": 3
-        },
-        "persona_stacked_constraints_adverse_recovery": {
-          "scoreMedians": {
-            "safety_recovery_fit": 10,
-            "goal_event_fit": 9,
-            "sequencing": 8,
-            "periodization_taper": 9,
-            "preference_capacity_fit": 9,
-            "robustness": 9,
-            "overall": 9
-          },
-          "dimensionMads": {
-            "safety_recovery_fit": 0,
-            "goal_event_fit": 0,
-            "sequencing": 0,
-            "periodization_taper": 1,
-            "preference_capacity_fit": 0,
-            "robustness": 0,
-            "overall": 0
-          },
-          "maxSpread": 3
+          "maxSpread": 4
         },
         "persona_stacked_constraints_low_time": {
           "scoreMedians": {
-            "safety_recovery_fit": 8,
+            "safety_recovery_fit": 9,
             "goal_event_fit": 8,
             "sequencing": 7,
             "periodization_taper": 9,
-            "preference_capacity_fit": 8,
+            "preference_capacity_fit": 9,
             "robustness": 8,
             "overall": 8
           },
           "dimensionMads": {
             "safety_recovery_fit": 0,
-            "goal_event_fit": 0,
-            "sequencing": 0,
-            "periodization_taper": 0,
-            "preference_capacity_fit": 0,
-            "robustness": 0,
-            "overall": 0
+            "goal_event_fit": 1,
+            "sequencing": 0.5,
+            "periodization_taper": 1,
+            "preference_capacity_fit": 0.5,
+            "robustness": 0.5,
+            "overall": 0.5
           },
-          "maxSpread": 2
+          "maxSpread": 6
         }
       }
     },
@@ -1070,16 +1051,16 @@
       "familyId": "persona_walking_preferred",
       "samples": 5,
       "familySensitivityMedian": 8.5,
-      "familySensitivityMad": 0.5,
-      "familySensitivitySpread": 1,
+      "familySensitivityMad": 0.5999999999999996,
+      "familySensitivitySpread": 2.1,
       "dimensionMadAverages": {
-        "safety_recovery_fit": 0,
-        "goal_event_fit": 0,
+        "safety_recovery_fit": 0.53,
+        "goal_event_fit": 0.1,
         "sequencing": 0.33,
-        "periodization_taper": 0.33,
-        "preference_capacity_fit": 0,
-        "robustness": 0,
-        "overall": 0.33
+        "periodization_taper": 0,
+        "preference_capacity_fit": 0.47,
+        "robustness": 0.13,
+        "overall": 0.2
       },
       "cases": {
         "persona_walking_baseline": {
@@ -1090,130 +1071,109 @@
             "periodization_taper": 9,
             "preference_capacity_fit": 9,
             "robustness": 8,
-            "overall": 9
+            "overall": 8.5
           },
           "dimensionMads": {
             "safety_recovery_fit": 0,
             "goal_event_fit": 0,
             "sequencing": 0,
-            "periodization_taper": 1,
+            "periodization_taper": 0,
             "preference_capacity_fit": 0,
             "robustness": 0,
             "overall": 0
           },
-          "maxSpread": 2
+          "maxSpread": 1.1
         },
         "persona_walking_adverse_recovery": {
           "scoreMedians": {
-            "safety_recovery_fit": 9,
+            "safety_recovery_fit": 8,
             "goal_event_fit": 9,
             "sequencing": 7,
             "periodization_taper": 8,
-            "preference_capacity_fit": 9,
+            "preference_capacity_fit": 8,
             "robustness": 9,
-            "overall": 8
+            "overall": 8.3
           },
           "dimensionMads": {
-            "safety_recovery_fit": 0,
+            "safety_recovery_fit": 1.5999999999999996,
             "goal_event_fit": 0,
             "sequencing": 1,
             "periodization_taper": 0,
-            "preference_capacity_fit": 0,
-            "robustness": 0,
-            "overall": 1
+            "preference_capacity_fit": 1,
+            "robustness": 0.3000000000000007,
+            "overall": 0.3999999999999986
           },
-          "maxSpread": 3
+          "maxSpread": 6
         },
         "persona_walking_low_time": {
           "scoreMedians": {
             "safety_recovery_fit": 9,
             "goal_event_fit": 9,
             "sequencing": 8,
-            "periodization_taper": 8,
+            "periodization_taper": 9,
             "preference_capacity_fit": 9,
-            "robustness": 8,
-            "overall": 9
+            "robustness": 9,
+            "overall": 8.7
           },
           "dimensionMads": {
             "safety_recovery_fit": 0,
-            "goal_event_fit": 0,
+            "goal_event_fit": 0.3000000000000007,
             "sequencing": 0,
             "periodization_taper": 0,
-            "preference_capacity_fit": 0,
-            "robustness": 0,
-            "overall": 0
+            "preference_capacity_fit": 0.40000000000000036,
+            "robustness": 0.09999999999999964,
+            "overall": 0.20000000000000107
           },
-          "maxSpread": 2
+          "maxSpread": 3
         }
       }
     },
     {
       "familyId": "persona_established_history",
       "samples": 5,
-      "familySensitivityMedian": 8.7,
+      "familySensitivityMedian": 9.2,
       "familySensitivityMad": 0.3000000000000007,
-      "familySensitivitySpread": 1,
+      "familySensitivitySpread": 1.5,
       "dimensionMadAverages": {
-        "safety_recovery_fit": 0.67,
-        "goal_event_fit": 0.33,
-        "sequencing": 0,
+        "safety_recovery_fit": 0.17,
+        "goal_event_fit": 0.17,
+        "sequencing": 0.33,
         "periodization_taper": 0.33,
-        "preference_capacity_fit": 0.33,
-        "robustness": 0.33,
-        "overall": 0.53
+        "preference_capacity_fit": 0,
+        "robustness": 0.5,
+        "overall": 0.47
       },
       "cases": {
         "persona_established_history_baseline": {
           "scoreMedians": {
             "safety_recovery_fit": 9,
-            "goal_event_fit": 9,
+            "goal_event_fit": 8,
             "sequencing": 8,
             "periodization_taper": 8,
             "preference_capacity_fit": 9,
-            "robustness": 9,
-            "overall": 8.7
+            "robustness": 8.5,
+            "overall": 9
           },
           "dimensionMads": {
             "safety_recovery_fit": 0,
             "goal_event_fit": 0,
-            "sequencing": 0,
-            "periodization_taper": 0,
+            "sequencing": 0.5,
+            "periodization_taper": 0.5,
             "preference_capacity_fit": 0,
-            "robustness": 0,
-            "overall": 0.3000000000000007
+            "robustness": 0.5,
+            "overall": 0.1999999999999993
           },
-          "maxSpread": 1
+          "maxSpread": 3
         },
         "persona_established_history_adverse_recovery": {
           "scoreMedians": {
-            "safety_recovery_fit": 7,
-            "goal_event_fit": 7,
-            "sequencing": 7,
-            "periodization_taper": 8,
-            "preference_capacity_fit": 8,
-            "robustness": 8,
-            "overall": 7
-          },
-          "dimensionMads": {
-            "safety_recovery_fit": 2,
-            "goal_event_fit": 1,
-            "sequencing": 0,
-            "periodization_taper": 1,
-            "preference_capacity_fit": 1,
-            "robustness": 1,
-            "overall": 1
-          },
-          "maxSpread": 5
-        },
-        "persona_established_history_low_motivation_only": {
-          "scoreMedians": {
             "safety_recovery_fit": 9,
-            "goal_event_fit": 9,
+            "goal_event_fit": 8,
             "sequencing": 8,
             "periodization_taper": 8,
             "preference_capacity_fit": 9,
             "robustness": 9,
-            "overall": 8.7
+            "overall": 8.5
           },
           "dimensionMads": {
             "safety_recovery_fit": 0,
@@ -1221,91 +1181,112 @@
             "sequencing": 0,
             "periodization_taper": 0,
             "preference_capacity_fit": 0,
-            "robustness": 0,
-            "overall": 0.3000000000000007
+            "robustness": 0.5,
+            "overall": 0.5
           },
-          "maxSpread": 2
+          "maxSpread": 2.5
+        },
+        "persona_established_history_low_motivation_only": {
+          "scoreMedians": {
+            "safety_recovery_fit": 9.5,
+            "goal_event_fit": 9,
+            "sequencing": 9,
+            "periodization_taper": 8,
+            "preference_capacity_fit": 9,
+            "robustness": 9.5,
+            "overall": 9.3
+          },
+          "dimensionMads": {
+            "safety_recovery_fit": 0.5,
+            "goal_event_fit": 0.5,
+            "sequencing": 0.5,
+            "periodization_taper": 0.5,
+            "preference_capacity_fit": 0,
+            "robustness": 0.5,
+            "overall": 0.6999999999999993
+          },
+          "maxSpread": 3
         }
       }
     },
     {
       "familyId": "persona_cycling_primary_hybrid",
       "samples": 5,
-      "familySensitivityMedian": 8.7,
-      "familySensitivityMad": 0.3000000000000007,
-      "familySensitivitySpread": 0.75,
+      "familySensitivityMedian": 8.5,
+      "familySensitivityMad": 0.1999999999999993,
+      "familySensitivitySpread": 0.85,
       "dimensionMadAverages": {
-        "safety_recovery_fit": 0,
-        "goal_event_fit": 1,
-        "sequencing": 0.4,
-        "periodization_taper": 0,
-        "preference_capacity_fit": 0.2,
-        "robustness": 0.3,
-        "overall": 0.44
+        "safety_recovery_fit": 0.2,
+        "goal_event_fit": 0.04,
+        "sequencing": 0.28,
+        "periodization_taper": 0.3,
+        "preference_capacity_fit": 0.32,
+        "robustness": 0.26,
+        "overall": 0.2
       },
       "cases": {
         "persona_cycling_hybrid_baseline": {
           "scoreMedians": {
             "safety_recovery_fit": 9,
-            "goal_event_fit": 9,
+            "goal_event_fit": 10,
             "sequencing": 9,
             "periodization_taper": 10,
-            "preference_capacity_fit": 9,
+            "preference_capacity_fit": 10,
             "robustness": 9,
-            "overall": 8.5
+            "overall": 9.5
           },
           "dimensionMads": {
             "safety_recovery_fit": 0,
-            "goal_event_fit": 1,
-            "sequencing": 0.5,
+            "goal_event_fit": 0,
+            "sequencing": 0,
             "periodization_taper": 0,
             "preference_capacity_fit": 0,
-            "robustness": 0.5,
-            "overall": 1
-          },
-          "maxSpread": 4
-        },
-        "persona_cycling_hybrid_adverse_recovery": {
-          "scoreMedians": {
-            "safety_recovery_fit": 9,
-            "goal_event_fit": 9,
-            "sequencing": 8,
-            "periodization_taper": 10,
-            "preference_capacity_fit": 9,
-            "robustness": 9.5,
-            "overall": 8.5
-          },
-          "dimensionMads": {
-            "safety_recovery_fit": 0,
-            "goal_event_fit": 1,
-            "sequencing": 0,
-            "periodization_taper": 0,
-            "preference_capacity_fit": 0.5,
-            "robustness": 0.5,
-            "overall": 0.5
-          },
-          "maxSpread": 4
-        },
-        "persona_cycling_hybrid_local_tissue_conflict": {
-          "scoreMedians": {
-            "safety_recovery_fit": 9,
-            "goal_event_fit": 9,
-            "sequencing": 8,
-            "periodization_taper": 10,
-            "preference_capacity_fit": 9,
-            "robustness": 9,
-            "overall": 8.5
-          },
-          "dimensionMads": {
-            "safety_recovery_fit": 0,
-            "goal_event_fit": 1,
-            "sequencing": 0,
-            "periodization_taper": 0,
-            "preference_capacity_fit": 0.5,
             "robustness": 0,
             "overall": 0
           },
-          "maxSpread": 4
+          "maxSpread": 2
+        },
+        "persona_cycling_hybrid_adverse_recovery": {
+          "scoreMedians": {
+            "safety_recovery_fit": 8,
+            "goal_event_fit": 9,
+            "sequencing": 8,
+            "periodization_taper": 9,
+            "preference_capacity_fit": 8,
+            "robustness": 8,
+            "overall": 8
+          },
+          "dimensionMads": {
+            "safety_recovery_fit": 1,
+            "goal_event_fit": 0,
+            "sequencing": 1,
+            "periodization_taper": 1,
+            "preference_capacity_fit": 0.1999999999999993,
+            "robustness": 1,
+            "overall": 0.5
+          },
+          "maxSpread": 3.6
+        },
+        "persona_cycling_hybrid_local_tissue_conflict": {
+          "scoreMedians": {
+            "safety_recovery_fit": 10,
+            "goal_event_fit": 10,
+            "sequencing": 8.6,
+            "periodization_taper": 10,
+            "preference_capacity_fit": 9,
+            "robustness": 9.5,
+            "overall": 9
+          },
+          "dimensionMads": {
+            "safety_recovery_fit": 0,
+            "goal_event_fit": 0,
+            "sequencing": 0.40000000000000036,
+            "periodization_taper": 0,
+            "preference_capacity_fit": 0.3000000000000007,
+            "robustness": 0.09999999999999964,
+            "overall": 0.3000000000000007
+          },
+          "maxSpread": 2
         },
         "persona_cycling_hybrid_strength_preference": {
           "scoreMedians": {
@@ -1314,38 +1295,38 @@
             "sequencing": 8,
             "periodization_taper": 10,
             "preference_capacity_fit": 9,
-            "robustness": 9,
-            "overall": 8.5
+            "robustness": 8,
+            "overall": 8.7
           },
           "dimensionMads": {
             "safety_recovery_fit": 0,
-            "goal_event_fit": 1,
-            "sequencing": 1,
+            "goal_event_fit": 0.1999999999999993,
+            "sequencing": 0,
             "periodization_taper": 0,
-            "preference_capacity_fit": 0,
-            "robustness": 0.5,
-            "overall": 0.5
+            "preference_capacity_fit": 0.40000000000000036,
+            "robustness": 0,
+            "overall": 0.1999999999999993
           },
-          "maxSpread": 4
+          "maxSpread": 3
         },
         "persona_cycling_hybrid_low_time": {
           "scoreMedians": {
             "safety_recovery_fit": 9,
             "goal_event_fit": 9,
             "sequencing": 8,
-            "periodization_taper": 10,
+            "periodization_taper": 9,
             "preference_capacity_fit": 9,
             "robustness": 9,
             "overall": 8.5
           },
           "dimensionMads": {
             "safety_recovery_fit": 0,
-            "goal_event_fit": 1,
-            "sequencing": 0.5,
-            "periodization_taper": 0,
-            "preference_capacity_fit": 0,
-            "robustness": 0,
-            "overall": 0.1999999999999993
+            "goal_event_fit": 0,
+            "sequencing": 0,
+            "periodization_taper": 0.5,
+            "preference_capacity_fit": 0.6999999999999993,
+            "robustness": 0.1999999999999993,
+            "overall": 0
           },
           "maxSpread": 4
         }
@@ -1355,101 +1336,101 @@
       "familyId": "persona_triathlon_established_olympic",
       "samples": 5,
       "familySensitivityMedian": 8.5,
-      "familySensitivityMad": 0.3000000000000007,
-      "familySensitivitySpread": 4.25,
+      "familySensitivityMad": 0.75,
+      "familySensitivitySpread": 2,
       "dimensionMadAverages": {
-        "safety_recovery_fit": 0.5,
-        "goal_event_fit": 0.63,
-        "sequencing": 0.25,
-        "periodization_taper": 0.38,
-        "preference_capacity_fit": 0.75,
-        "robustness": 0.5,
-        "overall": 0.7
+        "safety_recovery_fit": 0.25,
+        "goal_event_fit": 0.38,
+        "sequencing": 0.38,
+        "periodization_taper": 0.25,
+        "preference_capacity_fit": 0.25,
+        "robustness": 0.38,
+        "overall": 0.3
       },
       "cases": {
         "persona_triathlon_established_olympic_baseline": {
           "scoreMedians": {
             "safety_recovery_fit": 9,
-            "goal_event_fit": 9,
-            "sequencing": 8,
+            "goal_event_fit": 9.5,
+            "sequencing": 8.5,
             "periodization_taper": 9,
-            "preference_capacity_fit": 8,
-            "robustness": 8,
-            "overall": 8.7
-          },
-          "dimensionMads": {
-            "safety_recovery_fit": 0,
-            "goal_event_fit": 0,
-            "sequencing": 0,
-            "periodization_taper": 0,
-            "preference_capacity_fit": 1,
-            "robustness": 0,
-            "overall": 0.3000000000000007
-          },
-          "maxSpread": 2
-        },
-        "persona_triathlon_established_olympic_adverse_recovery": {
-          "scoreMedians": {
-            "safety_recovery_fit": 7,
-            "goal_event_fit": 8,
-            "sequencing": 8,
-            "periodization_taper": 8,
-            "preference_capacity_fit": 8,
-            "robustness": 8,
-            "overall": 7
-          },
-          "dimensionMads": {
-            "safety_recovery_fit": 2,
-            "goal_event_fit": 1,
-            "sequencing": 1,
-            "periodization_taper": 0.5,
-            "preference_capacity_fit": 1,
-            "robustness": 1.5,
-            "overall": 1
-          },
-          "maxSpread": 5
-        },
-        "persona_triathlon_established_olympic_short_time": {
-          "scoreMedians": {
-            "safety_recovery_fit": 9,
-            "goal_event_fit": 8,
-            "sequencing": 8,
-            "periodization_taper": 9,
-            "preference_capacity_fit": 7,
-            "robustness": 8,
-            "overall": 8
-          },
-          "dimensionMads": {
-            "safety_recovery_fit": 0,
-            "goal_event_fit": 1,
-            "sequencing": 0,
-            "periodization_taper": 0,
-            "preference_capacity_fit": 1,
-            "robustness": 0,
-            "overall": 1
-          },
-          "maxSpread": 4
-        },
-        "persona_triathlon_established_olympic_taper": {
-          "scoreMedians": {
-            "safety_recovery_fit": 9,
-            "goal_event_fit": 9,
-            "sequencing": 9,
-            "periodization_taper": 9,
-            "preference_capacity_fit": 8,
+            "preference_capacity_fit": 9,
             "robustness": 8.5,
             "overall": 9
           },
           "dimensionMads": {
             "safety_recovery_fit": 0,
             "goal_event_fit": 0.5,
+            "sequencing": 0.5,
+            "periodization_taper": 0,
+            "preference_capacity_fit": 0.5,
+            "robustness": 0.5,
+            "overall": 0
+          },
+          "maxSpread": 3
+        },
+        "persona_triathlon_established_olympic_adverse_recovery": {
+          "scoreMedians": {
+            "safety_recovery_fit": 9,
+            "goal_event_fit": 8,
+            "sequencing": 8,
+            "periodization_taper": 8.5,
+            "preference_capacity_fit": 9,
+            "robustness": 9.5,
+            "overall": 8.5
+          },
+          "dimensionMads": {
+            "safety_recovery_fit": 0.5,
+            "goal_event_fit": 0,
             "sequencing": 0,
-            "periodization_taper": 1,
+            "periodization_taper": 0.5,
             "preference_capacity_fit": 0,
             "robustness": 0.5,
             "overall": 0.5
           },
-          "maxSpread": 6
+          "maxSpread": 3
+        },
+        "persona_triathlon_established_olympic_short_time": {
+          "scoreMedians": {
+            "safety_recovery_fit": 8,
+            "goal_event_fit": 9,
+            "sequencing": 8,
+            "periodization_taper": 9,
+            "preference_capacity_fit": 9,
+            "robustness": 8,
+            "overall": 8.5
+          },
+          "dimensionMads": {
+            "safety_recovery_fit": 0,
+            "goal_event_fit": 0,
+            "sequencing": 0.5,
+            "periodization_taper": 0,
+            "preference_capacity_fit": 0,
+            "robustness": 0,
+            "overall": 0.5
+          },
+          "maxSpread": 4
+        },
+        "persona_triathlon_established_olympic_taper": {
+          "scoreMedians": {
+            "safety_recovery_fit": 8.5,
+            "goal_event_fit": 9,
+            "sequencing": 8,
+            "periodization_taper": 9.5,
+            "preference_capacity_fit": 9,
+            "robustness": 8,
+            "overall": 8.8
+          },
+          "dimensionMads": {
+            "safety_recovery_fit": 0.5,
+            "goal_event_fit": 1,
+            "sequencing": 0.5,
+            "periodization_taper": 0.5,
+            "preference_capacity_fit": 0.5,
+            "robustness": 0.5,
+            "overall": 0.1999999999999993
+          },
+          "maxSpread": 5
         }
       }
     }

--- a/docs/analysis/plan-judge-baseline.json
+++ b/docs/analysis/plan-judge-baseline.json
@@ -2,17 +2,17 @@
   "schema": "adaptive-training-recommender/ai-plan-judge-summary@3",
   "source": "artifacts/ai-plan-judge/latest/judge-scores.jsonl",
   "provenance": {
-    "corpusCommit": "d7615c46d5f38cde859e5de806549a311dce43e6",
+    "corpusCommit": "d33eb5bbc112f785db5d2ac46897a2a25ec85da8",
     "corpusSchema": "adaptive-training-recommender/ai-plan-judge-corpus@3",
-    "corpusSha256": "d3a110bdd9fb992ec1a9197f9b2487e649481783aa919eeab4d8c5ba646b3042",
-    "familiesSha256": "469cba303ed1bae2914c699a06f6f97d5f156a1cfbe372925c99e4712ee2671b",
+    "corpusSha256": "4ee4b4cd3e64b6a7a3188bcfc93aedec0be456e3fe59ad115750aa1129f52105",
+    "familiesSha256": "2c93a8c1ab782dbbeb196c9f987724aa20d3ea926436e5939af5872db2b358cc",
     "caseSetSha256": "26415bb41b7612f26ee5f8c783e36ff7e049968b34ce4e391cb90797a11d6e0e",
     "promptSha256": "21acc629e5710e513359c080de4ec5cf8fb56557f6e53af4b9bedcadd1b70f3c",
     "responseSchemaSha256": "ab96127b7dee8fb1bc664897fcfe7d0ff563ba7d7cabf4dd433e1d0b7ed2d21a",
-    "judgeScoresSha256": "c468ecdd62cfa2c761425eca5a5f4f7e0ef18fcd817f4073389d5cc3ac17a2d8",
+    "judgeScoresSha256": "871f03e2d1a95f7be84f0cd442b23d921e78cdd3121031dd61a291cd15f02cbe",
     "judgeModel": "hf.co/empero-ai/Qwen3.8-9B-Distill-GGUF:Q4_K_M",
     "judgeProvider": "local",
-    "analyzedAt": "2026-08-26T06:08:59.629Z",
+    "analyzedAt": "2026-09-08T21:54:31.542Z",
     "judgeSettings": {
       "provider": "local",
       "model": "hf.co/empero-ai/Qwen3.8-9B-Distill-GGUF:Q4_K_M",
@@ -47,427 +47,310 @@
   "familyCount": 13,
   "caseCount": 68,
   "scoreAverages": {
-    "safety_recovery_fit": 8.561764705882354,
-    "goal_event_fit": 8.313235294117646,
-    "sequencing": 7.998529411764707,
-    "periodization_taper": 7.738235294117648,
-    "preference_capacity_fit": 8.919117647058824,
-    "robustness": 7.9647058823529395,
-    "overall": 7.979411764705882
+    "safety_recovery_fit": 8.58970588235294,
+    "goal_event_fit": 8.4125,
+    "sequencing": 8.036764705882353,
+    "periodization_taper": 7.676470588235294,
+    "preference_capacity_fit": 9.176470588235293,
+    "robustness": 8.00294117647059,
+    "overall": 8
   },
-  "meanSensitivityQuality": 8.592307692307692,
+  "meanSensitivityQuality": 8.36923076923077,
   "familySensitivity": [
     {
-      "familyId": "delivered_dose_variance",
+      "familyId": "conflicting_tissue_vs_wearable",
       "sensitivityQuality": 7.5,
-      "rationale": "The planner demonstrates appropriate sensitivity to curtailed doses (adding recovery without overcompensating) and correct inaction for exact doses. However, it shows an overreaction pattern when faced with surged intensity — treating the increased load as a safety risk rather than recognizing that higher-intensity work is precisely what criterium preparation demands. The skipped case shows underreaction where additional threshold stimulus would have been beneficial.",
+      "rationale": "The algorithm correctly ignores irrelevant noise (e.g., neutral case) and appropriately escalates recovery when systemic wearables are catastrophically bad. However, it overreacts to local tissue soreness in the presence of excellent HRV, and underreacts to high life stress — both indicating that the weighting between local vs. systemic signals needs recalibration.",
       "overreactionCases": [
-        "judge_dose_surged"
+        "judge_conflict_sore_legs_great_hrv"
       ],
       "underreactionCases": [],
       "algorithmAdjustmentHypotheses": [
-        "The planner correctly treats exact delivered dose as requiring no adjustment — this is the expected baseline behavior.",
-        "For curtailed doses (partial completion), the planner appropriately adds a compensatory recovery day while preserving the rest structure, showing good sensitivity to sub-optimal stimulus delivery.",
-        "For surged doses, the planner overreacts by inserting additional hard sessions rather than accepting that the increased intensity already provides sufficient quality stimulus — this indicates an overly conservative fatigue model.",
-        "For skipped workouts, the planner underreacts by only adding one compensatory hard session instead of replacing it with a threshold-focused alternative, suggesting the algorithm may be treating 'skipped' as less severe than it should be for criterium preparation."
+        "The algorithm should weight local tissue signals (soreness, painFlag) more heavily than systemic wearable metrics when they conflict, especially for lower-body events like criteriums.",
+        "Life stress and motivation are not soft preferences but hard safety constraints that must reduce training load; the current model treats them as optional modifiers rather than gating factors.",
+        "The algorithm should enforce a minimum taper window before A-priority events regardless of how 'fresh' the athlete feels, to avoid performance degradation from accumulated cognitive or systemic fatigue."
+      ]
+    },
+    {
+      "familyId": "objective_recovery",
+      "sensitivityQuality": 7.5,
+      "rationale": "The algorithm demonstrates appropriate sensitivity to mild isolated variation (no overreaction to ~1 SD HRV/RHR shifts) but shows underreaction to moderate-to-severe signals. No cases exhibit overreaction — all underreactions are proportional to signal severity and could be improved with more aggressive load reduction.",
+      "overreactionCases": [],
+      "underreactionCases": [
+        "judge_obj_hrv_2sd",
+        "judge_obj_poor_sleep",
+        "judge_obj_low_battery"
+      ],
+      "algorithmAdjustmentHypotheses": [
+        "The algorithm correctly avoids overreacting to mild isolated variation (~1 SD HRV/RHR shifts) but underreacts to moderate-to-severe signals (2 SD HRV, 2 SD RHR, poor sleep, low body battery).",
+        "A more robust response would scale load reduction proportionally to the severity of the stress signal: ~1 SD → no change; ~2 SD → replace one hard session with Zone 2 and add a rest day; severe combined signals → multiple reductions including event-week adjustments.",
+        "The algorithm should weight body_battery_wake as a primary safety signal alongside HRV/RHR, since it captures systemic fatigue not reflected in traditional metrics."
+      ]
+    },
+    {
+      "familyId": "concurrent_strength_endurance",
+      "sensitivityQuality": 8,
+      "rationale": "The algorithm demonstrates appropriate sensitivity to upper-body perturbations (no interference with cycling) and power maintenance stimuli, but overreacts to heavy lower-body perturbations by unnecessarily reducing overall training volume. The heavy lower-body stimulus does not critically impair the neuromuscular systems most relevant to criterium performance (repeated surges, sprint power), so a more conservative response would be preferable.",
+      "overreactionCases": [
+        "judge_concurrent_heavy_lower"
+      ],
+      "underreactionCases": [],
+      "algorithmAdjustmentHypotheses": [
+        "The algorithm may be overreacting to heavy lower-body perturbations by reducing overall training volume beyond what is necessary for event preparation. A more nuanced approach would allow light active recovery or mobility on the day following a heavy lower-body session, rather than defaulting to full rest and reduced cycling.",
+        "For upper-body perturbations, the algorithm correctly recognizes that no interference exists with cycling-specific performance, suggesting the current sensitivity threshold is appropriately calibrated for this modality."
       ]
     },
     {
       "familyId": "planning_modes_overlays",
       "sensitivityQuality": 8,
-      "rationale": "The event-directed plan is the strongest overall, balancing safety, sequencing, and goal alignment. The evergreen mode overreacts by ignoring the event entirely. The conservative mode under-reacts to the event's intensity demands. The travel overlay appropriately adapts without compromising safety.",
+      "rationale": "The judge correctly identified that the conservative plan's Day-7 VO2 interval is a periodization error (not a safety issue), while the travel mode's lack of cycling stimulus is a goal-fit issue given the event context. The evergreen and event-directed plans show appropriate sensitivity to their respective axes without overreacting to mild readiness fluctuations.",
       "overreactionCases": [],
       "underreactionCases": [],
       "algorithmAdjustmentHypotheses": [
-        "The evergreen mode should be flagged as low event alignment when an A-priority event exists; it should not default to pure maintenance without any event-specific stimulus.",
-        "The conservative preference mode risks under-preparing for high-demand events by over-applying rest and avoiding hard sessions. It needs a minimum intensity floor tied to the event demand profile.",
-        "The travel overlay correctly handles zero-equipment constraints but may need an optional 'surges' template that can be executed with bodyweight or minimal equipment."
+        "The conservative_overlay mode should not allow high systemic-cost sessions within 3–4 days of an A-priority event; a hard safety rule should cap cumulative systemic cost in the final 5 days at ≤2.0.",
+        "Travel_constraints mode currently drops cycling entirely when equipment is unavailable — this may be too aggressive if outdoor bike access exists; consider allowing short outdoor rides as fallback.",
+        "Evergreen mode's frequent rest days (6/14) are appropriate for maintenance but could be tightened to 3–4 days per week for users seeking performance gains."
       ]
     },
     {
-      "familyId": "concurrent_strength_endurance",
-      "sensitivityQuality": 8.5,
-      "rationale": "The algorithm demonstrates appropriate sensitivity by inserting recovery after heavy lower-body work (decision-relevant for criterium) and correctly ignoring upper-body perturbations. However, it slightly overreacts to power maintenance strength by substituting active recovery/mobility instead of retaining the original reduced full-body session, which is unnecessary given its low systemic cost and non-specificity to cycling performance.",
-      "overreactionCases": [],
-      "underreactionCases": [],
+      "familyId": "delivered_dose_variance",
+      "sensitivityQuality": 8.2,
+      "rationale": "The family demonstrates appropriate sensitivity calibration: mild delivery variance (curtailed) leaves the plan unchanged, while complete absence of training history (skipped) triggers a valid adaptive response. The surged case is an overreaction because it treats a single session's intensity as requiring global de-escalation, ignoring that the event demand profile (repeatedSurges=0.9) does not require >105% intensity and that the exact-dose plan already provides sufficient repeated surge exposure.",
+      "overreactionCases": [
+        "judge_dose_surged"
+      ],
+      "underreactionCases": [
+        "judge_dose_skipped"
+      ],
       "algorithmAdjustmentHypotheses": [
-        "The algorithm correctly distinguishes between concurrent strength perturbations that are decision-relevant (heavy lower-body) versus those that are not (heavy upper-body, power maintenance).",
-        "Overreaction is detected when the plan inserts extra rest or active recovery for non-critical perturbations (power maintenance), suggesting the interference model may be slightly over-conservative for low-specificity strength work.",
-        "Mild overreaction in the heavy-lower case is acceptable given the high specificity of leg power to criterium performance, but could be calibrated by allowing very light aerobic activity on recovery days."
+        "The judge correctly distinguishes between mild delivery variance (curtailed case) and meaningful absence of training history (skipped case).",
+        "Overreaction occurs when a single high-intensity session's completion ratio is used to de-escalate the entire plan, ignoring that the event demand profile does not require >105% surge intensity.",
+        "Underreaction occurs when minor delivery variance (~33% reduction in one session) triggers no structural change to the plan, which is appropriate given the robustness of the overall stimulus distribution."
       ]
     },
     {
-      "familyId": "conflicting_tissue_vs_wearable",
-      "sensitivityQuality": 8.5,
-      "rationale": "The algorithm demonstrates good sensitivity by correctly identifying and responding to severe systemic fatigue (terrible HRV) with appropriate load reduction, while maintaining plan stability for neutral cases. The 'sore legs' case shows a slight overreaction—local tissue signals are given more weight than necessary given the excellent systemic recovery—but this is a minor calibration issue rather than a fundamental flaw.",
+      "familyId": "preferences_capacity",
+      "sensitivityQuality": 8.2,
+      "rationale": "The algorithm demonstrates appropriate sensitivity to preference axes. The conservative bias case is the only clear over-reaction, adding unnecessary rest and removing event-specific stimulus for a criterium that demands neuromuscular freshness. The active recovery and mixed recovery cases show good sensitivity by substituting low-cost modalities without compromising taper quality. The 45-minute case shows mild under-reaction (acceptable given constraints), while the neutral baseline serves as a solid reference point.",
+      "overreactionCases": [
+        "judge_pref_conservative"
+      ],
+      "underreactionCases": [
+        "judge_pref_45min"
+      ],
+      "algorithmAdjustmentHypotheses": [
+        "The algorithm correctly respects hard constraints (equipment availability, max time) across all cases.",
+        "Conservative bias triggers additional rest days but may over-react by removing necessary event-specific stimulus for high-surge events like criteriums.",
+        "Active recovery substitutions are well-executed and maintain tissue quality without adding systemic load.",
+        "Time capacity constraints (45/90 min) primarily affect session duration rather than structural plan changes, with the 45-min case showing slight under-reaction to taper needs due to compressed hard sessions."
+      ]
+    },
+    {
+      "familyId": "subjective_recovery",
+      "sensitivityQuality": 8.2,
+      "rationale": "The algorithm demonstrates good sensitivity to individual physiological signals (fatigue, soreness, stress) by appropriately reducing load. It correctly avoids overreacting to low motivation or mild readiness fluctuations. However, the combined bad case reveals a potential overreaction pattern — when multiple moderate signals combine, the algorithm may default to excessive rest rather than targeted intensity reduction. This suggests the combination logic may be too conservative, treating multiple moderate signals as equivalent to severe single signals.",
       "overreactionCases": [],
       "underreactionCases": [],
       "algorithmAdjustmentHypotheses": [
-        "The algorithm correctly prioritizes systemic wearable signals (HRV, RHR, sleep) over local tissue sensations in cases of severe conflict (terrible HRV with fresh legs), but may still be slightly conservative by not fully eliminating high-load sessions when systemic recovery is poor.",
-        "Local tissue soreness should carry more weight than currently implemented—soreness=8 warrants at least one additional rest or very easy day beyond what was provided in the 'sore_legs_great_hrv' case.",
-        "The algorithm appropriately does not overreact to mild isolated variations (e.g., neutral baseline) and maintains plan stability, which is correct behavior for robust planning.",
-        "Psychological stress signals are correctly treated as a soft constraint—plans can still include hard sessions when physical recovery is adequate, but volume is reduced."
+        "The algorithm correctly distinguishes between physiological safety signals (fatigue, soreness, stress) and non-physiological factors (motivation).",
+        "Mild isolated variations in subjective readiness (~1 SD movement) do not warrant plan changes when objective metrics support current load.",
+        "Combined adverse inputs can trigger overreaction — the algorithm may be too conservative when multiple moderate signals combine, leading to excessive rest and volume reduction.",
+        "The algorithm appropriately respects hard constraints (equipment availability, max time) across all cases."
       ]
     },
     {
       "familyId": "injury_constraints",
       "sensitivityQuality": 8.5,
-      "rationale": "The algorithm demonstrates good sensitivity by not overreacting to non-conflicting constraints (running restriction for a cycling criterium) and correctly reverting to baseline when constraints expire. The only under-reaction is in the lower-body-restricted case, where the event-week taper was insufficient — this is a periodization issue rather than a constraint-handling failure.",
+      "rationale": "The algorithm correctly identifies that mild or non-applicable constraints (running restriction when no running is scheduled, expired review) do not warrant plan changes. The healthy baseline and expired cases are appropriately unchanged. The only problematic case is judge_injury_lower_body_restricted, where the constraint was active but violated — this indicates an underreaction to a hard safety constraint rather than overreaction.",
       "overreactionCases": [],
-      "underreactionCases": [],
+      "underreactionCases": [
+        "judge_injury_lower_body_restricted"
+      ],
       "algorithmAdjustmentHypotheses": [
-        "The algorithm correctly distinguishes between active and expired injury constraints.",
-        "Non-conflicting constraints (e.g., restricted running for a cycling event) do not require plan changes — the system appropriately leaves the plan unchanged.",
-        "Under-tapering in the lower-body-restricted case reveals a need to strengthen event-week taper logic when guardrails are active, even if they don't directly conflict with the preferred modality."
+        "The lower-body-restricted case reveals a critical flaw: the planner treats 'avoid_heavy_lower_body' as a soft preference rather than a hard constraint. The guardrail flag is set but not enforced at the session level — sessions are still generated with moderate-to-high lowerBody cost values (0.3–0.8). This suggests the constraint enforcement logic needs to be strengthened: when avoid_heavy_lower_body is active, the planner should either exclude cycling entirely or only allow very low-resistance Zone 1 work that does not meaningfully load the lower body.",
+        "The running-restricted case correctly produces an unchanged plan because no running was ever scheduled — this confirms the constraint system properly handles 'no-op' scenarios where the restricted modality is never selected. This is appropriate behavior and should be preserved.",
+        "The expired-review case correctly reverts to baseline, confirming that inactive constraints do not leak into planning decisions. This is correct and expected."
       ]
     },
     {
-      "familyId": "interactions",
+      "familyId": "temporal_acute_vs_persistent",
       "sensitivityQuality": 8.5,
-      "rationale": "The algorithm demonstrates appropriate sensitivity to the interaction between objective metrics, subjective state, and recent training load. It correctly identifies when a plan should be conservative (bad objective + hard yesterday) versus when it can proceed normally (fresh athlete). The only potential overreaction is in judge_int_race7_badobj where the algorithm may be too risk-averse given that the poor objective signals are isolated to one day without a preceding hard session. No clear underreactions were identified — all plans respect safety constraints and scheduled events.",
+      "rationale": "The algorithm demonstrates good sensitivity by leaving the neutral baseline unchanged and responding appropriately to both acute and persistent adverse trajectories. The only issue is in the persistent adverse case where hard sessions were scheduled too early — this appears to be a thresholding issue rather than an overreaction. The algorithm correctly avoids overreacting to mild variation (neutral case) while still catching significant perturbations.",
       "overreactionCases": [],
       "underreactionCases": [],
       "algorithmAdjustmentHypotheses": [
-        "The algorithm correctly prioritizes objective physiological signals (HRV, RHR) over subjective feelings when they conflict — demonstrated in judge_int_badsubj_goodobj and judge_int_goodsubj_badobj cases.",
-        "Scheduled event load is consistently reserved as a fixed activity across all cases, preventing double-scheduling errors.",
-        "The algorithm appropriately escalates caution when both poor objective metrics AND hard recent training are present (judge_int_badobj_hard_yday).",
-        "Overreaction hypothesis: judge_int_race7_badobj may be overly conservative — the algorithm might be over-weighting single-day HRV/RHR signals without considering longer-term trends or the athlete's historical resilience.",
-        "Underreaction hypothesis: judge_int_fresh_hard_yday could benefit from slightly more aggressive taper given the hard yesterday, though the current plan is defensible.",
-        "The algorithm shows good sensitivity to equipment constraints and safety guardrails across all cases."
-      ]
-    },
-    {
-      "familyId": "objective_recovery",
-      "sensitivityQuality": 8.5,
-      "rationale": "The algorithm demonstrates good sensitivity by appropriately scaling responses to the severity of adverse metrics. Mild changes (1 SD HRV/RHR) receive minimal response, while severe combined deficits trigger comprehensive load reduction. The neutral case is correctly identified as requiring no change. The combined_bad case shows appropriate aggressive response to multiple simultaneous stressors. No cases show clear overreaction — all modifications are proportional to the severity of the input signals.",
-      "overreactionCases": [],
-      "underreactionCases": [],
-      "algorithmAdjustmentHypotheses": [
-        "The algorithm correctly distinguishes between mild (1 SD) and moderate/severe (>2 SD or combined) adverse signals, applying appropriate response intensity.",
-        "Sleep deficits are treated as significant stressors warranting load reduction, though the response could be more aggressive given the severity of sleep deprivation (~1 hour short).",
-        "The algorithm appropriately preserves race-specific surge work in all cases while reducing overall systemic load when recovery metrics degrade.",
-        "Combined adverse metrics trigger a more comprehensive plan modification than isolated single-metric changes, demonstrating proper signal integration.",
-        "The algorithm correctly avoids overreacting to mild HRV/RHR fluctuations (1 SD) that do not constitute hard safety signals."
-      ]
-    },
-    {
-      "familyId": "preferences_capacity",
-      "sensitivityQuality": 8.7,
-      "rationale": "The algorithm demonstrates good sensitivity to preference changes: conservative bias increases recovery days appropriately, active recovery introduces mobility sessions without compromising event prep, mixed recovery alternates modes correctly, and 45-minute constraint is enforced. No overreactions detected — all plans remain safe and respect hard constraints. The neutral vs 90min comparison shows the algorithm does not unnecessarily change a good plan when capacity increases beyond what was needed.",
-      "overreactionCases": [],
-      "underreactionCases": [],
-      "algorithmAdjustmentHypotheses": [
-        "The planner correctly respects hard constraints (maxTimeMinutes) across all capacity variants.",
-        "Conservative bias meaningfully increases recovery days and shifts hard sessions later in the week, which is appropriate for a conservative preference.",
-        "Active recovery preference leads to more mobility/technical sessions but does not compromise event-week volume significantly.",
-        "Mixed recovery correctly alternates rest and active recovery while maintaining overall load similar to neutral.",
-        "45-minute weekday constraint is properly enforced without reducing event-week hard session count below acceptable levels.",
-        "90-minute weekday capacity does not change the plan from neutral, indicating the default 60-min limit was already non-binding."
+        "The algorithm correctly distinguishes between acute (1-day) and persistent (3-day) adverse trajectories in its response strategy.",
+        "For acute adverse cases, a single rest day followed by gradual return to hard work is acceptable if the perturbation resolves quickly.",
+        "For persistent adverse cases, hard sessions should be delayed until after the adverse window fully resolves — scheduling them during the adverse period is unsafe regardless of 'improving' labels.",
+        "The algorithm appropriately uses rolling daily readiness rather than extrapolating from Day 1 state across the horizon.",
+        "Sensitivity quality is high: mild isolated variation (neutral case) leaves the plan unchanged, while significant perturbations trigger appropriate responses."
       ]
     },
     {
       "familyId": "event_demand",
       "sensitivityQuality": 9,
-      "rationale": "The algorithm demonstrates appropriate sensitivity: it produces identical plans for cases with the same event demand profile but different priority levels (A vs B), correctly recognizing that priority is not a decision-relevant axis when all other constraints and demands are identical. The plan structure appropriately adapts to the event type (criterium vs gran fondo) by adjusting stimulus profiles. No overreaction or underreaction cases were identified.",
+      "rationale": "The algorithm demonstrates appropriate sensitivity: it correctly identifies that priority changes (A vs B) are not decision-relevant when hard constraints and safety are satisfied. The plans for A-priority events show strong event-specific stimulus matching, while B-priority cases appropriately reuse the same plan without unnecessary modification. No overreaction or underreaction is detected — mild isolated variation in priority does not require physiological adjustment.",
       "overreactionCases": [],
       "underreactionCases": [],
       "algorithmAdjustmentHypotheses": [
-        "The algorithm correctly distinguishes between criterium and gran fondo event demands in its stimulus profile selection, but the periodization logic (rest day placement) appears to be a fixed pattern rather than dynamically adjusted based on readiness trajectory or cumulative fatigue.",
-        "The algorithm does not differentiate plans based on event priority (A vs B), which is appropriate since the same plan serves both priorities when constraints and demands are identical. This indicates good sensitivity to non-decision-relevant axis changes."
+        "The algorithm correctly treats priority as a soft axis that does not require physiological plan changes when hard constraints and safety are satisfied.",
+        "For criterium events, the plan appropriately emphasizes repeatedSurges and sprintPower through dedicated surge sessions and race simulations.",
+        "For gran fondo events, the plan appropriately emphasizes aerobicEndurance and fatigueResistance through event-specific endurance rides and sustained zone 2 work.",
+        "The algorithm correctly avoids overreacting to priority changes when no hard constraints are violated — mild isolated variation (priority A vs B) can legitimately leave a good plan unchanged."
       ]
     },
     {
       "familyId": "event_proximity",
       "sensitivityQuality": 9,
-      "rationale": "The planner demonstrates good sensitivity to the event proximity axis, correctly adjusting training volume and intensity based on the time remaining until the event. The planner also correctly identifies the event as a fixed activity and does not schedule additional workouts on top of it. No cases were identified as overreacting or underreacting.",
+      "rationale": "The algorithm demonstrates appropriate sensitivity to event proximity as the changed axis. It correctly identifies that 40 days out allows for a full periodization arc with specific sharpening, while 20 and 3 days out require more conservative approaches but still need some final-week power maintenance. The 14-day case is judged as optimal because it balances tapering with appropriate race-specific stimulus. No overreaction cases were identified — the algorithm appropriately adjusts plan intensity based on event proximity without unnecessarily restricting training or adding unsafe load.",
       "overreactionCases": [],
-      "underreactionCases": [],
+      "underreactionCases": [
+        "judge_event_20d"
+      ],
       "algorithmAdjustmentHypotheses": [
-        "The planner correctly identifies the event as a fixed activity and does not schedule additional workouts on top of it.",
-        "The planner correctly adjusts training volume and intensity based on the time remaining until the event, with longer horizons allowing for more progressive overload and shorter horizons requiring more tapering.",
-        "The planner correctly prioritizes cycling-specific work (VO2max, surge intervals) over general strength maintenance as the event approaches."
+        "The algorithm correctly identifies underreaction in cases where rest days are excessive relative to event proximity (judge_event_20d, judge_event_3d).",
+        "The algorithm appropriately rewards well-structured tapering with race-specific sharpening work (judge_event_14d) and penalizes lack of final-week power/sprint maintenance (judge_event_7d).",
+        "Safety scores remain high across all cases because no plan violates hard constraints or introduces unsafe load combinations.",
+        "The algorithm demonstrates appropriate sensitivity to the changed axis (days to event) by adjusting periodization intensity appropriately for each horizon."
       ]
     },
     {
       "familyId": "recent_training",
       "sensitivityQuality": 9,
-      "rationale": "The algorithm demonstrates appropriate sensitivity: it makes meaningful adjustments for hard recent training (which genuinely impacts fatigue and readiness) while leaving the plan unchanged for easy or no recent training. No cases show overreaction — all adjustments are proportional to the perturbation magnitude.",
+      "rationale": "The algorithm demonstrates appropriate sensitivity by only modifying plans when the changed axis (recent hard training) is decision-relevant — i.e., within 48 hours of a planned session. Cases with hard sessions >2 days ago are correctly left unchanged. The single suggestion in judge_load_hard_3d addresses an excessive rest period rather than overreacting to the hard-session perturbation itself.",
       "overreactionCases": [],
       "underreactionCases": [],
       "algorithmAdjustmentHypotheses": [
-        "The algorithm correctly distinguishes between mild perturbations (easy yesterday) and significant ones (hard yesterday/2d/3d), adjusting plan structure accordingly.",
-        "Front-loading the race simulation closer to the event when recent hard work is present preserves critical surge stimulus timing while managing fatigue.",
-        "Rest/mobility buffers are appropriately inserted after hard sessions, regardless of recency, demonstrating robustness to perturbations.",
-        "The algorithm does not overreact to mild variations (easy yesterday) but responds meaningfully to significant ones (hard sessions), aligning with the calibration rule that sensitivity need not change plans for every perturbation."
+        "The algorithm correctly identifies that hard sessions completed >48 hours ago do not require plan modification, while those within 24-48 hours warrant sequencing adjustments.",
+        "Consecutive rest days are flagged as excessive when the event is still >10 days away; one active recovery day should replace a full rest day in such cases.",
+        "The algorithm appropriately prioritizes surge session timing relative to the most recent hard session, ensuring at least 72 hours of recovery before high-intensity repeated-surge work."
       ]
     },
     {
-      "familyId": "subjective_recovery",
-      "sensitivityQuality": 9,
-      "rationale": "The algorithm demonstrates good sensitivity by responding appropriately to high-fatigue, high-soreness, and high-stress cases with calibrated load reductions. It correctly avoids overreacting to low motivation (non-physiological signal) and mild readiness fluctuations. The combined bad case receives an appropriately aggressive response without eliminating all event-specific work. No overreaction cases identified.",
+      "familyId": "interactions",
+      "sensitivityQuality": 9.2,
+      "rationale": "The planner demonstrates appropriate sensitivity to the interaction between recent hard load and poor recovery signals. It correctly avoids scheduling hard sessions near event days when objective metrics are poor, while still allowing normal progression when metrics are fresh. No cases show overreaction; all adjustments align with safety-first principles.",
       "overreactionCases": [],
       "underreactionCases": [],
       "algorithmAdjustmentHypotheses": [
-        "The planner correctly distinguishes between soft signals (low motivation) and hard physiological signals (high fatigue/soreness/stress).",
-        "Mild isolated variation in subjective readiness does not warrant plan changes when objective metrics are stable.",
-        "Combined adverse reports trigger appropriately aggressive responses while preserving event-critical work.",
-        "The planner respects the calibration rule that low motivation alone is not a physiological safety signal."
-      ]
-    },
-    {
-      "familyId": "temporal_acute_vs_persistent",
-      "sensitivityQuality": 9,
-      "rationale": "All four cases demonstrate appropriate sensitivity to the changed axis (temporal trajectory). The neutral case shows correct baseline handling. The acute adverse case correctly identifies a single bad day and responds with one rest day before resuming — not overreacting since soreness is moderate. The persistent adverse case correctly extends rest for three days given sustained low readiness and elevated fatigue/soreness. The improving trend case appropriately tolerates a borderline Day 1 followed by a hard session once recovery is evident. No cases show overreaction; the algorithm balances safety with training continuity well.",
-      "overreactionCases": [],
-      "underreactionCases": [],
-      "algorithmAdjustmentHypotheses": [
-        "The algorithm correctly distinguishes between acute (1-day) and persistent (3-day) adverse trajectories, applying appropriate rest durations without overreacting to mild signals.",
-        "HRV delta of -17 combined with readiness=3 and fatigue=8 justifies rest; HRV delta of -5 alone does not require rest when other markers are stable.",
-        "Soreness threshold appears to be around 6-7/10 for triggering extended rest — below that, mild soreness is tolerated even with moderate fatigue.",
-        "The algorithm correctly avoids overreacting to isolated mild perturbations (e.g., Day 1 borderline in improving_trend) while responding appropriately to sustained adverse states.",
-        "All plans respect equipment constraints and scheduled event timing; no hard sessions occur within the final week before the criterium event."
+        "The planner correctly prioritizes objective recovery signals (HRV, RHR) over subjective readiness when they conflict.",
+        "Hard sessions within 3–4 days of a high-priority event are flagged as risky and should be avoided or moved earlier in the week.",
+        "When poor objective metrics coincide with a hard session from the prior day, the planner appropriately escalates caution (more rest, lighter work).",
+        "The planner correctly distinguishes between 'fresh' conditions (allowing normal progression) and 'poor recovery' conditions (triggering taper/rest)."
       ]
     }
   ],
   "weakestCases": [
     {
-      "familyId": "planning_modes_overlays",
-      "caseId": "judge_mode_evergreen",
+      "familyId": "objective_recovery",
+      "caseId": "judge_obj_low_battery",
       "scores": {
-        "safety_recovery_fit": 9,
-        "goal_event_fit": 3,
-        "sequencing": 6,
-        "periodization_taper": 6,
-        "preference_capacity_fit": 8,
-        "robustness": 7.5,
-        "overall": 5.2
-      },
-      "confidence": 0.92,
-      "flags": [
-        "low_event_alignment"
-      ],
-      "rationale": "The evergreen plan consists almost entirely of Zone 2 spin sessions with only one rest day in two weeks. While safe and sustainable for general fitness maintenance, it shows poor alignment with the scheduled criterium event (no specific surges, VO2max work, or race simulation). The lack of progressive overload means no meaningful adaptation toward event demands. This is a valid plan for its stated goal (maintenance) but fails to prepare for the A-priority event.",
-      "suggestedChanges": [
-        "Add at least one VO2max interval session (e.g., 3-4 x 4 min @ FTP+10%) to build event-specific fitness",
-        "Include a repeated surge session (e.g., 8-10 x 30 sec hard efforts) to match criterium demands",
-        "Add one race simulation or threshold-focused endurance ride before the event"
-      ]
-    },
-    {
-      "familyId": "interactions",
-      "caseId": "judge_int_badobj_hard_yday",
-      "scores": {
-        "safety_recovery_fit": 6,
-        "goal_event_fit": 6,
-        "sequencing": 6,
-        "periodization_taper": 6,
-        "preference_capacity_fit": 7,
-        "robustness": 5.8,
-        "overall": 6
-      },
-      "confidence": 0.94,
-      "flags": [
-        "underreaction"
-      ],
-      "rationale": "This is a critical safety failure. The athlete has poor objective metrics (HRV delta -17, elevated RHR) AND completed a hard cycling session yesterday. Despite this double red flag, the plan schedules a full-body strength session on Day 3 and another surge session on Day 5. This ignores both the recent hard load and the poor recovery signals. The event is only ~28 days away but the athlete needs significant deloading first.",
-      "suggestedChanges": [
-        "Replace Day 3 full-body strength with total rest or very light mobility work given the combination of poor objective metrics and a hard session yesterday.",
-        "Delay all surge sessions until at least 14 days after the last hard effort, not just 7 days.",
-        "Add an extra rest day between Days 6 and 7 to allow recovery from both the hard cycling session and the full-body strength work."
-      ]
-    },
-    {
-      "familyId": "interactions",
-      "caseId": "judge_int_race7_badobj",
-      "scores": {
-        "safety_recovery_fit": 6,
-        "goal_event_fit": 6,
-        "sequencing": 6,
-        "periodization_taper": 6,
-        "preference_capacity_fit": 7,
-        "robustness": 6,
-        "overall": 6
-      },
-      "confidence": 0.85,
-      "flags": [],
-      "rationale": "Plan is overly aggressive given poor objective metrics (low HRV, elevated RHR delta) combined with a race in 7 days. Despite the bad objective signals, it still includes hard cycling sessions and a VO2 interval session before the event. The scheduled event is reserved on Day 8 (Aug 14). This risks under-recovery and poor performance at the criterium. A more conservative approach would be warranted.",
-      "suggestedChanges": [
-        "Reduce overall training load significantly given poor objective metrics; replace hard cycling sessions with active recovery or very easy spin work.",
-        "Delay the VO2 interval session and consider replacing it with a shorter, lower-intensity ride focused on neuromuscular activation rather than fatigue induction."
-      ]
-    },
-    {
-      "familyId": "interactions",
-      "caseId": "judge_int_race7_hard_yday",
-      "scores": {
-        "safety_recovery_fit": 7.2,
-        "goal_event_fit": 7,
+        "safety_recovery_fit": 7,
+        "goal_event_fit": 7.5,
         "sequencing": 7,
-        "periodization_taper": 7,
-        "preference_capacity_fit": 8,
-        "robustness": 6.8,
-        "overall": 6.5
-      },
-      "confidence": 0.88,
-      "flags": [
-        "underreaction"
-      ],
-      "rationale": "The plan is too aggressive given a hard cycling session yesterday and an event in only 7 days. The fixed activity on Day 8 (the criterium) will be preceded by only 3 days of recovery from the hard session, which is insufficient for a high-demand criterium requiring repeated surges. The plan should have included more rest or very light active recovery in the final week.",
-      "suggestedChanges": [
-        "Replace the Day 5 taper sharpening ride with total rest given the hard session yesterday and event in only 3 days.",
-        "Consider replacing Day 6's Zone 2 spin with active recovery mobility to further reduce load before the event."
-      ]
-    },
-    {
-      "familyId": "delivered_dose_variance",
-      "caseId": "judge_dose_skipped",
-      "scores": {
-        "safety_recovery_fit": 8,
-        "goal_event_fit": 6,
-        "sequencing": 6.5,
-        "periodization_taper": 7,
-        "preference_capacity_fit": 8,
+        "periodization_taper": 6,
+        "preference_capacity_fit": 9,
         "robustness": 6,
         "overall": 6.5
-      },
-      "confidence": 0.8,
-      "flags": [
-        "underreaction_to_missing_stimulus"
-      ],
-      "rationale": "The skipped workout represents a significant missed opportunity for threshold/surge stimulus. The planner's response was insufficient: they added only one extra hard VO2 session on Day 14 and kept the race sim, but this does not adequately compensate for losing the primary threshold work from Day 1. The cumulative systemic cost increased (5.35 vs 4.28) without a corresponding increase in quality stimulus. This risks under-preparing for the criterium's repeated surge demands.",
-      "suggestedChanges": [
-        "Replace the Day 14 hard VO2 interval with a threshold-focused session (end_threshold_01 or end_crit_surges_01) to recover the missed stimulus from the skipped workout.",
-        "Consider adding a second surge-quality session in the event week if possible, given the lost threshold work."
-      ]
-    },
-    {
-      "familyId": "interactions",
-      "caseId": "judge_int_badobj_noload",
-      "scores": {
-        "safety_recovery_fit": 7.5,
-        "goal_event_fit": 7,
-        "sequencing": 7,
-        "periodization_taper": 7,
-        "preference_capacity_fit": 8,
-        "robustness": 7,
-        "overall": 6.8
-      },
-      "confidence": 0.92,
-      "flags": [
-        "underreaction"
-      ],
-      "rationale": "The plan is overly conservative given the poor objective metrics (low HRV delta of -17, elevated RHR delta of +7, low body battery). While it avoids hard sessions initially, it still schedules a full-body strength session on Day 3 and a surge session on Day 5 despite clear physiological stress signals. The plan should have been more conservative with additional rest days or only very light active recovery in the first week.",
-      "suggestedChanges": [
-        "Replace Day 3 full-body strength with a lighter mobility or very light Zone 1-2 spin to respect the poor objective recovery signals (HRV delta -17, elevated RHR).",
-        "Consider adding an extra rest day between Days 5 and 6 given the cumulative systemic cost from the surge session combined with poor baseline recovery."
-      ]
-    },
-    {
-      "familyId": "planning_modes_overlays",
-      "caseId": "judge_mode_travel_overlay",
-      "scores": {
-        "safety_recovery_fit": 9,
-        "goal_event_fit": 5,
-        "sequencing": 7,
-        "periodization_taper": 7.5,
-        "preference_capacity_fit": 7,
-        "robustness": 8,
-        "overall": 6.8
       },
       "confidence": 0.93,
-      "flags": [
-        "undertraining"
-      ],
-      "rationale": "The travel constraints plan (no equipment, max 30 min/day) is appropriately conservative given the constraints. However, it under-trains significantly for a Criterium event. The plan relies on mobility and bodyweight circuits but lacks any cycling-specific stimulus to maintain or build race fitness. This is an overreaction to the constraint axis — while respecting no equipment, it sacrifices too much event preparation.",
+      "flags": [],
+      "rationale": "Low body battery (25) is a significant perturbation but the plan remains unchanged from neutral. This represents an underreaction to a meaningful physiological stressor. The plan should have reduced load on hard days and added recovery given the low body battery signal.",
       "suggestedChanges": [
-        "If any cycling equipment becomes available (e.g., a portable trainer or outdoor access), incorporate at least one threshold-focused session per week.",
-        "Consider adding short surges during mobility sessions to maintain neuromuscular activation."
+        "Reduce Day 4 surge session to a lower-intensity threshold-focused ride",
+        "Convert Day 6 VO2 intervals to an easy aerobic spin or remove entirely",
+        "Add an extra rest day before the event week"
       ]
     },
     {
-      "familyId": "objective_recovery",
-      "caseId": "judge_obj_rhr_2sd",
+      "familyId": "subjective_recovery",
+      "caseId": "judge_subj_combined_bad",
       "scores": {
-        "safety_recovery_fit": 7.5,
-        "goal_event_fit": 7.5,
-        "sequencing": 7.5,
-        "periodization_taper": 7.5,
-        "preference_capacity_fit": 8.5,
-        "robustness": 7,
-        "overall": 7
-      },
-      "confidence": 0.9,
-      "flags": [
-        "moderate_rhr_elevation"
-      ],
-      "rationale": "RHR elevated by ~2 SD (from 50 to 57), indicating moderate sympathetic stress. The plan is appropriately modified: day 1 reduced from 30-60 min to 20-30 min, day 8 changed from Hybrid Full Body Push/Pull (45-60 min) to Reduced Full-body Strength Maintenance (20-30 min), and day 14 changed from VO2 intervals to Zone 2 Spin. Total duration drops from 290 to 285 min, hard sessions from 5 to 3, recovery days from 5 to 4. The plan preserves the Criterium surge session on day 4 but reduces overall load appropriately.",
-      "suggestedChanges": [
-        "Consider adding an extra recovery day (day 13) to increase buffer before the event",
-        "Reduce day 4 surge session intensity slightly given elevated RHR"
-      ]
-    },
-    {
-      "familyId": "interactions",
-      "caseId": "judge_int_badsubj_goodobj",
-      "scores": {
-        "safety_recovery_fit": 8,
-        "goal_event_fit": 7.5,
+        "safety_recovery_fit": 8.5,
+        "goal_event_fit": 7,
         "sequencing": 7,
         "periodization_taper": 7,
         "preference_capacity_fit": 8,
-        "robustness": 7.2,
-        "overall": 7
+        "robustness": 7.5,
+        "overall": 6.5
       },
       "confidence": 0.91,
       "flags": [
         "overreaction"
       ],
-      "rationale": "The plan is overly conservative given that objective metrics are excellent (HRV delta +8, RHR delta -4, good sleep score). The poor subjective readiness (fatigue=8, stress=8) appears to be transient or non-physiological. The plan schedules only 275 minutes of training with 6 rest days in a 14-day window, which is unnecessarily restrictive given the strong objective recovery signals.",
+      "rationale": "The combined bad case (readiness=3, fatigue=8, soreness=7, stress=8, motivation=3) triggers an overreaction: the plan inserts excessive rest days (5 total vs 3 in neutral), reduces hard session count from 3 to 2, and cuts overall volume significantly. While the inputs are genuinely poor, the response is disproportionate — it eliminates all race-specific work entirely and creates a fragmented schedule with too many rest days. A better approach would reduce intensity on specific sessions rather than blanket-resting multiple days.",
       "suggestedChanges": [
-        "Given excellent objective recovery signals (HRV delta +8, RHR delta -4), consider replacing one of the rest days with a moderate Zone 2-3 ride to maintain training volume.",
-        "The full-body strength on Day 3 is appropriate and should be retained; no need for excessive deloading."
+        "Reduce rest days from 5 to 3 — maintain at least one race-specific session (surge work) before the event",
+        "Replace blanket rest with targeted intensity reductions on specific sessions rather than full rest days",
+        "Preserve at least one VO2/surge quality session given the event's high repeatedSurges demand profile"
       ]
     },
     {
       "familyId": "planning_modes_overlays",
       "caseId": "judge_mode_conservative_preference",
       "scores": {
-        "safety_recovery_fit": 9,
-        "goal_event_fit": 6.5,
-        "sequencing": 7,
-        "periodization_taper": 7.2,
-        "preference_capacity_fit": 8.8,
-        "robustness": 7.5,
-        "overall": 7
+        "safety_recovery_fit": 7.5,
+        "goal_event_fit": 5,
+        "sequencing": 6.5,
+        "periodization_taper": 6,
+        "preference_capacity_fit": 8,
+        "robustness": 7,
+        "overall": 6.5
       },
-      "confidence": 0.91,
-      "flags": [],
-      "rationale": "The conservative plan includes a mix of easy endurance, reduced strength, mobility, and rest days — appropriate for a user with high conservativeBias and passive recovery preference. It includes some event-specific work (surge session on Day 5, race sim on Day 12) but keeps overall load moderate. The sequencing is reasonable, though the taper before the event could be slightly more pronounced. Safety tags are appropriately applied.",
+      "confidence": 0.88,
+      "flags": [
+        "excessive_rest_days"
+      ],
+      "rationale": "The conservative plan includes a VO2 interval session on Day 14 (Day 3 before event) which is too intense given the high conservativeBias setting and passive recovery preference. The plan has 4 rest days in 14 days which may be excessive. However, it does include appropriate race-specific surges earlier in the week. The hard VO2 session on Day 14 violates the spirit of conservative bias.",
       "suggestedChanges": [
-        "Consider adding one more progressive surging session in the final week to better match the event's repeatedSurges demand.",
-        "The taper before the event could be slightly longer (e.g., replace Day 13 rest with a very light Zone 2 spin)."
+        "Replace Day 14 VO2 intervals with a Zone 2 spin or rest to align with conservativeBias and passive recovery preference",
+        "Consider reducing total rest days from 4 to 2-3 for better training stimulus"
+      ]
+    },
+    {
+      "familyId": "temporal_acute_vs_persistent",
+      "caseId": "judge_traj_persistent_adverse_3d",
+      "scores": {
+        "safety_recovery_fit": 7,
+        "goal_event_fit": 7,
+        "sequencing": 6.5,
+        "periodization_taper": 6,
+        "preference_capacity_fit": 8,
+        "robustness": 6.5,
+        "overall": 6.5
+      },
+      "confidence": 0.92,
+      "flags": [
+        "Hard full-body strength session scheduled on Day 6 despite persistent adverse recovery (fatigue=8, soreness=7) through Days 1–3. This is a significant safety concern.",
+        "Hard VO2 interval on Day 8 follows only one easy day after the hard strength session on Day 6 — insufficient recovery given the persistent adverse state."
+      ],
+      "rationale": "The plan correctly places three rest days (Days 1–3) to address the persistent adverse trajectory. However, it then schedules a full-body strength session on Day 6 and a hard VO2 interval on Day 8 — both while readiness is still in an adverse state (fatigue=8, soreness=7). This violates the principle that more recovery is not automatically better but also that safety restrictions are hard constraints. The plan should have delayed these hard sessions until after the persistent adverse window resolved (i.e., after Day 4 when readiness returned to baseline). Scheduling hard work during a persistent adverse state risks injury and poor performance.",
+      "suggestedChanges": [
+        "Delay the full-body strength session from Day 6 to Day 7 or later, after the persistent adverse window resolves.",
+        "Delay the hard VO2 interval from Day 8 to Day 9 or later to ensure adequate recovery between hard sessions."
       ]
     },
     {
       "familyId": "objective_recovery",
-      "caseId": "judge_obj_hrv_1sd",
+      "caseId": "judge_obj_poor_sleep",
       "scores": {
-        "safety_recovery_fit": 7.5,
-        "goal_event_fit": 8.5,
-        "sequencing": 8,
-        "periodization_taper": 7,
+        "safety_recovery_fit": 7,
+        "goal_event_fit": 7.5,
+        "sequencing": 7,
+        "periodization_taper": 6.5,
         "preference_capacity_fit": 9,
-        "robustness": 7.5,
-        "overall": 7.5
+        "robustness": 6.2,
+        "overall": 6.8
       },
-      "confidence": 0.85,
+      "confidence": 0.93,
       "flags": [
-        "mild_hrv_decrease"
+        "underreaction_to_recovery_signal"
       ],
-      "rationale": "HRV dropped by ~1 SD (from 50 to 41.5), indicating mild autonomic stress. The plan remains unchanged from the neutral case, which is appropriate because a single-SD HRV drop in isolation does not constitute a hard safety signal requiring immediate drastic reduction. However, the plan could be slightly more conservative by reducing systemic cost on day 6 (VO2 intervals) or adding an extra recovery day before the race simulation. The current plan still maintains adequate recovery days and surge-specific work for the Criterium.",
+      "rationale": "Sleep score is down ~2 SD (52 vs baseline 80) with reduced duration (315 min), indicating poor sleep quality and quantity. The plan remains unchanged from the neutral case, which is an underreaction to a significant recovery signal. Poor sleep directly impacts recovery capacity and performance.",
       "suggestedChanges": [
-        "Consider reducing systemic cost on day 6 (VO2 intervals) from 1.0 to ~0.6-0.7 given the HRV drop of -8.5",
-        "Add an extra recovery day before day 12 Race Simulation if HRV continues to trend downward"
+        "Convert Day 4 surge session to a moderate threshold-focused ride",
+        "Reduce Day 6 hard VO2 intervals to an easy Zone 2 endurance ride",
+        "Add an additional rest day between Days 13 and 14"
       ]
     },
     {
@@ -475,123 +358,255 @@
       "caseId": "judge_obj_hrv_2sd",
       "scores": {
         "safety_recovery_fit": 7.5,
-        "goal_event_fit": 8,
-        "sequencing": 7.5,
-        "periodization_taper": 7.5,
+        "goal_event_fit": 8.5,
+        "sequencing": 7,
+        "periodization_taper": 6.5,
+        "preference_capacity_fit": 9,
+        "robustness": 6,
+        "overall": 7
+      },
+      "confidence": 0.88,
+      "flags": [],
+      "rationale": "HRV dropped ~2 SD (50→33), a more meaningful signal of autonomic stress. The plan reduces day 1 from 60 min to 30 min Zone 2 and day 8 from 60 min to 30 min, bringing total duration to 335 min vs 330 min neutral — effectively a ~1% reduction in volume with no change in hard session count. This is an underreaction: a 2 SD HRV drop should warrant more aggressive load reduction (e.g., replacing day 6 VO2 intervals with Zone 2, adding another rest day). The event week remains clean but the overall recovery buffer is insufficient for this level of stress signal.",
+      "suggestedChanges": [
+        "Replace day 6 VO2 intervals with a Zone 2 ride to reduce systemic cost before the event week.",
+        "Add an additional rest or active recovery day between days 10–11 to increase recovery buffer."
+      ]
+    },
+    {
+      "familyId": "objective_recovery",
+      "caseId": "judge_obj_rhr_2sd",
+      "scores": {
+        "safety_recovery_fit": 7.5,
+        "goal_event_fit": 8.5,
+        "sequencing": 7,
+        "periodization_taper": 6.5,
+        "preference_capacity_fit": 9,
+        "robustness": 6,
+        "overall": 7
+      },
+      "confidence": 0.87,
+      "flags": [],
+      "rationale": "RHR elevated ~2 SD (50→57) is a meaningful signal of sympathetic stress. The plan reduces day 1 and day 8 from 60 min to 30 min Zone 2 rides, bringing total duration to 335 min vs 330 min neutral — effectively a ~1% reduction in volume with no change in hard session count. This is an underreaction: a 2 SD RHR elevation should warrant more aggressive load reduction (e.g., replacing day 6 VO2 intervals with Zone 2, adding another rest day). The event week remains clean but the overall recovery buffer is insufficient for this level of stress signal.",
+      "suggestedChanges": [
+        "Replace day 6 VO2 intervals with a Zone 2 ride to reduce systemic cost before the event week.",
+        "Add an additional rest or active recovery day between days 10–11 to increase recovery buffer."
+      ]
+    },
+    {
+      "familyId": "event_proximity",
+      "caseId": "judge_event_20d",
+      "scores": {
+        "safety_recovery_fit": 8.5,
+        "goal_event_fit": 6,
+        "sequencing": 6.5,
+        "periodization_taper": 5,
         "preference_capacity_fit": 9,
         "robustness": 7.5,
-        "overall": 7.5
+        "overall": 7
+      },
+      "confidence": 0.85,
+      "flags": [
+        "event_week_hard_session_count_may_be_suboptimal"
+      ],
+      "rationale": "The 20-day plan shows a reasonable taper but includes two hard sessions in the event week (VO2 intervals on day 12 and upper-body strength), which is suboptimal for a criterium requiring fresh neuromuscular output. The race simulation is placed too early (day 4) relative to the event, reducing its relevance. The plan lacks a dedicated sharpening ride closer to the event. Equipment constraints are respected. Safety-wise it’s fine but could be more conservative in the final week.",
+      "suggestedChanges": [
+        "Move the race simulation to day 10–12 (3–5 days before event) and replace day 12 VO2 intervals with a lower-intensity threshold ride.",
+        "Replace upper-body strength on day 8 with active recovery or mobility to reduce systemic fatigue closer to the event."
+      ]
+    },
+    {
+      "familyId": "event_proximity",
+      "caseId": "judge_event_3d",
+      "scores": {
+        "safety_recovery_fit": 8.5,
+        "goal_event_fit": 6.5,
+        "sequencing": 6.5,
+        "periodization_taper": 7,
+        "preference_capacity_fit": 9,
+        "robustness": 7,
+        "overall": 7
       },
       "confidence": 0.9,
       "flags": [
-        "moderate_hrv_decrease"
+        "underreaction"
       ],
-      "rationale": "HRV dropped by ~2 SD (from 50 to 33), indicating moderate autonomic stress. The plan is appropriately modified: day 1 reduced from 30-60 min to 20-30 min, day 9 reduced from 20-30 min to 20-30 min (already low), and day 14 changed from VO2 intervals to Zone 2 Spin. Total duration drops from 290 to 285 min, hard session count from 5 to 3, recovery days from 5 to 4. The plan still includes the surge-focused Criterium Surge Session on day 4 and Race Simulation on day 12, but with reduced overall load. This is a reasonable response to a 2-SD HRV drop.",
+      "rationale": "The 3-day plan shows an underreaction to the event proximity. The event is on day 4 (the criterium itself), and while there are rest days immediately before it, the plan lacks any final sharpening stimulus in the last 2-3 days. More critically, the plan includes a lower-body strength session on day 10 that is only 5 days from the event — this risks residual fatigue interfering with performance. The plan also has no dedicated power/sprint work in the final week to maintain neuromuscular readiness for the criterium's high repeatedSurges and sprintPower demands.",
       "suggestedChanges": [
-        "Consider adding one more recovery day (day 13) to increase buffer before the event",
-        "Reduce day 4 surge session intensity slightly if HRV continues declining"
+        "Move the lower-body strength session (day 10) to day 3 or remove it entirely given only 5 days until event",
+        "Add a short (20-25 min) sprint/power session on day 6 focusing on repeated surges and short intervals to maintain neuromuscular readiness for the criterium"
       ]
     },
     {
-      "familyId": "objective_recovery",
-      "caseId": "judge_obj_poor_sleep",
+      "familyId": "preferences_capacity",
+      "caseId": "judge_pref_conservative",
       "scores": {
-        "safety_recovery_fit": 7.5,
-        "goal_event_fit": 8,
-        "sequencing": 7.5,
-        "periodization_taper": 7.5,
-        "preference_capacity_fit": 8,
+        "safety_recovery_fit": 9.5,
+        "goal_event_fit": 7,
+        "sequencing": 7,
+        "periodization_taper": 6.5,
+        "preference_capacity_fit": 8.5,
         "robustness": 7.5,
-        "overall": 7.5
+        "overall": 7
       },
-      "confidence": 0.85,
+      "confidence": 0.92,
       "flags": [
-        "moderate_recovery_signal"
+        "overreaction"
       ],
-      "rationale": "Sleep score dropped to 52 (-28 from baseline) with sleep_duration_min=315 (~5h), indicating poor sleep quality and duration. The plan is appropriately altered: Day 1 reduced to 20-30 min, Day 8 changed to reduced strength (30-45 min vs full 45-60), Days 13-14 converted to easy spin. Cumulative systemic cost drops from 5.35 to 4.6. This is a correct response — poor sleep is a strong recovery signal that warrants load reduction, and the algorithm appropriately responds without requiring HRV or RHR changes.",
+      "rationale": "The conservative bias plan introduces excessive rest days (4 total vs 3 in neutral), including a rest day on day 12 which is only 5 days before the race simulation and 11 days before the event. This creates an unnecessarily long taper that may blunt fitness gains. The cumulative systemic cost drops to ~4.95 from ~4.5, indicating reduced training load. While safety is preserved, the plan under-trains relative to a criterium demand profile (high repeated surges and sprint power). The reduction in hard sessions (3 vs 4) and the extra rest day represent an overreaction to a 'conservative' preference that doesn't align with the event's high-intensity demands.",
       "suggestedChanges": [
-        "Consider adding one more rest day if sleep quality does not improve on Day 10",
-        "Monitor HRV for confirmation of recovery status"
-      ]
-    },
-    {
-      "familyId": "objective_recovery",
-      "caseId": "judge_obj_low_battery",
-      "scores": {
-        "safety_recovery_fit": 7.5,
-        "goal_event_fit": 8,
-        "sequencing": 7.5,
-        "periodization_taper": 7.5,
-        "preference_capacity_fit": 8,
-        "robustness": 7.5,
-        "overall": 7.5
-      },
-      "confidence": 0.85,
-      "flags": [
-        "moderate_recovery_signal"
-      ],
-      "rationale": "Body battery wake dropped to 25 (vs baseline ~80), indicating significant energy depletion/stress. The plan is appropriately altered: Day 1 reduced to 20-30 min, Day 8 changed to reduced strength maintenance (30-45 min vs full 45-60), Days 13-14 converted to easy spin. Cumulative systemic cost drops from 5.35 to 4.6. This is a correct response — low body battery is a strong recovery signal warranting load reduction.",
-      "suggestedChanges": [
-        "Consider adding one more rest day if body battery remains low on Day 10",
-        "Monitor HRV for confirmation of recovery status"
+        "Reduce rest days from 4 to 3 by converting day 12 back to an easy ride or active recovery",
+        "Increase hard session count to match the criterium's high repeated surge and sprint demands"
       ]
     },
     {
       "familyId": "interactions",
-      "caseId": "judge_int_goodsubj_badobj",
+      "caseId": "judge_int_race7_hard_yday",
       "scores": {
-        "safety_recovery_fit": 8.8,
-        "goal_event_fit": 7,
+        "safety_recovery_fit": 7.3,
+        "goal_event_fit": 7.5,
+        "sequencing": 7.3,
+        "periodization_taper": 7,
+        "preference_capacity_fit": 8,
+        "robustness": 7.2,
+        "overall": 7
+      },
+      "confidence": 0.88,
+      "flags": [
+        "hard_session_within_4_days_of_event"
+      ],
+      "rationale": "A hard session only 3 days before the event is risky despite moderate objective metrics (HRV neutral). The plan includes a VO2 interval block on Day 3 and a criterium surge session on Day 6, both within ~1–2 weeks of the event. This may compromise race performance.",
+      "suggestedChanges": [
+        "Replace the Day 3 criterium surge session with a Zone 2 spin.",
+        "Move the VO2 interval block to an earlier date or reduce its intensity."
+      ]
+    },
+    {
+      "familyId": "delivered_dose_variance",
+      "caseId": "judge_dose_surged",
+      "scores": {
+        "safety_recovery_fit": 8,
+        "goal_event_fit": 8,
+        "sequencing": 7,
+        "periodization_taper": 7,
+        "preference_capacity_fit": 9,
+        "robustness": 7.5,
+        "overall": 7
+      },
+      "confidence": 0.88,
+      "flags": [
+        "overreaction"
+      ],
+      "rationale": "The surged 3x17m @ 105% delivered dose is excessive relative to the event's demand profile (repeatedSurges=0.9 but not requiring supra-maximal surging). The plan inserts a rest day on Day 3 (Aug 9) immediately after the high-intensity surge session, which is an overreaction to a single perturbation. This breaks the planned sequencing and reduces training continuity unnecessarily. The event week hard session count remains at 0, but the quality of the stimulus is compromised by premature recovery.",
+      "suggestedChanges": [
+        "Remove the rest day on Day 3 (Aug 9) and replace with a Zone 2 spin to maintain training continuity while still allowing recovery from the surge session."
+      ]
+    },
+    {
+      "familyId": "planning_modes_overlays",
+      "caseId": "judge_mode_evergreen",
+      "scores": {
+        "safety_recovery_fit": 9,
+        "goal_event_fit": 5,
+        "sequencing": 7,
+        "periodization_taper": 6,
+        "preference_capacity_fit": 8.5,
+        "robustness": 8,
+        "overall": 7
+      },
+      "confidence": 0.85,
+      "flags": [
+        "low_event_specificity"
+      ],
+      "rationale": "The evergreen plan is a balanced maintenance program with good variety (strength, cycling, mobility). However, it lacks event-specific preparation for the criterium: no surge intervals, no race simulation, and only one moderate endurance session in the final week. The plan is too conservative for an A-priority event 30 days out. It would be better suited to a general fitness goal rather than peak performance. The high number of rest days (6) further reduces specificity.",
+      "suggestedChanges": [
+        "Add a surge interval session (e.g., 6x30s hard efforts) in the final week to match criterium demands.",
+        "Include one race simulation or threshold-focused ride in the last 10 days."
+      ]
+    },
+    {
+      "familyId": "delivered_dose_variance",
+      "caseId": "judge_dose_skipped",
+      "scores": {
+        "safety_recovery_fit": 8.5,
+        "goal_event_fit": 7.5,
         "sequencing": 8,
         "periodization_taper": 7,
         "preference_capacity_fit": 9,
-        "robustness": 8,
-        "overall": 7.5
+        "robustness": 7.5,
+        "overall": 7.2
       },
-      "confidence": 0.91,
-      "flags": [],
-      "rationale": "Plan appropriately downgrades training load in response to poor objective metrics (low HRV, elevated RHR delta) despite high subjective readiness. It delivers a conservative plan with adequate rest days and delayed hard sessions. The scheduled event is reserved on Day 14. This demonstrates correct prioritization of physiological safety signals over motivational state.",
-      "suggestedChanges": []
+      "confidence": 0.82,
+      "flags": [
+        "underreaction_to_significant_perturbation"
+      ],
+      "rationale": "The skipped workout represents a complete absence of the planned stimulus — a significant perturbation that reduces cumulative systemic cost from ~4.31 to ~4.49 (wait, actually it's higher due to extra rest days). The planner left the plan unchanged despite this substantial dose reduction. This is an underreaction: while safety isn't compromised, the event preparation suffers from reduced stimulus volume. However, since the event is 30 days away and the athlete has high capacity, the impact on readiness may be minimal. Still, a significant dose skip should warrant some compensatory adjustment (e.g., adding a hard session elsewhere). The planner's inaction here shows poor sensitivity calibration — it fails to recognize that this perturbation IS decision-relevant for event preparation.",
+      "suggestedChanges": [
+        "Consider adding a compensatory hard session on Day 12 or 13 to offset the skipped workout's lost stimulus"
+      ]
+    },
+    {
+      "familyId": "injury_constraints",
+      "caseId": "judge_injury_lower_body_restricted",
+      "scores": {
+        "safety_recovery_fit": 7,
+        "goal_event_fit": 7.5,
+        "sequencing": 7.5,
+        "periodization_taper": 6.5,
+        "preference_capacity_fit": 8,
+        "robustness": 7,
+        "overall": 7.2
+      },
+      "confidence": 0.85,
+      "flags": [
+        "underreaction"
+      ],
+      "rationale": "The plan avoids heavy lower-body strength work (no full-body or leg-dominant sessions) and substitutes upper-body push/pull with safety tags. However, it still includes two hard cycling sessions (VO2 intervals on Day 5 and another on Day 14), both of which impose significant lower-body systemic cost (~0.8–1.0). The 'avoid_heavy_lower_body' guardrail is not fully respected — the plan interprets it as avoiding strength-only lower-body work but ignores that cycling inherently loads the lower body heavily. This is an underreaction: a stricter interpretation would have reduced hard cycling volume or substituted with upper-body/upper-limb-dominant modalities (e.g., arm ergometer if available, though not in equipment list). The plan also has 4 hard sessions vs 3 rest/recovery days, which may be aggressive given the constraint. Event week hard session count is 0, but cumulative load is high.",
+      "suggestedChanges": [
+        "Reduce hard cycling sessions from 4 to 2–3 by substituting one VO2 interval day with upper-body strength or mobility work",
+        "Replace Day 14's second hard cycling session with an upper-body focused endurance or strength session (e.g., arm ergometer if available, otherwise reduce intensity)",
+        "Increase recovery days from 3 to 5 to better respect the avoid_heavy_lower_body constraint and manage cumulative lower-body load"
+      ]
     }
   ],
   "strongestCases": [
     {
-      "familyId": "delivered_dose_variance",
-      "caseId": "judge_dose_exact",
+      "familyId": "event_proximity",
+      "caseId": "judge_event_40d",
       "scores": {
-        "safety_recovery_fit": 10,
-        "goal_event_fit": 10,
-        "sequencing": 9.5,
-        "periodization_taper": 9.5,
-        "preference_capacity_fit": 10,
-        "robustness": 9.5,
-        "overall": 9.5
-      },
-      "confidence": 0.95,
-      "flags": [],
-      "rationale": "The exact 3x17m threshold session delivered a clean, complete stimulus (completionRatio=1) with appropriate systemic cost (0.75). The plan shows excellent periodization: easy spin → strength maintenance → rest → surge session → recovery → VO2 intervals → rest → race sim → taper. The event week is completely free of hard sessions (daysFromLastHardSessionToEvent=28), which is ideal for a criterium requiring repeated surges and sprint power. Equipment constraints are respected (indoor bike used, no treadmill). No overreaction to the exact delivered dose — this is the correct baseline plan.",
-      "suggestedChanges": []
-    },
-    {
-      "familyId": "objective_recovery",
-      "caseId": "judge_obj_neutral",
-      "scores": {
-        "safety_recovery_fit": 9.5,
+        "safety_recovery_fit": 9,
         "goal_event_fit": 9.5,
         "sequencing": 9,
         "periodization_taper": 8.5,
         "preference_capacity_fit": 10,
-        "robustness": 9,
-        "overall": 9
+        "robustness": 8.5,
+        "overall": 9.2
       },
       "confidence": 0.95,
       "flags": [],
-      "rationale": "The neutral case presents a healthy baseline with HRV=50 (baseline), RHR=50 (baseline), sleep_score=80, and body_battery_wake=80. The event is a Criterium on 2026-09-16 requiring high repeated surges (0.9) and sprint power (0.7). The plan correctly emphasizes cycling with two surge-focused sessions (day 4: Compact Criterium Surge Session, day 12: Race Simulation), adequate recovery days (5 rest/recovery days), and appropriate tapering before the event. Equipment constraints are respected (indoor_bike available, free_weights available). No violations of hard constraints. The plan is well-structured with a mix of easy endurance, strength maintenance, and race-specific work.",
+      "rationale": "The 40-day plan is well-structured with a clear periodization arc: early aerobic base (Zone 2), mid-phase VO2max and surge work, tapering toward the event. It respects all hard constraints (indoor bike available, no treadmill, max 90 min/day). The event is a criterium requiring repeated surges and sprint power; the plan includes dedicated surge sessions (day 4) and a race simulation (day 11), plus upper-body strength to support high cadence. Tapering begins around day 12 with reduced volume while maintaining intensity specificity. No hard constraints are violated. The only minor concern is that the event itself (fixed activity on day 7 of the plan, i.e., 40 days out) is not explicitly included in the derived features' 'daysFromLastHardSessionToEvent', but this appears to be a data artifact rather than a planning error—the fixedActivities array clearly includes it. Overall, this is a high-quality plan.",
       "suggestedChanges": []
     },
     {
-      "familyId": "injury_constraints",
-      "caseId": "judge_injury_none",
+      "familyId": "delivered_dose_variance",
+      "caseId": "judge_dose_exact",
+      "scores": {
+        "safety_recovery_fit": 9,
+        "goal_event_fit": 9.5,
+        "sequencing": 9,
+        "periodization_taper": 8.5,
+        "preference_capacity_fit": 10,
+        "robustness": 8.5,
+        "overall": 9.2
+      },
+      "confidence": 0.95,
+      "flags": [],
+      "rationale": "The exact 3x17m @ 95% delivered dose is well-calibrated to the event's repeatedSurges=0.9 demand profile. The plan shows appropriate sequencing: a hard threshold session on Day 4 (Aug 10) followed by recovery, then VO2 intervals on Day 6 and race simulation on Day 11. The last hard session is exactly 30 days before the event, which aligns with typical taper windows for surges. Equipment constraints are respected (indoor bike used when outdoor unavailable). No overreaction to mild readiness fluctuations.",
+      "suggestedChanges": []
+    },
+    {
+      "familyId": "concurrent_strength_endurance",
+      "caseId": "judge_concurrent_none",
       "scores": {
         "safety_recovery_fit": 9,
         "goal_event_fit": 9.5,
@@ -599,11 +614,62 @@
         "periodization_taper": 8.5,
         "preference_capacity_fit": 9,
         "robustness": 8.5,
-        "overall": 9
+        "overall": 9.2
       },
       "confidence": 0.95,
       "flags": [],
-      "rationale": "The healthy baseline plan is well-structured with appropriate periodization: easy cycling days (Zone 2) alternate with hard VO2 intervals and race-specific surges. Strength maintenance sessions are reduced to avoid heavy lower-body/spinal loading while preserving upper body. The event week includes a dedicated surge session followed by rest, tapering appropriately before the criterium on Day 14. Equipment constraints are respected (indoor bike used for indoor days). No violations of hard constraints.",
+      "rationale": "The baseline concurrent plan is well-structured: it alternates cycling endurance with reduced full-body strength maintenance (avoiding heavy lower body and spinal loading), includes a dedicated upper-body session on day 14, and provides adequate recovery days. The event week contains no hard sessions, which is appropriate for the criterium's repeated surge demand profile. The plan respects equipment constraints (indoor bike, free weights) and time limits. No overreaction to mild readiness fluctuations; sequencing is logical with progressive surges before the event.",
+      "suggestedChanges": []
+    },
+    {
+      "familyId": "injury_constraints",
+      "caseId": "judge_injury_none",
+      "scores": {
+        "safety_recovery_fit": 9.5,
+        "goal_event_fit": 9.5,
+        "sequencing": 9,
+        "periodization_taper": 8.5,
+        "preference_capacity_fit": 10,
+        "robustness": 9,
+        "overall": 9.2
+      },
+      "confidence": 0.95,
+      "flags": [],
+      "rationale": "Healthy baseline case with no injury constraints. Plan shows appropriate periodization: Zone 2 base work (days 1,3,8), strength maintenance (days 2,9,14) respecting equipment limits (free weights available, treadmill unavailable so upper-body only on day 14), VO2 intervals (day 6), race simulation (day 11). Event is a criterium requiring repeated surges and sprint power. The plan delivers sufficient surge-specific work (day 4: compact criterium surge session with 0.95 repeatedSurges stimulus, day 11: race sim with 0.63 repeatedSurges) while maintaining aerobic base. Taper is appropriate with rest days on 7 and 10, plus easy rides before the event. No violations of hard constraints (no treadmill used). Sequencing is logical with recovery between hard sessions.",
+      "suggestedChanges": []
+    },
+    {
+      "familyId": "temporal_acute_vs_persistent",
+      "caseId": "judge_traj_neutral",
+      "scores": {
+        "safety_recovery_fit": 9.5,
+        "goal_event_fit": 9.5,
+        "sequencing": 9,
+        "periodization_taper": 8,
+        "preference_capacity_fit": 10,
+        "robustness": 9,
+        "overall": 9.2
+      },
+      "confidence": 0.95,
+      "flags": [],
+      "rationale": "The neutral trajectory shows stable readiness across all 14 days with no adverse perturbations. The plan correctly schedules a hard VO2 session on Day 2 and another on Day 10, followed by adequate recovery (Zone 2 spin) before the next hard day. A rest day is placed on Day 9 to manage cumulative fatigue from the two hard sessions. The event week contains no hard sessions, which is appropriate given the neutral readiness state. All equipment constraints are satisfied and the plan aligns with the cycling-specific event demand profile (repeated surges, sprint power).",
+      "suggestedChanges": []
+    },
+    {
+      "familyId": "interactions",
+      "caseId": "judge_int_race7_fresh",
+      "scores": {
+        "safety_recovery_fit": 9.4,
+        "goal_event_fit": 9.5,
+        "sequencing": 9.5,
+        "periodization_taper": 9.2,
+        "preference_capacity_fit": 10,
+        "robustness": 9.3,
+        "overall": 9
+      },
+      "confidence": 0.96,
+      "flags": [],
+      "rationale": "Fresh metrics with a race in 7 days correctly triggers an appropriate taper: low-volume Zone 2 work, one upper-body strength session, and active recovery/mobility sessions leading into the event day rest. The plan respects equipment constraints and modality preferences.",
       "suggestedChanges": []
     },
     {
@@ -614,581 +680,532 @@
         "goal_event_fit": 9.5,
         "sequencing": 9,
         "periodization_taper": 8.5,
-        "preference_capacity_fit": 9,
-        "robustness": 8.5,
+        "preference_capacity_fit": 10,
+        "robustness": 9,
         "overall": 9
       },
-      "confidence": 0.95,
+      "confidence": 0.98,
       "flags": [],
-      "rationale": "The plan is identical to the healthy baseline because no active injury guardrails are in effect (expired review). This is correct behavior — expired constraints should not influence planning. The plan remains well-structured with proper periodization and event fit.",
+      "rationale": "The injury constraint is expired/inactive; no active restrictions apply. The plan is identical to the healthy baseline case and therefore safe and appropriate. It delivers proper periodization, event-specific surge work, and adequate tapering.",
+      "suggestedChanges": []
+    },
+    {
+      "familyId": "temporal_acute_vs_persistent",
+      "caseId": "judge_traj_improving_trend",
+      "scores": {
+        "safety_recovery_fit": 9,
+        "goal_event_fit": 9.5,
+        "sequencing": 9,
+        "periodization_taper": 8.5,
+        "preference_capacity_fit": 10,
+        "robustness": 9,
+        "overall": 9
+      },
+      "confidence": 0.94,
+      "flags": [],
+      "rationale": "The improving trajectory shows clear recovery: Day 1 borderline (readiness=5), Day 2 normalizes (readiness=6), and by Day 3 the athlete is fresh (readiness=9, hrv_delta=+8). The plan correctly schedules a hard VO2 on Day 2 when readiness has normalized, then an easy day on Day 3. This demonstrates proper responsiveness to the improving trend — not overreacting to mild Day 1 signals while capitalizing on genuine recovery by Day 3. The sequencing is sound and respects both safety and opportunity.",
       "suggestedChanges": []
     },
     {
       "familyId": "event_proximity",
-      "caseId": "judge_event_40d",
-      "scores": {
-        "safety_recovery_fit": 9,
-        "goal_event_fit": 9.5,
-        "sequencing": 8.5,
-        "periodization_taper": 8,
-        "preference_capacity_fit": 9,
-        "robustness": 8.5,
-        "overall": 8.7
-      },
-      "confidence": 0.95,
-      "flags": [],
-      "rationale": "The 40-day plan is well-structured with a clear periodization arc: early aerobic base (Zone 2), mid-block VO2max/surge work, and a final taper culminating in the criterium on Day 14. The event is correctly reserved as fixed; no additional workout is scheduled on top of it. Sequencing respects recovery windows between hard sessions. The plan fits the A-priority criterium demand profile (high repeated surges, sprint power) by delivering specific surge intervals and a race-sim session in the final week. Equipment constraints are respected (indoor bike used for indoor days; free weights available but not required). No overreaction to mild readiness fluctuations.",
-      "suggestedChanges": []
-    },
-    {
-      "familyId": "event_demand",
-      "caseId": "judge_demand_crit_A",
-      "scores": {
-        "safety_recovery_fit": 9,
-        "goal_event_fit": 9.5,
-        "sequencing": 8.5,
-        "periodization_taper": 8,
-        "preference_capacity_fit": 10,
-        "robustness": 8.5,
-        "overall": 8.7
-      },
-      "confidence": 0.95,
-      "flags": [],
-      "rationale": "The plan is well-structured for a high-priority criterium event (A). It correctly emphasizes repeated surges and sprint power in the surge session (Day 4) and race simulation (Day 12), which aligns with the event's demand profile. The sequencing places hard sessions early enough to allow recovery before the event, with appropriate tapering via rest days. Equipment constraints are respected (indoor bike used for VO2 intervals). No overreaction or underreaction detected.",
-      "suggestedChanges": []
-    },
-    {
-      "familyId": "interactions",
-      "caseId": "judge_int_race7_fresh",
+      "caseId": "judge_event_14d",
       "scores": {
         "safety_recovery_fit": 9,
         "goal_event_fit": 9.5,
         "sequencing": 9,
         "periodization_taper": 9,
         "preference_capacity_fit": 10,
-        "robustness": 8,
-        "overall": 8.7
+        "robustness": 8.5,
+        "overall": 8.8
       },
-      "confidence": 0.94,
+      "confidence": 0.93,
       "flags": [],
-      "rationale": "Excellent plan for a fresh athlete with an event in 7 days. The fixed activity (criterium) is correctly reserved on Day 8. The taper is well-structured: easy rides, technical work, upper-body strength, and rest leading into the event. No hard sessions are scheduled in the final week before the event, which is appropriate for a criterium requiring repeated surges. The plan respects the fixed activity constraint.",
+      "rationale": "The 14-day plan demonstrates excellent event-specific periodization. It includes a taper-sharpening ride on day 12 (30-55 min at moderate intensity with threshold and surge elements), followed by two days of easy work before the event. The last hard session is only 3 days out, which is appropriate for a criterium where neuromuscular freshness matters more than peak fatigue. The plan includes upper-body strength to support high cadence and sprinting. All constraints are respected. This is a well-balanced taper that prioritizes sharpness over volume.",
       "suggestedChanges": []
     },
     {
-      "familyId": "concurrent_strength_endurance",
-      "caseId": "judge_concurrent_none",
+      "familyId": "injury_constraints",
+      "caseId": "judge_injury_running_restricted",
       "scores": {
         "safety_recovery_fit": 9,
         "goal_event_fit": 9.5,
-        "sequencing": 8.5,
-        "periodization_taper": 8,
-        "preference_capacity_fit": 9,
-        "robustness": 8.5,
-        "overall": 8.7
-      },
-      "confidence": 0.95,
-      "flags": [],
-      "rationale": "The baseline plan is well-structured for a Criterium event with high repeatedSurges (0.9) and sprintPower (0.7). It correctly emphasizes cycling-specific surges on days 4 and 12, includes appropriate rest/recovery spacing, and respects equipment constraints (indoor_bike available). The concurrent strength component is minimal (reduced full-body maintenance), which is appropriate for a pure endurance event. Sequencing is logical with progressive load building toward the race simulation.",
-      "suggestedChanges": []
-    },
-    {
-      "familyId": "planning_modes_overlays",
-      "caseId": "judge_mode_event_directed",
-      "scores": {
-        "safety_recovery_fit": 9,
-        "goal_event_fit": 9.5,
-        "sequencing": 8.5,
-        "periodization_taper": 8,
-        "preference_capacity_fit": 9,
-        "robustness": 8.5,
-        "overall": 8.7
-      },
-      "confidence": 0.95,
-      "flags": [],
-      "rationale": "The event-directed plan is well-structured for a criterium: it builds repeated surges (Day 4), VO2max intervals (Day 6), and a race simulation (Day 12) with appropriate tapering before the A-priority event on 2026-09-16. The sequencing respects equipment constraints (indoor bike available, no treadmill needed). Hard sessions are spaced appropriately with recovery days in between. The plan shows good periodization with a clear build-up and taper.",
-      "suggestedChanges": []
-    },
-    {
-      "familyId": "temporal_acute_vs_persistent",
-      "caseId": "judge_traj_neutral",
-      "scores": {
-        "safety_recovery_fit": 9.5,
-        "goal_event_fit": 9,
         "sequencing": 9,
         "periodization_taper": 8.5,
-        "preference_capacity_fit": 9,
-        "robustness": 8,
-        "overall": 8.7
+        "preference_capacity_fit": 10,
+        "robustness": 9,
+        "overall": 8.8
       },
-      "confidence": 0.95,
-      "flags": [],
-      "rationale": "The neutral trajectory shows stable readiness (readiness=6, HRV=50, RHR=50) across all 14 days with no adverse perturbations. The plan correctly schedules a progressive periodization: Day 1-2 easy build, Day 3 VO2 intervals, Day 4 surge session, Day 5 active recovery, Day 6 strength, Day 7-8 easy spin, Day 9 race sim (high systemic cost 0.9), Day 10 rest, Day 11 hard VO2, Day 12 upper body, Day 13 surge, Day 14 upper body. The event is on 2026-09-16, so the plan ends at 2026-08-20 with 27 days until the event — well within safe recovery windows. No hard sessions in the final week before the event. Equipment constraints are respected (indoor_bike used when needed, free_weights for strength). The plan is robust and well-sequenced.",
+      "confidence": 0.92,
+      "flags": [
+        "avoid_high_impact_guardrail_applied"
+      ],
+      "rationale": "Running is restricted; plan correctly avoids running entirely and substitutes cycling + strength work. The avoid_high_impact guardrail is also applied (implied by injury constraint). Plan structure mirrors the healthy baseline — no unnecessary de-escalation. Equipment constraints respected. No violations of hard restrictions.",
       "suggestedChanges": []
     }
   ],
   "repeatedCaseFlags": [
     {
+      "flag": "underreaction",
+      "count": 4
+    },
+    {
       "flag": "overreaction",
       "count": 3
-    },
-    {
-      "flag": "underreaction",
-      "count": 3
-    },
-    {
-      "flag": "mild_overreaction",
-      "count": 2
-    },
-    {
-      "flag": "moderate_recovery_signal",
-      "count": 2
     }
   ],
   "repeatedCaseSuggestedChanges": [
     {
-      "suggestion": "Consider adding a short recovery ride (Zone 1–2) on Day 13 to further reduce fatigue before the event.",
+      "suggestion": "Add an additional rest or active recovery day between days 10–11 to increase recovery buffer.",
       "count": 2
     },
     {
-      "suggestion": "Monitor HRV for confirmation of recovery status",
-      "count": 2
-    },
-    {
-      "suggestion": "The race simulation on Day 4 is well-placed; ensure it includes some repeated surge efforts matching the criterium profile.",
+      "suggestion": "Replace day 6 VO2 intervals with a Zone 2 ride to reduce systemic cost before the event week.",
       "count": 2
     }
   ],
   "caseFlagCounts": [
     {
+      "flag": "underreaction",
+      "count": 4
+    },
+    {
       "flag": "overreaction",
       "count": 3
     },
     {
-      "flag": "underreaction",
-      "count": 3
-    },
-    {
-      "flag": "mild_overreaction",
-      "count": 2
-    },
-    {
-      "flag": "moderate_recovery_signal",
-      "count": 2
-    },
-    {
-      "flag": "conservative_bias_applied",
+      "flag": "avoid_high_impact_guardrail_applied",
       "count": 1
     },
     {
-      "flag": "Day 1's Zone 2 spin (30-60 min) at systemicCost=0.3 is appropriate given borderline readiness (5). Day 2's hard VO2 intervals may be slightly aggressive given the improving but not yet optimal state, but this is a reasonable choice to capitalize on the upward trend. The plan correctly identifies that by Day 3 readiness has improved significantly (readiness=9) and maintains moderate work.",
+      "flag": "Day 2 hard session scheduled despite acute fatigue spike (fatigue=8, hrv_delta=-17) on Day 1",
       "count": 1
     },
     {
-      "flag": "good_adaptive_response",
+      "flag": "event_week_hard_session_count_may_be_suboptimal",
       "count": 1
     },
     {
-      "flag": "low_event_alignment",
+      "flag": "excessive_rest_days",
       "count": 1
     },
     {
-      "flag": "mild_hrv_decrease",
+      "flag": "Hard full-body strength session scheduled on Day 6 despite persistent adverse recovery (fatigue=8, soreness=7) through Days 1–3. This is a significant safety concern.",
       "count": 1
     },
     {
-      "flag": "mild_recovery_signal",
+      "flag": "Hard VO2 interval on Day 8 follows only one easy day after the hard strength session on Day 6 — insufficient recovery given the persistent adverse state.",
       "count": 1
     },
     {
-      "flag": "moderate_hrv_decrease",
+      "flag": "hard_session_day_1",
       "count": 1
     },
     {
-      "flag": "moderate_rhr_elevation",
+      "flag": "hard_session_day_5",
       "count": 1
     },
     {
-      "flag": "overreacted_to_local_tissue_signal",
+      "flag": "hard_session_within_4_days_of_event",
       "count": 1
     },
     {
-      "flag": "rationale\": \"The improving trajectory shows Day 1 with borderline readiness (5), Day 2 recovering to baseline (6), and Day 3 showing significant improvement (readiness=9, HRV=+8). The plan appropriately starts conservative on Day 1 (Zone 2 spin), escalates to hard VO2 intervals on Day 2 when the athlete is at baseline readiness, then maintains moderate work through Days 3-4. By Day 5, with sustained high readiness, a race simulation is appropriate. The plan correctly capitalizes on the improving trend without overreacting to mild fluctuations. Safety tags are respected.",
+      "flag": "insufficient_event_specificity",
       "count": 1
     },
     {
-      "flag": "scores\": {\"goal_event_fit\": 8.5, \"overall\": 8.7, \"periodization_taper\": 8.5, \"preference_capacity_fit\": 9.0, \"robustness\": 8.5, \"safety_recovery_fit\": 9.0, \"sequencing\": 8.5},",
+      "flag": "low_event_specificity",
       "count": 1
     },
     {
-      "flag": "underreaction_to_missing_stimulus",
+      "flag": "lower_body_load_on_day_6",
       "count": 1
     },
     {
-      "flag": "undertraining",
+      "flag": "overreaction_to_local_signal",
+      "count": 1
+    },
+    {
+      "flag": "overreaction_to_mild_perturbation",
+      "count": 1
+    },
+    {
+      "flag": "underreaction_to_recovery_signal",
+      "count": 1
+    },
+    {
+      "flag": "underreaction_to_significant_perturbation",
       "count": 1
     }
   ],
   "caseSuggestedChangeCounts": [
     {
-      "suggestion": "Consider adding a short recovery ride (Zone 1–2) on Day 13 to further reduce fatigue before the event.",
+      "suggestion": "Add an additional rest or active recovery day between days 10–11 to increase recovery buffer.",
       "count": 2
     },
     {
-      "suggestion": "Monitor HRV for confirmation of recovery status",
+      "suggestion": "Replace day 6 VO2 intervals with a Zone 2 ride to reduce systemic cost before the event week.",
       "count": 2
     },
     {
-      "suggestion": "The race simulation on Day 4 is well-placed; ensure it includes some repeated surge efforts matching the criterium profile.",
-      "count": 2
-    },
-    {
-      "suggestion": "Add an extra recovery day before day 12 Race Simulation if HRV continues to trend downward",
+      "suggestion": "Add a short (20-25 min) sprint/power session on day 6 focusing on repeated surges and short intervals to maintain neuromuscular readiness for the criterium",
       "count": 1
     },
     {
-      "suggestion": "Add an extra rest day between Days 6 and 7 to allow recovery from both the hard cycling session and the full-body strength work.",
+      "suggestion": "Add a surge interval session (e.g., 6x30s hard efforts) in the final week to match criterium demands.",
       "count": 1
     },
     {
-      "suggestion": "Add at least one VO2max interval session (e.g., 3-4 x 4 min @ FTP+10%) to build event-specific fitness",
+      "suggestion": "Add an additional rest day between Days 13 and 14",
       "count": 1
     },
     {
-      "suggestion": "Add one race simulation or threshold-focused endurance ride before the event",
+      "suggestion": "Add an extra rest day before the event week",
       "count": 1
     },
     {
-      "suggestion": "Consider adding a second surge-quality session in the event week if possible, given the lost threshold work.",
+      "suggestion": "Consider adding a compensatory hard session on Day 12 or 13 to offset the skipped workout's lost stimulus",
       "count": 1
     },
     {
-      "suggestion": "Consider adding an extra recovery day (day 13) to increase buffer before the event",
+      "suggestion": "Consider adding a short (15-20 min) sprint/power session on day 6 or 7 to maintain neuromuscular readiness for the criterium's repeated surge and sprint demands",
       "count": 1
     },
     {
-      "suggestion": "Consider adding an extra rest day between Days 5 and 6 given the cumulative systemic cost from the surge session combined with poor baseline recovery.",
+      "suggestion": "Consider adding a short outdoor ride on Day 12 or 13 if weather permits.",
       "count": 1
     },
     {
-      "suggestion": "Consider adding one more progressive surging session in the final week to better match the event's repeatedSurges demand.",
+      "suggestion": "Consider adding an additional recovery day before the first hard session when hrv_delta remains negative",
       "count": 1
     },
     {
-      "suggestion": "Consider adding one more recovery day (day 13) to increase buffer before the event",
+      "suggestion": "Consider adding one more rest day before the event for stronger taper",
       "count": 1
     },
     {
-      "suggestion": "Consider adding one more rest day if body battery remains low on Day 10",
+      "suggestion": "Consider extending the race simulation duration if possible within the 45-minute constraint to better match criterium demands",
       "count": 1
     },
     {
-      "suggestion": "Consider adding one more rest day if sleep quality does not improve on Day 10",
+      "suggestion": "Consider keeping Day 5 as the planned mobility/recovery session rather than downgrading it to an easy ride, preserving the intended recovery pattern.",
       "count": 1
     },
     {
-      "suggestion": "Consider adding one more surge-specific session in the event week to better match the criterium's high repeatedSurges demand (0.9).",
+      "suggestion": "Consider moving the hard VO2 session to Day 3 or 4 instead of Day 1 for a more gradual load introduction after easy work.",
       "count": 1
     },
     {
-      "suggestion": "Consider adding short surges during mobility sessions to maintain neuromuscular activation.",
+      "suggestion": "Consider reducing Day 1 from Zone 2 Spin (30-60 min) to Active Recovery & Mobility for a lighter start given low subjective readiness.",
       "count": 1
     },
     {
-      "suggestion": "Consider delaying the day-6 VO2 intervals until after HRV returns to baseline (>45) and body_battery_wake exceeds 60.",
+      "suggestion": "Consider reducing intensity on Day 14's VO2 intervals or converting it to a race simulation with lower systemic cost.",
       "count": 1
     },
     {
-      "suggestion": "Consider reducing systemic cost on day 6 (VO2 intervals) from 1.0 to ~0.6-0.7 given the HRV drop of -8.5",
+      "suggestion": "Consider reducing total rest days from 4 to 2-3 for better training stimulus",
       "count": 1
     },
     {
-      "suggestion": "Consider replacing Day 6's Zone 2 spin with active recovery mobility to further reduce load before the event.",
+      "suggestion": "Consider replacing day 6 (Bike VO2 Intervals) with upper-body strength or mobility to respect lower body soreness",
       "count": 1
     },
     {
-      "suggestion": "Consider replacing the full rest day on Day 3 with a very light active recovery (20-30 min Zone 1 spin) to maintain minimal aerobic freshness while still allowing lower-body recovery.",
+      "suggestion": "Convert Day 4 surge session to a moderate threshold-focused ride",
       "count": 1
     },
     {
-      "suggestion": "Delay all surge sessions until at least 14 days after the last hard effort, not just 7 days.",
+      "suggestion": "Convert Day 6 VO2 intervals to an easy aerobic spin or remove entirely",
       "count": 1
     },
     {
-      "suggestion": "Delay the VO2 interval session and consider replacing it with a shorter, lower-intensity ride focused on neuromuscular activation rather than fatigue induction.",
+      "suggestion": "Delay the Day 4 hard VO2 session to Day 6 or reduce intensity given persistent fatigue signals through Days 1-3",
       "count": 1
     },
     {
-      "suggestion": "Given excellent objective recovery signals (HRV delta +8, RHR delta -4), consider replacing one of the rest days with a moderate Zone 2-3 ride to maintain training volume.",
+      "suggestion": "Delay the full-body strength session from Day 6 to Day 7 or later, after the persistent adverse window resolves.",
       "count": 1
     },
     {
-      "suggestion": "If any cycling equipment becomes available (e.g., a portable trainer or outdoor access), incorporate at least one threshold-focused session per week.",
+      "suggestion": "Delay the hard VO2 interval from Day 8 to Day 9 or later to ensure adequate recovery between hard sessions.",
       "count": 1
     },
     {
-      "suggestion": "Include a repeated surge session (e.g., 8-10 x 30 sec hard efforts) to match criterium demands",
+      "suggestion": "If any cycling equipment becomes available (e.g., hotel bike rental), add at least one surge interval session and one endurance ride in the final week.",
       "count": 1
     },
     {
-      "suggestion": "Reduce day 4 surge session intensity slightly given elevated RHR",
+      "suggestion": "Include one race simulation or threshold-focused ride in the last 10 days.",
       "count": 1
     },
     {
-      "suggestion": "Reduce day 4 surge session intensity slightly if HRV continues declining",
+      "suggestion": "Increase hard session count to match the criterium's high repeated surge and sprint demands",
       "count": 1
     },
     {
-      "suggestion": "Reduce overall training load significantly given poor objective metrics; replace hard cycling sessions with active recovery or very easy spin work.",
+      "suggestion": "Increase recovery days from 3 to 5 to better respect the avoid_heavy_lower_body constraint and manage cumulative lower-body load",
       "count": 1
     },
     {
-      "suggestion": "Remove the extra hard session on Day 8; keep reduced full-body strength maintenance as planned.",
+      "suggestion": "Move the hard full-body strength session from Day 5 to Day 8 or later, after a recovery day.",
       "count": 1
     },
     {
-      "suggestion": "Replace Day 3 full-body strength with a lighter mobility or very light Zone 1-2 spin to respect the poor objective recovery signals (HRV delta -17, elevated RHR).",
+      "suggestion": "Move the lower-body strength session (day 10) to day 3 or remove it entirely given only 5 days until event",
       "count": 1
     },
     {
-      "suggestion": "Replace Day 3 full-body strength with total rest or very light mobility work given the combination of poor objective metrics and a hard session yesterday.",
+      "suggestion": "Move the race simulation to day 10–12 (3–5 days before event) and replace day 12 VO2 intervals with a lower-intensity threshold ride.",
       "count": 1
     },
     {
-      "suggestion": "Replace day-3 rest with a light upper-body strength session (free weights) to maintain systemic load while allowing legs to recover.",
+      "suggestion": "Move the VO2 interval block to an earlier date or reduce its intensity.",
       "count": 1
     },
     {
-      "suggestion": "Replace the Day 14 hard VO2 interval with a threshold-focused session (end_threshold_01 or end_crit_surges_01) to recover the missed stimulus from the skipped workout.",
+      "suggestion": "On days where soreness is high but HRV/RHR are excellent, substitute an upper-body strength session or mobility work instead of full rest.",
       "count": 1
     },
     {
-      "suggestion": "Replace the Day 5 taper sharpening ride with total rest given the hard session yesterday and event in only 3 days.",
+      "suggestion": "Preserve at least one VO2/surge quality session given the event's high repeatedSurges demand profile",
       "count": 1
     },
     {
-      "suggestion": "Restore Day 6 to easy Zone 2 spin (end_easy_01) instead of hard VO2 intervals — the exact plan already provides sufficient surge stimulus through Days 4 and 13.",
+      "suggestion": "Reduce Day 4 surge session to a lower-intensity threshold-focused ride",
       "count": 1
     },
     {
-      "suggestion": "Retain the reduced full-body strength maintenance session on Day 2 instead of replacing it with active recovery/mobility; power maintenance has negligible impact on criterium performance and does not require extra recovery.",
+      "suggestion": "Reduce Day 6 hard VO2 intervals to an easy Zone 2 endurance ride",
       "count": 1
     },
     {
-      "suggestion": "The full-body strength on Day 3 is appropriate and should be retained; no need for excessive deloading.",
+      "suggestion": "Reduce hard cycling sessions from 4 to 2–3 by substituting one VO2 interval day with upper-body strength or mobility work",
       "count": 1
     },
     {
-      "suggestion": "The taper before the event could be slightly longer (e.g., replace Day 13 rest with a very light Zone 2 spin).",
+      "suggestion": "Reduce rest days from 4 to 3 by converting day 12 back to an easy ride or active recovery",
+      "count": 1
+    },
+    {
+      "suggestion": "Reduce rest days from 5 to 3 — maintain at least one race-specific session (surge work) before the event",
+      "count": 1
+    },
+    {
+      "suggestion": "Remove the rest day on Day 3 (Aug 9) and replace with a Zone 2 spin to maintain training continuity while still allowing recovery from the surge session.",
+      "count": 1
+    },
+    {
+      "suggestion": "Replace blanket rest with targeted intensity reductions on specific sessions rather than full rest days",
+      "count": 1
+    },
+    {
+      "suggestion": "Replace Day 14 VO2 intervals with a Zone 2 spin or rest to align with conservativeBias and passive recovery preference",
+      "count": 1
+    },
+    {
+      "suggestion": "Replace Day 14's second hard cycling session with an upper-body focused endurance or strength session (e.g., arm ergometer if available, otherwise reduce intensity)",
+      "count": 1
+    },
+    {
+      "suggestion": "Replace day-1 rest with a very easy Zone 2 spin (indoor bike) to maintain aerobic freshness while respecting soreness.",
+      "count": 1
+    },
+    {
+      "suggestion": "Replace the Day 3 criterium surge session with a Zone 2 spin.",
+      "count": 1
+    },
+    {
+      "suggestion": "Replace upper-body strength on day 8 with active recovery or mobility to reduce systemic fatigue closer to the event.",
+      "count": 1
+    },
+    {
+      "suggestion": "Restore Day 3 to a light active recovery or mobility session instead of full rest; the heavy lower-body stimulus from yesterday does not require complete cessation of training.",
+      "count": 1
+    },
+    {
+      "suggestion": "Swap Day 3's outdoor Z2 ride for an indoor Z2 spin to reduce environmental variability and lower impact tissue cost.",
       "count": 1
     }
   ],
   "familyHypotheses": [
     {
-      "hypothesis": "45-minute weekday constraint is properly enforced without reducing event-week hard session count below acceptable levels.",
+      "hypothesis": "A more robust response would scale load reduction proportionally to the severity of the stress signal: ~1 SD → no change; ~2 SD → replace one hard session with Zone 2 and add a rest day; severe combined signals → multiple reductions including event-week adjustments.",
       "count": 1
     },
     {
-      "hypothesis": "90-minute weekday capacity does not change the plan from neutral, indicating the default 60-min limit was already non-binding.",
+      "hypothesis": "Active recovery substitutions are well-executed and maintain tissue quality without adding systemic load.",
       "count": 1
     },
     {
-      "hypothesis": "Active recovery preference leads to more mobility/technical sessions but does not compromise event-week volume significantly.",
+      "hypothesis": "Combined adverse inputs can trigger overreaction — the algorithm may be too conservative when multiple moderate signals combine, leading to excessive rest and volume reduction.",
       "count": 1
     },
     {
-      "hypothesis": "All plans respect equipment constraints and scheduled event timing; no hard sessions occur within the final week before the criterium event.",
+      "hypothesis": "Consecutive rest days are flagged as excessive when the event is still >10 days away; one active recovery day should replace a full rest day in such cases.",
       "count": 1
     },
     {
-      "hypothesis": "Combined adverse metrics trigger a more comprehensive plan modification than isolated single-metric changes, demonstrating proper signal integration.",
+      "hypothesis": "Conservative bias triggers additional rest days but may over-react by removing necessary event-specific stimulus for high-surge events like criteriums.",
       "count": 1
     },
     {
-      "hypothesis": "Combined adverse reports trigger appropriately aggressive responses while preserving event-critical work.",
+      "hypothesis": "Evergreen mode's frequent rest days (6/14) are appropriate for maintenance but could be tightened to 3–4 days per week for users seeking performance gains.",
       "count": 1
     },
     {
-      "hypothesis": "Conservative bias meaningfully increases recovery days and shifts hard sessions later in the week, which is appropriate for a conservative preference.",
+      "hypothesis": "For acute adverse cases, a single rest day followed by gradual return to hard work is acceptable if the perturbation resolves quickly.",
       "count": 1
     },
     {
-      "hypothesis": "For curtailed doses (partial completion), the planner appropriately adds a compensatory recovery day while preserving the rest structure, showing good sensitivity to sub-optimal stimulus delivery.",
+      "hypothesis": "For criterium events, the plan appropriately emphasizes repeatedSurges and sprintPower through dedicated surge sessions and race simulations.",
       "count": 1
     },
     {
-      "hypothesis": "For skipped workouts, the planner underreacts by only adding one compensatory hard session instead of replacing it with a threshold-focused alternative, suggesting the algorithm may be treating 'skipped' as less severe than it should be for criterium preparation.",
+      "hypothesis": "For gran fondo events, the plan appropriately emphasizes aerobicEndurance and fatigueResistance through event-specific endurance rides and sustained zone 2 work.",
       "count": 1
     },
     {
-      "hypothesis": "For surged doses, the planner overreacts by inserting additional hard sessions rather than accepting that the increased intensity already provides sufficient quality stimulus — this indicates an overly conservative fatigue model.",
+      "hypothesis": "For persistent adverse cases, hard sessions should be delayed until after the adverse window fully resolves — scheduling them during the adverse period is unsafe regardless of 'improving' labels.",
       "count": 1
     },
     {
-      "hypothesis": "Front-loading the race simulation closer to the event when recent hard work is present preserves critical surge stimulus timing while managing fatigue.",
+      "hypothesis": "For upper-body perturbations, the algorithm correctly recognizes that no interference exists with cycling-specific performance, suggesting the current sensitivity threshold is appropriately calibrated for this modality.",
       "count": 1
     },
     {
-      "hypothesis": "HRV delta of -17 combined with readiness=3 and fatigue=8 justifies rest; HRV delta of -5 alone does not require rest when other markers are stable.",
+      "hypothesis": "Hard sessions within 3–4 days of a high-priority event are flagged as risky and should be avoided or moved earlier in the week.",
       "count": 1
     },
     {
-      "hypothesis": "Local tissue soreness should carry more weight than currently implemented—soreness=8 warrants at least one additional rest or very easy day beyond what was provided in the 'sore_legs_great_hrv' case.",
+      "hypothesis": "Life stress and motivation are not soft preferences but hard safety constraints that must reduce training load; the current model treats them as optional modifiers rather than gating factors.",
       "count": 1
     },
     {
-      "hypothesis": "Mild isolated variation in subjective readiness does not warrant plan changes when objective metrics are stable.",
+      "hypothesis": "Mild isolated variations in subjective readiness (~1 SD movement) do not warrant plan changes when objective metrics support current load.",
       "count": 1
     },
     {
-      "hypothesis": "Mild overreaction in the heavy-lower case is acceptable given the high specificity of leg power to criterium performance, but could be calibrated by allowing very light aerobic activity on recovery days.",
+      "hypothesis": "Overreaction occurs when a single high-intensity session's completion ratio is used to de-escalate the entire plan, ignoring that the event demand profile does not require >105% surge intensity.",
       "count": 1
     },
     {
-      "hypothesis": "Mixed recovery correctly alternates rest and active recovery while maintaining overall load similar to neutral.",
+      "hypothesis": "Safety scores remain high across all cases because no plan violates hard constraints or introduces unsafe load combinations.",
       "count": 1
     },
     {
-      "hypothesis": "Non-conflicting constraints (e.g., restricted running for a cycling event) do not require plan changes — the system appropriately leaves the plan unchanged.",
+      "hypothesis": "Sensitivity quality is high: mild isolated variation (neutral case) leaves the plan unchanged, while significant perturbations trigger appropriate responses.",
       "count": 1
     },
     {
-      "hypothesis": "Overreaction hypothesis: judge_int_race7_badobj may be overly conservative — the algorithm might be over-weighting single-day HRV/RHR signals without considering longer-term trends or the athlete's historical resilience.",
+      "hypothesis": "The algorithm appropriately prioritizes surge session timing relative to the most recent hard session, ensuring at least 72 hours of recovery before high-intensity repeated-surge work.",
       "count": 1
     },
     {
-      "hypothesis": "Overreaction is detected when the plan inserts extra rest or active recovery for non-critical perturbations (power maintenance), suggesting the interference model may be slightly over-conservative for low-specificity strength work.",
+      "hypothesis": "The algorithm appropriately respects hard constraints (equipment availability, max time) across all cases.",
       "count": 1
     },
     {
-      "hypothesis": "Psychological stress signals are correctly treated as a soft constraint—plans can still include hard sessions when physical recovery is adequate, but volume is reduced.",
+      "hypothesis": "The algorithm appropriately rewards well-structured tapering with race-specific sharpening work (judge_event_14d) and penalizes lack of final-week power/sprint maintenance (judge_event_7d).",
       "count": 1
     },
     {
-      "hypothesis": "Rest/mobility buffers are appropriately inserted after hard sessions, regardless of recency, demonstrating robustness to perturbations.",
+      "hypothesis": "The algorithm appropriately uses rolling daily readiness rather than extrapolating from Day 1 state across the horizon.",
       "count": 1
     },
     {
-      "hypothesis": "Scheduled event load is consistently reserved as a fixed activity across all cases, preventing double-scheduling errors.",
+      "hypothesis": "The algorithm correctly avoids overreacting to mild isolated variation (~1 SD HRV/RHR shifts) but underreacts to moderate-to-severe signals (2 SD HRV, 2 SD RHR, poor sleep, low body battery).",
       "count": 1
     },
     {
-      "hypothesis": "Sleep deficits are treated as significant stressors warranting load reduction, though the response could be more aggressive given the severity of sleep deprivation (~1 hour short).",
+      "hypothesis": "The algorithm correctly avoids overreacting to priority changes when no hard constraints are violated — mild isolated variation (priority A vs B) can legitimately leave a good plan unchanged.",
       "count": 1
     },
     {
-      "hypothesis": "Soreness threshold appears to be around 6-7/10 for triggering extended rest — below that, mild soreness is tolerated even with moderate fatigue.",
+      "hypothesis": "The algorithm correctly distinguishes between acute (1-day) and persistent (3-day) adverse trajectories in its response strategy.",
       "count": 1
     },
     {
-      "hypothesis": "The algorithm appropriately does not overreact to mild isolated variations (e.g., neutral baseline) and maintains plan stability, which is correct behavior for robust planning.",
+      "hypothesis": "The algorithm correctly distinguishes between physiological safety signals (fatigue, soreness, stress) and non-physiological factors (motivation).",
       "count": 1
     },
     {
-      "hypothesis": "The algorithm appropriately escalates caution when both poor objective metrics AND hard recent training are present (judge_int_badobj_hard_yday).",
+      "hypothesis": "The algorithm correctly identifies that hard sessions completed >48 hours ago do not require plan modification, while those within 24-48 hours warrant sequencing adjustments.",
       "count": 1
     },
     {
-      "hypothesis": "The algorithm appropriately preserves race-specific surge work in all cases while reducing overall systemic load when recovery metrics degrade.",
+      "hypothesis": "The algorithm correctly identifies underreaction in cases where rest days are excessive relative to event proximity (judge_event_20d, judge_event_3d).",
       "count": 1
     },
     {
-      "hypothesis": "The algorithm correctly avoids overreacting to isolated mild perturbations (e.g., Day 1 borderline in improving_trend) while responding appropriately to sustained adverse states.",
+      "hypothesis": "The algorithm correctly respects hard constraints (equipment availability, max time) across all cases.",
       "count": 1
     },
     {
-      "hypothesis": "The algorithm correctly avoids overreacting to mild HRV/RHR fluctuations (1 SD) that do not constitute hard safety signals.",
+      "hypothesis": "The algorithm correctly treats priority as a soft axis that does not require physiological plan changes when hard constraints and safety are satisfied.",
       "count": 1
     },
     {
-      "hypothesis": "The algorithm correctly distinguishes between active and expired injury constraints.",
+      "hypothesis": "The algorithm demonstrates appropriate sensitivity to the changed axis (days to event) by adjusting periodization intensity appropriately for each horizon.",
       "count": 1
     },
     {
-      "hypothesis": "The algorithm correctly distinguishes between acute (1-day) and persistent (3-day) adverse trajectories, applying appropriate rest durations without overreacting to mild signals.",
+      "hypothesis": "The algorithm may be overreacting to heavy lower-body perturbations by reducing overall training volume beyond what is necessary for event preparation. A more nuanced approach would allow light active recovery or mobility on the day following a heavy lower-body session, rather than defaulting to full rest and reduced cycling.",
       "count": 1
     },
     {
-      "hypothesis": "The algorithm correctly distinguishes between concurrent strength perturbations that are decision-relevant (heavy lower-body) versus those that are not (heavy upper-body, power maintenance).",
+      "hypothesis": "The algorithm should enforce a minimum taper window before A-priority events regardless of how 'fresh' the athlete feels, to avoid performance degradation from accumulated cognitive or systemic fatigue.",
       "count": 1
     },
     {
-      "hypothesis": "The algorithm correctly distinguishes between criterium and gran fondo event demands in its stimulus profile selection, but the periodization logic (rest day placement) appears to be a fixed pattern rather than dynamically adjusted based on readiness trajectory or cumulative fatigue.",
+      "hypothesis": "The algorithm should weight body_battery_wake as a primary safety signal alongside HRV/RHR, since it captures systemic fatigue not reflected in traditional metrics.",
       "count": 1
     },
     {
-      "hypothesis": "The algorithm correctly distinguishes between mild (1 SD) and moderate/severe (>2 SD or combined) adverse signals, applying appropriate response intensity.",
+      "hypothesis": "The algorithm should weight local tissue signals (soreness, painFlag) more heavily than systemic wearable metrics when they conflict, especially for lower-body events like criteriums.",
       "count": 1
     },
     {
-      "hypothesis": "The algorithm correctly distinguishes between mild perturbations (easy yesterday) and significant ones (hard yesterday/2d/3d), adjusting plan structure accordingly.",
+      "hypothesis": "The conservative_overlay mode should not allow high systemic-cost sessions within 3–4 days of an A-priority event; a hard safety rule should cap cumulative systemic cost in the final 5 days at ≤2.0.",
       "count": 1
     },
     {
-      "hypothesis": "The algorithm correctly prioritizes objective physiological signals (HRV, RHR) over subjective feelings when they conflict — demonstrated in judge_int_badsubj_goodobj and judge_int_goodsubj_badobj cases.",
+      "hypothesis": "The expired-review case correctly reverts to baseline, confirming that inactive constraints do not leak into planning decisions. This is correct and expected.",
       "count": 1
     },
     {
-      "hypothesis": "The algorithm correctly prioritizes systemic wearable signals (HRV, RHR, sleep) over local tissue sensations in cases of severe conflict (terrible HRV with fresh legs), but may still be slightly conservative by not fully eliminating high-load sessions when systemic recovery is poor.",
+      "hypothesis": "The judge correctly distinguishes between mild delivery variance (curtailed case) and meaningful absence of training history (skipped case).",
       "count": 1
     },
     {
-      "hypothesis": "The algorithm does not differentiate plans based on event priority (A vs B), which is appropriate since the same plan serves both priorities when constraints and demands are identical. This indicates good sensitivity to non-decision-relevant axis changes.",
+      "hypothesis": "The lower-body-restricted case reveals a critical flaw: the planner treats 'avoid_heavy_lower_body' as a soft preference rather than a hard constraint. The guardrail flag is set but not enforced at the session level — sessions are still generated with moderate-to-high lowerBody cost values (0.3–0.8). This suggests the constraint enforcement logic needs to be strengthened: when avoid_heavy_lower_body is active, the planner should either exclude cycling entirely or only allow very low-resistance Zone 1 work that does not meaningfully load the lower body.",
       "count": 1
     },
     {
-      "hypothesis": "The algorithm does not overreact to mild variations (easy yesterday) but responds meaningfully to significant ones (hard sessions), aligning with the calibration rule that sensitivity need not change plans for every perturbation.",
+      "hypothesis": "The planner correctly distinguishes between 'fresh' conditions (allowing normal progression) and 'poor recovery' conditions (triggering taper/rest).",
       "count": 1
     },
     {
-      "hypothesis": "The algorithm shows good sensitivity to equipment constraints and safety guardrails across all cases.",
+      "hypothesis": "The planner correctly prioritizes objective recovery signals (HRV, RHR) over subjective readiness when they conflict.",
       "count": 1
     },
     {
-      "hypothesis": "The conservative preference mode risks under-preparing for high-demand events by over-applying rest and avoiding hard sessions. It needs a minimum intensity floor tied to the event demand profile.",
+      "hypothesis": "The running-restricted case correctly produces an unchanged plan because no running was ever scheduled — this confirms the constraint system properly handles 'no-op' scenarios where the restricted modality is never selected. This is appropriate behavior and should be preserved.",
       "count": 1
     },
     {
-      "hypothesis": "The evergreen mode should be flagged as low event alignment when an A-priority event exists; it should not default to pure maintenance without any event-specific stimulus.",
+      "hypothesis": "Time capacity constraints (45/90 min) primarily affect session duration rather than structural plan changes, with the 45-min case showing slight under-reaction to taper needs due to compressed hard sessions.",
       "count": 1
     },
     {
-      "hypothesis": "The planner correctly adjusts training volume and intensity based on the time remaining until the event, with longer horizons allowing for more progressive overload and shorter horizons requiring more tapering.",
+      "hypothesis": "Travel_constraints mode currently drops cycling entirely when equipment is unavailable — this may be too aggressive if outdoor bike access exists; consider allowing short outdoor rides as fallback.",
       "count": 1
     },
     {
-      "hypothesis": "The planner correctly distinguishes between soft signals (low motivation) and hard physiological signals (high fatigue/soreness/stress).",
+      "hypothesis": "Underreaction occurs when minor delivery variance (~33% reduction in one session) triggers no structural change to the plan, which is appropriate given the robustness of the overall stimulus distribution.",
       "count": 1
     },
     {
-      "hypothesis": "The planner correctly identifies the event as a fixed activity and does not schedule additional workouts on top of it.",
-      "count": 1
-    },
-    {
-      "hypothesis": "The planner correctly prioritizes cycling-specific work (VO2max, surge intervals) over general strength maintenance as the event approaches.",
-      "count": 1
-    },
-    {
-      "hypothesis": "The planner correctly respects hard constraints (maxTimeMinutes) across all capacity variants.",
-      "count": 1
-    },
-    {
-      "hypothesis": "The planner correctly treats exact delivered dose as requiring no adjustment — this is the expected baseline behavior.",
-      "count": 1
-    },
-    {
-      "hypothesis": "The planner respects the calibration rule that low motivation alone is not a physiological safety signal.",
-      "count": 1
-    },
-    {
-      "hypothesis": "The travel overlay correctly handles zero-equipment constraints but may need an optional 'surges' template that can be executed with bodyweight or minimal equipment.",
-      "count": 1
-    },
-    {
-      "hypothesis": "Under-tapering in the lower-body-restricted case reveals a need to strengthen event-week taper logic when guardrails are active, even if they don't directly conflict with the preferred modality.",
-      "count": 1
-    },
-    {
-      "hypothesis": "Underreaction hypothesis: judge_int_fresh_hard_yday could benefit from slightly more aggressive taper given the hard yesterday, though the current plan is defensible.",
+      "hypothesis": "When poor objective metrics coincide with a hard session from the prior day, the planner appropriately escalates caution (more rest, lighter work).",
       "count": 1
     }
   ],

--- a/docs/analysis/plan-judge-stability.json
+++ b/docs/analysis/plan-judge-stability.json
@@ -2,35 +2,35 @@
   "schema": "adaptive-training-recommender/ai-plan-judge-stability@1",
   "samples": 5,
   "familiesCount": 13,
-  "maxContextUtilization": 0.786,
-  "totalPromptTokens": 2120830,
-  "totalCompletionTokens": 111639,
+  "maxContextUtilization": 0.811,
+  "totalPromptTokens": 2300975,
+  "totalCompletionTokens": 114961,
   "families": [
     {
       "familyId": "objective_recovery",
       "samples": 5,
-      "familySensitivityMedian": 8.5,
+      "familySensitivityMedian": 7.5,
       "familySensitivityMad": 0.5,
       "familySensitivitySpread": 2,
       "dimensionMadAverages": {
-        "safety_recovery_fit": 0.75,
-        "goal_event_fit": 0.38,
-        "sequencing": 0.38,
-        "periodization_taper": 0.13,
-        "preference_capacity_fit": 0.5,
-        "robustness": 0.38,
-        "overall": 0.29
+        "safety_recovery_fit": 0.46,
+        "goal_event_fit": 0.5,
+        "sequencing": 0.13,
+        "periodization_taper": 0.31,
+        "preference_capacity_fit": 0.25,
+        "robustness": 0.57,
+        "overall": 0.4
       },
       "cases": {
         "judge_obj_neutral": {
           "scoreMedians": {
-            "safety_recovery_fit": 9.5,
-            "goal_event_fit": 9.5,
-            "sequencing": 9,
-            "periodization_taper": 8.5,
+            "safety_recovery_fit": 9,
+            "goal_event_fit": 9,
+            "sequencing": 8.5,
+            "periodization_taper": 8,
             "preference_capacity_fit": 10,
-            "robustness": 9,
-            "overall": 9
+            "robustness": 8,
+            "overall": 8.5
           },
           "dimensionMads": {
             "safety_recovery_fit": 0,
@@ -38,492 +38,183 @@
             "sequencing": 0,
             "periodization_taper": 0,
             "preference_capacity_fit": 0,
-            "robustness": 0,
-            "overall": 0
-          },
-          "maxSpread": 1
-        },
-        "judge_obj_hrv_1sd": {
-          "scoreMedians": {
-            "safety_recovery_fit": 7.5,
-            "goal_event_fit": 8.5,
-            "sequencing": 8,
-            "periodization_taper": 7,
-            "preference_capacity_fit": 9,
-            "robustness": 7.5,
-            "overall": 7.5
-          },
-          "dimensionMads": {
-            "safety_recovery_fit": 1,
-            "goal_event_fit": 0,
-            "sequencing": 0.5,
-            "periodization_taper": 0,
-            "preference_capacity_fit": 1,
             "robustness": 0.5,
             "overall": 0
           },
-          "maxSpread": 2.5
+          "maxSpread": 1.5
+        },
+        "judge_obj_hrv_1sd": {
+          "scoreMedians": {
+            "safety_recovery_fit": 9,
+            "goal_event_fit": 9,
+            "sequencing": 8.5,
+            "periodization_taper": 8,
+            "preference_capacity_fit": 10,
+            "robustness": 8,
+            "overall": 8.5
+          },
+          "dimensionMads": {
+            "safety_recovery_fit": 0,
+            "goal_event_fit": 0,
+            "sequencing": 0,
+            "periodization_taper": 0,
+            "preference_capacity_fit": 0,
+            "robustness": 0.5,
+            "overall": 0.1999999999999993
+          },
+          "maxSpread": 1.5
         },
         "judge_obj_hrv_2sd": {
           "scoreMedians": {
             "safety_recovery_fit": 7.5,
-            "goal_event_fit": 8,
-            "sequencing": 7.5,
-            "periodization_taper": 7.5,
+            "goal_event_fit": 8.5,
+            "sequencing": 7,
+            "periodization_taper": 6.5,
             "preference_capacity_fit": 9,
-            "robustness": 7.5,
-            "overall": 7.5
+            "robustness": 6,
+            "overall": 7
           },
           "dimensionMads": {
             "safety_recovery_fit": 1,
-            "goal_event_fit": 0.5,
-            "sequencing": 0.5,
-            "periodization_taper": 0.5,
-            "preference_capacity_fit": 1,
-            "robustness": 1,
-            "overall": 0.5
-          },
-          "maxSpread": 3
-        },
-        "judge_obj_rhr_1sd": {
-          "scoreMedians": {
-            "safety_recovery_fit": 8.5,
-            "goal_event_fit": 9,
-            "sequencing": 8.5,
-            "periodization_taper": 7.5,
-            "preference_capacity_fit": 9,
-            "robustness": 8.5,
-            "overall": 8.5
-          },
-          "dimensionMads": {
-            "safety_recovery_fit": 0.5,
-            "goal_event_fit": 0,
-            "sequencing": 0.5,
+            "goal_event_fit": 1,
+            "sequencing": 0,
             "periodization_taper": 0.5,
             "preference_capacity_fit": 0,
             "robustness": 0,
-            "overall": 0
+            "overall": 0.5
+          },
+          "maxSpread": 2.5
+        },
+        "judge_obj_rhr_1sd": {
+          "scoreMedians": {
+            "safety_recovery_fit": 9,
+            "goal_event_fit": 9,
+            "sequencing": 8.5,
+            "periodization_taper": 8,
+            "preference_capacity_fit": 10,
+            "robustness": 8,
+            "overall": 8.5
+          },
+          "dimensionMads": {
+            "safety_recovery_fit": 0,
+            "goal_event_fit": 0,
+            "sequencing": 0,
+            "periodization_taper": 0,
+            "preference_capacity_fit": 0,
+            "robustness": 0.5,
+            "overall": 0.1999999999999993
           },
           "maxSpread": 1.5
         },
         "judge_obj_rhr_2sd": {
           "scoreMedians": {
             "safety_recovery_fit": 7.5,
-            "goal_event_fit": 7.5,
-            "sequencing": 7.5,
-            "periodization_taper": 7.5,
-            "preference_capacity_fit": 8.5,
-            "robustness": 7,
+            "goal_event_fit": 8.5,
+            "sequencing": 7,
+            "periodization_taper": 6.5,
+            "preference_capacity_fit": 9,
+            "robustness": 6,
             "overall": 7
           },
           "dimensionMads": {
-            "safety_recovery_fit": 1,
-            "goal_event_fit": 0.5,
-            "sequencing": 0.5,
-            "periodization_taper": 0,
-            "preference_capacity_fit": 1.5,
-            "robustness": 0.5,
-            "overall": 0.5
+            "safety_recovery_fit": 1.2000000000000002,
+            "goal_event_fit": 1,
+            "sequencing": 0,
+            "periodization_taper": 0.5,
+            "preference_capacity_fit": 0,
+            "robustness": 0.20000000000000018,
+            "overall": 0.7999999999999998
           },
-          "maxSpread": 3.5
+          "maxSpread": 3
         },
         "judge_obj_poor_sleep": {
           "scoreMedians": {
-            "safety_recovery_fit": 7.5,
-            "goal_event_fit": 8,
-            "sequencing": 7.5,
-            "periodization_taper": 7.5,
-            "preference_capacity_fit": 8,
-            "robustness": 7.5,
-            "overall": 7.5
+            "safety_recovery_fit": 7,
+            "goal_event_fit": 7.5,
+            "sequencing": 7,
+            "periodization_taper": 6.5,
+            "preference_capacity_fit": 9,
+            "robustness": 6.2,
+            "overall": 6.8
           },
           "dimensionMads": {
-            "safety_recovery_fit": 1,
+            "safety_recovery_fit": 0.5,
             "goal_event_fit": 0.5,
-            "sequencing": 0.5,
-            "periodization_taper": 0,
-            "preference_capacity_fit": 0,
-            "robustness": 0.5,
-            "overall": 0.5
+            "sequencing": 0,
+            "periodization_taper": 0.5,
+            "preference_capacity_fit": 1,
+            "robustness": 1.2000000000000002,
+            "overall": 0.2999999999999998
           },
           "maxSpread": 2.5
         },
         "judge_obj_low_battery": {
           "scoreMedians": {
-            "safety_recovery_fit": 7.5,
-            "goal_event_fit": 8,
-            "sequencing": 7.5,
-            "periodization_taper": 7.5,
-            "preference_capacity_fit": 8,
-            "robustness": 7.5,
-            "overall": 7.5
-          },
-          "dimensionMads": {
-            "safety_recovery_fit": 1,
-            "goal_event_fit": 0.5,
-            "sequencing": 0.5,
-            "periodization_taper": 0,
-            "preference_capacity_fit": 0,
-            "robustness": 0.5,
-            "overall": 0.5
-          },
-          "maxSpread": 2.5
-        },
-        "judge_obj_combined_bad": {
-          "scoreMedians": {
-            "safety_recovery_fit": 9,
-            "goal_event_fit": 8,
-            "sequencing": 8.5,
-            "periodization_taper": 9,
+            "safety_recovery_fit": 7,
+            "goal_event_fit": 7.5,
+            "sequencing": 7,
+            "periodization_taper": 6,
             "preference_capacity_fit": 9,
-            "robustness": 9,
-            "overall": 8.2
+            "robustness": 6,
+            "overall": 6.5
           },
           "dimensionMads": {
             "safety_recovery_fit": 0.5,
             "goal_event_fit": 1,
-            "sequencing": 0,
-            "periodization_taper": 0,
-            "preference_capacity_fit": 0.5,
-            "robustness": 0,
-            "overall": 0.3000000000000007
+            "sequencing": 0.5,
+            "periodization_taper": 0.5,
+            "preference_capacity_fit": 1,
+            "robustness": 1,
+            "overall": 0.7000000000000002
           },
-          "maxSpread": 2
+          "maxSpread": 3.5
+        },
+        "judge_obj_combined_bad": {
+          "scoreMedians": {
+            "safety_recovery_fit": 9,
+            "goal_event_fit": 8.5,
+            "sequencing": 8,
+            "periodization_taper": 9,
+            "preference_capacity_fit": 9,
+            "robustness": 8.2,
+            "overall": 8.5
+          },
+          "dimensionMads": {
+            "safety_recovery_fit": 0.5,
+            "goal_event_fit": 0.5,
+            "sequencing": 0.5,
+            "periodization_taper": 0.5,
+            "preference_capacity_fit": 0,
+            "robustness": 0.6999999999999993,
+            "overall": 0.5
+          },
+          "maxSpread": 2.5
         }
       }
     },
     {
       "familyId": "subjective_recovery",
       "samples": 5,
-      "familySensitivityMedian": 9,
-      "familySensitivityMad": 0.1999999999999993,
-      "familySensitivitySpread": 0.7,
+      "familySensitivityMedian": 8.2,
+      "familySensitivityMad": 0.8000000000000007,
+      "familySensitivitySpread": 2,
       "dimensionMadAverages": {
-        "safety_recovery_fit": 0.16,
-        "goal_event_fit": 0.44,
-        "sequencing": 0.2,
-        "periodization_taper": 0.41,
-        "preference_capacity_fit": 0,
-        "robustness": 0.35,
-        "overall": 0.3
+        "safety_recovery_fit": 0.5,
+        "goal_event_fit": 0.25,
+        "sequencing": 0.31,
+        "periodization_taper": 0.25,
+        "preference_capacity_fit": 0.25,
+        "robustness": 0.36,
+        "overall": 0.31
       },
       "cases": {
         "judge_subj_neutral": {
           "scoreMedians": {
-            "safety_recovery_fit": 8.5,
-            "goal_event_fit": 9,
-            "sequencing": 8.2,
-            "periodization_taper": 7.5,
-            "preference_capacity_fit": 9,
-            "robustness": 8,
-            "overall": 8.5
-          },
-          "dimensionMads": {
-            "safety_recovery_fit": 0.5,
-            "goal_event_fit": 0.5,
-            "sequencing": 0.1999999999999993,
-            "periodization_taper": 0.5,
-            "preference_capacity_fit": 0,
-            "robustness": 0.5,
-            "overall": 0.1999999999999993
-          },
-          "maxSpread": 1.5
-        },
-        "judge_subj_fresh": {
-          "scoreMedians": {
-            "safety_recovery_fit": 8.5,
-            "goal_event_fit": 9,
-            "sequencing": 8.2,
-            "periodization_taper": 7.5,
-            "preference_capacity_fit": 9,
-            "robustness": 8,
-            "overall": 8.5
-          },
-          "dimensionMads": {
-            "safety_recovery_fit": 0.5,
-            "goal_event_fit": 0.5,
-            "sequencing": 0.1999999999999993,
-            "periodization_taper": 0.5,
-            "preference_capacity_fit": 0,
-            "robustness": 0.5,
-            "overall": 0.1999999999999993
-          },
-          "maxSpread": 1.5
-        },
-        "judge_subj_low_readiness": {
-          "scoreMedians": {
-            "safety_recovery_fit": 8.5,
-            "goal_event_fit": 8.5,
-            "sequencing": 8,
-            "periodization_taper": 7.5,
-            "preference_capacity_fit": 9,
-            "robustness": 8,
-            "overall": 8.3
-          },
-          "dimensionMads": {
-            "safety_recovery_fit": 0,
-            "goal_event_fit": 0,
-            "sequencing": 0,
-            "periodization_taper": 0.5,
-            "preference_capacity_fit": 0,
-            "robustness": 0.5,
-            "overall": 0.3999999999999986
-          },
-          "maxSpread": 1
-        },
-        "judge_subj_fatigue": {
-          "scoreMedians": {
-            "safety_recovery_fit": 8.5,
-            "goal_event_fit": 8,
-            "sequencing": 8,
-            "periodization_taper": 7.5,
-            "preference_capacity_fit": 9,
-            "robustness": 8,
-            "overall": 8.2
-          },
-          "dimensionMads": {
-            "safety_recovery_fit": 0,
-            "goal_event_fit": 0.5,
-            "sequencing": 0.3000000000000007,
-            "periodization_taper": 0,
-            "preference_capacity_fit": 0,
-            "robustness": 0.1999999999999993,
-            "overall": 0.3000000000000007
-          },
-          "maxSpread": 2
-        },
-        "judge_subj_soreness": {
-          "scoreMedians": {
-            "safety_recovery_fit": 8.5,
-            "goal_event_fit": 8.5,
-            "sequencing": 8,
-            "periodization_taper": 7.5,
-            "preference_capacity_fit": 9,
-            "robustness": 8,
-            "overall": 8.3
-          },
-          "dimensionMads": {
-            "safety_recovery_fit": 0,
-            "goal_event_fit": 1,
-            "sequencing": 0.3000000000000007,
-            "periodization_taper": 0.5,
-            "preference_capacity_fit": 0,
-            "robustness": 0.1999999999999993,
-            "overall": 0.1999999999999993
-          },
-          "maxSpread": 2
-        },
-        "judge_subj_stress": {
-          "scoreMedians": {
-            "safety_recovery_fit": 8.5,
-            "goal_event_fit": 8.5,
-            "sequencing": 8,
-            "periodization_taper": 7.5,
-            "preference_capacity_fit": 9,
-            "robustness": 8,
-            "overall": 8.3
-          },
-          "dimensionMads": {
-            "safety_recovery_fit": 0,
-            "goal_event_fit": 1,
-            "sequencing": 0.3000000000000007,
-            "periodization_taper": 0.5,
-            "preference_capacity_fit": 0,
-            "robustness": 0.1999999999999993,
-            "overall": 0.1999999999999993
-          },
-          "maxSpread": 2
-        },
-        "judge_subj_low_motivation": {
-          "scoreMedians": {
-            "safety_recovery_fit": 8.5,
-            "goal_event_fit": 8.5,
-            "sequencing": 8,
-            "periodization_taper": 7.5,
-            "preference_capacity_fit": 9,
-            "robustness": 8,
-            "overall": 8.3
-          },
-          "dimensionMads": {
-            "safety_recovery_fit": 0,
-            "goal_event_fit": 0,
-            "sequencing": 0,
-            "periodization_taper": 0.5,
-            "preference_capacity_fit": 0,
-            "robustness": 0.5,
-            "overall": 0.3999999999999986
-          },
-          "maxSpread": 1
-        },
-        "judge_subj_combined_bad": {
-          "scoreMedians": {
-            "safety_recovery_fit": 8.5,
-            "goal_event_fit": 8,
-            "sequencing": 7.8,
-            "periodization_taper": 7.5,
-            "preference_capacity_fit": 9,
-            "robustness": 8.2,
-            "overall": 8
-          },
-          "dimensionMads": {
-            "safety_recovery_fit": 0.3000000000000007,
-            "goal_event_fit": 0,
-            "sequencing": 0.2999999999999998,
-            "periodization_taper": 0.2999999999999998,
-            "preference_capacity_fit": 0,
-            "robustness": 0.1999999999999993,
-            "overall": 0.5
-          },
-          "maxSpread": 2.3
-        }
-      }
-    },
-    {
-      "familyId": "recent_training",
-      "samples": 5,
-      "familySensitivityMedian": 9,
-      "familySensitivityMad": 0,
-      "familySensitivitySpread": 0.7,
-      "dimensionMadAverages": {
-        "safety_recovery_fit": 0.18,
-        "goal_event_fit": 0.4,
-        "sequencing": 0.32,
-        "periodization_taper": 0.76,
-        "preference_capacity_fit": 0.4,
-        "robustness": 0.1,
-        "overall": 0.2
-      },
-      "cases": {
-        "judge_load_none": {
-          "scoreMedians": {
-            "safety_recovery_fit": 9,
-            "goal_event_fit": 9,
-            "sequencing": 8,
-            "periodization_taper": 8,
-            "preference_capacity_fit": 9,
-            "robustness": 8,
-            "overall": 8.5
-          },
-          "dimensionMads": {
-            "safety_recovery_fit": 0,
-            "goal_event_fit": 0.5,
-            "sequencing": 0.5,
-            "periodization_taper": 1,
-            "preference_capacity_fit": 0,
-            "robustness": 0,
-            "overall": 0.1999999999999993
-          },
-          "maxSpread": 3
-        },
-        "judge_load_easy_yesterday": {
-          "scoreMedians": {
-            "safety_recovery_fit": 8.5,
-            "goal_event_fit": 8.5,
-            "sequencing": 8,
-            "periodization_taper": 8,
-            "preference_capacity_fit": 9,
-            "robustness": 8,
-            "overall": 8
-          },
-          "dimensionMads": {
-            "safety_recovery_fit": 0.5,
-            "goal_event_fit": 0.5,
-            "sequencing": 0.5,
-            "periodization_taper": 1,
-            "preference_capacity_fit": 0.5,
-            "robustness": 0,
-            "overall": 0.3000000000000007
-          },
-          "maxSpread": 3
-        },
-        "judge_load_hard_yesterday": {
-          "scoreMedians": {
-            "safety_recovery_fit": 8.5,
-            "goal_event_fit": 8.5,
-            "sequencing": 8,
-            "periodization_taper": 8,
-            "preference_capacity_fit": 9,
-            "robustness": 8.3,
-            "overall": 8
-          },
-          "dimensionMads": {
-            "safety_recovery_fit": 0,
-            "goal_event_fit": 0.5,
-            "sequencing": 0.1999999999999993,
-            "periodization_taper": 0.5,
-            "preference_capacity_fit": 0.5,
-            "robustness": 0.3000000000000007,
-            "overall": 0.09999999999999964
-          },
-          "maxSpread": 1.8
-        },
-        "judge_load_hard_2d": {
-          "scoreMedians": {
-            "safety_recovery_fit": 8.5,
-            "goal_event_fit": 8.5,
-            "sequencing": 8,
-            "periodization_taper": 8,
-            "preference_capacity_fit": 9,
-            "robustness": 8.2,
-            "overall": 8.2
-          },
-          "dimensionMads": {
-            "safety_recovery_fit": 0.1999999999999993,
-            "goal_event_fit": 0.5,
-            "sequencing": 0.40000000000000036,
-            "periodization_taper": 0.7999999999999998,
-            "preference_capacity_fit": 0.5,
-            "robustness": 0.10000000000000142,
-            "overall": 0.29999999999999893
-          },
-          "maxSpread": 3
-        },
-        "judge_load_hard_3d": {
-          "scoreMedians": {
-            "safety_recovery_fit": 8.7,
-            "goal_event_fit": 9,
-            "sequencing": 8,
-            "periodization_taper": 8.5,
-            "preference_capacity_fit": 9,
-            "robustness": 8.2,
-            "overall": 8.4
-          },
-          "dimensionMads": {
-            "safety_recovery_fit": 0.1999999999999993,
-            "goal_event_fit": 0,
-            "sequencing": 0,
-            "periodization_taper": 0.5,
-            "preference_capacity_fit": 0.5,
-            "robustness": 0.10000000000000142,
-            "overall": 0.09999999999999964
-          },
-          "maxSpread": 1.8
-        }
-      }
-    },
-    {
-      "familyId": "event_proximity",
-      "samples": 5,
-      "familySensitivityMedian": 9,
-      "familySensitivityMad": 0.5,
-      "familySensitivitySpread": 1,
-      "dimensionMadAverages": {
-        "safety_recovery_fit": 0.36,
-        "goal_event_fit": 0.5,
-        "sequencing": 0.38,
-        "periodization_taper": 0.6,
-        "preference_capacity_fit": 0.16,
-        "robustness": 0.24,
-        "overall": 0.42
-      },
-      "cases": {
-        "judge_event_40d": {
-          "scoreMedians": {
             "safety_recovery_fit": 9,
             "goal_event_fit": 9.5,
             "sequencing": 8.5,
-            "periodization_taper": 8,
-            "preference_capacity_fit": 9,
+            "periodization_taper": 9,
+            "preference_capacity_fit": 10,
             "robustness": 8.5,
             "overall": 8.7
           },
@@ -536,203 +227,182 @@
             "robustness": 0,
             "overall": 0
           },
+          "maxSpread": 1.5
+        },
+        "judge_subj_fresh": {
+          "scoreMedians": {
+            "safety_recovery_fit": 9,
+            "goal_event_fit": 9.5,
+            "sequencing": 8.5,
+            "periodization_taper": 9,
+            "preference_capacity_fit": 10,
+            "robustness": 8.5,
+            "overall": 8.7
+          },
+          "dimensionMads": {
+            "safety_recovery_fit": 0,
+            "goal_event_fit": 0,
+            "sequencing": 0,
+            "periodization_taper": 0,
+            "preference_capacity_fit": 0,
+            "robustness": 0,
+            "overall": 0
+          },
+          "maxSpread": 1.5
+        },
+        "judge_subj_low_readiness": {
+          "scoreMedians": {
+            "safety_recovery_fit": 7.5,
+            "goal_event_fit": 8.5,
+            "sequencing": 7.5,
+            "periodization_taper": 7,
+            "preference_capacity_fit": 8.5,
+            "robustness": 7.5,
+            "overall": 7.5
+          },
+          "dimensionMads": {
+            "safety_recovery_fit": 1.5,
+            "goal_event_fit": 1,
+            "sequencing": 1,
+            "periodization_taper": 1,
+            "preference_capacity_fit": 0.5,
+            "robustness": 1,
+            "overall": 1.1999999999999993
+          },
+          "maxSpread": 4
+        },
+        "judge_subj_fatigue": {
+          "scoreMedians": {
+            "safety_recovery_fit": 9,
+            "goal_event_fit": 8.5,
+            "sequencing": 8,
+            "periodization_taper": 8,
+            "preference_capacity_fit": 9,
+            "robustness": 8.2,
+            "overall": 7.8
+          },
+          "dimensionMads": {
+            "safety_recovery_fit": 0,
+            "goal_event_fit": 0,
+            "sequencing": 0,
+            "periodization_taper": 0.5,
+            "preference_capacity_fit": 0,
+            "robustness": 0.1999999999999993,
+            "overall": 0
+          },
+          "maxSpread": 1.5
+        },
+        "judge_subj_soreness": {
+          "scoreMedians": {
+            "safety_recovery_fit": 8,
+            "goal_event_fit": 8.5,
+            "sequencing": 8,
+            "periodization_taper": 7.5,
+            "preference_capacity_fit": 8.5,
+            "robustness": 7.5,
+            "overall": 7.5
+          },
+          "dimensionMads": {
+            "safety_recovery_fit": 1,
+            "goal_event_fit": 0,
+            "sequencing": 0,
+            "periodization_taper": 0.5,
+            "preference_capacity_fit": 0.5,
+            "robustness": 0.6999999999999993,
+            "overall": 0.2999999999999998
+          },
+          "maxSpread": 3.7
+        },
+        "judge_subj_stress": {
+          "scoreMedians": {
+            "safety_recovery_fit": 8,
+            "goal_event_fit": 8,
+            "sequencing": 7.5,
+            "periodization_taper": 7,
+            "preference_capacity_fit": 8.5,
+            "robustness": 7.5,
+            "overall": 7.5
+          },
+          "dimensionMads": {
+            "safety_recovery_fit": 1,
+            "goal_event_fit": 0.5,
+            "sequencing": 0.5,
+            "periodization_taper": 0,
+            "preference_capacity_fit": 0.5,
+            "robustness": 0.6999999999999993,
+            "overall": 0.2999999999999998
+          },
           "maxSpread": 2.5
         },
-        "judge_event_20d": {
+        "judge_subj_low_motivation": {
           "scoreMedians": {
-            "safety_recovery_fit": 8.5,
-            "goal_event_fit": 8.5,
-            "sequencing": 8,
-            "periodization_taper": 7,
-            "preference_capacity_fit": 9,
-            "robustness": 8.2,
-            "overall": 7.8
+            "safety_recovery_fit": 9,
+            "goal_event_fit": 9.5,
+            "sequencing": 8.5,
+            "periodization_taper": 9,
+            "preference_capacity_fit": 10,
+            "robustness": 8.5,
+            "overall": 8.7
           },
           "dimensionMads": {
-            "safety_recovery_fit": 0.5,
+            "safety_recovery_fit": 0,
             "goal_event_fit": 0,
             "sequencing": 0.5,
-            "periodization_taper": 0.5,
-            "preference_capacity_fit": 0.1999999999999993,
-            "robustness": 0.1999999999999993,
-            "overall": 0.39999999999999947
+            "periodization_taper": 0,
+            "preference_capacity_fit": 0,
+            "robustness": 0,
+            "overall": 0
           },
-          "maxSpread": 3
+          "maxSpread": 2
         },
-        "judge_event_14d": {
+        "judge_subj_combined_bad": {
           "scoreMedians": {
             "safety_recovery_fit": 8.5,
-            "goal_event_fit": 8,
-            "sequencing": 8,
-            "periodization_taper": 6.5,
-            "preference_capacity_fit": 9,
-            "robustness": 8.2,
-            "overall": 7.8
+            "goal_event_fit": 7,
+            "sequencing": 7,
+            "periodization_taper": 7,
+            "preference_capacity_fit": 8,
+            "robustness": 7.5,
+            "overall": 6.5
           },
           "dimensionMads": {
             "safety_recovery_fit": 0.5,
-            "goal_event_fit": 1,
-            "sequencing": 0.8000000000000007,
-            "periodization_taper": 2,
-            "preference_capacity_fit": 0.1999999999999993,
-            "robustness": 0.3000000000000007,
-            "overall": 0.8999999999999995
-          },
-          "maxSpread": 5
-        },
-        "judge_event_7d": {
-          "scoreMedians": {
-            "safety_recovery_fit": 9,
-            "goal_event_fit": 8.5,
-            "sequencing": 8.5,
-            "periodization_taper": 9,
-            "preference_capacity_fit": 9,
-            "robustness": 8.2,
-            "overall": 8.3
-          },
-          "dimensionMads": {
-            "safety_recovery_fit": 0.3000000000000007,
             "goal_event_fit": 0.5,
-            "sequencing": 0.3000000000000007,
+            "sequencing": 0.5,
             "periodization_taper": 0,
-            "preference_capacity_fit": 0.1999999999999993,
-            "robustness": 0.3000000000000007,
-            "overall": 0.3999999999999986
-          },
-          "maxSpread": 3
-        },
-        "judge_event_3d": {
-          "scoreMedians": {
-            "safety_recovery_fit": 9,
-            "goal_event_fit": 8.5,
-            "sequencing": 8.5,
-            "periodization_taper": 9,
-            "preference_capacity_fit": 9,
-            "robustness": 8.2,
-            "overall": 8
-          },
-          "dimensionMads": {
-            "safety_recovery_fit": 0.5,
-            "goal_event_fit": 1,
-            "sequencing": 0.3000000000000007,
-            "periodization_taper": 0.5,
-            "preference_capacity_fit": 0.1999999999999993,
-            "robustness": 0.40000000000000036,
-            "overall": 0.40000000000000036
+            "preference_capacity_fit": 0.5,
+            "robustness": 0.2999999999999998,
+            "overall": 0.7000000000000002
           },
           "maxSpread": 3
         }
       }
     },
     {
-      "familyId": "preferences_capacity",
+      "familyId": "recent_training",
       "samples": 5,
-      "familySensitivityMedian": 8.7,
-      "familySensitivityMad": 0.3000000000000007,
-      "familySensitivitySpread": 1,
+      "familySensitivityMedian": 9,
+      "familySensitivityMad": 0,
+      "familySensitivitySpread": 0.7,
       "dimensionMadAverages": {
-        "safety_recovery_fit": 0,
-        "goal_event_fit": 0.17,
-        "sequencing": 0,
-        "periodization_taper": 0.33,
-        "preference_capacity_fit": 0,
-        "robustness": 0.05,
-        "overall": 0.03
+        "safety_recovery_fit": 0.22,
+        "goal_event_fit": 0.3,
+        "sequencing": 0.58,
+        "periodization_taper": 0.46,
+        "preference_capacity_fit": 0.1,
+        "robustness": 0.2,
+        "overall": 0.24
       },
       "cases": {
-        "judge_pref_neutral": {
+        "judge_load_none": {
           "scoreMedians": {
             "safety_recovery_fit": 9,
-            "goal_event_fit": 9,
-            "sequencing": 8.5,
-            "periodization_taper": 7.5,
-            "preference_capacity_fit": 10,
-            "robustness": 8,
-            "overall": 8.5
-          },
-          "dimensionMads": {
-            "safety_recovery_fit": 0,
-            "goal_event_fit": 0,
-            "sequencing": 0,
-            "periodization_taper": 0,
-            "preference_capacity_fit": 0,
-            "robustness": 0,
-            "overall": 0
-          },
-          "maxSpread": 1
-        },
-        "judge_pref_conservative": {
-          "scoreMedians": {
-            "safety_recovery_fit": 9.5,
-            "goal_event_fit": 7.5,
-            "sequencing": 8,
+            "goal_event_fit": 9.5,
+            "sequencing": 9,
             "periodization_taper": 8,
             "preference_capacity_fit": 10,
             "robustness": 8.5,
-            "overall": 8
-          },
-          "dimensionMads": {
-            "safety_recovery_fit": 0,
-            "goal_event_fit": 0.5,
-            "sequencing": 0,
-            "periodization_taper": 1,
-            "preference_capacity_fit": 0,
-            "robustness": 0,
-            "overall": 0.1999999999999993
-          },
-          "maxSpread": 2
-        },
-        "judge_pref_active_recovery": {
-          "scoreMedians": {
-            "safety_recovery_fit": 9,
-            "goal_event_fit": 7.5,
-            "sequencing": 7.5,
-            "periodization_taper": 8,
-            "preference_capacity_fit": 10,
-            "robustness": 8,
-            "overall": 8
-          },
-          "dimensionMads": {
-            "safety_recovery_fit": 0,
-            "goal_event_fit": 0.5,
-            "sequencing": 0,
-            "periodization_taper": 0.5,
-            "preference_capacity_fit": 0,
-            "robustness": 0,
-            "overall": 0
-          },
-          "maxSpread": 2.5
-        },
-        "judge_pref_mixed_recovery": {
-          "scoreMedians": {
-            "safety_recovery_fit": 9,
-            "goal_event_fit": 9,
-            "sequencing": 8.5,
-            "periodization_taper": 7.5,
-            "preference_capacity_fit": 10,
-            "robustness": 8,
-            "overall": 8.5
-          },
-          "dimensionMads": {
-            "safety_recovery_fit": 0,
-            "goal_event_fit": 0,
-            "sequencing": 0,
-            "periodization_taper": 0,
-            "preference_capacity_fit": 0,
-            "robustness": 0.3000000000000007,
-            "overall": 0
-          },
-          "maxSpread": 4
-        },
-        "judge_pref_45min": {
-          "scoreMedians": {
-            "safety_recovery_fit": 9,
-            "goal_event_fit": 8.5,
-            "sequencing": 8,
-            "periodization_taper": 7.5,
-            "preference_capacity_fit": 10,
-            "robustness": 7.5,
-            "overall": 8
+            "overall": 8.7
           },
           "dimensionMads": {
             "safety_recovery_fit": 0,
@@ -745,26 +415,356 @@
           },
           "maxSpread": 1.5
         },
-        "judge_pref_90min": {
+        "judge_load_easy_yesterday": {
           "scoreMedians": {
-            "safety_recovery_fit": 9,
+            "safety_recovery_fit": 8.5,
             "goal_event_fit": 9,
-            "sequencing": 8.5,
+            "sequencing": 8,
             "periodization_taper": 7.5,
             "preference_capacity_fit": 10,
             "robustness": 8,
+            "overall": 8.2
+          },
+          "dimensionMads": {
+            "safety_recovery_fit": 0.6999999999999993,
+            "goal_event_fit": 0.5,
+            "sequencing": 1.3000000000000007,
+            "periodization_taper": 0.5,
+            "preference_capacity_fit": 0,
+            "robustness": 0.40000000000000036,
+            "overall": 0.40000000000000036
+          },
+          "maxSpread": 3.3
+        },
+        "judge_load_hard_yesterday": {
+          "scoreMedians": {
+            "safety_recovery_fit": 7,
+            "goal_event_fit": 8,
+            "sequencing": 7,
+            "periodization_taper": 7,
+            "preference_capacity_fit": 9.5,
+            "robustness": 7.2,
+            "overall": 7.3
+          },
+          "dimensionMads": {
+            "safety_recovery_fit": 0,
+            "goal_event_fit": 0.5,
+            "sequencing": 1,
+            "periodization_taper": 1,
+            "preference_capacity_fit": 0.5,
+            "robustness": 0.2999999999999998,
+            "overall": 0.5
+          },
+          "maxSpread": 3
+        },
+        "judge_load_hard_2d": {
+          "scoreMedians": {
+            "safety_recovery_fit": 9,
+            "goal_event_fit": 9,
+            "sequencing": 9,
+            "periodization_taper": 8,
+            "preference_capacity_fit": 10,
+            "robustness": 8.3,
             "overall": 8.5
+          },
+          "dimensionMads": {
+            "safety_recovery_fit": 0.1999999999999993,
+            "goal_event_fit": 0.5,
+            "sequencing": 0.3000000000000007,
+            "periodization_taper": 0,
+            "preference_capacity_fit": 0,
+            "robustness": 0.1999999999999993,
+            "overall": 0.1999999999999993
+          },
+          "maxSpread": 1
+        },
+        "judge_load_hard_3d": {
+          "scoreMedians": {
+            "safety_recovery_fit": 9,
+            "goal_event_fit": 9.5,
+            "sequencing": 8.8,
+            "periodization_taper": 8.3,
+            "preference_capacity_fit": 10,
+            "robustness": 8.5,
+            "overall": 8.6
+          },
+          "dimensionMads": {
+            "safety_recovery_fit": 0.1999999999999993,
+            "goal_event_fit": 0,
+            "sequencing": 0.3000000000000007,
+            "periodization_taper": 0.3000000000000007,
+            "preference_capacity_fit": 0,
+            "robustness": 0.09999999999999964,
+            "overall": 0.09999999999999964
+          },
+          "maxSpread": 1.3
+        }
+      }
+    },
+    {
+      "familyId": "event_proximity",
+      "samples": 5,
+      "familySensitivityMedian": 9,
+      "familySensitivityMad": 0.5,
+      "familySensitivitySpread": 1.5,
+      "dimensionMadAverages": {
+        "safety_recovery_fit": 0.2,
+        "goal_event_fit": 0.7,
+        "sequencing": 0.7,
+        "periodization_taper": 0.7,
+        "preference_capacity_fit": 0.5,
+        "robustness": 0.4,
+        "overall": 0.42
+      },
+      "cases": {
+        "judge_event_40d": {
+          "scoreMedians": {
+            "safety_recovery_fit": 9,
+            "goal_event_fit": 9.5,
+            "sequencing": 9,
+            "periodization_taper": 8.5,
+            "preference_capacity_fit": 10,
+            "robustness": 8.5,
+            "overall": 9.2
           },
           "dimensionMads": {
             "safety_recovery_fit": 0,
             "goal_event_fit": 0,
             "sequencing": 0,
-            "periodization_taper": 0,
+            "periodization_taper": 0.5,
             "preference_capacity_fit": 0,
-            "robustness": 0,
+            "robustness": 0.5,
             "overall": 0
           },
+          "maxSpread": 1
+        },
+        "judge_event_20d": {
+          "scoreMedians": {
+            "safety_recovery_fit": 8.5,
+            "goal_event_fit": 6,
+            "sequencing": 6.5,
+            "periodization_taper": 5,
+            "preference_capacity_fit": 9,
+            "robustness": 7.5,
+            "overall": 7
+          },
+          "dimensionMads": {
+            "safety_recovery_fit": 0.5,
+            "goal_event_fit": 1,
+            "sequencing": 1,
+            "periodization_taper": 1,
+            "preference_capacity_fit": 1,
+            "robustness": 0.5,
+            "overall": 1
+          },
+          "maxSpread": 5
+        },
+        "judge_event_14d": {
+          "scoreMedians": {
+            "safety_recovery_fit": 9,
+            "goal_event_fit": 9.5,
+            "sequencing": 9,
+            "periodization_taper": 9,
+            "preference_capacity_fit": 10,
+            "robustness": 8.5,
+            "overall": 8.8
+          },
+          "dimensionMads": {
+            "safety_recovery_fit": 0,
+            "goal_event_fit": 0,
+            "sequencing": 0,
+            "periodization_taper": 0.5,
+            "preference_capacity_fit": 0,
+            "robustness": 0,
+            "overall": 0.1999999999999993
+          },
+          "maxSpread": 1.5
+        },
+        "judge_event_7d": {
+          "scoreMedians": {
+            "safety_recovery_fit": 9,
+            "goal_event_fit": 8,
+            "sequencing": 8,
+            "periodization_taper": 8.5,
+            "preference_capacity_fit": 9.5,
+            "robustness": 8,
+            "overall": 8.4
+          },
+          "dimensionMads": {
+            "safety_recovery_fit": 0,
+            "goal_event_fit": 1,
+            "sequencing": 1,
+            "periodization_taper": 0.5,
+            "preference_capacity_fit": 0.5,
+            "robustness": 0.5,
+            "overall": 0.09999999999999964
+          },
+          "maxSpread": 2.5
+        },
+        "judge_event_3d": {
+          "scoreMedians": {
+            "safety_recovery_fit": 8.5,
+            "goal_event_fit": 6.5,
+            "sequencing": 6.5,
+            "periodization_taper": 7,
+            "preference_capacity_fit": 9,
+            "robustness": 7,
+            "overall": 7
+          },
+          "dimensionMads": {
+            "safety_recovery_fit": 0.5,
+            "goal_event_fit": 1.5,
+            "sequencing": 1.5,
+            "periodization_taper": 1,
+            "preference_capacity_fit": 1,
+            "robustness": 0.5,
+            "overall": 0.7999999999999998
+          },
           "maxSpread": 4
+        }
+      }
+    },
+    {
+      "familyId": "preferences_capacity",
+      "samples": 5,
+      "familySensitivityMedian": 8.2,
+      "familySensitivityMad": 0.3000000000000007,
+      "familySensitivitySpread": 0.9,
+      "dimensionMadAverages": {
+        "safety_recovery_fit": 0.1,
+        "goal_event_fit": 0.28,
+        "sequencing": 0.15,
+        "periodization_taper": 0.35,
+        "preference_capacity_fit": 0.13,
+        "robustness": 0.28,
+        "overall": 0.17
+      },
+      "cases": {
+        "judge_pref_neutral": {
+          "scoreMedians": {
+            "safety_recovery_fit": 9,
+            "goal_event_fit": 9.5,
+            "sequencing": 8.5,
+            "periodization_taper": 8.5,
+            "preference_capacity_fit": 9,
+            "robustness": 8.3,
+            "overall": 8.7
+          },
+          "dimensionMads": {
+            "safety_recovery_fit": 0,
+            "goal_event_fit": 0,
+            "sequencing": 0.3000000000000007,
+            "periodization_taper": 0,
+            "preference_capacity_fit": 0,
+            "robustness": 0.1999999999999993,
+            "overall": 0
+          },
+          "maxSpread": 1.5
+        },
+        "judge_pref_conservative": {
+          "scoreMedians": {
+            "safety_recovery_fit": 9.5,
+            "goal_event_fit": 7,
+            "sequencing": 7,
+            "periodization_taper": 6.5,
+            "preference_capacity_fit": 8.5,
+            "robustness": 7.5,
+            "overall": 7
+          },
+          "dimensionMads": {
+            "safety_recovery_fit": 0.3000000000000007,
+            "goal_event_fit": 0,
+            "sequencing": 0,
+            "periodization_taper": 1,
+            "preference_capacity_fit": 0.5,
+            "robustness": 0.5,
+            "overall": 0.20000000000000018
+          },
+          "maxSpread": 3
+        },
+        "judge_pref_active_recovery": {
+          "scoreMedians": {
+            "safety_recovery_fit": 9,
+            "goal_event_fit": 8.5,
+            "sequencing": 8.5,
+            "periodization_taper": 8,
+            "preference_capacity_fit": 9.5,
+            "robustness": 8.5,
+            "overall": 8.4
+          },
+          "dimensionMads": {
+            "safety_recovery_fit": 0,
+            "goal_event_fit": 0.5,
+            "sequencing": 0.09999999999999964,
+            "periodization_taper": 0.3000000000000007,
+            "preference_capacity_fit": 0.3000000000000007,
+            "robustness": 0.1999999999999993,
+            "overall": 0.09999999999999964
+          },
+          "maxSpread": 1.5
+        },
+        "judge_pref_mixed_recovery": {
+          "scoreMedians": {
+            "safety_recovery_fit": 9,
+            "goal_event_fit": 8.7,
+            "sequencing": 8.5,
+            "periodization_taper": 8.5,
+            "preference_capacity_fit": 9,
+            "robustness": 8.4,
+            "overall": 8.3
+          },
+          "dimensionMads": {
+            "safety_recovery_fit": 0,
+            "goal_event_fit": 0.3000000000000007,
+            "sequencing": 0,
+            "periodization_taper": 0,
+            "preference_capacity_fit": 0,
+            "robustness": 0.09999999999999964,
+            "overall": 0.1999999999999993
+          },
+          "maxSpread": 1.5
+        },
+        "judge_pref_45min": {
+          "scoreMedians": {
+            "safety_recovery_fit": 8.5,
+            "goal_event_fit": 7.5,
+            "sequencing": 7.5,
+            "periodization_taper": 7.5,
+            "preference_capacity_fit": 9,
+            "robustness": 7.2,
+            "overall": 7.5
+          },
+          "dimensionMads": {
+            "safety_recovery_fit": 0,
+            "goal_event_fit": 0.5,
+            "sequencing": 0.09999999999999964,
+            "periodization_taper": 0.2999999999999998,
+            "preference_capacity_fit": 0,
+            "robustness": 0.39999999999999947,
+            "overall": 0
+          },
+          "maxSpread": 2
+        },
+        "judge_pref_90min": {
+          "scoreMedians": {
+            "safety_recovery_fit": 8.5,
+            "goal_event_fit": 8.6,
+            "sequencing": 8.1,
+            "periodization_taper": 8,
+            "preference_capacity_fit": 9,
+            "robustness": 8.2,
+            "overall": 8
+          },
+          "dimensionMads": {
+            "safety_recovery_fit": 0.3000000000000007,
+            "goal_event_fit": 0.40000000000000036,
+            "sequencing": 0.40000000000000036,
+            "periodization_taper": 0.5,
+            "preference_capacity_fit": 0,
+            "robustness": 0.3000000000000007,
+            "overall": 0.5
+          },
+          "maxSpread": 2.7
         }
       }
     },
@@ -772,16 +772,16 @@
       "familyId": "event_demand",
       "samples": 5,
       "familySensitivityMedian": 9,
-      "familySensitivityMad": 0.1999999999999993,
-      "familySensitivitySpread": 0.7,
+      "familySensitivityMad": 0.5,
+      "familySensitivitySpread": 2,
       "dimensionMadAverages": {
         "safety_recovery_fit": 0,
-        "goal_event_fit": 0.17,
-        "sequencing": 0,
-        "periodization_taper": 0.1,
+        "goal_event_fit": 0.25,
+        "sequencing": 0.25,
+        "periodization_taper": 0,
         "preference_capacity_fit": 0,
-        "robustness": 0.12,
-        "overall": 0.12
+        "robustness": 0.15,
+        "overall": 0.2
       },
       "cases": {
         "judge_demand_crit_A": {
@@ -800,10 +800,10 @@
             "sequencing": 0,
             "periodization_taper": 0,
             "preference_capacity_fit": 0,
-            "robustness": 0,
-            "overall": 0.1999999999999993
+            "robustness": 0.1999999999999993,
+            "overall": 0
           },
-          "maxSpread": 1
+          "maxSpread": 3
         },
         "judge_demand_crit_B": {
           "scoreMedians": {
@@ -813,7 +813,7 @@
             "periodization_taper": 8,
             "preference_capacity_fit": 10,
             "robustness": 8.5,
-            "overall": 8.5
+            "overall": 8.7
           },
           "dimensionMads": {
             "safety_recovery_fit": 0,
@@ -824,28 +824,28 @@
             "robustness": 0.1999999999999993,
             "overall": 0
           },
-          "maxSpread": 1
+          "maxSpread": 3
         },
         "judge_demand_gran_A": {
           "scoreMedians": {
             "safety_recovery_fit": 9,
-            "goal_event_fit": 9.3,
+            "goal_event_fit": 9,
             "sequencing": 8.5,
             "periodization_taper": 8,
             "preference_capacity_fit": 10,
-            "robustness": 8.4,
-            "overall": 8.6
+            "robustness": 8.5,
+            "overall": 8.5
           },
           "dimensionMads": {
             "safety_recovery_fit": 0,
-            "goal_event_fit": 0.1999999999999993,
-            "sequencing": 0,
-            "periodization_taper": 0.1999999999999993,
+            "goal_event_fit": 0.5,
+            "sequencing": 0.5,
+            "periodization_taper": 0,
             "preference_capacity_fit": 0,
             "robustness": 0.09999999999999964,
-            "overall": 0.09999999999999964
+            "overall": 0.40000000000000036
           },
-          "maxSpread": 2.5
+          "maxSpread": 4.5
         },
         "judge_demand_gran_B": {
           "scoreMedians": {
@@ -854,233 +854,233 @@
             "sequencing": 8.5,
             "periodization_taper": 8,
             "preference_capacity_fit": 10,
-            "robustness": 8.3,
+            "robustness": 8.5,
             "overall": 8.5
           },
           "dimensionMads": {
             "safety_recovery_fit": 0,
             "goal_event_fit": 0.5,
-            "sequencing": 0,
-            "periodization_taper": 0.1999999999999993,
+            "sequencing": 0.5,
+            "periodization_taper": 0,
             "preference_capacity_fit": 0,
-            "robustness": 0.1999999999999993,
-            "overall": 0.1999999999999993
+            "robustness": 0.09999999999999964,
+            "overall": 0.40000000000000036
           },
-          "maxSpread": 2.5
+          "maxSpread": 4.5
         }
       }
     },
     {
       "familyId": "interactions",
       "samples": 5,
-      "familySensitivityMedian": 8.5,
-      "familySensitivityMad": 0.3000000000000007,
+      "familySensitivityMedian": 9.2,
+      "familySensitivityMad": 0,
       "familySensitivitySpread": 1,
       "dimensionMadAverages": {
-        "safety_recovery_fit": 0.45,
-        "goal_event_fit": 0.56,
-        "sequencing": 0.5,
-        "periodization_taper": 0.56,
-        "preference_capacity_fit": 0.22,
-        "robustness": 0.69,
-        "overall": 0.75
+        "safety_recovery_fit": 0.25,
+        "goal_event_fit": 0.13,
+        "sequencing": 0.2,
+        "periodization_taper": 0.39,
+        "preference_capacity_fit": 0.25,
+        "robustness": 0.29,
+        "overall": 0.21
       },
       "cases": {
         "judge_int_fresh_hard_yday": {
           "scoreMedians": {
-            "safety_recovery_fit": 9,
-            "goal_event_fit": 9,
-            "sequencing": 8,
-            "periodization_taper": 7,
+            "safety_recovery_fit": 9.2,
+            "goal_event_fit": 9.5,
+            "sequencing": 9,
+            "periodization_taper": 8.5,
             "preference_capacity_fit": 10,
-            "robustness": 8,
-            "overall": 8.5
+            "robustness": 9,
+            "overall": 8.7
           },
           "dimensionMads": {
-            "safety_recovery_fit": 0,
+            "safety_recovery_fit": 0.10000000000000142,
             "goal_event_fit": 0,
-            "sequencing": 1,
-            "periodization_taper": 1,
+            "sequencing": 0,
+            "periodization_taper": 0,
             "preference_capacity_fit": 0,
             "robustness": 0,
             "overall": 0
           },
-          "maxSpread": 3
+          "maxSpread": 0.5
         },
         "judge_int_badobj_noload": {
           "scoreMedians": {
-            "safety_recovery_fit": 7.5,
-            "goal_event_fit": 7,
-            "sequencing": 7,
-            "periodization_taper": 7,
-            "preference_capacity_fit": 8,
-            "robustness": 7,
-            "overall": 6.8
+            "safety_recovery_fit": 9,
+            "goal_event_fit": 8.5,
+            "sequencing": 8.5,
+            "periodization_taper": 8,
+            "preference_capacity_fit": 9,
+            "robustness": 8.5,
+            "overall": 7.8
           },
           "dimensionMads": {
-            "safety_recovery_fit": 0.5,
+            "safety_recovery_fit": 0.1999999999999993,
             "goal_event_fit": 0,
             "sequencing": 0,
-            "periodization_taper": 0.5,
-            "preference_capacity_fit": 0.7999999999999998,
-            "robustness": 1,
-            "overall": 0.7000000000000002
+            "periodization_taper": 0.1999999999999993,
+            "preference_capacity_fit": 0,
+            "robustness": 0.3000000000000007,
+            "overall": 0.10000000000000053
           },
-          "maxSpread": 3
+          "maxSpread": 3.5
         },
         "judge_int_badobj_hard_yday": {
           "scoreMedians": {
-            "safety_recovery_fit": 6,
-            "goal_event_fit": 6,
-            "sequencing": 6,
-            "periodization_taper": 6,
-            "preference_capacity_fit": 7,
-            "robustness": 5.8,
-            "overall": 6
+            "safety_recovery_fit": 9,
+            "goal_event_fit": 8.5,
+            "sequencing": 8.3,
+            "periodization_taper": 8,
+            "preference_capacity_fit": 8,
+            "robustness": 8.5,
+            "overall": 7.9
           },
           "dimensionMads": {
-            "safety_recovery_fit": 0.5,
-            "goal_event_fit": 1,
-            "sequencing": 1,
-            "periodization_taper": 0,
+            "safety_recovery_fit": 0.3000000000000007,
+            "goal_event_fit": 0,
+            "sequencing": 0.29999999999999893,
+            "periodization_taper": 1,
             "preference_capacity_fit": 0,
-            "robustness": 0.7999999999999998,
-            "overall": 2
+            "robustness": 0.40000000000000036,
+            "overall": 0.40000000000000036
           },
-          "maxSpread": 4.5
+          "maxSpread": 3.8
         },
         "judge_int_badsubj_goodobj": {
           "scoreMedians": {
-            "safety_recovery_fit": 8,
+            "safety_recovery_fit": 9,
+            "goal_event_fit": 8.5,
+            "sequencing": 8.3,
+            "periodization_taper": 8,
+            "preference_capacity_fit": 9,
+            "robustness": 8.5,
+            "overall": 7.9
+          },
+          "dimensionMads": {
+            "safety_recovery_fit": 0.3000000000000007,
+            "goal_event_fit": 0,
+            "sequencing": 0.29999999999999893,
+            "periodization_taper": 0.5,
+            "preference_capacity_fit": 1,
+            "robustness": 0.40000000000000036,
+            "overall": 0.40000000000000036
+          },
+          "maxSpread": 3
+        },
+        "judge_int_goodsubj_badobj": {
+          "scoreMedians": {
+            "safety_recovery_fit": 9,
+            "goal_event_fit": 8.5,
+            "sequencing": 8.5,
+            "periodization_taper": 8,
+            "preference_capacity_fit": 9,
+            "robustness": 8.5,
+            "overall": 7.9
+          },
+          "dimensionMads": {
+            "safety_recovery_fit": 0,
+            "goal_event_fit": 0,
+            "sequencing": 0.09999999999999964,
+            "periodization_taper": 0,
+            "preference_capacity_fit": 0,
+            "robustness": 0,
+            "overall": 0.10000000000000053
+          },
+          "maxSpread": 2
+        },
+        "judge_int_race7_fresh": {
+          "scoreMedians": {
+            "safety_recovery_fit": 9.4,
+            "goal_event_fit": 9.5,
+            "sequencing": 9.5,
+            "periodization_taper": 9.2,
+            "preference_capacity_fit": 10,
+            "robustness": 9.3,
+            "overall": 9
+          },
+          "dimensionMads": {
+            "safety_recovery_fit": 0.09999999999999964,
+            "goal_event_fit": 0,
+            "sequencing": 0.09999999999999964,
+            "periodization_taper": 0.1999999999999993,
+            "preference_capacity_fit": 0,
+            "robustness": 0.1999999999999993,
+            "overall": 0.1999999999999993
+          },
+          "maxSpread": 1
+        },
+        "judge_int_race7_hard_yday": {
+          "scoreMedians": {
+            "safety_recovery_fit": 7.3,
             "goal_event_fit": 7.5,
-            "sequencing": 7,
+            "sequencing": 7.3,
             "periodization_taper": 7,
             "preference_capacity_fit": 8,
             "robustness": 7.2,
             "overall": 7
           },
           "dimensionMads": {
-            "safety_recovery_fit": 1,
+            "safety_recovery_fit": 0.2999999999999998,
             "goal_event_fit": 0.5,
-            "sequencing": 1,
-            "periodization_taper": 1,
-            "preference_capacity_fit": 1,
-            "robustness": 0.7999999999999998,
+            "sequencing": 0.2999999999999998,
+            "periodization_taper": 0.5,
+            "preference_capacity_fit": 0.5,
+            "robustness": 0.20000000000000018,
             "overall": 0.5
           },
-          "maxSpread": 3.5
-        },
-        "judge_int_goodsubj_badobj": {
-          "scoreMedians": {
-            "safety_recovery_fit": 8.8,
-            "goal_event_fit": 7,
-            "sequencing": 8,
-            "periodization_taper": 7,
-            "preference_capacity_fit": 9,
-            "robustness": 8,
-            "overall": 7.5
-          },
-          "dimensionMads": {
-            "safety_recovery_fit": 0.8000000000000007,
-            "goal_event_fit": 1,
-            "sequencing": 0.5,
-            "periodization_taper": 1,
-            "preference_capacity_fit": 0,
-            "robustness": 0.1999999999999993,
-            "overall": 1
-          },
-          "maxSpread": 4
-        },
-        "judge_int_race7_fresh": {
-          "scoreMedians": {
-            "safety_recovery_fit": 9,
-            "goal_event_fit": 9.5,
-            "sequencing": 9,
-            "periodization_taper": 9,
-            "preference_capacity_fit": 10,
-            "robustness": 8,
-            "overall": 8.7
-          },
-          "dimensionMads": {
-            "safety_recovery_fit": 0,
-            "goal_event_fit": 0.5,
-            "sequencing": 0,
-            "periodization_taper": 0,
-            "preference_capacity_fit": 0,
-            "robustness": 0.5,
-            "overall": 0.3000000000000007
-          },
-          "maxSpread": 2
-        },
-        "judge_int_race7_hard_yday": {
-          "scoreMedians": {
-            "safety_recovery_fit": 7.2,
-            "goal_event_fit": 7,
-            "sequencing": 7,
-            "periodization_taper": 7,
-            "preference_capacity_fit": 8,
-            "robustness": 6.8,
-            "overall": 6.5
-          },
-          "dimensionMads": {
-            "safety_recovery_fit": 0.7999999999999998,
-            "goal_event_fit": 1,
-            "sequencing": 0,
-            "periodization_taper": 0.5,
-            "preference_capacity_fit": 0,
-            "robustness": 1.2000000000000002,
-            "overall": 1
-          },
-          "maxSpread": 3
+          "maxSpread": 4.8
         },
         "judge_int_race7_badobj": {
           "scoreMedians": {
-            "safety_recovery_fit": 6,
-            "goal_event_fit": 6,
-            "sequencing": 6,
-            "periodization_taper": 6,
-            "preference_capacity_fit": 7,
-            "robustness": 6,
-            "overall": 6
+            "safety_recovery_fit": 8.5,
+            "goal_event_fit": 8.5,
+            "sequencing": 8,
+            "periodization_taper": 7.5,
+            "preference_capacity_fit": 9,
+            "robustness": 8,
+            "overall": 8
           },
           "dimensionMads": {
-            "safety_recovery_fit": 0,
+            "safety_recovery_fit": 0.6999999999999993,
             "goal_event_fit": 0.5,
             "sequencing": 0.5,
-            "periodization_taper": 0.5,
-            "preference_capacity_fit": 0,
-            "robustness": 1,
-            "overall": 0.5
+            "periodization_taper": 0.7000000000000002,
+            "preference_capacity_fit": 0.5,
+            "robustness": 0.8000000000000007,
+            "overall": 0
           },
-          "maxSpread": 4
+          "maxSpread": 3
         }
       }
     },
     {
       "familyId": "delivered_dose_variance",
       "samples": 5,
-      "familySensitivityMedian": 7.5,
-      "familySensitivityMad": 0,
-      "familySensitivitySpread": 1,
+      "familySensitivityMedian": 8.2,
+      "familySensitivityMad": 0.3000000000000007,
+      "familySensitivitySpread": 2,
       "dimensionMadAverages": {
-        "safety_recovery_fit": 0.38,
-        "goal_event_fit": 0.38,
-        "sequencing": 0.38,
-        "periodization_taper": 0.38,
+        "safety_recovery_fit": 0.25,
+        "goal_event_fit": 0.63,
+        "sequencing": 0.5,
+        "periodization_taper": 0.63,
         "preference_capacity_fit": 0.13,
-        "robustness": 0.25,
-        "overall": 0.2
+        "robustness": 0.5,
+        "overall": 0.48
       },
       "cases": {
         "judge_dose_exact": {
           "scoreMedians": {
-            "safety_recovery_fit": 10,
-            "goal_event_fit": 10,
-            "sequencing": 9.5,
-            "periodization_taper": 9.5,
+            "safety_recovery_fit": 9,
+            "goal_event_fit": 9.5,
+            "sequencing": 9,
+            "periodization_taper": 8.5,
             "preference_capacity_fit": 10,
-            "robustness": 9.5,
-            "overall": 9.5
+            "robustness": 8.5,
+            "overall": 9.2
           },
           "dimensionMads": {
             "safety_recovery_fit": 0,
@@ -1088,41 +1088,20 @@
             "sequencing": 0,
             "periodization_taper": 0,
             "preference_capacity_fit": 0,
-            "robustness": 0,
-            "overall": 0.3000000000000007
+            "robustness": 0.5,
+            "overall": 0
           },
           "maxSpread": 1
         },
         "judge_dose_surged": {
           "scoreMedians": {
-            "safety_recovery_fit": 7,
+            "safety_recovery_fit": 8,
             "goal_event_fit": 8,
             "sequencing": 7,
             "periodization_taper": 7,
             "preference_capacity_fit": 9,
-            "robustness": 7,
-            "overall": 7.5
-          },
-          "dimensionMads": {
-            "safety_recovery_fit": 1,
-            "goal_event_fit": 0,
-            "sequencing": 0.5,
-            "periodization_taper": 1,
-            "preference_capacity_fit": 0,
-            "robustness": 0.5,
-            "overall": 0
-          },
-          "maxSpread": 3
-        },
-        "judge_dose_curtailed": {
-          "scoreMedians": {
-            "safety_recovery_fit": 8.5,
-            "goal_event_fit": 8.5,
-            "sequencing": 8.5,
-            "periodization_taper": 8.5,
-            "preference_capacity_fit": 9,
-            "robustness": 8.5,
-            "overall": 8
+            "robustness": 7.5,
+            "overall": 7
           },
           "dimensionMads": {
             "safety_recovery_fit": 0.5,
@@ -1131,61 +1110,124 @@
             "periodization_taper": 0.5,
             "preference_capacity_fit": 0,
             "robustness": 0.5,
-            "overall": 0.5
+            "overall": 0.20000000000000018
           },
-          "maxSpread": 4
+          "maxSpread": 3
+        },
+        "judge_dose_curtailed": {
+          "scoreMedians": {
+            "safety_recovery_fit": 8.5,
+            "goal_event_fit": 8,
+            "sequencing": 7.5,
+            "periodization_taper": 7,
+            "preference_capacity_fit": 9,
+            "robustness": 8,
+            "overall": 7.5
+          },
+          "dimensionMads": {
+            "safety_recovery_fit": 0.5,
+            "goal_event_fit": 1,
+            "sequencing": 1,
+            "periodization_taper": 1,
+            "preference_capacity_fit": 0.5,
+            "robustness": 0.5,
+            "overall": 1
+          },
+          "maxSpread": 2.5
         },
         "judge_dose_skipped": {
           "scoreMedians": {
-            "safety_recovery_fit": 8,
-            "goal_event_fit": 6,
-            "sequencing": 6.5,
+            "safety_recovery_fit": 8.5,
+            "goal_event_fit": 7.5,
+            "sequencing": 8,
             "periodization_taper": 7,
-            "preference_capacity_fit": 8,
-            "robustness": 6,
-            "overall": 6.5
+            "preference_capacity_fit": 9,
+            "robustness": 7.5,
+            "overall": 7.2
           },
           "dimensionMads": {
             "safety_recovery_fit": 0,
             "goal_event_fit": 1,
             "sequencing": 0.5,
-            "periodization_taper": 0,
-            "preference_capacity_fit": 0.5,
-            "robustness": 0,
-            "overall": 0
+            "periodization_taper": 1,
+            "preference_capacity_fit": 0,
+            "robustness": 0.5,
+            "overall": 0.7000000000000002
           },
-          "maxSpread": 4.5
+          "maxSpread": 2.5
         }
       }
     },
     {
       "familyId": "concurrent_strength_endurance",
       "samples": 5,
-      "familySensitivityMedian": 8.5,
-      "familySensitivityMad": 0,
-      "familySensitivitySpread": 0.7,
+      "familySensitivityMedian": 8,
+      "familySensitivityMad": 0.5,
+      "familySensitivitySpread": 1.8,
       "dimensionMadAverages": {
-        "safety_recovery_fit": 0.08,
-        "goal_event_fit": 0.25,
-        "sequencing": 0.15,
-        "periodization_taper": 0.42,
-        "preference_capacity_fit": 0.25,
-        "robustness": 0.23,
-        "overall": 0.32
+        "safety_recovery_fit": 0.2,
+        "goal_event_fit": 0.19,
+        "sequencing": 0.08,
+        "periodization_taper": 0,
+        "preference_capacity_fit": 0.13,
+        "robustness": 0.02,
+        "overall": 0.1
       },
       "cases": {
         "judge_concurrent_none": {
           "scoreMedians": {
             "safety_recovery_fit": 9,
             "goal_event_fit": 9.5,
-            "sequencing": 8.5,
-            "periodization_taper": 8,
+            "sequencing": 9,
+            "periodization_taper": 8.5,
             "preference_capacity_fit": 9,
             "robustness": 8.5,
-            "overall": 8.7
+            "overall": 9.2
           },
           "dimensionMads": {
-            "safety_recovery_fit": 0.3000000000000007,
+            "safety_recovery_fit": 0,
+            "goal_event_fit": 0,
+            "sequencing": 0,
+            "periodization_taper": 0,
+            "preference_capacity_fit": 0,
+            "robustness": 0,
+            "overall": 0.20000000000000107
+          },
+          "maxSpread": 1
+        },
+        "judge_concurrent_heavy_lower": {
+          "scoreMedians": {
+            "safety_recovery_fit": 8,
+            "goal_event_fit": 8,
+            "sequencing": 7.5,
+            "periodization_taper": 7.5,
+            "preference_capacity_fit": 8,
+            "robustness": 7.5,
+            "overall": 7.5
+          },
+          "dimensionMads": {
+            "safety_recovery_fit": 0.09999999999999964,
+            "goal_event_fit": 0.5,
+            "sequencing": 0,
+            "periodization_taper": 0,
+            "preference_capacity_fit": 0,
+            "robustness": 0.09999999999999964,
+            "overall": 0.09999999999999964
+          },
+          "maxSpread": 2
+        },
+        "judge_concurrent_heavy_upper": {
+          "scoreMedians": {
+            "safety_recovery_fit": 8.7,
+            "goal_event_fit": 9,
+            "sequencing": 8.5,
+            "periodization_taper": 8.5,
+            "preference_capacity_fit": 9,
+            "robustness": 8.5,
+            "overall": 8.5
+          },
+          "dimensionMads": {
+            "safety_recovery_fit": 0.1999999999999993,
             "goal_event_fit": 0,
             "sequencing": 0,
             "periodization_taper": 0,
@@ -1193,68 +1235,26 @@
             "robustness": 0,
             "overall": 0
           },
-          "maxSpread": 1.5
+          "maxSpread": 0.7
         },
-        "judge_concurrent_heavy_lower": {
-          "scoreMedians": {
-            "safety_recovery_fit": 9,
-            "goal_event_fit": 8.5,
-            "sequencing": 8,
-            "periodization_taper": 7.5,
-            "preference_capacity_fit": 8,
-            "robustness": 8.2,
-            "overall": 7.8
-          },
-          "dimensionMads": {
-            "safety_recovery_fit": 0,
-            "goal_event_fit": 0.5,
-            "sequencing": 0.3000000000000007,
-            "periodization_taper": 0.6999999999999993,
-            "preference_capacity_fit": 0.5,
-            "robustness": 0.5,
-            "overall": 0.7000000000000002
-          },
-          "maxSpread": 2
-        },
-        "judge_concurrent_heavy_upper": {
+        "judge_concurrent_power_maintenance": {
           "scoreMedians": {
             "safety_recovery_fit": 8.5,
-            "goal_event_fit": 9,
-            "sequencing": 8.5,
-            "periodization_taper": 8,
-            "preference_capacity_fit": 9,
+            "goal_event_fit": 8.75,
+            "sequencing": 8.2,
+            "periodization_taper": 8.5,
+            "preference_capacity_fit": 8.5,
             "robustness": 8.5,
             "overall": 8.5
           },
           "dimensionMads": {
-            "safety_recovery_fit": 0,
-            "goal_event_fit": 0,
-            "sequencing": 0,
-            "periodization_taper": 0.5,
-            "preference_capacity_fit": 0.1999999999999993,
-            "robustness": 0.09999999999999964,
-            "overall": 0
-          },
-          "maxSpread": 1.5
-        },
-        "judge_concurrent_power_maintenance": {
-          "scoreMedians": {
-            "safety_recovery_fit": 9,
-            "goal_event_fit": 8.5,
-            "sequencing": 8,
-            "periodization_taper": 7.5,
-            "preference_capacity_fit": 8.2,
-            "robustness": 8.2,
-            "overall": 7.9
-          },
-          "dimensionMads": {
-            "safety_recovery_fit": 0,
-            "goal_event_fit": 0.5,
+            "safety_recovery_fit": 0.5,
+            "goal_event_fit": 0.25,
             "sequencing": 0.3000000000000007,
-            "periodization_taper": 0.5,
-            "preference_capacity_fit": 0.3000000000000007,
-            "robustness": 0.3000000000000007,
-            "overall": 0.5999999999999996
+            "periodization_taper": 0,
+            "preference_capacity_fit": 0.5,
+            "robustness": 0,
+            "overall": 0.09999999999999964
           },
           "maxSpread": 1.8
         }
@@ -1264,27 +1264,27 @@
       "familyId": "injury_constraints",
       "samples": 5,
       "familySensitivityMedian": 8.5,
-      "familySensitivityMad": 0,
-      "familySensitivitySpread": 0.5,
+      "familySensitivityMad": 0.5,
+      "familySensitivitySpread": 1.5,
       "dimensionMadAverages": {
-        "safety_recovery_fit": 0.25,
-        "goal_event_fit": 0.25,
+        "safety_recovery_fit": 0.5,
+        "goal_event_fit": 0.13,
         "sequencing": 0.13,
-        "periodization_taper": 0,
-        "preference_capacity_fit": 0,
-        "robustness": 0.25,
-        "overall": 0
+        "periodization_taper": 0.13,
+        "preference_capacity_fit": 0.25,
+        "robustness": 0.42,
+        "overall": 0.37
       },
       "cases": {
         "judge_injury_none": {
           "scoreMedians": {
-            "safety_recovery_fit": 9,
+            "safety_recovery_fit": 9.5,
             "goal_event_fit": 9.5,
             "sequencing": 9,
             "periodization_taper": 8.5,
-            "preference_capacity_fit": 9,
-            "robustness": 8.5,
-            "overall": 9
+            "preference_capacity_fit": 10,
+            "robustness": 9,
+            "overall": 9.2
           },
           "dimensionMads": {
             "safety_recovery_fit": 0,
@@ -1301,53 +1301,11 @@
           "scoreMedians": {
             "safety_recovery_fit": 9,
             "goal_event_fit": 9.5,
-            "sequencing": 8.5,
-            "periodization_taper": 8.5,
-            "preference_capacity_fit": 9,
-            "robustness": 8.5,
-            "overall": 8.5
-          },
-          "dimensionMads": {
-            "safety_recovery_fit": 0.5,
-            "goal_event_fit": 0,
-            "sequencing": 0,
-            "periodization_taper": 0,
-            "preference_capacity_fit": 0,
-            "robustness": 0.5,
-            "overall": 0
-          },
-          "maxSpread": 1.5
-        },
-        "judge_injury_lower_body_restricted": {
-          "scoreMedians": {
-            "safety_recovery_fit": 8.5,
-            "goal_event_fit": 8,
-            "sequencing": 8,
-            "periodization_taper": 8,
-            "preference_capacity_fit": 9,
-            "robustness": 8,
-            "overall": 7.5
-          },
-          "dimensionMads": {
-            "safety_recovery_fit": 0.5,
-            "goal_event_fit": 1,
-            "sequencing": 0.5,
-            "periodization_taper": 0,
-            "preference_capacity_fit": 0,
-            "robustness": 0.5,
-            "overall": 0
-          },
-          "maxSpread": 2.5
-        },
-        "judge_injury_expired": {
-          "scoreMedians": {
-            "safety_recovery_fit": 9,
-            "goal_event_fit": 9.5,
             "sequencing": 9,
             "periodization_taper": 8.5,
-            "preference_capacity_fit": 9,
-            "robustness": 8.5,
-            "overall": 9
+            "preference_capacity_fit": 10,
+            "robustness": 9,
+            "overall": 8.8
           },
           "dimensionMads": {
             "safety_recovery_fit": 0,
@@ -1355,10 +1313,52 @@
             "sequencing": 0,
             "periodization_taper": 0,
             "preference_capacity_fit": 0,
-            "robustness": 0,
-            "overall": 0
+            "robustness": 0.1999999999999993,
+            "overall": 0.3000000000000007
           },
           "maxSpread": 1
+        },
+        "judge_injury_lower_body_restricted": {
+          "scoreMedians": {
+            "safety_recovery_fit": 7,
+            "goal_event_fit": 7.5,
+            "sequencing": 7.5,
+            "periodization_taper": 6.5,
+            "preference_capacity_fit": 8,
+            "robustness": 7,
+            "overall": 7.2
+          },
+          "dimensionMads": {
+            "safety_recovery_fit": 1.5,
+            "goal_event_fit": 0.5,
+            "sequencing": 0.5,
+            "periodization_taper": 0.5,
+            "preference_capacity_fit": 1,
+            "robustness": 1.5,
+            "overall": 0.9999999999999991
+          },
+          "maxSpread": 6.5
+        },
+        "judge_injury_expired": {
+          "scoreMedians": {
+            "safety_recovery_fit": 9,
+            "goal_event_fit": 9.5,
+            "sequencing": 9,
+            "periodization_taper": 8.5,
+            "preference_capacity_fit": 10,
+            "robustness": 9,
+            "overall": 9
+          },
+          "dimensionMads": {
+            "safety_recovery_fit": 0.5,
+            "goal_event_fit": 0,
+            "sequencing": 0,
+            "periodization_taper": 0,
+            "preference_capacity_fit": 0,
+            "robustness": 0,
+            "overall": 0.1999999999999993
+          },
+          "maxSpread": 2.5
         }
       }
     },
@@ -1367,24 +1367,24 @@
       "samples": 5,
       "familySensitivityMedian": 8,
       "familySensitivityMad": 0.5,
-      "familySensitivitySpread": 1,
+      "familySensitivitySpread": 1.5,
       "dimensionMadAverages": {
-        "safety_recovery_fit": 0,
-        "goal_event_fit": 0.25,
-        "sequencing": 0.35,
-        "periodization_taper": 0.45,
-        "preference_capacity_fit": 0.22,
-        "robustness": 0.38,
-        "overall": 0.25
+        "safety_recovery_fit": 0.5,
+        "goal_event_fit": 0.63,
+        "sequencing": 0.5,
+        "periodization_taper": 0.38,
+        "preference_capacity_fit": 0.25,
+        "robustness": 0.13,
+        "overall": 0.5
       },
       "cases": {
         "judge_mode_event_directed": {
           "scoreMedians": {
             "safety_recovery_fit": 9,
             "goal_event_fit": 9.5,
-            "sequencing": 8.5,
+            "sequencing": 9,
             "periodization_taper": 8,
-            "preference_capacity_fit": 9,
+            "preference_capacity_fit": 10,
             "robustness": 8.5,
             "overall": 8.7
           },
@@ -1394,70 +1394,70 @@
             "sequencing": 0,
             "periodization_taper": 0,
             "preference_capacity_fit": 0,
-            "robustness": 0,
-            "overall": 0
+            "robustness": 0.5,
+            "overall": 0.1999999999999993
           },
-          "maxSpread": 4
+          "maxSpread": 1.2
         },
         "judge_mode_evergreen": {
           "scoreMedians": {
             "safety_recovery_fit": 9,
-            "goal_event_fit": 3,
-            "sequencing": 6,
+            "goal_event_fit": 5,
+            "sequencing": 7,
             "periodization_taper": 6,
-            "preference_capacity_fit": 8,
-            "robustness": 7.5,
-            "overall": 5.2
+            "preference_capacity_fit": 8.5,
+            "robustness": 8,
+            "overall": 7
           },
           "dimensionMads": {
             "safety_recovery_fit": 0,
-            "goal_event_fit": 0.5,
+            "goal_event_fit": 1,
             "sequencing": 0.5,
-            "periodization_taper": 1,
-            "preference_capacity_fit": 0.20000000000000018,
-            "robustness": 0.5,
-            "overall": 0.2999999999999998
+            "periodization_taper": 0,
+            "preference_capacity_fit": 0,
+            "robustness": 0,
+            "overall": 1
           },
           "maxSpread": 4
         },
         "judge_mode_travel_overlay": {
           "scoreMedians": {
-            "safety_recovery_fit": 9,
-            "goal_event_fit": 5,
+            "safety_recovery_fit": 9.5,
+            "goal_event_fit": 4.5,
             "sequencing": 7,
-            "periodization_taper": 7.5,
+            "periodization_taper": 6,
             "preference_capacity_fit": 7,
-            "robustness": 8,
-            "overall": 6.8
+            "robustness": 8.5,
+            "overall": 7.5
           },
           "dimensionMads": {
-            "safety_recovery_fit": 0,
-            "goal_event_fit": 0,
+            "safety_recovery_fit": 0.5,
+            "goal_event_fit": 0.5,
             "sequencing": 0.5,
             "periodization_taper": 0,
-            "preference_capacity_fit": 0.5,
-            "robustness": 0.5,
-            "overall": 0.20000000000000018
+            "preference_capacity_fit": 1,
+            "robustness": 0,
+            "overall": 0.2999999999999998
           },
-          "maxSpread": 3.5
+          "maxSpread": 4
         },
         "judge_mode_conservative_preference": {
           "scoreMedians": {
-            "safety_recovery_fit": 9,
-            "goal_event_fit": 6.5,
-            "sequencing": 7,
-            "periodization_taper": 7.2,
-            "preference_capacity_fit": 8.8,
-            "robustness": 7.5,
-            "overall": 7
+            "safety_recovery_fit": 7.5,
+            "goal_event_fit": 5,
+            "sequencing": 6.5,
+            "periodization_taper": 6,
+            "preference_capacity_fit": 8,
+            "robustness": 7,
+            "overall": 6.5
           },
           "dimensionMads": {
-            "safety_recovery_fit": 0,
-            "goal_event_fit": 0.5,
-            "sequencing": 0.40000000000000036,
-            "periodization_taper": 0.7999999999999998,
-            "preference_capacity_fit": 0.1999999999999993,
-            "robustness": 0.5,
+            "safety_recovery_fit": 1.5,
+            "goal_event_fit": 1,
+            "sequencing": 1,
+            "periodization_taper": 1.5,
+            "preference_capacity_fit": 0,
+            "robustness": 0,
             "overall": 0.5
           },
           "maxSpread": 3.5
@@ -1467,86 +1467,125 @@
     {
       "familyId": "temporal_acute_vs_persistent",
       "samples": 5,
-      "familySensitivityMedian": 9,
-      "familySensitivityMad": 0.5,
+      "familySensitivityMedian": 8.5,
+      "familySensitivityMad": 0,
       "familySensitivitySpread": 1,
       "dimensionMadAverages": {
-        "safety_recovery_fit": 0.13,
-        "goal_event_fit": 0.13,
-        "sequencing": 0.3,
-        "periodization_taper": 0.63,
-        "preference_capacity_fit": 0.25,
-        "robustness": 0.13,
+        "safety_recovery_fit": 0.5,
+        "goal_event_fit": 0.25,
+        "sequencing": 0.38,
+        "periodization_taper": 0.38,
+        "preference_capacity_fit": 0.13,
+        "robustness": 0.25,
         "overall": 0.2
       },
       "cases": {
         "judge_traj_neutral": {
           "scoreMedians": {
             "safety_recovery_fit": 9.5,
-            "goal_event_fit": 9,
+            "goal_event_fit": 9.5,
             "sequencing": 9,
-            "periodization_taper": 8.5,
-            "preference_capacity_fit": 9,
-            "robustness": 8,
-            "overall": 8.7
+            "periodization_taper": 8,
+            "preference_capacity_fit": 10,
+            "robustness": 9,
+            "overall": 9.2
           },
           "dimensionMads": {
-            "safety_recovery_fit": 0.5,
+            "safety_recovery_fit": 0,
             "goal_event_fit": 0,
             "sequencing": 0,
             "periodization_taper": 0.5,
             "preference_capacity_fit": 0,
             "robustness": 0,
-            "overall": 0.1999999999999993
+            "overall": 0
           },
-          "maxSpread": 2
+          "maxSpread": 1.5
         },
         "judge_traj_acute_adverse_day1": {
           "scoreMedians": {
-            "safety_recovery_fit": 9,
-            "goal_event_fit": 9,
-            "sequencing": 8.2,
-            "periodization_taper": 8.5,
+            "safety_recovery_fit": 7,
+            "goal_event_fit": 8,
+            "sequencing": 7.5,
+            "periodization_taper": 7,
             "preference_capacity_fit": 9,
-            "robustness": 8,
-            "overall": 8.3
+            "robustness": 7,
+            "overall": 7.5
           },
           "dimensionMads": {
-            "safety_recovery_fit": 0,
-            "goal_event_fit": 0,
-            "sequencing": 0.1999999999999993,
+            "safety_recovery_fit": 1,
+            "goal_event_fit": 0.5,
+            "sequencing": 0.5,
             "periodization_taper": 0.5,
-            "preference_capacity_fit": 0.5,
-            "robustness": 0,
-            "overall": 0.1999999999999993
+            "preference_capacity_fit": 0,
+            "robustness": 0.5,
+            "overall": 0.5
           },
-          "maxSpread": 2
+          "maxSpread": 4.5
         },
         "judge_traj_persistent_adverse_3d": {
           "scoreMedians": {
-            "safety_recovery_fit": 9,
-            "goal_event_fit": 8.5,
-            "sequencing": 8,
-            "periodization_taper": 8,
+            "safety_recovery_fit": 7,
+            "goal_event_fit": 7,
+            "sequencing": 6.5,
+            "periodization_taper": 6,
             "preference_capacity_fit": 8,
-            "robustness": 8,
-            "overall": 8
+            "robustness": 6.5,
+            "overall": 6.5
           },
           "dimensionMads": {
-            "safety_recovery_fit": 0,
-            "goal_event_fit": 0.5,
+            "safety_recovery_fit": 0.5,
+            "goal_event_fit": 0,
             "sequencing": 0.5,
-            "periodization_taper": 1,
-            "preference_capacity_fit": 0,
+            "periodization_taper": 0,
+            "preference_capacity_fit": 0.5,
             "robustness": 0,
-            "overall": 0.20000000000000018
+            "overall": 0
           },
           "maxSpread": 3
         },
         "judge_traj_improving_trend": {
           "scoreMedians": {
             "safety_recovery_fit": 9,
-            "goal_event_fit": 9,
+            "goal_event_fit": 9.5,
+            "sequencing": 9,
+            "periodization_taper": 8.5,
+            "preference_capacity_fit": 10,
+            "robustness": 9,
+            "overall": 9
+          },
+          "dimensionMads": {
+            "safety_recovery_fit": 0.5,
+            "goal_event_fit": 0.5,
+            "sequencing": 0.5,
+            "periodization_taper": 0.5,
+            "preference_capacity_fit": 0,
+            "robustness": 0.5,
+            "overall": 0.3000000000000007
+          },
+          "maxSpread": 2
+        }
+      }
+    },
+    {
+      "familyId": "conflicting_tissue_vs_wearable",
+      "samples": 5,
+      "familySensitivityMedian": 7.5,
+      "familySensitivityMad": 0.5,
+      "familySensitivitySpread": 2,
+      "dimensionMadAverages": {
+        "safety_recovery_fit": 0.5,
+        "goal_event_fit": 0.5,
+        "sequencing": 0.5,
+        "periodization_taper": 0.63,
+        "preference_capacity_fit": 0.38,
+        "robustness": 0.5,
+        "overall": 0.37
+      },
+      "cases": {
+        "judge_conflict_neutral": {
+          "scoreMedians": {
+            "safety_recovery_fit": 9,
+            "goal_event_fit": 9.5,
             "sequencing": 8.5,
             "periodization_taper": 8.5,
             "preference_capacity_fit": 9,
@@ -1556,113 +1595,74 @@
           "dimensionMads": {
             "safety_recovery_fit": 0,
             "goal_event_fit": 0,
-            "sequencing": 0.5,
-            "periodization_taper": 0.5,
-            "preference_capacity_fit": 0.5,
-            "robustness": 0.5,
-            "overall": 0.1999999999999993
-          },
-          "maxSpread": 2
-        }
-      }
-    },
-    {
-      "familyId": "conflicting_tissue_vs_wearable",
-      "samples": 5,
-      "familySensitivityMedian": 8.5,
-      "familySensitivityMad": 0.5,
-      "familySensitivitySpread": 2.7,
-      "dimensionMadAverages": {
-        "safety_recovery_fit": 0.63,
-        "goal_event_fit": 0.38,
-        "sequencing": 0.25,
-        "periodization_taper": 0.38,
-        "preference_capacity_fit": 0.63,
-        "robustness": 0.55,
-        "overall": 0.3
-      },
-      "cases": {
-        "judge_conflict_neutral": {
-          "scoreMedians": {
-            "safety_recovery_fit": 9,
-            "goal_event_fit": 9.5,
-            "sequencing": 9,
-            "periodization_taper": 8.5,
-            "preference_capacity_fit": 9,
-            "robustness": 8.5,
-            "overall": 8.7
-          },
-          "dimensionMads": {
-            "safety_recovery_fit": 0,
-            "goal_event_fit": 0,
             "sequencing": 0,
             "periodization_taper": 0.5,
             "preference_capacity_fit": 0,
             "robustness": 0,
             "overall": 0
           },
-          "maxSpread": 1
+          "maxSpread": 2
         },
         "judge_conflict_sore_legs_great_hrv": {
           "scoreMedians": {
             "safety_recovery_fit": 8,
-            "goal_event_fit": 8.5,
-            "sequencing": 7.5,
-            "periodization_taper": 7.5,
+            "goal_event_fit": 8,
+            "sequencing": 7,
+            "periodization_taper": 6.5,
             "preference_capacity_fit": 8,
             "robustness": 7.5,
-            "overall": 7.5
+            "overall": 7.2
           },
           "dimensionMads": {
             "safety_recovery_fit": 1,
-            "goal_event_fit": 0.5,
+            "goal_event_fit": 1,
             "sequencing": 0.5,
             "periodization_taper": 0.5,
-            "preference_capacity_fit": 0.5,
-            "robustness": 0.6999999999999993,
+            "preference_capacity_fit": 1,
+            "robustness": 1,
             "overall": 0.2999999999999998
           },
-          "maxSpread": 2
+          "maxSpread": 4
         },
         "judge_conflict_fresh_legs_terrible_hrv": {
           "scoreMedians": {
-            "safety_recovery_fit": 8.5,
+            "safety_recovery_fit": 9,
             "goal_event_fit": 8,
-            "sequencing": 7.5,
-            "periodization_taper": 7.5,
-            "preference_capacity_fit": 8,
-            "robustness": 8,
+            "sequencing": 8,
+            "periodization_taper": 8,
+            "preference_capacity_fit": 7.5,
+            "robustness": 8.5,
             "overall": 7.5
           },
           "dimensionMads": {
             "safety_recovery_fit": 0.5,
             "goal_event_fit": 0.5,
             "sequencing": 0.5,
-            "periodization_taper": 0.5,
-            "preference_capacity_fit": 1,
+            "periodization_taper": 1,
+            "preference_capacity_fit": 0.5,
             "robustness": 0.5,
-            "overall": 0
+            "overall": 0.6999999999999993
           },
-          "maxSpread": 4
+          "maxSpread": 7.5
         },
         "judge_conflict_high_stress_fresh_body": {
           "scoreMedians": {
-            "safety_recovery_fit": 8,
+            "safety_recovery_fit": 8.5,
             "goal_event_fit": 8,
-            "sequencing": 8,
-            "periodization_taper": 8,
-            "preference_capacity_fit": 8,
-            "robustness": 7.5,
+            "sequencing": 7,
+            "periodization_taper": 7,
+            "preference_capacity_fit": 9,
+            "robustness": 8,
             "overall": 7.5
           },
           "dimensionMads": {
-            "safety_recovery_fit": 1,
+            "safety_recovery_fit": 0.5,
             "goal_event_fit": 0.5,
-            "sequencing": 0,
-            "periodization_taper": 0,
-            "preference_capacity_fit": 1,
-            "robustness": 1,
-            "overall": 0.9000000000000004
+            "sequencing": 1,
+            "periodization_taper": 0.5,
+            "preference_capacity_fit": 0,
+            "robustness": 0.5,
+            "overall": 0.5
           },
           "maxSpread": 3
         }

--- a/docs/analysis/simulation-baseline.json
+++ b/docs/analysis/simulation-baseline.json
@@ -254,7 +254,7 @@
             {
               "date": "2026-08-14",
               "weekIndex": 1,
-              "collision": 0.30488285442224433,
+              "collision": 0.2985241587700704,
               "costMagnitude": 1.1500000000000001,
               "topDimensions": [
                 "lowerBody",
@@ -264,7 +264,7 @@
             {
               "date": "2026-08-15",
               "weekIndex": 1,
-              "collision": 0.4521099895749268,
+              "collision": 0.4512052590337788,
               "costMagnitude": 1.645,
               "topDimensions": [
                 "neuromuscular",
@@ -274,7 +274,7 @@
             {
               "date": "2026-08-16",
               "weekIndex": 1,
-              "collision": 0.36266932336405944,
+              "collision": 0.3601804374542827,
               "costMagnitude": 0.36,
               "topDimensions": [
                 "lowerBody",
@@ -284,7 +284,7 @@
             {
               "date": "2026-08-17",
               "weekIndex": 1,
-              "collision": 0.28505172054336386,
+              "collision": 0.28315502103501267,
               "costMagnitude": 2.4,
               "topDimensions": [
                 "lowerBody",
@@ -301,7 +301,7 @@
             {
               "date": "2026-08-19",
               "weekIndex": 1,
-              "collision": 0.3073135391072979,
+              "collision": 0.3064402770896504,
               "costMagnitude": 2.4,
               "topDimensions": [
                 "lowerBody",
@@ -316,7 +316,7 @@
               "topDimensions": []
             }
           ],
-          "meanCollision": 0.24833797056090465,
+          "meanCollision": 0.24744352244454054,
           "maxCollision": 0.4690677459159886
         },
         "adjacentCostOverlap": {
@@ -388,7 +388,7 @@
           "utilityWinnerDifferentCount": 9,
           "utilityWinnerBlockedCount": 9,
           "utilityWinnerDifferentWithoutTierBlockCount": 0,
-          "meanBlockedUtilityGap": 0.31317465494316604,
+          "meanBlockedUtilityGap": 0.31349808009968755,
           "maxBlockedUtilityGap": 0.7069322795062469,
           "blockedByTier": {
             "coverage": 3,
@@ -457,7 +457,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "str_full_03",
               "bestUtilityTemplateId": "str_upper_01",
-              "selectedVsBestUtilityGap": 0.1944661261330891,
+              "selectedVsBestUtilityGap": 0.19484060226729427,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": true,
@@ -471,7 +471,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "mob_01",
               "bestUtilityTemplateId": "end_easy_01",
-              "selectedVsBestUtilityGap": 0.36468590202492923,
+              "selectedVsBestUtilityGap": 0.3666278145116255,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": true,
@@ -485,7 +485,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "end_mod_02",
               "bestUtilityTemplateId": "end_easy_01",
-              "selectedVsBestUtilityGap": 0.219136188501667,
+              "selectedVsBestUtilityGap": 0.2194689697487423,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -499,7 +499,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "end_mod_02",
               "bestUtilityTemplateId": "end_easy_01",
-              "selectedVsBestUtilityGap": 0.2168294896063922,
+              "selectedVsBestUtilityGap": 0.21700151025937559,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -513,7 +513,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.0851556596933192,
+              "selectedVsBestUtilityGap": 0.0852452955810524,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -888,7 +888,7 @@
             {
               "date": "2026-08-14",
               "weekIndex": 1,
-              "collision": 0.4340264431503356,
+              "collision": 0.4188572904589435,
               "costMagnitude": 1.1500000000000001,
               "topDimensions": [
                 "lowerBody",
@@ -898,7 +898,7 @@
             {
               "date": "2026-08-15",
               "weekIndex": 1,
-              "collision": 0.5022378455759636,
+              "collision": 0.49618086263682726,
               "costMagnitude": 1.645,
               "topDimensions": [
                 "lowerBody",
@@ -915,7 +915,7 @@
             {
               "date": "2026-08-17",
               "weekIndex": 1,
-              "collision": 0.2980711695881618,
+              "collision": 0.29303533962906053,
               "costMagnitude": 1.1500000000000001,
               "topDimensions": [
                 "lowerBody",
@@ -925,7 +925,7 @@
             {
               "date": "2026-08-18",
               "weekIndex": 1,
-              "collision": 0.33489898104531646,
+              "collision": 0.3317839978511641,
               "costMagnitude": 2.4,
               "topDimensions": [
                 "lowerBody",
@@ -942,7 +942,7 @@
             {
               "date": "2026-08-20",
               "weekIndex": 1,
-              "collision": 0.32601466054270495,
+              "collision": 0.324596555337673,
               "costMagnitude": 2.4,
               "topDimensions": [
                 "lowerBody",
@@ -950,8 +950,8 @@
               ]
             }
           ],
-          "meanCollision": 0.287801620365655,
-          "maxCollision": 0.5022378455759636
+          "meanCollision": 0.2856019736521683,
+          "maxCollision": 0.49618086263682726
         },
         "adjacentCostOverlap": {
           "perPair": [
@@ -1028,7 +1028,7 @@
               "weekIndex": 1,
               "hardDayCount": 3,
               "maxHardStreak": 1,
-              "recoveryAfterHighCollisionCount": 1,
+              "recoveryAfterHighCollisionCount": 0,
               "recoveryWhileFatigueLowAndWorkFeasibleCount": 0
             }
           ]
@@ -1038,7 +1038,7 @@
           "utilityWinnerDifferentCount": 8,
           "utilityWinnerBlockedCount": 8,
           "utilityWinnerDifferentWithoutTierBlockCount": 0,
-          "meanBlockedUtilityGap": 0.2903225538760131,
+          "meanBlockedUtilityGap": 0.2901565080666129,
           "maxBlockedUtilityGap": 0.7509250433284079,
           "blockedByTier": {
             "coverage": 2,
@@ -1093,7 +1093,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "str_full_03",
               "bestUtilityTemplateId": "str_upper_01",
-              "selectedVsBestUtilityGap": 0.21425101776043232,
+              "selectedVsBestUtilityGap": 0.2115723563384262,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": true,
@@ -1107,7 +1107,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.08599451170751893,
+              "selectedVsBestUtilityGap": 0.08708393898186825,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -1121,7 +1121,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "end_mod_02",
               "bestUtilityTemplateId": "end_walk_01",
-              "selectedVsBestUtilityGap": 0.05649981334598314,
+              "selectedVsBestUtilityGap": 0.05621198013530887,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -1135,7 +1135,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.0825290647183263,
+              "selectedVsBestUtilityGap": 0.08285505753149058,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -1149,7 +1149,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "end_mod_02",
               "bestUtilityTemplateId": "end_easy_01",
-              "selectedVsBestUtilityGap": 0.2122961349702664,
+              "selectedVsBestUtilityGap": 0.21251884304023144,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -1191,19 +1191,20 @@
       "totalDays": 14,
       "categoryDistribution": {
         "Full-body Strength": 3,
-        "Easy Endurance": 9,
+        "Easy Endurance": 7,
         "Mobility/Recovery": 1,
-        "Rest": 1
+        "Rest": 2,
+        "Moderate Endurance": 1
       },
       "modalityDistribution": {
         "Strength": 3,
         "Cycling": 5,
-        "Walking": 4,
+        "Walking": 3,
         "Mobility": 1,
-        "None": 1
+        "None": 2
       },
-      "restOrRecoveryDayCount": 2,
-      "restOrRecoveryDayPct": 14.3,
+      "restOrRecoveryDayCount": 3,
+      "restOrRecoveryDayPct": 21.4,
       "maxConsecutiveSameTemplateStreakWithinCall": 1,
       "maxConsecutiveSameTemplateStreakAcrossWeeks": 1,
       "objectiveResolution": [
@@ -1311,7 +1312,7 @@
         }
       ],
       "utilityDiagnostics": {
-        "fragileSelectionCount": 2,
+        "fragileSelectionCount": 3,
         "lowerBenefitSelectionCount": 3,
         "trainTierRestOrRecoveryCount": 0
       },
@@ -1341,8 +1342,8 @@
       "anchorScopeNote": "Anchor-day nomination only requires SOME focus event (Race-Specific Endurance templates' phaseEligibility.requiresFocusEvent doesn't check event category), so a nomination can appear even here -- but the optimizer's event-priority penalty for non-matching modalities makes it unlikely to actually win the day's pick. Treat eventSpecificAnchorHit/qualityAnchorHit, not the raw nomination, as the meaningful signal for non-cycling scenarios.",
       "fatigueTierDayCounts": {
         "train": 5,
-        "modify": 4,
-        "recover": 1
+        "modify": 3,
+        "recover": 2
       },
       "constraintViolations": [],
       "allocationReports": [
@@ -1631,7 +1632,7 @@
             {
               "date": "2026-08-14",
               "weekIndex": 1,
-              "collision": 0.6503645956687724,
+              "collision": 0.6118203439307821,
               "costMagnitude": 1.1500000000000001,
               "topDimensions": [
                 "lowerBody",
@@ -1641,7 +1642,7 @@
             {
               "date": "2026-08-15",
               "weekIndex": 1,
-              "collision": 0.562652620576996,
+              "collision": 0.5476952183959138,
               "costMagnitude": 1.645,
               "topDimensions": [
                 "lowerBody",
@@ -1658,8 +1659,8 @@
             {
               "date": "2026-08-17",
               "weekIndex": 1,
-              "collision": 0.3546346866223831,
-              "costMagnitude": 0.6900000000000002,
+              "collision": 0.3437250494387512,
+              "costMagnitude": 1.1500000000000001,
               "topDimensions": [
                 "lowerBody",
                 "systemic"
@@ -1668,8 +1669,8 @@
             {
               "date": "2026-08-18",
               "weekIndex": 1,
-              "collision": 0.32784731240128023,
-              "costMagnitude": 1.1500000000000001,
+              "collision": 0.3832534141096005,
+              "costMagnitude": 0.8624999999999998,
               "topDimensions": [
                 "lowerBody",
                 "systemic"
@@ -1678,8 +1679,8 @@
             {
               "date": "2026-08-19",
               "weekIndex": 1,
-              "collision": 0.3712041800331163,
-              "costMagnitude": 0.6900000000000002,
+              "collision": 0.3443619539078867,
+              "costMagnitude": 2.4,
               "topDimensions": [
                 "lowerBody",
                 "systemic"
@@ -1688,16 +1689,13 @@
             {
               "date": "2026-08-20",
               "weekIndex": 1,
-              "collision": 0.33417038030381707,
-              "costMagnitude": 1.1500000000000001,
-              "topDimensions": [
-                "lowerBody",
-                "systemic"
-              ]
+              "collision": 0,
+              "costMagnitude": 0,
+              "topDimensions": []
             }
           ],
-          "meanCollision": 0.3610237206803674,
-          "maxCollision": 0.6503645956687724
+          "meanCollision": 0.334593878121551,
+          "maxCollision": 0.6118203439307821
         },
         "adjacentCostOverlap": {
           "perPair": [
@@ -1752,44 +1750,37 @@
             {
               "date": "2026-08-18",
               "previousDate": "2026-08-17",
-              "overlap": 0.3737347558439819,
-              "lowerBodyOverlap": 0.12727922061357855,
-              "impactTissueOverlap": 0.042426406871192854,
-              "neuromuscularOverlap": 0.037797631496846194
+              "overlap": 0.8305216796532935,
+              "lowerBodyOverlap": 0.21213203435596426,
+              "impactTissueOverlap": 0.07071067811865477,
+              "neuromuscularOverlap": 0.06299605249474366
             },
             {
               "date": "2026-08-19",
               "previousDate": "2026-08-18",
-              "overlap": 0.8843332936260265,
-              "lowerBodyOverlap": 0.18,
-              "impactTissueOverlap": 0.06,
-              "neuromuscularOverlap": 0.06
-            },
-            {
-              "date": "2026-08-20",
-              "previousDate": "2026-08-19",
-              "overlap": 0.3737347558439819,
-              "lowerBodyOverlap": 0.12727922061357855,
-              "impactTissueOverlap": 0.042426406871192854,
-              "neuromuscularOverlap": 0.037797631496846194
+              "overlap": 0.22385154646905173,
+              "lowerBodyOverlap": 0.15909902576697318,
+              "impactTissueOverlap": 0.05303300858899108,
+              "neuromuscularOverlap": 0.04724703937105775
             }
           ],
           "maxLowerBodyOverlap": 0.3,
           "maxImpactTissueOverlap": 0.1,
           "maxNeuromuscularOverlap": 0.1,
-          "meanOverlap": 0.5036033947008893
+          "meanOverlap": 0.49437512163954495
         },
         "qualitySpacing": {
           "gapsDays": [
             6,
-            2
+            2,
+            4
           ],
           "minGapDays": 2,
           "medianGapDays": 4,
           "adjacentQualityDayCount": 0,
           "longestQualityStreak": 0,
           "qualityPer3DayWindowMax": 2,
-          "qualityPer7DayWindowMax": 2
+          "qualityPer7DayWindowMax": 3
         },
         "hardDayConcentration": {
           "weekly": [
@@ -1802,7 +1793,7 @@
             },
             {
               "weekIndex": 1,
-              "hardDayCount": 1,
+              "hardDayCount": 2,
               "maxHardStreak": 1,
               "recoveryAfterHighCollisionCount": 1,
               "recoveryWhileFatigueLowAndWorkFeasibleCount": 0
@@ -1811,15 +1802,15 @@
         },
         "opportunityCost": {
           "daysWithRankingAudit": 14,
-          "utilityWinnerDifferentCount": 4,
-          "utilityWinnerBlockedCount": 4,
+          "utilityWinnerDifferentCount": 6,
+          "utilityWinnerBlockedCount": 6,
           "utilityWinnerDifferentWithoutTierBlockCount": 0,
-          "meanBlockedUtilityGap": 0.4600860838020646,
+          "meanBlockedUtilityGap": 0.35425532007473143,
           "maxBlockedUtilityGap": 0.7201789511951029,
           "blockedByTier": {
             "coverage": 2,
-            "recovery": 0,
-            "benefit": 4
+            "recovery": 1,
+            "benefit": 6
           },
           "perDay": [
             {
@@ -1869,7 +1860,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "str_full_03",
               "bestUtilityTemplateId": "str_upper_01",
-              "selectedVsBestUtilityGap": 0.21873972738036274,
+              "selectedVsBestUtilityGap": 0.21567642415427574,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": true,
@@ -1877,6 +1868,34 @@
                 "benefit": true
               },
               "selectedAdvancesRequiredRole": true
+            },
+            {
+              "date": "2026-08-19",
+              "weekIndex": 1,
+              "selectedTemplateId": "end_mod_02",
+              "bestUtilityTemplateId": "end_easy_01",
+              "selectedVsBestUtilityGap": 0.20647188185887577,
+              "tierBlocked": true,
+              "blockedByTier": {
+                "coverage": false,
+                "recovery": false,
+                "benefit": true
+              },
+              "selectedAdvancesRequiredRole": false
+            },
+            {
+              "date": "2026-08-20",
+              "weekIndex": 1,
+              "selectedTemplateId": "rest_01",
+              "bestUtilityTemplateId": "mob_01",
+              "selectedVsBestUtilityGap": 0.08177900660734203,
+              "tierBlocked": true,
+              "blockedByTier": {
+                "coverage": false,
+                "recovery": true,
+                "benefit": true
+              },
+              "selectedAdvancesRequiredRole": false
             }
           ]
         }
@@ -1895,10 +1914,10 @@
           "weekIndex": 1,
           "fatigueTierDayCounts": {
             "train": 2,
-            "modify": 2,
-            "recover": 1
+            "modify": 1,
+            "recover": 2
           },
-          "restOrRecoveryDayCount": 1
+          "restOrRecoveryDayCount": 2
         }
       ]
     },
@@ -1937,7 +1956,7 @@
         {
           "key": "race_specific_endurance",
           "timesGenerated": 4,
-          "timesResolved": 3
+          "timesResolved": 0
         },
         {
           "key": "strength_maintenance",
@@ -2019,7 +2038,17 @@
           "templateId": "str_full_03",
           "templateTitle": "Reduced Full-body Strength Maintenance",
           "modality": "Strength",
-          "earnedCredit": 0.30000000000000004
+          "earnedCredit": 0.49
+        },
+        {
+          "weekIndex": 1,
+          "date": "2026-08-20",
+          "objectiveKey": "strength_maintenance",
+          "objectiveTitle": "Strength & Neuromuscular Maintenance",
+          "templateId": "str_upper_01",
+          "templateTitle": "Upper Body Push/Pull",
+          "modality": "Strength",
+          "earnedCredit": 0.020000000000000018
         },
         {
           "weekIndex": 2,
@@ -2029,17 +2058,7 @@
           "templateId": "end_hard_02",
           "templateTitle": "Bike VO2 Intervals",
           "modality": "Cycling",
-          "earnedCredit": 0.30000000000000004
-        },
-        {
-          "weekIndex": 2,
-          "date": "2026-08-22",
-          "objectiveKey": "strength_maintenance",
-          "objectiveTitle": "Strength & Neuromuscular Maintenance",
-          "templateId": "str_upper_01",
-          "templateTitle": "Upper Body Push/Pull",
-          "modality": "Strength",
-          "earnedCredit": 0.30000000000000004
+          "earnedCredit": 0.8
         },
         {
           "weekIndex": 3,
@@ -2050,16 +2069,25 @@
           "templateTitle": "Bike VO2 Intervals",
           "modality": "Cycling",
           "earnedCredit": 0.19999999999999996
+        },
+        {
+          "weekIndex": 3,
+          "date": "2026-09-02",
+          "objectiveKey": "strength_maintenance",
+          "objectiveTitle": "Strength & Neuromuscular Maintenance",
+          "templateId": "str_full_01",
+          "templateTitle": "Hybrid Full Body Push/Pull",
+          "modality": "Strength",
+          "earnedCredit": 0.30000000000000004
         }
       ],
       "utilityDiagnostics": {
-        "fragileSelectionCount": 11,
-        "lowerBenefitSelectionCount": 10,
+        "fragileSelectionCount": 13,
+        "lowerBenefitSelectionCount": 12,
         "trainTierRestOrRecoveryCount": 1
       },
       "qualityWarnings": [
-        "Unresolved weekly objectives: race_specific_endurance 3/4, strength_maintenance 3/4.",
-        "Resolved objective(s) without a projected credit source in this window: race_specific_endurance. Verify whether completion was seeded from prior history.",
+        "Unresolved weekly objectives: race_specific_endurance 0/4, strength_maintenance 3/4.",
         "Event-specific anchor missed in 1 nominated week(s).",
         "Event-specific exposure occurred off the nominated anchor date in 3 week(s) (adaptively fulfilled in-window).",
         "Rest or mobility selected on 1 projected train-tier day(s)."
@@ -2114,8 +2142,8 @@
       ],
       "anchorScopeNote": null,
       "fatigueTierDayCounts": {
-        "train": 11,
-        "modify": 2,
+        "train": 10,
+        "modify": 3,
         "recover": 7
       },
       "constraintViolations": [],
@@ -2375,7 +2403,7 @@
             {
               "date": "2026-08-14",
               "weekIndex": 1,
-              "collision": 0.4819971877971595,
+              "collision": 0.4386644961843659,
               "costMagnitude": 1.1500000000000001,
               "topDimensions": [
                 "lowerBody",
@@ -2385,11 +2413,11 @@
             {
               "date": "2026-08-15",
               "weekIndex": 1,
-              "collision": 0.510334133619218,
+              "collision": 0.49265596885032137,
               "costMagnitude": 1.645,
               "topDimensions": [
-                "lowerBody",
-                "neuromuscular"
+                "neuromuscular",
+                "lowerBody"
               ]
             },
             {
@@ -2402,7 +2430,7 @@
             {
               "date": "2026-08-17",
               "weekIndex": 1,
-              "collision": 0.28235851864809425,
+              "collision": 0.27066344465596837,
               "costMagnitude": 2.2105263157894735,
               "topDimensions": [
                 "systemic",
@@ -2412,7 +2440,7 @@
             {
               "date": "2026-08-18",
               "weekIndex": 1,
-              "collision": 0.472944785793999,
+              "collision": 0.46424579693400864,
               "costMagnitude": 0.6900000000000002,
               "topDimensions": [
                 "lowerBody",
@@ -2422,7 +2450,7 @@
             {
               "date": "2026-08-19",
               "weekIndex": 1,
-              "collision": 0.39394591445019983,
+              "collision": 0.3881161994285278,
               "costMagnitude": 1.1500000000000001,
               "topDimensions": [
                 "lowerBody",
@@ -2432,31 +2460,31 @@
             {
               "date": "2026-08-20",
               "weekIndex": 1,
-              "collision": 0.4086094521151354,
-              "costMagnitude": 0.6900000000000002,
+              "collision": 0.2391723646644645,
+              "costMagnitude": 1.575,
               "topDimensions": [
-                "lowerBody",
-                "systemic"
+                "systemic",
+                "neuromuscular"
               ]
             },
             {
               "date": "2026-08-21",
               "weekIndex": 2,
-              "collision": 0.46737579391680106,
+              "collision": 0.3628652234063623,
               "costMagnitude": 4,
               "topDimensions": [
                 "systemic",
-                "lowerBody"
+                "neuromuscular"
               ]
             },
             {
               "date": "2026-08-22",
               "weekIndex": 2,
-              "collision": 0.6045702765644768,
-              "costMagnitude": 1.575,
+              "collision": 0.7405132471214119,
+              "costMagnitude": 0.6900000000000002,
               "topDimensions": [
                 "systemic",
-                "upperBody"
+                "lowerBody"
               ]
             },
             {
@@ -2469,11 +2497,11 @@
             {
               "date": "2026-08-24",
               "weekIndex": 2,
-              "collision": 0.40264772221343903,
+              "collision": 0.32391987826481217,
               "costMagnitude": 2.35,
               "topDimensions": [
                 "lowerBody",
-                "neuromuscular"
+                "systemic"
               ]
             },
             {
@@ -2486,8 +2514,8 @@
             {
               "date": "2026-08-26",
               "weekIndex": 2,
-              "collision": 0.30336435175725124,
-              "costMagnitude": 0.82,
+              "collision": 0.29269400740917784,
+              "costMagnitude": 2.2105263157894735,
               "topDimensions": [
                 "systemic",
                 "lowerBody"
@@ -2496,8 +2524,8 @@
             {
               "date": "2026-08-27",
               "weekIndex": 2,
-              "collision": 0.314047817014459,
-              "costMagnitude": 1.1500000000000001,
+              "collision": 0.47452643352417495,
+              "costMagnitude": 0.6900000000000002,
               "topDimensions": [
                 "lowerBody",
                 "systemic"
@@ -2506,7 +2534,7 @@
             {
               "date": "2026-08-28",
               "weekIndex": 3,
-              "collision": 0.44569599878934807,
+              "collision": 0.39607169628218647,
               "costMagnitude": 1.1500000000000001,
               "topDimensions": [
                 "lowerBody",
@@ -2516,7 +2544,7 @@
             {
               "date": "2026-08-29",
               "weekIndex": 3,
-              "collision": 0.47089606016482427,
+              "collision": 0.4484540852055061,
               "costMagnitude": 0.6900000000000002,
               "topDimensions": [
                 "lowerBody",
@@ -2526,7 +2554,7 @@
             {
               "date": "2026-08-30",
               "weekIndex": 3,
-              "collision": 0.3464783048218145,
+              "collision": 0.3286395837295963,
               "costMagnitude": 4,
               "topDimensions": [
                 "lowerBody",
@@ -2550,8 +2578,8 @@
             {
               "date": "2026-09-02",
               "weekIndex": 3,
-              "collision": 0.2609929046849256,
-              "costMagnitude": 2.35,
+              "collision": 0.2561786250603074,
+              "costMagnitude": 4.1,
               "topDimensions": [
                 "lowerBody",
                 "systemic"
@@ -2565,8 +2593,8 @@
               "topDimensions": []
             }
           ],
-          "meanCollision": 0.281338089784113,
-          "maxCollision": 0.6045702765644768
+          "meanCollision": 0.27244958365447186,
+          "maxCollision": 0.7405132471214119
         },
         "adjacentCostOverlap": {
           "perPair": [
@@ -2621,42 +2649,42 @@
             {
               "date": "2026-08-20",
               "previousDate": "2026-08-19",
-              "overlap": 0.8843332936260265,
+              "overlap": 0.2821240426853516,
+              "lowerBodyOverlap": 0,
+              "impactTissueOverlap": 0.07071067811865477,
+              "neuromuscularOverlap": 0.06299605249474366
+            },
+            {
+              "date": "2026-08-21",
+              "previousDate": "2026-08-20",
+              "overlap": 0.1510341338264289,
+              "lowerBodyOverlap": 0,
+              "impactTissueOverlap": 0.05303300858899108,
+              "neuromuscularOverlap": 0.2362351968552887
+            },
+            {
+              "date": "2026-08-22",
+              "previousDate": "2026-08-21",
+              "overlap": 0.27881689188725084,
               "lowerBodyOverlap": 0.18,
               "impactTissueOverlap": 0.06,
               "neuromuscularOverlap": 0.06
             },
             {
-              "date": "2026-08-21",
-              "previousDate": "2026-08-20",
-              "overlap": 0.10744874230514481,
-              "lowerBodyOverlap": 0.12727922061357855,
-              "impactTissueOverlap": 0.042426406871192854,
-              "neuromuscularOverlap": 0.037797631496846194
-            },
-            {
-              "date": "2026-08-22",
-              "previousDate": "2026-08-21",
-              "overlap": 0.31197770285927406,
-              "lowerBodyOverlap": 0,
-              "impactTissueOverlap": 0.07500000000000001,
-              "neuromuscularOverlap": 0.375
-            },
-            {
               "date": "2026-08-27",
               "previousDate": "2026-08-26",
-              "overlap": 0.43548378758029166,
-              "lowerBodyOverlap": 0.09899494936611665,
-              "impactTissueOverlap": 0.042426406871192854,
-              "neuromuscularOverlap": 0.07559526299369239
+              "overlap": 0.5097716711735423,
+              "lowerBodyOverlap": 0.18,
+              "impactTissueOverlap": 0.06,
+              "neuromuscularOverlap": 0.06
             },
             {
               "date": "2026-08-28",
               "previousDate": "2026-08-27",
-              "overlap": 0.62289125973997,
-              "lowerBodyOverlap": 0.21213203435596426,
-              "impactTissueOverlap": 0.07071067811865477,
-              "neuromuscularOverlap": 0.06299605249474366
+              "overlap": 0.3737347558439819,
+              "lowerBodyOverlap": 0.12727922061357855,
+              "impactTissueOverlap": 0.042426406871192854,
+              "neuromuscularOverlap": 0.037797631496846194
             },
             {
               "date": "2026-08-29",
@@ -2677,8 +2705,8 @@
           ],
           "maxLowerBodyOverlap": 0.22273863607376249,
           "maxImpactTissueOverlap": 0.09899494936611665,
-          "maxNeuromuscularOverlap": 0.375,
-          "meanOverlap": 0.48450467555376203
+          "maxNeuromuscularOverlap": 0.2362351968552887,
+          "meanOverlap": 0.4255313455003658
         },
         "qualitySpacing": {
           "gapsDays": [
@@ -2712,7 +2740,7 @@
               "weekIndex": 1,
               "hardDayCount": 2,
               "maxHardStreak": 1,
-              "recoveryAfterHighCollisionCount": 1,
+              "recoveryAfterHighCollisionCount": 0,
               "recoveryWhileFatigueLowAndWorkFeasibleCount": 0
             },
             {
@@ -2733,15 +2761,15 @@
         },
         "opportunityCost": {
           "daysWithRankingAudit": 28,
-          "utilityWinnerDifferentCount": 17,
-          "utilityWinnerBlockedCount": 17,
+          "utilityWinnerDifferentCount": 19,
+          "utilityWinnerBlockedCount": 19,
           "utilityWinnerDifferentWithoutTierBlockCount": 0,
-          "meanBlockedUtilityGap": 0.5093448596050941,
-          "maxBlockedUtilityGap": 2.3992636006343773,
+          "meanBlockedUtilityGap": 0.39116553843227375,
+          "maxBlockedUtilityGap": 2.300576093003335,
           "blockedByTier": {
-            "coverage": 9,
+            "coverage": 11,
             "recovery": 6,
-            "benefit": 10
+            "benefit": 12
           },
           "perDay": [
             {
@@ -2805,7 +2833,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "end_easy_01",
               "bestUtilityTemplateId": "str_upper_01",
-              "selectedVsBestUtilityGap": 0.06988694188757805,
+              "selectedVsBestUtilityGap": 0.06653345374702913,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": true,
@@ -2819,7 +2847,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "str_full_03",
               "bestUtilityTemplateId": "str_upper_01",
-              "selectedVsBestUtilityGap": 0.14683473808924785,
+              "selectedVsBestUtilityGap": 0.14286134781680082,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": true,
@@ -2833,7 +2861,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.017311151248623723,
+              "selectedVsBestUtilityGap": 0.017846427844572264,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -2847,7 +2875,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "end_race_sim_01",
               "bestUtilityTemplateId": "end_race_specific_01",
-              "selectedVsBestUtilityGap": 0.08146952532206053,
+              "selectedVsBestUtilityGap": 0.07697029703299618,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -2857,11 +2885,39 @@
               "selectedAdvancesRequiredRole": true
             },
             {
+              "date": "2026-08-18",
+              "weekIndex": 1,
+              "selectedTemplateId": "end_easy_04",
+              "bestUtilityTemplateId": "str_upper_01",
+              "selectedVsBestUtilityGap": 0.08287148683720269,
+              "tierBlocked": true,
+              "blockedByTier": {
+                "coverage": true,
+                "recovery": false,
+                "benefit": true
+              },
+              "selectedAdvancesRequiredRole": false
+            },
+            {
+              "date": "2026-08-19",
+              "weekIndex": 1,
+              "selectedTemplateId": "end_easy_01",
+              "bestUtilityTemplateId": "str_upper_01",
+              "selectedVsBestUtilityGap": 0.12620342296708154,
+              "tierBlocked": true,
+              "blockedByTier": {
+                "coverage": true,
+                "recovery": false,
+                "benefit": true
+              },
+              "selectedAdvancesRequiredRole": false
+            },
+            {
               "date": "2026-08-21",
               "weekIndex": 2,
               "selectedTemplateId": "end_hard_02",
               "bestUtilityTemplateId": "end_mod_02",
-              "selectedVsBestUtilityGap": 0.4682164493756148,
+              "selectedVsBestUtilityGap": 0.5437152758018196,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": true,
@@ -2871,25 +2927,11 @@
               "selectedAdvancesRequiredRole": true
             },
             {
-              "date": "2026-08-22",
-              "weekIndex": 2,
-              "selectedTemplateId": "str_upper_01",
-              "bestUtilityTemplateId": "end_easy_01",
-              "selectedVsBestUtilityGap": 0.2832717044795831,
-              "tierBlocked": true,
-              "blockedByTier": {
-                "coverage": false,
-                "recovery": false,
-                "benefit": true
-              },
-              "selectedAdvancesRequiredRole": false
-            },
-            {
               "date": "2026-08-23",
               "weekIndex": 2,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.013499879400677477,
+              "selectedVsBestUtilityGap": 0.015809644733187155,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -2903,7 +2945,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.015606612892918204,
+              "selectedVsBestUtilityGap": 0.016637270359880038,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -2913,25 +2955,39 @@
               "selectedAdvancesRequiredRole": false
             },
             {
+              "date": "2026-08-26",
+              "weekIndex": 2,
+              "selectedTemplateId": "end_race_sim_01",
+              "bestUtilityTemplateId": "end_race_specific_01",
+              "selectedVsBestUtilityGap": 0.17922510980283768,
+              "tierBlocked": true,
+              "blockedByTier": {
+                "coverage": false,
+                "recovery": false,
+                "benefit": true
+              },
+              "selectedAdvancesRequiredRole": true
+            },
+            {
               "date": "2026-08-28",
               "weekIndex": 3,
-              "selectedTemplateId": "end_easy_04",
-              "bestUtilityTemplateId": "end_race_specific_01",
-              "selectedVsBestUtilityGap": 1.3574723476024926,
+              "selectedTemplateId": "end_easy_01",
+              "bestUtilityTemplateId": "str_upper_01",
+              "selectedVsBestUtilityGap": 0.061070630002967974,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": true,
                 "recovery": false,
                 "benefit": true
               },
-              "selectedAdvancesRequiredRole": false
+              "selectedAdvancesRequiredRole": true
             },
             {
               "date": "2026-08-31",
               "weekIndex": 3,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.012478990549070194,
+              "selectedVsBestUtilityGap": 0.012763741587719257,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -2945,7 +3001,7 @@
               "weekIndex": 3,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.034141653103796146,
+              "selectedVsBestUtilityGap": 0.034399679915231525,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -2957,9 +3013,9 @@
             {
               "date": "2026-09-02",
               "weekIndex": 3,
-              "selectedTemplateId": "str_full_03",
+              "selectedTemplateId": "str_full_01",
               "bestUtilityTemplateId": "end_race_specific_01",
-              "selectedVsBestUtilityGap": 2.3992636006343773,
+              "selectedVsBestUtilityGap": 2.300576093003335,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": true,
@@ -2973,7 +3029,7 @@
               "weekIndex": 3,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.017560756312223112,
+              "selectedVsBestUtilityGap": 0.012813086372204276,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -3007,8 +3063,8 @@
         {
           "weekIndex": 2,
           "fatigueTierDayCounts": {
-            "train": 3,
-            "modify": 0,
+            "train": 2,
+            "modify": 1,
             "recover": 2
           },
           "restOrRecoveryDayCount": 2
@@ -3033,22 +3089,21 @@
       "totalDays": 28,
       "categoryDistribution": {
         "Easy Endurance": 9,
-        "Full-body Strength": 3,
-        "Race-Specific Endurance": 4,
+        "Full-body Strength": 4,
+        "Race-Specific Endurance": 3,
         "Mobility/Recovery": 1,
         "Hard Endurance": 3,
-        "Rest": 6,
-        "Upper-body Strength": 1,
-        "Technical Skill": 1
+        "Rest": 7,
+        "Upper-body Strength": 1
       },
       "modalityDistribution": {
-        "Cycling": 17,
-        "Strength": 4,
+        "Cycling": 15,
+        "Strength": 5,
         "Mobility": 1,
-        "None": 6
+        "None": 7
       },
-      "restOrRecoveryDayCount": 7,
-      "restOrRecoveryDayPct": 25,
+      "restOrRecoveryDayCount": 8,
+      "restOrRecoveryDayPct": 28.6,
       "maxConsecutiveSameTemplateStreakWithinCall": 2,
       "maxConsecutiveSameTemplateStreakAcrossWeeks": 2,
       "objectiveResolution": [
@@ -3177,7 +3232,7 @@
           "templateId": "str_full_03",
           "templateTitle": "Reduced Full-body Strength Maintenance",
           "modality": "Strength",
-          "earnedCredit": 0.30000000000000004
+          "earnedCredit": 0.49
         },
         {
           "weekIndex": 1,
@@ -3190,6 +3245,16 @@
           "earnedCredit": 0.30000000000000004
         },
         {
+          "weekIndex": 1,
+          "date": "2026-08-20",
+          "objectiveKey": "strength_maintenance",
+          "objectiveTitle": "Strength & Neuromuscular Maintenance",
+          "templateId": "str_upper_01",
+          "templateTitle": "Upper Body Push/Pull",
+          "modality": "Strength",
+          "earnedCredit": 0.020000000000000018
+        },
+        {
           "weekIndex": 2,
           "date": "2026-08-21",
           "objectiveKey": "threshold_quality",
@@ -3197,17 +3262,17 @@
           "templateId": "end_hard_02",
           "templateTitle": "Bike VO2 Intervals",
           "modality": "Cycling",
-          "earnedCredit": 0.30000000000000004
+          "earnedCredit": 0.8
         },
         {
           "weekIndex": 2,
-          "date": "2026-08-22",
-          "objectiveKey": "strength_maintenance",
-          "objectiveTitle": "Strength & Neuromuscular Maintenance",
-          "templateId": "str_upper_01",
-          "templateTitle": "Upper Body Push/Pull",
-          "modality": "Strength",
-          "earnedCredit": 0.30000000000000004
+          "date": "2026-08-21",
+          "objectiveKey": "surge_repeatability",
+          "objectiveTitle": "Surge & High-Intensity Repeatability",
+          "templateId": "end_hard_02",
+          "templateTitle": "Bike VO2 Intervals",
+          "modality": "Cycling",
+          "earnedCredit": 0.37
         },
         {
           "weekIndex": 2,
@@ -3217,27 +3282,38 @@
           "templateId": "end_race_sim_01",
           "templateTitle": "Race Simulation",
           "modality": "Cycling",
-          "earnedCredit": 0.15000000000000002
+          "earnedCredit": 0.45999999999999996
         },
         {
           "weekIndex": 3,
-          "date": "2026-09-03",
-          "objectiveKey": "race_specific_endurance",
-          "objectiveTitle": "Cycling Race-Specific Endurance",
-          "templateId": "end_race_sim_01",
-          "templateTitle": "Race Simulation",
+          "date": "2026-08-30",
+          "objectiveKey": "threshold_quality",
+          "objectiveTitle": "Threshold Development",
+          "templateId": "end_hard_02",
+          "templateTitle": "Bike VO2 Intervals",
           "modality": "Cycling",
-          "earnedCredit": 0.15000000000000002
+          "earnedCredit": 0.19999999999999996
+        },
+        {
+          "weekIndex": 3,
+          "date": "2026-09-02",
+          "objectiveKey": "strength_maintenance",
+          "objectiveTitle": "Strength & Neuromuscular Maintenance",
+          "templateId": "str_full_01",
+          "templateTitle": "Hybrid Full Body Push/Pull",
+          "modality": "Strength",
+          "earnedCredit": 0.30000000000000004
         }
       ],
       "utilityDiagnostics": {
         "fragileSelectionCount": 13,
-        "lowerBenefitSelectionCount": 8,
+        "lowerBenefitSelectionCount": 12,
         "trainTierRestOrRecoveryCount": 0
       },
       "qualityWarnings": [
         "Unresolved weekly objectives: strength_maintenance 3/4.",
-        "Event-specific exposure occurred off the nominated anchor date in 4 week(s) (adaptively fulfilled in-window)."
+        "Event-specific anchor missed in 1 nominated week(s).",
+        "Event-specific exposure occurred off the nominated anchor date in 3 week(s) (adaptively fulfilled in-window)."
       ],
       "anchorWeeks": [
         {
@@ -3282,18 +3358,16 @@
           "eventSpecificAnchorDate": "2026-08-30",
           "qualityAnchorDate": "2026-09-01",
           "eventSpecificAnchorHit": false,
-          "eventSpecificExposureDates": [
-            "2026-09-03"
-          ],
-          "eventSpecificAnchorFulfilled": true,
+          "eventSpecificExposureDates": [],
+          "eventSpecificAnchorFulfilled": false,
           "qualityAnchorHit": false
         }
       ],
       "anchorScopeNote": null,
       "fatigueTierDayCounts": {
         "train": 9,
-        "modify": 5,
-        "recover": 6
+        "modify": 4,
+        "recover": 7
       },
       "constraintViolations": [],
       "allocationReports": [
@@ -3467,8 +3541,8 @@
                 },
                 "reservation": {
                   "occurrenceId": "september_cycling_event|2026-08-23|2026-09-12|peak|sustained_quality|september_cycling_event%3Asustained_quality|0",
-                  "nominatedDate": "2026-08-31",
-                  "assignedDate": "2026-08-31",
+                  "nominatedDate": "2026-08-30",
+                  "assignedDate": "2026-08-30",
                   "templateId": "end_hard_02",
                   "workoutId": "cycling_over_under_3x12_01",
                   "wasMoved": false
@@ -3552,7 +3626,7 @@
             {
               "date": "2026-08-14",
               "weekIndex": 1,
-              "collision": 0.49099693035116454,
+              "collision": 0.474780503666713,
               "costMagnitude": 1.1500000000000001,
               "topDimensions": [
                 "lowerBody",
@@ -3562,7 +3636,7 @@
             {
               "date": "2026-08-15",
               "weekIndex": 1,
-              "collision": 0.5122926338933348,
+              "collision": 0.5056160186379907,
               "costMagnitude": 1.645,
               "topDimensions": [
                 "lowerBody",
@@ -3579,7 +3653,7 @@
             {
               "date": "2026-08-17",
               "weekIndex": 1,
-              "collision": 0.2855504934112354,
+              "collision": 0.2806200526853362,
               "costMagnitude": 2.2105263157894735,
               "topDimensions": [
                 "systemic",
@@ -3589,7 +3663,7 @@
             {
               "date": "2026-08-18",
               "weekIndex": 1,
-              "collision": 0.47418328482836225,
+              "collision": 0.4704248027679383,
               "costMagnitude": 0.6900000000000002,
               "topDimensions": [
                 "lowerBody",
@@ -3599,7 +3673,7 @@
             {
               "date": "2026-08-19",
               "weekIndex": 1,
-              "collision": 0.3947548040051926,
+              "collision": 0.39220733808741043,
               "costMagnitude": 1.1500000000000001,
               "topDimensions": [
                 "lowerBody",
@@ -3609,31 +3683,31 @@
             {
               "date": "2026-08-20",
               "weekIndex": 1,
-              "collision": 0.40914204606127735,
-              "costMagnitude": 0.6900000000000002,
+              "collision": 0.24043316266674117,
+              "costMagnitude": 1.575,
               "topDimensions": [
-                "lowerBody",
-                "systemic"
+                "systemic",
+                "neuromuscular"
               ]
             },
             {
               "date": "2026-08-21",
               "weekIndex": 2,
-              "collision": 0.46737579391680106,
+              "collision": 0.3628652234063623,
               "costMagnitude": 4,
               "topDimensions": [
                 "systemic",
-                "lowerBody"
+                "neuromuscular"
               ]
             },
             {
               "date": "2026-08-22",
               "weekIndex": 2,
-              "collision": 0.6045702765644768,
-              "costMagnitude": 1.575,
+              "collision": 0.7405132471214119,
+              "costMagnitude": 0.6900000000000002,
               "topDimensions": [
                 "systemic",
-                "upperBody"
+                "lowerBody"
               ]
             },
             {
@@ -3646,11 +3720,11 @@
             {
               "date": "2026-08-24",
               "weekIndex": 2,
-              "collision": 0.40264772221343903,
+              "collision": 0.32391987826481217,
               "costMagnitude": 2.35,
               "topDimensions": [
                 "lowerBody",
-                "neuromuscular"
+                "systemic"
               ]
             },
             {
@@ -3663,7 +3737,7 @@
             {
               "date": "2026-08-26",
               "weekIndex": 2,
-              "collision": 0.31344618070103325,
+              "collision": 0.29269400740917784,
               "costMagnitude": 2.2105263157894735,
               "topDimensions": [
                 "systemic",
@@ -3673,7 +3747,7 @@
             {
               "date": "2026-08-27",
               "weekIndex": 2,
-              "collision": 0.48642626540185996,
+              "collision": 0.47452643352417495,
               "costMagnitude": 0.6900000000000002,
               "topDimensions": [
                 "lowerBody",
@@ -3683,7 +3757,7 @@
             {
               "date": "2026-08-28",
               "weekIndex": 3,
-              "collision": 0.5498288211929491,
+              "collision": 0.39607169628218647,
               "costMagnitude": 1.1500000000000001,
               "topDimensions": [
                 "lowerBody",
@@ -3693,18 +3767,18 @@
             {
               "date": "2026-08-29",
               "weekIndex": 3,
-              "collision": 0.5230141178126686,
-              "costMagnitude": 1.1500000000000001,
+              "collision": 0.4484540852055061,
+              "costMagnitude": 0.6900000000000002,
               "topDimensions": [
-                "neuromuscular",
+                "lowerBody",
                 "systemic"
               ]
             },
             {
               "date": "2026-08-30",
               "weekIndex": 3,
-              "collision": 0.44290702622241757,
-              "costMagnitude": 0.6900000000000002,
+              "collision": 0.3286395837295963,
+              "costMagnitude": 4,
               "topDimensions": [
                 "lowerBody",
                 "systemic"
@@ -3713,12 +3787,9 @@
             {
               "date": "2026-08-31",
               "weekIndex": 3,
-              "collision": 0.37350870415818216,
-              "costMagnitude": 4,
-              "topDimensions": [
-                "systemic",
-                "lowerBody"
-              ]
+              "collision": 0,
+              "costMagnitude": 0,
+              "topDimensions": []
             },
             {
               "date": "2026-09-01",
@@ -3730,23 +3801,23 @@
             {
               "date": "2026-09-02",
               "weekIndex": 3,
-              "collision": 0,
-              "costMagnitude": 0,
-              "topDimensions": []
+              "collision": 0.2561786250603074,
+              "costMagnitude": 4.1,
+              "topDimensions": [
+                "lowerBody",
+                "systemic"
+              ]
             },
             {
               "date": "2026-09-03",
               "weekIndex": 3,
-              "collision": 0.29156214491144844,
-              "costMagnitude": 2.2105263157894735,
-              "topDimensions": [
-                "systemic",
-                "lowerBody"
-              ]
+              "collision": 0,
+              "costMagnitude": 0,
+              "topDimensions": []
             }
           ],
-          "meanCollision": 0.32116281104746275,
-          "maxCollision": 0.6045702765644768
+          "meanCollision": 0.2842248615070992,
+          "maxCollision": 0.7405132471214119
         },
         "adjacentCostOverlap": {
           "perPair": [
@@ -3801,26 +3872,26 @@
             {
               "date": "2026-08-20",
               "previousDate": "2026-08-19",
-              "overlap": 0.8843332936260265,
-              "lowerBodyOverlap": 0.18,
-              "impactTissueOverlap": 0.06,
-              "neuromuscularOverlap": 0.06
+              "overlap": 0.2821240426853516,
+              "lowerBodyOverlap": 0,
+              "impactTissueOverlap": 0.07071067811865477,
+              "neuromuscularOverlap": 0.06299605249474366
             },
             {
               "date": "2026-08-21",
               "previousDate": "2026-08-20",
-              "overlap": 0.10744874230514481,
-              "lowerBodyOverlap": 0.12727922061357855,
-              "impactTissueOverlap": 0.042426406871192854,
-              "neuromuscularOverlap": 0.037797631496846194
+              "overlap": 0.1510341338264289,
+              "lowerBodyOverlap": 0,
+              "impactTissueOverlap": 0.05303300858899108,
+              "neuromuscularOverlap": 0.2362351968552887
             },
             {
               "date": "2026-08-22",
               "previousDate": "2026-08-21",
-              "overlap": 0.31197770285927406,
-              "lowerBodyOverlap": 0,
-              "impactTissueOverlap": 0.07500000000000001,
-              "neuromuscularOverlap": 0.375
+              "overlap": 0.27881689188725084,
+              "lowerBodyOverlap": 0.18,
+              "impactTissueOverlap": 0.06,
+              "neuromuscularOverlap": 0.06
             },
             {
               "date": "2026-08-27",
@@ -3841,22 +3912,14 @@
             {
               "date": "2026-08-29",
               "previousDate": "2026-08-28",
-              "overlap": 0.513838650962045,
-              "lowerBodyOverlap": 0.15,
-              "impactTissueOverlap": 0.05,
-              "neuromuscularOverlap": 0.06299605249474366
+              "overlap": 0.8843332936260265,
+              "lowerBodyOverlap": 0.18,
+              "impactTissueOverlap": 0.06,
+              "neuromuscularOverlap": 0.06
             },
             {
               "date": "2026-08-30",
               "previousDate": "2026-08-29",
-              "overlap": 0.5343410208132353,
-              "lowerBodyOverlap": 0.10606601717798213,
-              "impactTissueOverlap": 0.03535533905932738,
-              "neuromuscularOverlap": 0.06
-            },
-            {
-              "date": "2026-08-31",
-              "previousDate": "2026-08-30",
               "overlap": 0.10744874230514481,
               "lowerBodyOverlap": 0.12727922061357855,
               "impactTissueOverlap": 0.042426406871192854,
@@ -3865,8 +3928,8 @@
           ],
           "maxLowerBodyOverlap": 0.22273863607376249,
           "maxImpactTissueOverlap": 0.09899494936611665,
-          "maxNeuromuscularOverlap": 0.375,
-          "meanOverlap": 0.42031102405711745
+          "maxNeuromuscularOverlap": 0.2362351968552887,
+          "meanOverlap": 0.39451717601992126
         },
         "qualitySpacing": {
           "gapsDays": [
@@ -3877,7 +3940,7 @@
             4,
             3,
             2,
-            5,
+            4,
             3
           ],
           "minGapDays": 2,
@@ -3921,15 +3984,15 @@
         },
         "opportunityCost": {
           "daysWithRankingAudit": 28,
-          "utilityWinnerDifferentCount": 17,
-          "utilityWinnerBlockedCount": 17,
+          "utilityWinnerDifferentCount": 21,
+          "utilityWinnerBlockedCount": 21,
           "utilityWinnerDifferentWithoutTierBlockCount": 0,
-          "meanBlockedUtilityGap": 0.24577627388655454,
-          "maxBlockedUtilityGap": 1.1373156058749108,
+          "meanBlockedUtilityGap": 0.25940930860515204,
+          "maxBlockedUtilityGap": 1.2274698799948343,
           "blockedByTier": {
-            "coverage": 8,
-            "recovery": 5,
-            "benefit": 10
+            "coverage": 13,
+            "recovery": 6,
+            "benefit": 13
           },
           "perDay": [
             {
@@ -3993,7 +4056,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "end_easy_01",
               "bestUtilityTemplateId": "str_upper_01",
-              "selectedVsBestUtilityGap": 0.1510062322924085,
+              "selectedVsBestUtilityGap": 0.15139049591779746,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": true,
@@ -4007,7 +4070,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "str_full_03",
               "bestUtilityTemplateId": "str_upper_01",
-              "selectedVsBestUtilityGap": 0.14787981323321153,
+              "selectedVsBestUtilityGap": 0.14581480581307815,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": true,
@@ -4021,7 +4084,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.01722550594932274,
+              "selectedVsBestUtilityGap": 0.017482935917522306,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -4035,7 +4098,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "end_race_sim_01",
               "bestUtilityTemplateId": "end_crit_surges_01",
-              "selectedVsBestUtilityGap": 0.09914853162795223,
+              "selectedVsBestUtilityGap": 0.09912669028586674,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -4045,30 +4108,44 @@
               "selectedAdvancesRequiredRole": true
             },
             {
-              "date": "2026-08-21",
+              "date": "2026-08-18",
+              "weekIndex": 1,
+              "selectedTemplateId": "end_easy_04",
+              "bestUtilityTemplateId": "str_upper_01",
+              "selectedVsBestUtilityGap": 0.1729776044974442,
+              "tierBlocked": true,
+              "blockedByTier": {
+                "coverage": true,
+                "recovery": false,
+                "benefit": true
+              },
+              "selectedAdvancesRequiredRole": false
+            },
+            {
+              "date": "2026-08-19",
+              "weekIndex": 1,
+              "selectedTemplateId": "end_easy_01",
+              "bestUtilityTemplateId": "str_upper_01",
+              "selectedVsBestUtilityGap": 0.22404112890892403,
+              "tierBlocked": true,
+              "blockedByTier": {
+                "coverage": true,
+                "recovery": false,
+                "benefit": true
+              },
+              "selectedAdvancesRequiredRole": false
+            },
+            {
+              "date": "2026-08-22",
               "weekIndex": 2,
-              "selectedTemplateId": "end_hard_02",
-              "bestUtilityTemplateId": "end_mod_02",
-              "selectedVsBestUtilityGap": 0.28617624616036696,
+              "selectedTemplateId": "end_easy_01",
+              "bestUtilityTemplateId": "cycling_technical_01",
+              "selectedVsBestUtilityGap": 0.009361299315460758,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": true,
                 "recovery": false,
                 "benefit": false
-              },
-              "selectedAdvancesRequiredRole": true
-            },
-            {
-              "date": "2026-08-22",
-              "weekIndex": 2,
-              "selectedTemplateId": "str_upper_01",
-              "bestUtilityTemplateId": "cycling_technical_01",
-              "selectedVsBestUtilityGap": 0.24210449560479957,
-              "tierBlocked": true,
-              "blockedByTier": {
-                "coverage": false,
-                "recovery": false,
-                "benefit": true
               },
               "selectedAdvancesRequiredRole": false
             },
@@ -4077,7 +4154,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.013499879400677477,
+              "selectedVsBestUtilityGap": 0.015809644733187155,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -4091,7 +4168,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.015606612892918204,
+              "selectedVsBestUtilityGap": 0.016637270359880038,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -4105,7 +4182,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "end_race_sim_01",
               "bestUtilityTemplateId": "end_crit_surges_01",
-              "selectedVsBestUtilityGap": 0.19461639972292466,
+              "selectedVsBestUtilityGap": 0.30608435751043417,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -4115,15 +4192,57 @@
               "selectedAdvancesRequiredRole": true
             },
             {
-              "date": "2026-08-28",
-              "weekIndex": 3,
+              "date": "2026-08-27",
+              "weekIndex": 2,
               "selectedTemplateId": "end_easy_04",
               "bestUtilityTemplateId": "cycling_technical_01",
-              "selectedVsBestUtilityGap": 0.01932801366839476,
+              "selectedVsBestUtilityGap": 0.007598567236335008,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": true,
                 "recovery": false,
+                "benefit": false
+              },
+              "selectedAdvancesRequiredRole": true
+            },
+            {
+              "date": "2026-08-28",
+              "weekIndex": 3,
+              "selectedTemplateId": "end_easy_01",
+              "bestUtilityTemplateId": "str_upper_01",
+              "selectedVsBestUtilityGap": 0.15865936105059586,
+              "tierBlocked": true,
+              "blockedByTier": {
+                "coverage": true,
+                "recovery": false,
+                "benefit": true
+              },
+              "selectedAdvancesRequiredRole": true
+            },
+            {
+              "date": "2026-08-29",
+              "weekIndex": 3,
+              "selectedTemplateId": "end_easy_04",
+              "bestUtilityTemplateId": "str_upper_01",
+              "selectedVsBestUtilityGap": 0.08488876806549395,
+              "tierBlocked": true,
+              "blockedByTier": {
+                "coverage": true,
+                "recovery": false,
+                "benefit": true
+              },
+              "selectedAdvancesRequiredRole": false
+            },
+            {
+              "date": "2026-08-31",
+              "weekIndex": 3,
+              "selectedTemplateId": "rest_01",
+              "bestUtilityTemplateId": "mob_01",
+              "selectedVsBestUtilityGap": 0.012763741587719257,
+              "tierBlocked": true,
+              "blockedByTier": {
+                "coverage": false,
+                "recovery": true,
                 "benefit": false
               },
               "selectedAdvancesRequiredRole": false
@@ -4133,7 +4252,7 @@
               "weekIndex": 3,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.012239670422428559,
+              "selectedVsBestUtilityGap": 0.034399679915231525,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -4145,9 +4264,23 @@
             {
               "date": "2026-09-02",
               "weekIndex": 3,
+              "selectedTemplateId": "str_full_01",
+              "bestUtilityTemplateId": "end_crit_surges_01",
+              "selectedVsBestUtilityGap": 1.2274698799948343,
+              "tierBlocked": true,
+              "blockedByTier": {
+                "coverage": true,
+                "recovery": false,
+                "benefit": true
+              },
+              "selectedAdvancesRequiredRole": true
+            },
+            {
+              "date": "2026-09-03",
+              "weekIndex": 3,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.033936234710249896,
+              "selectedVsBestUtilityGap": 0.012813086372204276,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -4155,20 +4288,6 @@
                 "benefit": false
               },
               "selectedAdvancesRequiredRole": false
-            },
-            {
-              "date": "2026-09-03",
-              "weekIndex": 3,
-              "selectedTemplateId": "end_race_sim_01",
-              "bestUtilityTemplateId": "end_crit_surges_01",
-              "selectedVsBestUtilityGap": 0.19515285715958686,
-              "tierBlocked": true,
-              "blockedByTier": {
-                "coverage": false,
-                "recovery": false,
-                "benefit": true
-              },
-              "selectedAdvancesRequiredRole": true
             }
           ]
         }
@@ -4205,10 +4324,10 @@
           "weekIndex": 3,
           "fatigueTierDayCounts": {
             "train": 2,
-            "modify": 1,
-            "recover": 2
+            "modify": 0,
+            "recover": 3
           },
-          "restOrRecoveryDayCount": 2
+          "restOrRecoveryDayCount": 3
         }
       ]
     },
@@ -4220,23 +4339,20 @@
       "weeksSimulated": 4,
       "totalDays": 28,
       "categoryDistribution": {
-        "Easy Endurance": 10,
+        "Easy Endurance": 11,
         "Full-body Strength": 3,
-        "Race-Specific Endurance": 3,
+        "Race-Specific Endurance": 4,
         "Hard Endurance": 3,
-        "Mobility/Recovery": 1,
-        "Rest": 4,
-        "Upper-body Strength": 2,
-        "Technical Skill": 2
+        "Rest": 6,
+        "Technical Skill": 1
       },
       "modalityDistribution": {
-        "Cycling": 18,
-        "Strength": 5,
-        "Mobility": 1,
-        "None": 4
+        "Cycling": 19,
+        "Strength": 3,
+        "None": 6
       },
-      "restOrRecoveryDayCount": 5,
-      "restOrRecoveryDayPct": 17.9,
+      "restOrRecoveryDayCount": 6,
+      "restOrRecoveryDayPct": 21.4,
       "maxConsecutiveSameTemplateStreakWithinCall": 2,
       "maxConsecutiveSameTemplateStreakAcrossWeeks": 2,
       "objectiveResolution": [
@@ -4253,7 +4369,7 @@
         {
           "key": "strength_maintenance",
           "timesGenerated": 4,
-          "timesResolved": 3
+          "timesResolved": 1
         },
         {
           "key": "threshold_quality",
@@ -4369,7 +4485,7 @@
         },
         {
           "weekIndex": 1,
-          "date": "2026-08-17",
+          "date": "2026-08-18",
           "objectiveKey": "race_specific_endurance",
           "objectiveTitle": "Cycling Race-Specific Endurance",
           "templateId": "end_race_sim_01",
@@ -4378,28 +4494,48 @@
           "earnedCredit": 0.30000000000000004
         },
         {
-          "weekIndex": 1,
-          "date": "2026-08-19",
+          "weekIndex": 2,
+          "date": "2026-08-21",
           "objectiveKey": "strength_maintenance",
           "objectiveTitle": "Strength & Neuromuscular Maintenance",
-          "templateId": "str_upper_01",
-          "templateTitle": "Upper Body Push/Pull",
+          "templateId": "str_full_03",
+          "templateTitle": "Reduced Full-body Strength Maintenance",
           "modality": "Strength",
-          "earnedCredit": 0.30000000000000004
+          "earnedCredit": 0.49
         },
         {
           "weekIndex": 2,
-          "date": "2026-08-24",
+          "date": "2026-08-23",
           "objectiveKey": "threshold_quality",
           "objectiveTitle": "Threshold Development",
           "templateId": "end_hard_02",
           "templateTitle": "Bike VO2 Intervals",
           "modality": "Cycling",
-          "earnedCredit": 0.30000000000000004
+          "earnedCredit": 0.8
+        },
+        {
+          "weekIndex": 2,
+          "date": "2026-08-23",
+          "objectiveKey": "surge_repeatability",
+          "objectiveTitle": "Surge & High-Intensity Repeatability",
+          "templateId": "end_hard_02",
+          "templateTitle": "Bike VO2 Intervals",
+          "modality": "Cycling",
+          "earnedCredit": 0.37
+        },
+        {
+          "weekIndex": 2,
+          "date": "2026-08-26",
+          "objectiveKey": "race_specific_endurance",
+          "objectiveTitle": "Cycling Race-Specific Endurance",
+          "templateId": "end_race_sim_01",
+          "templateTitle": "Race Simulation",
+          "modality": "Cycling",
+          "earnedCredit": 0.45999999999999996
         },
         {
           "weekIndex": 3,
-          "date": "2026-08-28",
+          "date": "2026-08-29",
           "objectiveKey": "strength_maintenance",
           "objectiveTitle": "Strength & Neuromuscular Maintenance",
           "templateId": "str_full_03",
@@ -4409,44 +4545,33 @@
         },
         {
           "weekIndex": 3,
-          "date": "2026-08-30",
-          "objectiveKey": "race_specific_endurance",
-          "objectiveTitle": "Cycling Race-Specific Endurance",
-          "templateId": "end_race_sim_01",
-          "templateTitle": "Race Simulation",
-          "modality": "Cycling",
-          "earnedCredit": 0.85
-        },
-        {
-          "weekIndex": 3,
-          "date": "2026-08-30",
+          "date": "2026-08-31",
           "objectiveKey": "threshold_quality",
           "objectiveTitle": "Threshold Development",
-          "templateId": "end_race_sim_01",
-          "templateTitle": "Race Simulation",
+          "templateId": "end_hard_02",
+          "templateTitle": "Bike VO2 Intervals",
           "modality": "Cycling",
           "earnedCredit": 0.19999999999999996
         },
         {
           "weekIndex": 3,
-          "date": "2026-09-02",
-          "objectiveKey": "strength_maintenance",
-          "objectiveTitle": "Strength & Neuromuscular Maintenance",
-          "templateId": "str_upper_01",
-          "templateTitle": "Upper Body Push/Pull",
-          "modality": "Strength",
-          "earnedCredit": 0.51
+          "date": "2026-09-03",
+          "objectiveKey": "race_specific_endurance",
+          "objectiveTitle": "Cycling Race-Specific Endurance",
+          "templateId": "end_race_sim_01",
+          "templateTitle": "Race Simulation",
+          "modality": "Cycling",
+          "earnedCredit": 0.45999999999999996
         }
       ],
       "utilityDiagnostics": {
-        "fragileSelectionCount": 15,
-        "lowerBenefitSelectionCount": 9,
+        "fragileSelectionCount": 17,
+        "lowerBenefitSelectionCount": 10,
         "trainTierRestOrRecoveryCount": 0
       },
       "qualityWarnings": [
-        "Unresolved weekly objectives: strength_maintenance 3/4.",
-        "Event-specific anchor missed in 1 nominated week(s).",
-        "Event-specific exposure occurred off the nominated anchor date in 2 week(s) (adaptively fulfilled in-window)."
+        "Unresolved weekly objectives: strength_maintenance 1/4.",
+        "Event-specific exposure occurred off the nominated anchor date in 4 week(s) (adaptively fulfilled in-window)."
       ],
       "anchorWeeks": [
         {
@@ -4468,7 +4593,7 @@
           "qualityAnchorDate": "2026-08-18",
           "eventSpecificAnchorHit": false,
           "eventSpecificExposureDates": [
-            "2026-08-17"
+            "2026-08-18"
           ],
           "eventSpecificAnchorFulfilled": true,
           "qualityAnchorHit": false
@@ -4479,8 +4604,10 @@
           "eventSpecificAnchorDate": "2026-08-23",
           "qualityAnchorDate": "2026-08-25",
           "eventSpecificAnchorHit": false,
-          "eventSpecificExposureDates": [],
-          "eventSpecificAnchorFulfilled": false,
+          "eventSpecificExposureDates": [
+            "2026-08-26"
+          ],
+          "eventSpecificAnchorFulfilled": true,
           "qualityAnchorHit": false
         },
         {
@@ -4488,9 +4615,9 @@
           "weekStartDate": "2026-08-28",
           "eventSpecificAnchorDate": "2026-08-30",
           "qualityAnchorDate": "2026-09-01",
-          "eventSpecificAnchorHit": true,
+          "eventSpecificAnchorHit": false,
           "eventSpecificExposureDates": [
-            "2026-08-30"
+            "2026-09-03"
           ],
           "eventSpecificAnchorFulfilled": true,
           "qualityAnchorHit": false
@@ -4499,8 +4626,8 @@
       "anchorScopeNote": null,
       "fatigueTierDayCounts": {
         "train": 12,
-        "modify": 4,
-        "recover": 4
+        "modify": 2,
+        "recover": 6
       },
       "constraintViolations": [],
       "allocationReports": [
@@ -4610,6 +4737,35 @@
             "outcomes": [
               {
                 "occurrence": {
+                  "id": "september_cycling_event|2026-08-12|2026-09-12|peak|aerobic_volume|september_cycling_event%3Aaerobic_volume|0",
+                  "coverageSetId": "september_cycling_event",
+                  "coverageKey": "aerobic_volume",
+                  "authoredSessionIdentity": "september_cycling_event:aerobic_volume",
+                  "phase": "peak",
+                  "windowStart": "2026-08-12",
+                  "windowEnd": "2026-09-12",
+                  "ordinal": 0,
+                  "label": "Easy Zone 2 aerobic volume",
+                  "eligibleTemplateIds": [
+                    "end_easy_01",
+                    "end_easy_04"
+                  ],
+                  "eligibleWorkoutIds": [
+                    "cycling_zone2_standard_01"
+                  ]
+                },
+                "reservation": {
+                  "occurrenceId": "september_cycling_event|2026-08-12|2026-09-12|peak|aerobic_volume|september_cycling_event%3Aaerobic_volume|0",
+                  "nominatedDate": "2026-08-17",
+                  "assignedDate": "2026-08-17",
+                  "templateId": "end_easy_01",
+                  "workoutId": "cycling_zone2_standard_01",
+                  "wasMoved": false
+                },
+                "status": "fulfilled"
+              },
+              {
+                "occurrence": {
                   "id": "september_cycling_event|2026-08-12|2026-09-12|peak|outdoor_event_specific|september_cycling_event%3Aoutdoor_event_specific|0",
                   "coverageSetId": "september_cycling_event",
                   "coverageKey": "outdoor_event_specific",
@@ -4632,8 +4788,8 @@
                 },
                 "reservation": {
                   "occurrenceId": "september_cycling_event|2026-08-12|2026-09-12|peak|outdoor_event_specific|september_cycling_event%3Aoutdoor_event_specific|0",
-                  "nominatedDate": "2026-08-17",
-                  "assignedDate": "2026-08-17",
+                  "nominatedDate": "2026-08-18",
+                  "assignedDate": "2026-08-18",
                   "templateId": "end_race_sim_01",
                   "workoutId": "cycling_race_simulation_50_01",
                   "wasMoved": false
@@ -4661,13 +4817,17 @@
                 },
                 "reservation": {
                   "occurrenceId": "september_cycling_event|2026-08-12|2026-09-12|peak|primary_strength|september_cycling_event%3Aprimary_strength|0",
-                  "nominatedDate": "2026-08-20",
-                  "assignedDate": "2026-08-20",
-                  "templateId": "str_full_01",
-                  "workoutId": "strength_full_body_maintenance_01",
+                  "nominatedDate": null,
+                  "assignedDate": null,
+                  "templateId": null,
+                  "workoutId": null,
                   "wasMoved": false
                 },
-                "status": "fulfilled"
+                "status": "missed",
+                "reason": "hard_safety_or_recovery",
+                "observedBlockers": [
+                  "2026-08-20:RECOVERY_WINDOW_UNELAPSED"
+                ]
               }
             ]
           }
@@ -4696,8 +4856,8 @@
                 },
                 "reservation": {
                   "occurrenceId": "september_cycling_event|2026-08-16|2026-09-12|peak|sustained_quality|september_cycling_event%3Asustained_quality|0",
-                  "nominatedDate": "2026-08-24",
-                  "assignedDate": "2026-08-24",
+                  "nominatedDate": "2026-08-23",
+                  "assignedDate": "2026-08-23",
                   "templateId": "end_hard_02",
                   "workoutId": "cycling_over_under_3x12_01",
                   "wasMoved": false
@@ -4713,32 +4873,29 @@
             "outcomes": [
               {
                 "occurrence": {
-                  "id": "september_cycling_event|2026-08-23|2026-09-12|peak|outdoor_event_specific|september_cycling_event%3Aoutdoor_event_specific|0",
+                  "id": "september_cycling_event|2026-08-23|2026-09-12|peak|aerobic_volume|september_cycling_event%3Aaerobic_volume|0",
                   "coverageSetId": "september_cycling_event",
-                  "coverageKey": "outdoor_event_specific",
-                  "authoredSessionIdentity": "september_cycling_event:outdoor_event_specific",
+                  "coverageKey": "aerobic_volume",
+                  "authoredSessionIdentity": "september_cycling_event:aerobic_volume",
                   "phase": "peak",
                   "windowStart": "2026-08-23",
                   "windowEnd": "2026-09-12",
                   "ordinal": 0,
-                  "label": "Outdoor event-specific endurance ride",
+                  "label": "Easy Zone 2 aerobic volume",
                   "eligibleTemplateIds": [
-                    "end_crit_surges_01",
-                    "end_race_sim_01",
-                    "end_race_specific_01"
+                    "end_easy_01",
+                    "end_easy_04"
                   ],
                   "eligibleWorkoutIds": [
-                    "cycling_criterium_surges_01",
-                    "cycling_event_specific_endurance_01",
-                    "cycling_race_simulation_50_01"
+                    "cycling_zone2_standard_01"
                   ]
                 },
                 "reservation": {
-                  "occurrenceId": "september_cycling_event|2026-08-23|2026-09-12|peak|outdoor_event_specific|september_cycling_event%3Aoutdoor_event_specific|0",
+                  "occurrenceId": "september_cycling_event|2026-08-23|2026-09-12|peak|aerobic_volume|september_cycling_event%3Aaerobic_volume|0",
                   "nominatedDate": "2026-08-30",
                   "assignedDate": "2026-08-30",
-                  "templateId": "end_race_sim_01",
-                  "workoutId": "cycling_race_simulation_50_01",
+                  "templateId": "end_easy_04",
+                  "workoutId": "cycling_zone2_standard_01",
                   "wasMoved": false
                 },
                 "status": "fulfilled"
@@ -4823,7 +4980,7 @@
             {
               "date": "2026-08-14",
               "weekIndex": 1,
-              "collision": 0.7902503191783972,
+              "collision": 0.7543263584872656,
               "costMagnitude": 0.6900000000000002,
               "topDimensions": [
                 "lowerBody",
@@ -4833,8 +4990,8 @@
             {
               "date": "2026-08-15",
               "weekIndex": 1,
-              "collision": 0.6161501198482432,
-              "costMagnitude": 0.36,
+              "collision": 0.6640334470591832,
+              "costMagnitude": 0.6900000000000002,
               "topDimensions": [
                 "lowerBody",
                 "systemic"
@@ -4850,17 +5007,7 @@
             {
               "date": "2026-08-17",
               "weekIndex": 1,
-              "collision": 0.2514869970942538,
-              "costMagnitude": 2.2105263157894735,
-              "topDimensions": [
-                "systemic",
-                "lowerBody"
-              ]
-            },
-            {
-              "date": "2026-08-18",
-              "weekIndex": 1,
-              "collision": 0.45465021209049317,
+              "collision": 0.29376553411272416,
               "costMagnitude": 1.1500000000000001,
               "topDimensions": [
                 "lowerBody",
@@ -4868,39 +5015,46 @@
               ]
             },
             {
-              "date": "2026-08-19",
+              "date": "2026-08-18",
               "weekIndex": 1,
-              "collision": 0.26051025641329917,
-              "costMagnitude": 1.575,
-              "topDimensions": [
-                "systemic",
-                "neuromuscular"
-              ]
-            },
-            {
-              "date": "2026-08-20",
-              "weekIndex": 1,
-              "collision": 0.42044957623274704,
-              "costMagnitude": 4.1,
-              "topDimensions": [
-                "systemic",
-                "upperBody"
-              ]
-            },
-            {
-              "date": "2026-08-21",
-              "weekIndex": 2,
-              "collision": 0.7032711162498786,
-              "costMagnitude": 0.6900000000000002,
+              "collision": 0.3166026601587552,
+              "costMagnitude": 2.2105263157894735,
               "topDimensions": [
                 "systemic",
                 "lowerBody"
               ]
             },
             {
+              "date": "2026-08-19",
+              "weekIndex": 1,
+              "collision": 0,
+              "costMagnitude": 0,
+              "topDimensions": []
+            },
+            {
+              "date": "2026-08-20",
+              "weekIndex": 1,
+              "collision": 0.3167449992626728,
+              "costMagnitude": 1.1500000000000001,
+              "topDimensions": [
+                "lowerBody",
+                "systemic"
+              ]
+            },
+            {
+              "date": "2026-08-21",
+              "weekIndex": 2,
+              "collision": 0.26221675717077036,
+              "costMagnitude": 1.645,
+              "topDimensions": [
+                "lowerBody",
+                "systemic"
+              ]
+            },
+            {
               "date": "2026-08-22",
               "weekIndex": 2,
-              "collision": 0.6080486912374686,
+              "collision": 0.49425893160201284,
               "costMagnitude": 1.1500000000000001,
               "topDimensions": [
                 "neuromuscular",
@@ -4910,7 +5064,24 @@
             {
               "date": "2026-08-23",
               "weekIndex": 2,
-              "collision": 0.47609706442636784,
+              "collision": 0.37976442142892586,
+              "costMagnitude": 4,
+              "topDimensions": [
+                "systemic",
+                "neuromuscular"
+              ]
+            },
+            {
+              "date": "2026-08-24",
+              "weekIndex": 2,
+              "collision": 0,
+              "costMagnitude": 0,
+              "topDimensions": []
+            },
+            {
+              "date": "2026-08-25",
+              "weekIndex": 2,
+              "collision": 0.4672928271482743,
               "costMagnitude": 0.6900000000000002,
               "topDimensions": [
                 "lowerBody",
@@ -4918,44 +5089,27 @@
               ]
             },
             {
-              "date": "2026-08-24",
+              "date": "2026-08-26",
               "weekIndex": 2,
-              "collision": 0.40088494964958793,
-              "costMagnitude": 4,
+              "collision": 0.38041927003943926,
+              "costMagnitude": 2.2105263157894735,
               "topDimensions": [
                 "systemic",
                 "lowerBody"
               ]
             },
             {
-              "date": "2026-08-25",
-              "weekIndex": 2,
-              "collision": 0,
-              "costMagnitude": 0,
-              "topDimensions": []
-            },
-            {
-              "date": "2026-08-26",
-              "weekIndex": 2,
-              "collision": 0,
-              "costMagnitude": 0,
-              "topDimensions": []
-            },
-            {
               "date": "2026-08-27",
               "weekIndex": 2,
-              "collision": 0.3104872536958213,
-              "costMagnitude": 1.1500000000000001,
-              "topDimensions": [
-                "lowerBody",
-                "systemic"
-              ]
+              "collision": 0,
+              "costMagnitude": 0,
+              "topDimensions": []
             },
             {
               "date": "2026-08-28",
               "weekIndex": 3,
-              "collision": 0.27650096461628365,
-              "costMagnitude": 1.645,
+              "collision": 0.31837335737348266,
+              "costMagnitude": 0.6900000000000002,
               "topDimensions": [
                 "lowerBody",
                 "systemic"
@@ -4964,34 +5118,17 @@
             {
               "date": "2026-08-29",
               "weekIndex": 3,
-              "collision": 0.49828807947411635,
-              "costMagnitude": 1.1500000000000001,
+              "collision": 0.46672474462135266,
+              "costMagnitude": 1.645,
               "topDimensions": [
                 "neuromuscular",
-                "systemic"
+                "lowerBody"
               ]
             },
             {
               "date": "2026-08-30",
               "weekIndex": 3,
-              "collision": 0.382907471531197,
-              "costMagnitude": 3.5000000000000004,
-              "topDimensions": [
-                "systemic",
-                "neuromuscular"
-              ]
-            },
-            {
-              "date": "2026-08-31",
-              "weekIndex": 3,
-              "collision": 0,
-              "costMagnitude": 0,
-              "topDimensions": []
-            },
-            {
-              "date": "2026-09-01",
-              "weekIndex": 3,
-              "collision": 0.42470891104489256,
+              "collision": 0.3577983619193322,
               "costMagnitude": 1.1500000000000001,
               "topDimensions": [
                 "lowerBody",
@@ -4999,28 +5136,42 @@
               ]
             },
             {
+              "date": "2026-08-31",
+              "weekIndex": 3,
+              "collision": 0.3743720042892185,
+              "costMagnitude": 4,
+              "topDimensions": [
+                "lowerBody",
+                "systemic"
+              ]
+            },
+            {
+              "date": "2026-09-01",
+              "weekIndex": 3,
+              "collision": 0,
+              "costMagnitude": 0,
+              "topDimensions": []
+            },
+            {
               "date": "2026-09-02",
               "weekIndex": 3,
-              "collision": 0.27360564350656663,
-              "costMagnitude": 1.575,
-              "topDimensions": [
-                "systemic",
-                "neuromuscular"
-              ]
+              "collision": 0,
+              "costMagnitude": 0,
+              "topDimensions": []
             },
             {
               "date": "2026-09-03",
               "weekIndex": 3,
-              "collision": 0.3936030425493277,
-              "costMagnitude": 4,
+              "collision": 0.29192807114521785,
+              "costMagnitude": 2.2105263157894735,
               "topDimensions": [
                 "systemic",
-                "neuromuscular"
+                "lowerBody"
               ]
             }
           ],
-          "meanCollision": 0.3526950406542273,
-          "maxCollision": 0.7902503191783972
+          "meanCollision": 0.30257793626064455,
+          "maxCollision": 0.7543263584872656
         },
         "adjacentCostOverlap": {
           "perPair": [
@@ -5081,120 +5232,97 @@
               "neuromuscularOverlap": 0.06
             },
             {
-              "date": "2026-08-18",
-              "previousDate": "2026-08-17",
-              "overlap": 0.7800025214792088,
-              "lowerBodyOverlap": 0.2679562539233233,
-              "impactTissueOverlap": 0.08931875130777443,
-              "neuromuscularOverlap": 0.1
+              "date": "2026-08-15",
+              "previousDate": "2026-08-14",
+              "overlap": 0.6228912597399697,
+              "lowerBodyOverlap": 0.12727922061357855,
+              "impactTissueOverlap": 0.042426406871192854,
+              "neuromuscularOverlap": 0.037797631496846194
             },
             {
-              "date": "2026-08-19",
-              "previousDate": "2026-08-18",
-              "overlap": 0.2821240426853516,
-              "lowerBodyOverlap": 0,
+              "date": "2026-08-18",
+              "previousDate": "2026-08-17",
+              "overlap": 0.32405176250757967,
+              "lowerBodyOverlap": 0.21213203435596426,
               "impactTissueOverlap": 0.07071067811865477,
               "neuromuscularOverlap": 0.06299605249474366
             },
             {
-              "date": "2026-08-20",
-              "previousDate": "2026-08-19",
-              "overlap": 0.23865358957756844,
-              "lowerBodyOverlap": 0,
-              "impactTissueOverlap": 0.05303300858899108,
-              "neuromuscularOverlap": 0.2362351968552887
-            },
-            {
               "date": "2026-08-21",
               "previousDate": "2026-08-20",
-              "overlap": 0.26224333606315825,
-              "lowerBodyOverlap": 0.18,
-              "impactTissueOverlap": 0.06,
-              "neuromuscularOverlap": 0.06
-            },
-            {
-              "date": "2026-08-22",
-              "previousDate": "2026-08-21",
-              "overlap": 0.3737347558439819,
-              "lowerBodyOverlap": 0.12727922061357855,
-              "impactTissueOverlap": 0.042426406871192854,
-              "neuromuscularOverlap": 0.037797631496846194
-            },
-            {
-              "date": "2026-08-23",
-              "previousDate": "2026-08-22",
-              "overlap": 0.5343410208132353,
-              "lowerBodyOverlap": 0.10606601717798213,
-              "impactTissueOverlap": 0.03535533905932738,
-              "neuromuscularOverlap": 0.06
-            },
-            {
-              "date": "2026-08-24",
-              "previousDate": "2026-08-23",
-              "overlap": 0.10744874230514481,
-              "lowerBodyOverlap": 0.12727922061357855,
-              "impactTissueOverlap": 0.042426406871192854,
-              "neuromuscularOverlap": 0.037797631496846194
-            },
-            {
-              "date": "2026-08-28",
-              "previousDate": "2026-08-27",
               "overlap": 0.4267824463449943,
               "lowerBodyOverlap": 0.21213203435596426,
               "impactTissueOverlap": 0.07071067811865477,
               "neuromuscularOverlap": 0.06299605249474366
             },
             {
-              "date": "2026-08-29",
-              "previousDate": "2026-08-28",
+              "date": "2026-08-22",
+              "previousDate": "2026-08-21",
               "overlap": 0.5276396730439804,
               "lowerBodyOverlap": 0.15,
               "impactTissueOverlap": 0.05,
               "neuromuscularOverlap": 0.2425348021047631
             },
             {
-              "date": "2026-08-30",
-              "previousDate": "2026-08-29",
-              "overlap": 0.20396907141368195,
+              "date": "2026-08-23",
+              "previousDate": "2026-08-22",
+              "overlap": 0.17847293748697174,
               "lowerBodyOverlap": 0.10606601717798213,
               "impactTissueOverlap": 0.03535533905932738,
               "neuromuscularOverlap": 0.2834822362263465
             },
             {
-              "date": "2026-09-02",
-              "previousDate": "2026-09-01",
-              "overlap": 0.2821240426853516,
-              "lowerBodyOverlap": 0,
-              "impactTissueOverlap": 0.07071067811865477,
-              "neuromuscularOverlap": 0.06299605249474366
+              "date": "2026-08-26",
+              "previousDate": "2026-08-25",
+              "overlap": 0.19443105750454778,
+              "lowerBodyOverlap": 0.12727922061357855,
+              "impactTissueOverlap": 0.042426406871192854,
+              "neuromuscularOverlap": 0.037797631496846194
             },
             {
-              "date": "2026-09-03",
-              "previousDate": "2026-09-02",
-              "overlap": 0.1510341338264289,
-              "lowerBodyOverlap": 0,
-              "impactTissueOverlap": 0.05303300858899108,
-              "neuromuscularOverlap": 0.2362351968552887
+              "date": "2026-08-29",
+              "previousDate": "2026-08-28",
+              "overlap": 0.26127353752010896,
+              "lowerBodyOverlap": 0.12727922061357855,
+              "impactTissueOverlap": 0.042426406871192854,
+              "neuromuscularOverlap": 0.037797631496846194
+            },
+            {
+              "date": "2026-08-30",
+              "previousDate": "2026-08-29",
+              "overlap": 0.5059197085783343,
+              "lowerBodyOverlap": 0.22273863607376249,
+              "impactTissueOverlap": 0.09899494936611665,
+              "neuromuscularOverlap": 0.1
+            },
+            {
+              "date": "2026-08-31",
+              "previousDate": "2026-08-30",
+              "overlap": 0.17908123717524138,
+              "lowerBodyOverlap": 0.21213203435596426,
+              "impactTissueOverlap": 0.07071067811865477,
+              "neuromuscularOverlap": 0.06299605249474366
             }
           ],
           "maxLowerBodyOverlap": 0.28284271247461906,
           "maxImpactTissueOverlap": 0.09899494936611665,
           "maxNeuromuscularOverlap": 0.2834822362263465,
-          "meanOverlap": 0.3799011556523588
+          "meanOverlap": 0.39178551257590366
         },
         "qualitySpacing": {
           "gapsDays": [
             2,
             3,
-            4,
+            5,
             3,
-            4,
-            4,
             2,
-            4
+            3,
+            3,
+            2,
+            3
           ],
           "minGapDays": 2,
-          "medianGapDays": 3.5,
+          "medianGapDays": 3,
           "adjacentQualityDayCount": 0,
           "longestQualityStreak": 0,
           "qualityPer3DayWindowMax": 2,
@@ -5211,14 +5339,14 @@
             },
             {
               "weekIndex": 1,
-              "hardDayCount": 2,
+              "hardDayCount": 1,
               "maxHardStreak": 1,
-              "recoveryAfterHighCollisionCount": 2,
+              "recoveryAfterHighCollisionCount": 1,
               "recoveryWhileFatigueLowAndWorkFeasibleCount": 0
             },
             {
               "weekIndex": 2,
-              "hardDayCount": 1,
+              "hardDayCount": 3,
               "maxHardStreak": 1,
               "recoveryAfterHighCollisionCount": 0,
               "recoveryWhileFatigueLowAndWorkFeasibleCount": 0
@@ -5234,14 +5362,14 @@
         },
         "opportunityCost": {
           "daysWithRankingAudit": 28,
-          "utilityWinnerDifferentCount": 15,
-          "utilityWinnerBlockedCount": 15,
+          "utilityWinnerDifferentCount": 19,
+          "utilityWinnerBlockedCount": 19,
           "utilityWinnerDifferentWithoutTierBlockCount": 0,
-          "meanBlockedUtilityGap": 0.2919527218003052,
-          "maxBlockedUtilityGap": 0.8935870481560146,
+          "meanBlockedUtilityGap": 0.2043997089164925,
+          "maxBlockedUtilityGap": 1.0309173851344056,
           "blockedByTier": {
-            "coverage": 9,
-            "recovery": 3,
+            "coverage": 10,
+            "recovery": 6,
             "benefit": 11
           },
           "perDay": [
@@ -5278,7 +5406,21 @@
               "weekIndex": 1,
               "selectedTemplateId": "end_easy_01",
               "bestUtilityTemplateId": "cycling_technical_01",
-              "selectedVsBestUtilityGap": 0.020117889672856992,
+              "selectedVsBestUtilityGap": 0.020286098607040337,
+              "tierBlocked": true,
+              "blockedByTier": {
+                "coverage": true,
+                "recovery": false,
+                "benefit": false
+              },
+              "selectedAdvancesRequiredRole": true
+            },
+            {
+              "date": "2026-08-15",
+              "weekIndex": 1,
+              "selectedTemplateId": "end_easy_04",
+              "bestUtilityTemplateId": "cycling_technical_01",
+              "selectedVsBestUtilityGap": 0.03143047592607817,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": true,
@@ -5288,25 +5430,25 @@
               "selectedAdvancesRequiredRole": false
             },
             {
-              "date": "2026-08-15",
+              "date": "2026-08-16",
               "weekIndex": 1,
-              "selectedTemplateId": "mob_01",
-              "bestUtilityTemplateId": "cycling_technical_01",
-              "selectedVsBestUtilityGap": 0.35978146637727315,
+              "selectedTemplateId": "rest_01",
+              "bestUtilityTemplateId": "mob_01",
+              "selectedVsBestUtilityGap": 0.018609668876337825,
               "tierBlocked": true,
               "blockedByTier": {
-                "coverage": true,
-                "recovery": false,
-                "benefit": true
+                "coverage": false,
+                "recovery": true,
+                "benefit": false
               },
               "selectedAdvancesRequiredRole": false
             },
             {
-              "date": "2026-08-17",
+              "date": "2026-08-18",
               "weekIndex": 1,
               "selectedTemplateId": "end_race_sim_01",
               "bestUtilityTemplateId": "end_crit_surges_01",
-              "selectedVsBestUtilityGap": 0.10097423721567289,
+              "selectedVsBestUtilityGap": 0.10139384717151989,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -5316,53 +5458,95 @@
               "selectedAdvancesRequiredRole": true
             },
             {
-              "date": "2026-08-18",
+              "date": "2026-08-19",
               "weekIndex": 1,
-              "selectedTemplateId": "end_easy_04",
-              "bestUtilityTemplateId": "str_upper_01",
-              "selectedVsBestUtilityGap": 0.20915320491944228,
+              "selectedTemplateId": "rest_01",
+              "bestUtilityTemplateId": "mob_01",
+              "selectedVsBestUtilityGap": 0.01773229624031967,
               "tierBlocked": true,
               "blockedByTier": {
-                "coverage": true,
-                "recovery": false,
-                "benefit": true
+                "coverage": false,
+                "recovery": true,
+                "benefit": false
               },
               "selectedAdvancesRequiredRole": false
             },
             {
               "date": "2026-08-20",
               "weekIndex": 1,
-              "selectedTemplateId": "str_full_01",
-              "bestUtilityTemplateId": "str_full_03",
-              "selectedVsBestUtilityGap": 0.005143397273143502,
+              "selectedTemplateId": "end_easy_04",
+              "bestUtilityTemplateId": "str_upper_01",
+              "selectedVsBestUtilityGap": 0.2800006756753116,
               "tierBlocked": true,
               "blockedByTier": {
-                "coverage": false,
+                "coverage": true,
+                "recovery": false,
+                "benefit": true
+              },
+              "selectedAdvancesRequiredRole": false
+            },
+            {
+              "date": "2026-08-21",
+              "weekIndex": 2,
+              "selectedTemplateId": "str_full_03",
+              "bestUtilityTemplateId": "str_upper_01",
+              "selectedVsBestUtilityGap": 0.25038653171284686,
+              "tierBlocked": true,
+              "blockedByTier": {
+                "coverage": true,
                 "recovery": false,
                 "benefit": true
               },
               "selectedAdvancesRequiredRole": true
             },
             {
-              "date": "2026-08-25",
+              "date": "2026-08-24",
               "weekIndex": 2,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.011548090494997457,
+              "selectedVsBestUtilityGap": 0.012090855791727174,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
                 "recovery": true,
                 "benefit": false
+              },
+              "selectedAdvancesRequiredRole": false
+            },
+            {
+              "date": "2026-08-25",
+              "weekIndex": 2,
+              "selectedTemplateId": "end_easy_01",
+              "bestUtilityTemplateId": "str_upper_01",
+              "selectedVsBestUtilityGap": 0.18093770534387854,
+              "tierBlocked": true,
+              "blockedByTier": {
+                "coverage": true,
+                "recovery": false,
+                "benefit": true
               },
               "selectedAdvancesRequiredRole": false
             },
             {
               "date": "2026-08-26",
               "weekIndex": 2,
+              "selectedTemplateId": "end_race_sim_01",
+              "bestUtilityTemplateId": "end_crit_surges_01",
+              "selectedVsBestUtilityGap": 0.29181038908747325,
+              "tierBlocked": true,
+              "blockedByTier": {
+                "coverage": false,
+                "recovery": false,
+                "benefit": true
+              },
+              "selectedAdvancesRequiredRole": true
+            },
+            {
+              "date": "2026-08-27",
+              "weekIndex": 2,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.03330012585371653,
+              "selectedVsBestUtilityGap": 0.016780858037840872,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -5372,11 +5556,11 @@
               "selectedAdvancesRequiredRole": false
             },
             {
-              "date": "2026-08-27",
-              "weekIndex": 2,
+              "date": "2026-08-28",
+              "weekIndex": 3,
               "selectedTemplateId": "end_easy_01",
-              "bestUtilityTemplateId": "end_crit_surges_01",
-              "selectedVsBestUtilityGap": 0.7665462930170561,
+              "bestUtilityTemplateId": "str_upper_01",
+              "selectedVsBestUtilityGap": 0.23399810681921873,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": true,
@@ -5386,28 +5570,14 @@
               "selectedAdvancesRequiredRole": true
             },
             {
-              "date": "2026-08-28",
+              "date": "2026-08-29",
               "weekIndex": 3,
               "selectedTemplateId": "str_full_03",
               "bestUtilityTemplateId": "str_upper_01",
-              "selectedVsBestUtilityGap": 0.2576741082216687,
+              "selectedVsBestUtilityGap": 0.1397034992668989,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": true,
-                "recovery": false,
-                "benefit": true
-              },
-              "selectedAdvancesRequiredRole": true
-            },
-            {
-              "date": "2026-08-30",
-              "weekIndex": 3,
-              "selectedTemplateId": "end_race_sim_01",
-              "bestUtilityTemplateId": "end_crit_surges_01",
-              "selectedVsBestUtilityGap": 0.5197329954812329,
-              "tierBlocked": true,
-              "blockedByTier": {
-                "coverage": false,
                 "recovery": false,
                 "benefit": true
               },
@@ -5416,9 +5586,23 @@
             {
               "date": "2026-08-31",
               "weekIndex": 3,
+              "selectedTemplateId": "end_hard_02",
+              "bestUtilityTemplateId": "end_crit_surges_01",
+              "selectedVsBestUtilityGap": 1.0309173851344056,
+              "tierBlocked": true,
+              "blockedByTier": {
+                "coverage": true,
+                "recovery": false,
+                "benefit": true
+              },
+              "selectedAdvancesRequiredRole": true
+            },
+            {
+              "date": "2026-09-01",
+              "weekIndex": 3,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.013344215105069827,
+              "selectedVsBestUtilityGap": 0.012022798309132818,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -5428,28 +5612,28 @@
               "selectedAdvancesRequiredRole": false
             },
             {
-              "date": "2026-09-01",
+              "date": "2026-09-02",
               "weekIndex": 3,
-              "selectedTemplateId": "end_easy_01",
-              "bestUtilityTemplateId": "str_upper_01",
-              "selectedVsBestUtilityGap": 0.17375619232895223,
+              "selectedTemplateId": "rest_01",
+              "bestUtilityTemplateId": "mob_01",
+              "selectedVsBestUtilityGap": 0.033729493286504306,
               "tierBlocked": true,
               "blockedByTier": {
-                "coverage": true,
-                "recovery": false,
-                "benefit": true
+                "coverage": false,
+                "recovery": true,
+                "benefit": false
               },
               "selectedAdvancesRequiredRole": false
             },
             {
               "date": "2026-09-03",
               "weekIndex": 3,
-              "selectedTemplateId": "end_hard_02",
+              "selectedTemplateId": "end_race_sim_01",
               "bestUtilityTemplateId": "end_crit_surges_01",
-              "selectedVsBestUtilityGap": 0.8935870481560146,
+              "selectedVsBestUtilityGap": 0.19713222123934204,
               "tierBlocked": true,
               "blockedByTier": {
-                "coverage": true,
+                "coverage": false,
                 "recovery": false,
                 "benefit": true
               },
@@ -5472,8 +5656,8 @@
           "weekIndex": 1,
           "fatigueTierDayCounts": {
             "train": 3,
-            "modify": 1,
-            "recover": 1
+            "modify": 0,
+            "recover": 2
           },
           "restOrRecoveryDayCount": 2
         },
@@ -5490,10 +5674,10 @@
           "weekIndex": 3,
           "fatigueTierDayCounts": {
             "train": 3,
-            "modify": 1,
-            "recover": 1
+            "modify": 0,
+            "recover": 2
           },
-          "restOrRecoveryDayCount": 1
+          "restOrRecoveryDayCount": 2
         }
       ]
     },
@@ -5505,23 +5689,21 @@
       "weeksSimulated": 4,
       "totalDays": 28,
       "categoryDistribution": {
-        "Rest": 12,
-        "Easy Endurance": 7,
+        "Rest": 13,
+        "Easy Endurance": 8,
         "Full-body Strength": 3,
         "Hard Endurance": 2,
-        "Race-Specific Endurance": 2,
-        "Upper-body Strength": 1,
-        "Technical Skill": 1
+        "Race-Specific Endurance": 2
       },
       "modalityDistribution": {
-        "None": 12,
+        "None": 13,
         "Cycling": 12,
-        "Strength": 4
+        "Strength": 3
       },
-      "restOrRecoveryDayCount": 12,
-      "restOrRecoveryDayPct": 42.9,
+      "restOrRecoveryDayCount": 13,
+      "restOrRecoveryDayPct": 46.4,
       "maxConsecutiveSameTemplateStreakWithinCall": 2,
-      "maxConsecutiveSameTemplateStreakAcrossWeeks": 3,
+      "maxConsecutiveSameTemplateStreakAcrossWeeks": 4,
       "objectiveResolution": [
         {
           "key": "zone2_aerobic",
@@ -5622,23 +5804,23 @@
         },
         {
           "weekIndex": 2,
-          "date": "2026-08-23",
-          "objectiveKey": "strength_maintenance",
-          "objectiveTitle": "Strength & Neuromuscular Maintenance",
-          "templateId": "str_upper_01",
-          "templateTitle": "Upper Body Push/Pull",
-          "modality": "Strength",
-          "earnedCredit": 0.19999999999999996
-        },
-        {
-          "weekIndex": 2,
           "date": "2026-08-25",
           "objectiveKey": "threshold_quality",
           "objectiveTitle": "Threshold Development",
           "templateId": "end_hard_02",
           "templateTitle": "Bike VO2 Intervals",
           "modality": "Cycling",
-          "earnedCredit": 0.30000000000000004
+          "earnedCredit": 0.8
+        },
+        {
+          "weekIndex": 2,
+          "date": "2026-08-25",
+          "objectiveKey": "surge_repeatability",
+          "objectiveTitle": "Surge & High-Intensity Repeatability",
+          "templateId": "end_hard_02",
+          "templateTitle": "Bike VO2 Intervals",
+          "modality": "Cycling",
+          "earnedCredit": 0.37
         },
         {
           "weekIndex": 3,
@@ -5648,7 +5830,7 @@
           "templateId": "str_full_03",
           "templateTitle": "Reduced Full-body Strength Maintenance",
           "modality": "Strength",
-          "earnedCredit": 0.19999999999999996
+          "earnedCredit": 0.7
         },
         {
           "weekIndex": 3,
@@ -5663,13 +5845,14 @@
       ],
       "utilityDiagnostics": {
         "fragileSelectionCount": 16,
-        "lowerBenefitSelectionCount": 7,
+        "lowerBenefitSelectionCount": 13,
         "trainTierRestOrRecoveryCount": 0
       },
       "qualityWarnings": [
         "Unresolved weekly objectives: race_specific_endurance 3/4.",
         "Event-specific anchor missed in 2 nominated week(s).",
-        "Event-specific exposure occurred off the nominated anchor date in 2 week(s) (adaptively fulfilled in-window)."
+        "Event-specific exposure occurred off the nominated anchor date in 2 week(s) (adaptively fulfilled in-window).",
+        "Same-template streak reached 4 days."
       ],
       "anchorWeeks": [
         {
@@ -5720,8 +5903,8 @@
       "anchorScopeNote": null,
       "fatigueTierDayCounts": {
         "train": 13,
-        "modify": 3,
-        "recover": 4
+        "modify": 2,
+        "recover": 5
       },
       "constraintViolations": [],
       "allocationReports": [
@@ -6209,31 +6392,31 @@
             {
               "date": "2026-08-23",
               "weekIndex": 2,
-              "collision": 0.2805959192509766,
-              "costMagnitude": 2.1,
+              "collision": 0.3306868488747765,
+              "costMagnitude": 1.1500000000000001,
               "topDimensions": [
-                "upperBody",
-                "neuromuscular"
+                "lowerBody",
+                "systemic"
               ]
             },
             {
               "date": "2026-08-24",
               "weekIndex": 2,
-              "collision": 0.34244664050714196,
-              "costMagnitude": 0.6900000000000002,
+              "collision": 0.30047662544925163,
+              "costMagnitude": 1.1500000000000001,
               "topDimensions": [
-                "systemic",
-                "lowerBody"
+                "lowerBody",
+                "systemic"
               ]
             },
             {
               "date": "2026-08-25",
               "weekIndex": 2,
-              "collision": 0.30652842976014316,
+              "collision": 0.3190996961047473,
               "costMagnitude": 4,
               "topDimensions": [
-                "systemic",
-                "neuromuscular"
+                "lowerBody",
+                "systemic"
               ]
             },
             {
@@ -6246,12 +6429,9 @@
             {
               "date": "2026-08-27",
               "weekIndex": 2,
-              "collision": 0.4388494659734804,
-              "costMagnitude": 1.1500000000000001,
-              "topDimensions": [
-                "lowerBody",
-                "systemic"
-              ]
+              "collision": 0,
+              "costMagnitude": 0,
+              "topDimensions": []
             },
             {
               "date": "2026-08-28",
@@ -6280,37 +6460,37 @@
             {
               "date": "2026-08-31",
               "weekIndex": 3,
-              "collision": 0.37850319421084233,
+              "collision": 0.32345762790841465,
               "costMagnitude": 1.1500000000000001,
               "topDimensions": [
-                "neuromuscular",
+                "lowerBody",
                 "systemic"
               ]
             },
             {
               "date": "2026-09-01",
               "weekIndex": 3,
-              "collision": 0.37313347726894863,
+              "collision": 0.34438815330576905,
               "costMagnitude": 2.2105263157894735,
-              "topDimensions": [
-                "neuromuscular",
-                "systemic"
-              ]
-            },
-            {
-              "date": "2026-09-02",
-              "weekIndex": 3,
-              "collision": 0.5042007207573054,
-              "costMagnitude": 0.6900000000000002,
               "topDimensions": [
                 "systemic",
                 "lowerBody"
               ]
             },
             {
+              "date": "2026-09-02",
+              "weekIndex": 3,
+              "collision": 0.5094050156528706,
+              "costMagnitude": 0.6900000000000002,
+              "topDimensions": [
+                "lowerBody",
+                "systemic"
+              ]
+            },
+            {
               "date": "2026-09-03",
               "weekIndex": 3,
-              "collision": 0.41228834678258774,
+              "collision": 0.41590210596394317,
               "costMagnitude": 1.1500000000000001,
               "topDimensions": [
                 "lowerBody",
@@ -6318,8 +6498,8 @@
               ]
             }
           ],
-          "meanCollision": 0.19872397205432166,
-          "maxCollision": 0.5042007207573054
+          "meanCollision": 0.18111218200961973,
+          "maxCollision": 0.5094050156528706
         },
         "adjacentCostOverlap": {
           "perPair": [
@@ -6350,34 +6530,34 @@
             {
               "date": "2026-08-24",
               "previousDate": "2026-08-23",
-              "overlap": 0.27482366780979384,
-              "lowerBodyOverlap": 0,
-              "impactTissueOverlap": 0.06,
-              "neuromuscularOverlap": 0.06
+              "overlap": 0.62289125973997,
+              "lowerBodyOverlap": 0.21213203435596426,
+              "impactTissueOverlap": 0.07071067811865477,
+              "neuromuscularOverlap": 0.06299605249474366
             },
             {
               "date": "2026-08-25",
               "previousDate": "2026-08-24",
-              "overlap": 0.10744874230514481,
-              "lowerBodyOverlap": 0.12727922061357855,
-              "impactTissueOverlap": 0.042426406871192854,
-              "neuromuscularOverlap": 0.037797631496846194
+              "overlap": 0.17908123717524138,
+              "lowerBodyOverlap": 0.21213203435596426,
+              "impactTissueOverlap": 0.07071067811865477,
+              "neuromuscularOverlap": 0.06299605249474366
             },
             {
               "date": "2026-08-31",
               "previousDate": "2026-08-30",
-              "overlap": 0.5541176246497416,
-              "lowerBodyOverlap": 0.15,
-              "impactTissueOverlap": 0.05,
-              "neuromuscularOverlap": 0.34647828872109016
+              "overlap": 0.5423823083453668,
+              "lowerBodyOverlap": 0.3,
+              "impactTissueOverlap": 0.1,
+              "neuromuscularOverlap": 0.1
             },
             {
               "date": "2026-09-01",
               "previousDate": "2026-08-31",
-              "overlap": 0.32295102973832984,
-              "lowerBodyOverlap": 0.10606601717798213,
-              "impactTissueOverlap": 0.03535533905932738,
-              "neuromuscularOverlap": 0.2834822362263465
+              "overlap": 0.32405176250757967,
+              "lowerBodyOverlap": 0.21213203435596426,
+              "impactTissueOverlap": 0.07071067811865477,
+              "neuromuscularOverlap": 0.06299605249474366
             },
             {
               "date": "2026-09-02",
@@ -6396,10 +6576,10 @@
               "neuromuscularOverlap": 0.037797631496846194
             }
           ],
-          "maxLowerBodyOverlap": 0.21213203435596426,
-          "maxImpactTissueOverlap": 0.07071067811865477,
-          "maxNeuromuscularOverlap": 0.34647828872109016,
-          "meanOverlap": 0.2985228170299395
+          "maxLowerBodyOverlap": 0.3,
+          "maxImpactTissueOverlap": 0.1,
+          "maxNeuromuscularOverlap": 0.1,
+          "meanOverlap": 0.3439745396149559
         },
         "qualitySpacing": {
           "gapsDays": [
@@ -6451,15 +6631,15 @@
         },
         "opportunityCost": {
           "daysWithRankingAudit": 28,
-          "utilityWinnerDifferentCount": 20,
-          "utilityWinnerBlockedCount": 20,
+          "utilityWinnerDifferentCount": 24,
+          "utilityWinnerBlockedCount": 24,
           "utilityWinnerDifferentWithoutTierBlockCount": 0,
-          "meanBlockedUtilityGap": 0.14939946782251093,
+          "meanBlockedUtilityGap": 0.15333676145569577,
           "maxBlockedUtilityGap": 1.3980387489180963,
           "blockedByTier": {
-            "coverage": 6,
-            "recovery": 12,
-            "benefit": 4
+            "coverage": 9,
+            "recovery": 13,
+            "benefit": 7
           },
           "perDay": [
             {
@@ -6621,7 +6801,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.009094610753454638,
+              "selectedVsBestUtilityGap": 0.00922145689835107,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -6645,11 +6825,39 @@
               "selectedAdvancesRequiredRole": false
             },
             {
+              "date": "2026-08-23",
+              "weekIndex": 2,
+              "selectedTemplateId": "end_easy_01",
+              "bestUtilityTemplateId": "str_upper_01",
+              "selectedVsBestUtilityGap": 0.1661674633145993,
+              "tierBlocked": true,
+              "blockedByTier": {
+                "coverage": true,
+                "recovery": false,
+                "benefit": true
+              },
+              "selectedAdvancesRequiredRole": false
+            },
+            {
+              "date": "2026-08-24",
+              "weekIndex": 2,
+              "selectedTemplateId": "end_easy_04",
+              "bestUtilityTemplateId": "str_upper_01",
+              "selectedVsBestUtilityGap": 0.24144524977784787,
+              "tierBlocked": true,
+              "blockedByTier": {
+                "coverage": true,
+                "recovery": false,
+                "benefit": true
+              },
+              "selectedAdvancesRequiredRole": false
+            },
+            {
               "date": "2026-08-26",
               "weekIndex": 2,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.012743671070968444,
+              "selectedVsBestUtilityGap": 0.01296390151197195,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -6661,23 +6869,23 @@
             {
               "date": "2026-08-27",
               "weekIndex": 2,
-              "selectedTemplateId": "end_easy_04",
-              "bestUtilityTemplateId": "cycling_technical_01",
-              "selectedVsBestUtilityGap": 0.012094925302731485,
+              "selectedTemplateId": "rest_01",
+              "bestUtilityTemplateId": "mob_01",
+              "selectedVsBestUtilityGap": 0.03458611305475577,
               "tierBlocked": true,
               "blockedByTier": {
-                "coverage": true,
-                "recovery": false,
+                "coverage": false,
+                "recovery": true,
                 "benefit": false
               },
-              "selectedAdvancesRequiredRole": true
+              "selectedAdvancesRequiredRole": false
             },
             {
               "date": "2026-08-28",
               "weekIndex": 3,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.00922145689835107,
+              "selectedVsBestUtilityGap": 0.025221456898351074,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -6715,11 +6923,25 @@
               "selectedAdvancesRequiredRole": true
             },
             {
+              "date": "2026-08-31",
+              "weekIndex": 3,
+              "selectedTemplateId": "end_easy_01",
+              "bestUtilityTemplateId": "cycling_technical_01",
+              "selectedVsBestUtilityGap": 0.0016411803096371136,
+              "tierBlocked": true,
+              "blockedByTier": {
+                "coverage": true,
+                "recovery": false,
+                "benefit": false
+              },
+              "selectedAdvancesRequiredRole": false
+            },
+            {
               "date": "2026-09-01",
               "weekIndex": 3,
               "selectedTemplateId": "end_race_sim_01",
               "bestUtilityTemplateId": "end_crit_surges_01",
-              "selectedVsBestUtilityGap": 0.2760173816633902,
+              "selectedVsBestUtilityGap": 0.30343742276099595,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -6729,16 +6951,30 @@
               "selectedAdvancesRequiredRole": true
             },
             {
-              "date": "2026-09-03",
+              "date": "2026-09-02",
               "weekIndex": 3,
               "selectedTemplateId": "end_easy_04",
               "bestUtilityTemplateId": "cycling_technical_01",
-              "selectedVsBestUtilityGap": 0.009845891066349699,
+              "selectedVsBestUtilityGap": 0.015558079474625452,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": true,
                 "recovery": false,
                 "benefit": false
+              },
+              "selectedAdvancesRequiredRole": false
+            },
+            {
+              "date": "2026-09-03",
+              "weekIndex": 3,
+              "selectedTemplateId": "end_easy_01",
+              "bestUtilityTemplateId": "str_upper_01",
+              "selectedVsBestUtilityGap": 0.21086853124059018,
+              "tierBlocked": true,
+              "blockedByTier": {
+                "coverage": true,
+                "recovery": false,
+                "benefit": true
               },
               "selectedAdvancesRequiredRole": false
             }
@@ -6768,10 +7004,10 @@
           "weekIndex": 2,
           "fatigueTierDayCounts": {
             "train": 3,
-            "modify": 1,
-            "recover": 1
+            "modify": 0,
+            "recover": 2
           },
-          "restOrRecoveryDayCount": 3
+          "restOrRecoveryDayCount": 4
         },
         {
           "weekIndex": 3,
@@ -7566,19 +7802,19 @@
       "weeksSimulated": 4,
       "totalDays": 28,
       "categoryDistribution": {
-        "Moderate Endurance": 3,
-        "Easy Endurance": 6,
-        "Rest": 9,
-        "Race-Specific Endurance": 6,
+        "Moderate Endurance": 4,
+        "Easy Endurance": 8,
+        "Rest": 8,
+        "Race-Specific Endurance": 4,
         "Upper-body Strength": 4
       },
       "modalityDistribution": {
-        "Running": 15,
-        "None": 9,
+        "Running": 16,
+        "None": 8,
         "Strength": 4
       },
-      "restOrRecoveryDayCount": 9,
-      "restOrRecoveryDayPct": 32.1,
+      "restOrRecoveryDayCount": 8,
+      "restOrRecoveryDayPct": 28.6,
       "maxConsecutiveSameTemplateStreakWithinCall": 2,
       "maxConsecutiveSameTemplateStreakAcrossWeeks": 2,
       "objectiveResolution": [
@@ -7600,7 +7836,7 @@
         {
           "key": "race_specific_endurance",
           "timesGenerated": 4,
-          "timesResolved": 2
+          "timesResolved": 0
         }
       ],
       "objectiveCredits": [
@@ -7686,7 +7922,17 @@
         },
         {
           "weekIndex": 2,
-          "date": "2026-08-24",
+          "date": "2026-08-21",
+          "objectiveKey": "zone2_aerobic",
+          "objectiveTitle": "Aerobic Base (Zone 2)",
+          "templateId": "end_mod_01",
+          "templateTitle": "Steady-State Tempo Run",
+          "modality": "Running",
+          "earnedCredit": 0.33999999999999986
+        },
+        {
+          "weekIndex": 2,
+          "date": "2026-08-21",
           "objectiveKey": "threshold_quality",
           "objectiveTitle": "Threshold Development",
           "templateId": "end_mod_01",
@@ -7695,24 +7941,33 @@
           "earnedCredit": 0.8
         },
         {
+          "weekIndex": 2,
+          "date": "2026-08-25",
+          "objectiveKey": "threshold_quality",
+          "objectiveTitle": "Threshold Development",
+          "templateId": "end_mod_01",
+          "templateTitle": "Steady-State Tempo Run",
+          "modality": "Running",
+          "earnedCredit": 0.19999999999999996
+        },
+        {
           "weekIndex": 3,
-          "date": "2026-08-29",
+          "date": "2026-08-28",
           "objectiveKey": "strength_maintenance",
           "objectiveTitle": "Strength & Neuromuscular Maintenance",
           "templateId": "str_upper_01",
           "templateTitle": "Upper Body Push/Pull",
           "modality": "Strength",
-          "earnedCredit": 0.19999999999999996
+          "earnedCredit": 0.4
         }
       ],
       "utilityDiagnostics": {
-        "fragileSelectionCount": 12,
-        "lowerBenefitSelectionCount": 9,
+        "fragileSelectionCount": 11,
+        "lowerBenefitSelectionCount": 8,
         "trainTierRestOrRecoveryCount": 0
       },
       "qualityWarnings": [
-        "Unresolved weekly objectives: strength_maintenance 3/4, race_specific_endurance 2/4.",
-        "Resolved objective(s) without a projected credit source in this window: race_specific_endurance. Verify whether completion was seeded from prior history.",
+        "Unresolved weekly objectives: strength_maintenance 3/4, race_specific_endurance 0/4.",
         "Event-specific anchor missed in 4 nominated week(s)."
       ],
       "anchorWeeks": [
@@ -7759,9 +8014,9 @@
       ],
       "anchorScopeNote": "Anchor-day nomination only requires SOME focus event (Race-Specific Endurance templates' phaseEligibility.requiresFocusEvent doesn't check event category), so a nomination can appear even here -- but the optimizer's event-priority penalty for non-matching modalities makes it unlikely to actually win the day's pick. Treat eventSpecificAnchorHit/qualityAnchorHit, not the raw nomination, as the meaningful signal for non-cycling scenarios.",
       "fatigueTierDayCounts": {
-        "train": 9,
-        "modify": 2,
-        "recover": 9
+        "train": 8,
+        "modify": 4,
+        "recover": 8
       },
       "constraintViolations": [],
       "allocationReports": [
@@ -7860,21 +8115,21 @@
             {
               "date": "2026-08-14",
               "weekIndex": 1,
-              "collision": 0.4118697174197797,
+              "collision": 0.306921939224302,
               "costMagnitude": 2.1,
               "topDimensions": [
-                "systemic",
-                "upperBody"
+                "upperBody",
+                "neuromuscular"
               ]
             },
             {
               "date": "2026-08-15",
               "weekIndex": 1,
-              "collision": 0.5781316324453999,
+              "collision": 0.5206199011574218,
               "costMagnitude": 1.575,
               "topDimensions": [
                 "upperBody",
-                "systemic"
+                "neuromuscular"
               ]
             },
             {
@@ -7887,7 +8142,7 @@
             {
               "date": "2026-08-17",
               "weekIndex": 1,
-              "collision": 0.3243664206418701,
+              "collision": 0.22655901259150713,
               "costMagnitude": 1.1433333333333333,
               "topDimensions": [
                 "impactTissue",
@@ -7897,7 +8152,7 @@
             {
               "date": "2026-08-18",
               "weekIndex": 1,
-              "collision": 0.38691205855789246,
+              "collision": 0.31780054174072525,
               "costMagnitude": 1.55,
               "topDimensions": [
                 "impactTissue",
@@ -7907,25 +8162,25 @@
             {
               "date": "2026-08-19",
               "weekIndex": 1,
-              "collision": 0,
-              "costMagnitude": 0,
-              "topDimensions": []
-            },
-            {
-              "date": "2026-08-20",
-              "weekIndex": 1,
-              "collision": 0.3064591632954735,
-              "costMagnitude": 1.1433333333333333,
+              "collision": 0.4363475031560228,
+              "costMagnitude": 1.0850000000000002,
               "topDimensions": [
                 "impactTissue",
                 "lowerBody"
               ]
             },
             {
+              "date": "2026-08-20",
+              "weekIndex": 1,
+              "collision": 0,
+              "costMagnitude": 0,
+              "topDimensions": []
+            },
+            {
               "date": "2026-08-21",
               "weekIndex": 2,
-              "collision": 0.7453135334599693,
-              "costMagnitude": 1.55,
+              "collision": 0.2932028212895748,
+              "costMagnitude": 2.9,
               "topDimensions": [
                 "impactTissue",
                 "lowerBody"
@@ -7934,7 +8189,7 @@
             {
               "date": "2026-08-22",
               "weekIndex": 2,
-              "collision": 0.4951197245249989,
+              "collision": 0.4621259500624733,
               "costMagnitude": 1.575,
               "topDimensions": [
                 "upperBody",
@@ -7944,14 +8199,24 @@
             {
               "date": "2026-08-23",
               "weekIndex": 2,
+              "collision": 0.4702189763997924,
+              "costMagnitude": 1.1624999999999999,
+              "topDimensions": [
+                "impactTissue",
+                "systemic"
+              ]
+            },
+            {
+              "date": "2026-08-24",
+              "weekIndex": 2,
               "collision": 0,
               "costMagnitude": 0,
               "topDimensions": []
             },
             {
-              "date": "2026-08-24",
+              "date": "2026-08-25",
               "weekIndex": 2,
-              "collision": 0.35741866553671325,
+              "collision": 0.294723888523613,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "impactTissue",
@@ -7959,33 +8224,16 @@
               ]
             },
             {
-              "date": "2026-08-25",
+              "date": "2026-08-26",
               "weekIndex": 2,
               "collision": 0,
               "costMagnitude": 0,
               "topDimensions": []
-            },
-            {
-              "date": "2026-08-26",
-              "weekIndex": 2,
-              "collision": 0.4248417371986705,
-              "costMagnitude": 1.0850000000000002,
-              "topDimensions": [
-                "impactTissue",
-                "lowerBody"
-              ]
             },
             {
               "date": "2026-08-27",
               "weekIndex": 2,
-              "collision": 0,
-              "costMagnitude": 0,
-              "topDimensions": []
-            },
-            {
-              "date": "2026-08-28",
-              "weekIndex": 3,
-              "collision": 0.30700309961974925,
+              "collision": 0.3776078596013424,
               "costMagnitude": 1.1433333333333333,
               "topDimensions": [
                 "impactTissue",
@@ -7993,20 +8241,30 @@
               ]
             },
             {
-              "date": "2026-08-29",
+              "date": "2026-08-28",
               "weekIndex": 3,
-              "collision": 0.49551912641899304,
-              "costMagnitude": 1.575,
+              "collision": 0.3064560307160781,
+              "costMagnitude": 2.1,
               "topDimensions": [
                 "upperBody",
                 "neuromuscular"
               ]
             },
             {
+              "date": "2026-08-29",
+              "weekIndex": 3,
+              "collision": 0.48671337077284493,
+              "costMagnitude": 1.1624999999999999,
+              "topDimensions": [
+                "impactTissue",
+                "lowerBody"
+              ]
+            },
+            {
               "date": "2026-08-30",
               "weekIndex": 3,
-              "collision": 0.32252367506116175,
-              "costMagnitude": 2.2866666666666666,
+              "collision": 0.43285899070234246,
+              "costMagnitude": 1.0850000000000002,
               "topDimensions": [
                 "impactTissue",
                 "systemic"
@@ -8022,7 +8280,7 @@
             {
               "date": "2026-09-01",
               "weekIndex": 3,
-              "collision": 0.34648759275955493,
+              "collision": 0.2802314475430847,
               "costMagnitude": 1.1433333333333333,
               "topDimensions": [
                 "impactTissue",
@@ -8032,7 +8290,7 @@
             {
               "date": "2026-09-02",
               "weekIndex": 3,
-              "collision": 0.39915571237966974,
+              "collision": 0.3606941302286131,
               "costMagnitude": 1.55,
               "topDimensions": [
                 "impactTissue",
@@ -8047,8 +8305,8 @@
               "topDimensions": []
             }
           ],
-          "meanCollision": 0.272405699247321,
-          "maxCollision": 0.7453135334599693
+          "meanCollision": 0.26069000297552963,
+          "maxCollision": 0.5206199011574218
         },
         "adjacentCostOverlap": {
           "perPair": [
@@ -8093,36 +8351,52 @@
               "neuromuscularOverlap": 0.05879631566176075
             },
             {
-              "date": "2026-08-21",
-              "previousDate": "2026-08-20",
-              "overlap": 0.4707618504363185,
-              "lowerBodyOverlap": 0.18384776310850237,
-              "impactTissueOverlap": 0.20034692133618848,
-              "neuromuscularOverlap": 0.05879631566176075
+              "date": "2026-08-19",
+              "previousDate": "2026-08-18",
+              "overlap": 0.9108788047411419,
+              "lowerBodyOverlap": 0.21,
+              "impactTissueOverlap": 0.35,
+              "neuromuscularOverlap": 0.06299605249474366
             },
             {
               "date": "2026-08-22",
               "previousDate": "2026-08-21",
-              "overlap": 0.24615666552366847,
+              "overlap": 0.3260154515525037,
               "lowerBodyOverlap": 0,
               "impactTissueOverlap": 0.07500000000000001,
-              "neuromuscularOverlap": 0.06299605249474366
+              "neuromuscularOverlap": 0.25198420997897464
+            },
+            {
+              "date": "2026-08-23",
+              "previousDate": "2026-08-22",
+              "overlap": 0.2509679044072458,
+              "lowerBodyOverlap": 0,
+              "impactTissueOverlap": 0.05303300858899108,
+              "neuromuscularOverlap": 0.07500000000000001
+            },
+            {
+              "date": "2026-08-28",
+              "previousDate": "2026-08-27",
+              "overlap": 0.18684975125484024,
+              "lowerBodyOverlap": 0,
+              "impactTissueOverlap": 0.1,
+              "neuromuscularOverlap": 0.05879631566176075
             },
             {
               "date": "2026-08-29",
               "previousDate": "2026-08-28",
-              "overlap": 0.22316493470818188,
+              "overlap": 0.2594329311639227,
               "lowerBodyOverlap": 0,
-              "impactTissueOverlap": 0.07500000000000001,
-              "neuromuscularOverlap": 0.05879631566176075
+              "impactTissueOverlap": 0.07071067811865477,
+              "neuromuscularOverlap": 0.07500000000000001
             },
             {
               "date": "2026-08-30",
               "previousDate": "2026-08-29",
-              "overlap": 0.18813595636502892,
-              "lowerBodyOverlap": 0,
-              "impactTissueOverlap": 0.05303300858899108,
-              "neuromuscularOverlap": 0.18666666666666668
+              "overlap": 0.6906688902135376,
+              "lowerBodyOverlap": 0.15909902576697318,
+              "impactTissueOverlap": 0.26516504294495535,
+              "neuromuscularOverlap": 0.04724703937105775
             },
             {
               "date": "2026-09-02",
@@ -8136,21 +8410,20 @@
           "maxLowerBodyOverlap": 0.22499999999999998,
           "maxImpactTissueOverlap": 0.375,
           "maxNeuromuscularOverlap": 0.3149802624737183,
-          "meanOverlap": 0.4406888455824253
+          "meanOverlap": 0.4919568985103539
         },
         "qualitySpacing": {
           "gapsDays": [
             4,
             2,
             4,
-            3,
             4,
             4,
             2,
-            2
+            5
           ],
           "minGapDays": 2,
-          "medianGapDays": 3.5,
+          "medianGapDays": 4,
           "adjacentQualityDayCount": 0,
           "longestQualityStreak": 0,
           "qualityPer3DayWindowMax": 2,
@@ -8167,21 +8440,21 @@
             },
             {
               "weekIndex": 1,
-              "hardDayCount": 2,
+              "hardDayCount": 1,
               "maxHardStreak": 1,
               "recoveryAfterHighCollisionCount": 1,
               "recoveryWhileFatigueLowAndWorkFeasibleCount": 0
             },
             {
               "weekIndex": 2,
-              "hardDayCount": 1,
+              "hardDayCount": 3,
               "maxHardStreak": 1,
               "recoveryAfterHighCollisionCount": 0,
               "recoveryWhileFatigueLowAndWorkFeasibleCount": 0
             },
             {
               "weekIndex": 3,
-              "hardDayCount": 3,
+              "hardDayCount": 1,
               "maxHardStreak": 1,
               "recoveryAfterHighCollisionCount": 0,
               "recoveryWhileFatigueLowAndWorkFeasibleCount": 0
@@ -8190,15 +8463,15 @@
         },
         "opportunityCost": {
           "daysWithRankingAudit": 28,
-          "utilityWinnerDifferentCount": 13,
-          "utilityWinnerBlockedCount": 13,
+          "utilityWinnerDifferentCount": 10,
+          "utilityWinnerBlockedCount": 10,
           "utilityWinnerDifferentWithoutTierBlockCount": 0,
-          "meanBlockedUtilityGap": 0.08588328238469375,
-          "maxBlockedUtilityGap": 0.2994613231811178,
+          "meanBlockedUtilityGap": 0.07264966693668365,
+          "maxBlockedUtilityGap": 0.35179372663532965,
           "blockedByTier": {
             "coverage": 0,
-            "recovery": 9,
-            "benefit": 4
+            "recovery": 8,
+            "benefit": 2
           },
           "perDay": [
             {
@@ -8244,25 +8517,11 @@
               "selectedAdvancesRequiredRole": false
             },
             {
-              "date": "2026-08-14",
-              "weekIndex": 1,
-              "selectedTemplateId": "str_upper_01",
-              "bestUtilityTemplateId": "end_easy_02",
-              "selectedVsBestUtilityGap": 0.20032131035110937,
-              "tierBlocked": true,
-              "blockedByTier": {
-                "coverage": false,
-                "recovery": false,
-                "benefit": true
-              },
-              "selectedAdvancesRequiredRole": false
-            },
-            {
               "date": "2026-08-15",
               "weekIndex": 1,
               "selectedTemplateId": "str_upper_01",
               "bestUtilityTemplateId": "end_easy_02",
-              "selectedVsBestUtilityGap": 0.2994613231811178,
+              "selectedVsBestUtilityGap": 0.35179372663532965,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -8276,7 +8535,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.01464927029780002,
+              "selectedVsBestUtilityGap": 0.017893523983885204,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -8286,11 +8545,11 @@
               "selectedAdvancesRequiredRole": false
             },
             {
-              "date": "2026-08-19",
+              "date": "2026-08-20",
               "weekIndex": 1,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.018068737420728342,
+              "selectedVsBestUtilityGap": 0.019348568563024256,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -8300,11 +8559,11 @@
               "selectedAdvancesRequiredRole": false
             },
             {
-              "date": "2026-08-23",
+              "date": "2026-08-24",
               "weekIndex": 2,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.014822391368723077,
+              "selectedVsBestUtilityGap": 0.017613471741309256,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -8314,44 +8573,16 @@
               "selectedAdvancesRequiredRole": false
             },
             {
-              "date": "2026-08-25",
+              "date": "2026-08-26",
               "weekIndex": 2,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.01435957285329937,
+              "selectedVsBestUtilityGap": 0.01550455993681571,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
                 "recovery": true,
                 "benefit": false
-              },
-              "selectedAdvancesRequiredRole": false
-            },
-            {
-              "date": "2026-08-27",
-              "weekIndex": 2,
-              "selectedTemplateId": "rest_01",
-              "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.019518764890974066,
-              "tierBlocked": true,
-              "blockedByTier": {
-                "coverage": false,
-                "recovery": true,
-                "benefit": false
-              },
-              "selectedAdvancesRequiredRole": false
-            },
-            {
-              "date": "2026-08-29",
-              "weekIndex": 3,
-              "selectedTemplateId": "str_upper_01",
-              "bestUtilityTemplateId": "end_easy_02",
-              "selectedVsBestUtilityGap": 0.23438556536520103,
-              "tierBlocked": true,
-              "blockedByTier": {
-                "coverage": false,
-                "recovery": false,
-                "benefit": true
               },
               "selectedAdvancesRequiredRole": false
             },
@@ -8360,7 +8591,7 @@
               "weekIndex": 3,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.01615921142766711,
+              "selectedVsBestUtilityGap": 0.018830225186332712,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -8374,7 +8605,7 @@
               "weekIndex": 3,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.018422502589293087,
+              "selectedVsBestUtilityGap": 0.019198572065034107,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -8399,8 +8630,8 @@
         {
           "weekIndex": 1,
           "fatigueTierDayCounts": {
-            "train": 3,
-            "modify": 0,
+            "train": 2,
+            "modify": 1,
             "recover": 2
           },
           "restOrRecoveryDayCount": 2
@@ -8408,17 +8639,17 @@
         {
           "weekIndex": 2,
           "fatigueTierDayCounts": {
-            "train": 1,
+            "train": 2,
             "modify": 1,
-            "recover": 3
+            "recover": 2
           },
-          "restOrRecoveryDayCount": 3
+          "restOrRecoveryDayCount": 2
         },
         {
           "weekIndex": 3,
           "fatigueTierDayCounts": {
-            "train": 3,
-            "modify": 0,
+            "train": 2,
+            "modify": 1,
             "recover": 2
           },
           "restOrRecoveryDayCount": 2
@@ -8433,22 +8664,22 @@
       "weeksSimulated": 4,
       "totalDays": 28,
       "categoryDistribution": {
-        "Moderate Endurance": 6,
-        "Easy Endurance": 11,
-        "Upper-body Strength": 3,
-        "Lower-body Strength": 1,
-        "Rest": 4,
-        "Race-Specific Endurance": 3
+        "Moderate Endurance": 7,
+        "Easy Endurance": 10,
+        "Upper-body Strength": 2,
+        "Lower-body Strength": 2,
+        "Rest": 5,
+        "Race-Specific Endurance": 2
       },
       "modalityDistribution": {
-        "Cycling": 10,
+        "Cycling": 9,
         "Running": 6,
         "Strength": 4,
-        "None": 4,
+        "None": 5,
         "Swimming": 4
       },
-      "restOrRecoveryDayCount": 4,
-      "restOrRecoveryDayPct": 14.3,
+      "restOrRecoveryDayCount": 5,
+      "restOrRecoveryDayPct": 17.9,
       "maxConsecutiveSameTemplateStreakWithinCall": 2,
       "maxConsecutiveSameTemplateStreakAcrossWeeks": 2,
       "objectiveResolution": [
@@ -8604,24 +8835,44 @@
           "date": "2026-08-23",
           "objectiveKey": "strength_maintenance",
           "objectiveTitle": "Strength & Neuromuscular Maintenance",
-          "templateId": "str_upper_01",
-          "templateTitle": "Upper Body Push/Pull",
+          "templateId": "str_lower_01",
+          "templateTitle": "Lower Body Strength & Power",
           "modality": "Strength",
           "earnedCredit": 0.4
         },
         {
           "weekIndex": 3,
-          "date": "2026-08-29",
+          "date": "2026-08-28",
           "objectiveKey": "zone2_aerobic",
           "objectiveTitle": "Triathlon Run Aerobic Exposure",
-          "templateId": "end_easy_02",
-          "templateTitle": "Light Base Run",
+          "templateId": "end_mod_01",
+          "templateTitle": "Steady-State Tempo Run",
           "modality": "Running",
           "earnedCredit": 0.30000000000000004
         },
         {
           "weekIndex": 3,
-          "date": "2026-08-31",
+          "date": "2026-08-28",
+          "objectiveKey": "threshold_quality",
+          "objectiveTitle": "Threshold Development",
+          "templateId": "end_mod_01",
+          "templateTitle": "Steady-State Tempo Run",
+          "modality": "Running",
+          "earnedCredit": 0.19999999999999996
+        },
+        {
+          "weekIndex": 3,
+          "date": "2026-08-29",
+          "objectiveKey": "zone2_aerobic",
+          "objectiveTitle": "Triathlon Bike Aerobic Exposure",
+          "templateId": "end_easy_01",
+          "templateTitle": "Zone 2 Spin",
+          "modality": "Cycling",
+          "earnedCredit": 0.19999999999999996
+        },
+        {
+          "weekIndex": 3,
+          "date": "2026-08-30",
           "objectiveKey": "zone2_aerobic",
           "objectiveTitle": "Triathlon Swim Aerobic Exposure",
           "templateId": "swim_easy_01",
@@ -8631,7 +8882,7 @@
         },
         {
           "weekIndex": 3,
-          "date": "2026-09-03",
+          "date": "2026-08-31",
           "objectiveKey": "zone2_aerobic",
           "objectiveTitle": "Triathlon Swim Aerobic Exposure",
           "templateId": "swim_easy_01",
@@ -8641,13 +8892,14 @@
         }
       ],
       "utilityDiagnostics": {
-        "fragileSelectionCount": 9,
-        "lowerBenefitSelectionCount": 5,
+        "fragileSelectionCount": 12,
+        "lowerBenefitSelectionCount": 6,
         "trainTierRestOrRecoveryCount": 0
       },
       "qualityWarnings": [
         "Unresolved weekly objectives: zone2_aerobic 11/12.",
-        "Event-specific anchor missed in 2 nominated week(s)."
+        "Event-specific anchor missed in 2 nominated week(s).",
+        "Event-specific exposure occurred off the nominated anchor date in 1 week(s) (adaptively fulfilled in-window)."
       ],
       "anchorWeeks": [
         {
@@ -8678,28 +8930,28 @@
           "eventSpecificAnchorDate": "2026-08-23",
           "qualityAnchorDate": "2026-08-25",
           "eventSpecificAnchorHit": false,
-          "eventSpecificExposureDates": [],
-          "eventSpecificAnchorFulfilled": false,
-          "qualityAnchorHit": true
+          "eventSpecificExposureDates": [
+            "2026-08-26"
+          ],
+          "eventSpecificAnchorFulfilled": true,
+          "qualityAnchorHit": false
         },
         {
           "weekIndex": 3,
           "weekStartDate": "2026-08-28",
           "eventSpecificAnchorDate": "2026-08-30",
           "qualityAnchorDate": "2026-09-01",
-          "eventSpecificAnchorHit": true,
-          "eventSpecificExposureDates": [
-            "2026-08-30"
-          ],
-          "eventSpecificAnchorFulfilled": true,
+          "eventSpecificAnchorHit": false,
+          "eventSpecificExposureDates": [],
+          "eventSpecificAnchorFulfilled": false,
           "qualityAnchorHit": true
         }
       ],
       "anchorScopeNote": null,
       "fatigueTierDayCounts": {
-        "train": 10,
-        "modify": 6,
-        "recover": 4
+        "train": 11,
+        "modify": 4,
+        "recover": 5
       },
       "constraintViolations": [],
       "allocationReports": [
@@ -8801,17 +9053,17 @@
             {
               "date": "2026-08-14",
               "weekIndex": 1,
-              "collision": 0.3749324140331355,
+              "collision": 0.33920441111770433,
               "costMagnitude": 1.2499999999999998,
               "topDimensions": [
                 "systemic",
-                "upperBody"
+                "neuromuscular"
               ]
             },
             {
               "date": "2026-08-15",
               "weekIndex": 1,
-              "collision": 0.46848901418111927,
+              "collision": 0.46128090531111104,
               "costMagnitude": 0.6900000000000002,
               "topDimensions": [
                 "lowerBody",
@@ -8821,7 +9073,7 @@
             {
               "date": "2026-08-16",
               "weekIndex": 1,
-              "collision": 0.3615382925867255,
+              "collision": 0.34759583112807474,
               "costMagnitude": 1.64,
               "topDimensions": [
                 "systemic",
@@ -8831,7 +9083,7 @@
             {
               "date": "2026-08-17",
               "weekIndex": 1,
-              "collision": 0.4131046792373992,
+              "collision": 0.40033413403961515,
               "costMagnitude": 1.55,
               "topDimensions": [
                 "lowerBody",
@@ -8841,7 +9093,7 @@
             {
               "date": "2026-08-18",
               "weekIndex": 1,
-              "collision": 0.35757083075593465,
+              "collision": 0.3519398266953773,
               "costMagnitude": 1.2499999999999998,
               "topDimensions": [
                 "systemic",
@@ -8851,7 +9103,7 @@
             {
               "date": "2026-08-19",
               "weekIndex": 1,
-              "collision": 0.4192911858846235,
+              "collision": 0.41514841180465367,
               "costMagnitude": 2.4,
               "topDimensions": [
                 "systemic",
@@ -8868,7 +9120,7 @@
             {
               "date": "2026-08-21",
               "weekIndex": 2,
-              "collision": 0.3612675673938565,
+              "collision": 0.351574390264632,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "systemic",
@@ -8878,7 +9130,7 @@
             {
               "date": "2026-08-22",
               "weekIndex": 2,
-              "collision": 0.4891635491370491,
+              "collision": 0.48633929439160345,
               "costMagnitude": 1.575,
               "topDimensions": [
                 "upperBody",
@@ -8888,11 +9140,11 @@
             {
               "date": "2026-08-23",
               "weekIndex": 2,
-              "collision": 0.5103366622162439,
-              "costMagnitude": 1.575,
+              "collision": 0.4965717653106957,
+              "costMagnitude": 3.5,
               "topDimensions": [
-                "upperBody",
-                "neuromuscular"
+                "systemic",
+                "lowerBody"
               ]
             },
             {
@@ -8905,18 +9157,15 @@
             {
               "date": "2026-08-25",
               "weekIndex": 2,
-              "collision": 0.2699444338157143,
-              "costMagnitude": 2.4,
-              "topDimensions": [
-                "systemic",
-                "neuromuscular"
-              ]
+              "collision": 0,
+              "costMagnitude": 0,
+              "topDimensions": []
             },
             {
               "date": "2026-08-26",
               "weekIndex": 2,
-              "collision": 0.474324859629082,
-              "costMagnitude": 0.6900000000000002,
+              "collision": 0.28627341997921857,
+              "costMagnitude": 0.82,
               "topDimensions": [
                 "systemic",
                 "lowerBody"
@@ -8925,7 +9174,7 @@
             {
               "date": "2026-08-27",
               "weekIndex": 2,
-              "collision": 0.3937817448036283,
+              "collision": 0.3108158356981693,
               "costMagnitude": 1.1500000000000001,
               "topDimensions": [
                 "lowerBody",
@@ -8935,8 +9184,8 @@
             {
               "date": "2026-08-28",
               "weekIndex": 3,
-              "collision": 0.43463488138585266,
-              "costMagnitude": 1.1433333333333333,
+              "collision": 0.3550178647060573,
+              "costMagnitude": 2.9,
               "topDimensions": [
                 "lowerBody",
                 "systemic"
@@ -8945,27 +9194,27 @@
             {
               "date": "2026-08-29",
               "weekIndex": 3,
-              "collision": 0.7292318080205351,
-              "costMagnitude": 1.1624999999999999,
+              "collision": 0.5611564765667431,
+              "costMagnitude": 0.6900000000000002,
               "topDimensions": [
-                "impactTissue",
-                "lowerBody"
+                "lowerBody",
+                "systemic"
               ]
             },
             {
               "date": "2026-08-30",
               "weekIndex": 3,
-              "collision": 0.37166029000326295,
-              "costMagnitude": 1.64,
+              "collision": 0.32453023335054887,
+              "costMagnitude": 1.2499999999999998,
               "topDimensions": [
                 "systemic",
-                "lowerBody"
+                "cardiovascular"
               ]
             },
             {
               "date": "2026-08-31",
               "weekIndex": 3,
-              "collision": 0.3627190681333557,
+              "collision": 0.3657455426245152,
               "costMagnitude": 1.2499999999999998,
               "topDimensions": [
                 "systemic",
@@ -8975,11 +9224,11 @@
             {
               "date": "2026-09-01",
               "weekIndex": 3,
-              "collision": 0.41880106484373786,
+              "collision": 0.38956186365945494,
               "costMagnitude": 2.4,
               "topDimensions": [
                 "systemic",
-                "lowerBody"
+                "cardiovascular"
               ]
             },
             {
@@ -8992,16 +9241,16 @@
             {
               "date": "2026-09-03",
               "weekIndex": 3,
-              "collision": 0.29056897593392506,
-              "costMagnitude": 1.2499999999999998,
+              "collision": 0.32091318985459827,
+              "costMagnitude": 2.9,
               "topDimensions": [
                 "systemic",
-                "cardiovascular"
+                "lowerBody"
               ]
             }
           ],
-          "meanCollision": 0.3445481449055772,
-          "maxCollision": 0.7292318080205351
+          "meanCollision": 0.3110710761379914,
+          "maxCollision": 0.5611564765667431
         },
         "adjacentCostOverlap": {
           "perPair": [
@@ -9096,31 +9345,23 @@
             {
               "date": "2026-08-23",
               "previousDate": "2026-08-22",
-              "overlap": 0.6212569633447813,
+              "overlap": 0.170776005063188,
               "lowerBodyOverlap": 0,
               "impactTissueOverlap": 0.05303300858899108,
               "neuromuscularOverlap": 0.2362351968552887
             },
             {
-              "date": "2026-08-26",
-              "previousDate": "2026-08-25",
-              "overlap": 0.4637310800195986,
-              "lowerBodyOverlap": 0.18,
-              "impactTissueOverlap": 0.06,
-              "neuromuscularOverlap": 0.06
-            },
-            {
               "date": "2026-08-27",
               "previousDate": "2026-08-26",
-              "overlap": 0.3737347558439819,
-              "lowerBodyOverlap": 0.12727922061357855,
+              "overlap": 0.43548378758029166,
+              "lowerBodyOverlap": 0.09899494936611665,
               "impactTissueOverlap": 0.042426406871192854,
-              "neuromuscularOverlap": 0.037797631496846194
+              "neuromuscularOverlap": 0.07559526299369239
             },
             {
               "date": "2026-08-28",
               "previousDate": "2026-08-27",
-              "overlap": 0.5919487152066708,
+              "overlap": 0.24700860300033295,
               "lowerBodyOverlap": 0.21213203435596426,
               "impactTissueOverlap": 0.07071067811865477,
               "neuromuscularOverlap": 0.06299605249474366
@@ -9128,26 +9369,26 @@
             {
               "date": "2026-08-29",
               "previousDate": "2026-08-28",
-              "overlap": 0.6276824672484248,
-              "lowerBodyOverlap": 0.18384776310850237,
-              "impactTissueOverlap": 0.20034692133618848,
-              "neuromuscularOverlap": 0.05879631566176075
+              "overlap": 0.3746976526222189,
+              "lowerBodyOverlap": 0.18,
+              "impactTissueOverlap": 0.06,
+              "neuromuscularOverlap": 0.06
             },
             {
               "date": "2026-08-30",
               "previousDate": "2026-08-29",
-              "overlap": 0.338462096445703,
-              "lowerBodyOverlap": 0.15909902576697318,
-              "impactTissueOverlap": 0.12,
-              "neuromuscularOverlap": 0.04724703937105775
+              "overlap": 0.27285580529205034,
+              "lowerBodyOverlap": 0.08,
+              "impactTissueOverlap": 0.02,
+              "neuromuscularOverlap": 0.037797631496846194
             },
             {
               "date": "2026-08-31",
               "previousDate": "2026-08-30",
-              "overlap": 0.5701258876325062,
-              "lowerBodyOverlap": 0.08,
-              "impactTissueOverlap": 0.02,
-              "neuromuscularOverlap": 0.15
+              "overlap": 0.5945448574633859,
+              "lowerBodyOverlap": 0.05656854249492381,
+              "impactTissueOverlap": 0.014142135623730952,
+              "neuromuscularOverlap": 0.09449407874211549
             },
             {
               "date": "2026-09-01",
@@ -9159,9 +9400,9 @@
             }
           ],
           "maxLowerBodyOverlap": 0.22499999999999998,
-          "maxImpactTissueOverlap": 0.20034692133618848,
+          "maxImpactTissueOverlap": 0.2,
           "maxNeuromuscularOverlap": 0.25198420997897464,
-          "meanOverlap": 0.41471611309737005
+          "meanOverlap": 0.35489060522943505
         },
         "qualitySpacing": {
           "gapsDays": [
@@ -9170,13 +9411,14 @@
             4,
             3,
             2,
-            4,
+            2,
             3,
             2,
+            4,
             2
           ],
           "minGapDays": 2,
-          "medianGapDays": 3,
+          "medianGapDays": 2.5,
           "adjacentQualityDayCount": 0,
           "longestQualityStreak": 0,
           "qualityPer3DayWindowMax": 2,
@@ -9200,9 +9442,9 @@
             },
             {
               "weekIndex": 2,
-              "hardDayCount": 2,
+              "hardDayCount": 3,
               "maxHardStreak": 1,
-              "recoveryAfterHighCollisionCount": 1,
+              "recoveryAfterHighCollisionCount": 0,
               "recoveryWhileFatigueLowAndWorkFeasibleCount": 0
             },
             {
@@ -9216,15 +9458,15 @@
         },
         "opportunityCost": {
           "daysWithRankingAudit": 28,
-          "utilityWinnerDifferentCount": 12,
-          "utilityWinnerBlockedCount": 12,
+          "utilityWinnerDifferentCount": 14,
+          "utilityWinnerBlockedCount": 14,
           "utilityWinnerDifferentWithoutTierBlockCount": 0,
-          "meanBlockedUtilityGap": 0.25556937345326186,
+          "meanBlockedUtilityGap": 0.3002373342787811,
           "maxBlockedUtilityGap": 0.7299553450670971,
           "blockedByTier": {
             "coverage": 0,
-            "recovery": 4,
-            "benefit": 10
+            "recovery": 5,
+            "benefit": 13
           },
           "perDay": [
             {
@@ -9288,7 +9530,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "end_mod_02",
               "bestUtilityTemplateId": "end_easy_01",
-              "selectedVsBestUtilityGap": 0.2907396498693313,
+              "selectedVsBestUtilityGap": 0.2914075367061735,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -9302,7 +9544,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.07602332091796762,
+              "selectedVsBestUtilityGap": 0.07647854072802784,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -9316,7 +9558,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "str_upper_01",
               "bestUtilityTemplateId": "swim_easy_01",
-              "selectedVsBestUtilityGap": 0.6199153311821679,
+              "selectedVsBestUtilityGap": 0.6239158882850733,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -9328,9 +9570,9 @@
             {
               "date": "2026-08-23",
               "weekIndex": 2,
-              "selectedTemplateId": "str_upper_01",
-              "bestUtilityTemplateId": "cycling_technical_01",
-              "selectedVsBestUtilityGap": 0.3595036908398487,
+              "selectedTemplateId": "str_lower_01",
+              "bestUtilityTemplateId": "end_race_specific_01",
+              "selectedVsBestUtilityGap": 0.5395955627715185,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -9344,7 +9586,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.08296916653061295,
+              "selectedVsBestUtilityGap": 0.05396182793629348,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -9354,11 +9596,25 @@
               "selectedAdvancesRequiredRole": false
             },
             {
-              "date": "2026-08-28",
-              "weekIndex": 3,
-              "selectedTemplateId": "run_long_01",
-              "bestUtilityTemplateId": "end_easy_02",
-              "selectedVsBestUtilityGap": 0.6191738961452662,
+              "date": "2026-08-25",
+              "weekIndex": 2,
+              "selectedTemplateId": "rest_01",
+              "bestUtilityTemplateId": "mob_01",
+              "selectedVsBestUtilityGap": 0.1611148541466686,
+              "tierBlocked": true,
+              "blockedByTier": {
+                "coverage": false,
+                "recovery": true,
+                "benefit": true
+              },
+              "selectedAdvancesRequiredRole": false
+            },
+            {
+              "date": "2026-08-26",
+              "weekIndex": 2,
+              "selectedTemplateId": "end_race_specific_01",
+              "bestUtilityTemplateId": "end_easy_01",
+              "selectedVsBestUtilityGap": 0.6034334362097946,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -9368,11 +9624,11 @@
               "selectedAdvancesRequiredRole": false
             },
             {
-              "date": "2026-08-29",
+              "date": "2026-08-31",
               "weekIndex": 3,
-              "selectedTemplateId": "end_easy_02",
-              "bestUtilityTemplateId": "swim_easy_01",
-              "selectedVsBestUtilityGap": 0.00704511221005244,
+              "selectedTemplateId": "swim_easy_01",
+              "bestUtilityTemplateId": "swim_threshold_01",
+              "selectedVsBestUtilityGap": 0.4101009321886348,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -9386,12 +9642,26 @@
               "weekIndex": 3,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.015426660602756284,
+              "selectedVsBestUtilityGap": 0.0993247320047935,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
                 "recovery": true,
-                "benefit": false
+                "benefit": true
+              },
+              "selectedAdvancesRequiredRole": false
+            },
+            {
+              "date": "2026-09-03",
+              "weekIndex": 3,
+              "selectedTemplateId": "end_mod_01",
+              "bestUtilityTemplateId": "end_easy_01",
+              "selectedVsBestUtilityGap": 0.34795371578481826,
+              "tierBlocked": true,
+              "blockedByTier": {
+                "coverage": false,
+                "recovery": false,
+                "benefit": true
               },
               "selectedAdvancesRequiredRole": false
             }
@@ -9420,11 +9690,11 @@
         {
           "weekIndex": 2,
           "fatigueTierDayCounts": {
-            "train": 2,
-            "modify": 2,
-            "recover": 1
+            "train": 3,
+            "modify": 0,
+            "recover": 2
           },
-          "restOrRecoveryDayCount": 1
+          "restOrRecoveryDayCount": 2
         },
         {
           "weekIndex": 3,
@@ -9445,24 +9715,24 @@
       "weeksSimulated": 4,
       "totalDays": 28,
       "categoryDistribution": {
-        "Moderate Endurance": 4,
-        "Easy Endurance": 12,
-        "Rest": 6,
+        "Moderate Endurance": 3,
+        "Easy Endurance": 11,
+        "Rest": 8,
         "Hard Endurance": 2,
-        "Lower-body Strength": 2,
-        "Upper-body Strength": 2
+        "Lower-body Strength": 3,
+        "Upper-body Strength": 1
       },
       "modalityDistribution": {
-        "Running": 8,
+        "Running": 7,
         "Cycling": 6,
-        "None": 6,
+        "None": 8,
         "Strength": 4,
-        "Swimming": 4
+        "Swimming": 3
       },
-      "restOrRecoveryDayCount": 6,
-      "restOrRecoveryDayPct": 21.4,
-      "maxConsecutiveSameTemplateStreakWithinCall": 1,
-      "maxConsecutiveSameTemplateStreakAcrossWeeks": 1,
+      "restOrRecoveryDayCount": 8,
+      "restOrRecoveryDayPct": 28.6,
+      "maxConsecutiveSameTemplateStreakWithinCall": 2,
+      "maxConsecutiveSameTemplateStreakAcrossWeeks": 2,
       "objectiveResolution": [
         {
           "key": "zone2_aerobic",
@@ -9671,25 +9941,15 @@
           "date": "2026-08-31",
           "objectiveKey": "strength_maintenance",
           "objectiveTitle": "Strength & Neuromuscular Maintenance",
-          "templateId": "str_upper_01",
-          "templateTitle": "Upper Body Push/Pull",
+          "templateId": "str_lower_01",
+          "templateTitle": "Lower Body Strength & Power",
           "modality": "Strength",
           "earnedCredit": 0.09999999999999998
-        },
-        {
-          "weekIndex": 3,
-          "date": "2026-09-01",
-          "objectiveKey": "zone2_aerobic",
-          "objectiveTitle": "Triathlon Swim Aerobic Exposure",
-          "templateId": "swim_easy_01",
-          "templateTitle": "Easy Aerobic Swim",
-          "modality": "Swimming",
-          "earnedCredit": 0.19999999999999996
         }
       ],
       "utilityDiagnostics": {
-        "fragileSelectionCount": 9,
-        "lowerBenefitSelectionCount": 8,
+        "fragileSelectionCount": 12,
+        "lowerBenefitSelectionCount": 10,
         "trainTierRestOrRecoveryCount": 0
       },
       "qualityWarnings": [
@@ -9740,9 +10000,9 @@
       ],
       "anchorScopeNote": null,
       "fatigueTierDayCounts": {
-        "train": 12,
-        "modify": 2,
-        "recover": 6
+        "train": 11,
+        "modify": 1,
+        "recover": 8
       },
       "constraintViolations": [],
       "allocationReports": [
@@ -9841,7 +10101,7 @@
             {
               "date": "2026-08-14",
               "weekIndex": 1,
-              "collision": 0.5356431561750122,
+              "collision": 0.5282681561750123,
               "costMagnitude": 3.5,
               "topDimensions": [
                 "lowerBody",
@@ -9851,7 +10111,7 @@
             {
               "date": "2026-08-15",
               "weekIndex": 1,
-              "collision": 0.568166028177809,
+              "collision": 0.5664865425329244,
               "costMagnitude": 1.2499999999999998,
               "topDimensions": [
                 "systemic",
@@ -9868,7 +10128,7 @@
             {
               "date": "2026-08-17",
               "weekIndex": 1,
-              "collision": 0.2846147910973985,
+              "collision": 0.2838684093377335,
               "costMagnitude": 1.575,
               "topDimensions": [
                 "neuromuscular",
@@ -9878,7 +10138,7 @@
             {
               "date": "2026-08-18",
               "weekIndex": 1,
-              "collision": 0.3779954834567502,
+              "collision": 0.37652702718605935,
               "costMagnitude": 1.1500000000000001,
               "topDimensions": [
                 "systemic",
@@ -9888,7 +10148,7 @@
             {
               "date": "2026-08-19",
               "weekIndex": 1,
-              "collision": 0.3758399072720875,
+              "collision": 0.37486619940640636,
               "costMagnitude": 1.55,
               "topDimensions": [
                 "lowerBody",
@@ -9898,7 +10158,7 @@
             {
               "date": "2026-08-20",
               "weekIndex": 1,
-              "collision": 0.3489947898280575,
+              "collision": 0.3487054148280575,
               "costMagnitude": 1.2499999999999998,
               "topDimensions": [
                 "systemic",
@@ -9908,7 +10168,7 @@
             {
               "date": "2026-08-21",
               "weekIndex": 2,
-              "collision": 0.3803435625439818,
+              "collision": 0.37082365945698154,
               "costMagnitude": 4.6,
               "topDimensions": [
                 "systemic",
@@ -9918,7 +10178,7 @@
             {
               "date": "2026-08-22",
               "weekIndex": 2,
-              "collision": 0.7711687506529501,
+              "collision": 0.7667102934507483,
               "costMagnitude": 0.6900000000000002,
               "topDimensions": [
                 "systemic",
@@ -9935,7 +10195,7 @@
             {
               "date": "2026-08-24",
               "weekIndex": 2,
-              "collision": 0.3855006361287245,
+              "collision": 0.38308752175594285,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "impactTissue",
@@ -9952,7 +10212,7 @@
             {
               "date": "2026-08-26",
               "weekIndex": 2,
-              "collision": 0.3731138653769311,
+              "collision": 0.37226201662948716,
               "costMagnitude": 1.1500000000000001,
               "topDimensions": [
                 "lowerBody",
@@ -9962,7 +10222,7 @@
             {
               "date": "2026-08-27",
               "weekIndex": 2,
-              "collision": 0.42169872176351153,
+              "collision": 0.4210959205718188,
               "costMagnitude": 1.55,
               "topDimensions": [
                 "impactTissue",
@@ -9972,7 +10232,7 @@
             {
               "date": "2026-08-28",
               "weekIndex": 3,
-              "collision": 0.4321112942827549,
+              "collision": 0.425379151425612,
               "costMagnitude": 3.5,
               "topDimensions": [
                 "lowerBody",
@@ -9982,7 +10242,7 @@
             {
               "date": "2026-08-29",
               "weekIndex": 3,
-              "collision": 0.5249755074565918,
+              "collision": 0.523512688478374,
               "costMagnitude": 1.2499999999999998,
               "topDimensions": [
                 "systemic",
@@ -9999,46 +10259,40 @@
             {
               "date": "2026-08-31",
               "weekIndex": 3,
-              "collision": 0.26711437463443144,
-              "costMagnitude": 1.575,
+              "collision": 0.41951821465826883,
+              "costMagnitude": 3.5,
               "topDimensions": [
-                "systemic",
-                "neuromuscular"
+                "lowerBody",
+                "systemic"
               ]
             },
             {
               "date": "2026-09-01",
               "weekIndex": 3,
-              "collision": 0.3754246509557828,
-              "costMagnitude": 1.2499999999999998,
-              "topDimensions": [
-                "upperBody",
-                "systemic"
-              ]
+              "collision": 0,
+              "costMagnitude": 0,
+              "topDimensions": []
             },
             {
               "date": "2026-09-02",
               "weekIndex": 3,
-              "collision": 0.36880559038825833,
-              "costMagnitude": 1.1500000000000001,
-              "topDimensions": [
-                "systemic",
-                "lowerBody"
-              ]
+              "collision": 0,
+              "costMagnitude": 0,
+              "topDimensions": []
             },
             {
               "date": "2026-09-03",
               "weekIndex": 3,
-              "collision": 0.3548966168593903,
-              "costMagnitude": 2.9,
+              "collision": 0.29708444673428025,
+              "costMagnitude": 1.1500000000000001,
               "topDimensions": [
-                "systemic",
-                "lowerBody"
+                "lowerBody",
+                "systemic"
               ]
             }
           ],
-          "meanCollision": 0.3102714929067742,
-          "maxCollision": 0.7711687506529501
+          "meanCollision": 0.2856924906059629,
+          "maxCollision": 0.7667102934507483
         },
         "adjacentCostOverlap": {
           "perPair": [
@@ -10137,36 +10391,12 @@
               "lowerBodyOverlap": 0.08,
               "impactTissueOverlap": 0.02,
               "neuromuscularOverlap": 0.15
-            },
-            {
-              "date": "2026-09-01",
-              "previousDate": "2026-08-31",
-              "overlap": 0.4911290081761407,
-              "lowerBodyOverlap": 0,
-              "impactTissueOverlap": 0.02,
-              "neuromuscularOverlap": 0.15
-            },
-            {
-              "date": "2026-09-02",
-              "previousDate": "2026-09-01",
-              "overlap": 0.46873426325671474,
-              "lowerBodyOverlap": 0.05656854249492381,
-              "impactTissueOverlap": 0.014142135623730952,
-              "neuromuscularOverlap": 0.09449407874211549
-            },
-            {
-              "date": "2026-09-03",
-              "previousDate": "2026-09-02",
-              "overlap": 0.24700860300033295,
-              "lowerBodyOverlap": 0.21213203435596426,
-              "impactTissueOverlap": 0.07071067811865477,
-              "neuromuscularOverlap": 0.06299605249474366
             }
           ],
           "maxLowerBodyOverlap": 0.21213203435596426,
           "maxImpactTissueOverlap": 0.3535533905932738,
           "maxNeuromuscularOverlap": 0.15,
-          "meanOverlap": 0.3078365207162301
+          "meanOverlap": 0.2842229946925218
         },
         "qualitySpacing": {
           "gapsDays": [
@@ -10176,7 +10406,7 @@
             7,
             3,
             4,
-            6
+            3
           ],
           "minGapDays": 2,
           "medianGapDays": 3,
@@ -10219,15 +10449,15 @@
         },
         "opportunityCost": {
           "daysWithRankingAudit": 28,
-          "utilityWinnerDifferentCount": 14,
-          "utilityWinnerBlockedCount": 14,
+          "utilityWinnerDifferentCount": 15,
+          "utilityWinnerBlockedCount": 15,
           "utilityWinnerDifferentWithoutTierBlockCount": 0,
-          "meanBlockedUtilityGap": 0.19912673723302962,
-          "maxBlockedUtilityGap": 0.6258559678743074,
+          "meanBlockedUtilityGap": 0.18693435212439008,
+          "maxBlockedUtilityGap": 0.8433217006043003,
           "blockedByTier": {
             "coverage": 0,
-            "recovery": 6,
-            "benefit": 9
+            "recovery": 8,
+            "benefit": 8
           },
           "perDay": [
             {
@@ -10291,7 +10521,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "str_lower_01",
               "bestUtilityTemplateId": "swim_easy_01",
-              "selectedVsBestUtilityGap": 0.555930292125828,
+              "selectedVsBestUtilityGap": 0.5567747216246118,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -10305,7 +10535,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.013267150085098954,
+              "selectedVsBestUtilityGap": 0.013332367253278701,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -10319,7 +10549,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "str_upper_01",
               "bestUtilityTemplateId": "swim_easy_01",
-              "selectedVsBestUtilityGap": 0.2537422437230754,
+              "selectedVsBestUtilityGap": 0.254269682725067,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -10333,7 +10563,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.01417208645189217,
+              "selectedVsBestUtilityGap": 0.014287324585409933,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -10347,7 +10577,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "swim_threshold_01",
-              "selectedVsBestUtilityGap": 0.04528968413406176,
+              "selectedVsBestUtilityGap": 0.04814006942498117,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -10361,7 +10591,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.07075818353186708,
+              "selectedVsBestUtilityGap": 0.07099104233393935,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -10375,7 +10605,7 @@
               "weekIndex": 3,
               "selectedTemplateId": "str_lower_01",
               "bestUtilityTemplateId": "swim_easy_01",
-              "selectedVsBestUtilityGap": 0.5864665656125256,
+              "selectedVsBestUtilityGap": 0.5868249289045024,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -10389,7 +10619,7 @@
               "weekIndex": 3,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.01399270129582237,
+              "selectedVsBestUtilityGap": 0.014060797149280081,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -10401,9 +10631,9 @@
             {
               "date": "2026-08-31",
               "weekIndex": 3,
-              "selectedTemplateId": "str_upper_01",
+              "selectedTemplateId": "str_lower_01",
               "bestUtilityTemplateId": "swim_easy_01",
-              "selectedVsBestUtilityGap": 0.2522949732290548,
+              "selectedVsBestUtilityGap": 0.8433217006043003,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -10413,16 +10643,30 @@
               "selectedAdvancesRequiredRole": false
             },
             {
-              "date": "2026-09-03",
+              "date": "2026-09-01",
               "weekIndex": 3,
-              "selectedTemplateId": "end_mod_01",
-              "bestUtilityTemplateId": "end_easy_02",
-              "selectedVsBestUtilityGap": 0.6258559678743074,
+              "selectedTemplateId": "rest_01",
+              "bestUtilityTemplateId": "mob_01",
+              "selectedVsBestUtilityGap": 0.0126207537713479,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
-                "recovery": false,
-                "benefit": true
+                "recovery": true,
+                "benefit": false
+              },
+              "selectedAdvancesRequiredRole": false
+            },
+            {
+              "date": "2026-09-02",
+              "weekIndex": 3,
+              "selectedTemplateId": "rest_01",
+              "bestUtilityTemplateId": "mob_01",
+              "selectedVsBestUtilityGap": 0.03338742029025131,
+              "tierBlocked": true,
+              "blockedByTier": {
+                "coverage": false,
+                "recovery": true,
+                "benefit": false
               },
               "selectedAdvancesRequiredRole": false
             }
@@ -10460,11 +10704,11 @@
         {
           "weekIndex": 3,
           "fatigueTierDayCounts": {
-            "train": 3,
-            "modify": 1,
-            "recover": 1
+            "train": 2,
+            "modify": 0,
+            "recover": 3
           },
-          "restOrRecoveryDayCount": 1
+          "restOrRecoveryDayCount": 3
         }
       ]
     },
@@ -10476,22 +10720,22 @@
       "weeksSimulated": 4,
       "totalDays": 28,
       "categoryDistribution": {
-        "Moderate Endurance": 7,
-        "Easy Endurance": 11,
-        "Upper-body Strength": 3,
-        "Lower-body Strength": 1,
-        "Rest": 4,
-        "Race-Specific Endurance": 2
+        "Moderate Endurance": 6,
+        "Easy Endurance": 9,
+        "Upper-body Strength": 2,
+        "Lower-body Strength": 2,
+        "Rest": 6,
+        "Race-Specific Endurance": 3
       },
       "modalityDistribution": {
-        "Cycling": 10,
-        "Running": 6,
+        "Cycling": 9,
+        "Running": 5,
         "Strength": 4,
-        "None": 4,
+        "None": 6,
         "Swimming": 4
       },
-      "restOrRecoveryDayCount": 4,
-      "restOrRecoveryDayPct": 14.3,
+      "restOrRecoveryDayCount": 6,
+      "restOrRecoveryDayPct": 21.4,
       "maxConsecutiveSameTemplateStreakWithinCall": 2,
       "maxConsecutiveSameTemplateStreakAcrossWeeks": 2,
       "objectiveResolution": [
@@ -10647,8 +10891,8 @@
           "date": "2026-08-23",
           "objectiveKey": "strength_maintenance",
           "objectiveTitle": "Strength & Neuromuscular Maintenance",
-          "templateId": "str_upper_01",
-          "templateTitle": "Upper Body Push/Pull",
+          "templateId": "str_lower_01",
+          "templateTitle": "Lower Body Strength & Power",
           "modality": "Strength",
           "earnedCredit": 0.4
         },
@@ -10664,7 +10908,17 @@
         },
         {
           "weekIndex": 3,
-          "date": "2026-08-30",
+          "date": "2026-08-29",
+          "objectiveKey": "zone2_aerobic",
+          "objectiveTitle": "Triathlon Bike Aerobic Exposure",
+          "templateId": "end_easy_01",
+          "templateTitle": "Zone 2 Spin",
+          "modality": "Cycling",
+          "earnedCredit": 0.30000000000000004
+        },
+        {
+          "weekIndex": 3,
+          "date": "2026-08-31",
           "objectiveKey": "zone2_aerobic",
           "objectiveTitle": "Triathlon Swim Aerobic Exposure",
           "templateId": "swim_easy_01",
@@ -10674,7 +10928,7 @@
         },
         {
           "weekIndex": 3,
-          "date": "2026-08-31",
+          "date": "2026-09-03",
           "objectiveKey": "zone2_aerobic",
           "objectiveTitle": "Triathlon Swim Aerobic Exposure",
           "templateId": "swim_easy_01",
@@ -10685,12 +10939,12 @@
       ],
       "utilityDiagnostics": {
         "fragileSelectionCount": 10,
-        "lowerBenefitSelectionCount": 5,
+        "lowerBenefitSelectionCount": 6,
         "trainTierRestOrRecoveryCount": 0
       },
       "qualityWarnings": [
         "Unresolved weekly objectives: zone2_aerobic 11/12.",
-        "Event-specific anchor missed in 3 nominated week(s)."
+        "Event-specific anchor missed in 2 nominated week(s)."
       ],
       "anchorWeeks": [
         {
@@ -10723,24 +10977,26 @@
           "eventSpecificAnchorHit": false,
           "eventSpecificExposureDates": [],
           "eventSpecificAnchorFulfilled": false,
-          "qualityAnchorHit": true
+          "qualityAnchorHit": false
         },
         {
           "weekIndex": 3,
           "weekStartDate": "2026-08-28",
           "eventSpecificAnchorDate": "2026-08-30",
           "qualityAnchorDate": "2026-09-01",
-          "eventSpecificAnchorHit": false,
-          "eventSpecificExposureDates": [],
-          "eventSpecificAnchorFulfilled": false,
+          "eventSpecificAnchorHit": true,
+          "eventSpecificExposureDates": [
+            "2026-08-30"
+          ],
+          "eventSpecificAnchorFulfilled": true,
           "qualityAnchorHit": true
         }
       ],
       "anchorScopeNote": null,
       "fatigueTierDayCounts": {
-        "train": 10,
-        "modify": 6,
-        "recover": 4
+        "train": 11,
+        "modify": 3,
+        "recover": 6
       },
       "constraintViolations": [],
       "allocationReports": [
@@ -10842,17 +11098,17 @@
             {
               "date": "2026-08-14",
               "weekIndex": 1,
-              "collision": 0.3749324140331355,
+              "collision": 0.3384402768972766,
               "costMagnitude": 1.2499999999999998,
               "topDimensions": [
                 "systemic",
-                "upperBody"
+                "neuromuscular"
               ]
             },
             {
               "date": "2026-08-15",
               "weekIndex": 1,
-              "collision": 0.46848901418111927,
+              "collision": 0.46128090531111104,
               "costMagnitude": 0.6900000000000002,
               "topDimensions": [
                 "lowerBody",
@@ -10862,7 +11118,7 @@
             {
               "date": "2026-08-16",
               "weekIndex": 1,
-              "collision": 0.3615382925867255,
+              "collision": 0.34759583112807474,
               "costMagnitude": 1.64,
               "topDimensions": [
                 "systemic",
@@ -10872,7 +11128,7 @@
             {
               "date": "2026-08-17",
               "weekIndex": 1,
-              "collision": 0.4131046792373992,
+              "collision": 0.40033413403961515,
               "costMagnitude": 1.55,
               "topDimensions": [
                 "lowerBody",
@@ -10882,7 +11138,7 @@
             {
               "date": "2026-08-18",
               "weekIndex": 1,
-              "collision": 0.35757083075593465,
+              "collision": 0.3519398266953773,
               "costMagnitude": 1.2499999999999998,
               "topDimensions": [
                 "systemic",
@@ -10892,7 +11148,7 @@
             {
               "date": "2026-08-19",
               "weekIndex": 1,
-              "collision": 0.4192911858846235,
+              "collision": 0.41514841180465367,
               "costMagnitude": 2.4,
               "topDimensions": [
                 "systemic",
@@ -10909,7 +11165,7 @@
             {
               "date": "2026-08-21",
               "weekIndex": 2,
-              "collision": 0.32815400398784755,
+              "collision": 0.31469640019976863,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "systemic",
@@ -10919,7 +11175,7 @@
             {
               "date": "2026-08-22",
               "weekIndex": 2,
-              "collision": 0.4891635491370491,
+              "collision": 0.48633929439160345,
               "costMagnitude": 1.575,
               "topDimensions": [
                 "upperBody",
@@ -10929,11 +11185,11 @@
             {
               "date": "2026-08-23",
               "weekIndex": 2,
-              "collision": 0.5103366622162439,
-              "costMagnitude": 1.575,
+              "collision": 0.4965717653106957,
+              "costMagnitude": 3.5,
               "topDimensions": [
-                "upperBody",
-                "neuromuscular"
+                "systemic",
+                "lowerBody"
               ]
             },
             {
@@ -10946,37 +11202,31 @@
             {
               "date": "2026-08-25",
               "weekIndex": 2,
-              "collision": 0.2699444338157143,
-              "costMagnitude": 2.4,
-              "topDimensions": [
-                "systemic",
-                "neuromuscular"
-              ]
+              "collision": 0,
+              "costMagnitude": 0,
+              "topDimensions": []
             },
             {
               "date": "2026-08-26",
               "weekIndex": 2,
-              "collision": 0.474324859629082,
-              "costMagnitude": 0.6900000000000002,
-              "topDimensions": [
-                "systemic",
-                "lowerBody"
-              ]
-            },
-            {
-              "date": "2026-08-27",
-              "weekIndex": 2,
-              "collision": 0.3937817448036283,
-              "costMagnitude": 1.1500000000000001,
+              "collision": 0.3055831477524129,
+              "costMagnitude": 2.4,
               "topDimensions": [
                 "lowerBody",
                 "systemic"
               ]
             },
             {
+              "date": "2026-08-27",
+              "weekIndex": 2,
+              "collision": 0,
+              "costMagnitude": 0,
+              "topDimensions": []
+            },
+            {
               "date": "2026-08-28",
               "weekIndex": 3,
-              "collision": 0.416734047293926,
+              "collision": 0.3061375500427239,
               "costMagnitude": 1.7150000000000003,
               "topDimensions": [
                 "lowerBody",
@@ -10986,27 +11236,27 @@
             {
               "date": "2026-08-29",
               "weekIndex": 3,
-              "collision": 0.7292318080205351,
-              "costMagnitude": 1.1624999999999999,
+              "collision": 0.6461728112999585,
+              "costMagnitude": 0.6900000000000002,
               "topDimensions": [
-                "impactTissue",
-                "lowerBody"
+                "lowerBody",
+                "systemic"
               ]
             },
             {
               "date": "2026-08-30",
               "weekIndex": 3,
-              "collision": 0.31884756233527783,
-              "costMagnitude": 1.2499999999999998,
+              "collision": 0.3306647808701577,
+              "costMagnitude": 1.64,
               "topDimensions": [
                 "systemic",
-                "cardiovascular"
+                "lowerBody"
               ]
             },
             {
               "date": "2026-08-31",
               "weekIndex": 3,
-              "collision": 0.36287135078890875,
+              "collision": 0.3392518124861398,
               "costMagnitude": 1.2499999999999998,
               "topDimensions": [
                 "systemic",
@@ -11016,11 +11266,11 @@
             {
               "date": "2026-09-01",
               "weekIndex": 3,
-              "collision": 0.39044005646722835,
+              "collision": 0.40160203354810026,
               "costMagnitude": 2.4,
               "topDimensions": [
                 "systemic",
-                "cardiovascular"
+                "lowerBody"
               ]
             },
             {
@@ -11033,16 +11283,16 @@
             {
               "date": "2026-09-03",
               "weekIndex": 3,
-              "collision": 0.33875550398827653,
-              "costMagnitude": 2.4,
+              "collision": 0.28495590754910505,
+              "costMagnitude": 1.2499999999999998,
               "topDimensions": [
                 "systemic",
-                "lowerBody"
+                "cardiovascular"
               ]
             }
           ],
-          "meanCollision": 0.33711179200044405,
-          "maxCollision": 0.7292318080205351
+          "meanCollision": 0.2945833237920197,
+          "maxCollision": 0.6461728112999585
         },
         "adjacentCostOverlap": {
           "perPair": [
@@ -11137,58 +11387,34 @@
             {
               "date": "2026-08-23",
               "previousDate": "2026-08-22",
-              "overlap": 0.6212569633447813,
+              "overlap": 0.170776005063188,
               "lowerBodyOverlap": 0,
               "impactTissueOverlap": 0.05303300858899108,
               "neuromuscularOverlap": 0.2362351968552887
             },
             {
-              "date": "2026-08-26",
-              "previousDate": "2026-08-25",
-              "overlap": 0.4637310800195986,
+              "date": "2026-08-29",
+              "previousDate": "2026-08-28",
+              "overlap": 0.5958564451290169,
               "lowerBodyOverlap": 0.18,
               "impactTissueOverlap": 0.06,
               "neuromuscularOverlap": 0.06
             },
             {
-              "date": "2026-08-27",
-              "previousDate": "2026-08-26",
-              "overlap": 0.3737347558439819,
+              "date": "2026-08-30",
+              "previousDate": "2026-08-29",
+              "overlap": 0.26207010318328006,
               "lowerBodyOverlap": 0.12727922061357855,
               "impactTissueOverlap": 0.042426406871192854,
               "neuromuscularOverlap": 0.037797631496846194
             },
             {
-              "date": "2026-08-28",
-              "previousDate": "2026-08-27",
-              "overlap": 0.40013113286119706,
-              "lowerBodyOverlap": 0.21213203435596426,
-              "impactTissueOverlap": 0.07071067811865477,
-              "neuromuscularOverlap": 0.06299605249474366
-            },
-            {
-              "date": "2026-08-29",
-              "previousDate": "2026-08-28",
-              "overlap": 0.8235589434151638,
-              "lowerBodyOverlap": 0.22499999999999998,
-              "impactTissueOverlap": 0.3005203820042827,
-              "neuromuscularOverlap": 0.07500000000000001
-            },
-            {
-              "date": "2026-08-30",
-              "previousDate": "2026-08-29",
-              "overlap": 0.2700383535511857,
-              "lowerBodyOverlap": 0.08,
-              "impactTissueOverlap": 0.02,
-              "neuromuscularOverlap": 0.04724703937105775
-            },
-            {
               "date": "2026-08-31",
               "previousDate": "2026-08-30",
-              "overlap": 0.5945448574633859,
-              "lowerBodyOverlap": 0.05656854249492381,
-              "impactTissueOverlap": 0.014142135623730952,
-              "neuromuscularOverlap": 0.09449407874211549
+              "overlap": 0.5701258876325062,
+              "lowerBodyOverlap": 0.08,
+              "impactTissueOverlap": 0.02,
+              "neuromuscularOverlap": 0.15
             },
             {
               "date": "2026-09-01",
@@ -11200,9 +11426,9 @@
             }
           ],
           "maxLowerBodyOverlap": 0.22499999999999998,
-          "maxImpactTissueOverlap": 0.3005203820042827,
+          "maxImpactTissueOverlap": 0.2,
           "maxNeuromuscularOverlap": 0.25198420997897464,
-          "meanOverlap": 0.4126136984004031
+          "meanOverlap": 0.36821828900727216
         },
         "qualitySpacing": {
           "gapsDays": [
@@ -11211,17 +11437,18 @@
             4,
             3,
             2,
-            4,
+            2,
             3,
-            4,
+            2,
+            2,
             2
           ],
           "minGapDays": 2,
-          "medianGapDays": 3,
+          "medianGapDays": 2,
           "adjacentQualityDayCount": 0,
           "longestQualityStreak": 0,
           "qualityPer3DayWindowMax": 2,
-          "qualityPer7DayWindowMax": 3
+          "qualityPer7DayWindowMax": 4
         },
         "hardDayConcentration": {
           "weekly": [
@@ -11241,9 +11468,9 @@
             },
             {
               "weekIndex": 2,
-              "hardDayCount": 2,
+              "hardDayCount": 3,
               "maxHardStreak": 1,
-              "recoveryAfterHighCollisionCount": 1,
+              "recoveryAfterHighCollisionCount": 0,
               "recoveryWhileFatigueLowAndWorkFeasibleCount": 0
             },
             {
@@ -11260,12 +11487,12 @@
           "utilityWinnerDifferentCount": 14,
           "utilityWinnerBlockedCount": 14,
           "utilityWinnerDifferentWithoutTierBlockCount": 0,
-          "meanBlockedUtilityGap": 0.3576358776108975,
-          "maxBlockedUtilityGap": 0.9494546672632765,
+          "meanBlockedUtilityGap": 0.3826397034242381,
+          "maxBlockedUtilityGap": 1.0375693425714327,
           "blockedByTier": {
             "coverage": 0,
-            "recovery": 4,
-            "benefit": 13
+            "recovery": 6,
+            "benefit": 12
           },
           "perDay": [
             {
@@ -11315,7 +11542,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "end_race_specific_01",
               "bestUtilityTemplateId": "swim_easy_01",
-              "selectedVsBestUtilityGap": 0.10415738084885895,
+              "selectedVsBestUtilityGap": 0.10112627619219494,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -11329,7 +11556,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "end_mod_02",
               "bestUtilityTemplateId": "end_easy_01",
-              "selectedVsBestUtilityGap": 0.34888757984319774,
+              "selectedVsBestUtilityGap": 0.3496890440474083,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -11343,7 +11570,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.07602332091796762,
+              "selectedVsBestUtilityGap": 0.07647854072802784,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -11357,7 +11584,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "str_upper_01",
               "bestUtilityTemplateId": "swim_easy_01",
-              "selectedVsBestUtilityGap": 0.7689648364678097,
+              "selectedVsBestUtilityGap": 0.7738701868884114,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -11369,9 +11596,9 @@
             {
               "date": "2026-08-23",
               "weekIndex": 2,
-              "selectedTemplateId": "str_upper_01",
-              "bestUtilityTemplateId": "end_easy_01",
-              "selectedVsBestUtilityGap": 0.4445752603458229,
+              "selectedTemplateId": "str_lower_01",
+              "bestUtilityTemplateId": "end_race_specific_01",
+              "selectedVsBestUtilityGap": 0.5395955627715185,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -11385,7 +11612,49 @@
               "weekIndex": 2,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.08296916653061295,
+              "selectedVsBestUtilityGap": 0.05396182793629348,
+              "tierBlocked": true,
+              "blockedByTier": {
+                "coverage": false,
+                "recovery": true,
+                "benefit": true
+              },
+              "selectedAdvancesRequiredRole": false
+            },
+            {
+              "date": "2026-08-25",
+              "weekIndex": 2,
+              "selectedTemplateId": "rest_01",
+              "bestUtilityTemplateId": "mob_01",
+              "selectedVsBestUtilityGap": 0.1611148541466686,
+              "tierBlocked": true,
+              "blockedByTier": {
+                "coverage": false,
+                "recovery": true,
+                "benefit": true
+              },
+              "selectedAdvancesRequiredRole": false
+            },
+            {
+              "date": "2026-08-26",
+              "weekIndex": 2,
+              "selectedTemplateId": "end_mod_02",
+              "bestUtilityTemplateId": "end_easy_01",
+              "selectedVsBestUtilityGap": 0.875169310143532,
+              "tierBlocked": true,
+              "blockedByTier": {
+                "coverage": false,
+                "recovery": false,
+                "benefit": true
+              },
+              "selectedAdvancesRequiredRole": false
+            },
+            {
+              "date": "2026-08-27",
+              "weekIndex": 2,
+              "selectedTemplateId": "rest_01",
+              "bestUtilityTemplateId": "mob_01",
+              "selectedVsBestUtilityGap": 0.08252128935194289,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -11399,35 +11668,7 @@
               "weekIndex": 3,
               "selectedTemplateId": "run_long_01",
               "bestUtilityTemplateId": "end_easy_02",
-              "selectedVsBestUtilityGap": 0.9494546672632765,
-              "tierBlocked": true,
-              "blockedByTier": {
-                "coverage": false,
-                "recovery": false,
-                "benefit": true
-              },
-              "selectedAdvancesRequiredRole": false
-            },
-            {
-              "date": "2026-08-29",
-              "weekIndex": 3,
-              "selectedTemplateId": "end_easy_02",
-              "bestUtilityTemplateId": "swim_easy_01",
-              "selectedVsBestUtilityGap": 0.008454134652062795,
-              "tierBlocked": true,
-              "blockedByTier": {
-                "coverage": false,
-                "recovery": false,
-                "benefit": true
-              },
-              "selectedAdvancesRequiredRole": false
-            },
-            {
-              "date": "2026-08-31",
-              "weekIndex": 3,
-              "selectedTemplateId": "swim_easy_01",
-              "bestUtilityTemplateId": "swim_threshold_01",
-              "selectedVsBestUtilityGap": 0.49682468149308956,
+              "selectedVsBestUtilityGap": 1.0375693425714327,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -11441,26 +11682,12 @@
               "weekIndex": 3,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.07875556057937819,
+              "selectedVsBestUtilityGap": 0.019829784662317943,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
                 "recovery": true,
-                "benefit": true
-              },
-              "selectedAdvancesRequiredRole": false
-            },
-            {
-              "date": "2026-09-03",
-              "weekIndex": 3,
-              "selectedTemplateId": "end_mod_02",
-              "bestUtilityTemplateId": "end_easy_01",
-              "selectedVsBestUtilityGap": 0.3618058691109015,
-              "tierBlocked": true,
-              "blockedByTier": {
-                "coverage": false,
-                "recovery": false,
-                "benefit": true
+                "benefit": false
               },
               "selectedAdvancesRequiredRole": false
             }
@@ -11490,16 +11717,16 @@
           "weekIndex": 2,
           "fatigueTierDayCounts": {
             "train": 2,
-            "modify": 2,
-            "recover": 1
+            "modify": 0,
+            "recover": 3
           },
-          "restOrRecoveryDayCount": 1
+          "restOrRecoveryDayCount": 3
         },
         {
           "weekIndex": 3,
           "fatigueTierDayCounts": {
-            "train": 3,
-            "modify": 1,
+            "train": 4,
+            "modify": 0,
             "recover": 1
           },
           "restOrRecoveryDayCount": 1
@@ -11750,7 +11977,7 @@
             {
               "date": "2026-08-14",
               "weekIndex": 1,
-              "collision": 0.4991621465478303,
+              "collision": 0.49450789122868133,
               "costMagnitude": 2.35,
               "topDimensions": [
                 "upperBody",
@@ -11760,7 +11987,7 @@
             {
               "date": "2026-08-15",
               "weekIndex": 1,
-              "collision": 0.5262198521563047,
+              "collision": 0.5253425294143603,
               "costMagnitude": 0.6900000000000002,
               "topDimensions": [
                 "systemic",
@@ -11770,7 +11997,7 @@
             {
               "date": "2026-08-16",
               "weekIndex": 1,
-              "collision": 0.40993927801491686,
+              "collision": 0.40765710803332056,
               "costMagnitude": 2.4,
               "topDimensions": [
                 "systemic",
@@ -11787,7 +12014,7 @@
             {
               "date": "2026-08-18",
               "weekIndex": 1,
-              "collision": 0.3360409614646435,
+              "collision": 0.3344879023077022,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "systemic",
@@ -11804,7 +12031,7 @@
             {
               "date": "2026-08-20",
               "weekIndex": 1,
-              "collision": 0.352206571324998,
+              "collision": 0.3517035399122376,
               "costMagnitude": 2.4,
               "topDimensions": [
                 "lowerBody",
@@ -11812,8 +12039,8 @@
               ]
             }
           ],
-          "meanCollision": 0.31079089527593357,
-          "maxCollision": 0.5262198521563047
+          "meanCollision": 0.31008590680361986,
+          "maxCollision": 0.5253425294143603
         },
         "adjacentCostOverlap": {
           "perPair": [
@@ -11932,8 +12159,8 @@
           "utilityWinnerDifferentCount": 7,
           "utilityWinnerBlockedCount": 7,
           "utilityWinnerDifferentWithoutTierBlockCount": 0,
-          "meanBlockedUtilityGap": 0.3363050323767661,
-          "maxBlockedUtilityGap": 0.7568661032409818,
+          "meanBlockedUtilityGap": 0.3449740442330436,
+          "maxBlockedUtilityGap": 0.7589080276225943,
           "blockedByTier": {
             "coverage": 0,
             "recovery": 2,
@@ -11973,7 +12200,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "str_full_03",
               "bestUtilityTemplateId": "end_easy_01",
-              "selectedVsBestUtilityGap": 0.3260896339226607,
+              "selectedVsBestUtilityGap": 0.3283937574567849,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -11987,7 +12214,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.14876695037544085,
+              "selectedVsBestUtilityGap": 0.18658119446865218,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -12001,7 +12228,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_easy_02",
-              "selectedVsBestUtilityGap": 0.7568661032409818,
+              "selectedVsBestUtilityGap": 0.7589080276225943,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -12015,7 +12242,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.07286713503057429,
+              "selectedVsBestUtilityGap": 0.09123140450389763,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -12029,7 +12256,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "end_mod_02",
               "bestUtilityTemplateId": "end_easy_01",
-              "selectedVsBestUtilityGap": 0.3599115505192484,
+              "selectedVsBestUtilityGap": 0.36007007203091945,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -12122,7 +12349,7 @@
           "templateId": "str_lower_01",
           "templateTitle": "Lower Body Strength & Power",
           "modality": "Strength",
-          "earnedCredit": 0.19999999999999996
+          "earnedCredit": 0.4
         },
         {
           "weekIndex": 3,
@@ -12286,7 +12513,7 @@
             {
               "date": "2026-08-14",
               "weekIndex": 1,
-              "collision": 0.35723159755974954,
+              "collision": 0.3542830088500721,
               "costMagnitude": 1.55,
               "topDimensions": [
                 "lowerBody",
@@ -12296,7 +12523,7 @@
             {
               "date": "2026-08-15",
               "weekIndex": 1,
-              "collision": 0.4218100622096759,
+              "collision": 0.4212475974552585,
               "costMagnitude": 1.575,
               "topDimensions": [
                 "upperBody",
@@ -12306,7 +12533,7 @@
             {
               "date": "2026-08-16",
               "weekIndex": 1,
-              "collision": 0.37323107510451536,
+              "collision": 0.37124327412684305,
               "costMagnitude": 1.1500000000000001,
               "topDimensions": [
                 "systemic",
@@ -12316,7 +12543,7 @@
             {
               "date": "2026-08-17",
               "weekIndex": 1,
-              "collision": 0.3880457193436053,
+              "collision": 0.38676111803951146,
               "costMagnitude": 1.55,
               "topDimensions": [
                 "impactTissue",
@@ -12326,7 +12553,7 @@
             {
               "date": "2026-08-18",
               "weekIndex": 1,
-              "collision": 0.4361096053457087,
+              "collision": 0.4351918201765269,
               "costMagnitude": 0.8624999999999998,
               "topDimensions": [
                 "lowerBody",
@@ -12336,7 +12563,7 @@
             {
               "date": "2026-08-19",
               "weekIndex": 1,
-              "collision": 0.4208894384641809,
+              "collision": 0.42028087104813033,
               "costMagnitude": 1.55,
               "topDimensions": [
                 "impactTissue",
@@ -12353,7 +12580,7 @@
             {
               "date": "2026-08-21",
               "weekIndex": 2,
-              "collision": 0.35656285132249577,
+              "collision": 0.3410345904080877,
               "costMagnitude": 3.5,
               "topDimensions": [
                 "lowerBody",
@@ -12363,7 +12590,7 @@
             {
               "date": "2026-08-22",
               "weekIndex": 2,
-              "collision": 0.6339055817892602,
+              "collision": 0.6233998802288828,
               "costMagnitude": 0.8624999999999998,
               "topDimensions": [
                 "lowerBody",
@@ -12380,7 +12607,7 @@
             {
               "date": "2026-08-24",
               "weekIndex": 2,
-              "collision": 0.3424186268673105,
+              "collision": 0.3371510172503015,
               "costMagnitude": 0.8624999999999998,
               "topDimensions": [
                 "lowerBody",
@@ -12390,7 +12617,7 @@
             {
               "date": "2026-08-25",
               "weekIndex": 2,
-              "collision": 0.3329367554666923,
+              "collision": 0.32957376422923995,
               "costMagnitude": 1.55,
               "topDimensions": [
                 "lowerBody",
@@ -12400,7 +12627,7 @@
             {
               "date": "2026-08-26",
               "weekIndex": 2,
-              "collision": 0.40636005167673667,
+              "collision": 0.4040280253520296,
               "costMagnitude": 0.8624999999999998,
               "topDimensions": [
                 "lowerBody",
@@ -12410,7 +12637,7 @@
             {
               "date": "2026-08-27",
               "weekIndex": 2,
-              "collision": 0.40050411952667025,
+              "collision": 0.39895568883749577,
               "costMagnitude": 1.0850000000000002,
               "topDimensions": [
                 "impactTissue",
@@ -12420,17 +12647,17 @@
             {
               "date": "2026-08-28",
               "weekIndex": 3,
-              "collision": 0.5013168340272898,
+              "collision": 0.4202621451335948,
               "costMagnitude": 3.5,
               "topDimensions": [
                 "lowerBody",
-                "systemic"
+                "neuromuscular"
               ]
             },
             {
               "date": "2026-08-29",
               "weekIndex": 3,
-              "collision": 0.6795530848161361,
+              "collision": 0.6503726009574075,
               "costMagnitude": 0.8624999999999998,
               "topDimensions": [
                 "lowerBody",
@@ -12454,7 +12681,7 @@
             {
               "date": "2026-09-01",
               "weekIndex": 3,
-              "collision": 0.24985498057334612,
+              "collision": 0.23153516105451505,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "lowerBody",
@@ -12471,7 +12698,7 @@
             {
               "date": "2026-09-03",
               "weekIndex": 3,
-              "collision": 0.3443833981592468,
+              "collision": 0.33584798763736545,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "impactTissue",
@@ -12479,8 +12706,8 @@
               ]
             }
           ],
-          "meanCollision": 0.28446724089093844,
-          "maxCollision": 0.6795530848161361
+          "meanCollision": 0.2778977683385328,
+          "maxCollision": 0.6503726009574075
         },
         "adjacentCostOverlap": {
           "perPair": [
@@ -12646,7 +12873,7 @@
           "utilityWinnerDifferentCount": 14,
           "utilityWinnerBlockedCount": 14,
           "utilityWinnerDifferentWithoutTierBlockCount": 0,
-          "meanBlockedUtilityGap": 0.27097176385690186,
+          "meanBlockedUtilityGap": 0.2712876686803847,
           "maxBlockedUtilityGap": 1.2332358507338728,
           "blockedByTier": {
             "coverage": 0,
@@ -12729,7 +12956,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.08860481506330073,
+              "selectedVsBestUtilityGap": 0.08866293392797195,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -12743,7 +12970,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "str_lower_01",
               "bestUtilityTemplateId": "str_upper_01",
-              "selectedVsBestUtilityGap": 0.4527347810528647,
+              "selectedVsBestUtilityGap": 0.44298899512760126,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -12757,7 +12984,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.07920248092389828,
+              "selectedVsBestUtilityGap": 0.08022951083623259,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -12771,7 +12998,7 @@
               "weekIndex": 3,
               "selectedTemplateId": "str_lower_01",
               "bestUtilityTemplateId": "str_upper_01",
-              "selectedVsBestUtilityGap": 0.5097905291902556,
+              "selectedVsBestUtilityGap": 0.4919253417391062,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -12785,7 +13012,7 @@
               "weekIndex": 3,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.07141536941182045,
+              "selectedVsBestUtilityGap": 0.07599246672396653,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -12799,7 +13026,7 @@
               "weekIndex": 3,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.17689174088646487,
+              "selectedVsBestUtilityGap": 0.1809408276391971,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -12813,7 +13040,7 @@
               "weekIndex": 3,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_walk_01",
-              "selectedVsBestUtilityGap": 0.19633924752141363,
+              "selectedVsBestUtilityGap": 0.1958759097212212,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -12827,7 +13054,7 @@
               "weekIndex": 3,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.08017888603996712,
+              "selectedVsBestUtilityGap": 0.10219343264044217,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -12841,7 +13068,7 @@
               "weekIndex": 3,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_walk_01",
-              "selectedVsBestUtilityGap": 0.2060257110568033,
+              "selectedVsBestUtilityGap": 0.20679681031980923,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -12900,18 +13127,18 @@
       "weeksSimulated": 4,
       "totalDays": 28,
       "categoryDistribution": {
-        "Moderate Endurance": 2,
-        "Upper-body Strength": 2,
+        "Moderate Endurance": 3,
+        "Upper-body Strength": 3,
         "Rest": 7,
-        "Full-body Strength": 2,
-        "Easy Endurance": 12,
+        "Full-body Strength": 1,
+        "Easy Endurance": 11,
         "Race-Specific Endurance": 3
       },
       "modalityDistribution": {
-        "Running": 10,
+        "Running": 11,
         "Strength": 4,
         "None": 7,
-        "Walking": 7
+        "Walking": 6
       },
       "restOrRecoveryDayCount": 7,
       "restOrRecoveryDayPct": 25,
@@ -13040,35 +13267,35 @@
           "date": "2026-08-28",
           "objectiveKey": "zone2_aerobic",
           "objectiveTitle": "Aerobic Base (Zone 2)",
-          "templateId": "str_full_01",
-          "templateTitle": "Hybrid Full Body Push/Pull",
-          "modality": "Strength",
-          "earnedCredit": 0.2
+          "templateId": "end_mod_01",
+          "templateTitle": "Steady-State Tempo Run",
+          "modality": "Running",
+          "earnedCredit": 0.49
         },
         {
           "weekIndex": 3,
           "date": "2026-08-28",
-          "objectiveKey": "strength_maintenance",
-          "objectiveTitle": "Strength & Neuromuscular Maintenance",
-          "templateId": "str_full_01",
-          "templateTitle": "Hybrid Full Body Push/Pull",
-          "modality": "Strength",
-          "earnedCredit": 0.19999999999999996
+          "objectiveKey": "threshold_quality",
+          "objectiveTitle": "Threshold Development",
+          "templateId": "end_mod_01",
+          "templateTitle": "Steady-State Tempo Run",
+          "modality": "Running",
+          "earnedCredit": 0.15000000000000002
         },
         {
           "weekIndex": 3,
           "date": "2026-08-29",
-          "objectiveKey": "zone2_aerobic",
-          "objectiveTitle": "Aerobic Base (Zone 2)",
-          "templateId": "end_walk_01",
-          "templateTitle": "Brisk Continuous Walk",
-          "modality": "Walking",
-          "earnedCredit": 0.07
+          "objectiveKey": "strength_maintenance",
+          "objectiveTitle": "Strength & Neuromuscular Maintenance",
+          "templateId": "str_upper_01",
+          "templateTitle": "Upper Body Push/Pull",
+          "modality": "Strength",
+          "earnedCredit": 0.4
         }
       ],
       "utilityDiagnostics": {
         "fragileSelectionCount": 14,
-        "lowerBenefitSelectionCount": 12,
+        "lowerBenefitSelectionCount": 13,
         "trainTierRestOrRecoveryCount": 0
       },
       "qualityWarnings": [
@@ -13118,8 +13345,8 @@
       ],
       "anchorScopeNote": "Anchor-day nomination only requires SOME focus event (Race-Specific Endurance templates' phaseEligibility.requiresFocusEvent doesn't check event category), so a nomination can appear even here -- but the optimizer's event-priority penalty for non-matching modalities makes it unlikely to actually win the day's pick. Treat eventSpecificAnchorHit/qualityAnchorHit, not the raw nomination, as the meaningful signal for non-cycling scenarios.",
       "fatigueTierDayCounts": {
-        "train": 9,
-        "modify": 4,
+        "train": 10,
+        "modify": 3,
         "recover": 7
       },
       "constraintViolations": [],
@@ -13219,7 +13446,7 @@
             {
               "date": "2026-08-14",
               "weekIndex": 1,
-              "collision": 0.4386620262494775,
+              "collision": 0.43583944560431626,
               "costMagnitude": 1.55,
               "topDimensions": [
                 "impactTissue",
@@ -13229,7 +13456,7 @@
             {
               "date": "2026-08-15",
               "weekIndex": 1,
-              "collision": 0.4811185751420244,
+              "collision": 0.4798993170086354,
               "costMagnitude": 0.8624999999999998,
               "topDimensions": [
                 "lowerBody",
@@ -13239,7 +13466,7 @@
             {
               "date": "2026-08-16",
               "weekIndex": 1,
-              "collision": 0.44592046897520615,
+              "collision": 0.4445185253608584,
               "costMagnitude": 1.0850000000000002,
               "topDimensions": [
                 "impactTissue",
@@ -13249,7 +13476,7 @@
             {
               "date": "2026-08-17",
               "weekIndex": 1,
-              "collision": 0.3981408970484314,
+              "collision": 0.39728904830098766,
               "costMagnitude": 0.8624999999999998,
               "topDimensions": [
                 "lowerBody",
@@ -13259,7 +13486,7 @@
             {
               "date": "2026-08-18",
               "weekIndex": 1,
-              "collision": 0.40618142470375035,
+              "collision": 0.4055786235120576,
               "costMagnitude": 1.55,
               "topDimensions": [
                 "impactTissue",
@@ -13276,7 +13503,7 @@
             {
               "date": "2026-08-20",
               "weekIndex": 1,
-              "collision": 0.27652977668828804,
+              "collision": 0.276310050125788,
               "costMagnitude": 1.1500000000000001,
               "topDimensions": [
                 "lowerBody",
@@ -13286,7 +13513,7 @@
             {
               "date": "2026-08-21",
               "weekIndex": 2,
-              "collision": 0.37692908083791515,
+              "collision": 0.3524567063136654,
               "costMagnitude": 2.48,
               "topDimensions": [
                 "lowerBody",
@@ -13296,7 +13523,7 @@
             {
               "date": "2026-08-22",
               "weekIndex": 2,
-              "collision": 0.516221467779887,
+              "collision": 0.511548775844611,
               "costMagnitude": 1.575,
               "topDimensions": [
                 "upperBody",
@@ -13306,11 +13533,11 @@
             {
               "date": "2026-08-23",
               "weekIndex": 2,
-              "collision": 0.4579230020764114,
+              "collision": 0.4462323574041457,
               "costMagnitude": 3.7199999999999998,
               "topDimensions": [
                 "impactTissue",
-                "lowerBody"
+                "systemic"
               ]
             },
             {
@@ -13330,7 +13557,7 @@
             {
               "date": "2026-08-26",
               "weekIndex": 2,
-              "collision": 0.33491344611992063,
+              "collision": 0.33114783846950957,
               "costMagnitude": 2.48,
               "topDimensions": [
                 "impactTissue",
@@ -13347,55 +13574,55 @@
             {
               "date": "2026-08-28",
               "weekIndex": 3,
-              "collision": 0.411365052403891,
-              "costMagnitude": 4.1,
-              "topDimensions": [
-                "lowerBody",
-                "systemic"
-              ]
-            },
-            {
-              "date": "2026-08-29",
-              "weekIndex": 3,
-              "collision": 0.6740580566564304,
-              "costMagnitude": 0.8624999999999998,
-              "topDimensions": [
-                "lowerBody",
-                "systemic"
-              ]
-            },
-            {
-              "date": "2026-08-30",
-              "weekIndex": 3,
-              "collision": 0,
-              "costMagnitude": 0,
-              "topDimensions": []
-            },
-            {
-              "date": "2026-08-31",
-              "weekIndex": 3,
-              "collision": 0.36883044874178567,
-              "costMagnitude": 1.1500000000000001,
-              "topDimensions": [
-                "lowerBody",
-                "systemic"
-              ]
-            },
-            {
-              "date": "2026-09-01",
-              "weekIndex": 3,
-              "collision": 0.3948992016777747,
-              "costMagnitude": 1.1624999999999999,
+              "collision": 0.35350648384479366,
+              "costMagnitude": 2.9,
               "topDimensions": [
                 "impactTissue",
                 "lowerBody"
               ]
             },
             {
+              "date": "2026-08-29",
+              "weekIndex": 3,
+              "collision": 0.47420844757337416,
+              "costMagnitude": 1.575,
+              "topDimensions": [
+                "upperBody",
+                "neuromuscular"
+              ]
+            },
+            {
+              "date": "2026-08-30",
+              "weekIndex": 3,
+              "collision": 0.45590708729502455,
+              "costMagnitude": 0.8624999999999998,
+              "topDimensions": [
+                "systemic",
+                "lowerBody"
+              ]
+            },
+            {
+              "date": "2026-08-31",
+              "weekIndex": 3,
+              "collision": 0.4360945173147695,
+              "costMagnitude": 1.55,
+              "topDimensions": [
+                "impactTissue",
+                "lowerBody"
+              ]
+            },
+            {
+              "date": "2026-09-01",
+              "weekIndex": 3,
+              "collision": 0,
+              "costMagnitude": 0,
+              "topDimensions": []
+            },
+            {
               "date": "2026-09-02",
               "weekIndex": 3,
-              "collision": 0.39563874513066843,
-              "costMagnitude": 0.8624999999999998,
+              "collision": 0.2867734032959976,
+              "costMagnitude": 1.1500000000000001,
               "topDimensions": [
                 "lowerBody",
                 "systemic"
@@ -13404,7 +13631,7 @@
             {
               "date": "2026-09-03",
               "weekIndex": 3,
-              "collision": 0.38964697939220766,
+              "collision": 0.3659633009147892,
               "costMagnitude": 1.55,
               "topDimensions": [
                 "impactTissue",
@@ -13412,8 +13639,8 @@
               ]
             }
           ],
-          "meanCollision": 0.30408824904628584,
-          "maxCollision": 0.6740580566564304
+          "meanCollision": 0.29288450899483065,
+          "maxCollision": 0.511548775844611
         },
         "adjacentCostOverlap": {
           "perPair": [
@@ -13500,40 +13727,40 @@
             {
               "date": "2026-08-29",
               "previousDate": "2026-08-28",
-              "overlap": 0.3153066912865858,
-              "lowerBodyOverlap": 0.22499999999999998,
+              "overlap": 0.3260154515525037,
+              "lowerBodyOverlap": 0,
               "impactTissueOverlap": 0.07500000000000001,
+              "neuromuscularOverlap": 0.25198420997897464
+            },
+            {
+              "date": "2026-08-30",
+              "previousDate": "2026-08-29",
+              "overlap": 0.30431015187065164,
+              "lowerBodyOverlap": 0,
+              "impactTissueOverlap": 0.05303300858899108,
               "neuromuscularOverlap": 0.07500000000000001
             },
             {
-              "date": "2026-09-01",
-              "previousDate": "2026-08-31",
-              "overlap": 0.6161935042588952,
-              "lowerBodyOverlap": 0.21213203435596426,
-              "impactTissueOverlap": 0.07071067811865477,
-              "neuromuscularOverlap": 0.06299605249474366
-            },
-            {
-              "date": "2026-09-02",
-              "previousDate": "2026-09-01",
-              "overlap": 0.5312332794601735,
+              "date": "2026-08-31",
+              "previousDate": "2026-08-30",
+              "overlap": 0.3466088461456285,
               "lowerBodyOverlap": 0.15909902576697318,
-              "impactTissueOverlap": 0.07500000000000001,
+              "impactTissueOverlap": 0.05303300858899108,
               "neuromuscularOverlap": 0.04724703937105775
             },
             {
               "date": "2026-09-03",
               "previousDate": "2026-09-02",
-              "overlap": 0.3466088461456285,
-              "lowerBodyOverlap": 0.15909902576697318,
-              "impactTissueOverlap": 0.05303300858899108,
-              "neuromuscularOverlap": 0.04724703937105775
+              "overlap": 0.4621451281941713,
+              "lowerBodyOverlap": 0.21213203435596426,
+              "impactTissueOverlap": 0.07071067811865477,
+              "neuromuscularOverlap": 0.06299605249474366
             }
           ],
-          "maxLowerBodyOverlap": 0.22499999999999998,
+          "maxLowerBodyOverlap": 0.21213203435596426,
           "maxImpactTissueOverlap": 0.07500000000000001,
           "maxNeuromuscularOverlap": 0.25198420997897464,
-          "meanOverlap": 0.39355567635676575
+          "meanOverlap": 0.3671083375433138
         },
         "qualitySpacing": {
           "gapsDays": [
@@ -13578,7 +13805,7 @@
               "weekIndex": 3,
               "hardDayCount": 1,
               "maxHardStreak": 1,
-              "recoveryAfterHighCollisionCount": 1,
+              "recoveryAfterHighCollisionCount": 0,
               "recoveryWhileFatigueLowAndWorkFeasibleCount": 0
             }
           ]
@@ -13588,8 +13815,8 @@
           "utilityWinnerDifferentCount": 13,
           "utilityWinnerBlockedCount": 13,
           "utilityWinnerDifferentWithoutTierBlockCount": 0,
-          "meanBlockedUtilityGap": 0.1554180101282571,
-          "maxBlockedUtilityGap": 0.3328813855541087,
+          "meanBlockedUtilityGap": 0.1375741781308846,
+          "maxBlockedUtilityGap": 0.33101724594328197,
           "blockedByTier": {
             "coverage": 0,
             "recovery": 7,
@@ -13657,7 +13884,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.09075903641950256,
+              "selectedVsBestUtilityGap": 0.09083534836285928,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -13671,7 +13898,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "run_race_pace_01",
               "bestUtilityTemplateId": "str_upper_01",
-              "selectedVsBestUtilityGap": 0.24175134650246966,
+              "selectedVsBestUtilityGap": 0.22885847128591924,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -13685,7 +13912,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "run_race_pace_01",
               "bestUtilityTemplateId": "end_mod_01",
-              "selectedVsBestUtilityGap": 0.061801276076265566,
+              "selectedVsBestUtilityGap": 0.06213922076875161,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -13699,7 +13926,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.05396159955044433,
+              "selectedVsBestUtilityGap": 0.05467640528748971,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -13713,7 +13940,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.16205539689352094,
+              "selectedVsBestUtilityGap": 0.16274090407338965,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -13727,7 +13954,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "run_race_pace_01",
               "bestUtilityTemplateId": "str_upper_01",
-              "selectedVsBestUtilityGap": 0.3328813855541087,
+              "selectedVsBestUtilityGap": 0.33101724594328197,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -13741,7 +13968,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.08021251367776144,
+              "selectedVsBestUtilityGap": 0.08053165497216389,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -13751,11 +13978,11 @@
               "selectedAdvancesRequiredRole": false
             },
             {
-              "date": "2026-08-28",
+              "date": "2026-08-29",
               "weekIndex": 3,
-              "selectedTemplateId": "str_full_01",
-              "bestUtilityTemplateId": "str_upper_01",
-              "selectedVsBestUtilityGap": 0.28049004316150766,
+              "selectedTemplateId": "str_upper_01",
+              "bestUtilityTemplateId": "end_walk_01",
+              "selectedVsBestUtilityGap": 0.04617014792624108,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -13765,11 +13992,11 @@
               "selectedAdvancesRequiredRole": false
             },
             {
-              "date": "2026-08-30",
+              "date": "2026-09-01",
               "weekIndex": 3,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.07038964308477771,
+              "selectedVsBestUtilityGap": 0.0853630263344195,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -13812,8 +14039,8 @@
         {
           "weekIndex": 3,
           "fatigueTierDayCounts": {
-            "train": 2,
-            "modify": 2,
+            "train": 3,
+            "modify": 1,
             "recover": 1
           },
           "restOrRecoveryDayCount": 1
@@ -13962,6 +14189,16 @@
           "templateTitle": "Upper Body Push/Pull",
           "modality": "Strength",
           "earnedCredit": 0.09999999999999998
+        },
+        {
+          "weekIndex": 3,
+          "date": "2026-08-28",
+          "objectiveKey": "zone2_aerobic",
+          "objectiveTitle": "Aerobic Base (Zone 2)",
+          "templateId": "end_walk_01",
+          "templateTitle": "Brisk Continuous Walk",
+          "modality": "Walking",
+          "earnedCredit": 2.220446049250313e-16
         }
       ],
       "utilityDiagnostics": {
@@ -14115,7 +14352,7 @@
             {
               "date": "2026-08-14",
               "weekIndex": 1,
-              "collision": 0.42646517821840674,
+              "collision": 0.42377121270116536,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "lowerBody",
@@ -14125,7 +14362,7 @@
             {
               "date": "2026-08-15",
               "weekIndex": 1,
-              "collision": 0.61289791404654,
+              "collision": 0.6115767537392381,
               "costMagnitude": 0.8624999999999998,
               "topDimensions": [
                 "lowerBody",
@@ -14142,7 +14379,7 @@
             {
               "date": "2026-08-17",
               "weekIndex": 1,
-              "collision": 0.3371164916116373,
+              "collision": 0.33611569702821564,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "impactTissue",
@@ -14159,7 +14396,7 @@
             {
               "date": "2026-08-19",
               "weekIndex": 1,
-              "collision": 0.38019386557206786,
+              "collision": 0.379772158151874,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "impactTissue",
@@ -14176,7 +14413,7 @@
             {
               "date": "2026-08-21",
               "weekIndex": 2,
-              "collision": 0.4025202712792347,
+              "collision": 0.39831268199352043,
               "costMagnitude": 3.5,
               "topDimensions": [
                 "lowerBody",
@@ -14186,7 +14423,7 @@
             {
               "date": "2026-08-22",
               "weekIndex": 2,
-              "collision": 0.6600201692927142,
+              "collision": 0.6572427588479852,
               "costMagnitude": 0.8624999999999998,
               "topDimensions": [
                 "lowerBody",
@@ -14203,7 +14440,7 @@
             {
               "date": "2026-08-24",
               "weekIndex": 2,
-              "collision": 0.2030086123208569,
+              "collision": 0.20262582907820906,
               "costMagnitude": 1.575,
               "topDimensions": [
                 "neuromuscular",
@@ -14213,7 +14450,7 @@
             {
               "date": "2026-08-25",
               "weekIndex": 2,
-              "collision": 0.34868250988468696,
+              "collision": 0.34788376107257335,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "systemic",
@@ -14230,7 +14467,7 @@
             {
               "date": "2026-08-27",
               "weekIndex": 2,
-              "collision": 0.38153913442291826,
+              "collision": 0.38116324204684066,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "impactTissue",
@@ -14240,7 +14477,7 @@
             {
               "date": "2026-08-28",
               "weekIndex": 3,
-              "collision": 0.5636558224453686,
+              "collision": 0.5519443462668104,
               "costMagnitude": 1.1500000000000001,
               "topDimensions": [
                 "lowerBody",
@@ -14250,7 +14487,7 @@
             {
               "date": "2026-08-29",
               "weekIndex": 3,
-              "collision": 0.464079061521725,
+              "collision": 0.461106547844792,
               "costMagnitude": 1.575,
               "topDimensions": [
                 "upperBody",
@@ -14260,7 +14497,7 @@
             {
               "date": "2026-08-30",
               "weekIndex": 3,
-              "collision": 0.45603060247009014,
+              "collision": 0.4505319962784241,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "impactTissue",
@@ -14277,7 +14514,7 @@
             {
               "date": "2026-09-01",
               "weekIndex": 3,
-              "collision": 0.3967352041937853,
+              "collision": 0.3944713211096132,
               "costMagnitude": 0.8624999999999998,
               "topDimensions": [
                 "lowerBody",
@@ -14287,7 +14524,7 @@
             {
               "date": "2026-09-02",
               "weekIndex": 3,
-              "collision": 0.3804676932200652,
+              "collision": 0.3789199653218601,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "impactTissue",
@@ -14302,8 +14539,8 @@
               "topDimensions": []
             }
           ],
-          "meanCollision": 0.2771751733632868,
-          "maxCollision": 0.6600201692927142
+          "meanCollision": 0.2758189498268948,
+          "maxCollision": 0.6572427588479852
         },
         "adjacentCostOverlap": {
           "perPair": [
@@ -14450,7 +14687,7 @@
           "utilityWinnerDifferentCount": 19,
           "utilityWinnerBlockedCount": 19,
           "utilityWinnerDifferentWithoutTierBlockCount": 0,
-          "meanBlockedUtilityGap": 0.1408724987908559,
+          "meanBlockedUtilityGap": 0.1409117342393007,
           "maxBlockedUtilityGap": 0.28564402085464663,
           "blockedByTier": {
             "coverage": 0,
@@ -14519,7 +14756,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_easy_02",
-              "selectedVsBestUtilityGap": 0.12463084554162052,
+              "selectedVsBestUtilityGap": 0.12490424821683063,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -14533,7 +14770,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.07963777591435489,
+              "selectedVsBestUtilityGap": 0.0798955004366167,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -14547,7 +14784,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_walk_01",
-              "selectedVsBestUtilityGap": 0.20000418211133628,
+              "selectedVsBestUtilityGap": 0.200004848223101,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -14561,7 +14798,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.07401848340846143,
+              "selectedVsBestUtilityGap": 0.07411740235264597,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -14575,7 +14812,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_walk_01",
-              "selectedVsBestUtilityGap": 0.2063848674417656,
+              "selectedVsBestUtilityGap": 0.20639455760985156,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -14589,7 +14826,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.07165113962761446,
+              "selectedVsBestUtilityGap": 0.07169090514704635,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -14603,7 +14840,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "str_lower_01",
               "bestUtilityTemplateId": "str_upper_01",
-              "selectedVsBestUtilityGap": 0.27441692235601567,
+              "selectedVsBestUtilityGap": 0.27255271420877836,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -14617,7 +14854,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.07570125538587669,
+              "selectedVsBestUtilityGap": 0.07592336346244632,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -14631,7 +14868,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_walk_01",
-              "selectedVsBestUtilityGap": 0.19687583424115832,
+              "selectedVsBestUtilityGap": 0.19704773762106367,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -14645,7 +14882,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.07022227922971491,
+              "selectedVsBestUtilityGap": 0.07029090054248988,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -14659,7 +14896,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_walk_01",
-              "selectedVsBestUtilityGap": 0.204964310099243,
+              "selectedVsBestUtilityGap": 0.20506123526193745,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -14673,7 +14910,7 @@
               "weekIndex": 3,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_walk_01",
-              "selectedVsBestUtilityGap": 0.1926229776240047,
+              "selectedVsBestUtilityGap": 0.19326905733553276,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -14687,7 +14924,7 @@
               "weekIndex": 3,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.0635009741470926,
+              "selectedVsBestUtilityGap": 0.06397092962068532,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -14701,7 +14938,7 @@
               "weekIndex": 3,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_easy_02",
-              "selectedVsBestUtilityGap": 0.12488473277769466,
+              "selectedVsBestUtilityGap": 0.12499542896083146,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -14715,7 +14952,7 @@
               "weekIndex": 3,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.07092900637332455,
+              "selectedVsBestUtilityGap": 0.07107223079987232,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -14908,6 +15145,16 @@
           "templateTitle": "Upper Body Push/Pull",
           "modality": "Strength",
           "earnedCredit": 0.09999999999999998
+        },
+        {
+          "weekIndex": 3,
+          "date": "2026-08-28",
+          "objectiveKey": "zone2_aerobic",
+          "objectiveTitle": "Aerobic Base (Zone 2)",
+          "templateId": "end_walk_01",
+          "templateTitle": "Brisk Continuous Walk",
+          "modality": "Walking",
+          "earnedCredit": 2.220446049250313e-16
         }
       ],
       "utilityDiagnostics": {
@@ -15061,7 +15308,7 @@
             {
               "date": "2026-08-14",
               "weekIndex": 1,
-              "collision": 0.42646517821840674,
+              "collision": 0.42377121270116536,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "lowerBody",
@@ -15071,7 +15318,7 @@
             {
               "date": "2026-08-15",
               "weekIndex": 1,
-              "collision": 0.61289791404654,
+              "collision": 0.6115767537392381,
               "costMagnitude": 0.8624999999999998,
               "topDimensions": [
                 "lowerBody",
@@ -15088,7 +15335,7 @@
             {
               "date": "2026-08-17",
               "weekIndex": 1,
-              "collision": 0.3371164916116373,
+              "collision": 0.33611569702821564,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "impactTissue",
@@ -15105,7 +15352,7 @@
             {
               "date": "2026-08-19",
               "weekIndex": 1,
-              "collision": 0.38019386557206786,
+              "collision": 0.379772158151874,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "impactTissue",
@@ -15122,7 +15369,7 @@
             {
               "date": "2026-08-21",
               "weekIndex": 2,
-              "collision": 0.4025202712792347,
+              "collision": 0.39831268199352043,
               "costMagnitude": 3.5,
               "topDimensions": [
                 "lowerBody",
@@ -15132,7 +15379,7 @@
             {
               "date": "2026-08-22",
               "weekIndex": 2,
-              "collision": 0.6600201692927142,
+              "collision": 0.6572427588479852,
               "costMagnitude": 0.8624999999999998,
               "topDimensions": [
                 "lowerBody",
@@ -15149,7 +15396,7 @@
             {
               "date": "2026-08-24",
               "weekIndex": 2,
-              "collision": 0.2030086123208569,
+              "collision": 0.20262582907820906,
               "costMagnitude": 1.575,
               "topDimensions": [
                 "neuromuscular",
@@ -15159,7 +15406,7 @@
             {
               "date": "2026-08-25",
               "weekIndex": 2,
-              "collision": 0.34868250988468696,
+              "collision": 0.34788376107257335,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "systemic",
@@ -15176,7 +15423,7 @@
             {
               "date": "2026-08-27",
               "weekIndex": 2,
-              "collision": 0.38153913442291826,
+              "collision": 0.38116324204684066,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "impactTissue",
@@ -15186,7 +15433,7 @@
             {
               "date": "2026-08-28",
               "weekIndex": 3,
-              "collision": 0.5636558224453686,
+              "collision": 0.5519443462668104,
               "costMagnitude": 1.1500000000000001,
               "topDimensions": [
                 "lowerBody",
@@ -15196,7 +15443,7 @@
             {
               "date": "2026-08-29",
               "weekIndex": 3,
-              "collision": 0.464079061521725,
+              "collision": 0.461106547844792,
               "costMagnitude": 1.575,
               "topDimensions": [
                 "upperBody",
@@ -15206,7 +15453,7 @@
             {
               "date": "2026-08-30",
               "weekIndex": 3,
-              "collision": 0.45603060247009014,
+              "collision": 0.4505319962784241,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "impactTissue",
@@ -15223,7 +15470,7 @@
             {
               "date": "2026-09-01",
               "weekIndex": 3,
-              "collision": 0.3967352041937853,
+              "collision": 0.3944713211096132,
               "costMagnitude": 0.8624999999999998,
               "topDimensions": [
                 "lowerBody",
@@ -15233,7 +15480,7 @@
             {
               "date": "2026-09-02",
               "weekIndex": 3,
-              "collision": 0.3804676932200652,
+              "collision": 0.3789199653218601,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "impactTissue",
@@ -15248,8 +15495,8 @@
               "topDimensions": []
             }
           ],
-          "meanCollision": 0.2771751733632868,
-          "maxCollision": 0.6600201692927142
+          "meanCollision": 0.2758189498268948,
+          "maxCollision": 0.6572427588479852
         },
         "adjacentCostOverlap": {
           "perPair": [
@@ -15396,7 +15643,7 @@
           "utilityWinnerDifferentCount": 19,
           "utilityWinnerBlockedCount": 19,
           "utilityWinnerDifferentWithoutTierBlockCount": 0,
-          "meanBlockedUtilityGap": 0.1408724987908559,
+          "meanBlockedUtilityGap": 0.1409117342393007,
           "maxBlockedUtilityGap": 0.28564402085464663,
           "blockedByTier": {
             "coverage": 0,
@@ -15465,7 +15712,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_easy_02",
-              "selectedVsBestUtilityGap": 0.12463084554162052,
+              "selectedVsBestUtilityGap": 0.12490424821683063,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -15479,7 +15726,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.07963777591435489,
+              "selectedVsBestUtilityGap": 0.0798955004366167,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -15493,7 +15740,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_walk_01",
-              "selectedVsBestUtilityGap": 0.20000418211133628,
+              "selectedVsBestUtilityGap": 0.200004848223101,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -15507,7 +15754,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.07401848340846143,
+              "selectedVsBestUtilityGap": 0.07411740235264597,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -15521,7 +15768,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_walk_01",
-              "selectedVsBestUtilityGap": 0.2063848674417656,
+              "selectedVsBestUtilityGap": 0.20639455760985156,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -15535,7 +15782,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.07165113962761446,
+              "selectedVsBestUtilityGap": 0.07169090514704635,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -15549,7 +15796,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "str_lower_01",
               "bestUtilityTemplateId": "str_upper_01",
-              "selectedVsBestUtilityGap": 0.27441692235601567,
+              "selectedVsBestUtilityGap": 0.27255271420877836,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -15563,7 +15810,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.07570125538587669,
+              "selectedVsBestUtilityGap": 0.07592336346244632,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -15577,7 +15824,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_walk_01",
-              "selectedVsBestUtilityGap": 0.19687583424115832,
+              "selectedVsBestUtilityGap": 0.19704773762106367,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -15591,7 +15838,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.07022227922971491,
+              "selectedVsBestUtilityGap": 0.07029090054248988,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -15605,7 +15852,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_walk_01",
-              "selectedVsBestUtilityGap": 0.204964310099243,
+              "selectedVsBestUtilityGap": 0.20506123526193745,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -15619,7 +15866,7 @@
               "weekIndex": 3,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_walk_01",
-              "selectedVsBestUtilityGap": 0.1926229776240047,
+              "selectedVsBestUtilityGap": 0.19326905733553276,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -15633,7 +15880,7 @@
               "weekIndex": 3,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.0635009741470926,
+              "selectedVsBestUtilityGap": 0.06397092962068532,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -15647,7 +15894,7 @@
               "weekIndex": 3,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_easy_02",
-              "selectedVsBestUtilityGap": 0.12488473277769466,
+              "selectedVsBestUtilityGap": 0.12499542896083146,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -15661,7 +15908,7 @@
               "weekIndex": 3,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.07092900637332455,
+              "selectedVsBestUtilityGap": 0.07107223079987232,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -18786,7 +19033,7 @@
             {
               "date": "2026-08-09",
               "weekIndex": 0,
-              "collision": 0.3429566154600379,
+              "collision": 0.33864302564490695,
               "costMagnitude": 1.1500000000000001,
               "topDimensions": [
                 "lowerBody",
@@ -18796,11 +19043,11 @@
             {
               "date": "2026-08-10",
               "weekIndex": 0,
-              "collision": 0.227614788876649,
+              "collision": 0.2255822685514457,
               "costMagnitude": 4.1,
               "topDimensions": [
                 "lowerBody",
-                "systemic"
+                "neuromuscular"
               ]
             },
             {
@@ -18898,7 +19145,7 @@
               ]
             }
           ],
-          "meanCollision": 0.2650805609367532,
+          "meanCollision": 0.2646272673553008,
           "maxCollision": 0.5103075635110951
         },
         "adjacentCostOverlap": {
@@ -19000,7 +19247,7 @@
           "utilityWinnerDifferentCount": 10,
           "utilityWinnerBlockedCount": 10,
           "utilityWinnerDifferentWithoutTierBlockCount": 0,
-          "meanBlockedUtilityGap": 0.3351729118727138,
+          "meanBlockedUtilityGap": 0.33539220319759944,
           "maxBlockedUtilityGap": 1.034223152612104,
           "blockedByTier": {
             "coverage": 5,
@@ -19013,7 +19260,7 @@
               "weekIndex": 0,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.022457566339947402,
+              "selectedVsBestUtilityGap": 0.022639593908629435,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -19027,7 +19274,7 @@
               "weekIndex": 0,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.04203591927420849,
+              "selectedVsBestUtilityGap": 0.042121313299944355,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -19041,7 +19288,7 @@
               "weekIndex": 0,
               "selectedTemplateId": "str_full_01",
               "bestUtilityTemplateId": "str_full_03",
-              "selectedVsBestUtilityGap": 0.46232120270913235,
+              "selectedVsBestUtilityGap": 0.46424669436357047,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -21731,7 +21978,7 @@
           "templateId": "str_upper_01",
           "templateTitle": "Upper Body Push/Pull",
           "modality": "Strength",
-          "earnedCredit": 0.19999999999999996
+          "earnedCredit": 0.4
         },
         {
           "weekIndex": 3,
@@ -21895,7 +22142,7 @@
             {
               "date": "2026-08-14",
               "weekIndex": 1,
-              "collision": 0.42209238673514665,
+              "collision": 0.4199864084742772,
               "costMagnitude": 0.8624999999999998,
               "topDimensions": [
                 "lowerBody",
@@ -21905,7 +22152,7 @@
             {
               "date": "2026-08-15",
               "weekIndex": 1,
-              "collision": 0.4336741956582019,
+              "collision": 0.4329242426523121,
               "costMagnitude": 1.575,
               "topDimensions": [
                 "upperBody",
@@ -21915,7 +22162,7 @@
             {
               "date": "2026-08-16",
               "weekIndex": 1,
-              "collision": 0.3556916186932023,
+              "collision": 0.35414080705858064,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "systemic",
@@ -21932,7 +22179,7 @@
             {
               "date": "2026-08-18",
               "weekIndex": 1,
-              "collision": 0.38232206069564684,
+              "collision": 0.38167365137692083,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "impactTissue",
@@ -21949,7 +22196,7 @@
             {
               "date": "2026-08-20",
               "weekIndex": 1,
-              "collision": 0.36255047396004964,
+              "collision": 0.3623307473975496,
               "costMagnitude": 0.8624999999999998,
               "topDimensions": [
                 "lowerBody",
@@ -21959,7 +22206,7 @@
             {
               "date": "2026-08-21",
               "weekIndex": 2,
-              "collision": 0.40898011309981736,
+              "collision": 0.3941537641943938,
               "costMagnitude": 1.575,
               "topDimensions": [
                 "neuromuscular",
@@ -21969,7 +22216,7 @@
             {
               "date": "2026-08-22",
               "weekIndex": 2,
-              "collision": 0.47638850272646194,
+              "collision": 0.4669960859350956,
               "costMagnitude": 0.8624999999999998,
               "topDimensions": [
                 "lowerBody",
@@ -21979,7 +22226,7 @@
             {
               "date": "2026-08-23",
               "weekIndex": 2,
-              "collision": 0.3329050900802468,
+              "collision": 0.31786016241713205,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "systemic",
@@ -21996,7 +22243,7 @@
             {
               "date": "2026-08-25",
               "weekIndex": 2,
-              "collision": 0.3720605956804297,
+              "collision": 0.3656502294428622,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "impactTissue",
@@ -22013,7 +22260,7 @@
             {
               "date": "2026-08-27",
               "weekIndex": 2,
-              "collision": 0.36194669897412146,
+              "collision": 0.3587753105903657,
               "costMagnitude": 0.8624999999999998,
               "topDimensions": [
                 "lowerBody",
@@ -22023,7 +22270,7 @@
             {
               "date": "2026-08-28",
               "weekIndex": 3,
-              "collision": 0.417391447279839,
+              "collision": 0.40374473807354005,
               "costMagnitude": 1.575,
               "topDimensions": [
                 "neuromuscular",
@@ -22033,7 +22280,7 @@
             {
               "date": "2026-08-29",
               "weekIndex": 3,
-              "collision": 0.5389268213930938,
+              "collision": 0.5303581593327118,
               "costMagnitude": 1.575,
               "topDimensions": [
                 "upperBody",
@@ -22050,7 +22297,7 @@
             {
               "date": "2026-08-31",
               "weekIndex": 3,
-              "collision": 0.22367337718952507,
+              "collision": 0.21417370720817114,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "systemic",
@@ -22067,7 +22314,7 @@
             {
               "date": "2026-09-02",
               "weekIndex": 3,
-              "collision": 0.32614586964893727,
+              "collision": 0.32177350529967097,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "impactTissue",
@@ -22082,8 +22329,8 @@
               "topDimensions": []
             }
           ],
-          "meanCollision": 0.25794419569771676,
-          "maxCollision": 0.5389268213930938
+          "meanCollision": 0.2547224909705333,
+          "maxCollision": 0.5303581593327118
         },
         "adjacentCostOverlap": {
           "perPair": [
@@ -22227,7 +22474,7 @@
           "utilityWinnerDifferentCount": 18,
           "utilityWinnerBlockedCount": 18,
           "utilityWinnerDifferentWithoutTierBlockCount": 0,
-          "meanBlockedUtilityGap": 0.16455193310559119,
+          "meanBlockedUtilityGap": 0.16532008947165283,
           "maxBlockedUtilityGap": 0.5436800664346985,
           "blockedByTier": {
             "coverage": 0,
@@ -22296,7 +22543,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_walk_01",
-              "selectedVsBestUtilityGap": 0.20341621798271006,
+              "selectedVsBestUtilityGap": 0.20344735734026181,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -22310,7 +22557,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.07063035956281033,
+              "selectedVsBestUtilityGap": 0.07077887245899397,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -22324,7 +22571,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_walk_01",
-              "selectedVsBestUtilityGap": 0.20889456384066593,
+              "selectedVsBestUtilityGap": 0.20891698394229055,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -22338,7 +22585,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.07075420827991463,
+              "selectedVsBestUtilityGap": 0.0708153512998948,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -22352,7 +22599,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_easy_02",
-              "selectedVsBestUtilityGap": 0.13844097243908388,
+              "selectedVsBestUtilityGap": 0.14008782512961349,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -22366,7 +22613,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.07329491523197407,
+              "selectedVsBestUtilityGap": 0.07452999822331849,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -22380,7 +22627,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_walk_01",
-              "selectedVsBestUtilityGap": 0.20521396429586006,
+              "selectedVsBestUtilityGap": 0.2066248188432285,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -22394,7 +22641,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.07181666147196494,
+              "selectedVsBestUtilityGap": 0.07235259694924737,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -22408,7 +22655,7 @@
               "weekIndex": 3,
               "selectedTemplateId": "str_upper_01",
               "bestUtilityTemplateId": "str_full_03",
-              "selectedVsBestUtilityGap": 0.28428687391711205,
+              "selectedVsBestUtilityGap": 0.2869818694200426,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -22422,7 +22669,7 @@
               "weekIndex": 3,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.09371282274465417,
+              "selectedVsBestUtilityGap": 0.09592324101349708,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -22436,7 +22683,7 @@
               "weekIndex": 3,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_walk_01",
-              "selectedVsBestUtilityGap": 0.21473255137304137,
+              "selectedVsBestUtilityGap": 0.2161225159122674,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -22450,7 +22697,7 @@
               "weekIndex": 3,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.08076572926798017,
+              "selectedVsBestUtilityGap": 0.08166106560531683,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -22464,7 +22711,7 @@
               "weekIndex": 3,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_walk_01",
-              "selectedVsBestUtilityGap": 0.21665091136437648,
+              "selectedVsBestUtilityGap": 0.2178124881161027,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -22478,7 +22725,7 @@
               "weekIndex": 3,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.0751061316670755,
+              "selectedVsBestUtilityGap": 0.07548871377425731,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -22673,6 +22920,16 @@
           "templateTitle": "Upper Body Push/Pull",
           "modality": "Strength",
           "earnedCredit": 0.09999999999999998
+        },
+        {
+          "weekIndex": 3,
+          "date": "2026-08-28",
+          "objectiveKey": "zone2_aerobic",
+          "objectiveTitle": "Aerobic Base (Zone 2)",
+          "templateId": "end_walk_01",
+          "templateTitle": "Brisk Continuous Walk",
+          "modality": "Walking",
+          "earnedCredit": 2.220446049250313e-16
         }
       ],
       "utilityDiagnostics": {
@@ -22826,7 +23083,7 @@
             {
               "date": "2026-08-14",
               "weekIndex": 1,
-              "collision": 0.424122202390954,
+              "collision": 0.42035065066681604,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "lowerBody",
@@ -22836,7 +23093,7 @@
             {
               "date": "2026-08-15",
               "weekIndex": 1,
-              "collision": 0.61289791404654,
+              "collision": 0.6115767537392381,
               "costMagnitude": 0.8624999999999998,
               "topDimensions": [
                 "lowerBody",
@@ -22853,7 +23110,7 @@
             {
               "date": "2026-08-17",
               "weekIndex": 1,
-              "collision": 0.3371164916116373,
+              "collision": 0.33611569702821564,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "impactTissue",
@@ -22870,7 +23127,7 @@
             {
               "date": "2026-08-19",
               "weekIndex": 1,
-              "collision": 0.38019386557206786,
+              "collision": 0.379772158151874,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "impactTissue",
@@ -22887,7 +23144,7 @@
             {
               "date": "2026-08-21",
               "weekIndex": 2,
-              "collision": 0.3661419491759034,
+              "collision": 0.3615325741759035,
               "costMagnitude": 3.5,
               "topDimensions": [
                 "lowerBody",
@@ -22897,7 +23154,7 @@
             {
               "date": "2026-08-22",
               "weekIndex": 2,
-              "collision": 0.6600201692927142,
+              "collision": 0.6572427588479852,
               "costMagnitude": 0.8624999999999998,
               "topDimensions": [
                 "lowerBody",
@@ -22914,7 +23171,7 @@
             {
               "date": "2026-08-24",
               "weekIndex": 2,
-              "collision": 0.20179688005149474,
+              "collision": 0.20133039145170406,
               "costMagnitude": 1.575,
               "topDimensions": [
                 "neuromuscular",
@@ -22924,7 +23181,7 @@
             {
               "date": "2026-08-25",
               "weekIndex": 2,
-              "collision": 0.34868250988468696,
+              "collision": 0.34788376107257335,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "systemic",
@@ -22941,7 +23198,7 @@
             {
               "date": "2026-08-27",
               "weekIndex": 2,
-              "collision": 0.38153913442291826,
+              "collision": 0.38116324204684066,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "impactTissue",
@@ -22951,7 +23208,7 @@
             {
               "date": "2026-08-28",
               "weekIndex": 3,
-              "collision": 0.5636558224453686,
+              "collision": 0.5505204141375589,
               "costMagnitude": 1.1500000000000001,
               "topDimensions": [
                 "lowerBody",
@@ -22961,7 +23218,7 @@
             {
               "date": "2026-08-29",
               "weekIndex": 3,
-              "collision": 0.464079061521725,
+              "collision": 0.461106547844792,
               "costMagnitude": 1.575,
               "topDimensions": [
                 "upperBody",
@@ -22971,7 +23228,7 @@
             {
               "date": "2026-08-30",
               "weekIndex": 3,
-              "collision": 0.45603060247009014,
+              "collision": 0.4505319962784241,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "impactTissue",
@@ -22988,7 +23245,7 @@
             {
               "date": "2026-09-01",
               "weekIndex": 3,
-              "collision": 0.3967352041937853,
+              "collision": 0.3944713211096132,
               "costMagnitude": 0.8624999999999998,
               "topDimensions": [
                 "lowerBody",
@@ -22998,7 +23255,7 @@
             {
               "date": "2026-09-02",
               "weekIndex": 3,
-              "collision": 0.3804676932200652,
+              "collision": 0.3789199653218601,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "impactTissue",
@@ -23013,8 +23270,8 @@
               "topDimensions": []
             }
           ],
-          "meanCollision": 0.2709838721692447,
-          "maxCollision": 0.6600201692927142
+          "meanCollision": 0.26952096972543926,
+          "maxCollision": 0.6572427588479852
         },
         "adjacentCostOverlap": {
           "perPair": [
@@ -23161,8 +23418,8 @@
           "utilityWinnerDifferentCount": 19,
           "utilityWinnerBlockedCount": 19,
           "utilityWinnerDifferentWithoutTierBlockCount": 0,
-          "meanBlockedUtilityGap": 0.14614250623959385,
-          "maxBlockedUtilityGap": 0.3747865343810517,
+          "meanBlockedUtilityGap": 0.14620163816590473,
+          "maxBlockedUtilityGap": 0.37344550323406583,
           "blockedByTier": {
             "coverage": 0,
             "recovery": 9,
@@ -23230,7 +23487,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_easy_02",
-              "selectedVsBestUtilityGap": 0.12431711818151983,
+              "selectedVsBestUtilityGap": 0.12444004413536969,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -23244,7 +23501,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.07963777591435489,
+              "selectedVsBestUtilityGap": 0.0798955004366167,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -23258,7 +23515,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_walk_01",
-              "selectedVsBestUtilityGap": 0.20000418211133628,
+              "selectedVsBestUtilityGap": 0.200004848223101,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -23272,7 +23529,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.07401848340846143,
+              "selectedVsBestUtilityGap": 0.07411740235264597,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -23286,7 +23543,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_walk_01",
-              "selectedVsBestUtilityGap": 0.2063848674417656,
+              "selectedVsBestUtilityGap": 0.20639455760985156,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -23300,7 +23557,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.07165113962761446,
+              "selectedVsBestUtilityGap": 0.07169090514704635,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -23314,7 +23571,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "str_lower_01",
               "bestUtilityTemplateId": "str_upper_01",
-              "selectedVsBestUtilityGap": 0.3747865343810517,
+              "selectedVsBestUtilityGap": 0.37344550323406583,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -23328,7 +23585,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.07577551224696216,
+              "selectedVsBestUtilityGap": 0.07600295312409602,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -23342,7 +23599,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_walk_01",
-              "selectedVsBestUtilityGap": 0.19687583424115832,
+              "selectedVsBestUtilityGap": 0.19704773762106367,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -23356,7 +23613,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.07022227922971491,
+              "selectedVsBestUtilityGap": 0.07029090054248988,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -23370,7 +23627,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_walk_01",
-              "selectedVsBestUtilityGap": 0.204964310099243,
+              "selectedVsBestUtilityGap": 0.20506123526193745,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -23384,7 +23641,7 @@
               "weekIndex": 3,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_walk_01",
-              "selectedVsBestUtilityGap": 0.1926229776240047,
+              "selectedVsBestUtilityGap": 0.19326905733553276,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -23398,7 +23655,7 @@
               "weekIndex": 3,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.0635009741470926,
+              "selectedVsBestUtilityGap": 0.06397092962068532,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -23412,7 +23669,7 @@
               "weekIndex": 3,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_easy_02",
-              "selectedVsBestUtilityGap": 0.12488473277769466,
+              "selectedVsBestUtilityGap": 0.12499542896083146,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -23426,7 +23683,7 @@
               "weekIndex": 3,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.07092900637332455,
+              "selectedVsBestUtilityGap": 0.07107223079987232,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -23621,6 +23878,16 @@
           "templateTitle": "Upper Body Push/Pull",
           "modality": "Strength",
           "earnedCredit": 0.09999999999999998
+        },
+        {
+          "weekIndex": 3,
+          "date": "2026-08-28",
+          "objectiveKey": "zone2_aerobic",
+          "objectiveTitle": "Aerobic Base (Zone 2)",
+          "templateId": "end_walk_01",
+          "templateTitle": "Brisk Continuous Walk",
+          "modality": "Walking",
+          "earnedCredit": 2.220446049250313e-16
         }
       ],
       "utilityDiagnostics": {
@@ -23774,7 +24041,7 @@
             {
               "date": "2026-08-14",
               "weekIndex": 1,
-              "collision": 0.424122202390954,
+              "collision": 0.42035065066681604,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "lowerBody",
@@ -23784,7 +24051,7 @@
             {
               "date": "2026-08-15",
               "weekIndex": 1,
-              "collision": 0.61289791404654,
+              "collision": 0.6115767537392381,
               "costMagnitude": 0.8624999999999998,
               "topDimensions": [
                 "lowerBody",
@@ -23801,7 +24068,7 @@
             {
               "date": "2026-08-17",
               "weekIndex": 1,
-              "collision": 0.3371164916116373,
+              "collision": 0.33611569702821564,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "impactTissue",
@@ -23818,7 +24085,7 @@
             {
               "date": "2026-08-19",
               "weekIndex": 1,
-              "collision": 0.38019386557206786,
+              "collision": 0.379772158151874,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "impactTissue",
@@ -23835,7 +24102,7 @@
             {
               "date": "2026-08-21",
               "weekIndex": 2,
-              "collision": 0.40076841471370006,
+              "collision": 0.3965608254279858,
               "costMagnitude": 3.5,
               "topDimensions": [
                 "lowerBody",
@@ -23845,7 +24112,7 @@
             {
               "date": "2026-08-22",
               "weekIndex": 2,
-              "collision": 0.6600201692927142,
+              "collision": 0.6572427588479852,
               "costMagnitude": 0.8624999999999998,
               "topDimensions": [
                 "lowerBody",
@@ -23862,7 +24129,7 @@
             {
               "date": "2026-08-24",
               "weekIndex": 2,
-              "collision": 0.20292091886693525,
+              "collision": 0.20253813562428744,
               "costMagnitude": 1.575,
               "topDimensions": [
                 "neuromuscular",
@@ -23872,7 +24139,7 @@
             {
               "date": "2026-08-25",
               "weekIndex": 2,
-              "collision": 0.34868250988468696,
+              "collision": 0.34788376107257335,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "systemic",
@@ -23889,7 +24156,7 @@
             {
               "date": "2026-08-27",
               "weekIndex": 2,
-              "collision": 0.38153913442291826,
+              "collision": 0.38116324204684066,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "impactTissue",
@@ -23899,7 +24166,7 @@
             {
               "date": "2026-08-28",
               "weekIndex": 3,
-              "collision": 0.5636558224453686,
+              "collision": 0.5514580730119892,
               "costMagnitude": 1.1500000000000001,
               "topDimensions": [
                 "lowerBody",
@@ -23909,7 +24176,7 @@
             {
               "date": "2026-08-29",
               "weekIndex": 3,
-              "collision": 0.464079061521725,
+              "collision": 0.461106547844792,
               "costMagnitude": 1.575,
               "topDimensions": [
                 "upperBody",
@@ -23919,7 +24186,7 @@
             {
               "date": "2026-08-30",
               "weekIndex": 3,
-              "collision": 0.45603060247009014,
+              "collision": 0.4505319962784241,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "impactTissue",
@@ -23936,7 +24203,7 @@
             {
               "date": "2026-09-01",
               "weekIndex": 3,
-              "collision": 0.3967352041937853,
+              "collision": 0.3944713211096132,
               "costMagnitude": 0.8624999999999998,
               "topDimensions": [
                 "lowerBody",
@@ -23946,7 +24213,7 @@
             {
               "date": "2026-09-02",
               "weekIndex": 3,
-              "collision": 0.3804676932200652,
+              "collision": 0.3789199653218601,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "impactTissue",
@@ -23961,8 +24228,8 @@
               "topDimensions": []
             }
           ],
-          "meanCollision": 0.2765309369933076,
-          "maxCollision": 0.6600201692927142
+          "meanCollision": 0.27511886133328284,
+          "maxCollision": 0.6572427588479852
         },
         "adjacentCostOverlap": {
           "perPair": [
@@ -24109,7 +24376,7 @@
           "utilityWinnerDifferentCount": 19,
           "utilityWinnerBlockedCount": 19,
           "utilityWinnerDifferentWithoutTierBlockCount": 0,
-          "meanBlockedUtilityGap": 0.1409166992305565,
+          "meanBlockedUtilityGap": 0.14094755012047305,
           "maxBlockedUtilityGap": 0.28564402085464663,
           "blockedByTier": {
             "coverage": 0,
@@ -24178,7 +24445,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_easy_02",
-              "selectedVsBestUtilityGap": 0.12431711818151983,
+              "selectedVsBestUtilityGap": 0.12444004413536969,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -24192,7 +24459,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.07963777591435489,
+              "selectedVsBestUtilityGap": 0.0798955004366167,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -24206,7 +24473,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_walk_01",
-              "selectedVsBestUtilityGap": 0.20000418211133628,
+              "selectedVsBestUtilityGap": 0.200004848223101,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -24220,7 +24487,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.07401848340846143,
+              "selectedVsBestUtilityGap": 0.07411740235264597,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -24234,7 +24501,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_walk_01",
-              "selectedVsBestUtilityGap": 0.2063848674417656,
+              "selectedVsBestUtilityGap": 0.20639455760985156,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -24248,7 +24515,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.07165113962761446,
+              "selectedVsBestUtilityGap": 0.07169090514704635,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -24262,7 +24529,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "str_lower_01",
               "bestUtilityTemplateId": "str_upper_01",
-              "selectedVsBestUtilityGap": 0.27556508618354,
+              "selectedVsBestUtilityGap": 0.2736920345553767,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -24276,7 +24543,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.07570662727276445,
+              "selectedVsBestUtilityGap": 0.0759287489395829,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -24290,7 +24557,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_walk_01",
-              "selectedVsBestUtilityGap": 0.19687583424115832,
+              "selectedVsBestUtilityGap": 0.19704773762106367,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -24304,7 +24571,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.07022227922971491,
+              "selectedVsBestUtilityGap": 0.07029090054248988,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -24318,7 +24585,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_walk_01",
-              "selectedVsBestUtilityGap": 0.204964310099243,
+              "selectedVsBestUtilityGap": 0.20506123526193745,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -24332,7 +24599,7 @@
               "weekIndex": 3,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_walk_01",
-              "selectedVsBestUtilityGap": 0.1926229776240047,
+              "selectedVsBestUtilityGap": 0.19326905733553276,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -24346,7 +24613,7 @@
               "weekIndex": 3,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.0635009741470926,
+              "selectedVsBestUtilityGap": 0.06397092962068532,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -24360,7 +24627,7 @@
               "weekIndex": 3,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_easy_02",
-              "selectedVsBestUtilityGap": 0.12488473277769466,
+              "selectedVsBestUtilityGap": 0.12499542896083146,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -24374,7 +24641,7 @@
               "weekIndex": 3,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.07092900637332455,
+              "selectedVsBestUtilityGap": 0.07107223079987232,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -24569,6 +24836,16 @@
           "templateTitle": "Upper Body Push/Pull",
           "modality": "Strength",
           "earnedCredit": 0.09999999999999998
+        },
+        {
+          "weekIndex": 3,
+          "date": "2026-08-28",
+          "objectiveKey": "zone2_aerobic",
+          "objectiveTitle": "Aerobic Base (Zone 2)",
+          "templateId": "end_walk_01",
+          "templateTitle": "Brisk Continuous Walk",
+          "modality": "Walking",
+          "earnedCredit": 2.220446049250313e-16
         }
       ],
       "utilityDiagnostics": {
@@ -24722,7 +24999,7 @@
             {
               "date": "2026-08-14",
               "weekIndex": 1,
-              "collision": 0.4284156990290671,
+              "collision": 0.42572173351182574,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "lowerBody",
@@ -24732,7 +25009,7 @@
             {
               "date": "2026-08-15",
               "weekIndex": 1,
-              "collision": 0.61289791404654,
+              "collision": 0.6115767537392381,
               "costMagnitude": 0.8624999999999998,
               "topDimensions": [
                 "lowerBody",
@@ -24749,7 +25026,7 @@
             {
               "date": "2026-08-17",
               "weekIndex": 1,
-              "collision": 0.3371164916116373,
+              "collision": 0.33611569702821564,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "impactTissue",
@@ -24766,7 +25043,7 @@
             {
               "date": "2026-08-19",
               "weekIndex": 1,
-              "collision": 0.38019386557206786,
+              "collision": 0.379772158151874,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "impactTissue",
@@ -24783,7 +25060,7 @@
             {
               "date": "2026-08-21",
               "weekIndex": 2,
-              "collision": 0.4030545110160416,
+              "collision": 0.3988469217303274,
               "costMagnitude": 3.5,
               "topDimensions": [
                 "lowerBody",
@@ -24793,7 +25070,7 @@
             {
               "date": "2026-08-22",
               "weekIndex": 2,
-              "collision": 0.6600201692927142,
+              "collision": 0.6572427588479852,
               "costMagnitude": 0.8624999999999998,
               "topDimensions": [
                 "lowerBody",
@@ -24810,7 +25087,7 @@
             {
               "date": "2026-08-24",
               "weekIndex": 2,
-              "collision": 0.20179688005149474,
+              "collision": 0.20133039145170406,
               "costMagnitude": 1.575,
               "topDimensions": [
                 "neuromuscular",
@@ -24820,7 +25097,7 @@
             {
               "date": "2026-08-25",
               "weekIndex": 2,
-              "collision": 0.34868250988468696,
+              "collision": 0.34788376107257335,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "systemic",
@@ -24837,7 +25114,7 @@
             {
               "date": "2026-08-27",
               "weekIndex": 2,
-              "collision": 0.38153913442291826,
+              "collision": 0.38116324204684066,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "impactTissue",
@@ -24847,7 +25124,7 @@
             {
               "date": "2026-08-28",
               "weekIndex": 3,
-              "collision": 0.5636558224453686,
+              "collision": 0.551075150479102,
               "costMagnitude": 1.1500000000000001,
               "topDimensions": [
                 "lowerBody",
@@ -24857,7 +25134,7 @@
             {
               "date": "2026-08-29",
               "weekIndex": 3,
-              "collision": 0.464079061521725,
+              "collision": 0.461106547844792,
               "costMagnitude": 1.575,
               "topDimensions": [
                 "upperBody",
@@ -24867,7 +25144,7 @@
             {
               "date": "2026-08-30",
               "weekIndex": 3,
-              "collision": 0.45603060247009014,
+              "collision": 0.4505319962784241,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "impactTissue",
@@ -24884,7 +25161,7 @@
             {
               "date": "2026-09-01",
               "weekIndex": 3,
-              "collision": 0.3967352041937853,
+              "collision": 0.3944713211096132,
               "costMagnitude": 0.8624999999999998,
               "topDimensions": [
                 "lowerBody",
@@ -24894,7 +25171,7 @@
             {
               "date": "2026-09-02",
               "weekIndex": 3,
-              "collision": 0.3804676932200652,
+              "collision": 0.3789199653218601,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "impactTissue",
@@ -24909,8 +25186,8 @@
               "topDimensions": []
             }
           ],
-          "meanCollision": 0.27733887808762275,
-          "maxCollision": 0.6600201692927142
+          "meanCollision": 0.27594862236748613,
+          "maxCollision": 0.6572427588479852
         },
         "adjacentCostOverlap": {
           "perPair": [
@@ -25057,7 +25334,7 @@
           "utilityWinnerDifferentCount": 19,
           "utilityWinnerBlockedCount": 19,
           "utilityWinnerDifferentWithoutTierBlockCount": 0,
-          "meanBlockedUtilityGap": 0.14122394145470965,
+          "meanBlockedUtilityGap": 0.14126535396634762,
           "maxBlockedUtilityGap": 0.28564402085464663,
           "blockedByTier": {
             "coverage": 0,
@@ -25126,7 +25403,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_easy_02",
-              "selectedVsBestUtilityGap": 0.1248889226928123,
+              "selectedVsBestUtilityGap": 0.12516501639803979,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -25140,7 +25417,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.07963777591435489,
+              "selectedVsBestUtilityGap": 0.0798955004366167,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -25154,7 +25431,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_walk_01",
-              "selectedVsBestUtilityGap": 0.20000418211133628,
+              "selectedVsBestUtilityGap": 0.200004848223101,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -25168,7 +25445,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.07401848340846143,
+              "selectedVsBestUtilityGap": 0.07411740235264597,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -25182,7 +25459,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_walk_01",
-              "selectedVsBestUtilityGap": 0.2063848674417656,
+              "selectedVsBestUtilityGap": 0.20639455760985156,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -25196,7 +25473,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.07165113962761446,
+              "selectedVsBestUtilityGap": 0.07169090514704635,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -25210,7 +25487,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "str_lower_01",
               "bestUtilityTemplateId": "str_upper_01",
-              "selectedVsBestUtilityGap": 0.2807619989569598,
+              "selectedVsBestUtilityGap": 0.2789311311798107,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -25224,7 +25501,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.07577551224696216,
+              "selectedVsBestUtilityGap": 0.07600295312409602,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -25238,7 +25515,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_walk_01",
-              "selectedVsBestUtilityGap": 0.19687583424115832,
+              "selectedVsBestUtilityGap": 0.19704773762106367,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -25252,7 +25529,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.07022227922971491,
+              "selectedVsBestUtilityGap": 0.07029090054248988,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -25266,7 +25543,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_walk_01",
-              "selectedVsBestUtilityGap": 0.204964310099243,
+              "selectedVsBestUtilityGap": 0.20506123526193745,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -25280,7 +25557,7 @@
               "weekIndex": 3,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_walk_01",
-              "selectedVsBestUtilityGap": 0.1926229776240047,
+              "selectedVsBestUtilityGap": 0.19326905733553276,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -25294,7 +25571,7 @@
               "weekIndex": 3,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.0635009741470926,
+              "selectedVsBestUtilityGap": 0.06397092962068532,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -25308,7 +25585,7 @@
               "weekIndex": 3,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_easy_02",
-              "selectedVsBestUtilityGap": 0.12488473277769466,
+              "selectedVsBestUtilityGap": 0.12499542896083146,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -25322,7 +25599,7 @@
               "weekIndex": 3,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.07092900637332455,
+              "selectedVsBestUtilityGap": 0.07107223079987232,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -25494,7 +25771,7 @@
           "templateId": "str_upper_01",
           "templateTitle": "Upper Body Push/Pull",
           "modality": "Strength",
-          "earnedCredit": 0.19999999999999996
+          "earnedCredit": 0.4
         },
         {
           "weekIndex": 3,
@@ -25658,7 +25935,7 @@
             {
               "date": "2026-08-14",
               "weekIndex": 1,
-              "collision": 0.46266772077821383,
+              "collision": 0.46083348164777904,
               "costMagnitude": 0.8624999999999998,
               "topDimensions": [
                 "lowerBody",
@@ -25668,7 +25945,7 @@
             {
               "date": "2026-08-15",
               "weekIndex": 1,
-              "collision": 0.4336741956582019,
+              "collision": 0.4329242426523121,
               "costMagnitude": 1.575,
               "topDimensions": [
                 "upperBody",
@@ -25678,7 +25955,7 @@
             {
               "date": "2026-08-16",
               "weekIndex": 1,
-              "collision": 0.3556916186932023,
+              "collision": 0.35414080705858064,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "systemic",
@@ -25695,7 +25972,7 @@
             {
               "date": "2026-08-18",
               "weekIndex": 1,
-              "collision": 0.38232206069564684,
+              "collision": 0.38167365137692083,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "impactTissue",
@@ -25712,7 +25989,7 @@
             {
               "date": "2026-08-20",
               "weekIndex": 1,
-              "collision": 0.36255047396004964,
+              "collision": 0.3623307473975496,
               "costMagnitude": 0.8624999999999998,
               "topDimensions": [
                 "lowerBody",
@@ -25722,7 +25999,7 @@
             {
               "date": "2026-08-21",
               "weekIndex": 2,
-              "collision": 0.4197163980128853,
+              "collision": 0.4058806524183981,
               "costMagnitude": 1.575,
               "topDimensions": [
                 "upperBody",
@@ -25732,7 +26009,7 @@
             {
               "date": "2026-08-22",
               "weekIndex": 2,
-              "collision": 0.47638850272646194,
+              "collision": 0.4669960859350956,
               "costMagnitude": 0.8624999999999998,
               "topDimensions": [
                 "lowerBody",
@@ -25742,7 +26019,7 @@
             {
               "date": "2026-08-23",
               "weekIndex": 2,
-              "collision": 0.3334038392320098,
+              "collision": 0.32086957858109577,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "systemic",
@@ -25759,7 +26036,7 @@
             {
               "date": "2026-08-25",
               "weekIndex": 2,
-              "collision": 0.3720605956804297,
+              "collision": 0.3656502294428622,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "impactTissue",
@@ -25776,7 +26053,7 @@
             {
               "date": "2026-08-27",
               "weekIndex": 2,
-              "collision": 0.36194669897412146,
+              "collision": 0.3587753105903657,
               "costMagnitude": 0.8624999999999998,
               "topDimensions": [
                 "lowerBody",
@@ -25786,7 +26063,7 @@
             {
               "date": "2026-08-28",
               "weekIndex": 3,
-              "collision": 0.4202532691286239,
+              "collision": 0.40667794020080333,
               "costMagnitude": 1.575,
               "topDimensions": [
                 "upperBody",
@@ -25796,7 +26073,7 @@
             {
               "date": "2026-08-29",
               "weekIndex": 3,
-              "collision": 0.5389268213930938,
+              "collision": 0.5303581593327118,
               "costMagnitude": 1.575,
               "topDimensions": [
                 "upperBody",
@@ -25813,7 +26090,7 @@
             {
               "date": "2026-08-31",
               "weekIndex": 3,
-              "collision": 0.23489972298251197,
+              "collision": 0.2305417516869694,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "systemic",
@@ -25830,7 +26107,7 @@
             {
               "date": "2026-09-02",
               "weekIndex": 3,
-              "collision": 0.32614586964893727,
+              "collision": 0.32177350529967097,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "impactTissue",
@@ -25845,8 +26122,8 @@
               "topDimensions": []
             }
           ],
-          "meanCollision": 0.2610738182716677,
-          "maxCollision": 0.5389268213930938
+          "meanCollision": 0.25817304527369356,
+          "maxCollision": 0.5303581593327118
         },
         "adjacentCostOverlap": {
           "perPair": [
@@ -25990,7 +26267,7 @@
           "utilityWinnerDifferentCount": 18,
           "utilityWinnerBlockedCount": 18,
           "utilityWinnerDifferentWithoutTierBlockCount": 0,
-          "meanBlockedUtilityGap": 0.15963434695484255,
+          "meanBlockedUtilityGap": 0.1602477176041181,
           "maxBlockedUtilityGap": 0.5436800664346985,
           "blockedByTier": {
             "coverage": 0,
@@ -26059,7 +26336,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_walk_01",
-              "selectedVsBestUtilityGap": 0.20341621798271006,
+              "selectedVsBestUtilityGap": 0.20344735734026181,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -26073,7 +26350,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.07063035956281033,
+              "selectedVsBestUtilityGap": 0.07077887245899397,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -26087,7 +26364,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_walk_01",
-              "selectedVsBestUtilityGap": 0.20889456384066593,
+              "selectedVsBestUtilityGap": 0.20891698394229055,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -26101,7 +26378,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.07075420827991463,
+              "selectedVsBestUtilityGap": 0.0708153512998948,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -26115,7 +26392,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_easy_02",
-              "selectedVsBestUtilityGap": 0.1382982287127011,
+              "selectedVsBestUtilityGap": 0.13920977194572082,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -26129,7 +26406,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.07329491523197407,
+              "selectedVsBestUtilityGap": 0.07452999822331849,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -26143,7 +26420,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_walk_01",
-              "selectedVsBestUtilityGap": 0.20521396429586006,
+              "selectedVsBestUtilityGap": 0.2066248188432285,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -26157,7 +26434,7 @@
               "weekIndex": 2,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.07181666147196494,
+              "selectedVsBestUtilityGap": 0.07235259694924737,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -26171,7 +26448,7 @@
               "weekIndex": 3,
               "selectedTemplateId": "str_upper_01",
               "bestUtilityTemplateId": "str_full_03",
-              "selectedVsBestUtilityGap": 0.28428687391711205,
+              "selectedVsBestUtilityGap": 0.2869818694200426,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -26185,7 +26462,7 @@
               "weekIndex": 3,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.09090687982120638,
+              "selectedVsBestUtilityGap": 0.09186498741422003,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -26199,7 +26476,7 @@
               "weekIndex": 3,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_walk_01",
-              "selectedVsBestUtilityGap": 0.21092862893397818,
+              "selectedVsBestUtilityGap": 0.21152007070439444,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -26213,7 +26490,7 @@
               "weekIndex": 3,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.08076572926798017,
+              "selectedVsBestUtilityGap": 0.08166106560531683,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -26227,7 +26504,7 @@
               "weekIndex": 3,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_walk_01",
-              "selectedVsBestUtilityGap": 0.21665091136437648,
+              "selectedVsBestUtilityGap": 0.2178124881161027,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -26241,7 +26518,7 @@
               "weekIndex": 3,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.0751061316670755,
+              "selectedVsBestUtilityGap": 0.07548871377425731,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -26537,7 +26814,7 @@
             {
               "date": "2026-08-16",
               "weekIndex": 1,
-              "collision": 0.25606459742864063,
+              "collision": 0.2516162150186416,
               "costMagnitude": 1.55,
               "topDimensions": [
                 "impactTissue",
@@ -26547,7 +26824,7 @@
             {
               "date": "2026-08-17",
               "weekIndex": 1,
-              "collision": 0.3478649379130552,
+              "collision": 0.3440933861889173,
               "costMagnitude": 2.9,
               "topDimensions": [
                 "impactTissue",
@@ -26564,7 +26841,7 @@
             {
               "date": "2026-08-19",
               "weekIndex": 1,
-              "collision": 0.42138275470684267,
+              "collision": 0.419980811092495,
               "costMagnitude": 1.0850000000000002,
               "topDimensions": [
                 "impactTissue",
@@ -26579,7 +26856,7 @@
               "topDimensions": []
             }
           ],
-          "meanCollision": 0.1547986278722677,
+          "meanCollision": 0.15411135089023306,
           "maxCollision": 0.5099778798254879
         },
         "adjacentCostOverlap": {
@@ -26649,7 +26926,7 @@
           "utilityWinnerDifferentCount": 10,
           "utilityWinnerBlockedCount": 10,
           "utilityWinnerDifferentWithoutTierBlockCount": 0,
-          "meanBlockedUtilityGap": 0.21016965923235112,
+          "meanBlockedUtilityGap": 0.21049137077834437,
           "maxBlockedUtilityGap": 0.6980051532160169,
           "blockedByTier": {
             "coverage": 0,
@@ -26732,7 +27009,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.15342566849220365,
+              "selectedVsBestUtilityGap": 0.15550860112979928,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -26746,7 +27023,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.2442221868266924,
+              "selectedVsBestUtilityGap": 0.244833208860731,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -26760,7 +27037,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "end_mod_01",
               "bestUtilityTemplateId": "end_easy_03",
-              "selectedVsBestUtilityGap": 0.16317773684931408,
+              "selectedVsBestUtilityGap": 0.16311629385436832,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -26774,7 +27051,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.07459345140743842,
+              "selectedVsBestUtilityGap": 0.07497561498006713,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -26788,7 +27065,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.09920074756598898,
+              "selectedVsBestUtilityGap": 0.09940318777660409,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -26836,18 +27113,17 @@
         "Easy Endurance": 5,
         "Full-body Strength": 2,
         "Hard Endurance": 2,
-        "Rest": 2,
+        "Rest": 3,
         "Moderate Endurance": 1,
-        "Upper-body Strength": 1,
-        "Technical Skill": 1
+        "Upper-body Strength": 1
       },
       "modalityDistribution": {
-        "Cycling": 9,
+        "Cycling": 8,
         "Strength": 3,
-        "None": 2
+        "None": 3
       },
-      "restOrRecoveryDayCount": 2,
-      "restOrRecoveryDayPct": 14.3,
+      "restOrRecoveryDayCount": 3,
+      "restOrRecoveryDayPct": 21.4,
       "maxConsecutiveSameTemplateStreakWithinCall": 2,
       "maxConsecutiveSameTemplateStreakAcrossWeeks": 2,
       "objectiveResolution": [
@@ -26946,12 +27222,12 @@
           "templateId": "str_upper_01",
           "templateTitle": "Upper Body Push/Pull",
           "modality": "Strength",
-          "earnedCredit": 0.30000000000000004
+          "earnedCredit": 0.51
         }
       ],
       "utilityDiagnostics": {
-        "fragileSelectionCount": 5,
-        "lowerBenefitSelectionCount": 4,
+        "fragileSelectionCount": 6,
+        "lowerBenefitSelectionCount": 5,
         "trainTierRestOrRecoveryCount": 0
       },
       "qualityWarnings": [
@@ -26977,14 +27253,14 @@
           "eventSpecificAnchorHit": false,
           "eventSpecificExposureDates": [],
           "eventSpecificAnchorFulfilled": false,
-          "qualityAnchorHit": false
+          "qualityAnchorHit": true
         }
       ],
       "anchorScopeNote": null,
       "fatigueTierDayCounts": {
         "train": 4,
-        "modify": 4,
-        "recover": 2
+        "modify": 3,
+        "recover": 3
       },
       "constraintViolations": [],
       "allocationReports": [
@@ -27244,7 +27520,7 @@
             {
               "date": "2026-08-14",
               "weekIndex": 1,
-              "collision": 0.4497826689069807,
+              "collision": 0.41201778601721917,
               "costMagnitude": 2.4,
               "topDimensions": [
                 "lowerBody",
@@ -27254,7 +27530,7 @@
             {
               "date": "2026-08-15",
               "weekIndex": 1,
-              "collision": 0.4964424210455899,
+              "collision": 0.4882424844876387,
               "costMagnitude": 1.575,
               "topDimensions": [
                 "upperBody",
@@ -27264,7 +27540,7 @@
             {
               "date": "2026-08-16",
               "weekIndex": 1,
-              "collision": 0.5104878764636234,
+              "collision": 0.4931449773904952,
               "costMagnitude": 1.645,
               "topDimensions": [
                 "systemic",
@@ -27274,17 +27550,7 @@
             {
               "date": "2026-08-17",
               "weekIndex": 1,
-              "collision": 0.5079735001103215,
-              "costMagnitude": 1.1500000000000001,
-              "topDimensions": [
-                "neuromuscular",
-                "systemic"
-              ]
-            },
-            {
-              "date": "2026-08-18",
-              "weekIndex": 1,
-              "collision": 0.43329813834630065,
+              "collision": 0.4659238271352023,
               "costMagnitude": 0.6900000000000002,
               "topDimensions": [
                 "lowerBody",
@@ -27292,14 +27558,21 @@
               ]
             },
             {
-              "date": "2026-08-19",
+              "date": "2026-08-18",
               "weekIndex": 1,
-              "collision": 0.37627683823667646,
+              "collision": 0.3871095987672475,
               "costMagnitude": 4,
               "topDimensions": [
                 "systemic",
                 "lowerBody"
               ]
+            },
+            {
+              "date": "2026-08-19",
+              "weekIndex": 1,
+              "collision": 0,
+              "costMagnitude": 0,
+              "topDimensions": []
             },
             {
               "date": "2026-08-20",
@@ -27309,8 +27582,8 @@
               "topDimensions": []
             }
           ],
-          "meanCollision": 0.3467191656566394,
-          "maxCollision": 0.5104878764636234
+          "meanCollision": 0.309017539277233,
+          "maxCollision": 0.4931449773904952
         },
         "adjacentCostOverlap": {
           "perPair": [
@@ -27373,22 +27646,14 @@
             {
               "date": "2026-08-17",
               "previousDate": "2026-08-16",
-              "overlap": 0.5276396730439804,
-              "lowerBodyOverlap": 0.15,
-              "impactTissueOverlap": 0.05,
-              "neuromuscularOverlap": 0.2425348021047631
+              "overlap": 0.4986278549630146,
+              "lowerBodyOverlap": 0.18,
+              "impactTissueOverlap": 0.06,
+              "neuromuscularOverlap": 0.06
             },
             {
               "date": "2026-08-18",
               "previousDate": "2026-08-17",
-              "overlap": 0.5343410208132353,
-              "lowerBodyOverlap": 0.10606601717798213,
-              "impactTissueOverlap": 0.03535533905932738,
-              "neuromuscularOverlap": 0.06
-            },
-            {
-              "date": "2026-08-19",
-              "previousDate": "2026-08-18",
               "overlap": 0.10744874230514481,
               "lowerBodyOverlap": 0.12727922061357855,
               "impactTissueOverlap": 0.042426406871192854,
@@ -27398,17 +27663,17 @@
           "maxLowerBodyOverlap": 0.22273863607376249,
           "maxImpactTissueOverlap": 0.09899494936611665,
           "maxNeuromuscularOverlap": 0.25198420997897464,
-          "meanOverlap": 0.3690855452663835
+          "meanOverlap": 0.3475002904188482
         },
         "qualitySpacing": {
           "gapsDays": [
             2,
             4,
             2,
-            3
+            2
           ],
           "minGapDays": 2,
-          "medianGapDays": 2.5,
+          "medianGapDays": 2,
           "adjacentQualityDayCount": 0,
           "longestQualityStreak": 0,
           "qualityPer3DayWindowMax": 2,
@@ -27434,14 +27699,14 @@
         },
         "opportunityCost": {
           "daysWithRankingAudit": 14,
-          "utilityWinnerDifferentCount": 7,
-          "utilityWinnerBlockedCount": 7,
+          "utilityWinnerDifferentCount": 9,
+          "utilityWinnerBlockedCount": 9,
           "utilityWinnerDifferentWithoutTierBlockCount": 0,
-          "meanBlockedUtilityGap": 0.27380970221355627,
+          "meanBlockedUtilityGap": 0.22343033747050012,
           "maxBlockedUtilityGap": 0.9775852666484889,
           "blockedByTier": {
-            "coverage": 4,
-            "recovery": 2,
+            "coverage": 5,
+            "recovery": 3,
             "benefit": 4
           },
           "perDay": [
@@ -27506,7 +27771,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "str_upper_01",
               "bestUtilityTemplateId": "cycling_technical_01",
-              "selectedVsBestUtilityGap": 0.28469213584551256,
+              "selectedVsBestUtilityGap": 0.2909133203262477,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -27516,11 +27781,25 @@
               "selectedAdvancesRequiredRole": false
             },
             {
-              "date": "2026-08-19",
+              "date": "2026-08-17",
+              "weekIndex": 1,
+              "selectedTemplateId": "end_easy_01",
+              "bestUtilityTemplateId": "cycling_technical_01",
+              "selectedVsBestUtilityGap": 0.00029413921595816683,
+              "tierBlocked": true,
+              "blockedByTier": {
+                "coverage": true,
+                "recovery": false,
+                "benefit": false
+              },
+              "selectedAdvancesRequiredRole": false
+            },
+            {
+              "date": "2026-08-18",
               "weekIndex": 1,
               "selectedTemplateId": "end_hard_02",
-              "bestUtilityTemplateId": "cycling_technical_01",
-              "selectedVsBestUtilityGap": 0.2697960314153558,
+              "bestUtilityTemplateId": "end_mod_02",
+              "selectedVsBestUtilityGap": 0.3244736205834513,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": true,
@@ -27530,11 +27809,25 @@
               "selectedAdvancesRequiredRole": true
             },
             {
+              "date": "2026-08-19",
+              "weekIndex": 1,
+              "selectedTemplateId": "rest_01",
+              "bestUtilityTemplateId": "mob_01",
+              "selectedVsBestUtilityGap": 0.011603973145505375,
+              "tierBlocked": true,
+              "blockedByTier": {
+                "coverage": false,
+                "recovery": true,
+                "benefit": false
+              },
+              "selectedAdvancesRequiredRole": false
+            },
+            {
               "date": "2026-08-20",
               "weekIndex": 1,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.01194725327454682,
+              "selectedVsBestUtilityGap": 0.033355489003859755,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -27560,10 +27853,10 @@
           "weekIndex": 1,
           "fatigueTierDayCounts": {
             "train": 1,
-            "modify": 3,
-            "recover": 1
+            "modify": 2,
+            "recover": 2
           },
-          "restOrRecoveryDayCount": 1
+          "restOrRecoveryDayCount": 2
         }
       ]
     },
@@ -27761,7 +28054,7 @@
             {
               "date": "2026-08-14",
               "weekIndex": 1,
-              "collision": 0.4322207796210988,
+              "collision": 0.42431317092544657,
               "costMagnitude": 1.1500000000000001,
               "topDimensions": [
                 "lowerBody",
@@ -27771,7 +28064,7 @@
             {
               "date": "2026-08-15",
               "weekIndex": 1,
-              "collision": 0.44163243740048863,
+              "collision": 0.44057535798539454,
               "costMagnitude": 1.575,
               "topDimensions": [
                 "upperBody",
@@ -27781,7 +28074,7 @@
             {
               "date": "2026-08-16",
               "weekIndex": 1,
-              "collision": 0.381077910339687,
+              "collision": 0.3772747920426893,
               "costMagnitude": 2.4,
               "topDimensions": [
                 "systemic",
@@ -27798,7 +28091,7 @@
             {
               "date": "2026-08-18",
               "weekIndex": 1,
-              "collision": 0.35055695614401206,
+              "collision": 0.34872601247744806,
               "costMagnitude": 1.1500000000000001,
               "topDimensions": [
                 "lowerBody",
@@ -27808,7 +28101,7 @@
             {
               "date": "2026-08-19",
               "weekIndex": 1,
-              "collision": 0.3818511371123779,
+              "collision": 0.38060222036491403,
               "costMagnitude": 1.1500000000000001,
               "topDimensions": [
                 "lowerBody",
@@ -27818,7 +28111,7 @@
             {
               "date": "2026-08-20",
               "weekIndex": 1,
-              "collision": 0.4014254316448032,
+              "collision": 0.40057072716110764,
               "costMagnitude": 0.6900000000000002,
               "topDimensions": [
                 "lowerBody",
@@ -27826,7 +28119,7 @@
               ]
             }
           ],
-          "meanCollision": 0.3369825163544596,
+          "meanCollision": 0.33578948983264045,
           "maxCollision": 0.4733139539497455
         },
         "adjacentCostOverlap": {
@@ -27959,8 +28252,8 @@
           "utilityWinnerDifferentCount": 1,
           "utilityWinnerBlockedCount": 1,
           "utilityWinnerDifferentWithoutTierBlockCount": 0,
-          "meanBlockedUtilityGap": 0.015530122222044584,
-          "maxBlockedUtilityGap": 0.015530122222044584,
+          "meanBlockedUtilityGap": 0.019505184496377,
+          "maxBlockedUtilityGap": 0.019505184496377,
           "blockedByTier": {
             "coverage": 0,
             "recovery": 1,
@@ -27972,7 +28265,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.015530122222044584,
+              "selectedVsBestUtilityGap": 0.019505184496377,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -28256,17 +28549,17 @@
             {
               "date": "2026-08-14",
               "weekIndex": 1,
-              "collision": 0.5895525717979239,
+              "collision": 0.554357557349803,
               "costMagnitude": 1.1500000000000001,
               "topDimensions": [
-                "systemic",
-                "lowerBody"
+                "lowerBody",
+                "systemic"
               ]
             },
             {
               "date": "2026-08-15",
               "weekIndex": 1,
-              "collision": 0.5601758795304214,
+              "collision": 0.5413383706771661,
               "costMagnitude": 0.8624999999999998,
               "topDimensions": [
                 "lowerBody",
@@ -28283,7 +28576,7 @@
             {
               "date": "2026-08-17",
               "weekIndex": 1,
-              "collision": 0.27424885383633235,
+              "collision": 0.26446008114692254,
               "costMagnitude": 2.4,
               "topDimensions": [
                 "lowerBody",
@@ -28300,7 +28593,7 @@
             {
               "date": "2026-08-19",
               "weekIndex": 1,
-              "collision": 0.3008025923994581,
+              "collision": 0.2966108641575363,
               "costMagnitude": 2.4,
               "topDimensions": [
                 "lowerBody",
@@ -28315,8 +28608,8 @@
               "topDimensions": []
             }
           ],
-          "meanCollision": 0.3039094594011584,
-          "maxCollision": 0.5895525717979239
+          "meanCollision": 0.2990513862416792,
+          "maxCollision": 0.554357557349803
         },
         "adjacentCostOverlap": {
           "perPair": [
@@ -28424,15 +28717,15 @@
         },
         "opportunityCost": {
           "daysWithRankingAudit": 14,
-          "utilityWinnerDifferentCount": 9,
-          "utilityWinnerBlockedCount": 9,
+          "utilityWinnerDifferentCount": 8,
+          "utilityWinnerBlockedCount": 8,
           "utilityWinnerDifferentWithoutTierBlockCount": 0,
-          "meanBlockedUtilityGap": 0.22369943589663555,
+          "meanBlockedUtilityGap": 0.20686052038915773,
           "maxBlockedUtilityGap": 0.5392638473076878,
           "blockedByTier": {
             "coverage": 0,
             "recovery": 3,
-            "benefit": 9
+            "benefit": 8
           },
           "perDay": [
             {
@@ -28468,21 +28761,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "end_easy_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.32239940914531423,
-              "tierBlocked": true,
-              "blockedByTier": {
-                "coverage": false,
-                "recovery": false,
-                "benefit": true
-              },
-              "selectedAdvancesRequiredRole": false
-            },
-            {
-              "date": "2026-08-15",
-              "weekIndex": 1,
-              "selectedTemplateId": "end_walk_01",
-              "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.3165013693949286,
+              "selectedVsBestUtilityGap": 0.2735725550585545,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -28496,7 +28775,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.18528139547185046,
+              "selectedVsBestUtilityGap": 0.19022509153808337,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -28510,7 +28789,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "end_mod_02",
               "bestUtilityTemplateId": "end_easy_01",
-              "selectedVsBestUtilityGap": 0.1576892185659371,
+              "selectedVsBestUtilityGap": 0.15794187351122108,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -28524,7 +28803,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.08812631477959726,
+              "selectedVsBestUtilityGap": 0.08914208019728256,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -28538,7 +28817,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "end_mod_02",
               "bestUtilityTemplateId": "end_easy_01",
-              "selectedVsBestUtilityGap": 0.159098490076919,
+              "selectedVsBestUtilityGap": 0.15936281912743,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -28552,7 +28831,7 @@
               "weekIndex": 1,
               "selectedTemplateId": "rest_01",
               "bestUtilityTemplateId": "mob_01",
-              "selectedVsBestUtilityGap": 0.08652704566480474,
+              "selectedVsBestUtilityGap": 0.08696806371032192,
               "tierBlocked": true,
               "blockedByTier": {
                 "coverage": false,
@@ -28600,10 +28879,10 @@
       "trajectory": "fresh",
       "scenarioId": "cycling_criterium_fresh_A",
       "baselineScenarioId": "cycling_criterium_A",
-      "changedPlannedDays": 2,
+      "changedPlannedDays": 4,
       "restOrRecoveryDayDelta": -2,
-      "raceSpecificExposureDelta": -1,
-      "summary": "fresh trajectory: 2 modality day(s) changed; Rest/Mobility delta -2; race-specific exposure delta -1."
+      "raceSpecificExposureDelta": 1,
+      "summary": "fresh trajectory: 4 modality day(s) changed; Rest/Mobility delta -2; race-specific exposure delta +1."
     },
     {
       "trajectory": "stressed",
@@ -28611,8 +28890,8 @@
       "baselineScenarioId": "cycling_criterium_A",
       "changedPlannedDays": 6,
       "restOrRecoveryDayDelta": 5,
-      "raceSpecificExposureDelta": -2,
-      "summary": "stressed trajectory: 6 modality day(s) changed; Rest/Mobility delta +5; race-specific exposure delta -2."
+      "raceSpecificExposureDelta": -1,
+      "summary": "stressed trajectory: 6 modality day(s) changed; Rest/Mobility delta +5; race-specific exposure delta -1."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Refreshes the three evidence baselines (simulation, persona judge, plan judge) from the reviewed engine state at `d33eb5bb` (#471), and hardens the offline AI-judge comparison tooling so score deltas cannot silently mix engine drift with changes to the judge measurement setup.

The PR is now rebased by ancestry onto the latest `main` merge base (`a8385a19`, including #475): **0 commits behind, no conflicts**. The wall-clock architecture-test fix that was originally carried independently on this branch is already present on `main` and is therefore no longer part of the effective PR diff.

## Baseline refresh

### Deterministic simulation baseline

- 39 scenarios regenerated.
- 15 semantic changes vs. the previous baseline were reviewed as expected consequences of merged engine work (including rest/recovery distribution, objective-credit accounting, and same-template-streak diagnostics).
- Accepted with the reviewed baseline-update path.

### Persona judge baseline

- 9 families / 30 cases.
- Local `Qwen3.8-9B-Distill-GGUF:Q4_K_M`, 5 samples, matching the accepted baseline settings.
- Overall change: **+0.08**.
- `persona_former_elite_return` moved -0.7, near its observed dispersion; the family rationale contained no overreaction/underreaction flags. Treat as a soft watch item rather than evidence of a planner defect.

### Plan judge baseline

- 13 families / 68 cases.
- Re-run using the accepted baseline measurement bundle: blind packet v2, 5 samples, thinking disabled, `num_ctx=65536`.
- Overall change: **+0.02**.
- **0 regressions, 2 improvements** (`delivered_dose_variance`, `interactions`).

The initial development pass using the convenient `judge:local` defaults had produced a spurious “16 regressions, 0 improvements” result because those defaults use a different measurement setup. That result was discarded and is the motivating failure mode for the comparability guard below.

## Judge-comparability hardening

The diff checkers already rejected a changed judge model, but previously allowed materially different judge runs to be compared as though they measured engine drift.

### Plan judge

`check-plan-judge-drift.mjs` now treats the following recorded settings as part of the measurement instrument:

- `samples`
- `packetVersion`
- `thinkingEnabled`
- `baseSeed`
- `seedStrategy`
- `temperature`
- `numCtx`
- `numPredict`
- `rubricScale`
- `isPairwise`

A recorded mismatch is **NOT COMPARABLE** by default. `--allow-settings-change` permits an explicitly exploratory comparison; the existing `--allow-model-change` also covers settings changes.

If an individual field is missing on either side, the checker now emits an explicit warning naming the incomplete field and side. Previously only a completely missing `judgeSettings` object warned; partially populated provenance silently bypassed checks.

Historical `judge:diff:prev` artifacts now also persist and restore `judgeSettings`. Without this, the new guard degraded to “unknown settings” when comparing against a previous diff artifact even when that historical run originally had complete settings provenance.

### Persona judge

`check-persona-judge-drift.mjs` now compares the manifest-backed settings that materially define its stochastic run:

- `samples`
- `baseSeed`
- `seedStrategy`
- `thinkingEnabled`

It uses the same fatal-by-default / explicit exploratory-override semantics and the same per-field incomplete-provenance warnings.

## Baseline-update workflow/documentation

- `update-plan-judge-baseline.mjs` and `update-persona-judge-baseline.mjs` point reviewers toward `judge:e2e` / `persona:e2e`, rather than fast local commands whose defaults do not reproduce the committed baseline settings.
- `docs/analysis/ai-plan-judge.md` documents the baseline-comparable `judge:e2e` path, distinguishes it from fast iteration commands, and records the false-regression failure mode that motivated this work.

## Tests added

Settings/provenance coverage now includes **13 focused tests** across:

- `judgeDriftScript.test.ts`
- `personaJudgeDriftScript.test.ts`
- `judgeSettingsProvenance.test.ts`

They cover:

- fatal mismatch behavior;
- `--allow-settings-change` downgrade behavior;
- genuine settings matches;
- completely missing settings;
- individually missing settings fields;
- seed drift;
- historical settings propagation through `judge:diff:prev`.

## Validation

Latest head: `5edd658f`

GitHub Actions CI Pipeline #2803: **SUCCESS**

- Engine Simulations & AI Gates — green
- Frontend typecheck / lint / static gates / build — green
- Frontend unit tests — green
- Firestore security-rule emulator suite — green
- Python lint / format / mypy / pytest / audit — green
- Docker build / compose smoke — green

The deterministic simulation and AI corpus gates also run successfully against the current PR merge result with latest `main`.

## Review status

- No submitted human/bot code reviews are currently attached to the PR.
- No unresolved inline review threads exist.
- The only pre-existing conversation item is CodeRabbit’s generic notice that automatic review was not triggered for this repository; there was no substantive review feedback to reply to or resolve.

## Known follow-up

`persona:update-baseline` still derives `corpusCommit` from the current `git HEAD`, while the persona corpus/run manifest does not itself persist the engine commit used to generate the scored packets. In principle, stale on-disk persona scores could therefore be misattributed if HEAD changes between scoring and baseline acceptance.

That should be hardened by carrying the engine commit in the persona corpus/manifest and validating recorded provenance at baseline-update time, analogous to the plan-judge updater. I have intentionally **not** rewritten the accepted persona AI evidence in this PR without a new reproducible judge run; this is a provenance follow-up, not a reason to reinterpret the reviewed scores above.

## Risk / rollback

The effective PR changes are confined to evidence artifacts, offline judge/baseline tooling, tests, and documentation. No production recommendation logic, policy constants, Firestore rules, or runtime user-data paths are changed.

Rollback is a normal `git revert`; evidence files are regenerable through the documented simulation/judge workflows.