### PR TITLE
feat(nav): group mobile More drawer by intent with per-item active state (#486)

### DIFF
--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -111,7 +111,7 @@ export const Header: React.FC<HeaderProps> = ({
 
           <div className="more-menu-container" ref={desktopSettingsRef}>
             <button
-              className={`nav-link more-btn ${['constraints', 'preferences', 'plan'].includes(screen) ? 'active' : ''}`}
+              className={`nav-link more-btn ${['constraints', 'preferences', 'plan', 'brief'].includes(screen) ? 'active' : ''}`}
               onClick={() => setDesktopSettingsOpen((isOpen) => !isOpen)}
               aria-expanded={desktopSettingsOpen}
               aria-haspopup="menu"

--- a/app/src/components/MobileNav.css
+++ b/app/src/components/MobileNav.css
@@ -1,0 +1,31 @@
+.drawer-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.drawer-group + .drawer-group {
+  margin-top: 0.25rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.drawer-group-header {
+  padding: 0 0.25rem 0.1rem;
+}
+
+.drawer-group-title {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.drawer-group-description {
+  display: block;
+  margin-top: 0.15rem;
+  color: var(--text-secondary);
+  font-size: 0.775rem;
+}

--- a/app/src/components/MobileNav.test.tsx
+++ b/app/src/components/MobileNav.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import type { Screen } from '../types/navigation';
+import { MobileNav } from './MobileNav';
+
+function renderNav(screen: Screen): string {
+  return renderToStaticMarkup(
+    <MobileNav
+      screen={screen}
+      handleNavigate={vi.fn()}
+      loadDecisionInput={vi.fn()}
+      mobileMoreOpen
+      setMobileMoreOpen={vi.fn()}
+    />,
+  );
+}
+
+describe('MobileNav More drawer', () => {
+  it('renders the three intent groups with programmatic labels and descriptions', () => {
+    const markup = renderNav('sessions');
+
+    expect(markup.match(/role="group"/g)).toHaveLength(3);
+    expect(markup).toContain('aria-labelledby="mobile-more-train-title"');
+    expect(markup).toContain('aria-labelledby="mobile-more-configure-title"');
+    expect(markup).toContain('aria-labelledby="mobile-more-understand-title"');
+    expect(markup).toContain('class="drawer-group-description">Sessions, assessments, and the week-ahead plan</span>');
+    expect(markup).toContain('class="drawer-group-description">Goals, setup, and coaching preferences</span>');
+    expect(markup).toContain('class="drawer-group-description">Data review and AI context export</span>');
+  });
+
+  it('exposes the selected drawer destination as the current page', () => {
+    const markup = renderNav('sessions');
+
+    expect(markup.match(/aria-current="page"/g)).toHaveLength(1);
+    expect(markup).toMatch(/class="drawer-item active" aria-current="page"[^>]*>.*?Sessions/s);
+  });
+
+  it('keeps Plan current in both the primary tab set and the Train group', () => {
+    const markup = renderNav('plan');
+
+    expect(markup.match(/aria-current="page"/g)).toHaveLength(2);
+    expect(markup).toMatch(/class="nav-item active"[^>]*aria-current="page"[^>]*>.*?Plan/s);
+    expect(markup).toMatch(/class="drawer-item active" aria-current="page"[^>]*>.*?Plan/s);
+  });
+});

--- a/app/src/components/MobileNav.test.tsx
+++ b/app/src/components/MobileNav.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it, vi } from 'vitest';
 import type { Screen } from '../types/navigation';

--- a/app/src/components/MobileNav.tsx
+++ b/app/src/components/MobileNav.tsx
@@ -1,8 +1,9 @@
-import React, { useRef, useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import type { Screen } from '../types/navigation';
 import { SCREEN_LABELS } from '../types/navigation';
 import { getAuthInstance } from '../firebase';
 import { buildInfo } from '../buildInfo';
+import './MobileNav.css';
 
 interface MobileNavProps {
   screen: Screen;
@@ -12,20 +13,95 @@ interface MobileNavProps {
   setMobileMoreOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-/**
- * Group heading style for the More drawer sections (#486). Item sub-copy reuses the
- * existing `item-sub` class so group descriptions match the per-item pattern; only the
- * uppercase section title needs an inline style to stay inside the MobileNav lane
- * (no shared-stylesheet change).
- */
-const GROUP_TITLE_STYLE: React.CSSProperties = {
-  fontSize: '0.75rem',
-  fontWeight: 700,
-  letterSpacing: '0.08em',
-  textTransform: 'uppercase',
-  color: 'var(--text-secondary)',
-  padding: '0 0.25rem',
-};
+interface DrawerDestination {
+  screen: Screen;
+  icon: string;
+  description: string;
+  refreshDecisionInput?: boolean;
+}
+
+interface DrawerGroup {
+  id: string;
+  title: string;
+  description: string;
+  items: readonly DrawerDestination[];
+}
+
+const MOBILE_MORE_SCREENS: readonly Screen[] = [
+  'goals',
+  'constraints',
+  'preferences',
+  'data',
+  'brief',
+  'sessions',
+  'testing',
+];
+
+const DRAWER_GROUPS: readonly DrawerGroup[] = [
+  {
+    id: 'train',
+    title: 'Train',
+    description: 'Sessions, assessments, and the week-ahead plan',
+    items: [
+      {
+        screen: 'sessions',
+        icon: '🚀',
+        description: 'Run a multidomain fixture and record native measures',
+      },
+      {
+        screen: 'testing',
+        icon: '🧪',
+        description: 'Run a locked assessment and record comparable raw outcomes',
+      },
+      {
+        screen: 'plan',
+        icon: '📋',
+        description: 'Compare the coach plan against the adaptive forecast',
+      },
+    ],
+  },
+  {
+    id: 'configure',
+    title: 'Configure',
+    description: 'Goals, setup, and coaching preferences',
+    items: [
+      {
+        screen: 'goals',
+        icon: '🎯',
+        description: 'Manage events and target milestones',
+      },
+      {
+        screen: 'constraints',
+        icon: '⚠️',
+        description: 'Manage physical cautions & equipment',
+      },
+      {
+        screen: 'preferences',
+        icon: '⚙️',
+        description: 'Configure modalities & strain caps',
+      },
+    ],
+  },
+  {
+    id: 'understand',
+    title: 'Understand',
+    description: 'Data review and AI context export',
+    items: [
+      {
+        screen: 'data',
+        icon: '📊',
+        description: 'View analytics and snapshot telemetry',
+        refreshDecisionInput: true,
+      },
+      {
+        screen: 'brief',
+        icon: '📤',
+        description: 'Compile recent metrics & prompt for your AI',
+        refreshDecisionInput: true,
+      },
+    ],
+  },
+];
 
 export const MobileNav: React.FC<MobileNavProps> = ({ screen, handleNavigate, loadDecisionInput, mobileMoreOpen, setMobileMoreOpen }) => {
   const mobileMoreBtnRef = useRef<HTMLButtonElement>(null);
@@ -82,12 +158,20 @@ export const MobileNav: React.FC<MobileNavProps> = ({ screen, handleNavigate, lo
 
   const buildTitle = `Git commit ${buildInfo.gitSha}${buildInfo.dirty ? ' (local working tree has uncommitted changes)' : ''}`;
 
+  const navigateToDrawerDestination = (destination: DrawerDestination) => {
+    if (destination.refreshDecisionInput) {
+      loadDecisionInput();
+    }
+    handleNavigate(destination.screen);
+  };
+
   return (
     <>
-      <nav className="bottom-nav">
+      <nav className="bottom-nav" aria-label="Primary">
         <button
           className={`nav-item ${screen === 'home' ? 'active' : ''}`}
           onClick={() => handleNavigate('home')}
+          aria-current={screen === 'home' ? 'page' : undefined}
         >
           <span className="nav-icon">🏠</span>
           <span className="nav-label">{SCREEN_LABELS.home}</span>
@@ -96,6 +180,7 @@ export const MobileNav: React.FC<MobileNavProps> = ({ screen, handleNavigate, lo
         <button
           className={`nav-item ${screen === 'checkin' ? 'active' : ''}`}
           onClick={() => handleNavigate('checkin')}
+          aria-current={screen === 'checkin' ? 'page' : undefined}
         >
           <span className="nav-icon">✓</span>
           <span className="nav-label">{SCREEN_LABELS.checkin}</span>
@@ -104,6 +189,7 @@ export const MobileNav: React.FC<MobileNavProps> = ({ screen, handleNavigate, lo
         <button
           className={`nav-item ${screen === 'plan' ? 'active' : ''}`}
           onClick={() => handleNavigate('plan')}
+          aria-current={screen === 'plan' ? 'page' : undefined}
         >
           <span className="nav-icon">📋</span>
           <span className="nav-label">{SCREEN_LABELS.plan}</span>
@@ -111,7 +197,7 @@ export const MobileNav: React.FC<MobileNavProps> = ({ screen, handleNavigate, lo
 
         <button
           ref={mobileMoreBtnRef}
-          className={`nav-item ${['goals', 'constraints', 'preferences', 'data', 'brief', 'sessions', 'testing'].includes(screen) ? 'active' : ''}`}
+          className={`nav-item ${MOBILE_MORE_SCREENS.includes(screen) ? 'active' : ''}`}
           onClick={() => setMobileMoreOpen((isOpen) => !isOpen)}
           aria-expanded={mobileMoreOpen}
           aria-haspopup="dialog"
@@ -129,111 +215,42 @@ export const MobileNav: React.FC<MobileNavProps> = ({ screen, handleNavigate, lo
               <button className="close-drawer-btn" onClick={() => setMobileMoreOpen(false)} aria-label="Close navigation and settings">✕</button>
             </div>
             <div className="drawer-items">
-              <div className="drawer-group" role="presentation">
-                <span style={GROUP_TITLE_STYLE}>Train</span>
-                <span className="item-sub">Sessions, assessments, and the week-ahead plan</span>
-              </div>
-              <button
-                className={`drawer-item ${screen === 'sessions' ? 'active' : ''}`}
-                onClick={() => handleNavigate('sessions')}
-              >
-                <span className="item-icon">🚀</span>
-                <div className="item-text">
-                  <span className="item-title">{SCREEN_LABELS.sessions}</span>
-                  <span className="item-sub">Run a multidomain fixture and record native measures</span>
-                </div>
-              </button>
+              {DRAWER_GROUPS.map((group) => {
+                const titleId = `mobile-more-${group.id}-title`;
+                const descriptionId = `mobile-more-${group.id}-description`;
 
-              <button
-                className={`drawer-item ${screen === 'testing' ? 'active' : ''}`}
-                onClick={() => handleNavigate('testing')}
-              >
-                <span className="item-icon">🧪</span>
-                <div className="item-text">
-                  <span className="item-title">{SCREEN_LABELS.testing}</span>
-                  <span className="item-sub">Run a locked assessment and record comparable raw outcomes</span>
-                </div>
-              </button>
-
-              <button
-                className={`drawer-item ${screen === 'plan' ? 'active' : ''}`}
-                onClick={() => handleNavigate('plan')}
-              >
-                <span className="item-icon">📋</span>
-                <div className="item-text">
-                  <span className="item-title">{SCREEN_LABELS.plan}</span>
-                  <span className="item-sub">Compare the coach plan against the adaptive forecast</span>
-                </div>
-              </button>
-
-              <div className="drawer-group" role="presentation">
-                <span style={GROUP_TITLE_STYLE}>Configure</span>
-                <span className="item-sub">Goals, setup, and coaching preferences</span>
-              </div>
-              <button
-                className={`drawer-item ${screen === 'goals' ? 'active' : ''}`}
-                onClick={() => handleNavigate('goals')}
-              >
-                <span className="item-icon">🎯</span>
-                <div className="item-text">
-                  <span className="item-title">{SCREEN_LABELS.goals}</span>
-                  <span className="item-sub">Manage events and target milestones</span>
-                </div>
-              </button>
-
-              <button
-                className={`drawer-item ${screen === 'constraints' ? 'active' : ''}`}
-                onClick={() => handleNavigate('constraints')}
-              >
-                <span className="item-icon">⚠️</span>
-                <div className="item-text">
-                  <span className="item-title">{SCREEN_LABELS.constraints}</span>
-                  <span className="item-sub">Manage physical cautions & equipment</span>
-                </div>
-              </button>
-
-              <button
-                className={`drawer-item ${screen === 'preferences' ? 'active' : ''}`}
-                onClick={() => handleNavigate('preferences')}
-              >
-                <span className="item-icon">⚙️</span>
-                <div className="item-text">
-                  <span className="item-title">{SCREEN_LABELS.preferences}</span>
-                  <span className="item-sub">Configure modalities & strain caps</span>
-                </div>
-              </button>
-
-              <div className="drawer-group" role="presentation">
-                <span style={GROUP_TITLE_STYLE}>Understand</span>
-                <span className="item-sub">Data review and AI context export</span>
-              </div>
-              <button
-                className={`drawer-item ${screen === 'data' ? 'active' : ''}`}
-                onClick={() => {
-                  loadDecisionInput();
-                  handleNavigate('data');
-                }}
-              >
-                <span className="item-icon">📊</span>
-                <div className="item-text">
-                  <span className="item-title">{SCREEN_LABELS.data}</span>
-                  <span className="item-sub">View analytics and snapshot telemetry</span>
-                </div>
-              </button>
-
-              <button
-                className={`drawer-item ${screen === 'brief' ? 'active' : ''}`}
-                onClick={() => {
-                  loadDecisionInput();
-                  handleNavigate('brief');
-                }}
-              >
-                <span className="item-icon">📤</span>
-                <div className="item-text">
-                  <span className="item-title">{SCREEN_LABELS.brief}</span>
-                  <span className="item-sub">Compile recent metrics & prompt for your AI</span>
-                </div>
-              </button>
+                return (
+                  <div
+                    key={group.id}
+                    className="drawer-group"
+                    role="group"
+                    aria-labelledby={titleId}
+                    aria-describedby={descriptionId}
+                  >
+                    <div className="drawer-group-header">
+                      <h4 id={titleId} className="drawer-group-title">{group.title}</h4>
+                      <span id={descriptionId} className="drawer-group-description">{group.description}</span>
+                    </div>
+                    {group.items.map((destination) => {
+                      const active = screen === destination.screen;
+                      return (
+                        <button
+                          key={destination.screen}
+                          className={`drawer-item ${active ? 'active' : ''}`}
+                          onClick={() => navigateToDrawerDestination(destination)}
+                          aria-current={active ? 'page' : undefined}
+                        >
+                          <span className="item-icon">{destination.icon}</span>
+                          <div className="item-text">
+                            <span className="item-title">{SCREEN_LABELS[destination.screen]}</span>
+                            <span className="item-sub">{destination.description}</span>
+                          </div>
+                        </button>
+                      );
+                    })}
+                  </div>
+                );
+              })}
 
               <div className="drawer-divider" />
 

--- a/app/src/components/MobileNav.tsx
+++ b/app/src/components/MobileNav.tsx
@@ -12,6 +12,21 @@ interface MobileNavProps {
   setMobileMoreOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
+/**
+ * Group heading style for the More drawer sections (#486). Item sub-copy reuses the
+ * existing `item-sub` class so group descriptions match the per-item pattern; only the
+ * uppercase section title needs an inline style to stay inside the MobileNav lane
+ * (no shared-stylesheet change).
+ */
+const GROUP_TITLE_STYLE: React.CSSProperties = {
+  fontSize: '0.75rem',
+  fontWeight: 700,
+  letterSpacing: '0.08em',
+  textTransform: 'uppercase',
+  color: 'var(--text-secondary)',
+  padding: '0 0.25rem',
+};
+
 export const MobileNav: React.FC<MobileNavProps> = ({ screen, handleNavigate, loadDecisionInput, mobileMoreOpen, setMobileMoreOpen }) => {
   const mobileMoreBtnRef = useRef<HTMLButtonElement>(null);
   const mobileDrawerRef = useRef<HTMLDivElement>(null);
@@ -114,6 +129,47 @@ export const MobileNav: React.FC<MobileNavProps> = ({ screen, handleNavigate, lo
               <button className="close-drawer-btn" onClick={() => setMobileMoreOpen(false)} aria-label="Close navigation and settings">✕</button>
             </div>
             <div className="drawer-items">
+              <div className="drawer-group" role="presentation">
+                <span style={GROUP_TITLE_STYLE}>Train</span>
+                <span className="item-sub">Sessions, assessments, and the week-ahead plan</span>
+              </div>
+              <button
+                className={`drawer-item ${screen === 'sessions' ? 'active' : ''}`}
+                onClick={() => handleNavigate('sessions')}
+              >
+                <span className="item-icon">🚀</span>
+                <div className="item-text">
+                  <span className="item-title">{SCREEN_LABELS.sessions}</span>
+                  <span className="item-sub">Run a multidomain fixture and record native measures</span>
+                </div>
+              </button>
+
+              <button
+                className={`drawer-item ${screen === 'testing' ? 'active' : ''}`}
+                onClick={() => handleNavigate('testing')}
+              >
+                <span className="item-icon">🧪</span>
+                <div className="item-text">
+                  <span className="item-title">{SCREEN_LABELS.testing}</span>
+                  <span className="item-sub">Run a locked assessment and record comparable raw outcomes</span>
+                </div>
+              </button>
+
+              <button
+                className={`drawer-item ${screen === 'plan' ? 'active' : ''}`}
+                onClick={() => handleNavigate('plan')}
+              >
+                <span className="item-icon">📋</span>
+                <div className="item-text">
+                  <span className="item-title">{SCREEN_LABELS.plan}</span>
+                  <span className="item-sub">Compare the coach plan against the adaptive forecast</span>
+                </div>
+              </button>
+
+              <div className="drawer-group" role="presentation">
+                <span style={GROUP_TITLE_STYLE}>Configure</span>
+                <span className="item-sub">Goals, setup, and coaching preferences</span>
+              </div>
               <button
                 className={`drawer-item ${screen === 'goals' ? 'active' : ''}`}
                 onClick={() => handleNavigate('goals')}
@@ -122,20 +178,6 @@ export const MobileNav: React.FC<MobileNavProps> = ({ screen, handleNavigate, lo
                 <div className="item-text">
                   <span className="item-title">{SCREEN_LABELS.goals}</span>
                   <span className="item-sub">Manage events and target milestones</span>
-                </div>
-              </button>
-
-              <button
-                className={`drawer-item ${screen === 'data' ? 'active' : ''}`}
-                onClick={() => {
-                  loadDecisionInput();
-                  handleNavigate('data');
-                }}
-              >
-                <span className="item-icon">📊</span>
-                <div className="item-text">
-                  <span className="item-title">{SCREEN_LABELS.data}</span>
-                  <span className="item-sub">View analytics and snapshot telemetry</span>
                 </div>
               </button>
 
@@ -161,25 +203,21 @@ export const MobileNav: React.FC<MobileNavProps> = ({ screen, handleNavigate, lo
                 </div>
               </button>
 
+              <div className="drawer-group" role="presentation">
+                <span style={GROUP_TITLE_STYLE}>Understand</span>
+                <span className="item-sub">Data review and AI context export</span>
+              </div>
               <button
-                className={`drawer-item ${screen === 'sessions' ? 'active' : ''}`}
-                onClick={() => handleNavigate('sessions')}
+                className={`drawer-item ${screen === 'data' ? 'active' : ''}`}
+                onClick={() => {
+                  loadDecisionInput();
+                  handleNavigate('data');
+                }}
               >
-                <span className="item-icon">🚀</span>
+                <span className="item-icon">📊</span>
                 <div className="item-text">
-                  <span className="item-title">{SCREEN_LABELS.sessions}</span>
-                  <span className="item-sub">Run a multidomain fixture and record native measures</span>
-                </div>
-              </button>
-
-              <button
-                className={`drawer-item ${screen === 'testing' ? 'active' : ''}`}
-                onClick={() => handleNavigate('testing')}
-              >
-                <span className="item-icon">🧪</span>
-                <div className="item-text">
-                  <span className="item-title">{SCREEN_LABELS.testing}</span>
-                  <span className="item-sub">Run a locked assessment and record comparable raw outcomes</span>
+                  <span className="item-title">{SCREEN_LABELS.data}</span>
+                  <span className="item-sub">View analytics and snapshot telemetry</span>
                 </div>
               </button>
 

--- a/docs/architecture/user-flows.md
+++ b/docs/architecture/user-flows.md
@@ -131,7 +131,7 @@ Desktop and mobile expose all ten `Screen` values, but with different prominence
 |---|---|---|
 | `home` | `Home` plus brand → Home | Bottom `Home` |
 | `checkin` | `Check-in` | Bottom `Check-in` |
-| `plan` | Settings → `Plan` | Bottom `Plan` |
+| `plan` | Settings → `Plan` | Bottom `Plan`, also listed under More → Train |
 | `sessions` | `Sessions` | More → `Sessions` |
 | `testing` | `Testing` | More → `Testing` |
 | `goals` | `Goals` | More → `Goals` |
@@ -145,10 +145,20 @@ truth shared by `Header`, `MobileNav`, and each screen's heading (#485).
 
 Current chrome details worth preserving when changing navigation:
 
-* Desktop Settings is marked active for `constraints`, `preferences`, and `plan`, but not
-  `brief`.
-* Mobile More is marked active for `goals`, `constraints`, `preferences`, `data`, `brief`,
-  `sessions`, and `testing`.
+* The mobile More drawer groups its destinations by intent — Train (`Sessions`,
+  `Testing`, `Plan`), Configure (`Goals`, `Training Setup`, `Coach Preferences`),
+  Understand (`Data`, `Export Context for AI`) — and each group carries short sub-copy
+  in the existing `MobileNav` `item-sub` pattern. Every label renders from
+  `navigation.ts` `SCREEN_LABELS`; only the group names come from the drawer itself.
+* Desktop active-state rule (`Header`): top-level links are active on their exact
+  `Screen`; the Settings button is active for `constraints`, `preferences`, `plan`, and
+  `brief`; each Settings dropdown item is active on its exact `Screen`.
+* Mobile active-state rule (`MobileNav`): bottom tabs are active on their exact
+  `Screen` (`home`, `checkin`, `plan`); the More tab is active for every other drawer
+  destination (`goals`, `constraints`, `preferences`, `data`, `brief`, `sessions`,
+  `testing`); each drawer item is active on its exact `Screen` within its group, so the
+  athlete always sees both the section and the selected destination. Opening the drawer
+  while on `plan` shows the Train → `Plan` item active alongside the bottom tab.
 * Only desktop renders `GarminSyncBadge` beside the brand.
 * Both menus show a non-clickable `Build {label}` entry followed by a clickable `Sign Out`.
 
@@ -383,9 +393,16 @@ living-reference section when implementing them.
 1. ~~Use one user-facing name per `Screen` across Header, MobileNav, and screen titles.~~
    Done (#485): one canonical label per `Screen` renders from `navigation.ts`
    `SCREEN_LABELS` in Header, MobileNav, and each screen heading.
-2. Make desktop and mobile primary destinations more symmetrical, or document a deliberate
-   reason for the difference. A daily-loop set such as Today / Check-in / Plan is the most
-   obvious candidate.
+2. ~~Make desktop and mobile primary destinations more symmetrical, or document a deliberate~~
+   ~~reason for the difference. A daily-loop set such as Today / Check-in / Plan is the most~~
+   ~~obvious candidate.~~
+   Done (#486): the mobile More drawer is grouped by intent — Train, Configure,
+   Understand — with per-item active highlighting inside each group, and the desktop and
+   mobile active-state rules are documented in the Navigation chrome section above. The
+   desktop Settings lump now covers `brief` alongside `constraints`, `preferences`, and
+   `plan`. Full destination symmetry between desktop and mobile remains a deliberate
+   non-goal: desktop promotes Sessions, Testing, Goals, and Data while mobile promotes
+   Plan (see confusing spot 1).
 3. Group Mobile More by intent (train / configure / understand) rather than one flat list.
 
 ### Daily loop and repair

--- a/docs/architecture/user-flows.md
+++ b/docs/architecture/user-flows.md
@@ -147,18 +147,19 @@ Current chrome details worth preserving when changing navigation:
 
 * The mobile More drawer groups its destinations by intent — Train (`Sessions`,
   `Testing`, `Plan`), Configure (`Goals`, `Training Setup`, `Coach Preferences`),
-  Understand (`Data`, `Export Context for AI`) — and each group carries short sub-copy
-  in the existing `MobileNav` `item-sub` pattern. Every label renders from
-  `navigation.ts` `SCREEN_LABELS`; only the group names come from the drawer itself.
+  Understand (`Data`, `Export Context for AI`). Each group is a programmatically labelled
+  `role="group"` with short descriptive sub-copy whose typography matches the existing
+  drawer `item-sub` pattern; destination labels still render from `navigation.ts`
+  `SCREEN_LABELS`.
 * Desktop active-state rule (`Header`): top-level links are active on their exact
   `Screen`; the Settings button is active for `constraints`, `preferences`, `plan`, and
   `brief`; each Settings dropdown item is active on its exact `Screen`.
 * Mobile active-state rule (`MobileNav`): bottom tabs are active on their exact
   `Screen` (`home`, `checkin`, `plan`); the More tab is active for every other drawer
   destination (`goals`, `constraints`, `preferences`, `data`, `brief`, `sessions`,
-  `testing`); each drawer item is active on its exact `Screen` within its group, so the
-  athlete always sees both the section and the selected destination. Opening the drawer
-  while on `plan` shows the Train → `Plan` item active alongside the bottom tab.
+  `testing`); each drawer item is active on its exact `Screen` within its group and the
+  selected destination exposes `aria-current="page"`. Opening the drawer while on `plan`
+  therefore shows Train → `Plan` current alongside the current bottom Plan tab.
 * Only desktop renders `GarminSyncBadge` beside the brand.
 * Both menus show a non-clickable `Build {label}` entry followed by a clickable `Sign Out`.
 
@@ -321,10 +322,16 @@ Most of the surface is inspection/export. The Activities tab is the exception: i
 corrective actions (for example activity reclassification, and canonical-source unlinking
 when that read model is enabled), so the screen must not be described as strictly read-only.
 
-The `brief` route is the same `DataView` component opened on `Context brief`. The Data and
-brief navigation entries refresh decision input before navigating. If `decisionInput` is
-null, DataView shows `No data available`; that state has no in-component retry action,
-although the global navigation chrome remains available.
+The `brief` route is the same `DataView` component opened on `Context brief`, and it is
+the canonical Export-for-AI surface. From the Data screen, the Context brief tab and the
+Activities AI-export action deep-link to it (`App.tsx` `handleNavigate('brief')` via
+`DataView` `onNavigateToBrief`) instead of duplicating its export. On the canonical `brief`
+screen, the same Activities action returns to the local Context brief tab, so the legacy raw
+clipboard exporter is not reachable there either. Only the `brief` screen renders the daily
+(2-day) / full (14-day) brief with char and token counts. The Data and brief navigation
+entries refresh decision input before navigating. If `decisionInput` is null, DataView shows
+`No data available`; that state has no in-component retry action, although the global
+navigation chrome remains available.
 
 ### 10. Protocol testing
 
@@ -371,8 +378,9 @@ moving an input across an authority boundary.
    discover.
 4. Imported coach plan, adaptive week forecast, and Home recommendation can disagree without
    a single authority explanation in the UI.
-5. AI/context export appears as the `brief` route, the DataView Context brief tab, and raw
-   Activities JSON export.
+5. AI/context export has one canonical surface: the `brief` route. The DataView
+   Context brief tab and Activities AI-export action route to it rather than duplicating it;
+   when already inside the canonical `brief` screen, that action returns to Context brief.
 6. `sessions` and `testing` share `SessionRunner`, so the execution UI alone does not strongly
    communicate provenance.
 7. Several recovery states are weak rather than truly terminal: DataView's no-data state has
@@ -396,14 +404,14 @@ living-reference section when implementing them.
 2. ~~Make desktop and mobile primary destinations more symmetrical, or document a deliberate~~
    ~~reason for the difference. A daily-loop set such as Today / Check-in / Plan is the most~~
    ~~obvious candidate.~~
-   Done (#486): the mobile More drawer is grouped by intent — Train, Configure,
-   Understand — with per-item active highlighting inside each group, and the desktop and
-   mobile active-state rules are documented in the Navigation chrome section above. The
-   desktop Settings lump now covers `brief` alongside `constraints`, `preferences`, and
-   `plan`. Full destination symmetry between desktop and mobile remains a deliberate
-   non-goal: desktop promotes Sessions, Testing, Goals, and Data while mobile promotes
-   Plan (see confusing spot 1).
-3. Group Mobile More by intent (train / configure / understand) rather than one flat list.
+   Done (#486): the navigation reference now records the deliberate desktop/mobile
+   prominence difference and the exact active-state rules. Mobile keeps Plan as a primary
+   bottom destination while desktop promotes Sessions, Testing, Goals, and Data; the More
+   drawer groups the remaining mobile navigation by intent instead of pretending the two
+   shells are fully symmetrical.
+3. ~~Group Mobile More by intent (train / configure / understand) rather than one flat list.~~
+   Done (#486): Train, Configure, and Understand are labelled drawer groups with short
+   descriptions and per-destination visible/current state.
 
 ### Daily loop and repair
 
@@ -433,13 +441,24 @@ living-reference section when implementing them.
    Done (#484): removed the unused `Goals` `onNavigate` prop — no repair flow needed it —
    and kept `constraints` as the stable route key with user-facing copy in `navigation.ts`
    `SCREEN_LABELS` (`Training Setup`).
-9. Review immediate-persist Training Setup controls for undo/confirmation where a mistaken
-   toggle can materially change feasibility/safety decisions.
+9. ~~Review immediate-persist Training Setup controls for undo/confirmation where a mistaken
+   toggle can materially change feasibility/safety decisions.~~
+   Done (#492): destructive autosaved controls (equipment, safety limits, injury-constraint
+   add/edit/remove) offer a one-shot Undo toast that reverts to the pre-save snapshot via
+   `trainingSettingsService` `buildRevertUpdate`; non-destructive edits keep instant-save
+   with no toast. Gating semantics unchanged.
 
 ### Sessions and testing
 
-10. Differentiate normal session execution and protocol testing more strongly around the
-    shared runner, especially during execution and completion.
+10. ~~Differentiate normal session execution and protocol testing more strongly around the
+    shared runner, especially during execution and completion.~~ Done (#496):
+    `SessionRunner` takes a chrome-only `mode` (`session` | `assessment`, default
+    `session`): assessment mode tints the runner header with a `Locked assessment` badge,
+    `TestingWorkflow` keeps the protocol lock visible (collapsed) above the shared runner
+    during execution with the attempt id and abandon cost, and `SessionCompletionSheet`
+    identifies the saved `SessionExecution` plus its linked `AssessmentAttempt` context. The
+    `AssessmentAttempt` itself is completed only after raw observations are saved. No
+    execution or observation persistence semantics changed.
 11. ~~Consolidate the structured-session creation entry points behind a clearer `New session`
     chooser while preserving the underlying import/manual/template contracts.~~ Done (#495):
     one `New session` entry with a From template / From fixture / Import JSON / Build manually
@@ -458,7 +477,12 @@ living-reference section when implementing them.
 14. ~~Use distinct copy for app authentication (`Continue/Sign in with Garmin`) and wearable
     data connection (`Connect Garmin wearable`).~~ Done (#497): `LoginScreen` garmin mode
     uses `Sign in with Garmin`, `GarminConnectionSection` uses `Connect Garmin wearable`.
-15. Choose a canonical AI-export surface and make the other export affordances clearly point
-    to or distinguish themselves from it.
+15. ~~Choose a canonical AI-export surface and make the other export affordances clearly point
+    to or distinguish themselves from it.~~
+    Done (#491): `brief` is the canonical Export-for-AI surface; the DataView Context-brief
+    tab and Activities AI-export action route to it (or return to the local Context brief tab
+    when already on the canonical screen). The legacy raw Activities clipboard exporter is
+    removed from the UI. Exported brief content is unchanged (daily 2d vs full 14d windows,
+    char and token counts).
 16. Add local retry/repair affordances to weak recovery states, starting with DataView's
     null-input state and PlanView source failures.


### PR DESCRIPTION
## Summary
- Group the mobile More drawer by user intent: **Train** (Sessions, Testing, Plan), **Configure** (Goals, Training Setup, Coach Preferences), and **Understand** (Data, Export Context for AI).
- Keep destination labels sourced from `navigation.ts` `SCREEN_LABELS`, preserve the existing Data/AI decision-input refresh behavior, and keep Plan intentionally available both as a primary bottom tab and inside Train.
- Add exact per-destination current state: selected mobile destinations retain their visual active styling and expose `aria-current="page"`; the intent sections are programmatically labelled `role="group"` regions with descriptions.
- Fix the original group-description styling bug by adding local `MobileNav.css` styles matching the existing drawer secondary-text typography. The previous `item-sub` selector only applied beneath `.drawer-item`, so group descriptions were otherwise unstyled.
- Mark desktop Settings active for `brief`, matching the existing Export Context for AI menu destination.
- Update `docs/architecture/user-flows.md` with the grouped drawer, desktop/mobile active-state rules, and completed Recommendations 2 and 3.
- Merge current `main` into the branch and resolve the `user-flows.md` conflict while preserving the #510 Plan-authority documentation.

Closes #486.

No `POLICY_VERSION` bump: this PR changes navigation chrome, styling, tests, and documentation only; decision policy and persistence semantics are unchanged.

## Review fixes added in this pass
- Fixed the More-group description selector/styling mismatch.
- Added programmatic group labels/descriptions and `aria-current` coverage for selected mobile destinations.
- Added focused `MobileNav` SSR regression tests covering all three groups, normal drawer current state, and the intentional duplicate Plan-current case.
- Reconciled the architecture doc against latest `main` instead of overwriting newer #491/#492/#496/#510 documentation.
- Resolved the branch conflict with `main` explicitly.
- Fixed CI's `noUnusedLocals` TypeScript failure in the new test without removing coverage.

## Validation
- [x] GitHub Actions **CI Pipeline #2904** on final head `fc73fbcd4a600dfd68e4ba34594798b1fabebc1f`: **success**.
- [x] Frontend Hygiene & Static Gates: typecheck, lint, sports-knowledge validation, engine-knowledge coverage, workout-library validation, policy-version drift check, and production bundle build all passed.
- [x] Frontend Unit Tests & Firestore Rules: full frontend coverage suite and Firestore security-rule emulator suite passed, including the new `MobileNav` tests.
- [x] Engine Simulations & AI Gates passed.
- [x] Python 3.14 test/lint/type/coverage/audit job passed.
- [x] Docker build/compose smoke and routing/header smoke passed.
- [ ] Manual mobile-device/screenshot pass was not run in this execution; behavior is covered by the component regression tests and repository CI.

## Risk and reviewer guidance
- **Plan duplication is intentional:** on the Plan screen, both the bottom Plan destination and Train → Plan represent the current page.
- The More bottom tab remains a section affordance rather than a destination, so it stays visually active for drawer-only screens but does not receive `aria-current`.
- Data and Export Context for AI still refresh decision input before navigation via data-driven destination metadata.
- CSS is component-local; no engine, schema, Firestore write, or training-policy behavior changed.
- Rollback is code-only; there is no migration or persisted-data change.

## Review status
- There were no human or inline review threads on the PR during this pass.
- A manual `@coderabbitai review` was requested; CodeRabbit acknowledged it but reported **review rate limited**, so it produced no actionable review threads to reply to or resolve.