### PR TITLE
build: gate knowledge registry and coverage in `make check`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ This document outlines repository rules, code conventions, testing instructions,
 
 ### Full Suite (Makefile)
 * `make all` — Run all code checks, test suites, simulations, and build
-* `make check` — Run all backend and frontend checks (ruff, mypy, pytest, tsc, eslint, vitest, workout validation)
+* `make check` — the commit gate: `ruff check`, `ruff format --check`, `mypy`, `pytest`, `tsc -b`, `eslint`, `vitest`, `validate:knowledge`, `validate:knowledge-coverage`, workout validation. It covers every static frontend gate CI runs; only the Firestore rules emulator suite (`npm run test:rules`), `npm audit` and the base-SHA policy-drift check are CI-only.
 * `make test` — Run all unit test suites (pytest + vitest)
 * `make lint` — Run all linters (ruff + eslint)
 * `make format` — Auto-format Python and TypeScript code

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Quick guide for building, testing, and working on `adaptive-training-recommender
 
 ### All-in-One Commands (Makefile)
 - Run All Checks, Tests, Simulations & Build: `make all`
-- Run Full Validation Suite: `make check`
+- Run Full Validation Suite: `make check` (ruff lint+format, mypy, pytest, tsc, eslint, vitest, knowledge registry, knowledge coverage, workout catalog — a superset of CI's static frontend gates; only the Firestore rules suite, `npm audit` and the policy-drift check are CI-only)
 - Run All Tests (Python + Frontend): `make test`
 - Run Linters: `make lint`
 - Auto-Format Code: `make format`

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@
         format format-check format-python-check format-python format-frontend \
         typecheck typecheck-python typecheck-frontend \
         test test-python test-frontend test-coverage \
-        validate-workouts simulate simulate-scenarios simulate-diff \
+        validate-workouts validate-knowledge validate-knowledge-coverage \
+        simulate simulate-scenarios simulate-diff \
         simulate-calibrate simulate-fatigue-fusion simulate-subjective-drift \
         compare-sequence-search build build-frontend \
         deploy deploy-hosting deploy-all deploy-rules deploy-indexes \
@@ -43,7 +44,8 @@ check: check-python check-frontend
 check-python: lint-python typecheck-python test-python
 
 ## Run all frontend TypeScript checks and tests
-check-frontend: typecheck-frontend lint-frontend test-frontend validate-workouts
+## Mirrors app's own `npm run check` so this gate matches CI's Frontend Hygiene job
+check-frontend: typecheck-frontend lint-frontend test-frontend validate-knowledge validate-knowledge-coverage validate-workouts
 
 ## Run simulation scenario benchmarks and baseline diff verification
 simulate: simulate-scenarios simulate-diff
@@ -128,6 +130,14 @@ format-frontend:
 ## Run frontend unit and scenario test suite with vitest
 test-frontend:
 	npm --prefix app run test
+
+## Validate sports knowledge registry claims and evidence lineage
+validate-knowledge:
+	npm --prefix app run validate:knowledge
+
+## Validate engine knowledge-coverage inventory
+validate-knowledge-coverage:
+	npm --prefix app run validate:knowledge-coverage
 
 ## Validate workout catalog definitions and prescription contracts
 validate-workouts:
@@ -226,10 +236,12 @@ help:
 	@echo   make test-coverage     - Run pytest with coverage report
 	@echo --------------------------------------------------------------------------------
 	@echo Frontend Targets:
-	@echo   make check-frontend    - Run tsc, eslint, vitest, and workout validation
+	@echo   make check-frontend    - Run tsc, eslint, vitest, knowledge and workout validation
 	@echo   make typecheck-frontend- Run TypeScript compiler check
 	@echo   make lint-frontend     - Run ESLint
 	@echo   make test-frontend     - Run Vitest suite
+	@echo   make validate-knowledge- Validate sports knowledge registry
+	@echo   make validate-knowledge-coverage - Validate engine knowledge coverage inventory
 	@echo   make validate-workouts - Validate workout catalog and contracts
 	@echo   make simulate-scenarios- Run scenario simulations
 	@echo   make simulate-diff     - Compare scenario simulation against baseline


### PR DESCRIPTION
## Summary

- `make check` was a strict subset of CI. `check-frontend` depended on `typecheck-frontend lint-frontend test-frontend validate-workouts` and never ran `app`'s `validate:knowledge` or `validate:knowledge-coverage`, both of which CI's "Frontend Hygiene & Static Gates" job does gate. A change breaking the sports-knowledge registry (ADR-0033) or the knowledge-coverage inventory passed the documented local commit gate and failed in CI.
- Adds `validate-knowledge` and `validate-knowledge-coverage` targets alongside the existing `validate-workouts`, and wires both into `check-frontend`. Each stays usable on its own, matching the file's one-target-per-script structure; `.PHONY` and `make help` updated.
- Updates the `make check` descriptions in `CLAUDE.md` and `AGENTS.md` to match the new behaviour.
- Corrects a related inaccuracy in those descriptions: `ruff format --check` was implied to be CI-only, but `check-python` → `lint-python` has always run it. No `format-check` target was added to `check` — it would have been redundant.
- No user-visible change; developer tooling only.

## Validation

- [x] `uv run pytest` (backend changes)
- [x] `uv run ruff check .` and `uv run mypy src/garmin_sync` (backend changes)
- [x] `cd app && npm run check` (frontend changes)
- [ ] `cd app && npm run test:rules` (Firestore rules changes)
- [ ] `cd app && npm run simulate:scenarios` (recommendation-engine changes)
- [ ] `cd app && npm run visual:refresh` (material UI changes)

Results:
- `make check`: pass, end to end. It exercises the whole gate including both new targets, which is what this PR changes; that covers the three checked boxes above (`ruff check .`, `ruff format --check .`, `mypy src/garmin_sync`, `pytest` — 816 passed; then `typecheck`, `lint`, `test`, `validate:knowledge`, `validate:knowledge-coverage`, `validate:workouts`, the same six gates as `npm run check`).
- `make validate-knowledge`: pass standalone — 76 knowledge claims and 76 sources validated.
- `make validate-knowledge-coverage`: pass standalone — 54 coverage items; 33 covered, 14 partial, 1 uncovered, 6 n/a; 0 high-impact and 0 high-safety uncovered. Emits the same pre-existing partial-coverage warnings as CI; they are non-fatal.
- `make -n check` compared line-by-line against `.github/workflows/ci.yml`: the Python job's four gates and the Frontend Hygiene job's five static gates are all now covered locally. Remaining CI-only items are `npm audit`, the policy-drift check (needs a PR base SHA), `build:bundle` (that is `make build`), `test:rules` (Java emulator), and the simulation and Docker jobs.
- Unchecked boxes: no rules, engine, or UI code is touched — this PR changes only `Makefile`, `CLAUDE.md`, and `AGENTS.md`.

## Risk and reviewer guidance

Low risk: no application code changes, and `make check` was verified green with the new targets in place.

Two things worth a reviewer's attention:

1. **Choice of approach.** The alternative was to have `check-frontend` delegate to `npm --prefix app run check`, which already runs all six frontend gates. I kept individual targets because the Makefile consistently exposes one target per npm script, and delegating would have made `typecheck-frontend`, `lint-frontend`, and `test-frontend` redundant with the aggregate. The tradeoff is that the two lists must be kept in sync by hand if `app`'s `check` script grows a seventh gate.
2. **Overlap with #480.** That PR added a CLAUDE.md § 3 bullet and an AGENTS.md CI-gates table describing exactly the behaviour this PR changes, and it is still open on `claude/improve-claude-agents-docs-63e2e7`. Those lines are not on this branch, so I could not edit them here; both PRs touch the same regions of `CLAUDE.md` and `AGENTS.md` and will conflict textually whichever lands second. Corrections for #480 are prepared on `claude/pr480-doc-corrections` (branched from #480's tip, local only): commit `330b2290` fixes the `ruff format --check` claim and is safe to land independently, and `a835c057` records the knowledge-gate change and must land after or with this PR.

## Domain invariants

Not applicable — this change touches only build tooling and developer documentation. No Firestore access, no date logic, no decision logic, and no credentials are involved; `POLICY_VERSION` is unaffected.

## Screenshots or recordings

Not applicable — no user-visible change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
