### PR TITLE
H4 dedup unification, bundle-placement persistence, H5c design

### DIFF
--- a/app/firestore.rules
+++ b/app/firestore.rules
@@ -436,16 +436,21 @@ service cloud.firestore {
         // Firestore's per-request rule-evaluation ceiling -- adding even a minimal
         // 3-expression check for one more optional field (verified with the emulator
         // suite, not a guess) pushed a create/update over "the maximum of 1000
-        // expressions to evaluate". That display field is deliberately not persisted;
-        // `activeExternalPlanService.ts`'s bundle-aware primary-session selection (the
-        // actual decision-affecting behavior) does not depend on it. The
+        // expressions to evaluate". That display field is deliberately not persisted on
+        // *this* document; `activeExternalPlanService.ts`'s bundle-aware primary-session
+        // selection (the actual decision-affecting behavior) does not depend on it. The
         // primarySession/additionalSessions dedup above (issue #435) is a real, verified
         // reduction in this audit's evaluation cost, but re-tested with the emulator
         // suite and confirmed **still not enough headroom** for even the same minimal
-        // intradayBundle check -- the ceiling error recurred identically. Whoever revisits
-        // this next needs a bigger reduction than that one dedup (see issue #435's
-        // remaining candidates: knowledge-lineage unrolled-array cost, identity-provenance
-        // `get()` lookups, or moving this field outside `recommendationAudit` entirely).
+        // intradayBundle check -- the ceiling error recurred identically. The resolved
+        // placement is instead persisted at `users/{userId}/intraday_bundle_placements/
+        // {date}` (see that collection's rules and `intradayBundlePlacementAuditService.ts`
+        // below/elsewhere in this file) -- a separate document with its own independent
+        // expression budget, not another attempt at this one. Whoever revisits *this*
+        // document's own headroom for unrelated reasons still has issue #435's remaining
+        // candidates available (knowledge-lineage unrolled-array cost, identity-provenance
+        // `get()` lookups), but closing that headroom is no longer a blocker for placement
+        // display.
         && (!('externalPlan' in audit) || (
           audit.externalPlan is map
           && audit.externalPlan.keys().hasOnly(['planId', 'revision', 'sessionId', 'contentHash'])
@@ -1918,6 +1923,43 @@ service cloud.firestore {
         // Every mutating transition bumps revision by exactly one (plan step 6a): this is
         // the same optimistic-sequencing property that makes a concurrent claim conflict
         // and retry rather than silently overwrite another writer's reservation change.
+        && request.resource.data.revision == resource.data.revision + 1;
+      allow delete: if false;
+    }
+
+    // ADR-0036 (H4) D-PLACEMENT follow-up: a v4 intraday bundle's resolved window
+    // placement, persisted for display only -- see
+    // `intradayBundlePlacementAuditService.ts`'s header for why this is a separate
+    // sibling document rather than a `recommendationAudit.externalPlan` field
+    // (that path is already at Firestore's per-request rule-evaluation ceiling).
+    // Kept deliberately shallow/structural per PR #468's lesson: `bindings`' own field
+    // shapes are validated at the TS boundary (`IntradayBundlePlacementRecord`), not here.
+    function hasValidIntradayBundlePlacement(userId, date) {
+      let data = request.resource.data;
+      return hasOwnedUserId(userId)
+        && data.keys().hasOnly(['userId', 'date', 'bundleId', 'outcome', 'bindings', 'reason', 'revision', 'createdAt', 'updatedAt'])
+        && data.keys().hasAll(['userId', 'date', 'bundleId', 'outcome', 'bindings', 'reason', 'revision', 'createdAt', 'updatedAt'])
+        && data.date == date
+        && isValidActivityDate(data.date)
+        && data.bundleId is string && data.bundleId.size() > 0 && data.bundleId.size() <= 128
+        && data.outcome in ['placed', 'infeasible']
+        && data.bindings is list && data.bindings.size() <= 8
+        && (data.reason == null || (data.reason is string && data.reason.size() <= 512))
+        && data.revision is int && data.revision >= 1
+        && data.createdAt is string && data.updatedAt is string;
+    }
+
+    match /users/{userId}/intraday_bundle_placements/{date} {
+      allow read: if isOwner(userId);
+      allow create: if hasValidIntradayBundlePlacement(userId, date);
+      // A later re-proposal for the same date may legitimately replace this document
+      // (e.g. schedule windows changed since the last computation); the revision gate
+      // still stops a stale/slower write from clobbering a newer one that already
+      // committed.
+      allow update: if hasValidIntradayBundlePlacement(userId, date)
+        && keepsOwnership(userId)
+        && request.resource.data.date == resource.data.date
+        && request.resource.data.createdAt == resource.data.createdAt
         && request.resource.data.revision == resource.data.revision + 1;
       allow delete: if false;
     }

--- a/app/src/components/Home.tsx
+++ b/app/src/components/Home.tsx
@@ -46,6 +46,7 @@ import {
   adjudicateIntradayBundleMembers,
   type IntradayBundleMemberStatus,
 } from '../services/intradayBundleMemberAdjudication';
+import { recordIntradayBundlePlacement } from '../services/intradayBundlePlacementAuditService';
 import type { LedgerCeilings } from '../engine/dailyLedger';
 import { checkinService } from '../services/checkinService';
 import { sessionExecutionService } from '../services/sessionExecutionService';
@@ -502,6 +503,10 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
         const bundlePlacement = (activeExternal && bundleContext && isV4Plan(activeExternal.plan))
           ? resolveIntradayBundlePlacement(activeExternal, input.date, bundleContext)
           : null;
+        // Display-only persistence of the placement decision already made above (ADR-0036
+        // D-PLACEMENT follow-up) -- fire-and-forget, must never delay or fail today's
+        // recommendation; the service itself swallows write failures.
+        if (bundlePlacement) void recordIntradayBundlePlacement(userId, input.date, bundlePlacement);
         const externalContext = activeExternal ? externalPlanContextForDate(activeExternal, input.date, bundleContext) : null;
         const externalRestContext = activeExternal ? externalRestContextForDate(activeExternal, input.date) : null;
 

--- a/app/src/emulator/firestoreRules.emulator.test.ts
+++ b/app/src/emulator/firestoreRules.emulator.test.ts
@@ -1801,6 +1801,64 @@ emulatorDescribe('Firestore security rules', () => {
         }));
     });
 
+    it('enforces the intraday_bundle_placements display-audit contract (ADR-0036 D-PLACEMENT follow-up)', async () => {
+        const ownerDb = testEnvironment.authenticatedContext(ownerId).firestore();
+        const otherDb = testEnvironment.authenticatedContext(otherUserId).firestore();
+        const placementPath = `users/${ownerId}/intraday_bundle_placements/2026-08-18`;
+
+        function validPlacement() {
+            return {
+                userId: ownerId, date: '2026-08-18', bundleId: 'bundle-1', outcome: 'placed',
+                bindings: [{
+                    sessionId: 'w1-am', windowId: 'win-am',
+                    boundStartLocal: '06:00', boundEndLocal: '07:00',
+                    startInstant: '2026-08-18T04:00:00.000Z', endInstant: '2026-08-18T05:00:00.000Z',
+                }],
+                reason: null,
+                revision: 1,
+                createdAt: '2026-08-18T05:00:00Z', updatedAt: '2026-08-18T05:00:00Z',
+            };
+        }
+
+        // 1. Owner can record a valid placement.
+        await expect(assertSucceeds(setDoc(doc(ownerDb, placementPath), validPlacement())))
+            .resolves.toBeUndefined();
+
+        // 2. Cross-user read/write is denied.
+        await assertFails(getDoc(doc(otherDb, placementPath)));
+        await assertFails(setDoc(doc(otherDb, placementPath), { ...validPlacement(), userId: otherUserId }));
+
+        // 3. A revision jump greater than 1 is rejected.
+        await assertFails(setDoc(doc(ownerDb, placementPath), { ...validPlacement(), revision: 3 }));
+
+        // 4. A legitimate +1 re-proposal update succeeds.
+        await expect(assertSucceeds(setDoc(doc(ownerDb, placementPath), {
+            ...validPlacement(), revision: 2, updatedAt: '2026-08-18T06:00:00Z',
+        }))).resolves.toBeUndefined();
+
+        // 5. date/createdAt are immutable once created.
+        await assertFails(setDoc(doc(ownerDb, placementPath), { ...validPlacement(), revision: 3, createdAt: '2026-08-18T07:00:00Z' }));
+
+        // 6. Deletes are never allowed.
+        await assertFails(deleteDoc(doc(ownerDb, placementPath)));
+
+        // 7. An infeasible outcome with an empty bindings list and a reason is valid.
+        const infeasiblePath = `users/${ownerId}/intraday_bundle_placements/2026-08-19`;
+        await expect(assertSucceeds(setDoc(doc(ownerDb, infeasiblePath), {
+            ...validPlacement(), date: '2026-08-19', outcome: 'infeasible', bindings: [], reason: 'insufficient daily systemic-cost budget',
+        }))).resolves.toBeUndefined();
+
+        // 8. An unknown outcome value is rejected.
+        await assertFails(setDoc(doc(ownerDb, `users/${ownerId}/intraday_bundle_placements/2026-08-20`), {
+            ...validPlacement(), date: '2026-08-20', outcome: 'maybe',
+        }));
+
+        // 9. Rejects a malformed shape (missing a required field).
+        const malformed = validPlacement() as Partial<ReturnType<typeof validPlacement>>;
+        delete malformed.bundleId;
+        await assertFails(setDoc(doc(ownerDb, `users/${ownerId}/intraday_bundle_placements/2026-08-21`), malformed));
+    });
+
     it('allows recommendations with primarySession and additionalSessions bindings', async () => {
         const base = validRecommendation();
         const recWithBindings = {

--- a/app/src/engine/externalEventFixedActivityCredit.test.ts
+++ b/app/src/engine/externalEventFixedActivityCredit.test.ts
@@ -76,4 +76,26 @@ describe('external event fixed-activity objective credit', () => {
 
         expect(external.credits).toEqual([]);
     });
+
+    it('credits a same-day duplicate occurrence only once, through the shared ledger identity', () => {
+        const activity = baseActivity({ id: 'catalog', templateId: 'end_easy_01' });
+        // A genuine duplicate record for the same occurrence (e.g. two reads racing before
+        // the caller's own array-level dedup runs) must not double-count its stimulus --
+        // this now goes through `dedupeFixedActivitiesByLedgerIdentity`, the same
+        // occurrenceId/revision identity `dailyLedger.ts` uses, instead of a local Set.
+        const result = applyFixedActivityStimulusCredit(microcycle(), [activity, { ...activity }], DATE);
+
+        expect(result.exposures).toHaveLength(1);
+        expect(result.credits).toHaveLength(1);
+        expect(result.credits[0].earnedCredit).toBeCloseTo(0.8, 6);
+    });
+
+    it('fails closed on two conflicting same-day records for the same occurrence identity', () => {
+        const first = baseActivity({ id: 'catalog', templateId: 'end_easy_01', durationMin: 60 });
+        const conflicting = baseActivity({ id: 'catalog', templateId: 'end_easy_01', durationMin: 90 });
+
+        expect(() => applyFixedActivityStimulusCredit(microcycle(), [first, conflicting], DATE)).toThrow(
+            /Conflicting fixed-activity revisions/,
+        );
+    });
 });

--- a/app/src/engine/externallyPlannedMode.test.ts
+++ b/app/src/engine/externallyPlannedMode.test.ts
@@ -263,6 +263,10 @@ describe('evaluateTrainingWithIntent in externally_planned mode', () => {
         fixedTrace.count = 0;
         fixedTrace.cost = { systemic: 0, cardiovascular: 0, lowerBody: 0, upperBody: 0, impactTissue: 0, neuromuscular: 0 };
         fixedTrace.stimulus = { aerobicEndurance: 0, thresholdPower: 0, vo2MaxPower: 0, repeatedSurges: 0, sprintPower: 0, fatigueResistance: 0, maxStrength: 0, hypertrophy: 0 };
+        // The projection now diffs by occurrence identity (`entries`) rather than the
+        // count/aggregate fields above -- clear it too so this fixture still simulates
+        // "no unrepresented fixed activity" for tomorrow's projection.
+        fixedTrace.entries = [];
 
         const withEvent = await evaluateNextDayPlanWithIntent(
             'u1', [], readiness(), context(), DATE, today, undefined, EMPTY_HISTORY, [], [],
@@ -270,6 +274,38 @@ describe('evaluateTrainingWithIntent in externally_planned mode', () => {
         );
         const withoutEvent = await evaluateNextDayPlanWithIntent(
             'u1', [], readiness(), context(), DATE, withoutDecisionOnlyFixed, undefined, EMPTY_HISTORY, [], [],
+            profile('externally_planned'), null, 'max',
+        );
+        const withSystemic = withEvent.branches.green.recommendation.decisionTrace?.calibration?.fatigue.rawExternalLoad.systemic ?? 0;
+        const withoutSystemic = withoutEvent.branches.green.recommendation.decisionTrace?.calibration?.fatigue.rawExternalLoad.systemic ?? 0;
+        expect(withSystemic).toBeGreaterThan(withoutSystemic);
+    });
+
+    it('still credits the in-memory event by occurrence identity when an unrelated fixed activity brings the represented count up to the trace count', async () => {
+        const today = await evaluate(externalPlan({
+            isEvent: true,
+            title: 'Road Race',
+            placement: { week: 1, preferredDay: 'tuesday', flexibility: 'fixed', ifMissed: 'drop' },
+            gating: { modality: 'cycling', intensity: 'max', durationMin: 50, durationMax: 60, environment: 'outdoor', equipment: [] },
+        }));
+        const withoutDecisionOnlyFixed = structuredClone(today);
+        const fixedTrace = withoutDecisionOnlyFixed.decisionTrace?.calibration?.fixedActivity;
+        if (!fixedTrace) throw new Error('Expected fixed-activity calibration');
+        fixedTrace.entries = [];
+
+        // An unrelated real commitment on the same date brings `represented.length` up to
+        // the synthetic event's own trace count. The prior count-only guard
+        // (`trace.count <= represented.length`) would have wrongly treated the event as
+        // already represented by this unrelated activity and dropped its credit; the
+        // identity-based diff must not be fooled by a matching count.
+        const decoy = [fixedActivity({ id: 'decoy-commitment' })];
+
+        const withEvent = await evaluateNextDayPlanWithIntent(
+            'u1', [], readiness(), context(), DATE, today, undefined, EMPTY_HISTORY, decoy, [],
+            profile('externally_planned'), null, 'max',
+        );
+        const withoutEvent = await evaluateNextDayPlanWithIntent(
+            'u1', [], readiness(), context(), DATE, withoutDecisionOnlyFixed, undefined, EMPTY_HISTORY, decoy, [],
             profile('externally_planned'), null, 'max',
         );
         const withSystemic = withEvent.branches.green.recommendation.decisionTrace?.calibration?.fatigue.rawExternalLoad.systemic ?? 0;

--- a/app/src/engine/models.ts
+++ b/app/src/engine/models.ts
@@ -1023,6 +1023,15 @@ export interface Recommendation {
                 count: number;
                 cost: WorkoutCostProfile;
                 stimulus: WorkoutStimulusProfile;
+                /** Per-occurrence identity for the fixed activities behind the aggregate
+                 * above, keyed by the same `fixedActivityOccurrenceKey` the daily ledger
+                 * uses. Lets a later date's projection diff by occurrence identity instead
+                 * of inferring an unrepresented activity from count/aggregate subtraction. */
+                entries: Array<{
+                    occurrenceId: string;
+                    cost: WorkoutCostProfile;
+                    stimulus: WorkoutStimulusProfile;
+                }>;
             };
         };
     };

--- a/app/src/engine/planner.ts
+++ b/app/src/engine/planner.ts
@@ -89,7 +89,7 @@ import {
 } from './weeklyAllocation';
 import type { CompletedExposure, TrainingHistoryProvider } from './trainingHistory';
 import type { TrainingHistorySnapshot } from './trainingHistorySnapshot';
-import { resolveFixedActivityIdentity } from './fixedActivityIdentity';
+import { fixedActivityOccurrenceKey, resolveFixedActivityIdentity } from './fixedActivityIdentity';
 import { sumFixedActivityCostProfiles } from './fixedActivityCostProfile';
 import { admitsCandidate, computeDailyLedger, type DailyLedgerResult } from './dailyLedger';
 import { dedupeFixedActivitiesByLedgerIdentity, pendingFixedActivityLedgerEntries } from './fixedActivityLedger';
@@ -959,16 +959,20 @@ export function applyFixedActivityStimulusCredit(
     fixedActivities: FixedActivity[],
     date: string,
 ): FixedActivityStimulusResult {
-    const dayActivities = fixedActivities.filter(a => a.date === date && !a.isCompleted && a.expectedStimulus);
+    // Deduped through the same occurrenceId/revision identity `dailyLedger.ts` and the
+    // top-level `generateWeekAheadPlan` fixed-activity array already use, rather than a
+    // local ad hoc Set: a genuine same-day revision conflict now fails closed instead of
+    // silently keeping whichever record happened to appear first in `fixedActivities`.
+    const dayActivities = dedupeFixedActivitiesByLedgerIdentity(
+        fixedActivities.filter(a => a.date === date && !a.isCompleted && a.expectedStimulus),
+    );
     let nextMicrocycle = microcycle;
     const credits: PlannedObjectiveCredit[] = [];
     const exposures: ProjectionExposure[] = [];
-    const seenOccurrences = new Set<string>();
 
     dayActivities.forEach(activity => {
         const identity = resolveFixedActivityIdentity(activity);
-        if (!identity || seenOccurrences.has(identity.occurrenceKey)) return;
-        seenOccurrences.add(identity.occurrenceKey);
+        if (!identity) return;
 
         const stimulus: WorkoutStimulusProfile = { ...ZERO_STIMULUS, ...activity.expectedStimulus };
         const stimulusConfidence = identity.stimulusConfidence ?? 'exact';
@@ -1174,9 +1178,13 @@ export function generateWeekAheadPlan(
     };
 
     const applyFixedActivityCost = (date: string) => {
+        // Cost and stimulus are independent axes credited from the same fixed-activity
+        // identity (`fixedActivityOccurrenceKey`), each tracked in its own namespace --
+        // `:cost` here vs. the exposure occurrenceKey in `appliedProjectionOccurrences` --
+        // so crediting one axis never suppresses the other.
         const dayActivities = getFixedActivitiesForDate(date).filter(a => !a.isCompleted && a.expectedCost);
         const freshActivities = dayActivities.filter(activity => {
-            const key = `fixed:${activity.id}:cost`;
+            const key = `${fixedActivityOccurrenceKey(activity)}:cost`;
             if (appliedFixedCostOccurrences.has(key)) return false;
             appliedFixedCostOccurrences.add(key);
             return true;

--- a/app/src/engine/policy.test.ts
+++ b/app/src/engine/policy.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, it } from 'vitest';
 import { isHistoricalPolicyVersion, HISTORICAL_POLICY_VERSIONS, POLICY_VERSION } from './policy';
 
 describe('isHistoricalPolicyVersion', () => {
-    it('records the exact D-LEDGER planner-admission transition once', () => {
-        expect(POLICY_VERSION).toBe('2026-09-h4-d-ledger-planner-admission-v2');
+    it('records the exact fixed-activity dedup-identity-unification transition once', () => {
+        expect(POLICY_VERSION).toBe('2026-09-fixed-activity-dedup-identity-unification-v1');
         expect(
             HISTORICAL_POLICY_VERSIONS.filter(
-                (version) => version === '2026-09-h4-intraday-bundle-member-launch-v1',
+                (version) => version === '2026-09-h4-d-ledger-planner-admission-v2',
             ),
         ).toHaveLength(1);
     });

--- a/app/src/engine/policy.ts
+++ b/app/src/engine/policy.ts
@@ -1,11 +1,12 @@
 /** Increment whenever a change can alter a persisted recommendation decision. (Refactoring does not require a bump) */
 
-export const POLICY_VERSION = '2026-09-h4-d-ledger-planner-admission-v2';
+export const POLICY_VERSION = '2026-09-fixed-activity-dedup-identity-unification-v1';
 
 /** Historical versions are intentionally not re-executed by this build. Their compact
  * audits remain readable evidence, but replay is rejected explicitly because the old
  * decision function is not bundled alongside the current policy. */
 export const HISTORICAL_POLICY_VERSIONS = [
+    '2026-09-h4-d-ledger-planner-admission-v2',
     '2026-09-h4-d-ledger-planner-admission-v1',
     '2026-09-h4-intraday-bundle-member-launch-v1',
     '2026-09-simulation-sequence-occupational-context-v2',

--- a/app/src/engine/rules.ts
+++ b/app/src/engine/rules.ts
@@ -37,6 +37,7 @@ import { isTemplatePhaseEligible } from './periodization';
 import { resolveMinimumDaysAfterHardLowerBody, resolveRecoveryHoursForTemplate } from './planningCandidate';
 import { adjudicateExternalSession } from './externalSession';
 import { externalEventAsFixedActivity, toSyntheticTemplate, externalSessionDisplayPrescription } from './externalSessionProfiles';
+import { fixedActivityOccurrenceKey } from './fixedActivityIdentity';
 // M3.6: this module only ever reads gating/isEvent/id/title, identical on v1 and v2
 // sessions -- widened to accept either rather than kept v1-only.
 import type { AnyExternalPlanSession as ExternalPlanSession } from '../sessions/externalPlanV2';
@@ -51,7 +52,6 @@ import { isSevereAdverseRecoveryReadiness } from './evergreenStrategy';
 import { buildCoverageState, resolveCoverageHistory } from './coverage';
 import { applyPlanningOverlays } from './planningOverlays';
 import { mergeKnowledgeRefs, readinessKnowledgeRefs, trainingIntentKnowledgeRefs } from './knowledgeLineage';
-import { sumFixedActivityCostProfiles } from './fixedActivityCostProfile';
 
 function pickTemplate(options: SessionTemplate[], seedDate: string): SessionTemplate | undefined {
     if (options.length === 0) return undefined;
@@ -110,7 +110,20 @@ function calibrationTrace(
             projectedCredit: objective.projectedCredit ?? 0,
             requiredCredit: objective.requiredCredit ?? objective.targetExposures,
         })),
-        fixedActivity: { count: todayActivities.length, cost, stimulus },
+        fixedActivity: {
+            count: todayActivities.length,
+            cost,
+            stimulus,
+            // Per-occurrence identity alongside the aggregate above so a later date's
+            // projection (`unrepresentedFixedActivityProjection`) can diff by
+            // `occurrenceId` instead of inferring an unrepresented activity from a bare
+            // count/aggregate-profile subtraction.
+            entries: todayActivities.map(activity => ({
+                occurrenceId: fixedActivityOccurrenceKey(activity),
+                cost: { systemic: 0, cardiovascular: 0, lowerBody: 0, upperBody: 0, impactTissue: 0, neuromuscular: 0, ...(activity.expectedCost ?? {}) },
+                stimulus: { aerobicEndurance: 0, thresholdPower: 0, vo2MaxPower: 0, repeatedSurges: 0, sprintPower: 0, fatigueResistance: 0, maxStrength: 0, hypertrophy: 0, ...(activity.expectedStimulus ?? {}) },
+            })),
+        },
     };
 }
 
@@ -1282,28 +1295,32 @@ function unrepresentedFixedActivityProjection(
     const trace = rec.decisionTrace?.calibration?.fixedActivity;
     if (!trace) return null;
     const represented = fixedActivities.filter(activity => activity.date === date && !activity.isCompleted);
-    if (trace.count <= represented.length) return null;
+    // Identity-based diff (ADR-0036 D-LEDGER's occurrenceId model) rather than a
+    // count-triggered aggregate-profile subtraction: exactly the occurrences today's
+    // ranking saw but that are absent from the caller's own array are unrepresented,
+    // regardless of whether an unrelated activity was also added or removed meanwhile.
+    const representedIds = new Set(represented.map(fixedActivityOccurrenceKey));
+    const unrepresentedEntries = trace.entries.filter(entry => !representedIds.has(entry.occurrenceId));
+    if (unrepresentedEntries.length === 0) return null;
 
-    const representedCost = sumFixedActivityCostProfiles(represented);
-    const representedStimulus = represented.reduce<WorkoutStimulusProfile>((sum, activity) => ({
-        aerobicEndurance: sum.aerobicEndurance + (activity.expectedStimulus?.aerobicEndurance ?? 0),
-        thresholdPower: sum.thresholdPower + (activity.expectedStimulus?.thresholdPower ?? 0),
-        vo2MaxPower: sum.vo2MaxPower + (activity.expectedStimulus?.vo2MaxPower ?? 0),
-        repeatedSurges: sum.repeatedSurges + (activity.expectedStimulus?.repeatedSurges ?? 0),
-        sprintPower: sum.sprintPower + (activity.expectedStimulus?.sprintPower ?? 0),
-        fatigueResistance: sum.fatigueResistance + (activity.expectedStimulus?.fatigueResistance ?? 0),
-        maxStrength: sum.maxStrength + (activity.expectedStimulus?.maxStrength ?? 0),
-        hypertrophy: sum.hypertrophy + (activity.expectedStimulus?.hypertrophy ?? 0),
+    const costProfile = unrepresentedEntries.reduce<WorkoutCostProfile>((sum, entry) => ({
+        systemic: sum.systemic + entry.cost.systemic,
+        cardiovascular: sum.cardiovascular + entry.cost.cardiovascular,
+        lowerBody: sum.lowerBody + entry.cost.lowerBody,
+        upperBody: sum.upperBody + entry.cost.upperBody,
+        impactTissue: sum.impactTissue + entry.cost.impactTissue,
+        neuromuscular: sum.neuromuscular + entry.cost.neuromuscular,
+    }), ZERO_COST);
+    const stimulusProfile = unrepresentedEntries.reduce<WorkoutStimulusProfile>((sum, entry) => ({
+        aerobicEndurance: sum.aerobicEndurance + entry.stimulus.aerobicEndurance,
+        thresholdPower: sum.thresholdPower + entry.stimulus.thresholdPower,
+        vo2MaxPower: sum.vo2MaxPower + entry.stimulus.vo2MaxPower,
+        repeatedSurges: sum.repeatedSurges + entry.stimulus.repeatedSurges,
+        sprintPower: sum.sprintPower + entry.stimulus.sprintPower,
+        fatigueResistance: sum.fatigueResistance + entry.stimulus.fatigueResistance,
+        maxStrength: sum.maxStrength + entry.stimulus.maxStrength,
+        hypertrophy: sum.hypertrophy + entry.stimulus.hypertrophy,
     }), ZERO_STIMULUS);
-
-    const costProfile = Object.fromEntries(
-        (Object.keys(ZERO_COST) as (keyof WorkoutCostProfile)[])
-            .map(key => [key, Math.max(0, trace.cost[key] - representedCost[key])]),
-    ) as unknown as WorkoutCostProfile;
-    const stimulusProfile = Object.fromEntries(
-        (Object.keys(ZERO_STIMULUS) as (keyof WorkoutStimulusProfile)[])
-            .map(key => [key, Math.max(0, trace.stimulus[key] - representedStimulus[key])]),
-    ) as unknown as WorkoutStimulusProfile;
     const hasCost = Object.values(costProfile).some(value => value > 0);
     const hasStimulus = Object.values(stimulusProfile).some(value => value > 0);
     if (!hasCost && !hasStimulus) return null;

--- a/app/src/services/activeExternalPlanService.ts
+++ b/app/src/services/activeExternalPlanService.ts
@@ -258,12 +258,16 @@ export function placedSessionForDate(
  *
  * `bundleContext`, when supplied, activates D-PLACEMENT: the primary session is chosen
  * bundle-order-aware rather than purely by priority (see `placedSessionForDate`).
- * Launching this session still goes through the single-session path unchanged; a second
- * bundle member is not independently launchable yet (no execution-binding pipeline
- * exists for external plans at all, primary included -- building one is a separate
- * future project). The resolved bundle placement is not persisted for display here --
+ * Launching this session still goes through the single-session path unchanged; a
+ * non-primary bundle member's own launch goes through issue #434's separate
+ * execution-binding pipeline (`intradayBundleMemberAdjudication.ts` /
+ * `intradayLaunchClaim.ts`), not through this function.
+ *
+ * This function does not itself persist the resolved bundle placement for display --
+ * `resolveIntradayBundlePlacement`'s result is recorded by the caller (`Home.tsx`, via
+ * `intradayBundlePlacementAuditService.ts`) into a separate sibling document, because
  * `hasValidRecommendationAudit`'s `externalPlan` shape is already at Firestore's
- * per-request rule-evaluation ceiling and has no room left for it (verified with the
+ * per-request rule-evaluation ceiling with no room left for it (verified with the
  * emulator suite); see the comment there.
  */
 export function externalPlanContextForDate(

--- a/app/src/services/intradayBundlePlacementAuditService.test.ts
+++ b/app/src/services/intradayBundlePlacementAuditService.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const firestore = vi.hoisted(() => ({
     doc: vi.fn(() => ({ __ref: true })),
@@ -26,8 +26,27 @@ function placedProposal(): BundlePlacementProposal {
     };
 }
 
+function persistedRecord(overrides: Record<string, unknown> = {}) {
+    return {
+        userId: 'u1',
+        date: '2026-08-18',
+        bundleId: 'old-bundle',
+        outcome: 'infeasible',
+        bindings: [],
+        reason: 'old placement',
+        revision: 3,
+        createdAt: '2026-08-17T05:00:00.000Z',
+        updatedAt: '2026-08-18T05:00:00.000Z',
+        ...overrides,
+    };
+}
+
 beforeEach(() => {
     vi.clearAllMocks();
+});
+
+afterEach(() => {
+    vi.useRealTimers();
 });
 
 describe('recordIntradayBundlePlacement', () => {
@@ -51,13 +70,15 @@ describe('recordIntradayBundlePlacement', () => {
         expect((written as { createdAt: string }).createdAt).toBe((written as { updatedAt: string }).updatedAt);
     });
 
-    it('increments revision and preserves createdAt on a later write', async () => {
+    it('increments revision and preserves createdAt on a later observation', async () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-08-18T06:00:00.000Z'));
         let written: unknown;
         firestore.runTransaction.mockImplementation(async (_db: unknown, updateFn: (t: unknown) => unknown) => {
             const transaction = {
                 get: vi.fn().mockResolvedValue({
                     exists: () => true,
-                    data: () => ({ revision: 3, createdAt: '2026-08-17T05:00:00.000Z' }),
+                    data: () => persistedRecord(),
                 }),
                 set: vi.fn((_ref: unknown, record: unknown) => { written = record; }),
             };
@@ -66,7 +87,51 @@ describe('recordIntradayBundlePlacement', () => {
 
         await recordIntradayBundlePlacement('u1', '2026-08-18', placedProposal());
 
-        expect(written).toMatchObject({ revision: 4, createdAt: '2026-08-17T05:00:00.000Z' });
+        expect(written).toMatchObject({
+            revision: 4,
+            createdAt: '2026-08-17T05:00:00.000Z',
+            updatedAt: '2026-08-18T06:00:00.000Z',
+        });
+    });
+
+    it('does not let an older observation overwrite evidence that committed later', async () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-08-18T06:00:00.000Z'));
+        const set = vi.fn();
+        firestore.runTransaction.mockImplementation(async (_db: unknown, updateFn: (t: unknown) => unknown) => updateFn({
+            get: vi.fn().mockResolvedValue({
+                exists: () => true,
+                data: () => persistedRecord({ updatedAt: '2026-08-18T06:00:00.001Z' }),
+            }),
+            set,
+        }));
+
+        await recordIntradayBundlePlacement('u1', '2026-08-18', placedProposal());
+
+        expect(set).not.toHaveBeenCalled();
+    });
+
+    it('does not manufacture a new revision when the placement evidence is unchanged', async () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-08-18T06:00:00.000Z'));
+        const proposal = placedProposal();
+        const set = vi.fn();
+        firestore.runTransaction.mockImplementation(async (_db: unknown, updateFn: (t: unknown) => unknown) => updateFn({
+            get: vi.fn().mockResolvedValue({
+                exists: () => true,
+                data: () => persistedRecord({
+                    bundleId: proposal.bundleId,
+                    outcome: proposal.outcome,
+                    bindings: proposal.bindings,
+                    reason: null,
+                }),
+            }),
+            set,
+        }));
+
+        await recordIntradayBundlePlacement('u1', '2026-08-18', proposal);
+
+        expect(set).not.toHaveBeenCalled();
     });
 
     it('records an infeasible outcome with an empty bindings list and the reason, not a fabricated binding', async () => {

--- a/app/src/services/intradayBundlePlacementAuditService.test.ts
+++ b/app/src/services/intradayBundlePlacementAuditService.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const firestore = vi.hoisted(() => ({
+    doc: vi.fn(() => ({ __ref: true })),
+    getDoc: vi.fn(),
+    runTransaction: vi.fn(),
+}));
+
+vi.mock('firebase/firestore', () => firestore);
+vi.mock('../firebase', () => ({ getDb: vi.fn(() => ({})) }));
+
+import { getIntradayBundlePlacement, recordIntradayBundlePlacement } from './intradayBundlePlacementAuditService';
+import type { BundlePlacementProposal } from '../engine/intradayBundlePlacement';
+
+function placedProposal(): BundlePlacementProposal {
+    return {
+        bundleId: 'bundle-1',
+        outcome: 'placed',
+        bindings: [
+            {
+                sessionId: 'w1-am', windowId: 'win-am',
+                boundStartLocal: '06:00', boundEndLocal: '07:00',
+                startInstant: '2026-08-18T04:00:00.000Z', endInstant: '2026-08-18T05:00:00.000Z',
+            },
+        ],
+    };
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+describe('recordIntradayBundlePlacement', () => {
+    it('writes revision 1 with createdAt/updatedAt when no prior document exists', async () => {
+        let written: unknown;
+        firestore.runTransaction.mockImplementation(async (_db: unknown, updateFn: (t: unknown) => unknown) => {
+            const transaction = {
+                get: vi.fn().mockResolvedValue({ exists: () => false, data: () => undefined }),
+                set: vi.fn((_ref: unknown, record: unknown) => { written = record; }),
+            };
+            return updateFn(transaction);
+        });
+
+        await recordIntradayBundlePlacement('u1', '2026-08-18', placedProposal());
+
+        expect(written).toMatchObject({
+            userId: 'u1', date: '2026-08-18', bundleId: 'bundle-1', outcome: 'placed',
+            revision: 1, reason: null,
+        });
+        expect((written as { bindings: unknown[] }).bindings).toHaveLength(1);
+        expect((written as { createdAt: string }).createdAt).toBe((written as { updatedAt: string }).updatedAt);
+    });
+
+    it('increments revision and preserves createdAt on a later write', async () => {
+        let written: unknown;
+        firestore.runTransaction.mockImplementation(async (_db: unknown, updateFn: (t: unknown) => unknown) => {
+            const transaction = {
+                get: vi.fn().mockResolvedValue({
+                    exists: () => true,
+                    data: () => ({ revision: 3, createdAt: '2026-08-17T05:00:00.000Z' }),
+                }),
+                set: vi.fn((_ref: unknown, record: unknown) => { written = record; }),
+            };
+            return updateFn(transaction);
+        });
+
+        await recordIntradayBundlePlacement('u1', '2026-08-18', placedProposal());
+
+        expect(written).toMatchObject({ revision: 4, createdAt: '2026-08-17T05:00:00.000Z' });
+    });
+
+    it('records an infeasible outcome with an empty bindings list and the reason, not a fabricated binding', async () => {
+        let written: unknown;
+        firestore.runTransaction.mockImplementation(async (_db: unknown, updateFn: (t: unknown) => unknown) => {
+            const transaction = {
+                get: vi.fn().mockResolvedValue({ exists: () => false, data: () => undefined }),
+                set: vi.fn((_ref: unknown, record: unknown) => { written = record; }),
+            };
+            return updateFn(transaction);
+        });
+
+        await recordIntradayBundlePlacement('u1', '2026-08-18', {
+            bundleId: 'bundle-1', outcome: 'infeasible', reason: 'insufficient daily systemic-cost budget',
+        });
+
+        expect(written).toMatchObject({ outcome: 'infeasible', bindings: [], reason: 'insufficient daily systemic-cost budget' });
+    });
+
+    it('never throws when the transaction fails -- a display-only write must not fail the caller', async () => {
+        firestore.runTransaction.mockRejectedValue(new Error('offline'));
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        await expect(recordIntradayBundlePlacement('u1', '2026-08-18', placedProposal())).resolves.toBeUndefined();
+        expect(errorSpy).toHaveBeenCalled();
+        errorSpy.mockRestore();
+    });
+});
+
+describe('getIntradayBundlePlacement', () => {
+    it('returns null when no document has been recorded', async () => {
+        firestore.getDoc.mockResolvedValue({ exists: () => false, data: () => undefined });
+        await expect(getIntradayBundlePlacement('u1', '2026-08-18')).resolves.toBeNull();
+    });
+
+    it('returns the persisted record when present', async () => {
+        const record = { userId: 'u1', date: '2026-08-18', bundleId: 'bundle-1', outcome: 'placed', bindings: [], reason: null, revision: 1, createdAt: 'x', updatedAt: 'x' };
+        firestore.getDoc.mockResolvedValue({ exists: () => true, data: () => record });
+        await expect(getIntradayBundlePlacement('u1', '2026-08-18')).resolves.toEqual(record);
+    });
+});

--- a/app/src/services/intradayBundlePlacementAuditService.ts
+++ b/app/src/services/intradayBundlePlacementAuditService.ts
@@ -1,0 +1,97 @@
+/**
+ * ADR-0036 (H4) D-PLACEMENT follow-up: persists a v4 intraday bundle's resolved window
+ * placement for display, at `users/{userId}/intraday_bundle_placements/{date}`.
+ *
+ * Scope note (see `docs/plans/cycling-primary-hybrid-evaluation.md`, "Work item 2"):
+ * this is deliberately the smaller, **display-only** slice of ADR-0036 D-AUDIT, not the
+ * full contract. It does NOT satisfy D-AUDIT's complete bar -- there is no daily-ledger
+ * ceiling/reservation snapshot, no override/supersession id, and replay does not
+ * recompute or verify this document. It exists so a bundle's already-made placement
+ * decision (computed live every time by `intradayBundlePlacement.ts`'s
+ * `proposeBundlePlacement`, already wired into primary-session selection) can also be
+ * shown after the fact, without depending on schedule-window/ledger state that may have
+ * since changed.
+ *
+ * Why a separate sibling document rather than a `recommendationAudit.externalPlan`
+ * field: that path was already attempted and re-verified insufficient.
+ * `hasValidRecommendationAudit` (`firestore.rules`) is already at Firestore's per-request
+ * rule-evaluation ceiling; PR #468's cost reduction did not create enough headroom for
+ * even a minimal `intradayBundle` check (see that function's own comment). Following
+ * `daily_ledgers`/`intraday_decisions`'s existing precedent of a named sibling document
+ * keeps this write inside its own, independent expression budget.
+ *
+ * The write is best-effort and non-blocking by design (mirrors Phase 5's `SessionResponse`
+ * write discipline): a failure here must never fail or delay generating today's
+ * recommendation, since this document is display evidence, not a decision input.
+ */
+
+import { doc, getDoc, runTransaction, type Firestore } from 'firebase/firestore';
+import { getDb } from '../firebase';
+import type { BundlePlacementProposal, ResolvedWindowBinding } from '../engine/intradayBundlePlacement';
+
+export interface IntradayBundlePlacementRecord {
+    userId: string;
+    date: string;
+    bundleId: string;
+    outcome: 'placed' | 'infeasible';
+    bindings: ResolvedWindowBinding[];
+    reason: string | null;
+    revision: number;
+    createdAt: string;
+    updatedAt: string;
+}
+
+function docRef(db: Firestore, userId: string, date: string) {
+    return doc(db, 'users', userId, 'intraday_bundle_placements', date);
+}
+
+/**
+ * Records the latest resolved placement for one date's bundle. Revision-gated (mirrors
+ * `daily_ledgers`'s optimistic-concurrency rule) so a slower, stale computation can never
+ * clobber a newer one that already committed -- it simply loses the race silently, which
+ * is correct for passive display evidence.
+ *
+ * Never throws: a write failure is logged and swallowed so a display-only write can never
+ * fail the caller's recommendation generation.
+ */
+export async function recordIntradayBundlePlacement(
+    userId: string,
+    date: string,
+    proposal: BundlePlacementProposal,
+): Promise<void> {
+    try {
+        const db = getDb();
+        const ref = docRef(db, userId, date);
+        const now = new Date().toISOString();
+        await runTransaction(db, async transaction => {
+            const snapshot = await transaction.get(ref);
+            const current = snapshot.exists() ? (snapshot.data() as IntradayBundlePlacementRecord) : null;
+            const record: IntradayBundlePlacementRecord = {
+                userId,
+                date,
+                bundleId: proposal.bundleId,
+                outcome: proposal.outcome,
+                bindings: proposal.outcome === 'placed' ? (proposal.bindings ?? []) : [],
+                reason: proposal.outcome === 'infeasible' ? (proposal.reason ?? null) : null,
+                revision: (current?.revision ?? 0) + 1,
+                createdAt: current?.createdAt ?? now,
+                updatedAt: now,
+            };
+            transaction.set(ref, record);
+        });
+    } catch (error) {
+        console.error('recordIntradayBundlePlacement: best-effort write failed', error);
+    }
+}
+
+/** Reads the persisted placement for one date, or null when never recorded. Read-only;
+ * callers must not treat this as authoritative for any decision -- it is display evidence
+ * of what `proposeBundlePlacement` already resolved live. */
+export async function getIntradayBundlePlacement(
+    userId: string,
+    date: string,
+): Promise<IntradayBundlePlacementRecord | null> {
+    const db = getDb();
+    const snapshot = await getDoc(docRef(db, userId, date));
+    return snapshot.exists() ? (snapshot.data() as IntradayBundlePlacementRecord) : null;
+}

--- a/app/src/services/intradayBundlePlacementAuditService.ts
+++ b/app/src/services/intradayBundlePlacementAuditService.ts
@@ -45,11 +45,41 @@ function docRef(db: Firestore, userId: string, date: string) {
     return doc(db, 'users', userId, 'intraday_bundle_placements', date);
 }
 
+function bindingsEqual(left: ResolvedWindowBinding[], right: ResolvedWindowBinding[]): boolean {
+    return left.length === right.length && left.every((binding, index) => {
+        const other = right[index];
+        return other !== undefined
+            && binding.sessionId === other.sessionId
+            && binding.windowId === other.windowId
+            && binding.boundStartLocal === other.boundStartLocal
+            && binding.boundEndLocal === other.boundEndLocal
+            && binding.startInstant === other.startInstant
+            && binding.endInstant === other.endInstant;
+    });
+}
+
+function samePlacement(
+    current: IntradayBundlePlacementRecord,
+    proposal: BundlePlacementProposal,
+): boolean {
+    const bindings = proposal.outcome === 'placed' ? (proposal.bindings ?? []) : [];
+    const reason = proposal.outcome === 'infeasible' ? (proposal.reason ?? null) : null;
+    return current.bundleId === proposal.bundleId
+        && current.outcome === proposal.outcome
+        && current.reason === reason
+        && bindingsEqual(current.bindings, bindings);
+}
+
 /**
- * Records the latest resolved placement for one date's bundle. Revision-gated (mirrors
- * `daily_ledgers`'s optimistic-concurrency rule) so a slower, stale computation can never
- * clobber a newer one that already committed -- it simply loses the race silently, which
- * is correct for passive display evidence.
+ * Records the latest resolved placement for one date's bundle.
+ *
+ * Firestore transactions retry when a document read by the transaction changes. A plain
+ * `revision + 1` therefore serializes writes but does **not** prove freshness: an older
+ * computation can retry after a newer one and otherwise become the last writer. Capture
+ * `observedAt` before entering the retriable callback and keep it fixed across retries;
+ * when a later observation has already committed, this attempt no-ops. Re-saving the
+ * exact same placement also no-ops so passive dashboard refreshes do not manufacture audit
+ * revisions with no evidence change.
  *
  * Never throws: a write failure is logged and swallowed so a display-only write can never
  * fail the caller's recommendation generation.
@@ -59,13 +89,25 @@ export async function recordIntradayBundlePlacement(
     date: string,
     proposal: BundlePlacementProposal,
 ): Promise<void> {
+    const observedAt = new Date().toISOString();
     try {
         const db = getDb();
         const ref = docRef(db, userId, date);
-        const now = new Date().toISOString();
         await runTransaction(db, async transaction => {
             const snapshot = await transaction.get(ref);
             const current = snapshot.exists() ? (snapshot.data() as IntradayBundlePlacementRecord) : null;
+
+            if (current) {
+                if (samePlacement(current, proposal)) return;
+                const currentUpdatedAt = Date.parse(current.updatedAt);
+                const observedAtMs = Date.parse(observedAt);
+                if (Number.isFinite(currentUpdatedAt)
+                    && Number.isFinite(observedAtMs)
+                    && currentUpdatedAt >= observedAtMs) {
+                    return;
+                }
+            }
+
             const record: IntradayBundlePlacementRecord = {
                 userId,
                 date,
@@ -74,8 +116,8 @@ export async function recordIntradayBundlePlacement(
                 bindings: proposal.outcome === 'placed' ? (proposal.bindings ?? []) : [],
                 reason: proposal.outcome === 'infeasible' ? (proposal.reason ?? null) : null,
                 revision: (current?.revision ?? 0) + 1,
-                createdAt: current?.createdAt ?? now,
-                updatedAt: now,
+                createdAt: current?.createdAt ?? observedAt,
+                updatedAt: observedAt,
             };
             transaction.set(ref, record);
         });

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -81,19 +81,22 @@ unexpected fatigue, and notes; multi-region tissue feedback remains in the daily
 check-in as the canonical tissue authority. PR 3 Phase 6 applies the cumulative
 `2026-09-h4-intraday-bundle-member-launch-v1` policy contract, completing the live H4
 release. The [bundle-launch plan](./h4-434-pr3-bundle-second-member-launch.md) records the
-delivered phases. Beyond PR 3, H4
-also still needs ledger remainder/admission as a real ranking input in `planner.ts`, and a
-bundle's resolved placement persisted for display. The latter was previously blocked by
-Firestore's per-request rule-evaluation ceiling, but #468 reduced recommendation-audit
-validation cost and closed #435; persistence is therefore unblocked but still unimplemented
-and still requires its own schema/rules/replay review.
+delivered phases. Beyond PR 3, H4's ledger remainder/admission is now a real ranking input
+in the rolling forecast (`planner.ts`'s `evaluateProjectedDate`, PR #474), and the three
+narrower ad hoc fixed-activity dedup mechanisms that PR left un-unified are now unified onto
+the same occurrenceId/revision identity. A bundle's resolved placement is also now persisted
+for display, at `users/{userId}/intraday_bundle_placements/{date}` -- a separate sibling
+document, not a `recommendationAudit.externalPlan` field, since that document's own
+rule-evaluation budget was re-verified insufficient even after #468's reduction closed #435.
 H5 block intent and controlled progression is accepted in
 [ADR-0037](../adr/0037-block-intent-and-controlled-progression.md) and is **In progress**:
 H5a intent contracts and canonical replay (`engine/blockIntent.ts`,
 `engine/blockIntentReplay.ts`) and H5b report-only progression review
 (`engine/progressionReview.ts`) are delivered, neither wired into daily recommendation
-selection; H5c confirmed bounded revisions and cumulative `external-plan@5` are unstarted
-and independently startable. H4's same-day canonical performed-fact boundary is verified;
+selection; H5c confirmed bounded revisions and cumulative `external-plan@5` are unstarted,
+though H5c's transaction design is now specified in
+[the progression-claim design](./h5c-progression-claim-design.md) (design only, no code).
+H4's same-day canonical performed-fact boundary is verified;
 H5 runtime needs validated intent mappings and linked response evidence. H5
 delivers intent authoring, report-only review, then confirmed bounded revisions. The work
 does not replace the reviewed active persona-judge baseline. The

--- a/docs/plans/cycling-primary-hybrid-evaluation.md
+++ b/docs/plans/cycling-primary-hybrid-evaluation.md
@@ -12,17 +12,24 @@ post-AM `SessionResponse` completion facts, while multi-region tissue feedback r
 the daily check-in as the canonical tissue authority. Phase 6 applies the cumulative
 `2026-09-h4-intraday-bundle-member-launch-v1` policy transition, completing the H4 release;
 dependent members still require the response and separation checks before they become
-launchable. The broader ledger-based ranking/admission unification
-and persistence of a bundle's resolved placement for display also remain; H5 design is
+launchable. The rolling planner's ledger-based ranking/admission gating is also delivered
+(PR #474, `2026-09-h4-d-ledger-planner-admission-v2`); still open are unifying three
+narrower ad hoc fixed-activity dedup mechanisms onto that same ledger identity, and
+persisting a bundle's resolved placement for display. H5 design is
 accepted as ADR-0037 with H5a/H5b delivered (H5c and cumulative `external-plan@5` unstarted).
 **Blocked by:** Personal M00/M01 prescription requires current workload/restriction
 confirmation; H4's live release is delivered through PR 3 Phase 6, recorded in
 [the PR 3 plan](./h4-434-pr3-bundle-second-member-launch.md). H4's remaining non-gating
-work also needs its own decision-affecting PR(s): unifying `planner.ts`'s three ad hoc dedup
-mechanisms onto the ledger's remainder/admission semantics as a real ranking input, and
-persisting a bundle's resolved placement for display. The latter was previously blocked by
-`firestore.rules`' per-request expression ceiling, but #468 reduced recommendation-audit
-validation cost and closed #435, so it is now unblocked rather than complete. H5c needs the
+work needs its own decision-affecting PR(s): unifying `applyFixedActivityStimulusCredit`'s,
+`generateWeekAheadPlan`'s and `unrepresentedFixedActivityProjection`'s three separate ad hoc
+occurrence-dedup key schemes onto the ledger's `occurrenceId`/`revision` identity (narrower
+than, and not to be confused with, the ranking/admission gating PR #474 already delivered),
+and persisting a bundle's resolved placement for display. The latter was previously blocked
+by `firestore.rules`' per-request expression ceiling; #468 reduced recommendation-audit
+validation cost and closed #435, but re-testing with the emulator suite confirmed that
+reduction still is not enough headroom for even a minimal `intradayBundle` field on
+`recommendationAudit` -- the follow-up therefore needs a separate sibling document rather
+than another `recommendationAudit` budget attempt. H5c needs the
 athlete-scoped singleton progression-claim transaction design, and cumulative
 `external-plan@5` acceptance is unblocked now that H4's v4 contract has landed.
 **Unlocks:** Reproducible acceptance cases for equipment specificity, block authority and hybrid plan quality.

--- a/docs/plans/cycling-primary-hybrid-evaluation.md
+++ b/docs/plans/cycling-primary-hybrid-evaluation.md
@@ -15,8 +15,10 @@ dependent members still require the response and separation checks before they b
 launchable. The rolling planner's ledger-based ranking/admission gating is also delivered
 (PR #474, `2026-09-h4-d-ledger-planner-admission-v2`), and the three narrower ad hoc
 fixed-activity dedup mechanisms that PR left un-unified are now unified onto the same
-occurrenceId/revision identity (engine-internal only; `decisionTrace.calibration` is
-transient and not persisted). A bundle's resolved placement is also now persisted for
+occurrenceId/revision identity, activating `2026-09-fixed-activity-dedup-identity-unification-v1`
+(mechanical bump -- `simulate:diff` proves the refactor is output-preserving, but the drift
+gate cannot prove that from source alone; `decisionTrace.calibration` itself is transient and
+not persisted). A bundle's resolved placement is also now persisted for
 display, at `users/{userId}/intraday_bundle_placements/{date}` -- a separate sibling
 document rather than a `recommendationAudit.externalPlan` field, since that document's
 rule-evaluation budget was re-verified insufficient. H5 design is
@@ -531,9 +533,14 @@ remainder/admission as a real ranking/admission input": that broader gate (`admi
 `computeDailyLedger` deciding whether a *candidate template* is admitted) is a separate
 concern already delivered in the rolling forecast's `evaluateProjectedDate` (PR #474) -- these
 three sites credit/cost-track fixed *commitments* that already exist, not admit ranking
-candidates, so they were never candidates for `admitsCandidate` gating themselves. Verified
-output-preserving: `simulate:diff` shows no semantic difference and
-`check-policy-drift.mjs` confirms no `POLICY_VERSION` bump is required.
+candidates, so they were never candidates for `admitsCandidate` gating themselves.
+`simulate:diff` shows no semantic difference against the committed baseline -- this refactor
+is genuinely output-preserving for every simulated scenario -- but `rules.ts`/`planner.ts`
+are both on the drift gate's watched decision-file list, and this is a substantive restructure
+rather than a comment/whitespace-only change, so `check-policy-drift.mjs` correctly still
+requires a bump; it cannot prove semantic equivalence from an AST diff alone. `POLICY_VERSION`
+was therefore bumped mechanically to `2026-09-fixed-activity-dedup-identity-unification-v1`,
+the same precedent as the earlier `2026-09-fixed-activity-cost-dedup-v1` transition.
 
 ### Issue #434 execution-binding pipeline (delivered through PR 3 Phase 4)
 
@@ -637,6 +644,10 @@ change. PR 3 Phase 5 added the post-AM evidence path, and Phase 6 completed the 
 H4 transition by archiving the then-current
 `2026-09-simulation-sequence-occupational-context-v2` policy and activating
 `2026-09-h4-intraday-bundle-member-launch-v1`. The planner's D-LEDGER admission wiring then
-archived that version and activated `2026-09-h4-d-ledger-planner-admission-v1`. H5c will
-require normal policy review when it changes decision behavior. Do not enable experimental
-personalization simply to improve a judge score.
+archived that version and activated `2026-09-h4-d-ledger-planner-admission-v1`, later
+superseded by `-v2` for the fixed-activity cost-reduce reduce consolidation. The
+fixed-activity dedup-identity unification then archived `-v2` and activated
+`2026-09-fixed-activity-dedup-identity-unification-v1` -- another mechanical bump, not a
+behavior change (`simulate:diff` clean). H5c will require normal policy review when it
+changes decision behavior. Do not enable experimental personalization simply to improve a
+judge score.

--- a/docs/plans/cycling-primary-hybrid-evaluation.md
+++ b/docs/plans/cycling-primary-hybrid-evaluation.md
@@ -13,25 +13,24 @@ the daily check-in as the canonical tissue authority. Phase 6 applies the cumula
 `2026-09-h4-intraday-bundle-member-launch-v1` policy transition, completing the H4 release;
 dependent members still require the response and separation checks before they become
 launchable. The rolling planner's ledger-based ranking/admission gating is also delivered
-(PR #474, `2026-09-h4-d-ledger-planner-admission-v2`); still open are unifying three
-narrower ad hoc fixed-activity dedup mechanisms onto that same ledger identity, and
-persisting a bundle's resolved placement for display. H5 design is
-accepted as ADR-0037 with H5a/H5b delivered (H5c and cumulative `external-plan@5` unstarted).
+(PR #474, `2026-09-h4-d-ledger-planner-admission-v2`), and the three narrower ad hoc
+fixed-activity dedup mechanisms that PR left un-unified are now unified onto the same
+occurrenceId/revision identity (engine-internal only; `decisionTrace.calibration` is
+transient and not persisted). A bundle's resolved placement is also now persisted for
+display, at `users/{userId}/intraday_bundle_placements/{date}` -- a separate sibling
+document rather than a `recommendationAudit.externalPlan` field, since that document's
+rule-evaluation budget was re-verified insufficient. H5 design is
+accepted as ADR-0037 with H5a/H5b delivered (H5c and cumulative `external-plan@5` unstarted,
+though H5c now has an accepted transaction design -- see below).
 **Blocked by:** Personal M00/M01 prescription requires current workload/restriction
 confirmation; H4's live release is delivered through PR 3 Phase 6, recorded in
-[the PR 3 plan](./h4-434-pr3-bundle-second-member-launch.md). H4's remaining non-gating
-work needs its own decision-affecting PR(s): unifying `applyFixedActivityStimulusCredit`'s,
-`generateWeekAheadPlan`'s and `unrepresentedFixedActivityProjection`'s three separate ad hoc
-occurrence-dedup key schemes onto the ledger's `occurrenceId`/`revision` identity (narrower
-than, and not to be confused with, the ranking/admission gating PR #474 already delivered),
-and persisting a bundle's resolved placement for display. The latter was previously blocked
-by `firestore.rules`' per-request expression ceiling; #468 reduced recommendation-audit
-validation cost and closed #435, but re-testing with the emulator suite confirmed that
-reduction still is not enough headroom for even a minimal `intradayBundle` field on
-`recommendationAudit` -- the follow-up therefore needs a separate sibling document rather
-than another `recommendationAudit` budget attempt. H5c needs the
-athlete-scoped singleton progression-claim transaction design, and cumulative
-`external-plan@5` acceptance is unblocked now that H4's v4 contract has landed.
+[the PR 3 plan](./h4-434-pr3-bundle-second-member-launch.md). H4's non-gating follow-up work
+(dedup unification and placement-display persistence) is delivered -- see the H4 section
+below for what it does and deliberately does not yet cover (full ADR-0036 D-AUDIT compliance
+for placement remains separate). H5c's transaction design is written
+([the progression-claim design](./h5c-progression-claim-design.md)); implementation still
+needs "the existing authoring boundary" named concretely, and cumulative `external-plan@5`
+acceptance is unblocked by the landed H4 v4 contract but in practice follows H5c.
 **Unlocks:** Reproducible acceptance cases for equipment specificity, block authority and hybrid plan quality.
 
 ## Decision
@@ -468,11 +467,20 @@ display and atomic launch.
 Surfacing the bundle's *resolved binding data* for display in recommendation audit was
 attempted and reverted in the original placement-wiring PR because an extra optional-field
 check exceeded Firestore's per-request rules-expression ceiling. That was a real emulator
-failure and correctly blocked the change at the time. It is no longer a current blocker:
-PR #468 reduced recommendation-audit evaluation cost and closed #435. The resolved placement
-is still not persisted, however, so a follow-up must reintroduce the field with schema,
-rules, replay and expression-budget coverage rather than treating #468 as implementation of
-the feature itself.
+failure and correctly blocked the change at the time. #468 reduced recommendation-audit
+evaluation cost and closed #435, but re-testing with the emulator suite confirmed that
+reduction still was not enough headroom for even a minimal `intradayBundle` check on
+`recommendationAudit` -- the ceiling error recurred identically, so #468 alone did not
+implement this feature. The resolved placement is now persisted instead at a separate
+sibling document, `users/{userId}/intraday_bundle_placements/{date}`
+(`intradayBundlePlacementAuditService.ts`), written best-effort/non-blocking from `Home.tsx`
+right where `resolveIntradayBundlePlacement` already computes the proposal. This is
+deliberately the smaller **display-only** slice of ADR-0036 D-AUDIT: no replay
+recomputation/verification, no ledger-ceiling snapshot, no override/supersession id, and no
+`POLICY_VERSION` bump (the decision-affecting bundle-aware primary-session selection above
+was already shipped separately and does not depend on this document). Verified with a
+dedicated emulator rules test (revision-gating, cross-user denial, malformed-shape
+rejection, infeasible-outcome shape) independent of `recommendationAudit`'s own budget.
 
 ### Same-day canonical performed-fact boundary (verified)
 
@@ -496,7 +504,7 @@ occurrence. `getPerformedTrainingFactsThroughToday`
 (`training-occurrence/performedTrainingFactsService.ts`) makes that an explicit,
 correctly-named function. It is not called from any production/decision path yet.
 
-### Fixed-activity cost-reduce duplication unified (delivered)
+### Fixed-activity cost-reduce duplication unified (delivered; dedup-mechanism unification also delivered)
 
 `schedule.ts`'s `calculateReservedCapacityProfile`, `planner.ts`'s
 `fixedActivityCostProfileForDate` (also used by `externalCritique.ts`), and `rules.ts`'s
@@ -510,13 +518,22 @@ not prove semantic equivalence for the restructured call sites.
 The three different ad hoc dedup mechanisms across these sites (`seenOccurrences` in
 `applyFixedActivityStimulusCredit`, `appliedFixedCostOccurrences`/
 `appliedProjectionOccurrences` in `generateWeekAheadPlan`, and the decision-trace delta
-in `unrepresentedFixedActivityProjection`) are **not yet unified** onto the ledger's
-`occurrenceId`/`revision` model, and none of these call sites yet consult
-`computeDailyLedger`'s remainder or `admitsCandidate` when ranking or admitting a
-candidate. D-PLACEMENT's own placement-correctness wiring is delivered. The execution-
-binding pipeline and D-REASSESS/D-AUDIT now have live wiring through PR 3 Phase 4; using
-the ledger's remainder/admission semantics as a real ranking/admission input across these
-three call sites remains separate decision-affecting work.
+in `unrepresentedFixedActivityProjection`) are now **unified** onto the ledger's
+`occurrenceId`/`revision` identity (`fixedActivityOccurrenceKey`/
+`dedupeFixedActivitiesByLedgerIdentity` from `fixedActivityLedger.ts`, reused rather than
+each site's own key scheme). `unrepresentedFixedActivityProjection` specifically now diffs
+by occurrence identity instead of a count-triggered aggregate cost/stimulus subtraction --
+`decisionTrace.calibration.fixedActivity` gained a per-occurrence `entries[]` alongside its
+existing aggregate fields for this. `decisionTrace.calibration` is confirmed transient
+(`provenance.ts` does not persist it into `RecommendationAudit`), so this needed no
+Firestore/rules/replay change and is engine-internal only. Note this is narrower than "ledger
+remainder/admission as a real ranking/admission input": that broader gate (`admitsCandidate`/
+`computeDailyLedger` deciding whether a *candidate template* is admitted) is a separate
+concern already delivered in the rolling forecast's `evaluateProjectedDate` (PR #474) -- these
+three sites credit/cost-track fixed *commitments* that already exist, not admit ranking
+candidates, so they were never candidates for `admitsCandidate` gating themselves. Verified
+output-preserving: `simulate:diff` shows no semantic difference and
+`check-policy-drift.mjs` confirms no `POLICY_VERSION` bump is required.
 
 ### Issue #434 execution-binding pipeline (delivered through PR 3 Phase 4)
 
@@ -548,7 +565,11 @@ contract the current decision policy.
 
 **What remains:** no PR 3 release-gating work. Phases 4-5 provide the launch and post-AM
 evidence path; Phase 6 activates their cumulative policy contract. The broader ledger
-ranking/admission and placement-persistence follow-ups remain separate H4 work.
+dedup-unification and placement-persistence follow-ups (both delivered -- see "Fixed-activity
+cost-reduce duplication unified" and "D-PLACEMENT wiring" below) were the last separate H4
+work; full ADR-0036 D-AUDIT compliance for the persisted placement (replay verification,
+ledger-ceiling snapshot, override/supersession id) remains a deliberately separate,
+unscoped follow-up.
 
 ## H5 — Explicit develop/maintain intent and progression
 
@@ -556,10 +577,13 @@ ranking/admission and placement-persistence follow-ups remain separate H4 work.
 **H5a (intent contracts + canonical replay) and H5b (report-only progression review)
 delivered** in `engine/blockIntent.ts`/`blockIntentReplay.ts`/`progressionReview.ts`,
 per the implementation handoff's H5 work order. H5c (athlete-confirmed bounded
-revisions) and cumulative `external-plan@5` are unstarted.
-**Dependencies:** H5c needs the athlete-scoped singleton progression-claim transaction
-design. `external-plan@5` acceptance depends on the landed H4 v4 contract, which has
-landed.
+revisions) and cumulative `external-plan@5` are unstarted; H5c's transaction design is
+now specified in [the progression-claim design](./h5c-progression-claim-design.md)
+(no code yet -- design only).
+**Dependencies:** H5c's design is written; implementation additionally needs "the existing
+authoring boundary" that produces a new plan/definition revision named concretely (see that
+document's Work item 3). `external-plan@5` acceptance depends on the landed H4 v4 contract,
+which has landed, and in practice on H5c's shape being implemented first.
 
 Decision: per-objective `develop | maintain` intent is separate from priority and profile
 commitment. Use existing plan, dose, coverage, response and outcome authorities. New import

--- a/docs/plans/h5c-progression-claim-design.md
+++ b/docs/plans/h5c-progression-claim-design.md
@@ -1,0 +1,206 @@
+# H5c — athlete-scoped singleton progression-claim design
+
+**Status:** Approved (design agreed) — not `Ready`: this document specifies the
+confirmation/singleton-claim contract; no code exists yet.
+**Blocked by:** Nothing for the design itself. Implementation additionally needs "the
+existing authoring boundary" that produces a new plan/definition revision to be named
+concretely (see Work item 3) — that boundary already exists elsewhere in the codebase but
+has not yet been identified as the specific integration point H5c's confirmation writes
+through.
+**Unlocks:** H5c implementation (athlete-confirmed bounded progression revisions);
+cumulative `external-plan@5` acceptance, which the cycling hybrid evaluation plan already
+notes is otherwise unblocked now that H4's v4 contract has landed.
+**Governs:** [ADR-0037](../adr/0037-block-intent-and-controlled-progression.md) D-AUTHORITY,
+D-CHANGE's one-active-experiment rule.
+**Builds on:** H5a (`engine/blockIntent.ts`, `engine/blockIntentReplay.ts`) and H5b
+(`engine/progressionReview.ts`), both delivered. The transaction shape below is modeled
+directly on H4's `services/intradayLaunchClaim.ts` (`claimIntradayMemberLaunch` /
+`releaseIntradayMemberClaim`) and `services/dailyLedgerAggregateService.ts` — the closest
+existing "one addressable claim document + revision-gated transaction + compare-and-clear
+release" precedent in this codebase.
+
+## Goal
+
+Specify, before any code is written, how confirming a `progressionReview.ts` proposal
+(`advance_proposal` / `reduce_proposal` / `redirect`) can create exactly one new bounded
+progression revision per athlete at a time — atomically, without a query-then-create race,
+idempotently under retry, and without ever losing or double-applying an increment.
+
+## Preconditions
+
+- H5a's `IntentBlock`/`BlockProgressionContract` and H5b's `evaluateProgressionReview` are
+  delivered (they are).
+- ADR-0037 is Accepted (it is); this document does not reopen its decisions, only fills in
+  the transaction/schema detail it deliberately left to implementation.
+
+## Design
+
+### The invariant, quoted from the ADR
+
+ADR-0037 D-CHANGE: *"At most one confirmed active progression experiment is allowed per
+athlete across active blocks in the initial release... Pending proposals are not active
+experiments and do not acquire the singleton slot; they may coexist until one is confirmed,
+rejected, superseded or withdrawn."*
+
+D-AUTHORITY states the atomicity bar directly: confirmation must, in one Firestore
+transaction (or equivalent serializable compare-and-set), either (1) observe no competing
+non-terminal claim, validate the proposal against the still-current source revision, write
+the forward-only revision/activation records, and acquire the claim — or (2) fail
+deterministically without activating anything or applying any dose revision. It explicitly
+forbids establishing uniqueness by querying active block/proposal collections and then
+creating an experiment outside that same atomic operation, "because that check can race
+across blocks."
+
+### 1. Claim document
+
+**Path:** `users/{userId}/progression_experiment_claim/{singleton}` — one fixed-id document
+per athlete, independent of block/proposal storage (per the ADR's own requirement that the
+claim's identity not be derivable by querying blocks).
+
+```ts
+interface ProgressionExperimentClaim {
+    userId: string;
+    state: 'held' | 'released';
+    experimentId: string;
+    blockId: string;
+    proposalId: string;
+    sourcePlanRevision: number;
+    activationRevisionId: string;   // id of the created forward-only revision record
+    acquiredAt: string;
+    revision: number;               // bumped by exactly 1 on every mutation
+    createdAt: string;
+    updatedAt: string;
+}
+```
+
+Why one fixed id rather than a per-block or per-date document (unlike H4's
+`daily_ledgers/{date}`): the rule being enforced is per-*athlete*, not per-*day* or
+per-*block* — a `daily_ledgers`-shaped per-block claim would let two blocks each acquire
+their own claim and both proceed, which is exactly the race the ADR prohibits.
+
+### 2. Confirmation transaction
+
+`confirmProgressionRevision(userId, blockId, proposalId, expectedSourcePlanRevision, proposedChange)`,
+modeled directly on `claimIntradayMemberLaunch`'s structure:
+
+1. **Reads before writes** (Firestore's own rule, and the pattern H4 already follows):
+   read the claim document by direct reference; read the block/plan document at
+   `expectedSourcePlanRevision`'s path to confirm it is still current; read any existing
+   activation record for `(blockId, proposalId)` for idempotency.
+2. **Branch, inside the same transaction:**
+   - Existing activation record for this exact `(blockId, proposalId)` already exists →
+     return it unchanged (idempotent replay; no second increment, no second claim write).
+   - Claim `state == 'held'` and `experimentId` belongs to a *different* block/proposal →
+     fail with `active_progression_experiment_exists` (a typed conflict, not a thrown
+     Firestore error — mirror `StaleDecisionCode`'s pattern in `intradayLaunchClaim.ts`).
+   - Current source plan revision does not match `expectedSourcePlanRevision` → fail with a
+     **distinct** conflict, e.g. `stale-source-revision` (never collapse this into the same
+     code as the previous branch — a caller needs to know whether to re-fetch the proposal
+     or tell the athlete someone else is mid-experiment).
+   - Otherwise: write the new forward-only revision/activation record through "the existing
+     authoring boundary" (name the concrete function once identified — see Work item 3) and
+     `transaction.set` the claim to `{ state: 'held', experimentId, blockId, proposalId,
+     sourcePlanRevision: expectedSourcePlanRevision, activationRevisionId, revision:
+     current.revision + 1, ... }` in the same transaction.
+3. **No query-then-create, ever.** Step 1 reads the claim by direct document reference
+   only. Nothing in this function runs a collection query across blocks or proposals before
+   acquiring the claim.
+
+### 3. Release (compare-and-clear)
+
+`releaseProgressionClaim(userId, experimentId)`, modeled on `releaseIntradayMemberClaim`:
+read the claim; if `state !== 'held'` or `claim.experimentId !== experimentId`, no-op /
+return `{ released: false }` — a delayed cleanup for an old experiment must never clear a
+newer one's claim, exactly as `releaseIntradayMemberClaim` refuses to reverse a reservation
+that isn't in the exact state it expects. Only when the stored identity matches does the
+transaction set `state: 'released'` and bump `revision`.
+
+Called when an experiment reaches a terminal state: completed its bounded run, was
+cancelled, or was redirected per D-CHANGE's `redirect` action.
+
+### 4. Firestore rules sketch
+
+Model on `daily_ledgers`'s revision-gated update, in the same shallow/structural style PR
+#468 established (detail validation at the TS boundary, not in rules):
+
+```
+match /users/{userId}/progression_experiment_claim/{singleton} {
+  allow read: if isOwner(userId);
+  allow create: if hasValidProgressionClaim(userId);
+  allow update: if hasValidProgressionClaim(userId)
+    && keepsOwnership(userId)
+    && request.resource.data.revision == resource.data.revision + 1;
+  allow delete: if false;
+}
+```
+
+`hasValidProgressionClaim` checks `state in ['held', 'released']`, required-key shape, and
+bounded string sizes only — no cross-field business logic in rules, matching the lesson
+`recommendationAudit`'s budget failure already taught this codebase.
+
+### 5. Idempotency and failure-mode table
+
+| Scenario | Required outcome |
+|---|---|
+| Two concurrent confirmations for two *different* blocks/proposals | Exactly one commits and acquires the claim; the other fails with `active_progression_experiment_exists` |
+| The same confirmation retried (network retry, double-tap) | Returns/reuses the existing activation; claim revision does not increment a second time |
+| Source plan revision moved since the proposal was generated | Fails with the stale-source conflict; no claim/activation write |
+| Release racing a newer confirmation for a different experiment | The stale release's `experimentId` no longer matches; it no-ops, never clearing the newer claim |
+| Failure between validation and commit (e.g. transaction abort) | Neither an orphan claim nor a partial activation record exists — Firestore transactions already give this atomicity by construction; no custom two-phase cleanup is needed *inside* the transaction, only correct ordering of what the transaction writes |
+
+## Tests to add (at implementation time)
+
+- Concurrent-confirmation test: two parallel `confirmProgressionRevision` calls for
+  different experiments against an empty claim — assert exactly one activation and exactly
+  one `active_progression_experiment_exists` conflict (a real emulator transaction-race
+  test, not a mocked sequential call — the guarantee being tested is Firestore's own
+  transaction serialization).
+- Idempotent-retry test: same `(blockId, proposalId)` confirmed twice — second call returns
+  the first's activation, claim revision unchanged after the second call.
+- Stale-source test: source plan revision bumped between proposal generation and
+  confirmation — confirmation fails with the distinct stale-source conflict, no claim/
+  activation written.
+- Compare-and-clear test: release called with a stale `experimentId` after a newer
+  experiment has already acquired the claim — release no-ops, newer claim intact.
+- Rules emulator test mirroring the `daily_ledgers` pattern: revision-jump rejection,
+  cross-user denial, delete always denied.
+
+## Acceptance criteria
+
+- [ ] Exactly one athlete-scoped claim document model exists, independent of block storage.
+- [ ] Confirmation acquires the claim and writes the forward-only revision in one
+      transaction; no code path queries blocks/proposals before acquiring the claim.
+- [ ] Two distinct, typed conflict codes exist for "claim held by another experiment" vs.
+      "stale source revision."
+- [ ] Repeated confirmation of the same proposal is provably idempotent (test above).
+- [ ] Release is compare-and-clear and cannot clear a claim it does not own.
+- [ ] `POLICY_VERSION` is bumped only if/when H5c's confirmation path is wired into daily
+      recommendation selection — this design doc's scope (confirmation/claim mechanics) does
+      not by itself change decision behavior.
+
+## Risks & rollback
+
+- **Getting the claim scope wrong (per-block instead of per-athlete)** would silently
+  reintroduce the exact race the ADR prohibits. The design fixes this by making the claim
+  document's path athlete-scoped only, with no block/date segment.
+- **Reusing `StaleDecisionCode`-style stringly-typed conflicts without keeping them
+  distinct** would make callers unable to tell a "someone else is experimenting" state from
+  a "your proposal is stale" state, which the ADR explicitly requires to stay separate.
+- Rollback is simple because nothing is implemented yet: this document can be revised or
+  superseded without any migration, since no claim documents exist in production.
+
+## Out of scope (for this design; left for implementation or a later document)
+
+- The confirmation review UI (before/after dose, tradeoffs, affected future sessions
+  display).
+- Naming the concrete "existing authoring boundary" function that creates the new plan/
+  definition revision — an implementation-time task, not a design decision.
+- Cumulative `external-plan@5` (depends on this design, but is separately scoped).
+- Wiring `progressionReview.ts`'s output into any live recommendation-selection path — H5b
+  remains report-only until H5c's confirmation path is built and separately policy-reviewed.
+
+## Docs to update once this lands
+
+- `docs/plans/README.md`'s H5 row — link this document, note H5c now has an accepted design.
+- `docs/plans/cycling-primary-hybrid-evaluation.md`'s H5 section — replace "H5c needs the
+  athlete-scoped singleton progression-claim transaction design" with a link here.

--- a/docs/plans/h5c-progression-claim-design.md
+++ b/docs/plans/h5c-progression-claim-design.md
@@ -2,22 +2,21 @@
 
 **Status:** Approved (design agreed) — not `Ready`: this document specifies the
 confirmation/singleton-claim contract; no code exists yet.
-**Blocked by:** Nothing for the design itself. Implementation additionally needs "the
-existing authoring boundary" that produces a new plan/definition revision to be named
-concretely (see Work item 3) — that boundary already exists elsewhere in the codebase but
-has not yet been identified as the specific integration point H5c's confirmation writes
-through.
+**Blocked by:** Runtime implementation must first identify the existing plan/definition
+authoring boundary and make that boundary transaction-aware (or introduce a shared
+transaction-aware primitive) so the accepted plan revision, singleton claim and activation
+audit are committed by the **same caller-owned Firestore transaction**. A boundary that
+starts its own transaction or calls `setDoc` out of band does not satisfy this design.
 **Unlocks:** H5c implementation (athlete-confirmed bounded progression revisions);
 cumulative `external-plan@5` acceptance, which the cycling hybrid evaluation plan already
 notes is otherwise unblocked now that H4's v4 contract has landed.
 **Governs:** [ADR-0037](../adr/0037-block-intent-and-controlled-progression.md) D-AUTHORITY,
 D-CHANGE's one-active-experiment rule.
 **Builds on:** H5a (`engine/blockIntent.ts`, `engine/blockIntentReplay.ts`) and H5b
-(`engine/progressionReview.ts`), both delivered. The transaction shape below is modeled
-directly on H4's `services/intradayLaunchClaim.ts` (`claimIntradayMemberLaunch` /
-`releaseIntradayMemberClaim`) and `services/dailyLedgerAggregateService.ts` — the closest
-existing "one addressable claim document + revision-gated transaction + compare-and-clear
-release" precedent in this codebase.
+(`engine/progressionReview.ts`), both delivered. The compare-and-clear/revision discipline
+is modeled on H4's `services/intradayLaunchClaim.ts` and
+`services/dailyLedgerAggregateService.ts`, but H5c additionally needs a deterministic
+activation record because confirmation must be idempotent across client/network retries.
 
 ## Goal
 
@@ -32,6 +31,10 @@ idempotently under retry, and without ever losing or double-applying an incremen
   delivered (they are).
 - ADR-0037 is Accepted (it is); this document does not reopen its decisions, only fills in
   the transaction/schema detail it deliberately left to implementation.
+- Before runtime activation, the normal plan-authoring write path must be named and exposed
+  as a primitive that can enqueue its reads/writes on a **transaction supplied by the H5c
+  caller**. No nested `runTransaction`, `setDoc`, network side effect, telemetry emission or
+  other non-transactional mutation may occur from inside the retriable callback.
 
 ## Design
 
@@ -51,11 +54,14 @@ forbids establishing uniqueness by querying active block/proposal collections an
 creating an experiment outside that same atomic operation, "because that check can race
 across blocks."
 
-### 1. Claim document
+### 1. Singleton claim document
 
-**Path:** `users/{userId}/progression_experiment_claim/{singleton}` — one fixed-id document
-per athlete, independent of block/proposal storage (per the ADR's own requirement that the
-claim's identity not be derivable by querying blocks).
+**Literal path:** `users/{userId}/progression_experiment_claim/current`.
+
+`current` is part of the invariant, not an example id. Using
+`progression_experiment_claim/{singleton}` would let multiple differently named documents
+exist and would leave "singleton" enforcement to application convention. A literal path
+lets both application code and Firestore rules address exactly one athlete-scoped claim.
 
 ```ts
 interface ProgressionExperimentClaim {
@@ -65,7 +71,8 @@ interface ProgressionExperimentClaim {
     blockId: string;
     proposalId: string;
     sourcePlanRevision: number;
-    activationRevisionId: string;   // id of the created forward-only revision record
+    activationKey: string;
+    activationRevisionId: string;   // id of the created forward-only plan/definition revision
     acquiredAt: string;
     revision: number;               // bumped by exactly 1 on every mutation
     createdAt: string;
@@ -75,132 +82,224 @@ interface ProgressionExperimentClaim {
 
 Why one fixed id rather than a per-block or per-date document (unlike H4's
 `daily_ledgers/{date}`): the rule being enforced is per-*athlete*, not per-*day* or
-per-*block* — a `daily_ledgers`-shaped per-block claim would let two blocks each acquire
-their own claim and both proceed, which is exactly the race the ADR prohibits.
+per-*block* — a per-block claim would let two blocks each acquire their own claim and both
+proceed, exactly the race ADR-0037 prohibits.
 
-### 2. Confirmation transaction
+### 2. Deterministic activation/idempotency document
 
-`confirmProgressionRevision(userId, blockId, proposalId, expectedSourcePlanRevision, proposedChange)`,
-modeled directly on `claimIntradayMemberLaunch`'s structure:
+**Path:** `users/{userId}/progression_experiment_activations/{activationKey}`.
 
-1. **Reads before writes** (Firestore's own rule, and the pattern H4 already follows):
-   read the claim document by direct reference; read the block/plan document at
-   `expectedSourcePlanRevision`'s path to confirm it is still current; read any existing
-   activation record for `(blockId, proposalId)` for idempotency.
-2. **Branch, inside the same transaction:**
-   - Existing activation record for this exact `(blockId, proposalId)` already exists →
-     return it unchanged (idempotent replay; no second increment, no second claim write).
-   - Claim `state == 'held'` and `experimentId` belongs to a *different* block/proposal →
-     fail with `active_progression_experiment_exists` (a typed conflict, not a thrown
-     Firestore error — mirror `StaleDecisionCode`'s pattern in `intradayLaunchClaim.ts`).
-   - Current source plan revision does not match `expectedSourcePlanRevision` → fail with a
-     **distinct** conflict, e.g. `stale-source-revision` (never collapse this into the same
-     code as the previous branch — a caller needs to know whether to re-fetch the proposal
-     or tell the athlete someone else is mid-experiment).
-   - Otherwise: write the new forward-only revision/activation record through "the existing
-     authoring boundary" (name the concrete function once identified — see Work item 3) and
-     `transaction.set` the claim to `{ state: 'held', experimentId, blockId, proposalId,
-     sourcePlanRevision: expectedSourcePlanRevision, activationRevisionId, revision:
-     current.revision + 1, ... }` in the same transaction.
-3. **No query-then-create, ever.** Step 1 reads the claim by direct document reference
-   only. Nothing in this function runs a collection query across blocks or proposals before
-   acquiring the claim.
+`activationKey` must be a deterministic, bounded, Firestore-safe encoding/hash of
+`(blockId, proposalId)` produced by one shared helper. It must not contain a random UUID or
+request timestamp. The same logical confirmation on another tab/device therefore resolves
+to the same document reference without a collection query.
 
-### 3. Release (compare-and-clear)
+```ts
+interface ProgressionExperimentActivation {
+    userId: string;
+    activationKey: string;
+    experimentId: string;
+    blockId: string;
+    proposalId: string;
+    sourcePlanRevision: number;
+    activationRevisionId: string;
+    claimRevision: number;
+    activatedAt: string;
+    // Minimal before/after values needed to explain/replay the accepted bounded change.
+    priorSettings: ProgressionSettingsSnapshot;
+    acceptedSettings: ProgressionSettingsSnapshot;
+}
+```
+
+The activation document is **create-once and immutable**. It is the durable idempotency
+answer: if it already exists and its stored block/proposal identity matches the requested
+activation, confirmation returns that record unchanged and performs no claim or plan write.
+An identity mismatch at the deterministic key is an invariant/data-integrity failure, not a
+reason to overwrite it.
+
+### 3. Confirmation transaction
+
+`confirmProgressionRevision(userId, blockId, proposalId, expectedSourcePlanRevision, proposedChange)`:
+
+Before `runTransaction`, compute the literal claim reference, deterministic activation
+reference, and any deterministic identifiers/timestamps needed by the attempted activation.
+They stay stable if Firestore retries the transaction callback.
+
+Inside one caller-owned Firestore transaction, with **all reads before writes**:
+
+1. Read the activation document by direct deterministic reference.
+   - If it exists and matches `(blockId, proposalId)`, return it unchanged. This is the
+     idempotent replay path: no second dose increment, plan revision or claim revision.
+   - If it exists but the identity does not match, fail with an invariant-conflict result.
+2. Read `progression_experiment_claim/current` by direct reference.
+3. Read the current authored block/plan state and revision required to revalidate the
+   proposal. Do not read a historical path and infer that it is still current.
+4. Branch before any write:
+   - Claim `state == 'held'` for a different block/proposal → return
+     `active_progression_experiment_exists`.
+   - Current source revision differs from `expectedSourcePlanRevision`, or the proposal no
+     longer validates against the current block state → return the distinct
+     `stale-source-revision`/typed revalidation conflict. No claim/activation/plan write.
+5. Invoke the shared **transaction-aware authoring primitive** with this same transaction to
+   enqueue the normal forward-only plan/definition revision. The primitive must preserve
+   every invariant of ordinary authoring; H5c must not invent a parallel storage format.
+6. Enqueue claim create/update at the literal `/current` document with
+   `revision = previous.revision + 1` (or `1` on first create), the same experiment identity,
+   source revision and deterministic `activationKey`.
+7. Enqueue **create-only** activation evidence at the deterministic activation document,
+   recording the resulting authored revision id and claim revision.
+8. Commit. Firestore serialization/retry is the concurrency boundary; no external side
+   effect is allowed from inside the retriable callback.
+
+This ordering is deliberate. A transaction retry can rerun validation/application logic, so
+random ids, `Date.now()`-style evidence timestamps that change on each callback run,
+telemetry, toasts, navigation, or independent writes belong outside the callback. Only the
+transaction's own reads/writes may determine committed state.
+
+### 4. Release (compare-and-clear)
 
 `releaseProgressionClaim(userId, experimentId)`, modeled on `releaseIntradayMemberClaim`:
-read the claim; if `state !== 'held'` or `claim.experimentId !== experimentId`, no-op /
-return `{ released: false }` — a delayed cleanup for an old experiment must never clear a
-newer one's claim, exactly as `releaseIntradayMemberClaim` refuses to reverse a reservation
-that isn't in the exact state it expects. Only when the stored identity matches does the
-transaction set `state: 'released'` and bump `revision`.
+read `/progression_experiment_claim/current`; if `state !== 'held'` or
+`claim.experimentId !== experimentId`, no-op / return `{ released: false }` — a delayed
+cleanup for an old experiment must never clear a newer one's claim. Only when the stored
+identity matches does the transaction set `state: 'released'` and bump `revision`.
 
-Called when an experiment reaches a terminal state: completed its bounded run, was
-cancelled, or was redirected per D-CHANGE's `redirect` action.
+The immutable activation record is **not** deleted or mutated on release. It remains the
+historical/idempotency evidence for that accepted proposal.
 
-### 4. Firestore rules sketch
+Release is called when an experiment reaches a terminal state: completed its bounded run,
+was cancelled, or was redirected per D-CHANGE's `redirect` action.
 
-Model on `daily_ledgers`'s revision-gated update, in the same shallow/structural style PR
-#468 established (detail validation at the TS boundary, not in rules):
+### 5. Firestore rules sketch
 
-```
-match /users/{userId}/progression_experiment_claim/{singleton} {
+Use a literal claim path and an immutable activation collection. Keep rules shallow and
+structural, following PR #468's rule-budget lesson; proposal business validation remains in
+the transaction service/authoring boundary.
+
+```text
+match /users/{userId}/progression_experiment_claim/current {
   allow read: if isOwner(userId);
-  allow create: if hasValidProgressionClaim(userId);
+  allow create: if hasValidProgressionClaim(userId)
+    && request.resource.data.revision == 1;
   allow update: if hasValidProgressionClaim(userId)
     && keepsOwnership(userId)
     && request.resource.data.revision == resource.data.revision + 1;
   allow delete: if false;
 }
+
+match /users/{userId}/progression_experiment_activations/{activationKey} {
+  allow read: if isOwner(userId);
+  allow create: if hasValidProgressionActivation(userId, activationKey);
+  allow update, delete: if false;
+}
 ```
 
-`hasValidProgressionClaim` checks `state in ['held', 'released']`, required-key shape, and
-bounded string sizes only — no cross-field business logic in rules, matching the lesson
-`recommendationAudit`'s budget failure already taught this codebase.
+`hasValidProgressionClaim` / `hasValidProgressionActivation` check exact required-key shape,
+ownership, bounded strings/numbers, and for the activation record that the payload's
+`activationKey` equals the path id. They do not query blocks or encode the progression
+policy in rules.
 
-### 5. Idempotency and failure-mode table
+### 6. Idempotency and failure-mode table
 
 | Scenario | Required outcome |
 |---|---|
-| Two concurrent confirmations for two *different* blocks/proposals | Exactly one commits and acquires the claim; the other fails with `active_progression_experiment_exists` |
-| The same confirmation retried (network retry, double-tap) | Returns/reuses the existing activation; claim revision does not increment a second time |
-| Source plan revision moved since the proposal was generated | Fails with the stale-source conflict; no claim/activation write |
-| Release racing a newer confirmation for a different experiment | The stale release's `experimentId` no longer matches; it no-ops, never clearing the newer claim |
-| Failure between validation and commit (e.g. transaction abort) | Neither an orphan claim nor a partial activation record exists — Firestore transactions already give this atomicity by construction; no custom two-phase cleanup is needed *inside* the transaction, only correct ordering of what the transaction writes |
+| Two concurrent confirmations for two *different* blocks/proposals | Exactly one commits and acquires `/current`; the other retries/observes the held claim and returns `active_progression_experiment_exists` |
+| Two concurrent confirmations for the *same* block/proposal | Both resolve the same deterministic activation reference; exactly one authored revision and one activation are committed, and both callers resolve to that activation |
+| Same confirmation retried after network ambiguity/double-tap | Direct-read existing activation and return it; claim revision and authored plan revision do not increment again |
+| Source plan revision moved since proposal generation | Typed stale/revalidation conflict; zero claim, activation or authored-plan writes |
+| Release racing a newer confirmation for another experiment | Stale release identity does not match `/current`; no-op, newer claim remains held |
+| Transaction callback retries | Deterministic refs/ids remain stable; callback performs no out-of-band side effects; one atomic committed state exists |
+| Transaction aborts | Neither orphan claim, partial activation nor partial authored revision exists |
+
+## Authoring-boundary implementation gate
+
+H5c is **not runtime-ready** until the current plan/definition authoring provider and commit
+path are identified. The implementation work item must:
+
+1. name the current shared authoring function(s) used by normal user-facing plan changes;
+2. verify which document(s), revision preconditions, hashes/provenance and audit records that
+   path writes;
+3. expose a transaction-aware primitive that accepts the caller's Firestore transaction (or
+   an equivalent write/precondition abstraction) and enqueues the same mutation; and
+4. prove with tests that H5c confirmation cannot create a plan revision if claim/activation
+   commit fails, and cannot acquire a claim if plan revision creation fails.
+
+If the existing authoring path cannot participate in a caller-owned transaction, the correct
+next implementation step is to refactor/add that primitive. Calling an existing `setDoc`
+helper from inside the H5c callback or starting a nested transaction would violate
+D-AUTHORITY even if happy-path tests pass.
+
+## No recommendation-time query
+
+The direct activation/claim/current-plan reads above happen only during an explicit athlete
+confirmation. They must **not** be added to ordinary recommendation generation. H5b remains
+report-only until H5c is separately implemented/activated, so this design adds no
+recommendation-time read or latency path.
 
 ## Tests to add (at implementation time)
 
-- Concurrent-confirmation test: two parallel `confirmProgressionRevision` calls for
-  different experiments against an empty claim — assert exactly one activation and exactly
-  one `active_progression_experiment_exists` conflict (a real emulator transaction-race
-  test, not a mocked sequential call — the guarantee being tested is Firestore's own
-  transaction serialization).
-- Idempotent-retry test: same `(blockId, proposalId)` confirmed twice — second call returns
-  the first's activation, claim revision unchanged after the second call.
-- Stale-source test: source plan revision bumped between proposal generation and
-  confirmation — confirmation fails with the distinct stale-source conflict, no claim/
-  activation written.
-- Compare-and-clear test: release called with a stale `experimentId` after a newer
-  experiment has already acquired the claim — release no-ops, newer claim intact.
-- Rules emulator test mirroring the `daily_ledgers` pattern: revision-jump rejection,
-  cross-user denial, delete always denied.
+- Real-emulator concurrent confirmation: two different proposals against an empty claim —
+  exactly one activation; the other returns `active_progression_experiment_exists`.
+- Real-emulator same-proposal race: two tabs confirm identical `(blockId, proposalId)` —
+  one activation document and exactly one authored revision; both callers resolve the same
+  activation.
+- Idempotent retry after simulated network ambiguity — existing deterministic activation is
+  returned; claim and authored revision counters are unchanged.
+- Stale-source test: bump source plan revision between proposal generation and confirmation —
+  typed stale conflict and **zero writes** to claim/activation/accepted plan revision.
+- Authoring atomicity test: force the authoring mutation/precondition to fail — claim and
+  activation remain absent/unchanged; force activation/claim failure — authored revision is
+  absent.
+- Compare-and-clear test: stale `experimentId` cannot release a newer held claim.
+- Rules emulator tests: literal `/current` ownership/shape/revision checks; differently named
+  claim documents are not writable; activation create shape/key binding; activation update
+  and delete are always denied; cross-user access denied.
 
 ## Acceptance criteria
 
-- [ ] Exactly one athlete-scoped claim document model exists, independent of block storage.
-- [ ] Confirmation acquires the claim and writes the forward-only revision in one
-      transaction; no code path queries blocks/proposals before acquiring the claim.
-- [ ] Two distinct, typed conflict codes exist for "claim held by another experiment" vs.
-      "stale source revision."
-- [ ] Repeated confirmation of the same proposal is provably idempotent (test above).
+- [ ] The only writable athlete-scoped claim path is
+      `users/{userId}/progression_experiment_claim/current`.
+- [ ] A deterministic `(blockId, proposalId)` activation key is shared by code, tests and
+      rules; activation evidence is create-once/immutable.
+- [ ] Confirmation reads an existing activation by direct reference first and is idempotent
+      across concurrent same-proposal calls and client/network retries.
+- [ ] Claim, accepted forward-only plan/definition revision and activation audit commit in
+      one caller-owned transaction through the **normal transaction-aware authoring
+      boundary**.
+- [ ] No code path queries blocks/proposals to establish singleton uniqueness.
+- [ ] Distinct typed conflicts exist for "another active experiment", stale source/revalidation,
+      and deterministic-key invariant mismatch.
 - [ ] Release is compare-and-clear and cannot clear a claim it does not own.
-- [ ] `POLICY_VERSION` is bumped only if/when H5c's confirmation path is wired into daily
-      recommendation selection — this design doc's scope (confirmation/claim mechanics) does
-      not by itself change decision behavior.
+- [ ] H5c adds no recommendation-time query/read path while still report-only.
+- [ ] `POLICY_VERSION` is bumped only if/when H5c is wired into live recommendation
+      selection; this design/confirmation persistence alone does not change decision policy.
 
 ## Risks & rollback
 
-- **Getting the claim scope wrong (per-block instead of per-athlete)** would silently
-  reintroduce the exact race the ADR prohibits. The design fixes this by making the claim
-  document's path athlete-scoped only, with no block/date segment.
-- **Reusing `StaleDecisionCode`-style stringly-typed conflicts without keeping them
-  distinct** would make callers unable to tell a "someone else is experimenting" state from
-  a "your proposal is stale" state, which the ADR explicitly requires to stay separate.
-- Rollback is simple because nothing is implemented yet: this document can be revised or
-  superseded without any migration, since no claim documents exist in production.
+- **Convention-only singleton id:** allowing `{singleton}` as an arbitrary id can create two
+  claim documents. The literal `/current` path removes that ambiguity.
+- **Query-based idempotency:** searching for "any existing activation" can race or require
+  indexes. The deterministic activation reference makes idempotency a direct transactional
+  read.
+- **Nested/out-of-band authoring write:** a helper that starts its own transaction or calls
+  `setDoc` breaks the atomicity promised by D-AUTHORITY. The transaction-aware authoring
+  boundary is therefore an implementation blocker, not cleanup work.
+- **Retry side effects:** Firestore may rerun transaction callbacks. Keeping ids/timestamps
+  stable and all side effects outside the callback prevents duplicate observable actions.
+- Rollback remains simple because nothing is implemented yet: this design can be revised or
+  superseded without data migration.
 
 ## Out of scope (for this design; left for implementation or a later document)
 
-- The confirmation review UI (before/after dose, tradeoffs, affected future sessions
-  display).
-- Naming the concrete "existing authoring boundary" function that creates the new plan/
-  definition revision — an implementation-time task, not a design decision.
-- Cumulative `external-plan@5` (depends on this design, but is separately scoped).
-- Wiring `progressionReview.ts`'s output into any live recommendation-selection path — H5b
-  remains report-only until H5c's confirmation path is built and separately policy-reviewed.
+- The confirmation review UI (before/after dose, tradeoffs, affected future sessions display).
+- Naming the concrete existing authoring function — identifying/refactoring it is the first
+  implementation gate above, not something this design may guess.
+- Cumulative `external-plan@5` (depends on H5c, separately scoped).
+- Wiring `progressionReview.ts` output into live recommendation selection — H5b remains
+  report-only until H5c's confirmation path is built and separately policy-reviewed.
 
-## Docs to update once this lands
+## Docs to update once runtime implementation lands
 
-- `docs/plans/README.md`'s H5 row — link this document, note H5c now has an accepted design.
-- `docs/plans/cycling-primary-hybrid-evaluation.md`'s H5 section — replace "H5c needs the
-  athlete-scoped singleton progression-claim transaction design" with a link here.
+- `docs/plans/README.md` H5 row/status — distinguish accepted design from implemented H5c.
+- `docs/plans/cycling-primary-hybrid-evaluation.md` H5 section — record the concrete
+  transaction-aware authoring boundary and implementation evidence.


### PR DESCRIPTION
## Summary

Closes out three open items from [`docs/plans/cycling-primary-hybrid-evaluation.md`](docs/plans/cycling-primary-hybrid-evaluation.md), plus a stale-status correction found while scoping the work.

1. **Doc correction** — the plan's top-level "Blocked by" section described PR #474's already-delivered ledger-admission ranking/gate as outstanding work. Corrected and disambiguated from the narrower item below that PR #474 did *not* cover.
2. **H4 dedup unification** — `applyFixedActivityStimulusCredit`, `generateWeekAheadPlan`, and `unrepresentedFixedActivityProjection` now share the ledger's occurrence identity/revision semantics rather than separate ad hoc sets/count deltas. `decisionTrace.calibration.fixedActivity` carries transient per-occurrence entries so the projection can diff identities directly.
3. **H4 placement-display persistence** — resolved v4 bundle placement is persisted best-effort at `users/{userId}/intraday_bundle_placements/{date}` as a separate shallow sibling document rather than extending `recommendationAudit`, whose rules budget remains insufficient. This is deliberately a **display-only partial D-AUDIT slice**, not authoritative replay evidence.
4. **H5c design** — `docs/plans/h5c-progression-claim-design.md` specifies the athlete-scoped singleton confirmation transaction. It is design-only; no live H5c activation is introduced.

## Review follow-up fixes

A full review of the PR found and fixed one placement-persistence concurrency defect and hardened the H5c design before implementation:

- **Stale Firestore transaction retry:** a plain `revision + 1` serializes mutations but does not prove freshness because Firestore may retry a transaction after another writer commits. `recordIntradayBundlePlacement` now captures a fixed observation timestamp outside the retriable callback, refuses an older observation after a newer one has committed, and no-ops when placement evidence is unchanged. Targeted tests cover stale retry ordering and duplicate/no-change writes. This protects retry reordering for the partial display record; the record is still intentionally not full cross-plan replay evidence.
- **H5c singleton enforcement:** the claim is now a literal `users/{userId}/progression_experiment_claim/current` path rather than a convention-only `{singleton}` id.
- **H5c idempotency:** confirmation uses a deterministic `(blockId, proposalId)` activation document that is create-once/immutable, eliminating an ambiguous "read any activation" lookup and making same-proposal concurrent retries converge on one record.
- **H5c atomic authoring:** runtime implementation is explicitly blocked until the normal plan/definition authoring path can participate in the same caller-owned Firestore transaction. Nested transactions or out-of-band `setDoc` calls would violate ADR-0037 D-AUTHORITY.

## Why

The plan doc claimed several things were still open that were either already delivered elsewhere and just undocumented or were real gaps worth closing now that H4's v4 contract has landed. The review follow-up additionally distinguishes serialization from freshness and makes H5c's future atomicity/idempotency requirements executable rather than convention-based.

## Verification

- Reviewed head: `88e8fe0077e7881b680ea9a836df88f4c36da673`.
- GitHub **CI Pipeline #2922: green** on the reviewed head.
- Frontend static gates: typecheck, lint, knowledge/workout validation, policy-drift check and production build passed.
- Frontend unit suite passed, including the new stale/duplicate placement-persistence tests.
- Firestore security-rule emulator suite passed.
- Python lint/type/test/dependency gates passed.
- Docker/smoke and the remaining repository CI lanes passed.
- Original branch verification also reported `simulate:scenarios` / `simulate:diff` with no semantic difference against the committed baseline for the H4 dedup refactor.

### Policy-version note

The H4 dedup restructure **does** intentionally bump `POLICY_VERSION` to `2026-09-fixed-activity-dedup-identity-unification-v1` because `rules.ts`/`planner.ts` are decision-file drift-gate inputs and the drift checker cannot prove output equivalence from the structural change alone. The display-only placement persistence follow-up and H5c design changes do **not** require an additional policy bump.

## Notes for reviewers

- The placement sibling document must not be treated as recommendation authority or full ADR-0036 D-AUDIT replay evidence. It does not contain the complete ledger/replay/supersession source context.
- H4 planner scoring is already canonicalized through `dedupeFixedActivitiesByLedgerIdentity` before the affected cost/stimulus paths; the review did not broaden recommendation behavior beyond the PR's intended unification.
- H5c remains design-only. Its first runtime implementation task is to identify/refactor the existing authoring boundary into a transaction-aware primitive, then implement the literal singleton + deterministic activation contract and emulator race tests.
- No actionable inline review threads existed during this review; CodeRabbit's only comment reports that automatic review is disabled.

🤖 Reviewed and follow-up fixes applied with ChatGPT.