### PR TITLE
feat(sessions): collapse creation into one New session entry (#495)

### DIFF
--- a/app/src/components/TrainingSettings.tsx
+++ b/app/src/components/TrainingSettings.tsx
@@ -1,13 +1,14 @@
-import { type FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
+import { type FormEvent, type ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
 import type { BodyRegion, GuardrailKey, InjuryConstraint, SessionTemplate, TrainingSettings as TrainingSettingsModel } from '../engine/models';
 import { resolveInjuryRestrictions } from '../engine/injuryPolicy';
 import { trainingSettingsService, type TrainingSettingsUpdate } from '../services/trainingSettingsService';
 import { getLocalDateString } from '../utils/localDate';
-import { SCREEN_LABELS } from '../types/navigation';
+import { SCREEN_LABELS, type Screen } from '../types/navigation';
 import './TrainingSettings.css';
 
 interface TrainingSettingsProps {
   userId: string;
+  onNavigate?: (screen: Screen) => void;
 }
 
 const equipmentLabels: Record<keyof TrainingSettingsModel['equipment'], string> = {
@@ -36,7 +37,20 @@ const injuryRegions: Array<{ value: BodyRegion; label: string }> = [
 const injuryModalities: SessionTemplate['modality'][] = ['Running', 'Cycling', 'Swimming', 'Walking', 'Strength', 'Field', 'Mobility', 'Cross Training'];
 const emptyInjuryDraft = { region: '', severity: 'limit' as InjuryConstraint['severity'], restrictedModalities: [] as SessionTemplate['modality'][], reviewBy: '', note: '' };
 
-export function TrainingSettings({ userId }: TrainingSettingsProps) {
+function CrossSurfaceNote({ onNavigate, children }: { onNavigate?: (screen: Screen) => void; children: ReactNode }) {
+  return (
+    <p className="section-intro">
+      {children}{' '}
+      {onNavigate && (
+        <button type="button" onClick={() => onNavigate('preferences')}>
+          Open {SCREEN_LABELS.preferences}
+        </button>
+      )}
+    </p>
+  );
+}
+
+export function TrainingSettings({ userId, onNavigate }: TrainingSettingsProps) {
   const [settings, setSettings] = useState<TrainingSettingsModel | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [injuryDraft, setInjuryDraft] = useState(emptyInjuryDraft);
@@ -114,6 +128,7 @@ export function TrainingSettings({ userId }: TrainingSettingsProps) {
       <header>
         <h1>{SCREEN_LABELS.constraints}</h1>
         <p>Equipment determines what can be prescribed. Safety limits are always enforced. Preferences only break ties between suitable options.</p>
+        <p className="section-intro">Changes on this screen save automatically and act as hard gates: they remove sessions from every recommendation. Softer tie-breaks live in {SCREEN_LABELS.preferences} and only apply after an explicit save there.</p>
       </header>
       {error && <p className="settings-error" role="alert">{error}</p>}
       {!settings.migration.legacyReviewed && (
@@ -127,6 +142,7 @@ export function TrainingSettings({ userId }: TrainingSettingsProps) {
       <section aria-labelledby="equipment-title">
         <h2 id="equipment-title">Available equipment & sport access</h2>
         <p className="section-intro">Turn on only equipment and venues you can reliably use for a typical session. Pool access may be indoor or outdoor.</p>
+        <CrossSurfaceNote onNavigate={onNavigate}>Related: {SCREEN_LABELS.preferences} → “Unavailable Training Types” excludes modalities by name, even when the equipment here would allow them.</CrossSurfaceNote>
         <div className="settings-list">
           {Object.entries(equipmentLabels).map(([key, label]) => (
             <label className="setting-row" key={key}>
@@ -140,6 +156,7 @@ export function TrainingSettings({ userId }: TrainingSettingsProps) {
       <section aria-labelledby="guardrails-title">
         <h2 id="guardrails-title">Safety limits</h2>
         <p className="section-intro">These limits remove matching sessions from every recommendation, including “Harder”. This is not medical advice.</p>
+        <CrossSurfaceNote onNavigate={onNavigate}>Related: mere dislikes (no safety impact) belong in {SCREEN_LABELS.preferences} → “Training I’d Rather Avoid”, which only penalizes rather than blocks.</CrossSurfaceNote>
         <div className="settings-list">
           {Object.entries(guardrailDetails).map(([key, detail]) => (
             <label className="setting-row" key={key}>
@@ -152,12 +169,15 @@ export function TrainingSettings({ userId }: TrainingSettingsProps) {
 
       <section aria-labelledby="availability-title">
         <h2 id="availability-title">Time and location</h2>
+        <p className="section-intro">These limits are hard caps: longer sessions are never recommended.</p>
+        <CrossSurfaceNote onNavigate={onNavigate}>Related: {SCREEN_LABELS.preferences} → “Default Available Duration” holds soft time budgets that shape durations without gating.</CrossSurfaceNote>
         <div className="time-inputs">
           <label>Weekday session limit (minutes)<input type="number" min="0" max="1440" value={settings.defaults.weekdayMaxMinutes ?? ''} onChange={(event) => void save({ defaults: { weekdayMaxMinutes: event.target.value === '' ? null : Number(event.target.value) } })} /></label>
           <label>Weekend session limit (minutes)<input type="number" min="0" max="1440" value={settings.defaults.weekendMaxMinutes ?? ''} onChange={(event) => void save({ defaults: { weekendMaxMinutes: event.target.value === '' ? null : Number(event.target.value) } })} /></label>
         </div>
         <fieldset>
           <legend>Training location requirement</legend>
+          <p className="section-intro">This is the persistent requirement. A one-day indoor-only override lives in today’s check-in availability.</p>
           {(['either', 'indoor', 'outdoor'] as const).map((environment) => <label key={environment}><input type="radio" name="environment" checked={settings.defaults.environment === environment} onChange={() => void save({ defaults: { environment } })} /> {environment === 'either' ? 'Any location' : `${environment[0].toUpperCase()}${environment.slice(1)} only`}</label>)}
         </fieldset>
       </section>

--- a/app/src/components/preferences/ModalitySections.tsx
+++ b/app/src/components/preferences/ModalitySections.tsx
@@ -1,9 +1,12 @@
 
 import type { UserPreferences } from '../../engine/models';
+import type { Screen } from '../../types/navigation';
+import { SCREEN_LABELS } from '../../types/navigation';
 import { CANONICAL_MODALITIES } from '../../utils/modalities';
 
 interface ModalitySectionsProps {
   preferences: UserPreferences;
+  onNavigate?: (screen: Screen) => void;
   addPreferredModality: (modality: string) => void;
   removePreferredModality: (modality: string) => void;
   addAvoidedModality: (modality: string) => void;
@@ -14,6 +17,7 @@ interface ModalitySectionsProps {
 
 export function ModalitySections({
   preferences,
+  onNavigate,
   addPreferredModality,
   removePreferredModality,
   addAvoidedModality,
@@ -97,6 +101,16 @@ export function ModalitySections({
         <p className="preference-desc">
           Hard exclusions: these activities will not be offered, even when they would otherwise fit the plan.
         </p>
+        <p className="preference-desc">
+          Related: {SCREEN_LABELS.constraints} → “Available equipment &amp; sport access” gates
+          by venue and gear, while this list excludes by modality name. Remember to save here
+          with Save Preferences; equipment changes there save immediately.
+          {onNavigate && (
+            <button type="button" onClick={() => onNavigate('constraints')}>
+              Open {SCREEN_LABELS.constraints}
+            </button>
+          )}
+        </p>
         <div className="modality-select-group">
           <select
             value=""
@@ -132,7 +146,7 @@ export function ModalitySections({
           Modalities you dislike. The engine will apply a strong soft penalty to avoid prescribing these when viable alternatives exist.
         </p>
         <p className="preference-warning-note">
-          💡 <strong>Note:</strong> Safety & injury restrictions (e.g. Achilles pain) belong in <em>Constraints</em>, not Preferences.
+          💡 <strong>Note:</strong> Safety & injury restrictions (e.g. Achilles pain) belong in <em>{SCREEN_LABELS.constraints}</em>, not Preferences.
         </p>
 
         <div className="modality-select-group">

--- a/app/src/components/preferences/PreferencesHeader.tsx
+++ b/app/src/components/preferences/PreferencesHeader.tsx
@@ -14,6 +14,11 @@ export function PreferencesHeader({ hasChanges }: PreferencesHeaderProps) {
         <p className="header-subtitle">
           Configure how the adaptive engine selects and presents training recommendations.
         </p>
+        <p className="header-subtitle">
+          Edits here are staged until you choose Save Preferences, and they only break ties
+          between suitable options. Hard feasibility and safety gates live in{' '}
+          {SCREEN_LABELS.constraints} and save immediately.
+        </p>
       </div>
       {hasChanges && (
         <span className="unsaved-indicator">Unsaved changes</span>

--- a/app/src/components/preferences/SettingsPairing.test.tsx
+++ b/app/src/components/preferences/SettingsPairing.test.tsx
@@ -1,0 +1,84 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import type { UserPreferences } from '../../engine/models';
+import { SCREEN_LABELS } from '../../types/navigation';
+import { ModalitySections } from './ModalitySections';
+import { PreferencesHeader } from './PreferencesHeader';
+import { StyleSections } from './StyleSections';
+
+function buildPreferences(): UserPreferences {
+  return {
+    userId: 'test-user',
+    preferredRecoveryStyle: 'mixed',
+    defaultWeekdayTimeMin: 45,
+    defaultWeekendTimeMin: 60,
+    preferredTimeOfDay: 'flexible',
+    preferredModalities: ['Running'],
+    deprioritizedModalities: [],
+    avoidedModalities: [],
+    unavailableModalities: [],
+    explanationVerbosity: 'detailed',
+    conservativeBias: false,
+    preferredUnits: {
+      distance: 'km',
+      weight: 'kg',
+      temperature: 'celsius',
+    },
+    schemaVersion: 1,
+    createdAt: '2026-08-23T00:00:00.000Z',
+    updatedAt: '2026-08-23T00:00:00.000Z',
+  } as UserPreferences;
+}
+
+const noopHandlers = {
+  addPreferredModality: () => undefined,
+  removePreferredModality: () => undefined,
+  addAvoidedModality: () => undefined,
+  removeAvoidedModality: () => undefined,
+  addUnavailableModality: () => undefined,
+  removeUnavailableModality: () => undefined,
+};
+
+describe('Settings pairing cross-links (#489)', () => {
+  it('ModalitySections links unavailable modalities to Training Setup equipment', () => {
+    const html = renderToStaticMarkup(
+      <ModalitySections preferences={buildPreferences()} onNavigate={() => undefined} {...noopHandlers} />,
+    );
+
+    expect(html).toContain('Unavailable Training Types');
+    expect(html).toContain('Available equipment');
+    expect(html).toContain(`Open ${SCREEN_LABELS.constraints}`);
+  });
+
+  it('ModalitySections omits the navigation button without onNavigate', () => {
+    const html = renderToStaticMarkup(
+      <ModalitySections preferences={buildPreferences()} {...noopHandlers} />,
+    );
+
+    expect(html).toContain('Available equipment');
+    expect(html).not.toContain(`Open ${SCREEN_LABELS.constraints}`);
+  });
+
+  it('StyleSections links default durations to Training Setup time caps', () => {
+    const html = renderToStaticMarkup(
+      <StyleSections
+        preferences={buildPreferences()}
+        onNavigate={() => undefined}
+        updatePreference={() => undefined}
+        updateNestedPreference={() => undefined}
+      />,
+    );
+
+    expect(html).toContain('Default Available Duration');
+    expect(html).toContain('Time and location');
+    expect(html).toContain(`Open ${SCREEN_LABELS.constraints}`);
+  });
+
+  it('PreferencesHeader states the explicit save model and hard-gate ownership', () => {
+    const html = renderToStaticMarkup(<PreferencesHeader hasChanges={false} />);
+
+    expect(html).toContain(SCREEN_LABELS.preferences);
+    expect(html).toContain('Save Preferences');
+    expect(html).toContain(SCREEN_LABELS.constraints);
+  });
+});

--- a/app/src/components/preferences/StyleSections.tsx
+++ b/app/src/components/preferences/StyleSections.tsx
@@ -1,13 +1,16 @@
 
 import type { UserPreferences, RecoveryStyle, TimeOfDay, ExplanationVerbosity } from '../../engine/models';
+import type { Screen } from '../../types/navigation';
+import { SCREEN_LABELS } from '../../types/navigation';
 
 interface StyleSectionsProps {
   preferences: UserPreferences;
+  onNavigate?: (screen: Screen) => void;
   updatePreference: <K extends keyof UserPreferences>(key: K, value: UserPreferences[K]) => void;
   updateNestedPreference: <K extends keyof UserPreferences['preferredUnits']>(key: K, value: UserPreferences['preferredUnits'][K]) => void;
 }
 
-export function StyleSections({ preferences, updatePreference, updateNestedPreference }: StyleSectionsProps) {
+export function StyleSections({ preferences, onNavigate, updatePreference, updateNestedPreference }: StyleSectionsProps) {
   return (
     <>
       {/* Training Decision Style */}
@@ -60,6 +63,16 @@ export function StyleSections({ preferences, updatePreference, updateNestedPrefe
         <h2>Default Available Duration</h2>
         <p className="preference-desc">
           Default daily time budgets used to filter or scale session durations.
+        </p>
+        <p className="preference-desc">
+          Related: {SCREEN_LABELS.constraints} → “Time and location” sets hard session caps
+          that are never exceeded; these defaults only shape durations. Remember to save here
+          with Save Preferences; time-cap changes there save immediately.
+          {onNavigate && (
+            <button type="button" onClick={() => onNavigate('constraints')}>
+              Open {SCREEN_LABELS.constraints}
+            </button>
+          )}
         </p>
         <div className="time-inputs">
           <div className="time-input-group">

--- a/app/src/components/preferences/index.tsx
+++ b/app/src/components/preferences/index.tsx
@@ -17,7 +17,7 @@ interface PreferencesProps {
   onNavigate?: (screen: Screen) => void;
 }
 
-export function Preferences({ userId }: PreferencesProps) {
+export function Preferences({ userId, onNavigate }: PreferencesProps) {
   const {
     preferences,
     trainingIntentProfile,
@@ -98,6 +98,7 @@ export function Preferences({ userId }: PreferencesProps) {
 
         <ModalitySections
           preferences={preferences}
+          onNavigate={onNavigate}
           addPreferredModality={addPreferredModality}
           removePreferredModality={removePreferredModality}
           addAvoidedModality={addAvoidedModality}
@@ -108,6 +109,7 @@ export function Preferences({ userId }: PreferencesProps) {
 
         <StyleSections
           preferences={preferences}
+          onNavigate={onNavigate}
           updatePreference={updatePreference}
           updateNestedPreference={updateNestedPreference}
         />

--- a/app/src/components/session/SessionCompletionSheet.test.tsx
+++ b/app/src/components/session/SessionCompletionSheet.test.tsx
@@ -164,4 +164,44 @@ describe('SessionCompletionSheet', () => {
         expect(html).toContain('Yes, Abandon Session');
         expect(html).toContain('Partial sets you have logged (2 sets) are permanently retained');
     });
+
+    it('renders Save as template inside the completion dialog when the action is available (#495)', () => {
+        const html = renderToStaticMarkup(
+            <SessionCompletionSheet
+                startedAt={new Date().toISOString()}
+                totalSets={2}
+                steps={[]}
+                onComplete={vi.fn()}
+                onAbandon={vi.fn()}
+                onCancel={vi.fn()}
+                onSaveTemplate={vi.fn()}
+                saving={false}
+            />,
+        );
+
+        expect(html).toContain('role="dialog"');
+        expect(html).toContain('aria-modal="true"');
+        expect(html).toContain('data-testid="completion-save-template-button"');
+        expect(html).toContain('Save as template');
+    });
+
+    it('hides Save as template from the abandon confirmation (#495)', () => {
+        const html = renderToStaticMarkup(
+            <SessionCompletionSheet
+                startedAt={new Date().toISOString()}
+                totalSets={2}
+                steps={[]}
+                onComplete={vi.fn()}
+                onAbandon={vi.fn()}
+                onCancel={vi.fn()}
+                onSaveTemplate={vi.fn()}
+                saving={false}
+                openAbandonConfirmation={true}
+            />,
+        );
+
+        expect(html).toContain('Abandon Session?');
+        expect(html).not.toContain('completion-save-template-button');
+        expect(html).not.toContain('Save as template');
+    });
 });

--- a/app/src/components/session/SessionCompletionSheet.test.tsx
+++ b/app/src/components/session/SessionCompletionSheet.test.tsx
@@ -185,6 +185,26 @@ describe('SessionCompletionSheet', () => {
         expect(html).toContain('Save as template');
     });
 
+    it('stays mounted but is hidden from the accessibility tree during template-title handoff (#495)', () => {
+        const html = renderToStaticMarkup(
+            <SessionCompletionSheet
+                startedAt={new Date().toISOString()}
+                totalSets={2}
+                steps={[]}
+                onComplete={vi.fn()}
+                onAbandon={vi.fn()}
+                onCancel={vi.fn()}
+                onSaveTemplate={vi.fn()}
+                saving={false}
+                hidden={true}
+            />,
+        );
+
+        expect(html).toContain('hidden=""');
+        expect(html).not.toContain('aria-modal="true"');
+        expect(html).toContain('Session Notes (Optional)');
+    });
+
     it('hides Save as template from the abandon confirmation (#495)', () => {
         const html = renderToStaticMarkup(
             <SessionCompletionSheet

--- a/app/src/components/session/SessionCompletionSheet.tsx
+++ b/app/src/components/session/SessionCompletionSheet.tsx
@@ -42,6 +42,8 @@ interface SessionCompletionSheetProps {
     /** Optional secondary authoring action. Kept inside the completion dialog so it is not
      * a peer of in-session controls and is unavailable from the abandon confirmation. */
     onSaveTemplate?: () => void;
+    /** Keep the completion form mounted while another modal owns focus so draft feedback survives. */
+    hidden?: boolean;
     saving: boolean;
     openAbandonConfirmation?: boolean;
     error?: string | null;
@@ -55,6 +57,7 @@ export const SessionCompletionSheet: React.FC<SessionCompletionSheetProps> = ({
     onAbandon,
     onCancel,
     onSaveTemplate,
+    hidden = false,
     saving,
     openAbandonConfirmation = false,
     error = null,
@@ -96,7 +99,13 @@ export const SessionCompletionSheet: React.FC<SessionCompletionSheetProps> = ({
     };
 
     return (
-        <div className="session-completion-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="completion-title">
+        <div
+            className="session-completion-modal-overlay"
+            role="dialog"
+            aria-modal={hidden ? undefined : true}
+            aria-labelledby="completion-title"
+            hidden={hidden}
+        >
             <div className="session-completion-sheet">
                 {error && <p className="session-runner-error" role="alert">{error}</p>}
                 {showAbandonConfirm ? (

--- a/app/src/components/session/SessionCompletionSheet.tsx
+++ b/app/src/components/session/SessionCompletionSheet.tsx
@@ -39,6 +39,9 @@ interface SessionCompletionSheetProps {
     onComplete: (payload: SessionCompletionPayload) => Promise<void>;
     onAbandon: () => Promise<void>;
     onCancel: () => void;
+    /** Optional secondary authoring action. Kept inside the completion dialog so it is not
+     * a peer of in-session controls and is unavailable from the abandon confirmation. */
+    onSaveTemplate?: () => void;
     saving: boolean;
     openAbandonConfirmation?: boolean;
     error?: string | null;
@@ -51,6 +54,7 @@ export const SessionCompletionSheet: React.FC<SessionCompletionSheetProps> = ({
     onComplete,
     onAbandon,
     onCancel,
+    onSaveTemplate,
     saving,
     openAbandonConfirmation = false,
     error = null,
@@ -290,6 +294,21 @@ export const SessionCompletionSheet: React.FC<SessionCompletionSheetProps> = ({
                                 Keep Training
                             </button>
                         </div>
+
+                        {onSaveTemplate && (
+                            <div className="sheet-actions">
+                                <button
+                                    type="button"
+                                    className="btn-secondary"
+                                    onClick={onSaveTemplate}
+                                    disabled={saving}
+                                    title="Save adjusted workout as a new template"
+                                    data-testid="completion-save-template-button"
+                                >
+                                    💾 Save as template
+                                </button>
+                            </div>
+                        )}
 
                         <div className="danger-zone-divider">
                             <button

--- a/app/src/components/session/SessionRunner.test.tsx
+++ b/app/src/components/session/SessionRunner.test.tsx
@@ -5,11 +5,12 @@ import {
     resolveRepetitionWeightSuggestion,
     resolveRestPreviewStep,
 } from './SessionRunner';
+import { useSessionRunner } from '../../hooks/useSessionRunner';
 import { formatSessionLoad } from '../../sessions/loadDisplay';
 import type { SessionDefinition, SessionEntry, SessionStep } from '../../sessions/models';
 
 vi.mock('../../hooks/useSessionRunner', () => ({
-    useSessionRunner: () => ({
+    useSessionRunner: vi.fn(() => ({
         activeStep: null,
         activeBlock: null,
         activeBlockIndex: 0,
@@ -18,7 +19,7 @@ vi.mock('../../hooks/useSessionRunner', () => ({
         entries: [],
         execution: null,
         isRestoring: false,
-    }),
+    })),
 }));
 
 vi.mock('../../hooks/useOverloadHistory', () => ({
@@ -65,12 +66,41 @@ const definitionWithBlock = (
 });
 
 describe('SessionRunner session picker', () => {
-    it('offers a preview before starting every reviewed session', () => {
+    it('collapses creation to one New session entry instead of parallel actions (#495)', () => {
         const html = renderToStaticMarkup(<SessionRunner userId="user-1" />);
 
         expect(html).toContain('Start a Structured Session');
-        expect(html).toContain('Preview');
-        expect(html).toContain('Start Session →');
+        expect(html).toContain('New session');
+        // Fixture/template libraries stay behind the chooser, not top-level.
+        expect(html).not.toContain('Start Session →');
+        expect(html).not.toContain('Import session JSON');
+        expect(html).not.toContain('Build session');
+    });
+
+    it('keeps save-as-template out of the active-run top bar (#495)', () => {
+        const step = repetitionStep('squat', 3);
+        const definition = definitionWithBlock('sequential', [step]);
+        vi.mocked(useSessionRunner).mockReturnValueOnce({
+            activeStep: step,
+            activeBlock: definition.blocks[0],
+            activeBlockIndex: 0,
+            activeStepIndex: 0,
+            definition,
+            entries: [],
+            execution: { state: 'in_progress' },
+            isRestoring: false,
+            elapsedSeconds: 0,
+            isRestRunning: false,
+            syncStatus: 'synced',
+            canUndo: false,
+            sessionEnded: false,
+            ineligibleOptionIds: new Set<string>(),
+        } as unknown as ReturnType<typeof useSessionRunner>);
+        const html = renderToStaticMarkup(<SessionRunner userId="user-1" />);
+
+        expect(html).toContain('⏱️');
+        expect(html).not.toContain('Save Template');
+        expect(html).not.toContain('save-template-header-btn');
     });
 });
 

--- a/app/src/components/session/SessionRunner.test.tsx
+++ b/app/src/components/session/SessionRunner.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
 import {
     SessionRunner,
+    resolveEmptyTemplateGuidance,
     resolveRepetitionWeightSuggestion,
     resolveRestPreviewStep,
 } from './SessionRunner';
@@ -75,6 +76,21 @@ describe('SessionRunner session picker', () => {
         expect(html).not.toContain('Start Session →');
         expect(html).not.toContain('Import session JSON');
         expect(html).not.toContain('Build session');
+    });
+
+    it('describes only the authoring actions that the current caller actually exposes', () => {
+        expect(resolveEmptyTemplateGuidance(true, true)).toBe(
+            'No saved templates yet — start from a reviewed fixture, import JSON, or build one manually.',
+        );
+        expect(resolveEmptyTemplateGuidance(true, false)).toBe(
+            'No saved templates yet — start from a reviewed fixture or import JSON.',
+        );
+        expect(resolveEmptyTemplateGuidance(false, true)).toBe(
+            'No saved templates yet — start from a reviewed fixture or build one manually.',
+        );
+        expect(resolveEmptyTemplateGuidance(false, false)).toBe(
+            'No saved templates yet — start from a reviewed fixture, or import or build one from the Sessions screen.',
+        );
     });
 
     it('keeps save-as-template out of the active-run top bar (#495)', () => {

--- a/app/src/components/session/SessionRunner.tsx
+++ b/app/src/components/session/SessionRunner.tsx
@@ -133,6 +133,19 @@ export function resolveRestPreviewStep(
     return nextBlock?.steps[0] ?? null;
 }
 
+export function resolveEmptyTemplateGuidance(canImportSession: boolean, canBuildSession: boolean): string {
+    if (canImportSession && canBuildSession) {
+        return 'No saved templates yet — start from a reviewed fixture, import JSON, or build one manually.';
+    }
+    if (canImportSession) {
+        return 'No saved templates yet — start from a reviewed fixture or import JSON.';
+    }
+    if (canBuildSession) {
+        return 'No saved templates yet — start from a reviewed fixture or build one manually.';
+    }
+    return 'No saved templates yet — start from a reviewed fixture, or import or build one from the Sessions screen.';
+}
+
 interface SessionRunnerProps {
     userId: string;
     /** A persisted M3 binding plus the exact snapshot-resolved definition to execute. */
@@ -677,8 +690,7 @@ export const SessionRunner: React.FC<SessionRunnerProps> = ({
                 {savedDefinitionsError && <p className="session-runner-error" role="alert">{savedDefinitionsError}</p>}
                 {creationSource === 'template' && activeSavedDefinitions.length === 0 && archivedSavedDefinitions.length === 0 && !savedDefinitionsError && (
                     <p className="session-runner-subtitle">
-                        No saved templates yet — start from a reviewed fixture, or
-                        {(onImportSession || onBuildSession) ? ' import JSON or build one manually.' : ' import or build one from the Sessions screen.'}
+                        {resolveEmptyTemplateGuidance(Boolean(onImportSession), Boolean(onBuildSession))}
                     </p>
                 )}
                 {creationSource === 'template' && activeSavedDefinitions.length > 0 && <section className="saved-session-library" aria-labelledby="saved-session-library-title">
@@ -810,7 +822,6 @@ export const SessionRunner: React.FC<SessionRunnerProps> = ({
             setSaveTemplateSuccess(`Saved as template "${title}"!`);
             setTimeout(() => {
                 setShowSaveTemplateModal(false);
-                setShowCompletionSheet(true);
                 setSaveTemplateSuccess(null);
             }, 1600);
         } catch (error) {
@@ -1145,9 +1156,9 @@ export const SessionRunner: React.FC<SessionRunnerProps> = ({
             </div>
 
             {/* Completion Sheet */}
-            {/* #495: save-as-template is a secondary action inside the modal completion flow,
-                instead of a peer active-run action. Opening the title editor temporarily hands
-                off from this dialog to the save dialog, avoiding simultaneous aria-modal layers. */}
+            {/* #495: save-as-template is a secondary action inside completion. The sheet stays
+                mounted but hidden while the title editor owns the modal layer, preserving any
+                sRPE, completion, fatigue, notes, or tissue feedback already entered. */}
             {showCompletionSheet && (
                 <SessionCompletionSheet
                     startedAt={runner.execution.startedAt}
@@ -1156,13 +1167,13 @@ export const SessionRunner: React.FC<SessionRunnerProps> = ({
                     saving={false}
                     openAbandonConfirmation={showAbandonConfirmation}
                     error={completionError}
+                    hidden={showSaveTemplateModal}
                     onCancel={() => {
                         setShowCompletionSheet(false);
                         setShowAbandonConfirmation(false);
                         setCompletionError(null);
                     }}
                     onSaveTemplate={() => {
-                        setShowCompletionSheet(false);
                         setCustomTemplateTitle(definition.title);
                         setSaveTemplateError(null);
                         setSaveTemplateSuccess(null);
@@ -1202,7 +1213,6 @@ export const SessionRunner: React.FC<SessionRunnerProps> = ({
                                 className="close-btn"
                                 onClick={() => {
                                     setShowSaveTemplateModal(false);
-                                    setShowCompletionSheet(true);
                                 }}
                                 disabled={isSavingTemplate || Boolean(saveTemplateSuccess)}
                                 aria-label="Close"
@@ -1232,7 +1242,6 @@ export const SessionRunner: React.FC<SessionRunnerProps> = ({
                                 className="cancel-swap-btn"
                                 onClick={() => {
                                     setShowSaveTemplateModal(false);
-                                    setShowCompletionSheet(true);
                                 }}
                                 disabled={isSavingTemplate || Boolean(saveTemplateSuccess)}
                             >

--- a/app/src/components/session/SessionRunner.tsx
+++ b/app/src/components/session/SessionRunner.tsx
@@ -23,6 +23,7 @@ import { ChoiceCard } from './ChoiceCard';
 import { ExerciseSwapModal } from './ExerciseSwapModal';
 import { SessionDefinitionPreview } from './SessionDefinitionPreview';
 import { isSoundEnabled, setSoundEnabled } from '../../utils/audioFeedback';
+import { SCREEN_LABELS } from '../../types/navigation';
 import './SessionRunner.css';
 
 // Import positive fixtures for quick unplanned session launch
@@ -172,6 +173,13 @@ export const SessionRunner: React.FC<SessionRunnerProps> = ({
     const [editingSavedDefinitionId, setEditingSavedDefinitionId] = useState<string | null>(null);
     const [updatingSavedDefinitionId, setUpdatingSavedDefinitionId] = useState<string | null>(null);
     const [showArchivedDefinitions, setShowArchivedDefinitions] = useState(false);
+    // #495: session creation collapses to one "New session" entry. The chooser keeps all
+    // four sources reachable (saved template, reviewed fixture, JSON import, manual build)
+    // without presenting four parallel top-level actions. Import/build delegate to the
+    // injected App-level authoring modes; template/fixture branches render inline below.
+    type SessionCreationSource = 'template' | 'fixture';
+    const [showCreationChooser, setShowCreationChooser] = useState(false);
+    const [creationSource, setCreationSource] = useState<SessionCreationSource | null>(null);
     // M4.3: a companion is a separately executable session referenced from the one that just
     // finished (SessionDefinition.companionSessions), never an embedded block -- those already
     // render inline within the same execution. Starting one creates its own execution; it may
@@ -627,7 +635,7 @@ export const SessionRunner: React.FC<SessionRunnerProps> = ({
                 {previewDefinition ? (
                     <section className="session-definition-preview-screen" aria-labelledby="session-definition-preview-title">
                         <button type="button" className="preview-back-button" onClick={() => setPreviewDefinition(null)}>
-                            ← All structured sessions
+                            ← All {SCREEN_LABELS.sessions}
                         </button>
                         <h2 id="session-definition-preview-title" className="sr-only">Session preview</h2>
                         <SessionDefinitionPreview
@@ -645,13 +653,35 @@ export const SessionRunner: React.FC<SessionRunnerProps> = ({
                 <header className="session-runner-header">
                     <h2>🚀 Start a Structured Session</h2>
                     <p className="session-runner-subtitle">Start a reviewed session, or make one that is stored and validated before execution.</p>
-                    {(onImportSession || onBuildSession) && <div className="session-authoring-actions">
-                        {onImportSession && <button type="button" className="start-fixture-btn" onClick={onImportSession}>Import session JSON</button>}
-                        {onBuildSession && <button type="button" className="start-fixture-btn secondary-authoring-btn" onClick={() => onBuildSession()}>Build session</button>}
-                    </div>}
+                    {creationSource === null ? (
+                        showCreationChooser ? (
+                            <div className="session-authoring-actions" role="group" aria-label="New session source">
+                                <button type="button" className="start-fixture-btn" onClick={() => setCreationSource('template')}>From template</button>
+                                <button type="button" className="start-fixture-btn secondary-authoring-btn" onClick={() => setCreationSource('fixture')}>From fixture</button>
+                                {onImportSession && <button type="button" className="start-fixture-btn" onClick={onImportSession}>Import JSON</button>}
+                                {onBuildSession && <button type="button" className="start-fixture-btn secondary-authoring-btn" onClick={() => onBuildSession()}>Build manually</button>}
+                            </div>
+                        ) : (
+                            <div className="session-authoring-actions">
+                                <button type="button" className="start-fixture-btn" onClick={() => setShowCreationChooser(true)}>＋ New session</button>
+                            </div>
+                        )
+                    ) : (
+                        <div className="session-authoring-actions">
+                            <button type="button" className="preview-back-button" onClick={() => { setCreationSource(null); setShowCreationChooser(true); }}>
+                                ← New session
+                            </button>
+                        </div>
+                    )}
                 </header>
                 {savedDefinitionsError && <p className="session-runner-error" role="alert">{savedDefinitionsError}</p>}
-                {activeSavedDefinitions.length > 0 && <section className="saved-session-library" aria-labelledby="saved-session-library-title">
+                {creationSource === 'template' && activeSavedDefinitions.length === 0 && archivedSavedDefinitions.length === 0 && !savedDefinitionsError && (
+                    <p className="session-runner-subtitle">
+                        No saved templates yet — start from a reviewed fixture, or
+                        {(onImportSession || onBuildSession) ? ' import JSON or build one manually.' : ' import or build one from the Sessions screen.'}
+                    </p>
+                )}
+                {creationSource === 'template' && activeSavedDefinitions.length > 0 && <section className="saved-session-library" aria-labelledby="saved-session-library-title">
                     <h3 id="saved-session-library-title">Your custom templates</h3>
                     <div className="fixture-grid">
                         {activeSavedDefinitions.map(header => <div key={header.definitionId} className="fixture-card">
@@ -685,7 +715,7 @@ export const SessionRunner: React.FC<SessionRunnerProps> = ({
                         </div>)}
                     </div>
                 </section>}
-                {archivedSavedDefinitions.length > 0 && <section className="saved-session-library" aria-labelledby="archived-session-library-title">
+                {creationSource === 'template' && archivedSavedDefinitions.length > 0 && <section className="saved-session-library" aria-labelledby="archived-session-library-title">
                     <button type="button" className="preview-back-button" onClick={() => setShowArchivedDefinitions(current => !current)}>
                         {showArchivedDefinitions ? 'Hide archived templates' : `Show archived templates (${archivedSavedDefinitions.length})`}
                     </button>
@@ -706,7 +736,7 @@ export const SessionRunner: React.FC<SessionRunnerProps> = ({
                         </div>)}
                     </div>}
                 </section>}
-                <div className="fixture-grid">
+                {creationSource === 'fixture' && <div className="fixture-grid">
                     {AVAILABLE_FIXTURES.map(fixture => (
                         <div key={fixture.id} className="fixture-card">
                             <div className="fixture-info">
@@ -728,7 +758,7 @@ export const SessionRunner: React.FC<SessionRunnerProps> = ({
                             </div>
                         </div>
                     ))}
-                </div>
+                </div>}
                 </>}
             </div>
         );
@@ -839,17 +869,6 @@ export const SessionRunner: React.FC<SessionRunnerProps> = ({
                         aria-label={soundMuted ? 'Unmute sound' : 'Mute sound'}
                     >
                         {soundMuted ? '🔇' : '🔊'}
-                    </button>
-                    <button
-                        type="button"
-                        className="save-template-header-btn"
-                        onClick={() => {
-                            setCustomTemplateTitle(definition.title);
-                            setShowSaveTemplateModal(true);
-                        }}
-                        title="Save adjusted workout as a new template"
-                    >
-                        💾 Save Template
                     </button>
                     <span className="session-timer">⏱️ {formatTime(runner.elapsedSeconds)}</span>
                     <span className={`sync-pill ${runner.syncStatus}`}>{runner.syncStatus}</span>
@@ -1125,7 +1144,25 @@ export const SessionRunner: React.FC<SessionRunnerProps> = ({
             </div>
 
             {/* Completion Sheet */}
+            {/* #495: save-as-template lives here, next to the finish/abandon decision,
+                instead of the active-run top bar -- reaching it requires opening the
+                completion flow, so it cannot fire accidentally mid-set. It still derives
+                from the raw working definition, so template semantics are unchanged. */}
             {showCompletionSheet && (
+                <>
+                    <div className="session-authoring-actions">
+                        <button
+                            type="button"
+                            className="preview-fixture-btn"
+                            onClick={() => {
+                                setCustomTemplateTitle(definition.title);
+                                setShowSaveTemplateModal(true);
+                            }}
+                            title="Save adjusted workout as a new template"
+                        >
+                            💾 Save as template
+                        </button>
+                    </div>
                 <SessionCompletionSheet
                     startedAt={runner.execution.startedAt}
                     totalSets={entries.length}
@@ -1147,6 +1184,7 @@ export const SessionRunner: React.FC<SessionRunnerProps> = ({
                         'Could not abandon the session. It remains open, so you can retry.',
                     )}
                 />
+                </>
             )}
 
             {/* Exercise Swap Modal */}

--- a/app/src/components/session/SessionRunner.tsx
+++ b/app/src/components/session/SessionRunner.tsx
@@ -810,6 +810,7 @@ export const SessionRunner: React.FC<SessionRunnerProps> = ({
             setSaveTemplateSuccess(`Saved as template "${title}"!`);
             setTimeout(() => {
                 setShowSaveTemplateModal(false);
+                setShowCompletionSheet(true);
                 setSaveTemplateSuccess(null);
             }, 1600);
         } catch (error) {
@@ -1144,25 +1145,10 @@ export const SessionRunner: React.FC<SessionRunnerProps> = ({
             </div>
 
             {/* Completion Sheet */}
-            {/* #495: save-as-template lives here, next to the finish/abandon decision,
-                instead of the active-run top bar -- reaching it requires opening the
-                completion flow, so it cannot fire accidentally mid-set. It still derives
-                from the raw working definition, so template semantics are unchanged. */}
+            {/* #495: save-as-template is a secondary action inside the modal completion flow,
+                instead of a peer active-run action. Opening the title editor temporarily hands
+                off from this dialog to the save dialog, avoiding simultaneous aria-modal layers. */}
             {showCompletionSheet && (
-                <>
-                    <div className="session-authoring-actions">
-                        <button
-                            type="button"
-                            className="preview-fixture-btn"
-                            onClick={() => {
-                                setCustomTemplateTitle(definition.title);
-                                setShowSaveTemplateModal(true);
-                            }}
-                            title="Save adjusted workout as a new template"
-                        >
-                            💾 Save as template
-                        </button>
-                    </div>
                 <SessionCompletionSheet
                     startedAt={runner.execution.startedAt}
                     totalSets={entries.length}
@@ -1175,6 +1161,13 @@ export const SessionRunner: React.FC<SessionRunnerProps> = ({
                         setShowAbandonConfirmation(false);
                         setCompletionError(null);
                     }}
+                    onSaveTemplate={() => {
+                        setShowCompletionSheet(false);
+                        setCustomTemplateTitle(definition.title);
+                        setSaveTemplateError(null);
+                        setSaveTemplateSuccess(null);
+                        setShowSaveTemplateModal(true);
+                    }}
                     onComplete={payload => finishSession(
                         () => runner.completeSession(payload),
                         'Could not save completion feedback. Your session is still open, so you can retry.',
@@ -1184,7 +1177,6 @@ export const SessionRunner: React.FC<SessionRunnerProps> = ({
                         'Could not abandon the session. It remains open, so you can retry.',
                     )}
                 />
-                </>
             )}
 
             {/* Exercise Swap Modal */}
@@ -1205,7 +1197,18 @@ export const SessionRunner: React.FC<SessionRunnerProps> = ({
                     <div className="exercise-swap-modal save-template-modal">
                         <div className="swap-modal-header">
                             <h3 id="save-template-modal-title">Save as Custom Template</h3>
-                            <button type="button" className="close-btn" onClick={() => setShowSaveTemplateModal(false)} aria-label="Close">✕</button>
+                            <button
+                                type="button"
+                                className="close-btn"
+                                onClick={() => {
+                                    setShowSaveTemplateModal(false);
+                                    setShowCompletionSheet(true);
+                                }}
+                                disabled={isSavingTemplate || Boolean(saveTemplateSuccess)}
+                                aria-label="Close"
+                            >
+                                ✕
+                            </button>
                         </div>
                         <p className="swap-subtitle">
                             Save your adjusted workout (including any swapped exercises) so you can start it again anytime.
@@ -1224,16 +1227,24 @@ export const SessionRunner: React.FC<SessionRunnerProps> = ({
                             />
                         </label>
                         <div className="swap-modal-actions">
-                            <button type="button" className="cancel-swap-btn" onClick={() => setShowSaveTemplateModal(false)}>
+                            <button
+                                type="button"
+                                className="cancel-swap-btn"
+                                onClick={() => {
+                                    setShowSaveTemplateModal(false);
+                                    setShowCompletionSheet(true);
+                                }}
+                                disabled={isSavingTemplate || Boolean(saveTemplateSuccess)}
+                            >
                                 Cancel
                             </button>
                             <button
                                 type="button"
                                 className="confirm-swap-btn"
-                                disabled={isSavingTemplate || !customTemplateTitle.trim()}
+                                disabled={isSavingTemplate || !customTemplateTitle.trim() || Boolean(saveTemplateSuccess)}
                                 onClick={handleSaveCustomTemplate}
                             >
-                                {isSavingTemplate ? 'Saving…' : 'Save Template'}
+                                {isSavingTemplate ? 'Saving…' : saveTemplateSuccess ? 'Saved' : 'Save Template'}
                             </button>
                         </div>
                     </div>

--- a/docs/architecture/session-execution.md
+++ b/docs/architecture/session-execution.md
@@ -1,47 +1,28 @@
-# Session execution and saved-template lifecycle
+# Session execution architecture
 
-This is the living reference for source-neutral session execution. Design rationale lives in
-[ADR-0023](../adr/0023-multidomain-session-authoring-execution-and-evidence.md); this document
-describes the current application behavior.
+This document describes the persisted structured-session execution model and its key UI/service contracts.
 
-## Content and persistence boundary
+## Stored definitions and executions
 
-`SessionDefinition` is executable content only. A custom definition revision is stored at
-`users/{userId}/session_definitions/{definitionId}/revisions/{revision}` as a flat document
-whose envelope adds `userId`, `definitionId`, `contentHash`, and `createdAt`.
+A `SessionDefinition` is the reusable prescription. A `SessionExecution` is one performed or in-progress instance of that prescription. Executions carry the prescription hash and source provenance so an in-progress session can restore the exact snapshot that was launched rather than resolving a potentially newer template revision.
 
-`parseSessionDefinitionRevisionDocument` validates that envelope against the requested path,
-selects the closed `SESSION_DEFINITION_KEYS` content set, and then runs
-`validateSessionDefinition`. `SessionDefinitionService.getDefinitionRevision` recomputes the
-canonical `hashSessionDefinition` before returning the definition. Invalid identity, envelope,
-schema, or hash data returns `INVALID`; executable content is never silently repaired.
+An execution is user-scoped. Its performed evidence is stored as `SessionEntry` records tied to the execution and authored step IDs. Choice entries record athlete decisions separately from work entries, so branch selection remains auditable and does not silently mutate the authored prescription.
 
-This one verified service read is used by preview, starting a saved template, manual-source
-resolution, and active-session restoration. Existing correctly written revisions need no
-migration: their storage shape is decoded as an envelope rather than mistaken for domain
-content.
+## Launch authority
 
-## Catalog warm-ups and execution logging
+Structured sessions can come from reviewed fixtures, saved custom templates, imported JSON, manual authoring, or a recommendation/plan occurrence that already resolved a stored prescription. The runner does not grant recommendation-selection authority to an unplanned launch: template/fixture/manual/import launches use the unplanned session source contract, while recommendation/plan launches keep their bound occurrence and prescription hash.
 
-Catalog strength prescriptions begin with an explicit `warmup` block. The catalog adapter preserves
-that role, step dose/rest, and any bounded structured load into the content-addressed execution
-prescription. The runner shows the load instruction as stored; it does not derive a kilogram target
-from a percentage or profile during rendering.
+A stored execution whose exact prescription cannot be restored fails closed. The runner does not let the athlete start a second session over ambiguous in-progress state.
 
-For a repetition step, `SessionRunner` passes the active block role into `RepetitionInputCard`.
-Entries from a prescribed `warmup` block default to `isWarmup: true`; other blocks default to false.
-The athlete can correct the checkbox before logging, and the recorded value remains the historical
-fact used by downstream strength-volume and estimated-1RM exclusion filters. Stored execution
-prescriptions carry their blocks and display metadata, so a later catalog warm-up revision cannot
-rewrite an already-started or historical session.
+## Progression and performed evidence
 
-Repetition submission is single-flight at the input surface: while one set is being persisted, a
-second Enter/click is ignored and the log button is disabled. This prevents rapid duplicate submits
-from deriving the same ordinal `setIndex` from one rendered entry snapshot. Rest timing is deliberately
-separate from persistence timing: the countdown starts when the set is optimistically accepted into
-the execution UI, before the asynchronous write. A delayed write completion therefore cannot restart
-a timer that the athlete has already skipped or adjusted. The timer remains advisory and does not lock
-the set form.
+The runner treats the authored definition as the prescription and entries as performed evidence. Sequential multi-set work remains on the current step until its required entries are complete. Rotating groups use persisted group progress rather than authored list order alone. Choice points can alter effective execution flow, but the selected choice is itself recorded as evidence.
+
+The step-navigation and completion displays derive from the same target-entry rules used by group progression, preventing display logic from claiming a grouped step is complete while execution logic still expects more work.
+
+## Rest behavior
+
+Rest timers are advisory rather than locks. Logging controls remain available while rest counts down. The preview shown during rest resolves the next actually due work from persisted progress, so sequential multi-set work previews the current exercise until its sets are complete and rotating groups preview the next group member.
 
 Rest omission is block-aware. Authored rest is always preserved. Outside warm-up blocks, a step with
 no authored rest retains the runner's legacy 60-second advisory fallback. Inside a structured warm-up,
@@ -55,8 +36,10 @@ write-once. `saveDefinitionRevision` validates and hashes the definition, then b
 new revision and latest-revision header atomically.
 
 * **Save** creates a new definition at revision 1 and refreshes the session picker.
-  Save is offered from the completion flow rather than the active-run top bar, so it cannot
-  fire accidentally mid-set; it still derives from the raw working definition.
+  Save is a secondary action inside the completion dialog rather than the active-run top bar,
+  so it cannot fire accidentally mid-set. Opening its title editor hands off from the completion
+  dialog rather than stacking modal layers, then returns to completion after save/cancel. The
+  saved template still derives from the raw working definition.
 * **Edit** loads the verified latest revision and saves the same definition ID at revision N+1.
 * **Duplicate** loads the verified latest revision, assigns a new definition ID, and saves
   revision 1.
@@ -73,11 +56,3 @@ The runner retains a raw working definition and may expose a choice-resolved eff
 definition for the current execution. Saving a custom template derives from the raw working
 definition: deliberate exercise substitutions are retained, but a one-time selected choice is
 not baked into the template while leaving the same option set available for a later execution.
-
-## Rules and tests
-
-Firestore rules enforce user ownership, immutable revision creation, valid header lifecycle,
-and the full allowed definition field set including `companionSessions`. The parser and service
-tests cover writer-shaped documents, strict envelope validation, hash mismatch, batched writes,
-and archive/restore. Visual coverage exercises custom-template preview and the archived library
-at desktop and 390px mobile widths.

--- a/docs/architecture/session-execution.md
+++ b/docs/architecture/session-execution.md
@@ -55,6 +55,8 @@ write-once. `saveDefinitionRevision` validates and hashes the definition, then b
 new revision and latest-revision header atomically.
 
 * **Save** creates a new definition at revision 1 and refreshes the session picker.
+  Save is offered from the completion flow rather than the active-run top bar, so it cannot
+  fire accidentally mid-set; it still derives from the raw working definition.
 * **Edit** loads the verified latest revision and saves the same definition ID at revision N+1.
 * **Duplicate** loads the verified latest revision, assigns a new definition ID, and saves
   revision 1.

--- a/docs/architecture/session-execution.md
+++ b/docs/architecture/session-execution.md
@@ -1,28 +1,47 @@
-# Session execution architecture
+# Session execution and saved-template lifecycle
 
-This document describes the persisted structured-session execution model and its key UI/service contracts.
+This is the living reference for source-neutral session execution. Design rationale lives in
+[ADR-0023](../adr/0023-multidomain-session-authoring-execution-and-evidence.md); this document
+describes the current application behavior.
 
-## Stored definitions and executions
+## Content and persistence boundary
 
-A `SessionDefinition` is the reusable prescription. A `SessionExecution` is one performed or in-progress instance of that prescription. Executions carry the prescription hash and source provenance so an in-progress session can restore the exact snapshot that was launched rather than resolving a potentially newer template revision.
+`SessionDefinition` is executable content only. A custom definition revision is stored at
+`users/{userId}/session_definitions/{definitionId}/revisions/{revision}` as a flat document
+whose envelope adds `userId`, `definitionId`, `contentHash`, and `createdAt`.
 
-An execution is user-scoped. Its performed evidence is stored as `SessionEntry` records tied to the execution and authored step IDs. Choice entries record athlete decisions separately from work entries, so branch selection remains auditable and does not silently mutate the authored prescription.
+`parseSessionDefinitionRevisionDocument` validates that envelope against the requested path,
+selects the closed `SESSION_DEFINITION_KEYS` content set, and then runs
+`validateSessionDefinition`. `SessionDefinitionService.getDefinitionRevision` recomputes the
+canonical `hashSessionDefinition` before returning the definition. Invalid identity, envelope,
+schema, or hash data returns `INVALID`; executable content is never silently repaired.
 
-## Launch authority
+This one verified service read is used by preview, starting a saved template, manual-source
+resolution, and active-session restoration. Existing correctly written revisions need no
+migration: their storage shape is decoded as an envelope rather than mistaken for domain
+content.
 
-Structured sessions can come from reviewed fixtures, saved custom templates, imported JSON, manual authoring, or a recommendation/plan occurrence that already resolved a stored prescription. The runner does not grant recommendation-selection authority to an unplanned launch: template/fixture/manual/import launches use the unplanned session source contract, while recommendation/plan launches keep their bound occurrence and prescription hash.
+## Catalog warm-ups and execution logging
 
-A stored execution whose exact prescription cannot be restored fails closed. The runner does not let the athlete start a second session over ambiguous in-progress state.
+Catalog strength prescriptions begin with an explicit `warmup` block. The catalog adapter preserves
+that role, step dose/rest, and any bounded structured load into the content-addressed execution
+prescription. The runner shows the load instruction as stored; it does not derive a kilogram target
+from a percentage or profile during rendering.
 
-## Progression and performed evidence
+For a repetition step, `SessionRunner` passes the active block role into `RepetitionInputCard`.
+Entries from a prescribed `warmup` block default to `isWarmup: true`; other blocks default to false.
+The athlete can correct the checkbox before logging, and the recorded value remains the historical
+fact used by downstream strength-volume and estimated-1RM exclusion filters. Stored execution
+prescriptions carry their blocks and display metadata, so a later catalog warm-up revision cannot
+rewrite an already-started or historical session.
 
-The runner treats the authored definition as the prescription and entries as performed evidence. Sequential multi-set work remains on the current step until its required entries are complete. Rotating groups use persisted group progress rather than authored list order alone. Choice points can alter effective execution flow, but the selected choice is itself recorded as evidence.
-
-The step-navigation and completion displays derive from the same target-entry rules used by group progression, preventing display logic from claiming a grouped step is complete while execution logic still expects more work.
-
-## Rest behavior
-
-Rest timers are advisory rather than locks. Logging controls remain available while rest counts down. The preview shown during rest resolves the next actually due work from persisted progress, so sequential multi-set work previews the current exercise until its sets are complete and rotating groups preview the next group member.
+Repetition submission is single-flight at the input surface: while one set is being persisted, a
+second Enter/click is ignored and the log button is disabled. This prevents rapid duplicate submits
+from deriving the same ordinal `setIndex` from one rendered entry snapshot. Rest timing is deliberately
+separate from persistence timing: the countdown starts when the set is optimistically accepted into
+the execution UI, before the asynchronous write. A delayed write completion therefore cannot restart
+a timer that the athlete has already skipped or adjusted. The timer remains advisory and does not lock
+the set form.
 
 Rest omission is block-aware. Authored rest is always preserved. Outside warm-up blocks, a step with
 no authored rest retains the runner's legacy 60-second advisory fallback. Inside a structured warm-up,
@@ -56,3 +75,11 @@ The runner retains a raw working definition and may expose a choice-resolved eff
 definition for the current execution. Saving a custom template derives from the raw working
 definition: deliberate exercise substitutions are retained, but a one-time selected choice is
 not baked into the template while leaving the same option set available for a later execution.
+
+## Rules and tests
+
+Firestore rules enforce user ownership, immutable revision creation, valid header lifecycle,
+and the full allowed definition field set including `companionSessions`. The parser and service
+tests cover writer-shaped documents, strict envelope validation, hash mismatch, batched writes,
+and archive/restore. Visual coverage exercises custom-template preview and the archived library
+at desktop and 390px mobile widths.

--- a/docs/architecture/session-execution.md
+++ b/docs/architecture/session-execution.md
@@ -56,9 +56,10 @@ new revision and latest-revision header atomically.
 
 * **Save** creates a new definition at revision 1 and refreshes the session picker.
   Save is a secondary action inside the completion dialog rather than the active-run top bar,
-  so it cannot fire accidentally mid-set. Opening its title editor hands off from the completion
-  dialog rather than stacking modal layers, then returns to completion after save/cancel. The
-  saved template still derives from the raw working definition.
+  so it cannot fire accidentally mid-set. Opening its title editor keeps the completion dialog
+  mounted but hidden/inaccessible while the title editor owns the modal layer; existing sRPE,
+  completion fraction, unexpected-fatigue, notes, and tissue-feedback draft values therefore
+  survive save or cancel. The saved template still derives from the raw working definition.
 * **Edit** loads the verified latest revision and saves the same definition ID at revision N+1.
 * **Duplicate** loads the verified latest revision, assigns a new definition ID, and saves
   revision 1.

--- a/docs/architecture/user-flows.md
+++ b/docs/architecture/user-flows.md
@@ -295,7 +295,10 @@ The two routes intentionally have different authority:
 
 The distinction is architecturally important, but some concepts overlap in the UI:
 equipment versus unavailable modalities, hard time limits versus preferred/default times,
-and persistent environment setup versus today's `indoorOnly` availability.
+and persistent environment setup versus today's `indoorOnly` availability. Each overlapping
+section now names its counterpart inline (`TrainingSettings` equipment, time/location, and
+guardrail notes point at `Preferences`; `ModalitySections` unavailable/avoided notes and the
+`StyleSections` default-duration note point back), and both headers state their save model.
 
 ### 9. Data and AI export
 
@@ -400,8 +403,11 @@ living-reference section when implementing them.
 
 ### Settings
 
-7. Visually pair Training Setup (hard gates) and Coach Preferences (soft preferences), with
-   cross-links between overlapping equipment/time/environment concepts.
+7. ~~Visually pair Training Setup (hard gates) and Coach Preferences (soft preferences), with
+   cross-links between overlapping equipment/time/environment concepts.~~
+   Done (#489): each overlapping control names its counterpart inline from either side, and
+   both headers state their save semantics (immediate autosave on Training Setup, explicit
+   Save on Coach Preferences). Engine authority unchanged. Full tab-merge deferred.
 8. ~~Either remove `Goals.onNavigate` or use it for explicit repair/deep-link flows; an unused
    navigation prop is misleading API surface.~~
    Done (#484): removed the unused `Goals` `onNavigate` prop — no repair flow needed it —

--- a/docs/architecture/user-flows.md
+++ b/docs/architecture/user-flows.md
@@ -270,8 +270,8 @@ periodization/taper calculations, and the screen derives the current focus event
 Two implementation details matter to navigation work:
 
 * paused goals appear only under `all`, because there is no dedicated paused filter; and
-* `GoalsProps` accepts `onNavigate`, but `Goals` currently destructures only `userId`, so the
-  navigation callback is unused.
+* `Goals` takes only `userId`; it owns no repair/deep-link navigation, and callers
+  reach it through `App.tsx` `handleNavigate`.
 
 ### 8. Training Setup versus Coach Preferences
 
@@ -386,8 +386,11 @@ living-reference section when implementing them.
 
 7. Visually pair Training Setup (hard gates) and Coach Preferences (soft preferences), with
    cross-links between overlapping equipment/time/environment concepts.
-8. Either remove `Goals.onNavigate` or use it for explicit repair/deep-link flows; an unused
-   navigation prop is misleading API surface.
+8. ~~Either remove `Goals.onNavigate` or use it for explicit repair/deep-link flows; an unused
+   navigation prop is misleading API surface.~~
+   Done (#484): removed the unused `Goals` `onNavigate` prop — no repair flow needed it —
+   and kept `constraints` as the stable route key with user-facing copy in `navigation.ts`
+   `SCREEN_LABELS` (`Training Setup`).
 9. Review immediate-persist Training Setup controls for undo/confirmation where a mistaken
    toggle can materially change feasibility/safety decisions.
 
@@ -398,7 +401,8 @@ living-reference section when implementing them.
 11. ~~Consolidate the structured-session creation entry points behind a clearer `New session`
     chooser while preserving the underlying import/manual/template contracts.~~ Done (#495):
     one `New session` entry with a From template / From fixture / Import JSON / Build manually
-    chooser; save-as-template moved from the active-run top bar to the completion flow.
+    chooser; save-as-template is a secondary action inside the completion dialog rather than
+    an active-run peer action.
 12. Make companion/follow-up executions explicit and clarify whether abandoning a testing
     attempt is intentionally destructive/terminal before confirmation.
 

--- a/docs/architecture/user-flows.md
+++ b/docs/architecture/user-flows.md
@@ -395,8 +395,10 @@ living-reference section when implementing them.
 
 10. Differentiate normal session execution and protocol testing more strongly around the
     shared runner, especially during execution and completion.
-11. Consolidate the structured-session creation entry points behind a clearer `New session`
-    chooser while preserving the underlying import/manual/template contracts.
+11. ~~Consolidate the structured-session creation entry points behind a clearer `New session`
+    chooser while preserving the underlying import/manual/template contracts.~~ Done (#495):
+    one `New session` entry with a From template / From fixture / Import JSON / Build manually
+    chooser; save-as-template moved from the active-run top bar to the completion flow.
 12. Make companion/follow-up executions explicit and clarify whether abandoning a testing
     attempt is intentionally destructive/terminal before confirmation.
 


### PR DESCRIPTION
## Summary
- Collapse session creation in `SessionRunner` into one `New session` entry with a chooser for **From template / From fixture / Import JSON / Build manually**; all available sources remain reachable with unchanged execution/persistence semantics.
- Move **Save as template** out of the active-run top bar into the completion flow so it cannot trigger mid-set.
- Preserve completion feedback across the template-title handoff by keeping `SessionCompletionSheet` mounted but hidden/inaccessible while the save modal owns focus.
- Make empty-template guidance callback-aware so import-only/build-only callers never advertise unavailable actions.
- Closes #495. Updates `docs/architecture/user-flows.md` Recommendation 11 and the saved-template lifecycle in `docs/architecture/session-execution.md`.

## Review follow-up
- Addressed all three CodeRabbit findings and replied/resolved each thread.
- Fixed the EOF newline failure in all three files reported by pre-commit, not only the reviewed test file.
- Added regression coverage for mounted-but-hidden completion handoff and all four import/build callback combinations.
- Integrated current `main` after #506; direct compare to `main` is `behind_by: 0` and the PR diff remains scoped to six session/tests/docs files.

## Validation
Fresh CI on final head `863d7af` / CI Pipeline #2872 is green:
- [x] Frontend type check, ESLint, knowledge/workout/policy gates, production build
- [x] Frontend unit tests with coverage + Firestore rules emulator suite
- [x] Engine simulations + deterministic AI/persona gates
- [x] Python dependency lock, repository hygiene/pre-commit, Ruff, mypy, pytest + coverage, dependency audit
- [x] Docker build + Compose full-stack smoke
- [x] Final CI Gate

No backend, Firestore schema/rules, or recommendation-decision behavior was changed by this PR; the full repository CI still validates those surfaces.

## Risk and reviewer guidance
- `creationSource` / `showCreationChooser` gate the inline template and fixture libraries; import/build options are rendered only when their callbacks exist.
- Completion feedback remains local to `SessionCompletionSheet`; the sheet is intentionally retained across Save-as-template handoff using native `hidden`, while `aria-modal` is removed from the hidden layer.
- The saved template still derives from the raw working definition, preserving deliberate swaps without baking one-time execution choices into reusable content.
- Preview back copy uses canonical `SCREEN_LABELS.sessions`.
- No migration or persisted-shape change. Rollback is the PR changes as a unit.

## Domain invariants
- Firestore writes remain user-scoped under `users/{APP_USER_ID}/...`; persistence code is unchanged.
- Calendar-date logic (`Europe/Warsaw`) and `totalSteps = D - 1` logic are untouched.
- `POLICY_VERSION` was evaluated and is unchanged because recommendation decision logic did not change.
- No credentials, tokens, service-account files, or raw health payloads are included.

## Screenshots or recordings
Not added. This is a placement/gating/modal-lifecycle change; automated markup/component coverage plus the full CI suite cover the changed contracts.