### PR TITLE
feat(settings): cross-link Training Setup and Coach Preferences controls (#489)

### DIFF
--- a/app/src/components/TrainingSettings.tsx
+++ b/app/src/components/TrainingSettings.tsx
@@ -1,13 +1,14 @@
-import { type FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
+import { type FormEvent, type ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
 import type { BodyRegion, GuardrailKey, InjuryConstraint, SessionTemplate, TrainingSettings as TrainingSettingsModel } from '../engine/models';
 import { resolveInjuryRestrictions } from '../engine/injuryPolicy';
 import { trainingSettingsService, type TrainingSettingsUpdate } from '../services/trainingSettingsService';
 import { getLocalDateString } from '../utils/localDate';
-import { SCREEN_LABELS } from '../types/navigation';
+import { SCREEN_LABELS, type Screen } from '../types/navigation';
 import './TrainingSettings.css';
 
 interface TrainingSettingsProps {
   userId: string;
+  onNavigate?: (screen: Screen) => void;
 }
 
 const equipmentLabels: Record<keyof TrainingSettingsModel['equipment'], string> = {
@@ -36,7 +37,20 @@ const injuryRegions: Array<{ value: BodyRegion; label: string }> = [
 const injuryModalities: SessionTemplate['modality'][] = ['Running', 'Cycling', 'Swimming', 'Walking', 'Strength', 'Field', 'Mobility', 'Cross Training'];
 const emptyInjuryDraft = { region: '', severity: 'limit' as InjuryConstraint['severity'], restrictedModalities: [] as SessionTemplate['modality'][], reviewBy: '', note: '' };
 
-export function TrainingSettings({ userId }: TrainingSettingsProps) {
+function CrossSurfaceNote({ onNavigate, children }: { onNavigate?: (screen: Screen) => void; children: ReactNode }) {
+  return (
+    <p className="section-intro">
+      {children}{' '}
+      {onNavigate && (
+        <button type="button" onClick={() => onNavigate('preferences')}>
+          Open {SCREEN_LABELS.preferences}
+        </button>
+      )}
+    </p>
+  );
+}
+
+export function TrainingSettings({ userId, onNavigate }: TrainingSettingsProps) {
   const [settings, setSettings] = useState<TrainingSettingsModel | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [injuryDraft, setInjuryDraft] = useState(emptyInjuryDraft);
@@ -114,6 +128,7 @@ export function TrainingSettings({ userId }: TrainingSettingsProps) {
       <header>
         <h1>{SCREEN_LABELS.constraints}</h1>
         <p>Equipment determines what can be prescribed. Safety limits are always enforced. Preferences only break ties between suitable options.</p>
+        <p className="section-intro">Changes on this screen save automatically and act as hard gates: they remove sessions from every recommendation. Softer tie-breaks live in {SCREEN_LABELS.preferences} and only apply after an explicit save there.</p>
       </header>
       {error && <p className="settings-error" role="alert">{error}</p>}
       {!settings.migration.legacyReviewed && (
@@ -127,6 +142,7 @@ export function TrainingSettings({ userId }: TrainingSettingsProps) {
       <section aria-labelledby="equipment-title">
         <h2 id="equipment-title">Available equipment & sport access</h2>
         <p className="section-intro">Turn on only equipment and venues you can reliably use for a typical session. Pool access may be indoor or outdoor.</p>
+        <CrossSurfaceNote onNavigate={onNavigate}>Related: {SCREEN_LABELS.preferences} → “Unavailable Training Types” excludes modalities by name, even when the equipment here would allow them.</CrossSurfaceNote>
         <div className="settings-list">
           {Object.entries(equipmentLabels).map(([key, label]) => (
             <label className="setting-row" key={key}>
@@ -140,6 +156,7 @@ export function TrainingSettings({ userId }: TrainingSettingsProps) {
       <section aria-labelledby="guardrails-title">
         <h2 id="guardrails-title">Safety limits</h2>
         <p className="section-intro">These limits remove matching sessions from every recommendation, including “Harder”. This is not medical advice.</p>
+        <CrossSurfaceNote onNavigate={onNavigate}>Related: mere dislikes (no safety impact) belong in {SCREEN_LABELS.preferences} → “Training I’d Rather Avoid”, which only penalizes rather than blocks.</CrossSurfaceNote>
         <div className="settings-list">
           {Object.entries(guardrailDetails).map(([key, detail]) => (
             <label className="setting-row" key={key}>
@@ -152,12 +169,15 @@ export function TrainingSettings({ userId }: TrainingSettingsProps) {
 
       <section aria-labelledby="availability-title">
         <h2 id="availability-title">Time and location</h2>
+        <p className="section-intro">These limits are hard caps: longer sessions are never recommended.</p>
+        <CrossSurfaceNote onNavigate={onNavigate}>Related: {SCREEN_LABELS.preferences} → “Default Available Duration” holds soft time budgets that shape durations without gating.</CrossSurfaceNote>
         <div className="time-inputs">
           <label>Weekday session limit (minutes)<input type="number" min="0" max="1440" value={settings.defaults.weekdayMaxMinutes ?? ''} onChange={(event) => void save({ defaults: { weekdayMaxMinutes: event.target.value === '' ? null : Number(event.target.value) } })} /></label>
           <label>Weekend session limit (minutes)<input type="number" min="0" max="1440" value={settings.defaults.weekendMaxMinutes ?? ''} onChange={(event) => void save({ defaults: { weekendMaxMinutes: event.target.value === '' ? null : Number(event.target.value) } })} /></label>
         </div>
         <fieldset>
           <legend>Training location requirement</legend>
+          <p className="section-intro">This is the persistent requirement. A one-day indoor-only override lives in today’s check-in availability.</p>
           {(['either', 'indoor', 'outdoor'] as const).map((environment) => <label key={environment}><input type="radio" name="environment" checked={settings.defaults.environment === environment} onChange={() => void save({ defaults: { environment } })} /> {environment === 'either' ? 'Any location' : `${environment[0].toUpperCase()}${environment.slice(1)} only`}</label>)}
         </fieldset>
       </section>

--- a/app/src/components/preferences/ModalitySections.tsx
+++ b/app/src/components/preferences/ModalitySections.tsx
@@ -1,9 +1,12 @@
 
 import type { UserPreferences } from '../../engine/models';
+import type { Screen } from '../../types/navigation';
+import { SCREEN_LABELS } from '../../types/navigation';
 import { CANONICAL_MODALITIES } from '../../utils/modalities';
 
 interface ModalitySectionsProps {
   preferences: UserPreferences;
+  onNavigate?: (screen: Screen) => void;
   addPreferredModality: (modality: string) => void;
   removePreferredModality: (modality: string) => void;
   addAvoidedModality: (modality: string) => void;
@@ -14,6 +17,7 @@ interface ModalitySectionsProps {
 
 export function ModalitySections({
   preferences,
+  onNavigate,
   addPreferredModality,
   removePreferredModality,
   addAvoidedModality,
@@ -97,6 +101,16 @@ export function ModalitySections({
         <p className="preference-desc">
           Hard exclusions: these activities will not be offered, even when they would otherwise fit the plan.
         </p>
+        <p className="preference-desc">
+          Related: {SCREEN_LABELS.constraints} → “Available equipment &amp; sport access” gates
+          by venue and gear, while this list excludes by modality name. Remember to save here
+          with Save Preferences; equipment changes there save immediately.
+          {onNavigate && (
+            <button type="button" onClick={() => onNavigate('constraints')}>
+              Open {SCREEN_LABELS.constraints}
+            </button>
+          )}
+        </p>
         <div className="modality-select-group">
           <select
             value=""
@@ -132,7 +146,7 @@ export function ModalitySections({
           Modalities you dislike. The engine will apply a strong soft penalty to avoid prescribing these when viable alternatives exist.
         </p>
         <p className="preference-warning-note">
-          💡 <strong>Note:</strong> Safety & injury restrictions (e.g. Achilles pain) belong in <em>Constraints</em>, not Preferences.
+          💡 <strong>Note:</strong> Safety & injury restrictions (e.g. Achilles pain) belong in <em>{SCREEN_LABELS.constraints}</em>, not Preferences.
         </p>
 
         <div className="modality-select-group">

--- a/app/src/components/preferences/PreferencesHeader.tsx
+++ b/app/src/components/preferences/PreferencesHeader.tsx
@@ -14,6 +14,11 @@ export function PreferencesHeader({ hasChanges }: PreferencesHeaderProps) {
         <p className="header-subtitle">
           Configure how the adaptive engine selects and presents training recommendations.
         </p>
+        <p className="header-subtitle">
+          Edits here are staged until you choose Save Preferences, and they only break ties
+          between suitable options. Hard feasibility and safety gates live in{' '}
+          {SCREEN_LABELS.constraints} and save immediately.
+        </p>
       </div>
       {hasChanges && (
         <span className="unsaved-indicator">Unsaved changes</span>

--- a/app/src/components/preferences/SettingsPairing.test.tsx
+++ b/app/src/components/preferences/SettingsPairing.test.tsx
@@ -1,0 +1,84 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import type { UserPreferences } from '../../engine/models';
+import { SCREEN_LABELS } from '../../types/navigation';
+import { ModalitySections } from './ModalitySections';
+import { PreferencesHeader } from './PreferencesHeader';
+import { StyleSections } from './StyleSections';
+
+function buildPreferences(): UserPreferences {
+  return {
+    userId: 'test-user',
+    preferredRecoveryStyle: 'mixed',
+    defaultWeekdayTimeMin: 45,
+    defaultWeekendTimeMin: 60,
+    preferredTimeOfDay: 'flexible',
+    preferredModalities: ['Running'],
+    deprioritizedModalities: [],
+    avoidedModalities: [],
+    unavailableModalities: [],
+    explanationVerbosity: 'detailed',
+    conservativeBias: false,
+    preferredUnits: {
+      distance: 'km',
+      weight: 'kg',
+      temperature: 'celsius',
+    },
+    schemaVersion: 1,
+    createdAt: '2026-08-23T00:00:00.000Z',
+    updatedAt: '2026-08-23T00:00:00.000Z',
+  } as UserPreferences;
+}
+
+const noopHandlers = {
+  addPreferredModality: () => undefined,
+  removePreferredModality: () => undefined,
+  addAvoidedModality: () => undefined,
+  removeAvoidedModality: () => undefined,
+  addUnavailableModality: () => undefined,
+  removeUnavailableModality: () => undefined,
+};
+
+describe('Settings pairing cross-links (#489)', () => {
+  it('ModalitySections links unavailable modalities to Training Setup equipment', () => {
+    const html = renderToStaticMarkup(
+      <ModalitySections preferences={buildPreferences()} onNavigate={() => undefined} {...noopHandlers} />,
+    );
+
+    expect(html).toContain('Unavailable Training Types');
+    expect(html).toContain('Available equipment');
+    expect(html).toContain(`Open ${SCREEN_LABELS.constraints}`);
+  });
+
+  it('ModalitySections omits the navigation button without onNavigate', () => {
+    const html = renderToStaticMarkup(
+      <ModalitySections preferences={buildPreferences()} {...noopHandlers} />,
+    );
+
+    expect(html).toContain('Available equipment');
+    expect(html).not.toContain(`Open ${SCREEN_LABELS.constraints}`);
+  });
+
+  it('StyleSections links default durations to Training Setup time caps', () => {
+    const html = renderToStaticMarkup(
+      <StyleSections
+        preferences={buildPreferences()}
+        onNavigate={() => undefined}
+        updatePreference={() => undefined}
+        updateNestedPreference={() => undefined}
+      />,
+    );
+
+    expect(html).toContain('Default Available Duration');
+    expect(html).toContain('Time and location');
+    expect(html).toContain(`Open ${SCREEN_LABELS.constraints}`);
+  });
+
+  it('PreferencesHeader states the explicit save model and hard-gate ownership', () => {
+    const html = renderToStaticMarkup(<PreferencesHeader hasChanges={false} />);
+
+    expect(html).toContain(SCREEN_LABELS.preferences);
+    expect(html).toContain('Save Preferences');
+    expect(html).toContain(SCREEN_LABELS.constraints);
+  });
+});

--- a/app/src/components/preferences/StyleSections.tsx
+++ b/app/src/components/preferences/StyleSections.tsx
@@ -1,13 +1,16 @@
 
 import type { UserPreferences, RecoveryStyle, TimeOfDay, ExplanationVerbosity } from '../../engine/models';
+import type { Screen } from '../../types/navigation';
+import { SCREEN_LABELS } from '../../types/navigation';
 
 interface StyleSectionsProps {
   preferences: UserPreferences;
+  onNavigate?: (screen: Screen) => void;
   updatePreference: <K extends keyof UserPreferences>(key: K, value: UserPreferences[K]) => void;
   updateNestedPreference: <K extends keyof UserPreferences['preferredUnits']>(key: K, value: UserPreferences['preferredUnits'][K]) => void;
 }
 
-export function StyleSections({ preferences, updatePreference, updateNestedPreference }: StyleSectionsProps) {
+export function StyleSections({ preferences, onNavigate, updatePreference, updateNestedPreference }: StyleSectionsProps) {
   return (
     <>
       {/* Training Decision Style */}
@@ -60,6 +63,16 @@ export function StyleSections({ preferences, updatePreference, updateNestedPrefe
         <h2>Default Available Duration</h2>
         <p className="preference-desc">
           Default daily time budgets used to filter or scale session durations.
+        </p>
+        <p className="preference-desc">
+          Related: {SCREEN_LABELS.constraints} → “Time and location” sets hard session caps
+          that are never exceeded; these defaults only shape durations. Remember to save here
+          with Save Preferences; time-cap changes there save immediately.
+          {onNavigate && (
+            <button type="button" onClick={() => onNavigate('constraints')}>
+              Open {SCREEN_LABELS.constraints}
+            </button>
+          )}
         </p>
         <div className="time-inputs">
           <div className="time-input-group">

--- a/app/src/components/preferences/index.tsx
+++ b/app/src/components/preferences/index.tsx
@@ -16,7 +16,7 @@ interface PreferencesProps {
   onNavigate?: (screen: Screen) => void;
 }
 
-export function Preferences({ userId }: PreferencesProps) {
+export function Preferences({ userId, onNavigate }: PreferencesProps) {
   const {
     preferences,
     trainingIntentProfile,
@@ -95,6 +95,7 @@ export function Preferences({ userId }: PreferencesProps) {
 
         <ModalitySections
           preferences={preferences}
+          onNavigate={onNavigate}
           addPreferredModality={addPreferredModality}
           removePreferredModality={removePreferredModality}
           addAvoidedModality={addAvoidedModality}
@@ -105,6 +106,7 @@ export function Preferences({ userId }: PreferencesProps) {
 
         <StyleSections
           preferences={preferences}
+          onNavigate={onNavigate}
           updatePreference={updatePreference}
           updateNestedPreference={updateNestedPreference}
         />

--- a/docs/architecture/user-flows.md
+++ b/docs/architecture/user-flows.md
@@ -284,7 +284,10 @@ The two routes intentionally have different authority:
 
 The distinction is architecturally important, but some concepts overlap in the UI:
 equipment versus unavailable modalities, hard time limits versus preferred/default times,
-and persistent environment setup versus today's `indoorOnly` availability.
+and persistent environment setup versus today's `indoorOnly` availability. Each overlapping
+section now names its counterpart inline (`TrainingSettings` equipment, time/location, and
+guardrail notes point at `Preferences`; `ModalitySections` unavailable/avoided notes and the
+`StyleSections` default-duration note point back), and both headers state their save model.
 
 ### 9. Data and AI export
 
@@ -384,8 +387,11 @@ living-reference section when implementing them.
 
 ### Settings
 
-7. Visually pair Training Setup (hard gates) and Coach Preferences (soft preferences), with
-   cross-links between overlapping equipment/time/environment concepts.
+7. ~~Visually pair Training Setup (hard gates) and Coach Preferences (soft preferences), with
+   cross-links between overlapping equipment/time/environment concepts.~~
+   Done (#489): each overlapping control names its counterpart inline from either side, and
+   both headers state their save semantics (immediate autosave on Training Setup, explicit
+   Save on Coach Preferences). Engine authority unchanged. Full tab-merge deferred.
 8. Either remove `Goals.onNavigate` or use it for explicit repair/deep-link flows; an unused
    navigation prop is misleading API surface.
 9. Review immediate-persist Training Setup controls for undo/confirmation where a mistaken


### PR DESCRIPTION
## Summary
- Pairs Training Setup (hard gates, autosaved) with Coach Preferences (soft tie-breaks, explicit Save) via inline cross-links on every overlapping control, using the minimal option from #489: equipment <-> unavailable modalities, hard time caps <-> default durations, persistent environment <-> check-in indoor-only, guardrails <-> avoided modalities.
- Both headers now state their save semantics; Preferences sections render Open Training Setup buttons through the already-passed onNavigate, TrainingSettings accepts an optional onNavigate for the reverse direction.
- Labels render from navigation.ts SCREEN_LABELS; engine authority unchanged (hard gates gate, preferences tie-break only).
- Closes #489. References docs/architecture/user-flows.md Recommendation 7 (marked done).

## Validation
- [x] npm run typecheck: pass
- [x] npx eslint on all touched files: pass
- [x] New SettingsPairing.test.tsx (4 tests): pass; neighboring preferences suites pass
- [x] npm run check (tsc + eslint + full vitest + knowledge/coverage/workout validators): pass except one flaky timing gate (weeklyAllocationPlanner p95 latency, fails under parallel load, passes in isolation) — unrelated, no engine files touched
- [x] node scripts/check-policy-drift.mjs origin/main: pass (no POLICY_VERSION bump needed)
- Manual check: N/A (copy-only UI; verified via static-markup tests)

## Risk and reviewer guidance
- Copy-only UI change; no decision logic, Firestore, or routing changes. Review copy wording and button placement.
- Follow-up (not in lane): pass onNavigate into TrainingSettings in App.tsx/VisualReviewApp so the Training Setup -> Coach Preferences buttons activate in production (Preferences direction already works). Full tab-merge with shared save model deliberately deferred.

## Domain invariants
- Firestore writes remain user-scoped — unchanged, no persistence code touched.
- Calendar-date logic uses Europe/Warsaw; totalSteps still D-1 — untouched.
- No credentials/tokens/service-account files/raw health payloads included.
- Decision logic changed: no — POLICY_VERSION not bumped; drift check passes; docs/architecture/user-flows.md updated (Rec 7 struck-through + Done note, section 8 current behavior).

## Screenshots or recordings
- Not applicable — text-only cross-link notes, covered by static-markup tests.