### PR TITLE
feat(onboarding): add wizard Skip with relaunch and telemetry (#490)

### DIFF
--- a/app/src/components/OnboardingWizard.test.tsx
+++ b/app/src/components/OnboardingWizard.test.tsx
@@ -12,6 +12,14 @@ describe('OnboardingWizard', () => {
     expect(html).toContain('Welcome to Adaptive Training');
     expect(html).toContain('Let&#x27;s Set Up Your Profile →');
   });
+
+  it('offers an explicit Skip path on the welcome step without starting setup', () => {
+    const html = renderToStaticMarkup(
+      <OnboardingWizard userId="athlete-1" onCompleted={() => {}} />
+    );
+
+    expect(html).toContain('Skip for now');
+  });
 });
 
 describe('ExerciseDaysSlider', () => {

--- a/app/src/components/OnboardingWizard.test.tsx
+++ b/app/src/components/OnboardingWizard.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { ExerciseDaysSlider, OnboardingWizard, skipOnboardingForNow } from './OnboardingWizard';
+import { ExerciseDaysSlider, OnboardingWizard } from './OnboardingWizard';
+import { skipOnboardingForNow } from './onboarding/skipOnboarding';
 import { weeklyCommitmentFromExerciseDays } from './onboarding/weeklyCommitment';
 import { goalService } from '../services/goalService';
 import { trainingSettingsService } from '../services/trainingSettingsService';

--- a/app/src/components/OnboardingWizard.test.tsx
+++ b/app/src/components/OnboardingWizard.test.tsx
@@ -1,9 +1,34 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { ExerciseDaysSlider, OnboardingWizard } from './OnboardingWizard';
+import { ExerciseDaysSlider, OnboardingWizard, skipOnboardingForNow } from './OnboardingWizard';
 import { weeklyCommitmentFromExerciseDays } from './onboarding/weeklyCommitment';
+import { goalService } from '../services/goalService';
+import { trainingSettingsService } from '../services/trainingSettingsService';
+import { trainingIntentProfileService } from '../services/trainingIntentProfileService';
+import { getOnboardingDoneStorageKey } from '../utils/onboardingStorage';
+import { usabilityMetrics } from '../utils/usabilityMetrics';
 
 describe('OnboardingWizard', () => {
+  const storage = new Map<string, string>();
+
+  beforeEach(() => {
+    storage.clear();
+    vi.stubGlobal('window', {
+      localStorage: {
+        getItem: (key: string) => storage.get(key) ?? null,
+        setItem: (key: string, value: string) => storage.set(key, String(value)),
+        removeItem: (key: string) => storage.delete(key),
+      },
+    });
+    usabilityMetrics.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    usabilityMetrics.clear();
+  });
+
   it('renders Step 1 welcome screen by default', () => {
     const html = renderToStaticMarkup(
       <OnboardingWizard userId="athlete-1" onCompleted={() => {}} />
@@ -19,6 +44,27 @@ describe('OnboardingWizard', () => {
     );
 
     expect(html).toContain('Skip for now');
+  });
+
+  it('dismisses and records Skip without writing settings, intent, or goals', () => {
+    const settingsWrite = vi.spyOn(trainingSettingsService, 'updateTrainingSettings');
+    const intentWrite = vi.spyOn(trainingIntentProfileService, 'upsert');
+    const goalList = vi.spyOn(goalService, 'listGoals');
+    const goalWrite = vi.spyOn(goalService, 'createGoal');
+    const onCompleted = vi.fn();
+
+    skipOnboardingForNow('athlete-1', 'focus', 1500, onCompleted);
+
+    expect(settingsWrite).not.toHaveBeenCalled();
+    expect(intentWrite).not.toHaveBeenCalled();
+    expect(goalList).not.toHaveBeenCalled();
+    expect(goalWrite).not.toHaveBeenCalled();
+    expect(storage.get(getOnboardingDoneStorageKey('athlete-1'))).toBe('true');
+    expect(onCompleted).toHaveBeenCalledTimes(1);
+
+    const report = usabilityMetrics.generateSummaryReport();
+    expect(report.wizardSkips).toBe(1);
+    expect(report.wizardSkipsByStage).toEqual({ focus: 1 });
   });
 });
 

--- a/app/src/components/OnboardingWizard.tsx
+++ b/app/src/components/OnboardingWizard.tsx
@@ -2,9 +2,9 @@ import { useState, memo } from 'react';
 import { goalService } from '../services/goalService';
 import { trainingSettingsService } from '../services/trainingSettingsService';
 import { trainingIntentProfileService } from '../services/trainingIntentProfileService';
-import { dismissOnboardingForUser } from '../utils/onboardingStorage';
 import { usabilityMetrics, type OnboardingWizardStage } from '../utils/usabilityMetrics';
 import { getLocalDateString } from '../utils/localDate';
+import { skipOnboardingForNow } from './onboarding/skipOnboarding';
 import { weeklyCommitmentFromExerciseDays } from './onboarding/weeklyCommitment';
 import './OnboardingWizard.css';
 
@@ -20,22 +20,6 @@ interface ExerciseDaysSliderProps {
     value: number;
     onChange: (days: number) => void;
     disabled?: boolean;
-}
-
-/**
- * Explicit dismissal action kept separate from the Firestore-writing completion path.
- * This narrow seam is intentionally testable so Skip cannot regress into a partial setup
- * write when onboarding evolves.
- */
-export function skipOnboardingForNow(
-    userId: string,
-    stage: OnboardingWizardStage,
-    elapsedMs: number | undefined,
-    onCompleted: () => void,
-): void {
-    dismissOnboardingForUser(userId);
-    usabilityMetrics.recordWizardCompleted(userId, getLocalDateString(), 'skipped', elapsedMs, stage);
-    onCompleted();
 }
 
 export function ExerciseDaysSlider({ value, onChange, disabled = false }: ExerciseDaysSliderProps) {

--- a/app/src/components/OnboardingWizard.tsx
+++ b/app/src/components/OnboardingWizard.tsx
@@ -2,6 +2,9 @@ import { useState, memo } from 'react';
 import { goalService } from '../services/goalService';
 import { trainingSettingsService } from '../services/trainingSettingsService';
 import { trainingIntentProfileService } from '../services/trainingIntentProfileService';
+import { dismissOnboardingForUser } from '../utils/onboardingStorage';
+import { usabilityMetrics } from '../utils/usabilityMetrics';
+import { getLocalDateString } from '../utils/localDate';
 import { weeklyCommitmentFromExerciseDays } from './onboarding/weeklyCommitment';
 import './OnboardingWizard.css';
 
@@ -62,6 +65,24 @@ export const OnboardingWizard = memo(function OnboardingWizard({ userId, onCompl
     const [sportAccess, setSportAccess] = useState({ outdoor_bike: false, swim_access: false });
     const [saving, setSaving] = useState(false);
     const [saveError, setSaveError] = useState<string | null>(null);
+    // Mount time anchors the wizard-completion telemetry, mirroring the
+    // first-view TTR clock in `usabilityMetrics`.
+    const [wizardStartMs] = useState(() => (typeof performance !== 'undefined' ? performance.now() : 0));
+
+    const wizardElapsedMs = () => {
+        if (typeof performance === 'undefined') return undefined;
+        return Math.round(performance.now() - wizardStartMs);
+    };
+
+    const handleSkip = () => {
+        if (saving) return;
+        // Skip persists dismissal only: no goal is created and training
+        // settings are left untouched. When browser storage is blocked the
+        // dismissal is session-only and the wizard may resurface on refresh.
+        dismissOnboardingForUser(userId);
+        usabilityMetrics.recordWizardCompleted(userId, getLocalDateString(), 'skipped', wizardElapsedMs());
+        onCompleted();
+    };
 
     const handleFinish = async () => {
         if (saving) return;
@@ -126,6 +147,7 @@ export const OnboardingWizard = memo(function OnboardingWizard({ userId, onCompl
                 });
             }
 
+            usabilityMetrics.recordWizardCompleted(userId, getLocalDateString(), 'completed', wizardElapsedMs());
             onCompleted();
         } catch (err) {
             console.error('Failed to complete rapid onboarding:', err);
@@ -148,6 +170,9 @@ export const OnboardingWizard = memo(function OnboardingWizard({ userId, onCompl
                         <div className="onboarding-action-row">
                             <button type="button" className="btn-primary btn-large" onClick={() => setStep(2)}>
                                 Let&apos;s Set Up Your Profile →
+                            </button>
+                            <button type="button" className="btn-secondary" onClick={handleSkip}>
+                                Skip for now
                             </button>
                         </div>
                     </div>
@@ -189,6 +214,7 @@ export const OnboardingWizard = memo(function OnboardingWizard({ userId, onCompl
                         <div className="onboarding-action-row">
                             <button type="button" className="btn-secondary" onClick={() => setStep(1)}>Back</button>
                             <button type="button" className="btn-primary" onClick={() => setStep(3)}>Next: Equipment & Days →</button>
+                            <button type="button" className="btn-secondary" onClick={handleSkip}>Skip for now</button>
                         </div>
                     </div>
                 )}
@@ -240,6 +266,7 @@ export const OnboardingWizard = memo(function OnboardingWizard({ userId, onCompl
                             <button type="button" className="btn-primary btn-large" onClick={() => void handleFinish()} disabled={saving}>
                                 {saving ? 'Building Your Plan...' : 'Generate Today’s Recommendation →'}
                             </button>
+                            <button type="button" className="btn-secondary" onClick={handleSkip} disabled={saving}>Skip for now</button>
                         </div>
                     </div>
                 )}

--- a/app/src/components/OnboardingWizard.tsx
+++ b/app/src/components/OnboardingWizard.tsx
@@ -22,6 +22,22 @@ interface ExerciseDaysSliderProps {
     disabled?: boolean;
 }
 
+/**
+ * Explicit dismissal action kept separate from the Firestore-writing completion path.
+ * This narrow seam is intentionally testable so Skip cannot regress into a partial setup
+ * write when onboarding evolves.
+ */
+export function skipOnboardingForNow(
+    userId: string,
+    stage: OnboardingWizardStage,
+    elapsedMs: number | undefined,
+    onCompleted: () => void,
+): void {
+    dismissOnboardingForUser(userId);
+    usabilityMetrics.recordWizardCompleted(userId, getLocalDateString(), 'skipped', elapsedMs, stage);
+    onCompleted();
+}
+
 export function ExerciseDaysSlider({ value, onChange, disabled = false }: ExerciseDaysSliderProps) {
     return (
         <div className="choice-group days-slider-group">
@@ -85,15 +101,7 @@ export const OnboardingWizard = memo(function OnboardingWizard({ userId, onCompl
         // Skip persists dismissal only: no goal is created and training
         // settings are left untouched. When browser storage is blocked the
         // dismissal is session-only and the wizard may resurface on refresh.
-        dismissOnboardingForUser(userId);
-        usabilityMetrics.recordWizardCompleted(
-            userId,
-            getLocalDateString(),
-            'skipped',
-            wizardElapsedMs(),
-            currentWizardStage,
-        );
-        onCompleted();
+        skipOnboardingForNow(userId, currentWizardStage, wizardElapsedMs(), onCompleted);
     };
 
     const handleFinish = async () => {

--- a/app/src/components/OnboardingWizard.tsx
+++ b/app/src/components/OnboardingWizard.tsx
@@ -3,7 +3,7 @@ import { goalService } from '../services/goalService';
 import { trainingSettingsService } from '../services/trainingSettingsService';
 import { trainingIntentProfileService } from '../services/trainingIntentProfileService';
 import { dismissOnboardingForUser } from '../utils/onboardingStorage';
-import { usabilityMetrics } from '../utils/usabilityMetrics';
+import { usabilityMetrics, type OnboardingWizardStage } from '../utils/usabilityMetrics';
 import { getLocalDateString } from '../utils/localDate';
 import { weeklyCommitmentFromExerciseDays } from './onboarding/weeklyCommitment';
 import './OnboardingWizard.css';
@@ -74,13 +74,25 @@ export const OnboardingWizard = memo(function OnboardingWizard({ userId, onCompl
         return Math.round(performance.now() - wizardStartMs);
     };
 
+    const currentWizardStage: OnboardingWizardStage = step === 1
+        ? 'welcome'
+        : step === 2
+            ? 'focus'
+            : 'equipment';
+
     const handleSkip = () => {
         if (saving) return;
         // Skip persists dismissal only: no goal is created and training
         // settings are left untouched. When browser storage is blocked the
         // dismissal is session-only and the wizard may resurface on refresh.
         dismissOnboardingForUser(userId);
-        usabilityMetrics.recordWizardCompleted(userId, getLocalDateString(), 'skipped', wizardElapsedMs());
+        usabilityMetrics.recordWizardCompleted(
+            userId,
+            getLocalDateString(),
+            'skipped',
+            wizardElapsedMs(),
+            currentWizardStage,
+        );
         onCompleted();
     };
 
@@ -147,7 +159,13 @@ export const OnboardingWizard = memo(function OnboardingWizard({ userId, onCompl
                 });
             }
 
-            usabilityMetrics.recordWizardCompleted(userId, getLocalDateString(), 'completed', wizardElapsedMs());
+            usabilityMetrics.recordWizardCompleted(
+                userId,
+                getLocalDateString(),
+                'completed',
+                wizardElapsedMs(),
+                'equipment',
+            );
             onCompleted();
         } catch (err) {
             console.error('Failed to complete rapid onboarding:', err);

--- a/app/src/components/onboarding/skipOnboarding.ts
+++ b/app/src/components/onboarding/skipOnboarding.ts
@@ -1,0 +1,19 @@
+import { dismissOnboardingForUser } from '../../utils/onboardingStorage';
+import { getLocalDateString } from '../../utils/localDate';
+import { usabilityMetrics, type OnboardingWizardStage } from '../../utils/usabilityMetrics';
+
+/**
+ * Explicit dismissal action kept separate from the Firestore-writing completion path.
+ * This narrow seam is intentionally testable so Skip cannot regress into a partial setup
+ * write when onboarding evolves.
+ */
+export function skipOnboardingForNow(
+  userId: string,
+  stage: OnboardingWizardStage,
+  elapsedMs: number | undefined,
+  onCompleted: () => void,
+): void {
+  dismissOnboardingForUser(userId);
+  usabilityMetrics.recordWizardCompleted(userId, getLocalDateString(), 'skipped', elapsedMs, stage);
+  onCompleted();
+}

--- a/app/src/components/preferences/OnboardingRelaunchSection.test.tsx
+++ b/app/src/components/preferences/OnboardingRelaunchSection.test.tsx
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { OnboardingRelaunchSection } from './OnboardingRelaunchSection';
+
+// Markup-level smoke test, matching the sibling-section convention: the relaunch
+// affordance must be discoverable on the Preferences surface for skipped users.
+describe('OnboardingRelaunchSection', () => {
+  it('renders the re-run entry with goal-less gating copy', () => {
+    const html = renderToStaticMarkup(
+      <OnboardingRelaunchSection userId="u1" />,
+    );
+
+    expect(html).toContain('Re-run setup wizard');
+    expect(html).toContain('no active goal');
+  });
+});

--- a/app/src/components/preferences/OnboardingRelaunchSection.test.tsx
+++ b/app/src/components/preferences/OnboardingRelaunchSection.test.tsx
@@ -2,8 +2,8 @@ import { describe, expect, it } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { OnboardingRelaunchSection } from './OnboardingRelaunchSection';
 
-// Markup-level smoke test, matching the sibling-section convention: the relaunch
-// affordance must be discoverable on the Preferences surface for skipped users.
+// Markup-level smoke tests, matching the sibling-section convention: the relaunch
+// affordance must be discoverable without allowing a reload to discard pending edits.
 describe('OnboardingRelaunchSection', () => {
   it('renders the re-run entry with goal-less gating copy', () => {
     const html = renderToStaticMarkup(
@@ -12,5 +12,15 @@ describe('OnboardingRelaunchSection', () => {
 
     expect(html).toContain('Re-run setup wizard');
     expect(html).toContain('no active goal');
+    expect(html).not.toContain('disabled=""');
+  });
+
+  it('disables relaunch while Coach Preferences has unsaved changes', () => {
+    const html = renderToStaticMarkup(
+      <OnboardingRelaunchSection userId="u1" disabled />,
+    );
+
+    expect(html).toContain('Save or reset your pending Coach Preferences changes');
+    expect(html).toContain('disabled=""');
   });
 });

--- a/app/src/components/preferences/OnboardingRelaunchSection.tsx
+++ b/app/src/components/preferences/OnboardingRelaunchSection.tsx
@@ -1,0 +1,29 @@
+import { clearOnboardingDismissalForUser } from '../../utils/onboardingStorage';
+
+interface OnboardingRelaunchSectionProps {
+  userId: string;
+}
+
+export function OnboardingRelaunchSection({ userId }: OnboardingRelaunchSectionProps) {
+  const handleRelaunch = () => {
+    // Clearing the dismissal lets a goal-less account see the wizard again on
+    // reload. Accounts with an active goal stay on the normal dashboard: the
+    // overlay gate suppresses the wizard once onboarding has produced a goal.
+    clearOnboardingDismissalForUser(userId);
+    window.location.reload();
+  };
+
+  return (
+    <section className="preference-section">
+      <h2>Setup wizard</h2>
+      <p className="preference-desc">
+        Re-run the rapid setup wizard to configure training setup and goals from
+        scratch. The wizard appears when your account has no active goal; if you
+        skipped setup earlier, this is how you get it back.
+      </p>
+      <button type="button" className="login-btn" onClick={handleRelaunch}>
+        Re-run setup wizard
+      </button>
+    </section>
+  );
+}

--- a/app/src/components/preferences/OnboardingRelaunchSection.tsx
+++ b/app/src/components/preferences/OnboardingRelaunchSection.tsx
@@ -2,10 +2,12 @@ import { clearOnboardingDismissalForUser } from '../../utils/onboardingStorage';
 
 interface OnboardingRelaunchSectionProps {
   userId: string;
+  disabled?: boolean;
 }
 
-export function OnboardingRelaunchSection({ userId }: OnboardingRelaunchSectionProps) {
+export function OnboardingRelaunchSection({ userId, disabled = false }: OnboardingRelaunchSectionProps) {
   const handleRelaunch = () => {
+    if (disabled) return;
     // Clearing the dismissal lets a goal-less account see the wizard again on
     // reload. Accounts with an active goal stay on the normal dashboard: the
     // overlay gate suppresses the wizard once onboarding has produced a goal.
@@ -21,7 +23,12 @@ export function OnboardingRelaunchSection({ userId }: OnboardingRelaunchSectionP
         scratch. The wizard appears when your account has no active goal; if you
         skipped setup earlier, this is how you get it back.
       </p>
-      <button type="button" className="login-btn" onClick={handleRelaunch}>
+      {disabled && (
+        <p className="preference-warning-note" role="status">
+          Save or reset your pending Coach Preferences changes before re-running setup.
+        </p>
+      )}
+      <button type="button" className="login-btn" onClick={handleRelaunch} disabled={disabled}>
         Re-run setup wizard
       </button>
     </section>

--- a/app/src/components/preferences/index.tsx
+++ b/app/src/components/preferences/index.tsx
@@ -8,6 +8,7 @@ import { PerformanceSections } from './PerformanceSections';
 import { GarminConnectionSection } from './GarminConnectionSection';
 import { GoogleHealthConnectionSection } from './GoogleHealthConnectionSection';
 import { HealthRunYogaPresetSection } from './HealthRunYogaPresetSection';
+import { OnboardingRelaunchSection } from './OnboardingRelaunchSection';
 import type { Screen } from '../../types/navigation';
 import '../Preferences.css';
 
@@ -84,6 +85,8 @@ export function Preferences({ userId }: PreferencesProps) {
           userId={userId}
           onApplied={loadPreferences}
         />
+
+        <OnboardingRelaunchSection userId={userId} />
 
         <TrainingPlanSection
           trainingIntentProfile={trainingIntentProfile}

--- a/app/src/components/preferences/index.tsx
+++ b/app/src/components/preferences/index.tsx
@@ -86,7 +86,7 @@ export function Preferences({ userId }: PreferencesProps) {
           onApplied={loadPreferences}
         />
 
-        <OnboardingRelaunchSection userId={userId} />
+        <OnboardingRelaunchSection userId={userId} disabled={hasChanges} />
 
         <TrainingPlanSection
           trainingIntentProfile={trainingIntentProfile}

--- a/app/src/utils/onboardingStorage.test.ts
+++ b/app/src/utils/onboardingStorage.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
-import { getOnboardingDoneStorageKey, isOnboardingDismissedForUser } from './onboardingStorage';
+import { clearOnboardingDismissalForUser, dismissOnboardingForUser, getOnboardingDoneStorageKey, isOnboardingDismissedForUser } from './onboardingStorage';
 
 describe('onboardingStorage user isolation', () => {
   const storage = new Map<string, string>();
@@ -70,5 +70,36 @@ describe('onboardingStorage user isolation', () => {
     // User B later completes onboarding
     window.localStorage.setItem(getOnboardingDoneStorageKey(userB), 'true');
     expect(isOnboardingDismissedForUser(userB)).toBe(true);
+  });
+
+  it('dismiss persists dismissal without requiring a goal write', () => {
+    expect(dismissOnboardingForUser('firebase-uid-skipper')).toBe(true);
+    expect(isOnboardingDismissedForUser('firebase-uid-skipper')).toBe(true);
+  });
+
+  it('dismiss returns false for null or empty user IDs', () => {
+    expect(dismissOnboardingForUser(null)).toBe(false);
+    expect(dismissOnboardingForUser('')).toBe(false);
+  });
+
+  it('clear removes a stored dismissal so the wizard can be re-launched', () => {
+    const userId = 'firebase-uid-relaunch';
+    window.localStorage.setItem(getOnboardingDoneStorageKey(userId), 'true');
+    expect(isOnboardingDismissedForUser(userId)).toBe(true);
+
+    clearOnboardingDismissalForUser(userId);
+    expect(isOnboardingDismissedForUser(userId)).toBe(false);
+  });
+
+  it('clear leaves other users dismissed', () => {
+    const userA = 'firebase-uid-stays-dismissed';
+    const userB = 'firebase-uid-relaunching';
+    window.localStorage.setItem(getOnboardingDoneStorageKey(userA), 'true');
+    window.localStorage.setItem(getOnboardingDoneStorageKey(userB), 'true');
+
+    clearOnboardingDismissalForUser(userB);
+
+    expect(isOnboardingDismissedForUser(userA)).toBe(true);
+    expect(isOnboardingDismissedForUser(userB)).toBe(false);
   });
 });

--- a/app/src/utils/onboardingStorage.ts
+++ b/app/src/utils/onboardingStorage.ts
@@ -10,3 +10,28 @@ export function isOnboardingDismissedForUser(userId: string | null): boolean {
     return false;
   }
 }
+
+/**
+ * Persists wizard dismissal for one user WITHOUT creating a goal or touching
+ * training settings. Returns false when browser storage is unavailable, so the
+ * caller knows the dismissal is session-only and the wizard may resurface.
+ */
+export function dismissOnboardingForUser(userId: string | null): boolean {
+  if (!userId || typeof window === 'undefined') return false;
+  try {
+    window.localStorage.setItem(getOnboardingDoneStorageKey(userId), 'true');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Clears a stored dismissal so a goal-less account can re-launch the wizard. */
+export function clearOnboardingDismissalForUser(userId: string | null): void {
+  if (!userId || typeof window === 'undefined') return;
+  try {
+    window.localStorage.removeItem(getOnboardingDoneStorageKey(userId));
+  } catch {
+    // Non-critical local UI-state failure; the wizard gate also checks active goals.
+  }
+}

--- a/app/src/utils/usabilityMetrics.test.ts
+++ b/app/src/utils/usabilityMetrics.test.ts
@@ -58,8 +58,22 @@ describe('usabilityMetrics task-based evaluation', () => {
         expect(report.errorRate).toBe(1);
     });
 
-    it('safely handles corrupted or [null] entries in localStorage', () => {
-        if (typeof window !== 'undefined' && window.localStorage) {
+    it('records wizard completion and skip outcomes in local telemetry', () => {
+        const userId = 'athlete-test';
+        const date = '2026-08-26';
+
+        usabilityMetrics.recordWizardCompleted(userId, date, 'completed', 12000);
+        usabilityMetrics.recordWizardCompleted(userId, date, 'skipped', 3000);
+
+        const report = usabilityMetrics.generateSummaryReport();
+        expect(report.wizardCompletions).toBe(1);
+        expect(report.wizardSkips).toBe(1);
+        // Wizard telemetry is additive: recommendation TTR reporting is unchanged.
+        expect(report.totalViews).toBe(0);
+        expect(report.totalActions).toBe(0);
+    });
+
+    it('safely handles corrupted or [null] entries in localStorage', () => {        if (typeof window !== 'undefined' && window.localStorage) {
             window.localStorage.setItem('adaptive_training_usability_events_v1', JSON.stringify([null, { malformed: true }]));
             const report = usabilityMetrics.generateSummaryReport();
             expect(report.totalViews).toBe(0);

--- a/app/src/utils/usabilityMetrics.test.ts
+++ b/app/src/utils/usabilityMetrics.test.ts
@@ -1,8 +1,27 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { usabilityMetrics } from './usabilityMetrics';
+
+const STORAGE_KEY = 'adaptive_training_usability_events_v1';
+
+function installLocalStorage() {
+    const storage = new Map<string, string>();
+    const localStorageMock = {
+        getItem: (key: string) => storage.get(key) ?? null,
+        setItem: (key: string, value: string) => storage.set(key, String(value)),
+        removeItem: (key: string) => storage.delete(key),
+        clear: () => storage.clear(),
+    };
+    vi.stubGlobal('window', { localStorage: localStorageMock });
+    return storage;
+}
 
 describe('usabilityMetrics task-based evaluation', () => {
     beforeEach(() => {
+        usabilityMetrics.clear();
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
         usabilityMetrics.clear();
     });
 
@@ -58,26 +77,58 @@ describe('usabilityMetrics task-based evaluation', () => {
         expect(report.errorRate).toBe(1);
     });
 
-    it('records wizard completion and skip outcomes in local telemetry', () => {
+    it('records wizard completion and skip outcomes including the skip stage', () => {
         const userId = 'athlete-test';
         const date = '2026-08-26';
 
-        usabilityMetrics.recordWizardCompleted(userId, date, 'completed', 12000);
-        usabilityMetrics.recordWizardCompleted(userId, date, 'skipped', 3000);
+        usabilityMetrics.recordWizardCompleted(userId, date, 'completed', 12000, 'equipment');
+        usabilityMetrics.recordWizardCompleted(userId, date, 'skipped', 3000, 'focus');
 
         const report = usabilityMetrics.generateSummaryReport();
         expect(report.wizardCompletions).toBe(1);
         expect(report.wizardSkips).toBe(1);
+        expect(report.wizardSkipsByStage).toEqual({ focus: 1 });
         // Wizard telemetry is additive: recommendation TTR reporting is unchanged.
         expect(report.totalViews).toBe(0);
         expect(report.totalActions).toBe(0);
     });
 
-    it('safely handles corrupted or [null] entries in localStorage', () => {        if (typeof window !== 'undefined' && window.localStorage) {
-            window.localStorage.setItem('adaptive_training_usability_events_v1', JSON.stringify([null, { malformed: true }]));
-            const report = usabilityMetrics.generateSummaryReport();
-            expect(report.totalViews).toBe(0);
-            expect(report.totalActions).toBe(0);
-        }
+    it('keeps session telemetry available when localStorage reads work but writes fail', () => {
+        vi.stubGlobal('window', {
+            localStorage: {
+                getItem: () => null,
+                setItem: () => { throw new Error('storage blocked'); },
+                removeItem: () => undefined,
+            },
+        });
+
+        usabilityMetrics.recordWizardCompleted('athlete-test', '2026-08-26', 'skipped', 3000, 'welcome');
+
+        const report = usabilityMetrics.generateSummaryReport();
+        expect(report.wizardSkips).toBe(1);
+        expect(report.wizardSkipsByStage).toEqual({ welcome: 1 });
+    });
+
+    it('does not classify malformed wizard outcomes as completions', () => {
+        const storage = installLocalStorage();
+        storage.set(STORAGE_KEY, JSON.stringify([
+            null,
+            { malformed: true },
+            {
+                id: 'evt-wizard-malformed',
+                timestamp: '2026-08-26T10:00:00.000Z',
+                eventType: 'wizard_completed',
+                userId: 'athlete-test',
+                date: '2026-08-26',
+                details: { outcome: 'unknown' },
+            },
+        ]));
+
+        const report = usabilityMetrics.generateSummaryReport();
+        expect(report.totalViews).toBe(0);
+        expect(report.totalActions).toBe(0);
+        expect(report.wizardCompletions).toBe(0);
+        expect(report.wizardSkips).toBe(0);
+        expect(report.wizardSkipsByStage).toEqual({});
     });
 });

--- a/app/src/utils/usabilityMetrics.ts
+++ b/app/src/utils/usabilityMetrics.ts
@@ -9,11 +9,14 @@ export interface UsabilitySessionEvent {
     details?: Record<string, unknown>;
 }
 
+export type OnboardingWizardStage = 'welcome' | 'focus' | 'equipment';
+
 export interface UsabilitySummaryReport {
     totalViews: number;
     totalActions: number;
     wizardCompletions: number;
     wizardSkips: number;
+    wizardSkipsByStage: Record<string, number>;
     averageTtrMs: number;
     medianTtrMs: number;
     overrideRate: number;
@@ -47,23 +50,33 @@ class UsabilityMetricsTracker {
     }
 
     private getStoredEvents(): UsabilitySessionEvent[] {
-        return this.readPersistedEvents() ?? this.memoryEvents;
+        const persisted = this.readPersistedEvents();
+        if (persisted === null) return this.memoryEvents;
+        if (this.memoryEvents.length === 0) return persisted;
+
+        // Session events are also kept in memory so telemetry still works when a
+        // browser permits reads but rejects localStorage writes. Merge by id to avoid
+        // double-counting events that were persisted successfully.
+        const merged = new Map(persisted.map(event => [event.id, event]));
+        for (const event of this.memoryEvents) merged.set(event.id, event);
+        return [...merged.values()];
     }
 
     private saveEvent(event: UsabilitySessionEvent): void {
-        this.memoryEvents.push(event);
+        this.memoryEvents = [...this.memoryEvents, event].slice(-200);
         if (typeof window === 'undefined') return;
 
         try {
-            // Read storage directly instead of getStoredEvents(). getStoredEvents() falls
-            // back to memory, which already contains `event` and would duplicate the first
-            // browser event when localStorage is initially empty.
+            // Read storage directly instead of getStoredEvents(). getStoredEvents() merges
+            // memory, which already contains `event` and would duplicate the first browser
+            // event when localStorage is initially empty without the id de-duplication above.
             const persisted = this.readPersistedEvents();
             if (persisted === null) return;
             const trimmed = [...persisted, event].slice(-200);
             window.localStorage?.setItem(this.storageKey, JSON.stringify(trimmed));
         } catch {
-            // Non-critical local instrumentation failure.
+            // Non-critical local instrumentation failure. The current session still retains
+            // the event in memory and generateSummaryReport() will include it.
         }
     }
 
@@ -147,7 +160,13 @@ class UsabilityMetricsTracker {
         });
     }
 
-    recordWizardCompleted(userId: string, date: string, outcome: 'completed' | 'skipped', durationMs?: number): void {
+    recordWizardCompleted(
+        userId: string,
+        date: string,
+        outcome: 'completed' | 'skipped',
+        durationMs?: number,
+        stage?: OnboardingWizardStage,
+    ): void {
         this.saveEvent({
             id: `evt-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
             timestamp: new Date().toISOString(),
@@ -155,7 +174,7 @@ class UsabilityMetricsTracker {
             userId,
             date,
             durationMs,
-            details: { outcome },
+            details: { outcome, stage },
         });
     }
 
@@ -164,6 +183,7 @@ class UsabilityMetricsTracker {
         const views = events.filter(e => e.eventType === 'recommendation_view');
         const actions = events.filter(e => e.eventType === 'action_selected');
         const wizardOutcomes = events.filter(e => e.eventType === 'wizard_completed');
+        const wizardSkips = wizardOutcomes.filter(e => e.details?.outcome === 'skipped');
         const overrides = events.filter(e => e.eventType === 'override_attempt');
         const blockedOverrides = overrides.filter(e => e.details?.blockedByGate === true);
 
@@ -186,14 +206,24 @@ class UsabilityMetricsTracker {
             actionBreakdown[key] = (actionBreakdown[key] ?? 0) + 1;
         }
 
+        const wizardSkipsByStage: Record<string, number> = {};
+        for (const event of wizardSkips) {
+            const stage = event.details?.stage;
+            const key = stage === 'welcome' || stage === 'focus' || stage === 'equipment'
+                ? stage
+                : 'unknown';
+            wizardSkipsByStage[key] = (wizardSkipsByStage[key] ?? 0) + 1;
+        }
+
         const overrideRate = actions.length > 0 ? overrides.length / actions.length : 0;
         const errorRate = overrides.length > 0 ? blockedOverrides.length / overrides.length : 0;
 
         return {
             totalViews: views.length,
             totalActions: actions.length,
-            wizardCompletions: wizardOutcomes.filter(e => e.details?.outcome !== 'skipped').length,
-            wizardSkips: wizardOutcomes.filter(e => e.details?.outcome === 'skipped').length,
+            wizardCompletions: wizardOutcomes.filter(e => e.details?.outcome === 'completed').length,
+            wizardSkips: wizardSkips.length,
+            wizardSkipsByStage,
             averageTtrMs: Math.round(avgTtr),
             medianTtrMs: Math.round(medianTtr),
             overrideRate: Math.round(overrideRate * 100) / 100,

--- a/app/src/utils/usabilityMetrics.ts
+++ b/app/src/utils/usabilityMetrics.ts
@@ -1,7 +1,7 @@
 export interface UsabilitySessionEvent {
     id: string;
     timestamp: string;
-    eventType: 'recommendation_view' | 'action_selected' | 'alternative_chosen' | 'override_attempt' | 'completion_reported';
+    eventType: 'recommendation_view' | 'action_selected' | 'alternative_chosen' | 'override_attempt' | 'completion_reported' | 'wizard_completed';
     userId: string;
     date: string;
     durationMs?: number;
@@ -12,6 +12,8 @@ export interface UsabilitySessionEvent {
 export interface UsabilitySummaryReport {
     totalViews: number;
     totalActions: number;
+    wizardCompletions: number;
+    wizardSkips: number;
     averageTtrMs: number;
     medianTtrMs: number;
     overrideRate: number;
@@ -145,10 +147,23 @@ class UsabilityMetricsTracker {
         });
     }
 
+    recordWizardCompleted(userId: string, date: string, outcome: 'completed' | 'skipped', durationMs?: number): void {
+        this.saveEvent({
+            id: `evt-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+            timestamp: new Date().toISOString(),
+            eventType: 'wizard_completed',
+            userId,
+            date,
+            durationMs,
+            details: { outcome },
+        });
+    }
+
     generateSummaryReport(): UsabilitySummaryReport {
         const events = this.getStoredEvents();
         const views = events.filter(e => e.eventType === 'recommendation_view');
         const actions = events.filter(e => e.eventType === 'action_selected');
+        const wizardOutcomes = events.filter(e => e.eventType === 'wizard_completed');
         const overrides = events.filter(e => e.eventType === 'override_attempt');
         const blockedOverrides = overrides.filter(e => e.details?.blockedByGate === true);
 
@@ -177,6 +192,8 @@ class UsabilityMetricsTracker {
         return {
             totalViews: views.length,
             totalActions: actions.length,
+            wizardCompletions: wizardOutcomes.filter(e => e.details?.outcome !== 'skipped').length,
+            wizardSkips: wizardOutcomes.filter(e => e.details?.outcome === 'skipped').length,
             averageTtrMs: Math.round(avgTtr),
             medianTtrMs: Math.round(medianTtr),
             overrideRate: Math.round(overrideRate * 100) / 100,

--- a/docs/architecture/morning-decision-ux.md
+++ b/docs/architecture/morning-decision-ux.md
@@ -74,6 +74,8 @@ That last distinction is intentional documentation of current behavior; the UI m
 
 The rapid wizard persists training settings before creating the active goal. The active goal is used by the app as an onboarding-complete signal, so creating it first could suppress the wizard after a partial write failure while leaving equipment/time settings at defaults.
 
+Skip is the deliberate exception to that write order: it persists only the per-user browser dismissal key and never creates a goal or writes training settings, so there is no partial-write state to order. A skipped goal-less account can re-launch the wizard from the Coach Preferences surface.
+
 Failures remain in the wizard with the athlete's current selections intact so completion can be retried safely.
 
 ## 7. Usability telemetry
@@ -83,6 +85,7 @@ Failures remain in the wizard with the athlete's current selections intact so co
 - events are stored in browser `localStorage` when available;
 - storage is capped to the most recent 200 persisted events;
 - recommendation TTR is measured from the **first recorded view** to the **first deliberate action** for that user/date;
+- wizard completion is recorded as a `wizard_completed` event with a `completed` / `skipped` outcome and the elapsed time since the wizard mounted;
 - repeated renders before that action do not restart the clock;
 - later actions are recorded but are not assigned the original first-action TTR;
 - browser-storage failure is non-fatal and falls back to in-memory collection for the current runtime.

--- a/docs/architecture/morning-decision-ux.md
+++ b/docs/architecture/morning-decision-ux.md
@@ -74,7 +74,7 @@ That last distinction is intentional documentation of current behavior; the UI m
 
 The rapid wizard persists training settings before creating the active goal. The active goal is used by the app as an onboarding-complete signal, so creating it first could suppress the wizard after a partial write failure while leaving equipment/time settings at defaults.
 
-Skip is the deliberate exception to that write order: it persists only the per-user browser dismissal key and never creates a goal or writes training settings, so there is no partial-write state to order. A skipped goal-less account can re-launch the wizard from the Coach Preferences surface.
+Skip is the deliberate exception to that write order: it persists only the per-user browser dismissal key and never creates a goal or writes training settings, so there is no partial-write state to order. A skipped goal-less account can re-launch the wizard from the Coach Preferences surface. Because re-launch reloads the page to discard stale onboarding-dependent state, the action is disabled while Coach Preferences has unsaved edits.
 
 Failures remain in the wizard with the athlete's current selections intact so completion can be retried safely.
 
@@ -83,12 +83,12 @@ Failures remain in the wizard with the athlete's current selections intact so co
 `usabilityMetrics.ts` is local task telemetry, not a remote analytics pipeline.
 
 - events are stored in browser `localStorage` when available;
-- storage is capped to the most recent 200 persisted events;
+- storage is capped to the most recent 200 persisted events and the current-runtime memory buffer is capped to the same size;
 - recommendation TTR is measured from the **first recorded view** to the **first deliberate action** for that user/date;
-- wizard completion is recorded as a `wizard_completed` event with a `completed` / `skipped` outcome and the elapsed time since the wizard mounted;
+- wizard completion is recorded as a `wizard_completed` event with a `completed` / `skipped` outcome, the elapsed time since the wizard mounted, and the wizard stage (`welcome`, `focus`, or `equipment`); skip summaries retain a per-stage breakdown;
 - repeated renders before that action do not restart the clock;
 - later actions are recorded but are not assigned the original first-action TTR;
-- browser-storage failure is non-fatal and falls back to in-memory collection for the current runtime.
+- browser-storage failure is non-fatal and falls back to in-memory collection for the current runtime; reports merge persisted and in-memory events by event id so a readable-but-unwritable `localStorage` does not hide current-session telemetry.
 
 Do not interpret these events as server-side population telemetry unless a future backend pipeline is added explicitly.
 
@@ -101,7 +101,8 @@ Keyboard shortcuts `[1]`, `[2]`, and `[3]` are convenience controls. A synchrono
 The change set is covered by:
 
 - decision-evidence unit tests for safety locks, confidence, deltas, and alternative IDs;
-- usability-metrics unit tests for first-action timing behavior;
+- usability-metrics unit tests for first-action timing, wizard outcome/stage reporting, malformed outcomes, and storage-write fallback behavior;
+- onboarding-storage and relaunch-section tests for per-user dismissal/relaunch state and protection against discarding unsaved Coach Preferences;
 - Firestore emulator tests for activity-override owner CRUD, cross-user denial, malformed writes, and immutable identity/date/creation fields;
 - the repository CI typecheck, lint, unit-test, catalog-validation, and production-build gates.
 

--- a/docs/architecture/user-flows.md
+++ b/docs/architecture/user-flows.md
@@ -86,11 +86,12 @@ Successful onboarding writes training settings, the training-intent profile, and
 athlete is still goal-less) an active goal before `onCompleted` stores the per-user browser
 dismissal key. Skip persists only that dismissal key — it never creates a goal and never
 writes training settings — and is logged to local usability telemetry as a skipped wizard
-completion. A skipped (goal-less, dismissed) account can re-launch the wizard from the
-Coach Preferences surface, which clears the dismissal key and reloads. A blocked
-`localStorage` write alone does
-not make a successfully onboarded athlete loop forever, because the active-goal gate also
-suppresses the overlay.
+completion with the stage where Skip was chosen. A skipped (goal-less, dismissed) account
+can re-launch the wizard from the Coach Preferences surface, which clears the dismissal key
+and reloads; the relaunch action is disabled while Coach Preferences has unsaved edits so the
+reload cannot silently discard them. A blocked `localStorage` write alone does not make a
+successfully onboarded athlete loop forever, because the active-goal gate also suppresses the
+overlay.
 
 `App` can also render two resume/cleanup banners above `<main>`:
 
@@ -274,8 +275,8 @@ periodization/taper calculations, and the screen derives the current focus event
 Two implementation details matter to navigation work:
 
 * paused goals appear only under `all`, because there is no dedicated paused filter; and
-* `GoalsProps` accepts `onNavigate`, but `Goals` currently destructures only `userId`, so the
-  navigation callback is unused.
+* `Goals` takes only `userId`; it owns no repair/deep-link navigation, and callers
+  reach it through `App.tsx` `handleNavigate`.
 
 ### 8. Training Setup versus Coach Preferences
 
@@ -391,8 +392,11 @@ living-reference section when implementing them.
 
 7. Visually pair Training Setup (hard gates) and Coach Preferences (soft preferences), with
    cross-links between overlapping equipment/time/environment concepts.
-8. Either remove `Goals.onNavigate` or use it for explicit repair/deep-link flows; an unused
-   navigation prop is misleading API surface.
+8. ~~Either remove `Goals.onNavigate` or use it for explicit repair/deep-link flows; an unused
+   navigation prop is misleading API surface.~~
+   Done (#484): removed the unused `Goals` `onNavigate` prop — no repair flow needed it —
+   and kept `constraints` as the stable route key with user-facing copy in `navigation.ts`
+   `SCREEN_LABELS` (`Training Setup`).
 9. Review immediate-persist Training Setup controls for undo/confirmation where a mistaken
    toggle can materially change feasibility/safety decisions.
 
@@ -410,11 +414,11 @@ living-reference section when implementing them.
 13. ~~Add an explicit onboarding Skip/dismiss path only if product semantics define what a
     goal-less dismissed account should do; do not implement it as a browser flag alone.~~
     Done (#490): Skip persists only the per-user dismissal key — no goal, no training-settings
-    writes — skipped completions are logged to local usability telemetry, and a goal-less
-    dismissed account can re-launch the wizard from Coach Preferences.
- 14. ~~Use distinct copy for app authentication (`Continue/Sign in with Garmin`) and wearable
-     data connection (`Connect Garmin wearable`).~~ Done (#497): `LoginScreen` garmin mode
-     uses `Sign in with Garmin`, `GarminConnectionSection` uses `Connect Garmin wearable`.
+    writes — skipped completions are logged to local usability telemetry (including skip
+    stage), and a goal-less dismissed account can re-launch the wizard from Coach Preferences.
+14. ~~Use distinct copy for app authentication (`Continue/Sign in with Garmin`) and wearable
+    data connection (`Connect Garmin wearable`).~~ Done (#497): `LoginScreen` garmin mode
+    uses `Sign in with Garmin`, `GarminConnectionSection` uses `Connect Garmin wearable`.
 15. Choose a canonical AI-export surface and make the other export affordances clearly point
     to or distinguish themselves from it.
 16. Add local retry/repair affordances to weak recovery states, starting with DataView's

--- a/docs/architecture/user-flows.md
+++ b/docs/architecture/user-flows.md
@@ -84,7 +84,11 @@ drawer; it is not a URL/history transition.
 
 Successful onboarding writes training settings, the training-intent profile, and (if the
 athlete is still goal-less) an active goal before `onCompleted` stores the per-user browser
-dismissal key. There is currently no Skip action. A blocked `localStorage` write alone does
+dismissal key. Skip persists only that dismissal key — it never creates a goal and never
+writes training settings — and is logged to local usability telemetry as a skipped wizard
+completion. A skipped (goal-less, dismissed) account can re-launch the wizard from the
+Coach Preferences surface, which clears the dismissal key and reloads. A blocked
+`localStorage` write alone does
 not make a successfully onboarded athlete loop forever, because the active-goal gate also
 suppresses the overlay.
 
@@ -354,7 +358,8 @@ moving an input across an authority boundary.
 7. Several recovery states are weak rather than truly terminal: DataView's no-data state has
    no local retry, some PlanView invalid states have limited repair affordance, a missing
    stored session prescription is fail-closed, testing abandonment is terminal for that
-   attempt, and onboarding has no Skip.
+   attempt, and a skipped onboarding with blocked browser storage resurfaces the wizard on
+   refresh (dismissal persistence needs working `localStorage`).
 8. Garmin is used both as an app sign-in path and as a wearable/provider connection, which
    can read as one task even though the flows and credentials have different purposes.
 
@@ -402,8 +407,11 @@ living-reference section when implementing them.
 
 ### Onboarding, auth, and export
 
-13. Add an explicit onboarding Skip/dismiss path only if product semantics define what a
-    goal-less dismissed account should do; do not implement it as a browser flag alone.
+13. ~~Add an explicit onboarding Skip/dismiss path only if product semantics define what a
+    goal-less dismissed account should do; do not implement it as a browser flag alone.~~
+    Done (#490): Skip persists only the per-user dismissal key — no goal, no training-settings
+    writes — skipped completions are logged to local usability telemetry, and a goal-less
+    dismissed account can re-launch the wizard from Coach Preferences.
  14. ~~Use distinct copy for app authentication (`Continue/Sign in with Garmin`) and wearable
      data connection (`Connect Garmin wearable`).~~ Done (#497): `LoginScreen` garmin mode
      uses `Sign in with Garmin`, `GarminConnectionSection` uses `Connect Garmin wearable`.


### PR DESCRIPTION
## Summary
- Add explicit **Skip for now** on every onboarding step through a dedicated no-Firestore skip action. Skip persists only the per-user dismissal key, records elapsed local usability telemetry plus the wizard stage (`welcome` / `focus` / `equipment`), and never reads or writes goals/training settings/training intent.
- Add a **Setup wizard** section to Coach Preferences so skipped, goal-less accounts can re-launch onboarding. Relaunch still clears the dismissal and reloads to refresh onboarding-dependent state, but is disabled while Coach Preferences has unsaved edits so pending changes cannot be silently discarded.
- Harden local usability telemetry: merge/dedupe persisted + current-runtime events when `localStorage` reads succeed but writes are blocked, strictly count only `outcome === 'completed'` as completions, and report skips by stage.
- Reconcile `docs/architecture/user-flows.md` with the newly merged navigation cleanup from #501 while preserving this PR's onboarding semantics; update `morning-decision-ux.md` with skip/relaunch/telemetry contracts.
- Preserve the completion write order: training settings → training intent profile → active goal → dismissal callback. No engine/policy or Firestore-rule semantics change. Closes #490.

## Validation
- [x] Latest GitHub CI Pipeline **#2855** on `9dc05069b4cfc5b3d3fa35e35d2742c2e77f61f1`: **PASS**.
  - frontend typecheck, ESLint, validators, policy-drift gate, production bundle
  - frontend unit tests + coverage
  - Firestore security-rule emulator suite
  - engine simulations + deterministic AI/persona gates
  - Python lint/format/typecheck/pytest/dependency audit
  - Docker/compose smoke and final CI summary
- [x] Skip regression test invokes the production skip action and asserts **zero calls** to training-settings update, training-intent upsert, goal listing, and goal creation; dismissal, callback, telemetry outcome, and skip stage are verified.
- [x] Telemetry regression tests cover completed/skipped counts, per-stage skip reporting, readable-but-unwritable `localStorage`, and malformed wizard outcomes.
- [x] Relaunch tests cover normal discoverability and the unsaved-Preferences guard.
- [x] GitHub reports the PR **mergeable** after reconciling the `user-flows.md` overlap introduced by #501.
- [x] Original branch `npm run check` and pre-push hooks were already green before the review-hardening commits.

## Review findings addressed
1. **Potential data loss on wizard relaunch** — full-page reload could discard unsaved Coach Preferences. Relaunch is now disabled with explanatory copy until the user saves or resets those edits.
2. **Telemetry lost when storage is readable but unwritable** — reports now merge/dedupe persisted and in-memory events instead of allowing readable persisted state to mask current-session events.
3. **Malformed wizard outcome inflated completions** — completion counting is now explicit (`outcome === 'completed'`).
4. **Skip telemetry lacked drop-off location** — skip events now retain wizard stage and summaries expose `wizardSkipsByStage`.
5. **Acceptance criterion was not behaviorally enforced** — added a direct no-write regression test for the production Skip action.
6. **Fast Refresh lint contract** — moved the testable pure Skip action into `components/onboarding/skipOnboarding.ts` instead of weakening `react-refresh/only-export-components`.
7. **Concurrent mainline conflict** — reconciled #501's `Goals.onNavigate`/screen-label documentation changes with this PR's onboarding documentation.

## Risk and reviewer guidance
- Skip is structurally separate from the Firestore-writing completion path. `skipOnboardingForNow()` performs browser dismissal + local telemetry + `onCompleted()` only.
- A blocked dismissal write remains session-only; a goal-less skipped account can therefore see onboarding again after refresh. That fallback is documented rather than silently treated as durable persistence.
- Accounts that already have an active goal still do not see the overlay after using the Preferences relaunch entry because the existing active-goal gate remains authoritative.
- Wizard telemetry remains **local browser instrumentation**, not server-side analytics.

## Review/comments
- No inline review threads or submitted human review comments were present to reply to or resolve during this pass.
- A fresh CodeRabbit review was requested, but the repository's included review quota was exhausted; the bot produced no actionable code-review findings.

## Screenshots or recordings
- Not added. The functional changes are button/copy/state behavior and are covered by markup + behavioral regression tests; the repository CI build is green.