### PR TITLE
fix(persistence): accept schemaVersion 4 in training-history recommendation parser

### DIFF
--- a/app/src/contracts/enginePersistenceContract.test.ts
+++ b/app/src/contracts/enginePersistenceContract.test.ts
@@ -148,12 +148,12 @@ describe('EnginePersistenceContract', () => {
             mode: 'train',
             rationale: 'rationale',
             revision: 1,
-            schemaVersion: 4,
+            schemaVersion: 5,
         };
 
         const contractResult = validatePersistedRecommendationContract(persistedDoc);
         expect(contractResult.valid).toBe(false);
-        expect(contractResult.errors).toContain('schemaVersion must be 1, 2, or 3 when present, got 4');
+        expect(contractResult.errors).toContain('schemaVersion must be 1, 2, 3, or 4 when present, got 5');
 
         const parseResult = parseDailyRecommendation(persistedDoc, 'users/user-1/daily_recommendations/2026-08-26');
         expect(parseResult.status).toBe('INVALID');

--- a/app/src/contracts/enginePersistenceContract.ts
+++ b/app/src/contracts/enginePersistenceContract.ts
@@ -76,10 +76,10 @@ export function validatePersistedRecommendationContract(rec: unknown): EnginePer
 
     const r = rec as Record<string, any>;
     // parseDailyRecommendation (persistence/parsers/trainingHistory.ts) rejects a
-    // defined schemaVersion that isn't 1, 2, or 3 as 'unsupported-schema-version' --
+    // defined schemaVersion that isn't 1, 2, 3, or 4 as 'unsupported-schema-version' --
     // keep this contract in lockstep so a bad version fails here, not only at parse time.
-    if (r.schemaVersion !== undefined && ![1, 2, 3].includes(r.schemaVersion)) {
-        errors.push('schemaVersion must be 1, 2, or 3 when present, got ' + r.schemaVersion);
+    if (r.schemaVersion !== undefined && ![1, 2, 3, 4].includes(r.schemaVersion)) {
+        errors.push('schemaVersion must be 1, 2, 3, or 4 when present, got ' + r.schemaVersion);
     }
     if (typeof r.userId !== 'string' || !r.userId.trim()) errors.push('userId is required');
     if (typeof r.date !== 'string' || !/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/.test(r.date)) errors.push('date is required (YYYY-MM-DD)');

--- a/app/src/persistence/parsers/trainingHistory.test.ts
+++ b/app/src/persistence/parsers/trainingHistory.test.ts
@@ -15,6 +15,29 @@ const recommendation = {
     adherence: { respondedAt: null, followed: null, actualModality: null, actualDurationMin: null, skipped: false, notes: null },
 };
 
+// Mirrors validV4Recommendation() in engine/validationRecommendation.test.ts -- a real v4
+// document written since "persist recommendation knowledge lineage" always carries this
+// shape (recommendationAudit.knowledgeLineage populated).
+const recommendationV4 = {
+    ...recommendation,
+    date: '2026-08-31',
+    schemaVersion: 4,
+    recommendationAudit: {
+        policyVersion: '2026-08-skr1-persisted-knowledge-lineage-v1',
+        evaluatedAt: '2026-08-31T06:00:00Z',
+        decisionContextRevision: 'history-v1:2026-08-31:7:none:none',
+        safetyStatus: 'complete',
+        history: {
+            completedEventCount: 0,
+            unmatchedEventCount: 0,
+            sourceStatuses: { activities: 'AVAILABLE', recommendations: 'AVAILABLE', manualTraining: 'MISSING' },
+        },
+        envelope: { safetyRestrictedModalityCount: 0, planMaxAllowableTier: 'Easy' },
+        candidateScores: [],
+        knowledgeLineage: [{ claimId: 'readiness.objective_mode_thresholds', version: 1 }],
+    },
+};
+
 describe('training-history persistence parsers', () => {
     it('accepts the documented schema-less legacy Garmin record', () => {
         const parsed = parseNormalizedGarminActivity(activity, 'users/u1/activities/a-1', 'a-1');
@@ -291,8 +314,15 @@ describe('training-history persistence parsers', () => {
         expect(parseDailyRecommendation(recommendation, 'users/u1/daily_recommendations/2026-08-06')).toMatchObject({ status: 'AVAILABLE', data: { date: '2026-08-06' } });
         expect(parseDailyRecommendation({ ...recommendation, schemaVersion: 3 }, 'users/u1/daily_recommendations/2026-08-06'))
             .toMatchObject({ status: 'INVALID', issues: [{ field: 'recommendationAudit' }] });
+        // v4 (persisted knowledge lineage) is accepted through the same strict validator
+        // once it carries a valid recommendationAudit.knowledgeLineage; without one it
+        // fails schema validation, not the version gate.
         expect(parseDailyRecommendation({ ...recommendation, schemaVersion: 4 }, 'users/u1/daily_recommendations/2026-08-06'))
-            .toMatchObject({ status: 'INVALID', issues: [{ code: 'unsupported-schema-version', schemaVersion: 4 }] });
+            .toMatchObject({ status: 'INVALID', issues: [{ field: 'recommendationAudit' }, { field: 'recommendationAudit.knowledgeLineage' }] });
+        expect(parseDailyRecommendation(recommendationV4, 'users/u1/daily_recommendations/2026-08-31'))
+            .toMatchObject({ status: 'AVAILABLE', data: { date: '2026-08-31', schemaVersion: 4 } });
+        expect(parseDailyRecommendation({ ...recommendation, schemaVersion: 5 }, 'users/u1/daily_recommendations/2026-08-06'))
+            .toMatchObject({ status: 'INVALID', issues: [{ code: 'unsupported-schema-version', schemaVersion: 5 }] });
     });
 
     it('preserves a valid exact Phase 9 engine verdict without changing the historical schema version', () => {

--- a/app/src/persistence/parsers/trainingHistory.ts
+++ b/app/src/persistence/parsers/trainingHistory.ts
@@ -323,15 +323,17 @@ export function parseNormalizedGarminActivity(
     };
 }
 
-/** v1/v2/v3 persisted recommendations are accepted through the existing strict validator;
+/** v1/v2/v3/v4 persisted recommendations are accepted through the existing strict
+ * validator (v4 adds `recommendationAudit.knowledgeLineage`, written since the "persist
+ * recommendation knowledge lineage" change and fully validated by validateRecommendation);
  * newer schemas must not silently enter the engine before an explicit migration exists.
  * Phase 9.0 adds one backward-compatible evidence-only field, `engineVerdict`, validated
- * here because the historical recommendation validator intentionally owns only the v1-v3
+ * here because the historical recommendation validator intentionally owns only the v1-v4
  * decision shape. */
 export function parseDailyRecommendation(raw: unknown, documentPath: string): DataState<DailyRecommendation> {
     if (!isObject(raw)) return invalid(documentPath, 'not-an-object');
     const schemaVersion = raw.schemaVersion;
-    if (schemaVersion !== undefined && schemaVersion !== 1 && schemaVersion !== 2 && schemaVersion !== 3) {
+    if (schemaVersion !== undefined && schemaVersion !== 1 && schemaVersion !== 2 && schemaVersion !== 3 && schemaVersion !== 4) {
         return invalid(documentPath, 'unsupported-schema-version', 'schemaVersion', typeof schemaVersion === 'number' ? schemaVersion : undefined);
     }
     if (raw.engineVerdict !== undefined && !isShadowVerdict(raw.engineVerdict)) {


### PR DESCRIPTION
## Summary

Fixes a live prod bug: the main dashboard fails to load with `TrainingHistorySourceError: Training history recommendations source is invalid`, and Retry never helps.

## Root cause

- [`recommendationService.ts`](app/src/services/recommendationService.ts#L116-L118) has written `schemaVersion: 4` since commit `c93fd4fd` ("persist recommendation knowledge lineage", Aug 31) whenever a saved recommendation carries `recommendationAudit.knowledgeLineage`.
- `firestore.rules` and the core validator (`validationCore.ts`) were updated at the same time to fully accept and validate v4 documents.
- But `parseDailyRecommendation` in [`persistence/parsers/trainingHistory.ts`](app/src/persistence/parsers/trainingHistory.ts) — used only by the 7-day training-history range read that feeds every dashboard load — still hard-rejected any `schemaVersion` above 3 as `unsupported-schema-version`. Its mirrored gate in `enginePersistenceContract.ts` had the same stale `[1,2,3]` list (its own comment says to keep it "in lockstep" with the parser — it just never was, after v4 shipped).
- `buildTrainingHistorySnapshot` treats any `INVALID` recommendations source as fatal by design (ADR-0010), so a single ordinary v4 save anywhere in the rolling 7-day window bricks the whole dashboard permanently — retrying just re-reads the same "invalid" doc.

Confirmed directly against production data: `users/9fp9JuWSecVo1DRqv8cXzz8ucNI2/daily_recommendations/2026-09-08` is a perfectly valid v4 document that was being rejected; it now parses as `AVAILABLE`.

## Fix

- Widen the version gate in `trainingHistory.ts` to accept `schemaVersion` 1-4.
- Widen the mirrored gate in `enginePersistenceContract.ts` to match.
- Update tests that had pinned the old (buggy) behavior, add a positive-path v4 case, and move the "rejects future schema" test to a genuinely unsupported version (5).

No production data needed to change — this was a read-side bug only; existing v4 documents are fine as-is once the parser catches up.

## Testing

- `npx tsc --noEmit` — clean
- `npx vitest run` — 4023 passed, 249 skipped
- `npx eslint` on changed files — clean
- Re-validated the real prod document that was failing — now `AVAILABLE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)