### PR TITLE
feat(export): consolidate Export for AI into canonical brief surface (#491)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -349,6 +349,7 @@ function App() {
                 decisionInput={decisionInput}
                 userId={userId!}
                 onBack={() => handleNavigate('home')}
+                onNavigateToBrief={() => handleNavigate('brief')}
               />
               {decisionInput && (
                 <HealthAnomalyShadowPanel

--- a/app/src/components/DataView.tsx
+++ b/app/src/components/DataView.tsx
@@ -8,7 +8,6 @@ import { contextBriefService, type ContextBriefResult } from '../services/contex
 import { briefWindowDaysFor, type BriefWindowPreset } from '../engine/contextBrief';
 import { addDaysToLocalDateString, getLocalDateString } from '../utils/localDate';
 import {
-  copyActivitiesBundleToClipboard,
   downloadActivitiesJsonFile,
   exportActivitiesBundleToJson,
 } from '../utils/activityJsonExport';
@@ -28,10 +27,9 @@ interface DataViewProps {
   userId: string;
   onBack: () => void;
   initialTab?: DataViewTab;
-  /** When provided, the duplicate export affordances (Context-brief tab content and
-   * Activities Copy All) become deep links to the canonical `brief` screen instead of
-   * reimplementing its export (#491). The `brief` screen itself omits this prop so it
-   * keeps the full export UI. */
+  /** When provided, Context-brief and AI-export affordances deep-link to the canonical
+   * `brief` screen. The canonical `brief` screen omits this prop so it renders the full
+   * brief while still routing any in-view AI export action back to that brief tab. */
   onNavigateToBrief?: () => void;
 }
 
@@ -113,7 +111,6 @@ export function DataView({ decisionInput, userId, initialTab = 'recovery', onNav
   } | null>(null);
   const [reclassifyModalOpen, setReclassifyModalOpen] = useState(false);
   const [activityOverrides, setActivityOverrides] = useState<Record<string, ActivityOverride>>({});
-  const [allActivitiesCopied, setAllActivitiesCopied] = useState(false);
   // ADR-0034 PR2: canonical Activities read model, gated by VITE_TRAINING_OCCURRENCE_ACTIVITIES_POLICY.
   // Default 'off' leaves activityWindow/ActivityTelemetry above as the sole, unchanged
   // production path -- this state and its effect are inert unless explicitly enabled.
@@ -228,21 +225,12 @@ export function DataView({ decisionInput, userId, initialTab = 'recovery', onNav
     }
   };
 
-  const handleCopyAllActivities = async () => {
-    if (!activityWindow || activityWindow.state.status !== 'AVAILABLE' || activityWindow.state.data.length === 0) return;
-    const startInclusive = addDaysToLocalDateString(briefDate ?? getLocalDateString(), -6);
-    const throughDateExclusive = addDaysToLocalDateString(briefDate ?? getLocalDateString(), 1);
-    try {
-      await copyActivitiesBundleToClipboard(activityWindow.state.data, {
-        userId,
-        startDateInclusive: startInclusive,
-        throughDateExclusive,
-      });
-      setAllActivitiesCopied(true);
-      window.setTimeout(() => setAllActivitiesCopied(false), 2000);
-    } catch (err) {
-      console.error('Failed to copy activities bundle to clipboard', err);
+  const openCanonicalBrief = () => {
+    if (onNavigateToBrief) {
+      onNavigateToBrief();
+      return;
     }
+    setActiveTab('brief');
   };
 
   const handleDownloadActivities = () => {
@@ -1058,12 +1046,7 @@ export function DataView({ decisionInput, userId, initialTab = 'recovery', onNav
         </button>
         <button
           className={activeTab === 'brief' ? 'active' : ''}
-          onClick={() => {
-            // The `brief` screen is the canonical Export-for-AI surface (#491);
-            // from the Data screen this tab deep-links to it instead of duplicating it.
-            if (onNavigateToBrief) onNavigateToBrief();
-            else setActiveTab('brief');
-          }}
+          onClick={openCanonicalBrief}
         >
           Context brief
         </button>
@@ -1077,32 +1060,20 @@ export function DataView({ decisionInput, userId, initialTab = 'recovery', onNav
               <div>
                 <h3 style={{ margin: 0 }}>Recent activity telemetry</h3>
                 <p className="activities-tab-subtitle">
-                  Inspect detailed Garmin telemetry. Export structured JSON for external AI agent planning.
+                  Inspect detailed Garmin telemetry. Use the canonical context brief for AI planning; JSON download remains a data export.
                 </p>
               </div>
               {activityWindow?.state.status === 'AVAILABLE' && activityWindow.state.data.length > 0 && (
                 <div className="activities-header-actions">
-                  {onNavigateToBrief ? (
-                    <button
-                      type="button"
-                      className="quick-action-btn secondary"
-                      style={{ width: 'auto', padding: '0.4rem 0.8rem', fontSize: '0.85rem' }}
-                      onClick={onNavigateToBrief}
-                      title="Open the canonical Export Context for AI surface for AI planning export"
-                    >
-                      📋 Export via {SCREEN_LABELS.brief}
-                    </button>
-                  ) : (
-                    <button
-                      type="button"
-                      className="quick-action-btn secondary"
-                      style={{ width: 'auto', padding: '0.4rem 0.8rem', fontSize: '0.85rem' }}
-                      onClick={handleCopyAllActivities}
-                      title="Copy all recent activities with detailed telemetry as JSON for AI planning"
-                    >
-                      {allActivitiesCopied ? '✓ Copied All JSON' : '📋 Copy All (JSON)'}
-                    </button>
-                  )}
+                  <button
+                    type="button"
+                    className="quick-action-btn secondary"
+                    style={{ width: 'auto', padding: '0.4rem 0.8rem', fontSize: '0.85rem' }}
+                    onClick={openCanonicalBrief}
+                    title="Open the canonical Export Context for AI surface for AI planning export"
+                  >
+                    📋 Export via {SCREEN_LABELS.brief}
+                  </button>
                   <button
                     type="button"
                     className="quick-action-btn secondary"

--- a/app/src/components/DataView.tsx
+++ b/app/src/components/DataView.tsx
@@ -28,6 +28,11 @@ interface DataViewProps {
   userId: string;
   onBack: () => void;
   initialTab?: DataViewTab;
+  /** When provided, the duplicate export affordances (Context-brief tab content and
+   * Activities Copy All) become deep links to the canonical `brief` screen instead of
+   * reimplementing its export (#491). The `brief` screen itself omits this prop so it
+   * keeps the full export UI. */
+  onNavigateToBrief?: () => void;
 }
 
 type DataViewTab = 'recovery' | 'activities' | 'strength' | 'checkin' | 'goals' | 'constraints' | 'preferences' | 'adherence' | 'brief';
@@ -88,7 +93,7 @@ function formatCandidateBaseline(
   return `7d med ${formatCandidateNumber(median7d)} · 28d med ${formatCandidateNumber(median28d)} · MAD ${formatCandidateNumber(mad28d)} · Δ7 ${formatCandidateDelta(delta7d)} · Δ28 ${formatCandidateDelta(delta28d)}`;
 }
 
-export function DataView({ decisionInput, userId, initialTab = 'recovery' }: DataViewProps) {
+export function DataView({ decisionInput, userId, initialTab = 'recovery', onNavigateToBrief }: DataViewProps) {
   const [activeTab, setActiveTab] = useState<DataViewTab>(initialTab);
   const [brief, setBrief] = useState<ContextBriefResult | null>(null);
   // Tagged with the date it belongs to, so a failure for one date is not rendered
@@ -186,7 +191,9 @@ export function DataView({ decisionInput, userId, initialTab = 'recovery' }: Dat
     // `briefDate` must be defined for the comparison to settle: passing undefined lets the
     // service default to today, whose asOfDate would never equal undefined and would
     // re-trigger this effect on every render.
-    if (activeTab !== 'brief' || !briefDate || (brief?.asOfDate === briefDate && brief.preset === briefPreset)) return;
+    // When this view only links to the canonical export surface (#491), never fetch
+    // the brief here -- the `brief` screen builds it.
+    if (onNavigateToBrief || activeTab !== 'brief' || !briefDate || (brief?.asOfDate === briefDate && brief.preset === briefPreset)) return;
     let cancelled = false;
     contextBriefService.build(userId, briefDate, briefWindowDaysFor(briefPreset), briefPreset)
       .then(result => { if (!cancelled) { setBrief(result); setBriefError(null); } })
@@ -200,7 +207,7 @@ export function DataView({ decisionInput, userId, initialTab = 'recovery' }: Dat
         setBriefError({ date: briefDate, message: 'Could not assemble the brief. Retry the dashboard refresh.' });
       });
     return () => { cancelled = true; };
-  }, [activeTab, userId, brief?.asOfDate, brief?.preset, briefDate, briefPreset]);
+  }, [onNavigateToBrief, activeTab, userId, brief?.asOfDate, brief?.preset, briefDate, briefPreset]);
 
   const selectBriefPreset = (preset: BriefWindowPreset) => {
     setBriefPreset(preset);
@@ -865,6 +872,26 @@ export function DataView({ decisionInput, userId, initialTab = 'recovery' }: Dat
   const visibleBriefError = briefError && briefError.date === briefDate ? briefError.message : null;
 
   const renderContextBrief = () => {
+    // Deep-link fallback: the Context-brief tab navigates to the canonical export
+    // surface directly (#491), so this branch is only reachable if the tab is active
+    // while a navigate handler is set.
+    if (onNavigateToBrief) {
+      return (
+        <div className="data-section">
+          <h3>Context brief</h3>
+          <p className="brief-intro">
+            Export for AI lives in one place now — open {SCREEN_LABELS.brief} for the
+            canonical daily (2-day) or full (14-day) brief with char and token counts.
+            {' '}Read-only: generating it changes nothing.
+          </p>
+          <div className="brief-actions">
+            <button className="brief-copy" onClick={onNavigateToBrief}>
+              Open {SCREEN_LABELS.brief}
+            </button>
+          </div>
+        </div>
+      );
+    }
     const approxTokens = brief ? Math.ceil(brief.text.length / 4) : null;
     return (
       <div className="data-section">
@@ -1031,7 +1058,12 @@ export function DataView({ decisionInput, userId, initialTab = 'recovery' }: Dat
         </button>
         <button
           className={activeTab === 'brief' ? 'active' : ''}
-          onClick={() => setActiveTab('brief')}
+          onClick={() => {
+            // The `brief` screen is the canonical Export-for-AI surface (#491);
+            // from the Data screen this tab deep-links to it instead of duplicating it.
+            if (onNavigateToBrief) onNavigateToBrief();
+            else setActiveTab('brief');
+          }}
         >
           Context brief
         </button>
@@ -1050,15 +1082,27 @@ export function DataView({ decisionInput, userId, initialTab = 'recovery' }: Dat
               </div>
               {activityWindow?.state.status === 'AVAILABLE' && activityWindow.state.data.length > 0 && (
                 <div className="activities-header-actions">
-                  <button
-                    type="button"
-                    className="quick-action-btn secondary"
-                    style={{ width: 'auto', padding: '0.4rem 0.8rem', fontSize: '0.85rem' }}
-                    onClick={handleCopyAllActivities}
-                    title="Copy all recent activities with detailed telemetry as JSON for AI planning"
-                  >
-                    {allActivitiesCopied ? '✓ Copied All JSON' : '📋 Copy All (JSON)'}
-                  </button>
+                  {onNavigateToBrief ? (
+                    <button
+                      type="button"
+                      className="quick-action-btn secondary"
+                      style={{ width: 'auto', padding: '0.4rem 0.8rem', fontSize: '0.85rem' }}
+                      onClick={onNavigateToBrief}
+                      title="Open the canonical Export Context for AI surface for AI planning export"
+                    >
+                      📋 Export via {SCREEN_LABELS.brief}
+                    </button>
+                  ) : (
+                    <button
+                      type="button"
+                      className="quick-action-btn secondary"
+                      style={{ width: 'auto', padding: '0.4rem 0.8rem', fontSize: '0.85rem' }}
+                      onClick={handleCopyAllActivities}
+                      title="Copy all recent activities with detailed telemetry as JSON for AI planning"
+                    >
+                      {allActivitiesCopied ? '✓ Copied All JSON' : '📋 Copy All (JSON)'}
+                    </button>
+                  )}
                   <button
                     type="button"
                     className="quick-action-btn secondary"

--- a/docs/architecture/user-flows.md
+++ b/docs/architecture/user-flows.md
@@ -313,12 +313,14 @@ when that read model is enabled), so the screen must not be described as strictl
 
 The `brief` route is the same `DataView` component opened on `Context brief`, and it is
 the canonical Export-for-AI surface. From the Data screen, the Context brief tab and the
-Activities Copy All action deep-link to it (`App.tsx` `handleNavigate('brief')` via
-`DataView` `onNavigateToBrief`) instead of duplicating its export; only the `brief`
-screen renders the daily (2-day) / full (14-day) brief with char and token counts.
-The Data and brief navigation entries refresh decision input before navigating. If
-`decisionInput` is null, DataView shows `No data available`; that state has no
-in-component retry action, although the global navigation chrome remains available.
+Activities AI-export action deep-link to it (`App.tsx` `handleNavigate('brief')` via
+`DataView` `onNavigateToBrief`) instead of duplicating its export. On the canonical `brief`
+screen, the same Activities action returns to the local Context brief tab, so the legacy raw
+clipboard exporter is not reachable there either. Only the `brief` screen renders the daily
+(2-day) / full (14-day) brief with char and token counts. The Data and brief navigation
+entries refresh decision input before navigating. If `decisionInput` is null, DataView shows
+`No data available`; that state has no in-component retry action, although the global
+navigation chrome remains available.
 
 ### 10. Protocol testing
 
@@ -366,7 +368,8 @@ moving an input across an authority boundary.
 4. Imported coach plan, adaptive week forecast, and Home recommendation can disagree without
    a single authority explanation in the UI.
 5. AI/context export has one canonical surface: the `brief` route. The DataView
-   Context brief tab and Activities Copy All deep-link to it rather than duplicating it.
+   Context brief tab and Activities AI-export action route to it rather than duplicating it;
+   when already inside the canonical `brief` screen, that action returns to Context brief.
 6. `sessions` and `testing` share `SessionRunner`, so the execution UI alone does not strongly
    communicate provenance.
 7. Several recovery states are weak rather than truly terminal: DataView's no-data state has
@@ -447,9 +450,10 @@ living-reference section when implementing them.
     uses `Sign in with Garmin`, `GarminConnectionSection` uses `Connect Garmin wearable`.
 15. ~~Choose a canonical AI-export surface and make the other export affordances clearly point
     to or distinguish themselves from it.~~
-    Done (#491): `brief` is the canonical Export-for-AI surface; the DataView
-    Context-brief tab and Activities Copy All deep-link to it (`DataView`
-    `onNavigateToBrief` → `App.tsx` `handleNavigate('brief')`). Exported content is
-    unchanged (daily 2d vs full 14d windows, char and token counts).
+    Done (#491): `brief` is the canonical Export-for-AI surface; the DataView Context-brief
+    tab and Activities AI-export action route to it (or return to the local Context brief tab
+    when already on the canonical screen). The legacy raw Activities clipboard exporter is
+    removed from the UI. Exported brief content is unchanged (daily 2d vs full 14d windows,
+    char and token counts).
 16. Add local retry/repair affordances to weak recovery states, starting with DataView's
     null-input state and PlanView source failures.

--- a/docs/architecture/user-flows.md
+++ b/docs/architecture/user-flows.md
@@ -311,10 +311,14 @@ Most of the surface is inspection/export. The Activities tab is the exception: i
 corrective actions (for example activity reclassification, and canonical-source unlinking
 when that read model is enabled), so the screen must not be described as strictly read-only.
 
-The `brief` route is the same `DataView` component opened on `Context brief`. The Data and
-brief navigation entries refresh decision input before navigating. If `decisionInput` is
-null, DataView shows `No data available`; that state has no in-component retry action,
-although the global navigation chrome remains available.
+The `brief` route is the same `DataView` component opened on `Context brief`, and it is
+the canonical Export-for-AI surface. From the Data screen, the Context brief tab and the
+Activities Copy All action deep-link to it (`App.tsx` `handleNavigate('brief')` via
+`DataView` `onNavigateToBrief`) instead of duplicating its export; only the `brief`
+screen renders the daily (2-day) / full (14-day) brief with char and token counts.
+The Data and brief navigation entries refresh decision input before navigating. If
+`decisionInput` is null, DataView shows `No data available`; that state has no
+in-component retry action, although the global navigation chrome remains available.
 
 ### 10. Protocol testing
 
@@ -361,8 +365,8 @@ moving an input across an authority boundary.
    discover.
 4. Imported coach plan, adaptive week forecast, and Home recommendation can disagree without
    a single authority explanation in the UI.
-5. AI/context export appears as the `brief` route, the DataView Context brief tab, and raw
-   Activities JSON export.
+5. AI/context export has one canonical surface: the `brief` route. The DataView
+   Context brief tab and Activities Copy All deep-link to it rather than duplicating it.
 6. `sessions` and `testing` share `SessionRunner`, so the execution UI alone does not strongly
    communicate provenance.
 7. Several recovery states are weak rather than truly terminal: DataView's no-data state has
@@ -441,7 +445,11 @@ living-reference section when implementing them.
 14. ~~Use distinct copy for app authentication (`Continue/Sign in with Garmin`) and wearable
     data connection (`Connect Garmin wearable`).~~ Done (#497): `LoginScreen` garmin mode
     uses `Sign in with Garmin`, `GarminConnectionSection` uses `Connect Garmin wearable`.
-15. Choose a canonical AI-export surface and make the other export affordances clearly point
-    to or distinguish themselves from it.
+15. ~~Choose a canonical AI-export surface and make the other export affordances clearly point
+    to or distinguish themselves from it.~~
+    Done (#491): `brief` is the canonical Export-for-AI surface; the DataView
+    Context-brief tab and Activities Copy All deep-link to it (`DataView`
+    `onNavigateToBrief` → `App.tsx` `handleNavigate('brief')`). Exported content is
+    unchanged (daily 2d vs full 14d windows, char and token counts).
 16. Add local retry/repair affordances to weak recovery states, starting with DataView's
     null-input state and PlanView source failures.


### PR DESCRIPTION
## Summary
- `brief` remains the single canonical **Export Context for AI** surface.
- From Data, both the Context brief tab and the Activities AI-export action navigate to `brief`.
- From the canonical `brief` screen, the Activities AI-export action returns to the local Context brief tab instead of exposing the legacy raw clipboard exporter.
- Removed the duplicate raw Activities **Copy All (JSON)** path; **Download JSON** remains a separate data export.
- Exported brief content is unchanged: daily (2-day) / full (14-day) context with char/token counts via `contextBriefService`.
- Updated `docs/architecture/user-flows.md` to match the final behavior.
- Closes #491.

## Validation
- [x] Final-head CI (`c598bed`): all required gates green.
  - Frontend unit tests + Firestore rules: pass
  - Frontend typecheck, lint, knowledge/workout validation, policy drift, bundle build: pass
  - Engine simulations + AI deterministic gates: pass
  - Python 3.14 lint/format/type/tests/dependency audit: pass
  - Docker build + Compose full-stack smoke: pass
  - Aggregate CI Gate: pass
- [x] PR is clean/mergeable against current `main`.
- [x] No unresolved review threads at the time of the final review pass; an opt-in CodeRabbit review was triggered after the fixes.
- Component-level browser test was not added because the repository does not currently include a React DOM testing harness. The behavior is instead expressed through one `openCanonicalBrief` path and exercised by the existing project gates.

## Risk / reviewer guidance
- Focus on `DataView.tsx`: `openCanonicalBrief` deliberately has two destinations depending on context — route callback from Data, local Context brief tab on the canonical `brief` screen.
- `contextBriefService` and brief text generation are untouched.
- Activity **Download JSON** and reclassification/source-correction actions are untouched.
- No persistence, decision-engine, policy-version, or health-data logic changed.

## Review follow-up commits
- `fbaf156` — `fix(export): keep AI export canonical from every DataView tab`
- `c598bed` — `docs(export): align canonical brief flow after review fix`

## Domain invariants
- Firestore writes remain user-scoped; no persistence contract changed.
- Calendar-date / recovery semantics are untouched.
- No credentials, tokens, service-account files, or raw health payloads were added.
- Decision logic is unchanged, so no `POLICY_VERSION` bump is required.