### PR TITLE
refactor(nav): unify screen labels behind SCREEN_LABELS (#485)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -94,7 +94,7 @@ function App() {
 
       // HA-D evidence collection is deliberately fire-and-forget relative to readiness.
       // Only an explicit shadow-v1 runtime value reaches the HA service, and the result is
-      // retained solely so the Detailed Data trace can update after immutable persistence.
+      // retained solely so the Data trace can update after immutable persistence.
       void runConfiguredHealthAnomalyShadow(requestUserId, input.date)
         .then(result => {
           if (

--- a/app/src/components/DailyCheckin.tsx
+++ b/app/src/components/DailyCheckin.tsx
@@ -14,6 +14,7 @@ import { getLocalDateString, addDaysToLocalDateString } from '../utils/localDate
 import { resolveDefaultTimeAvailable, type CheckinAvailabilityDefault } from '../utils/checkinDefaults';
 import { getErrorMessage } from '../utils/errors';
 import type { Screen } from '../types/navigation';
+import { SCREEN_LABELS } from '../types/navigation';
 import { HealthContextSection } from './checkin/HealthContextSection';
 import { PhysicalWorkSection } from './checkin/PhysicalWorkSection';
 import { SubjectiveScaleRow } from './checkin/SubjectiveScaleRow';
@@ -563,7 +564,7 @@ export function DailyCheckin({ userId, onNavigate, onBack, onCheckinSaved }: Dai
           </button>
         )}
         <div className="checkin-title-group">
-          <h1>Morning Check-in</h1>
+          <h1>{SCREEN_LABELS.checkin}</h1>
           <span className="checkin-date-badge">Today · {checkin.date || getLocalDateString()}</span>
         </div>
       </div>

--- a/app/src/components/DataView.tsx
+++ b/app/src/components/DataView.tsx
@@ -20,6 +20,7 @@ import { unlinkCompletedWorkoutSource } from './completedWorkoutActions';
 import { configuredActivitiesReadModelPolicy } from '../training-occurrence/activitiesReadModelPolicy';
 import { getCompletedWorkoutsInRange } from '../training-occurrence/activitiesReadModelService';
 import type { CompletedWorkoutView } from '../training-occurrence/completedWorkoutView';
+import { SCREEN_LABELS } from '../types/navigation';
 import './DataView.css';
 
 interface DataViewProps {
@@ -254,7 +255,7 @@ export function DataView({ decisionInput, userId, initialTab = 'recovery' }: Dat
     return (
       <div className="data-view-container">
         <div className="data-view-header">
-          <h1>Detailed Data & Telemetry</h1>
+          <h1>{initialTab === 'brief' ? SCREEN_LABELS.brief : SCREEN_LABELS.data}</h1>
         </div>
         <div className="no-data">
           <p>No data available</p>
@@ -762,7 +763,7 @@ export function DataView({ decisionInput, userId, initialTab = 'recovery' }: Dat
 
   const renderConstraintsData = () => (
     <div className="data-section">
-      <h3>Training Settings</h3>
+      <h3>{SCREEN_LABELS.constraints}</h3>
       <div className="constraints-list">
         <div className="constraint-detail">
           <h4>Available equipment</h4>
@@ -974,7 +975,7 @@ export function DataView({ decisionInput, userId, initialTab = 'recovery' }: Dat
     <div className="data-view-container">
       <div className="data-view-header">
         <div>
-          <h1>Detailed Data & Telemetry</h1>
+          <h1>{initialTab === 'brief' ? SCREEN_LABELS.brief : SCREEN_LABELS.data}</h1>
           <p className="header-subtitle">Inspect engine inputs, recovery metrics, activity telemetry, and adherence.</p>
         </div>
       </div>
@@ -1014,13 +1015,13 @@ export function DataView({ decisionInput, userId, initialTab = 'recovery' }: Dat
           className={activeTab === 'constraints' ? 'active' : ''}
           onClick={() => setActiveTab('constraints')}
         >
-          Training Settings
+          {SCREEN_LABELS.constraints}
         </button>
         <button
           className={activeTab === 'preferences' ? 'active' : ''}
           onClick={() => setActiveTab('preferences')}
         >
-          Preferences
+          {SCREEN_LABELS.preferences}
         </button>
         <button
           className={activeTab === 'adherence' ? 'active' : ''}

--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -1,5 +1,6 @@
 import React, { useRef, useEffect } from 'react';
 import type { Screen } from '../types/navigation';
+import { SCREEN_LABELS } from '../types/navigation';
 import { getAuthInstance } from '../firebase';
 import { buildInfo } from '../buildInfo';
 import { GarminSyncBadge } from './GarminSyncBadge';
@@ -72,31 +73,31 @@ export const Header: React.FC<HeaderProps> = ({
             className={`nav-link ${screen === 'home' ? 'active' : ''}`}
             onClick={() => handleNavigate('home')}
           >
-            Home
+            {SCREEN_LABELS.home}
           </button>
           <button
             className={`nav-link ${screen === 'checkin' ? 'active' : ''}`}
             onClick={() => handleNavigate('checkin')}
           >
-            Check-in
+            {SCREEN_LABELS.checkin}
           </button>
           <button
             className={`nav-link ${screen === 'sessions' ? 'active' : ''}`}
             onClick={() => handleNavigate('sessions')}
           >
-            Sessions
+            {SCREEN_LABELS.sessions}
           </button>
           <button
             className={`nav-link ${screen === 'testing' ? 'active' : ''}`}
             onClick={() => handleNavigate('testing')}
           >
-            Testing
+            {SCREEN_LABELS.testing}
           </button>
           <button
             className={`nav-link ${screen === 'goals' ? 'active' : ''}`}
             onClick={() => handleNavigate('goals')}
           >
-            Goals
+            {SCREEN_LABELS.goals}
           </button>
           <button
             className={`nav-link ${screen === 'data' ? 'active' : ''}`}
@@ -105,7 +106,7 @@ export const Header: React.FC<HeaderProps> = ({
               handleNavigate('data');
             }}
           >
-            Data
+            {SCREEN_LABELS.data}
           </button>
 
           <div className="more-menu-container" ref={desktopSettingsRef}>
@@ -126,7 +127,7 @@ export const Header: React.FC<HeaderProps> = ({
                   onClick={() => handleNavigate('plan')}
                   role="menuitem"
                 >
-                  <span className="item-icon">📋</span> Import Training Plan
+                  <span className="item-icon">📋</span> {SCREEN_LABELS.plan}
                 </button>
                 <button
                   className={`dropdown-item ${screen === 'brief' ? 'active' : ''}`}
@@ -136,21 +137,21 @@ export const Header: React.FC<HeaderProps> = ({
                   }}
                   role="menuitem"
                 >
-                  <span className="item-icon">📤</span> Export Context for AI
+                  <span className="item-icon">📤</span> {SCREEN_LABELS.brief}
                 </button>
                 <button
                   className={`dropdown-item ${screen === 'constraints' ? 'active' : ''}`}
                   onClick={() => handleNavigate('constraints')}
                   role="menuitem"
                 >
-                  <span className="item-icon">⚙️</span> Training Setup
+                  <span className="item-icon">⚙️</span> {SCREEN_LABELS.constraints}
                 </button>
                 <button
                   className={`dropdown-item ${screen === 'preferences' ? 'active' : ''}`}
                   onClick={() => handleNavigate('preferences')}
                   role="menuitem"
                 >
-                  <span className="item-icon">⚙️</span> Coach Preferences
+                  <span className="item-icon">⚙️</span> {SCREEN_LABELS.preferences}
                 </button>
                 <div className="dropdown-divider" />
                 <div

--- a/app/src/components/HealthAnomalyFollowupCard.tsx
+++ b/app/src/components/HealthAnomalyFollowupCard.tsx
@@ -164,7 +164,7 @@ interface HealthAnomalyFollowupCardProps {
 }
 
 /**
- * Shadow-era HA6 surface. It intentionally lives on Detailed Data rather than Home: HA7 still
+  * Shadow-era HA6 surface. It intentionally lives on Data rather than Home: HA7 still
  * owns any visible anomaly/possible-illness alert semantics. This card only collects a later
  * retrospective label for an episode that the shadow evaluator already persisted.
  */

--- a/app/src/components/Home.tsx
+++ b/app/src/components/Home.tsx
@@ -1554,7 +1554,7 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
 
             {onViewData && (
               <button onClick={onViewData} className="quick-action-btn secondary full-width">
-                📊 View Detailed Data
+                📊 View Data
               </button>
             )}
           </div>

--- a/app/src/components/MobileNav.tsx
+++ b/app/src/components/MobileNav.tsx
@@ -1,5 +1,6 @@
 import React, { useRef, useEffect } from 'react';
 import type { Screen } from '../types/navigation';
+import { SCREEN_LABELS } from '../types/navigation';
 import { getAuthInstance } from '../firebase';
 import { buildInfo } from '../buildInfo';
 
@@ -74,7 +75,7 @@ export const MobileNav: React.FC<MobileNavProps> = ({ screen, handleNavigate, lo
           onClick={() => handleNavigate('home')}
         >
           <span className="nav-icon">🏠</span>
-          <span className="nav-label">Today</span>
+          <span className="nav-label">{SCREEN_LABELS.home}</span>
         </button>
 
         <button
@@ -82,7 +83,7 @@ export const MobileNav: React.FC<MobileNavProps> = ({ screen, handleNavigate, lo
           onClick={() => handleNavigate('checkin')}
         >
           <span className="nav-icon">✓</span>
-          <span className="nav-label">Check-in</span>
+          <span className="nav-label">{SCREEN_LABELS.checkin}</span>
         </button>
 
         <button
@@ -90,7 +91,7 @@ export const MobileNav: React.FC<MobileNavProps> = ({ screen, handleNavigate, lo
           onClick={() => handleNavigate('plan')}
         >
           <span className="nav-icon">📋</span>
-          <span className="nav-label">Plan</span>
+          <span className="nav-label">{SCREEN_LABELS.plan}</span>
         </button>
 
         <button
@@ -119,7 +120,7 @@ export const MobileNav: React.FC<MobileNavProps> = ({ screen, handleNavigate, lo
               >
                 <span className="item-icon">🎯</span>
                 <div className="item-text">
-                  <span className="item-title">Goals & Target Events</span>
+                  <span className="item-title">{SCREEN_LABELS.goals}</span>
                   <span className="item-sub">Manage events and target milestones</span>
                 </div>
               </button>
@@ -133,7 +134,7 @@ export const MobileNav: React.FC<MobileNavProps> = ({ screen, handleNavigate, lo
               >
                 <span className="item-icon">📊</span>
                 <div className="item-text">
-                  <span className="item-title">Detailed Data</span>
+                  <span className="item-title">{SCREEN_LABELS.data}</span>
                   <span className="item-sub">View analytics and snapshot telemetry</span>
                 </div>
               </button>
@@ -144,7 +145,7 @@ export const MobileNav: React.FC<MobileNavProps> = ({ screen, handleNavigate, lo
               >
                 <span className="item-icon">⚠️</span>
                 <div className="item-text">
-                  <span className="item-title">Training Setup</span>
+                  <span className="item-title">{SCREEN_LABELS.constraints}</span>
                   <span className="item-sub">Manage physical cautions & equipment</span>
                 </div>
               </button>
@@ -155,7 +156,7 @@ export const MobileNav: React.FC<MobileNavProps> = ({ screen, handleNavigate, lo
               >
                 <span className="item-icon">⚙️</span>
                 <div className="item-text">
-                  <span className="item-title">Coach Preferences</span>
+                  <span className="item-title">{SCREEN_LABELS.preferences}</span>
                   <span className="item-sub">Configure modalities & strain caps</span>
                 </div>
               </button>
@@ -166,7 +167,7 @@ export const MobileNav: React.FC<MobileNavProps> = ({ screen, handleNavigate, lo
               >
                 <span className="item-icon">🚀</span>
                 <div className="item-text">
-                  <span className="item-title">Structured Sessions</span>
+                  <span className="item-title">{SCREEN_LABELS.sessions}</span>
                   <span className="item-sub">Run a multidomain fixture and record native measures</span>
                 </div>
               </button>
@@ -177,7 +178,7 @@ export const MobileNav: React.FC<MobileNavProps> = ({ screen, handleNavigate, lo
               >
                 <span className="item-icon">🧪</span>
                 <div className="item-text">
-                  <span className="item-title">Protocol Testing</span>
+                  <span className="item-title">{SCREEN_LABELS.testing}</span>
                   <span className="item-sub">Run a locked assessment and record comparable raw outcomes</span>
                 </div>
               </button>
@@ -191,7 +192,7 @@ export const MobileNav: React.FC<MobileNavProps> = ({ screen, handleNavigate, lo
               >
                 <span className="item-icon">📤</span>
                 <div className="item-text">
-                  <span className="item-title">Export Context for AI</span>
+                  <span className="item-title">{SCREEN_LABELS.brief}</span>
                   <span className="item-sub">Compile recent metrics & prompt for your AI</span>
                 </div>
               </button>

--- a/app/src/components/PlanView.tsx
+++ b/app/src/components/PlanView.tsx
@@ -34,6 +34,7 @@ import type {
   NextDayPotentialPlan,
 } from '../engine/models';
 import type { Screen } from '../types/navigation';
+import { SCREEN_LABELS } from '../types/navigation';
 import { ExternalPlanWeek } from './ExternalPlanWeek';
 import { ExternalPlanImport } from './ExternalPlanImport';
 import { WeekAheadStrip } from './WeekAheadStrip';
@@ -420,7 +421,7 @@ export const PlanView: React.FC<PlanViewProps> = ({ userId, onNavigate, onPlanCh
       <div className="plan-view-header">
         <div className="plan-view-title-group">
           <span className="plan-view-badge">Week Architecture</span>
-          <h2 className="plan-view-heading">Training Plan</h2>
+          <h2 className="plan-view-heading">{SCREEN_LABELS.plan}</h2>
           <p className="plan-week-range">Next 7 days · {formatWeekRange(today)}</p>
         </div>
         <div className="plan-header-actions">

--- a/app/src/components/TrainingSettings.tsx
+++ b/app/src/components/TrainingSettings.tsx
@@ -3,6 +3,7 @@ import type { BodyRegion, GuardrailKey, InjuryConstraint, SessionTemplate, Train
 import { resolveInjuryRestrictions } from '../engine/injuryPolicy';
 import { trainingSettingsService, type TrainingSettingsUpdate } from '../services/trainingSettingsService';
 import { getLocalDateString } from '../utils/localDate';
+import { SCREEN_LABELS } from '../types/navigation';
 import './TrainingSettings.css';
 
 interface TrainingSettingsProps {
@@ -111,7 +112,7 @@ export function TrainingSettings({ userId }: TrainingSettingsProps) {
   return (
     <main className="training-settings">
       <header>
-        <h1>Training Settings</h1>
+        <h1>{SCREEN_LABELS.constraints}</h1>
         <p>Equipment determines what can be prescribed. Safety limits are always enforced. Preferences only break ties between suitable options.</p>
       </header>
       {error && <p className="settings-error" role="alert">{error}</p>}

--- a/app/src/components/preferences/PreferencesHeader.tsx
+++ b/app/src/components/preferences/PreferencesHeader.tsx
@@ -1,5 +1,7 @@
 
 
+import { SCREEN_LABELS } from '../../types/navigation';
+
 interface PreferencesHeaderProps {
   hasChanges: boolean;
 }
@@ -8,7 +10,7 @@ export function PreferencesHeader({ hasChanges }: PreferencesHeaderProps) {
   return (
     <div className="preferences-header">
       <div>
-        <h1>Preferences</h1>
+        <h1>{SCREEN_LABELS.preferences}</h1>
         <p className="header-subtitle">
           Configure how the adaptive engine selects and presents training recommendations.
         </p>

--- a/app/src/types/navigation.ts
+++ b/app/src/types/navigation.ts
@@ -1,1 +1,19 @@
 export type Screen = 'home' | 'checkin' | 'goals' | 'constraints' | 'preferences' | 'data' | 'plan' | 'brief' | 'sessions' | 'testing';
+
+/**
+ * Canonical user-facing label per Screen value (#485).
+ * Header, MobileNav, and each screen's heading all render from this map
+ * so the same Screen is never labeled differently across surfaces.
+ */
+export const SCREEN_LABELS: Record<Screen, string> = {
+  home: 'Home',
+  checkin: 'Check-in',
+  goals: 'Goals',
+  constraints: 'Training Setup',
+  preferences: 'Coach Preferences',
+  data: 'Data',
+  plan: 'Plan',
+  brief: 'Export Context for AI',
+  sessions: 'Sessions',
+  testing: 'Testing',
+};

--- a/docs/architecture/health-anomaly-shadow.md
+++ b/docs/architecture/health-anomaly-shadow.md
@@ -89,7 +89,7 @@ prior-day lookback over already-persisted assessment revisions. No future data i
 into the original assessment; only the separate outcome document is written or revised.
 
 The follow-up form (`HealthAnomalyFollowupCard`) is mounted only beside the existing shadow
-trace on the Detailed Data screen. It carries the same "evidence only, does not change your
+trace on the Data screen. It carries the same "evidence only, does not change your
 recommendation" framing as the shadow trace itself, and never renders the
 `possible illness or systemic stress` alert wording — that remains gated on the HA7 evidence
 decision.
@@ -100,7 +100,7 @@ without fitting sparse noise.
 
 ## Shadow diagnostics
 
-When `shadow-v1` is explicitly enabled, the Detailed Data screen appends a developer-only
+When `shadow-v1` is explicitly enabled, the Data screen appends a developer-only
 **Health anomaly (shadow)** trace. It shows:
 
 - state, evidence level, episode/persistence and policy/revision provenance;

--- a/docs/architecture/physiological-identity-passport.md
+++ b/docs/architecture/physiological-identity-passport.md
@@ -138,7 +138,7 @@ allowed enum values; automatic assessments and passport documents are server-wri
 
 ## Suspicious-night review UI (PI7)
 
-`IdentityReviewCard` (mounted on the Detailed Data screen, next to `HealthAnomalyShadowPanel`)
+`IdentityReviewCard` (mounted on the Data screen, next to `HealthAnomalyShadowPanel`)
 surfaces the most recent night whose automatic evaluator abstained for a reason the athlete can
 actually confirm or deny — `identityReviewUi.ts`'s `needsSuspiciousNightReview()` deliberately
 excludes nights that are `UNCERTAIN` only because the passport is immature or pairing was

--- a/docs/architecture/user-flows.md
+++ b/docs/architecture/user-flows.md
@@ -124,16 +124,19 @@ Desktop and mobile expose all ten `Screen` values, but with different prominence
 
 | Screen | Desktop `Header` | Mobile `MobileNav` |
 |---|---|---|
-| `home` | `Home` plus brand → Home | Bottom `Today` |
+| `home` | `Home` plus brand → Home | Bottom `Home` |
 | `checkin` | `Check-in` | Bottom `Check-in` |
-| `plan` | Settings → `Import Training Plan` | Bottom `Plan` |
-| `sessions` | `Sessions` | More → `Structured Sessions` |
-| `testing` | `Testing` | More → `Protocol Testing` |
-| `goals` | `Goals` | More → `Goals & Target Events` |
-| `data` | `Data` (refreshes decision input first) | More → `Detailed Data` (refreshes first) |
+| `plan` | Settings → `Plan` | Bottom `Plan` |
+| `sessions` | `Sessions` | More → `Sessions` |
+| `testing` | `Testing` | More → `Testing` |
+| `goals` | `Goals` | More → `Goals` |
+| `data` | `Data` (refreshes decision input first) | More → `Data` (refreshes first) |
 | `brief` | Settings → `Export Context for AI` | More → `Export Context for AI` |
 | `constraints` | Settings → `Training Setup` | More → `Training Setup` |
 | `preferences` | Settings → `Coach Preferences` | More → `Coach Preferences` |
+
+Every label above renders from `navigation.ts` `SCREEN_LABELS`, the single source of
+truth shared by `Header`, `MobileNav`, and each screen's heading (#485).
 
 Current chrome details worth preserving when changing navigation:
 
@@ -288,7 +291,7 @@ and persistent environment setup versus today's `indoorOnly` availability.
 `DataView` has nine tabs:
 
 `Recovery` | `Activities` | `Strength History` | `Check-in` | `Goals` |
-`Training Settings` | `Preferences` | `Adherence` | `Context brief`.
+`Training Setup` | `Coach Preferences` | `Adherence` | `Context brief`.
 
 Most of the surface is inspection/export. The Activities tab is the exception: it exposes
 corrective actions (for example activity reclassification, and canonical-source unlinking
@@ -362,9 +365,9 @@ living-reference section when implementing them.
 
 ### Information architecture and naming
 
-1. Use one user-facing name per `Screen` across Header, MobileNav, and screen titles. In
-   particular, converge `Training Settings`/`Training Setup` and desktop `Import Training
-   Plan` versus mobile `Plan`.
+1. ~~Use one user-facing name per `Screen` across Header, MobileNav, and screen titles.~~
+   Done (#485): one canonical label per `Screen` renders from `navigation.ts`
+   `SCREEN_LABELS` in Header, MobileNav, and each screen heading.
 2. Make desktop and mobile primary destinations more symmetrical, or document a deliberate
    reason for the difference. A daily-loop set such as Today / Check-in / Plan is the most
    obvious candidate.


### PR DESCRIPTION
## Summary
- Every Screen value now has exactly one canonical label, rendered from a new SCREEN_LABELS map in app/src/types/navigation.ts and shared by Header, MobileNav, and each screen heading.
- Canonical labels: Home, Check-in, Goals, Training Setup, Coach Preferences, Data, Plan, Export Context for AI, Sessions, Testing.
- Visible changes: desktop Settings menu Import Training Plan becomes Plan; mobile bottom tab Today becomes Home; mobile More items Goals and Target Events / Detailed Data / Structured Sessions / Protocol Testing become Goals / Data / Sessions / Testing; headings Training Settings becomes Training Setup, Preferences becomes Coach Preferences, Training Plan becomes Plan, Morning Check-in becomes Check-in, Detailed Data and Telemetry becomes Data (Export Context for AI when entered via the brief screen).
- No routing or behavior change, copy-only PR. No user-visible change beyond consistent naming.
- Closes #485. Implements docs/architecture/user-flows.md Recommendation 1 (PR #481 follow-up).

## Validation
- [x] cd app && npm run check: pass (tsc, eslint, vitest, workout catalog, knowledge validators; EXIT=0)
- [x] Pre-commit hooks on commit and push: pass (ruff, eslint, frontend typecheck + lint + tests + workout validation)
- [ ] cd app && npm run test:rules (Firestore rules changes) — not applicable, no rules touched
- [ ] cd app && npm run simulate:scenarios (recommendation-engine changes) — not applicable, no engine logic touched
- [ ] cd app && npm run visual:refresh (material UI changes) — not run; copy-only, no layout change
- Manual check: label matrix re-verified after edits — no Import Training Plan / Structured Sessions / Protocol Testing / Goals and Target Events / Morning Check-in / Detailed Data / Training Settings / Today nav-label occurrences remain in app/src or living docs.

## Risk and reviewer guidance
- Review SCREEN_LABELS in app/src/types/navigation.ts first — every other hunk should render from it.
- Closest attention: DataView conditional h1 (initialTab brief shows Export Context for AI) and the DataView constraints/preferences tabs now rendering Training Setup / Coach Preferences.
- Deliberately untouched: SessionRunner empty-state CTA, TestingWorkflow protocol-title fallback, TrainingPlanSection, MorningDecisionCard kicker, PlanView import/revise buttons — action prompts, not screen titles.
- Low risk: string-only UI change plus living-doc updates; rollback is a clean revert.

## Domain invariants
- [x] Firestore writes remain user-scoped under users/{APP_USER_ID}/...; no default_user or top-level recovery snapshots were introduced.
- [x] Calendar-date logic uses Europe/Warsaw; completed totalSteps still means the previous calendar day (D - 1).
- [x] No credentials, tokens, service-account files, or raw health payloads are included.
- [x] Recommendation decision logic changed: POLICY_VERSION was evaluated — not bumped, no engine decision logic touched; docs/architecture/user-flows.md navigation table, tab list, and Recommendation 1 plus Data-screen references in health-anomaly-shadow.md and physiological-identity-passport.md were updated.

## Screenshots or recordings
Not applicable — copy-only change with no layout difference.