### PR TITLE
feat(settings): add undo toast for destructive autosaved toggles (#492)

### DIFF
--- a/app/src/components/TrainingSettings.css
+++ b/app/src/components/TrainingSettings.css
@@ -166,6 +166,39 @@ fieldset input[type="radio"] {
   background: rgba(251, 191, 36, 0.3);
 }
 
+.settings-undo-toast {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 1rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid rgba(96, 165, 250, 0.4);
+  border-radius: 8px;
+  background: rgba(59, 130, 246, 0.12);
+  color: var(--text-primary);
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.settings-undo-toast button {
+  padding: 0.4rem 0.9rem;
+  border-radius: 8px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.settings-undo-toast button:first-of-type {
+  background: rgba(96, 165, 250, 0.25);
+  color: #bfdbfe;
+  border: 1px solid rgba(96, 165, 250, 0.5);
+}
+
+.settings-undo-toast button:last-of-type {
+  background: transparent;
+  color: var(--text-secondary);
+  border: 1px solid transparent;
+}
+
 .settings-error {
   color: #f87171;
   background: rgba(239, 68, 68, 0.1);

--- a/app/src/components/TrainingSettings.tsx
+++ b/app/src/components/TrainingSettings.tsx
@@ -1,7 +1,7 @@
 import { type FormEvent, type ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
 import type { BodyRegion, GuardrailKey, InjuryConstraint, SessionTemplate, TrainingSettings as TrainingSettingsModel } from '../engine/models';
 import { resolveInjuryRestrictions } from '../engine/injuryPolicy';
-import { trainingSettingsService, type TrainingSettingsUpdate } from '../services/trainingSettingsService';
+import { trainingSettingsService, buildRevertUpdate, type TrainingSettingsUpdate } from '../services/trainingSettingsService';
 import { getLocalDateString } from '../utils/localDate';
 import { SCREEN_LABELS, type Screen } from '../types/navigation';
 import './TrainingSettings.css';
@@ -55,6 +55,7 @@ export function TrainingSettings({ userId, onNavigate }: TrainingSettingsProps) 
   const [error, setError] = useState<string | null>(null);
   const [injuryDraft, setInjuryDraft] = useState(emptyInjuryDraft);
   const [editingInjuryIndex, setEditingInjuryIndex] = useState<number | null>(null);
+  const [undoState, setUndoState] = useState<{ message: string; revert: TrainingSettingsUpdate } | null>(null);
 
   const load = useCallback(async () => {
     try {
@@ -81,6 +82,28 @@ export function TrainingSettings({ userId, onNavigate }: TrainingSettingsProps) 
     }
   };
 
+  // Destructive autosaved changes (equipment, safety limits, injury constraints)
+  // act as hard recommendation gates, so they persist instantly but offer a
+  // one-shot Undo toast that reverts to the pre-save snapshot. Non-destructive
+  // edits (time/location, recovery preferences, migration review) keep plain
+  // instant-save via `save` with no toast.
+  const saveDestructive = async (update: TrainingSettingsUpdate, message: string) => {
+    const previous = settings;
+    const updated = await save(update);
+    if (updated && previous) {
+      const revert = buildRevertUpdate(previous, updated);
+      setUndoState(revert ? { message, revert } : null);
+    }
+    return updated;
+  };
+
+  const undoLastChange = async () => {
+    const current = undoState;
+    setUndoState(null);
+    if (!current) return;
+    await save(current.revert);
+  };
+
   const saveInjury = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     if (!settings) return;
@@ -92,9 +115,10 @@ export function TrainingSettings({ userId, onNavigate }: TrainingSettingsProps) 
       ...(injuryDraft.note.trim() ? { note: injuryDraft.note.trim() } : {}),
     };
     const nextInjuries = [...(settings.injuries ?? [])];
-    if (editingInjuryIndex === null) nextInjuries.push(injury);
+    const isNewInjury = editingInjuryIndex === null;
+    if (isNewInjury) nextInjuries.push(injury);
     else nextInjuries[editingInjuryIndex] = injury;
-    if (await save({ injuries: nextInjuries })) {
+    if (await saveDestructive({ injuries: nextInjuries }, isNewInjury ? 'Injury constraint added.' : 'Injury constraint updated.')) {
       setInjuryDraft(emptyInjuryDraft);
       setEditingInjuryIndex(null);
     }
@@ -131,6 +155,13 @@ export function TrainingSettings({ userId, onNavigate }: TrainingSettingsProps) 
         <p className="section-intro">Changes on this screen save automatically and act as hard gates: they remove sessions from every recommendation. Softer tie-breaks live in {SCREEN_LABELS.preferences} and only apply after an explicit save there.</p>
       </header>
       {error && <p className="settings-error" role="alert">{error}</p>}
+      {undoState && (
+        <div className="settings-undo-toast" role="alert">
+          <span>{undoState.message}</span>
+          <button type="button" onClick={() => void undoLastChange()}>Undo</button>
+          <button type="button" onClick={() => setUndoState(null)} aria-label="Dismiss undo">Dismiss</button>
+        </div>
+      )}
       {!settings.migration.legacyReviewed && (
         <section className="settings-review" aria-labelledby="legacy-review-title">
           <h2 id="legacy-review-title">Review migrated settings</h2>
@@ -146,7 +177,7 @@ export function TrainingSettings({ userId, onNavigate }: TrainingSettingsProps) 
         <div className="settings-list">
           {Object.entries(equipmentLabels).map(([key, label]) => (
             <label className="setting-row" key={key}>
-              <input type="checkbox" checked={settings.equipment[key as keyof TrainingSettingsModel['equipment']]} onChange={(event) => void save({ equipment: { [key]: event.target.checked } })} />
+              <input type="checkbox" checked={settings.equipment[key as keyof TrainingSettingsModel['equipment']]} onChange={(event) => void saveDestructive({ equipment: { [key]: event.target.checked } }, `${label} ${event.target.checked ? 'enabled' : 'disabled'}.`)} />
               <span><strong>{label}</strong><small>{settings.equipment[key as keyof TrainingSettingsModel['equipment']] ? 'Available for recommendations' : 'Not used in recommendations'}</small></span>
             </label>
           ))}
@@ -160,7 +191,7 @@ export function TrainingSettings({ userId, onNavigate }: TrainingSettingsProps) 
         <div className="settings-list">
           {Object.entries(guardrailDetails).map(([key, detail]) => (
             <label className="setting-row" key={key}>
-              <input type="checkbox" checked={settings.guardrails[key as GuardrailKey]} onChange={(event) => void save({ guardrails: { [key]: event.target.checked } })} />
+              <input type="checkbox" checked={settings.guardrails[key as GuardrailKey]} onChange={(event) => void saveDestructive({ guardrails: { [key]: event.target.checked } }, `${detail.label} ${event.target.checked ? 'enabled' : 'disabled'}.`)} />
               <span><strong>{detail.label}</strong><small>{detail.effect}</small></span>
             </label>
           ))}
@@ -237,7 +268,7 @@ export function TrainingSettings({ userId, onNavigate }: TrainingSettingsProps) 
                   <button type="button" onClick={() => {
                     const nextInjuries = (settings.injuries ?? []).filter((_, i) => i !== index);
                     if (editingInjuryIndex === index) { setInjuryDraft(emptyInjuryDraft); setEditingInjuryIndex(null); }
-                    void save({ injuries: nextInjuries });
+                    void saveDestructive({ injuries: nextInjuries }, 'Injury constraint removed.');
                   }}>Remove</button>
                 </div>
               </div>

--- a/app/src/components/TrainingSettings.tsx
+++ b/app/src/components/TrainingSettings.tsx
@@ -56,6 +56,7 @@ export function TrainingSettings({ userId, onNavigate }: TrainingSettingsProps) 
   const [injuryDraft, setInjuryDraft] = useState(emptyInjuryDraft);
   const [editingInjuryIndex, setEditingInjuryIndex] = useState<number | null>(null);
   const [undoState, setUndoState] = useState<{ message: string; revert: TrainingSettingsUpdate } | null>(null);
+  const [undoInFlight, setUndoInFlight] = useState(false);
 
   const load = useCallback(async () => {
     try {
@@ -84,14 +85,13 @@ export function TrainingSettings({ userId, onNavigate }: TrainingSettingsProps) 
 
   // Destructive autosaved changes (equipment, safety limits, injury constraints)
   // act as hard recommendation gates, so they persist instantly but offer a
-  // one-shot Undo toast that reverts to the pre-save snapshot. Non-destructive
+  // one-shot Undo toast containing a field-scoped inverse patch. Non-destructive
   // edits (time/location, recovery preferences, migration review) keep plain
   // instant-save via `save` with no toast.
   const saveDestructive = async (update: TrainingSettingsUpdate, message: string) => {
-    const previous = settings;
+    const revert = settings ? buildRevertUpdate(settings, update) : null;
     const updated = await save(update);
-    if (updated && previous) {
-      const revert = buildRevertUpdate(previous, updated);
+    if (updated) {
       setUndoState(revert ? { message, revert } : null);
     }
     return updated;
@@ -99,9 +99,14 @@ export function TrainingSettings({ userId, onNavigate }: TrainingSettingsProps) 
 
   const undoLastChange = async () => {
     const current = undoState;
-    setUndoState(null);
-    if (!current) return;
-    await save(current.revert);
+    if (!current || undoInFlight) return;
+
+    setUndoInFlight(true);
+    const restored = await save(current.revert);
+    if (restored) {
+      setUndoState(latest => latest === current ? null : latest);
+    }
+    setUndoInFlight(false);
   };
 
   const saveInjury = async (event: FormEvent<HTMLFormElement>) => {
@@ -156,10 +161,10 @@ export function TrainingSettings({ userId, onNavigate }: TrainingSettingsProps) 
       </header>
       {error && <p className="settings-error" role="alert">{error}</p>}
       {undoState && (
-        <div className="settings-undo-toast" role="alert">
+        <div className="settings-undo-toast" role="status" aria-live="polite" aria-atomic="true">
           <span>{undoState.message}</span>
-          <button type="button" onClick={() => void undoLastChange()}>Undo</button>
-          <button type="button" onClick={() => setUndoState(null)} aria-label="Dismiss undo">Dismiss</button>
+          <button type="button" disabled={undoInFlight} onClick={() => void undoLastChange()}>{undoInFlight ? 'Undoing…' : 'Undo'}</button>
+          <button type="button" disabled={undoInFlight} onClick={() => setUndoState(null)} aria-label="Dismiss undo">Dismiss</button>
         </div>
       )}
       {!settings.migration.legacyReviewed && (

--- a/app/src/services/trainingSettingsService.test.ts
+++ b/app/src/services/trainingSettingsService.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildRevertUpdate, createDefaultTrainingSettings, mergeSettings, migrateLegacyConstraints, parseTrainingSettings } from './trainingSettingsService';
+import { buildRevertUpdate, createDefaultTrainingSettings, mergeSettings, migrateLegacyConstraints, parseTrainingSettings, type TrainingSettingsUpdate } from './trainingSettingsService';
 import type { UserConstraint } from '../engine/models';
 
 function legacy(key: string, value: UserConstraint['value'], isActive = true): UserConstraint {
@@ -84,19 +84,32 @@ describe('training settings storage parsing', () => {
 });
 
 describe('destructive settings revert (#492)', () => {
-    it('builds an equipment revert that restores the previous value', () => {
+    it('builds a field-scoped equipment revert that restores the previous value', () => {
         const previous = createDefaultTrainingSettings('athlete', '2026-08-07T10:00:00.000Z');
-        const next = mergeSettings(previous, { equipment: { treadmill: true } });
-        const revert = buildRevertUpdate(previous, next);
-        expect(revert).toEqual({ equipment: previous.equipment });
+        const update: TrainingSettingsUpdate = { equipment: { treadmill: true } };
+        const next = mergeSettings(previous, update);
+        const revert = buildRevertUpdate(previous, update);
+        expect(revert).toEqual({ equipment: { treadmill: false } });
         expect(mergeSettings(next, revert!).equipment.treadmill).toBe(false);
     });
 
-    it('builds a guardrail revert that restores the previous avoid flags', () => {
+    it('does not clobber a later equipment save when undoing an earlier toggle', () => {
         const previous = createDefaultTrainingSettings('athlete', '2026-08-07T10:00:00.000Z');
-        const next = mergeSettings(previous, { guardrails: { avoid_high_impact: true, avoid_heavy_spinal_loading: true } });
-        const revert = buildRevertUpdate(previous, next);
-        expect(revert).toEqual({ guardrails: previous.guardrails });
+        const firstUpdate: TrainingSettingsUpdate = { equipment: { treadmill: true } };
+        const revert = buildRevertUpdate(previous, firstUpdate);
+        const afterFirst = mergeSettings(previous, firstUpdate);
+        const afterLaterSave = mergeSettings(afterFirst, { equipment: { outdoor_bike: true } });
+        const restored = mergeSettings(afterLaterSave, revert!);
+        expect(restored.equipment.treadmill).toBe(false);
+        expect(restored.equipment.outdoor_bike).toBe(true);
+    });
+
+    it('builds a guardrail revert only for the avoid flags that changed', () => {
+        const previous = createDefaultTrainingSettings('athlete', '2026-08-07T10:00:00.000Z');
+        const update: TrainingSettingsUpdate = { guardrails: { avoid_high_impact: true, avoid_heavy_spinal_loading: true } };
+        const next = mergeSettings(previous, update);
+        const revert = buildRevertUpdate(previous, update);
+        expect(revert).toEqual({ guardrails: { avoid_high_impact: false, avoid_heavy_spinal_loading: false } });
         const restored = mergeSettings(next, revert!);
         expect(restored.guardrails.avoid_high_impact).toBe(false);
         expect(restored.guardrails.avoid_heavy_spinal_loading).toBe(false);
@@ -104,8 +117,9 @@ describe('destructive settings revert (#492)', () => {
 
     it('reverts an injury-constraint add back to the previous list', () => {
         const previous = createDefaultTrainingSettings('athlete', '2026-08-07T10:00:00.000Z');
-        const next = mergeSettings(previous, { injuries: [{ region: 'knee', severity: 'limit' }] });
-        const revert = buildRevertUpdate(previous, next);
+        const update: TrainingSettingsUpdate = { injuries: [{ region: 'knee', severity: 'limit' }] };
+        const next = mergeSettings(previous, update);
+        const revert = buildRevertUpdate(previous, update);
         expect(revert).toEqual({ injuries: [] });
         expect(mergeSettings(next, revert!).injuries).toEqual([]);
     });
@@ -113,14 +127,15 @@ describe('destructive settings revert (#492)', () => {
     it('reverts an injury-constraint edit back to the previous list', () => {
         const previous = createDefaultTrainingSettings('athlete', '2026-08-07T10:00:00.000Z');
         const withInjury = mergeSettings(previous, { injuries: [{ region: 'knee', severity: 'monitor' }] });
-        const edited = mergeSettings(withInjury, { injuries: [{ region: 'knee', severity: 'exclude' }] });
-        const revert = buildRevertUpdate(withInjury, edited);
+        const update: TrainingSettingsUpdate = { injuries: [{ region: 'knee', severity: 'exclude' }] };
+        const edited = mergeSettings(withInjury, update);
+        const revert = buildRevertUpdate(withInjury, update);
         expect(revert).toEqual({ injuries: withInjury.injuries });
         expect(mergeSettings(edited, revert!).injuries).toEqual([{ region: 'knee', severity: 'monitor' }]);
     });
 
-    it('returns null when nothing changed', () => {
+    it('returns null when the requested update would not change anything', () => {
         const previous = createDefaultTrainingSettings('athlete', '2026-08-07T10:00:00.000Z');
-        expect(buildRevertUpdate(previous, previous)).toBeNull();
+        expect(buildRevertUpdate(previous, { equipment: { treadmill: false } })).toBeNull();
     });
 });

--- a/app/src/services/trainingSettingsService.test.ts
+++ b/app/src/services/trainingSettingsService.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createDefaultTrainingSettings, mergeSettings, migrateLegacyConstraints, parseTrainingSettings } from './trainingSettingsService';
+import { buildRevertUpdate, createDefaultTrainingSettings, mergeSettings, migrateLegacyConstraints, parseTrainingSettings } from './trainingSettingsService';
 import type { UserConstraint } from '../engine/models';
 
 function legacy(key: string, value: UserConstraint['value'], isActive = true): UserConstraint {
@@ -80,5 +80,47 @@ describe('training settings storage parsing', () => {
         const clearingUpdate = { defaults: { weekdayMaxMinutes: 30 }, recoveryBootstrapDate: null } as unknown as Parameters<typeof mergeSettings>[1];
         const clearedAttempt = mergeSettings(withBootstrap, clearingUpdate);
         expect(clearedAttempt.recoveryBootstrapDate).toBe('2026-09-01');
+    });
+});
+
+describe('destructive settings revert (#492)', () => {
+    it('builds an equipment revert that restores the previous value', () => {
+        const previous = createDefaultTrainingSettings('athlete', '2026-08-07T10:00:00.000Z');
+        const next = mergeSettings(previous, { equipment: { treadmill: true } });
+        const revert = buildRevertUpdate(previous, next);
+        expect(revert).toEqual({ equipment: previous.equipment });
+        expect(mergeSettings(next, revert!).equipment.treadmill).toBe(false);
+    });
+
+    it('builds a guardrail revert that restores the previous avoid flags', () => {
+        const previous = createDefaultTrainingSettings('athlete', '2026-08-07T10:00:00.000Z');
+        const next = mergeSettings(previous, { guardrails: { avoid_high_impact: true, avoid_heavy_spinal_loading: true } });
+        const revert = buildRevertUpdate(previous, next);
+        expect(revert).toEqual({ guardrails: previous.guardrails });
+        const restored = mergeSettings(next, revert!);
+        expect(restored.guardrails.avoid_high_impact).toBe(false);
+        expect(restored.guardrails.avoid_heavy_spinal_loading).toBe(false);
+    });
+
+    it('reverts an injury-constraint add back to the previous list', () => {
+        const previous = createDefaultTrainingSettings('athlete', '2026-08-07T10:00:00.000Z');
+        const next = mergeSettings(previous, { injuries: [{ region: 'knee', severity: 'limit' }] });
+        const revert = buildRevertUpdate(previous, next);
+        expect(revert).toEqual({ injuries: [] });
+        expect(mergeSettings(next, revert!).injuries).toEqual([]);
+    });
+
+    it('reverts an injury-constraint edit back to the previous list', () => {
+        const previous = createDefaultTrainingSettings('athlete', '2026-08-07T10:00:00.000Z');
+        const withInjury = mergeSettings(previous, { injuries: [{ region: 'knee', severity: 'monitor' }] });
+        const edited = mergeSettings(withInjury, { injuries: [{ region: 'knee', severity: 'exclude' }] });
+        const revert = buildRevertUpdate(withInjury, edited);
+        expect(revert).toEqual({ injuries: withInjury.injuries });
+        expect(mergeSettings(edited, revert!).injuries).toEqual([{ region: 'knee', severity: 'monitor' }]);
+    });
+
+    it('returns null when nothing changed', () => {
+        const previous = createDefaultTrainingSettings('athlete', '2026-08-07T10:00:00.000Z');
+        expect(buildRevertUpdate(previous, previous)).toBeNull();
     });
 });

--- a/app/src/services/trainingSettingsService.ts
+++ b/app/src/services/trainingSettingsService.ts
@@ -141,24 +141,54 @@ export function mergeSettings(current: TrainingSettings, update: TrainingSetting
     return next;
 }
 
-function slicesEqual(left: unknown, right: unknown): boolean {
+function valuesEqual(left: unknown, right: unknown): boolean {
     return JSON.stringify(left) === JSON.stringify(right);
 }
 
+function buildPartialRevert<T extends object>(previous: T, update: Partial<T>): Partial<T> | null {
+    const revert: Partial<T> = {};
+    for (const key of Object.keys(update) as Array<keyof T>) {
+        if (!valuesEqual(previous[key], update[key])) {
+            revert[key] = previous[key];
+        }
+    }
+    return Object.keys(revert).length > 0 ? revert : null;
+}
+
 /**
- * Builds the update that restores `previous` from `next` for every changed
- * top-level settings slice, so a destructive autosaved change (equipment,
- * guardrails, injuries) can be reverted from the UI with one toast action.
- * Returns `null` when nothing changed. Pure: no Firestore IO.
+ * Builds the smallest update that restores the values touched by `update` to
+ * their state in `previous`. Keeping the inverse patch field-scoped prevents
+ * Undo from overwriting unrelated settings saved after the destructive action.
+ * Returns `null` when the requested update would not change anything. Pure: no
+ * Firestore IO.
  */
-export function buildRevertUpdate(previous: TrainingSettings, next: TrainingSettings): TrainingSettingsUpdate | null {
+export function buildRevertUpdate(previous: TrainingSettings, update: TrainingSettingsUpdate): TrainingSettingsUpdate | null {
     const revert: TrainingSettingsUpdate = {};
-    if (!slicesEqual(previous.equipment, next.equipment)) revert.equipment = { ...previous.equipment };
-    if (!slicesEqual(previous.guardrails, next.guardrails)) revert.guardrails = { ...previous.guardrails };
-    if (!slicesEqual(previous.injuries, next.injuries)) revert.injuries = previous.injuries ? [...previous.injuries] : [];
-    if (!slicesEqual(previous.defaults, next.defaults)) revert.defaults = { ...previous.defaults };
-    if (!slicesEqual(previous.preferences, next.preferences)) revert.preferences = { ...previous.preferences };
-    if (!slicesEqual(previous.migration, next.migration)) revert.migration = { ...previous.migration };
+
+    if (update.equipment) {
+        const equipment = buildPartialRevert(previous.equipment, update.equipment);
+        if (equipment) revert.equipment = equipment;
+    }
+    if (update.guardrails) {
+        const guardrails = buildPartialRevert(previous.guardrails, update.guardrails);
+        if (guardrails) revert.guardrails = guardrails;
+    }
+    if (update.injuries !== undefined && !valuesEqual(previous.injuries ?? [], update.injuries)) {
+        revert.injuries = [...(previous.injuries ?? [])];
+    }
+    if (update.defaults) {
+        const defaults = buildPartialRevert(previous.defaults, update.defaults);
+        if (defaults) revert.defaults = defaults;
+    }
+    if (update.preferences) {
+        const preferences = buildPartialRevert(previous.preferences, update.preferences);
+        if (preferences) revert.preferences = preferences;
+    }
+    if (update.migration) {
+        const migration = buildPartialRevert(previous.migration, update.migration);
+        if (migration) revert.migration = migration;
+    }
+
     return Object.keys(revert).length > 0 ? revert : null;
 }
 

--- a/app/src/services/trainingSettingsService.ts
+++ b/app/src/services/trainingSettingsService.ts
@@ -141,6 +141,27 @@ export function mergeSettings(current: TrainingSettings, update: TrainingSetting
     return next;
 }
 
+function slicesEqual(left: unknown, right: unknown): boolean {
+    return JSON.stringify(left) === JSON.stringify(right);
+}
+
+/**
+ * Builds the update that restores `previous` from `next` for every changed
+ * top-level settings slice, so a destructive autosaved change (equipment,
+ * guardrails, injuries) can be reverted from the UI with one toast action.
+ * Returns `null` when nothing changed. Pure: no Firestore IO.
+ */
+export function buildRevertUpdate(previous: TrainingSettings, next: TrainingSettings): TrainingSettingsUpdate | null {
+    const revert: TrainingSettingsUpdate = {};
+    if (!slicesEqual(previous.equipment, next.equipment)) revert.equipment = { ...previous.equipment };
+    if (!slicesEqual(previous.guardrails, next.guardrails)) revert.guardrails = { ...previous.guardrails };
+    if (!slicesEqual(previous.injuries, next.injuries)) revert.injuries = previous.injuries ? [...previous.injuries] : [];
+    if (!slicesEqual(previous.defaults, next.defaults)) revert.defaults = { ...previous.defaults };
+    if (!slicesEqual(previous.preferences, next.preferences)) revert.preferences = { ...previous.preferences };
+    if (!slicesEqual(previous.migration, next.migration)) revert.migration = { ...previous.migration };
+    return Object.keys(revert).length > 0 ? revert : null;
+}
+
 export class TrainingSettingsService {
     private ref(userId: string) {
         return doc(getDb(), 'users', userId, COLLECTION, DOCUMENT);

--- a/docs/architecture/user-flows.md
+++ b/docs/architecture/user-flows.md
@@ -416,8 +416,12 @@ living-reference section when implementing them.
    Done (#484): removed the unused `Goals` `onNavigate` prop — no repair flow needed it —
    and kept `constraints` as the stable route key with user-facing copy in `navigation.ts`
    `SCREEN_LABELS` (`Training Setup`).
-9. Review immediate-persist Training Setup controls for undo/confirmation where a mistaken
-   toggle can materially change feasibility/safety decisions.
+9. ~~Review immediate-persist Training Setup controls for undo/confirmation where a mistaken
+   toggle can materially change feasibility/safety decisions.~~
+   Done (#492): destructive autosaved controls (equipment, safety limits, injury-constraint
+   add/edit/remove) offer a one-shot Undo toast that reverts to the pre-save snapshot via
+   `trainingSettingsService` `buildRevertUpdate`; non-destructive edits keep instant-save
+   with no toast. Gating semantics unchanged.
 
 ### Sessions and testing
 


### PR DESCRIPTION
## Summary
- Adds one-shot **Undo** for destructive autosaved Training Settings changes: equipment, safety guardrails, and injury constraint create/edit/remove.
- Keeps the original mutation **immediate**; Undo is a compensating write rather than delayed persistence.
- Builds a **field-scoped inverse patch** from the pre-save state so Undo restores only fields touched by that action. Injury arrays remain atomic because the current service API updates them as a list.
- Keeps Undo available when the revert write fails and serializes Undo/Dismiss while a revert is in flight.
- Uses specific user-facing copy and a polite `role="status"` live region for non-urgent status feedback.
- Leaves non-destructive time/location, recovery preference, and migration-review edits on the existing instant-save path without Undo.
- Completes architecture recommendation 9 / closes #492.

## Validation
- GitHub Actions **CI Pipeline #2888** is green on `2a6b836`: frontend static gates/build, frontend unit coverage + Firestore rules, engine simulations/AI gates, Python checks/tests, Docker smoke, and the final CI Gate all passed.
- Service-level revert coverage includes equipment, guardrails, injury add/edit, no-op behavior, and a regression proving a later same-slice equipment save survives Undo of an earlier toggle.
- PR is mergeable against the current `main`; no conflicts are reported.

## Risk / notes
- No recommendation-engine semantics changed; this is settings persistence/UI recovery behavior.
- Equipment/guardrail Undo no longer overwrites unrelated same-slice values saved later.
- Injury Undo restores the previous injury list atomically, matching the existing `TrainingSettingsUpdate.injuries` API shape.
- Existing architecture Rec 9 documentation remains accurate, so no additional doc churn was needed.

Closes #492