### PR TITLE
fix(ui): standardize fail-closed repair triplet on Home and PlanView (#483)

### DIFF
--- a/app/src/components/Home.tsx
+++ b/app/src/components/Home.tsx
@@ -76,7 +76,11 @@ import { activityService } from '../services/activityService';
 import { usabilityMetrics } from '../utils/usabilityMetrics';
 import { TEMPLATES, TEMPLATES_BY_ID } from '../engine/templates';
 import type { ActivityOverride, DailyRecoverySnapshot, NormalizedGarminActivity } from '../engine/models';
-import type { ErrorRepairAction } from './errorRepairAction';
+import {
+  resolveDecisionCompositionRepairState,
+  resolveDecisionSourceRepairState,
+  type ErrorRepairAction,
+} from './errorRepairAction';
 import { useAutoGarminSync } from '../hooks/useAutoGarminSync';
 import { resolveWearablePlanningMode } from '../utils/wearablePlanningGate';
 import {
@@ -317,26 +321,13 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
         return;
       }
 
-      const decisionSourceFailure = input.sourceStates
-        && [input.sourceStates.activeGoals, input.sourceStates.preferences, input.sourceStates.trainingSettings]
-          .find(state => state.status === 'INVALID' || state.status === 'UNAVAILABLE');
+      const decisionSourceFailure = resolveDecisionSourceRepairState(input.sourceStates);
       if (decisionSourceFailure) {
         setRecommendation(null);
         setNextDayPlan(null);
         clearExternalPlanState();
-        if (decisionSourceFailure.status === 'INVALID') {
-          // Point the user at whichever screen owns the invalid document(s) so the error
-          // is actionable rather than a dead end -- re-saving there re-runs validation
-          // and clears the INVALID state.
-          const repairTargets: ErrorRepairAction[] = [];
-          if (input.sourceStates?.activeGoals.status === 'INVALID') repairTargets.push({ kind: 'navigate', screen: 'goals', label: `Review ${SCREEN_LABELS.goals}` });
-          if (input.sourceStates?.preferences.status === 'INVALID') repairTargets.push({ kind: 'navigate', screen: 'preferences', label: `Review ${SCREEN_LABELS.preferences}` });
-          if (input.sourceStates?.trainingSettings.status === 'INVALID') repairTargets.push({ kind: 'navigate', screen: 'constraints', label: `Review ${SCREEN_LABELS.constraints}` });
-          setErrorRepairTargets(repairTargets);
-        }
-        setError(decisionSourceFailure.status === 'UNAVAILABLE'
-          ? 'Decision inputs are temporarily unavailable. Please retry before generating a plan.'
-          : 'Decision inputs need repair before generating a plan.');
+        setErrorRepairTargets(decisionSourceFailure.actions);
+        setError(decisionSourceFailure.message);
         return;
       }
 
@@ -775,7 +766,13 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
     } catch (err) {
       if (!isCurrent()) return;
       console.error('Error loading dashboard data:', err);
-      setError('Failed to load dashboard data');
+      const compositionRepair = resolveDecisionCompositionRepairState(err);
+      if (compositionRepair) {
+        setErrorRepairTargets(compositionRepair.actions);
+        setError(compositionRepair.message);
+      } else {
+        setError('Failed to load dashboard data');
+      }
     } finally {
       if (isCurrent()) setLoading(false);
     }

--- a/app/src/components/Home.tsx
+++ b/app/src/components/Home.tsx
@@ -87,6 +87,7 @@ import {
 import './Home.css';
 
 import type { Screen } from '../types/navigation';
+import { SCREEN_LABELS } from '../types/navigation';
 
 interface HomeProps {
   userId: string;
@@ -328,9 +329,9 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
           // is actionable rather than a dead end -- re-saving there re-runs validation
           // and clears the INVALID state.
           const repairTargets: ErrorRepairAction[] = [];
-          if (input.sourceStates?.activeGoals.status === 'INVALID') repairTargets.push({ kind: 'navigate', screen: 'goals', label: 'Review goals' });
-          if (input.sourceStates?.preferences.status === 'INVALID') repairTargets.push({ kind: 'navigate', screen: 'preferences', label: 'Review preferences' });
-          if (input.sourceStates?.trainingSettings.status === 'INVALID') repairTargets.push({ kind: 'navigate', screen: 'constraints', label: 'Review training settings' });
+          if (input.sourceStates?.activeGoals.status === 'INVALID') repairTargets.push({ kind: 'navigate', screen: 'goals', label: `Review ${SCREEN_LABELS.goals}` });
+          if (input.sourceStates?.preferences.status === 'INVALID') repairTargets.push({ kind: 'navigate', screen: 'preferences', label: `Review ${SCREEN_LABELS.preferences}` });
+          if (input.sourceStates?.trainingSettings.status === 'INVALID') repairTargets.push({ kind: 'navigate', screen: 'constraints', label: `Review ${SCREEN_LABELS.constraints}` });
           setErrorRepairTargets(repairTargets);
         }
         setError(decisionSourceFailure.status === 'UNAVAILABLE'
@@ -355,6 +356,9 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
           setRecommendation(null);
           setNextDayPlan(null);
           clearExternalPlanState();
+          // Connection configuration lives under Coach Preferences -- link there so the
+          // state names the missing input, offers the fixing screen, and still retries.
+          setErrorRepairTargets([{ kind: 'navigate', screen: 'preferences', label: `Review ${SCREEN_LABELS.preferences}` }]);
           setError('Garmin connection status could not be verified. Retry before using wearable-free mode.');
           return;
         }

--- a/app/src/components/PlanView.tsx
+++ b/app/src/components/PlanView.tsx
@@ -438,6 +438,7 @@ export const PlanView: React.FC<PlanViewProps> = ({ userId, onNavigate, onPlanCh
     [decisionInput?.subjectiveCheckin],
   );
   const canGenerateAdaptiveForecast = canGenerateNormalRecommendation(safetyCheckinStatus);
+  const wearableRepairAction = wearableForecastBlock?.repairAction;
 
   return (
     <div className="plan-view-container">
@@ -577,13 +578,13 @@ export const PlanView: React.FC<PlanViewProps> = ({ userId, onNavigate, onPlanCh
             <div className="plan-missing-recovery-card">
               <p>📊 {wearableForecastBlock.message}</p>
               <div className="plan-unavailable-actions">
-                {wearableForecastBlock.repairAction?.kind === 'navigate' && onNavigate && (
+                {wearableRepairAction?.kind === 'navigate' && onNavigate && (
                   <button
                     type="button"
                     className="plan-retry-btn"
-                    onClick={() => onNavigate(wearableForecastBlock.repairAction!.screen)}
+                    onClick={() => onNavigate(wearableRepairAction.screen)}
                   >
-                    {wearableForecastBlock.repairAction.label} →
+                    {wearableRepairAction.label} →
                   </button>
                 )}
                 {wearableForecastBlock.canResync && (

--- a/app/src/components/PlanView.tsx
+++ b/app/src/components/PlanView.tsx
@@ -39,7 +39,11 @@ import { ExternalPlanWeek } from './ExternalPlanWeek';
 import { ExternalPlanImport } from './ExternalPlanImport';
 import { WeekAheadStrip } from './WeekAheadStrip';
 import { GarminSyncNowButton } from './GarminSyncNowButton';
-import type { ErrorRepairAction } from './errorRepairAction';
+import {
+  resolveDecisionCompositionRepairState,
+  resolveDecisionSourceRepairState,
+  type ErrorRepairAction,
+} from './errorRepairAction';
 import {
   resolveWearablePlanningMode,
   type WearablePlanningMode,
@@ -61,6 +65,12 @@ function formatWeekRange(startDateStr: string): string {
   return `${WEEKDAY_FORMATTER.format(start)} – ${WEEKDAY_FORMATTER.format(end)}`;
 }
 
+function formatSourceList(items: string[]): string {
+  if (items.length <= 1) return items[0] ?? '';
+  if (items.length === 2) return `${items[0]} and ${items[1]}`;
+  return `${items.slice(0, -1).join(', ')}, and ${items.at(-1)}`;
+}
+
 export const PlanView: React.FC<PlanViewProps> = ({ userId, onNavigate, onPlanChanged }) => {
   const today = useMemo(() => getLocalDateString(), []);
   const [activePlan, setActivePlan] = useState<ActiveExternalPlan | null>(null);
@@ -75,12 +85,14 @@ export const PlanView: React.FC<PlanViewProps> = ({ userId, onNavigate, onPlanCh
   const [loadError, setLoadError] = useState<string | null>(null);
   const [forecastUnavailable, setForecastUnavailable] = useState<string | null>(null);
   const [forecastRepairTargets, setForecastRepairTargets] = useState<ErrorRepairAction[]>([]);
-  // An unverifiable (INVALID) active coach plan is repaired in the import/revise UI on
-  // this same screen -- offer opening it as a forward action beyond retry.
+  // An INVALID active coach plan cannot be reviewed in place: ExternalPlanImport starts with
+  // a blank import surface. Offer replacement with a corrected revision rather than claiming
+  // that the malformed stored plan itself will be opened for editing.
   const [planImportRepairOffered, setPlanImportRepairOffered] = useState<boolean>(false);
   const [wearableForecastBlock, setWearableForecastBlock] = useState<{
     message: string;
     canResync: boolean;
+    repairAction?: ErrorRepairAction;
   } | null>(null);
   const [writeError, setWriteError] = useState<string | null>(null);
   const [showImport, setShowImport] = useState<boolean>(false);
@@ -112,45 +124,35 @@ export const PlanView: React.FC<PlanViewProps> = ({ userId, onNavigate, onPlanCh
       setDecisionInput(input);
 
       // P0: Enforce strict DataState semantics. Do NOT silently convert unavailable/invalid
-      // schedule data into empty arrays. Name which schedule input failed so the state is
-      // actionable; these inputs have no owning repair screen, so retry is the repair.
+      // schedule data into empty arrays. These inputs have no owning repair screen, so the
+      // copy names each failing status precisely and Retry remains the only local action.
       if (actState.status !== 'AVAILABLE' || blocksState.status !== 'AVAILABLE') {
-        const failedInputs: string[] = [];
-        if (actState.status !== 'AVAILABLE') failedInputs.push('fixed activities');
-        if (blocksState.status !== 'AVAILABLE') failedInputs.push('plan blocks');
-        const failedInputsLabel = failedInputs.join(' and ');
-        const unavailMsg =
-          actState.status === 'UNAVAILABLE' || blocksState.status === 'UNAVAILABLE'
-            ? `The plan week's ${failedInputsLabel} are temporarily unavailable. Check your connection and retry.`
-            : `The plan week's ${failedInputsLabel} could not be verified. Please retry before using this plan.`;
-        setForecastUnavailable(unavailMsg);
+        const invalidInputs: string[] = [];
+        const unavailableInputs: string[] = [];
+        if (actState.status === 'INVALID') invalidInputs.push('fixed activities');
+        if (blocksState.status === 'INVALID') invalidInputs.push('plan blocks');
+        if (actState.status === 'UNAVAILABLE') unavailableInputs.push('fixed activities');
+        if (blocksState.status === 'UNAVAILABLE') unavailableInputs.push('plan blocks');
+
+        const statusParts: string[] = [];
+        if (invalidInputs.length > 0) {
+          statusParts.push(`${formatSourceList(invalidInputs)} ${invalidInputs.length === 1 ? 'is' : 'are'} invalid`);
+        }
+        if (unavailableInputs.length > 0) {
+          statusParts.push(`${formatSourceList(unavailableInputs)} ${unavailableInputs.length === 1 ? 'is' : 'are'} temporarily unavailable`);
+        }
+        setForecastUnavailable(
+          `The plan week cannot be verified because ${statusParts.join('; ')}. Retry after the invalid schedule data is corrected or the unavailable source recovers.`,
+        );
         setFixedActivities([]);
         setActivePlan(null);
         return;
       }
 
-      // Check decision input source states like Home.tsx
-      const decisionSourceFailure =
-        input.sourceStates &&
-        [input.sourceStates.activeGoals, input.sourceStates.preferences, input.sourceStates.trainingSettings].find(
-          (state) => state.status === 'INVALID' || state.status === 'UNAVAILABLE',
-        );
+      const decisionSourceFailure = resolveDecisionSourceRepairState(input.sourceStates);
       if (decisionSourceFailure) {
-        if (decisionSourceFailure.status === 'INVALID') {
-          // Point the user at whichever screen owns the invalid document(s) so the error
-          // is actionable rather than a dead end -- re-saving there re-runs validation
-          // and clears the INVALID state.
-          const repairTargets: ErrorRepairAction[] = [];
-          if (input.sourceStates?.activeGoals.status === 'INVALID') repairTargets.push({ kind: 'navigate', screen: 'goals', label: `Review ${SCREEN_LABELS.goals}` });
-          if (input.sourceStates?.preferences.status === 'INVALID') repairTargets.push({ kind: 'navigate', screen: 'preferences', label: `Review ${SCREEN_LABELS.preferences}` });
-          if (input.sourceStates?.trainingSettings.status === 'INVALID') repairTargets.push({ kind: 'navigate', screen: 'constraints', label: `Review ${SCREEN_LABELS.constraints}` });
-          setForecastRepairTargets(repairTargets);
-        }
-        setForecastUnavailable(
-          decisionSourceFailure.status === 'UNAVAILABLE'
-            ? 'Decision inputs are temporarily unavailable. Please retry before generating a plan.'
-            : 'Decision inputs need repair before generating a plan.',
-        );
+        setForecastRepairTargets(decisionSourceFailure.actions);
+        setForecastUnavailable(decisionSourceFailure.message);
         return;
       }
 
@@ -181,8 +183,9 @@ export const PlanView: React.FC<PlanViewProps> = ({ userId, onNavigate, onPlanCh
         }
         if (wearableMode === 'unavailable') {
           setWearableForecastBlock({
-            message: 'Garmin connection status could not be verified. Retry before using wearable-free mode.',
+            message: 'Garmin connection status could not be verified. Review Coach Preferences or retry before using wearable-free mode.',
             canResync: false,
+            repairAction: { kind: 'navigate', screen: 'preferences', label: `Review ${SCREEN_LABELS.preferences}` },
           });
         }
       }
@@ -199,7 +202,7 @@ export const PlanView: React.FC<PlanViewProps> = ({ userId, onNavigate, onPlanCh
         setForecastUnavailable(
           activePlanState.status === 'UNAVAILABLE'
             ? 'Your active coach plan is temporarily unavailable. Check your connection and retry.'
-            : 'Your active coach plan could not be verified. Retry before using this schedule.',
+            : 'Your active coach plan is invalid. Import a corrected plan revision, then retry.',
         );
         setFixedActivities([]);
         setActivePlan(null);
@@ -334,7 +337,18 @@ export const PlanView: React.FC<PlanViewProps> = ({ userId, onNavigate, onPlanCh
       }
     } catch (err) {
       console.error('Failed to load plan or forecast in PlanView:', err);
-      setLoadError('An unexpected error occurred while generating the plan. Please retry.');
+      const compositionRepair = resolveDecisionCompositionRepairState(err);
+      if (compositionRepair) {
+        // Schedule overlays are repaired by ScheduleOverlayCard on this screen; navigating
+        // to Plan again would be a no-op, so keep the named message and Retry while exposing
+        // cross-screen repair actions (for example Training Setup) normally.
+        setForecastRepairTargets(compositionRepair.actions.filter(
+          action => action.kind !== 'navigate' || action.screen !== 'plan',
+        ));
+        setForecastUnavailable(compositionRepair.message);
+      } else {
+        setLoadError('An unexpected error occurred while generating the plan. Please retry.');
+      }
     } finally {
       setLoading(false);
     }
@@ -355,8 +369,7 @@ export const PlanView: React.FC<PlanViewProps> = ({ userId, onNavigate, onPlanCh
         { fixedActivities },
         today,
       );
-    },
-    [activePlan, fixedActivities, today],
+    }, [activePlan, fixedActivities, today],
   );
 
   const persistAssignments = useCallback(
@@ -487,7 +500,7 @@ export const PlanView: React.FC<PlanViewProps> = ({ userId, onNavigate, onPlanCh
         </div>
       ) : forecastUnavailable ? (
         <div className="plan-unavailable-card">
-          <h3>7-Day Forecast Temporarily Unavailable</h3>
+          <h3>7-Day Forecast Unavailable</h3>
           <p className="plan-unavailable-message">{forecastUnavailable}</p>
           {forecastRepairTargets.length > 0 && (
             <p className="plan-unavailable-message">
@@ -513,7 +526,7 @@ export const PlanView: React.FC<PlanViewProps> = ({ userId, onNavigate, onPlanCh
             ))}
             {planImportRepairOffered && (
               <button type="button" className="plan-retry-btn" onClick={() => setShowImport(true)}>
-                📥 Review imported plan
+                📥 Import corrected plan
               </button>
             )}
             <button type="button" className="plan-retry-btn" onClick={loadPlanData}>
@@ -564,6 +577,15 @@ export const PlanView: React.FC<PlanViewProps> = ({ userId, onNavigate, onPlanCh
             <div className="plan-missing-recovery-card">
               <p>📊 {wearableForecastBlock.message}</p>
               <div className="plan-unavailable-actions">
+                {wearableForecastBlock.repairAction?.kind === 'navigate' && onNavigate && (
+                  <button
+                    type="button"
+                    className="plan-retry-btn"
+                    onClick={() => onNavigate(wearableForecastBlock.repairAction!.screen)}
+                  >
+                    {wearableForecastBlock.repairAction.label} →
+                  </button>
+                )}
                 {wearableForecastBlock.canResync && (
                   <GarminSyncNowButton userId={userId} onSynced={loadPlanData} />
                 )}

--- a/app/src/components/PlanView.tsx
+++ b/app/src/components/PlanView.tsx
@@ -75,6 +75,9 @@ export const PlanView: React.FC<PlanViewProps> = ({ userId, onNavigate, onPlanCh
   const [loadError, setLoadError] = useState<string | null>(null);
   const [forecastUnavailable, setForecastUnavailable] = useState<string | null>(null);
   const [forecastRepairTargets, setForecastRepairTargets] = useState<ErrorRepairAction[]>([]);
+  // An unverifiable (INVALID) active coach plan is repaired in the import/revise UI on
+  // this same screen -- offer opening it as a forward action beyond retry.
+  const [planImportRepairOffered, setPlanImportRepairOffered] = useState<boolean>(false);
   const [wearableForecastBlock, setWearableForecastBlock] = useState<{
     message: string;
     canResync: boolean;
@@ -91,6 +94,7 @@ export const PlanView: React.FC<PlanViewProps> = ({ userId, onNavigate, onPlanCh
     setLoadError(null);
     setForecastUnavailable(null);
     setForecastRepairTargets([]);
+    setPlanImportRepairOffered(false);
     setWearableForecastBlock(null);
     setWeekAheadPlan(null);
     setNextDayPlan(null);
@@ -108,12 +112,17 @@ export const PlanView: React.FC<PlanViewProps> = ({ userId, onNavigate, onPlanCh
       setDecisionInput(input);
 
       // P0: Enforce strict DataState semantics. Do NOT silently convert unavailable/invalid
-      // schedule data into empty arrays.
+      // schedule data into empty arrays. Name which schedule input failed so the state is
+      // actionable; these inputs have no owning repair screen, so retry is the repair.
       if (actState.status !== 'AVAILABLE' || blocksState.status !== 'AVAILABLE') {
+        const failedInputs: string[] = [];
+        if (actState.status !== 'AVAILABLE') failedInputs.push('fixed activities');
+        if (blocksState.status !== 'AVAILABLE') failedInputs.push('plan blocks');
+        const failedInputsLabel = failedInputs.join(' and ');
         const unavailMsg =
           actState.status === 'UNAVAILABLE' || blocksState.status === 'UNAVAILABLE'
-            ? 'Some schedule inputs are temporarily unavailable. Check your connection and retry.'
-            : 'Schedule data could not be verified. Please retry before using this plan.';
+            ? `The plan week's ${failedInputsLabel} are temporarily unavailable. Check your connection and retry.`
+            : `The plan week's ${failedInputsLabel} could not be verified. Please retry before using this plan.`;
         setForecastUnavailable(unavailMsg);
         setFixedActivities([]);
         setActivePlan(null);
@@ -132,9 +141,9 @@ export const PlanView: React.FC<PlanViewProps> = ({ userId, onNavigate, onPlanCh
           // is actionable rather than a dead end -- re-saving there re-runs validation
           // and clears the INVALID state.
           const repairTargets: ErrorRepairAction[] = [];
-          if (input.sourceStates?.activeGoals.status === 'INVALID') repairTargets.push({ kind: 'navigate', screen: 'goals', label: 'Review goals' });
-          if (input.sourceStates?.preferences.status === 'INVALID') repairTargets.push({ kind: 'navigate', screen: 'preferences', label: 'Review preferences' });
-          if (input.sourceStates?.trainingSettings.status === 'INVALID') repairTargets.push({ kind: 'navigate', screen: 'constraints', label: 'Review training settings' });
+          if (input.sourceStates?.activeGoals.status === 'INVALID') repairTargets.push({ kind: 'navigate', screen: 'goals', label: `Review ${SCREEN_LABELS.goals}` });
+          if (input.sourceStates?.preferences.status === 'INVALID') repairTargets.push({ kind: 'navigate', screen: 'preferences', label: `Review ${SCREEN_LABELS.preferences}` });
+          if (input.sourceStates?.trainingSettings.status === 'INVALID') repairTargets.push({ kind: 'navigate', screen: 'constraints', label: `Review ${SCREEN_LABELS.constraints}` });
           setForecastRepairTargets(repairTargets);
         }
         setForecastUnavailable(
@@ -186,6 +195,7 @@ export const PlanView: React.FC<PlanViewProps> = ({ userId, onNavigate, onPlanCh
       // silently decay to MISSING / no plan, as that could discard athlete placements.
       const activePlanState = await activeExternalPlanService.getActivePlanState(userId, today, acts);
       if (activePlanState.status === 'INVALID' || activePlanState.status === 'UNAVAILABLE') {
+        if (activePlanState.status === 'INVALID') setPlanImportRepairOffered(true);
         setForecastUnavailable(
           activePlanState.status === 'UNAVAILABLE'
             ? 'Your active coach plan is temporarily unavailable. Check your connection and retry.'
@@ -501,6 +511,11 @@ export const PlanView: React.FC<PlanViewProps> = ({ userId, onNavigate, onPlanCh
             ) : (
               <GarminSyncNowButton key="resync" userId={userId} onSynced={loadPlanData} />
             ))}
+            {planImportRepairOffered && (
+              <button type="button" className="plan-retry-btn" onClick={() => setShowImport(true)}>
+                📥 Review imported plan
+              </button>
+            )}
             <button type="button" className="plan-retry-btn" onClick={loadPlanData}>
               🔄 Retry
             </button>

--- a/app/src/components/errorRepairAction.test.ts
+++ b/app/src/components/errorRepairAction.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import type { DataStateSummary } from '../engine/dataState';
+import {
+  resolveDecisionCompositionRepairState,
+  resolveDecisionSourceRepairState,
+} from './errorRepairAction';
+
+const available: DataStateSummary = { status: 'AVAILABLE', revision: 'rev-1' };
+const invalid: DataStateSummary = {
+  status: 'INVALID',
+  issues: [{ code: 'schema', documentPath: 'users/u/doc' }],
+};
+const unavailable: DataStateSummary = {
+  status: 'UNAVAILABLE',
+  operation: 'read source',
+  retryable: true,
+};
+
+describe('resolveDecisionSourceRepairState', () => {
+  it('keeps repair actions for INVALID sources even when an earlier source is UNAVAILABLE', () => {
+    const result = resolveDecisionSourceRepairState({
+      activeGoals: unavailable,
+      preferences: invalid,
+      trainingSettings: available,
+    });
+
+    expect(result).toEqual({
+      message: 'Decision inputs need attention: Coach Preferences is invalid; Goals is temporarily unavailable. Review the invalid input, then retry.',
+      actions: [{ kind: 'navigate', screen: 'preferences', label: 'Review Coach Preferences' }],
+    });
+  });
+
+  it('names every invalid source and returns each owning repair screen', () => {
+    const result = resolveDecisionSourceRepairState({
+      activeGoals: invalid,
+      preferences: available,
+      trainingSettings: invalid,
+    });
+
+    expect(result).toEqual({
+      message: 'Decision inputs need repair: Goals and Training Setup are invalid. Review the invalid inputs, then retry.',
+      actions: [
+        { kind: 'navigate', screen: 'goals', label: 'Review Goals' },
+        { kind: 'navigate', screen: 'constraints', label: 'Review Training Setup' },
+      ],
+    });
+  });
+
+  it('returns null when no blocking decision source failed', () => {
+    expect(resolveDecisionSourceRepairState({
+      activeGoals: available,
+      preferences: { status: 'MISSING' },
+      trainingSettings: available,
+    })).toBeNull();
+  });
+});
+
+describe('resolveDecisionCompositionRepairState', () => {
+  it('routes invalid Training Settings to Training Setup', () => {
+    expect(resolveDecisionCompositionRepairState(
+      new Error('Training settings are invalid. Please review and save them again.'),
+    )).toEqual({
+      message: 'Training Setup is invalid. Review and save it again, then retry.',
+      actions: [{ kind: 'navigate', screen: 'constraints', label: 'Review Training Setup' }],
+    });
+  });
+
+  it('routes invalid schedule overlays to Plan', () => {
+    expect(resolveDecisionCompositionRepairState(
+      new Error('Schedule overlays are invalid. Please review or remove the affected schedule block.'),
+    )).toEqual({
+      message: 'Schedule overlays are invalid. Review or remove the affected schedule block in Plan, then retry.',
+      actions: [{ kind: 'navigate', screen: 'plan', label: 'Review Plan' }],
+    });
+  });
+
+  it('does not guess a repair surface for unknown exceptions', () => {
+    expect(resolveDecisionCompositionRepairState(new Error('boom'))).toBeNull();
+  });
+});

--- a/app/src/components/errorRepairAction.ts
+++ b/app/src/components/errorRepairAction.ts
@@ -1,4 +1,5 @@
-import type { Screen } from '../types/navigation';
+import type { DataStateSummary } from '../engine/dataState';
+import { SCREEN_LABELS, type Screen } from '../types/navigation';
 
 /** An actionable next step surfaced on a load-error screen: either a specific screen that
  * owns the flagged document (re-saving there re-runs validation), or a forced Garmin
@@ -7,3 +8,114 @@ import type { Screen } from '../types/navigation';
 export type ErrorRepairAction =
     | { kind: 'navigate'; screen: Screen; label: string }
     | { kind: 'resync' };
+
+export interface ErrorRepairState {
+    message: string;
+    actions: ErrorRepairAction[];
+}
+
+type DecisionSourceStates = {
+    activeGoals: DataStateSummary;
+    preferences: DataStateSummary;
+    trainingSettings: DataStateSummary;
+};
+
+const DECISION_SOURCES = [
+    { key: 'activeGoals', screen: 'goals', label: SCREEN_LABELS.goals },
+    { key: 'preferences', screen: 'preferences', label: SCREEN_LABELS.preferences },
+    { key: 'trainingSettings', screen: 'constraints', label: SCREEN_LABELS.constraints },
+] as const satisfies ReadonlyArray<{
+    key: keyof DecisionSourceStates;
+    screen: Screen;
+    label: string;
+}>;
+
+function formatList(items: string[]): string {
+    if (items.length <= 1) return items[0] ?? '';
+    if (items.length === 2) return `${items[0]} and ${items[1]}`;
+    return `${items.slice(0, -1).join(', ')}, and ${items.at(-1)}`;
+}
+
+function agreement(items: readonly unknown[]): 'is' | 'are' {
+    return items.length === 1 ? 'is' : 'are';
+}
+
+/**
+ * Aggregate every decision-source failure instead of letting the first array match hide a
+ * later INVALID source. A mixed UNAVAILABLE + INVALID state must still expose the repair
+ * screen for the invalid document while accurately naming the unavailable input(s).
+ */
+export function resolveDecisionSourceRepairState(
+    sourceStates: DecisionSourceStates | null | undefined,
+): ErrorRepairState | null {
+    if (!sourceStates) return null;
+
+    const invalid = DECISION_SOURCES.filter(({ key }) => sourceStates[key].status === 'INVALID');
+    const unavailable = DECISION_SOURCES.filter(({ key }) => sourceStates[key].status === 'UNAVAILABLE');
+    if (invalid.length === 0 && unavailable.length === 0) return null;
+
+    const actions: ErrorRepairAction[] = invalid.map(({ screen, label }) => ({
+        kind: 'navigate',
+        screen,
+        label: `Review ${label}`,
+    }));
+    const invalidLabels = invalid.map(({ label }) => label);
+    const unavailableLabels = unavailable.map(({ label }) => label);
+
+    if (invalid.length > 0 && unavailable.length > 0) {
+        return {
+            actions,
+            message: `Decision inputs need attention: ${formatList(invalidLabels)} ${agreement(invalid)} invalid; ${formatList(unavailableLabels)} ${agreement(unavailable)} temporarily unavailable. Review the invalid input${invalid.length === 1 ? '' : 's'}, then retry.`,
+        };
+    }
+
+    if (invalid.length > 0) {
+        return {
+            actions,
+            message: `Decision inputs need repair: ${formatList(invalidLabels)} ${agreement(invalid)} invalid. Review the invalid input${invalid.length === 1 ? '' : 's'}, then retry.`,
+        };
+    }
+
+    return {
+        actions,
+        message: `Decision inputs are temporarily unavailable: ${formatList(unavailableLabels)}. Retry when ${unavailable.length === 1 ? 'that input can' : 'those inputs can'} be read.`,
+    };
+}
+
+/**
+ * Some required composition inputs cannot be represented as a returned DailyDecisionInput
+ * when they fail (notably Training Settings and schedule overlays), so DecisionComposer
+ * throws before Home/PlanView can inspect sourceStates. Preserve that fail-closed contract
+ * while mapping only the composer's explicit, known error messages to owning repair UI.
+ * Unknown exceptions remain generic rather than guessing at a repair surface.
+ */
+export function resolveDecisionCompositionRepairState(error: unknown): ErrorRepairState | null {
+    if (!(error instanceof Error)) return null;
+
+    if (error.message.startsWith('Training settings are invalid.')) {
+        return {
+            message: `${SCREEN_LABELS.constraints} is invalid. Review and save it again, then retry.`,
+            actions: [{ kind: 'navigate', screen: 'constraints', label: `Review ${SCREEN_LABELS.constraints}` }],
+        };
+    }
+    if (error.message.startsWith('Training settings are temporarily unavailable.')) {
+        return {
+            message: `${SCREEN_LABELS.constraints} is temporarily unavailable. Retry when it can be read.`,
+            actions: [],
+        };
+    }
+    if (error.message.startsWith('Schedule overlays are invalid.')) {
+        return {
+            message: 'Schedule overlays are invalid. Review or remove the affected schedule block in Plan, then retry.',
+            actions: [{ kind: 'navigate', screen: 'plan', label: `Review ${SCREEN_LABELS.plan}` }],
+        };
+    }
+    if (error.message.startsWith('Schedule overlays are temporarily unavailable.')) {
+        return {
+            message: 'Schedule overlays are temporarily unavailable. Retry when they can be read.',
+            actions: [],
+        };
+    }
+
+    return null;
+}

--- a/docs/architecture/user-flows.md
+++ b/docs/architecture/user-flows.md
@@ -377,8 +377,11 @@ living-reference section when implementing them.
 
 4. Add an explicit authority/explanation banner when coach plan, adaptive forecast, and the
    Home recommendation differ.
-5. Standardize fail-closed recovery: say what is missing, link to the owning repair surface,
-   and provide retry when retry is meaningful.
+5. ~~Standardize fail-closed recovery: say what is missing, link to the owning repair surface,~~
+   ~~and provide retry when retry is meaningful.~~
+   Done (#483): every Home and PlanView blocking state names the missing input, links to
+   the owning repair surface where one exists (goals, preferences, training setup, Garmin
+   resync, plan import), and always offers retry or resync with no silent dead ends.
 6. Make Check-in progress and partial-save semantics explicit so Back/Skip versus submit is
    unambiguous.
 


### PR DESCRIPTION
## Summary
- Standardizes the fail-closed repair triplet on Home and PlanView: every blocking state now names the missing input, deep-links to the fixing screen where one exists, and always offers retry or resync. No silent dead ends on either screen.
- Home: the unverifiable-Garmin-connection block now links to Coach Preferences (which owns connection configuration) alongside Retry; decision-source repair labels now use the canonical navigation.ts SCREEN_LABELS names (Goals / Coach Preferences / Training Setup).
- PlanView: schedule-input failures now name which input failed (fixed activities and/or plan blocks); an unverifiable (INVALID) active coach plan offers a Review imported plan forward action opening the import/revise UI, in addition to Retry. Repair labels use SCREEN_LABELS.
- Docs: user-flows.md Recommendation 5 marked done (struck-through + Done note).
- No engine, gating, Firestore, or schedule logic touched; no behavior change beyond repair affordances.
- Closes #483. References docs/architecture/user-flows.md Recommendation 5 and navigation.ts SCREEN_LABELS (#485).
## Validation
- [x] npm run check in app/: pass - tsc -b, eslint, vitest (422 files passed, 4023 tests passed), knowledge validation (76 claims), knowledge-coverage validation, workout validation
- [x] node scripts/check-policy-drift.mjs origin/main: pass - no decision-affecting engine files modified
- Manual check: N/A - error states are fail-closed branches requiring INVALID/UNAVAILABLE Firestore states; no dedicated Home/PlanView component harness exists. Verified by code inspection that every blocking branch renders at least one forward action (Retry is unconditional in both error cards).
## Risk and reviewer guidance
- Inspect closely: the new planImportRepairOffered flag lifecycle in PlanView loadPlanData (reset on every reload, set only on active-plan INVALID) and the added navigate target in Home's wearable-unavailable branch.
- Could regress: repair-button copy (canonical label names) and the schedule-failure message composition. No migration, deployment, or rollback notes; UI-only change.
## Domain invariants
- Firestore writes remain user-scoped - no persistence code touched; how checked: diff contains only two components plus one architecture doc.
- Calendar-date logic uses Europe/Warsaw; totalSteps still D - 1 - untouched; how checked: no date or step code in diff.
- No credentials/tokens/service-account files/raw health payloads included; how checked: git status shows only the three intended files.
- Decision logic changed: not needed - POLICY_VERSION untouched because all changes are repair affordances around unchanged fail-closed gates (policy-drift check passes).
## Screenshots or recordings
- Not applicable - copy and button affordances on fail-closed error branches with no existing component harness; no visual-review baseline for these states.