### PR TITLE
fix(auth): disambiguate Garmin sign-in vs wearable-connect copy (#497)

### DIFF
--- a/app/src/components/LoginScreen.test.tsx
+++ b/app/src/components/LoginScreen.test.tsx
@@ -51,7 +51,7 @@ describe('LoginScreen', () => {
     expect(html).toContain('Sign In');
     expect(html).toContain('Create Account');
     expect(html).toContain('Forgot password?');
-    expect(html).toContain('Continue with Garmin');
+    expect(html).toContain('Sign in with Garmin');
   });
 
   it('returns null when authPhase is AUTHENTICATED', () => {

--- a/app/src/components/LoginScreen.tsx
+++ b/app/src/components/LoginScreen.tsx
@@ -237,13 +237,13 @@ export const LoginScreen: React.FC = () => {
     );
   }
 
-  // Mode: Continue with Garmin
+  // Mode: Sign in with Garmin
   if (mode === 'garmin') {
     return (
       <div className="app-container auth-container">
         <div className="auth-card">
           <form onSubmit={handleGarminLogin}>
-            <h1>{challengeId ? 'Verify Garmin login' : 'Continue with Garmin'}</h1>
+            <h1>{challengeId ? 'Verify Garmin login' : 'Sign in with Garmin'}</h1>
             <p>
               {challengeId
                 ? 'Enter the verification code requested by Garmin.'
@@ -423,7 +423,7 @@ export const LoginScreen: React.FC = () => {
             className="auth-secondary-btn"
             onClick={() => switchMode('garmin')}
           >
-            Continue with Garmin
+            Sign in with Garmin
           </button>
         </form>
       </div>

--- a/app/src/components/preferences/GarminConnectionSection.tsx
+++ b/app/src/components/preferences/GarminConnectionSection.tsx
@@ -110,9 +110,9 @@ export function GarminConnectionSection({ userId }: GarminConnectionSectionProps
 
   return (
     <section className="preference-section">
-      <h2>Garmin account</h2>
+      <h2>Garmin wearable</h2>
       <p className="preference-desc">
-        Connect Garmin to this app account. Your password is used only for Garmin authentication;
+        Connect Garmin wearable to this app account for sync. Your password is used only for Garmin authentication;
         the app keeps the resulting refreshable session token, not the password.
       </p>
 
@@ -129,7 +129,7 @@ export function GarminConnectionSection({ userId }: GarminConnectionSectionProps
 
       {!loadingConnection && isConnected && !showForm && (
         <button type="button" className="auth-secondary-btn" onClick={() => setShowForm(true)}>
-          Reconnect Garmin
+          Reconnect Garmin wearable
         </button>
       )}
 
@@ -172,9 +172,9 @@ export function GarminConnectionSection({ userId }: GarminConnectionSectionProps
             </>
           )}
           {error && <p className="error-message">{error}</p>}
-          {success && <p className="preference-success-note">Garmin is connected to this app account.</p>}
+          {success && <p className="preference-success-note">Garmin wearable is connected to this app account.</p>}
           <button type="submit" className="login-btn" disabled={loading}>
-            {loading ? 'Connecting...' : challengeId ? 'Verify Garmin' : 'Connect Garmin'}
+            {loading ? 'Connecting...' : challengeId ? 'Verify Garmin wearable' : 'Connect Garmin wearable'}
           </button>
           {challengeId && (
             <button

--- a/docs/architecture/morning-decision-ux.md
+++ b/docs/architecture/morning-decision-ux.md
@@ -109,7 +109,7 @@ The change set is covered by:
 - Segmented tab control toggling between **Sign In** and **Create Account (Sign Up)**;
 - New password accounts are validated against the Firebase project password policy, receive an email-verification message in the background, and are automatically logged in upon creation;
 - Password reset always returns the same "if an account exists" acknowledgement, including on older Firebase projects that still return `user-not-found`;
-- **Continue with Garmin** is retained as an accessible alternative sign-in and account linking flow rather than the exclusive entry point;
+- **Sign in with Garmin** is retained as an accessible alternative sign-in and account linking flow rather than the exclusive entry point;
 - Upon first login, `initializeUserData` in `AuthContext.tsx` creates default user preferences and v3 training settings under strict `users/{userId}/...` path isolation.
 
 Email verification is best-effort identity hygiene in the current product, not an authorization gate. User data authorization remains scoped to the authenticated Firebase UID. If a future feature requires verified email ownership, enforce `email_verified` at that feature's backend or Security Rules boundary instead of reintroducing a global client-side sign-out gate.

--- a/docs/architecture/user-flows.md
+++ b/docs/architecture/user-flows.md
@@ -166,7 +166,7 @@ Entry is automatic whenever auth is not authenticated.
 
 Success is observed by Firebase auth; no explicit screen navigation is required.
 
-Potential confusion: "Continue with Garmin" is an app-authentication method, while Garmin
+Potential confusion: "Sign in with Garmin" is an app-authentication method, while Garmin
 connection controls under Preferences link wearable data for sync. They are separate tasks.
 
 ### 2. First run / onboarding
@@ -404,8 +404,9 @@ living-reference section when implementing them.
 
 13. Add an explicit onboarding Skip/dismiss path only if product semantics define what a
     goal-less dismissed account should do; do not implement it as a browser flag alone.
-14. Use distinct copy for app authentication (`Continue/Sign in with Garmin`) and wearable
-    data connection (`Connect Garmin wearable`).
+ 14. ~~Use distinct copy for app authentication (`Continue/Sign in with Garmin`) and wearable
+     data connection (`Connect Garmin wearable`).~~ Done (#497): `LoginScreen` garmin mode
+     uses `Sign in with Garmin`, `GarminConnectionSection` uses `Connect Garmin wearable`.
 15. Choose a canonical AI-export surface and make the other export affordances clearly point
     to or distinguish themselves from it.
 16. Add local retry/repair affordances to weak recovery states, starting with DataView's

--- a/docs/ops/multi-user-family-setup.md
+++ b/docs/ops/multi-user-family-setup.md
@@ -6,7 +6,7 @@ Garmin linking is an application flow, not an operations workflow:
 
 ```text
 web app
-  -> Continue with Garmin / Connect Garmin
+  -> Sign in with Garmin / Connect Garmin wearable
   -> Garmin credentials (+ MFA when required)
   -> garmin-account-link Cloud Run service
   -> resolve stable Garmin identity
@@ -58,9 +58,9 @@ The self-service implementation follows these rules:
 - Those two top-level collections are intentionally server-only: browser Firestore rules contain no allow rule for them. Firebase Admin/Cloud Run owns them.
 - User training data remains under `users/{uid}/...`, retaining the existing ownership rules.
 
-## New user: Continue with Garmin
+## New user: Sign in with Garmin
 
-1. Open the app and choose **Continue with Garmin**.
+1. Open the app and choose **Sign in with Garmin**.
 2. Enter Garmin email/password.
 3. If Garmin requests MFA, enter the code in the app.
 4. The backend checks whether this Garmin identity is already linked.
@@ -78,11 +78,11 @@ Migration is deliberately explicit once:
 
 1. Deploy the new Garmin service and frontend.
 2. On the login screen choose **Use existing app login** and sign into the existing Firebase account.
-3. Open **Preferences -> Garmin account**.
-4. Choose **Connect Garmin** and complete Garmin MFA if requested.
+3. Open **Preferences -> Garmin wearable**.
+4. Choose **Connect Garmin wearable** and complete Garmin MFA if requested.
 5. The browser sends the existing Firebase ID token with the Garmin login. The backend therefore binds that Garmin identity to the **existing UID** rather than creating a new user.
 6. The new token is stored at `garmin/users/<existing-uid>/garmin_tokens.json`.
-7. From then on, sign out and use **Continue with Garmin**. It resolves back to the existing UID and all historical data remains in place.
+7. From then on, sign out and use **Sign in with Garmin**. It resolves back to the existing UID and all historical data remains in place.
 
 The previous shared object `garmin/garmin_tokens.json` is intentionally not used as a fallback. Explicit re-linking prevents a stale/shared token from being silently associated with the wrong Firebase user.
 
@@ -91,7 +91,7 @@ The previous shared object `garmin/garmin_tokens.json` is intentionally not used
 After the existing-user migration, adding another person is entirely self-service:
 
 1. Sign out.
-2. The family member chooses **Continue with Garmin**.
+2. The family member chooses **Sign in with Garmin**.
 3. She authenticates her own Garmin account and completes MFA if needed.
 4. A new internal Firebase user is created automatically because the Garmin identity has no mapping yet.
 5. Her data is stored only under her new UID and her token only under `garmin/users/<her-uid>/...`.
@@ -153,7 +153,7 @@ Then deploy in this order:
 1. **Deploy Garmin Sync** — deploys the account-link HTTP service plus the three scheduled jobs.
 2. **Deploy Frontend & Firestore Rules** — deploys the Firebase Hosting rewrite `/api/garmin/** -> garmin-account-link` plus the web UI.
 3. Perform the existing-user migration above.
-4. Sign out and onboard the spouse with **Continue with Garmin**.
+4. Sign out and onboard the spouse with **Sign in with Garmin**.
 5. Run a manual/smoke sync and verify each login sees only its own data.
 
 GitHub no longer needs `GARMIN_EMAIL`, `GARMIN_PASSWORD`, `GARMIN_TOTP_SECRET`, `APP_USER_IDS`, or the old per-user Garmin Environments. Legacy `APP_USER_ID` remains supported only for explicit local/manual single-user CLI operations.


### PR DESCRIPTION
## Summary
- Copy-only disambiguation of the two Garmin concepts: `LoginScreen` garmin mode now reads **Sign in with Garmin** (was `Continue with Garmin`), and the Preferences `GarminConnectionSection` now reads **Connect Garmin wearable** (was `Connect Garmin`), with matching heading/description/reconnect/MFA/success copy (`Garmin wearable`).
- No auth or sync behavior change: no logic, service, or schema edits; only string literals plus the one test assertion that pinned the old copy.
- Stale references to the renamed labels updated in `docs/architecture/user-flows.md` (Recommendation 14 marked done), `docs/architecture/morning-decision-ux.md`, and `docs/ops/multi-user-family-setup.md`.
- Closes #497.

## Validation
- [x] `npm run check` in `app/`: pass (exit 0 — tsc + eslint + vitest 422 files / 4023 tests passed + knowledge, knowledge-coverage, and workout validators)
- [x] `LoginScreen.test.tsx` assertion updated to `Sign in with Garmin`: 3/3 pass
- [x] Pre-commit and pre-push hooks: pass (secrets, ruff, eslint, frontend gate)
- Manual check: N/A (string-literal change; copy verified by grep that no `Continue with Garmin` / bare `Connect Garmin` label remains in `app/src` or `docs`)

## Risk and reviewer guidance
- Review closely: exact user-facing strings in `LoginScreen.tsx` `LoginScreen` garmin mode and `GarminConnectionSection`.
- Regression risk: negligible — no control flow touched. One deliberate wording choice to confirm: MFA/secondary strings use `Verify Garmin login` / `Restart Garmin login` (auth) vs `Verify Garmin wearable` (sync).
- Rollback: revert single commit.

## Domain invariants
- Firestore writes remain user-scoped — how checked: no Firestore or persistence code touched (diff is UI strings + docs + one test assertion).
- Calendar-date logic uses `Europe/Warsaw`; `totalSteps` still `D - 1` — how checked: not applicable, no date/step code touched.
- No credentials/tokens/service-account files/raw health payloads included — verified via `git status` (6 files only) and the `Detect hardcoded secrets` hook passing.
- Decision logic changed: not needed — copy-only, so no `POLICY_VERSION` bump and no engine behavior update.

## Screenshots or recordings
- Not applicable — copy-only change with no layout alteration.
