### PR TITLE
feat(nav): converge desktop and mobile on Home Check-in Plan primaries (#482)

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -230,7 +230,7 @@
   position: absolute;
   top: calc(100% + 0.5rem);
   right: 0;
-  width: 200px;
+  width: 248px;
   background: #1e293b;
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 12px;
@@ -249,6 +249,15 @@
     opacity: 1;
     transform: translateY(0);
   }
+}
+
+.dropdown-group-title {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  padding: 0.5rem 0.75rem 0.25rem;
 }
 
 .dropdown-item {

--- a/app/src/components/Header.test.tsx
+++ b/app/src/components/Header.test.tsx
@@ -2,6 +2,7 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it, vi } from 'vitest';
 import type { Screen } from '../types/navigation';
 import { SCREEN_LABELS } from '../types/navigation';
+import { PRIMARY_NAV_ITEMS } from './navigationGroups';
 import { Header } from './Header';
 
 function renderHeader(screen: Screen, desktopSettingsOpen = true): string {
@@ -17,12 +18,12 @@ function renderHeader(screen: Screen, desktopSettingsOpen = true): string {
 }
 
 describe('Header primary navigation', () => {
-  it('promotes the daily-loop primaries with canonical labels', () => {
+  it('promotes the shared daily-loop primaries with canonical labels', () => {
     const markup = renderHeader('home', false);
 
-    expect(markup).toContain(`>${SCREEN_LABELS.home}<`);
-    expect(markup).toContain(`>${SCREEN_LABELS.checkin}<`);
-    expect(markup).toContain(`>${SCREEN_LABELS.plan}<`);
+    for (const destination of PRIMARY_NAV_ITEMS) {
+      expect(markup).toContain(`>${SCREEN_LABELS[destination.screen]}<`);
+    }
     expect(markup).toContain('>More<');
   });
 
@@ -35,37 +36,40 @@ describe('Header primary navigation', () => {
     expect(markup).not.toContain(`>${SCREEN_LABELS.data}<`);
   });
 
-  it('groups the More overflow by intent like the mobile drawer', () => {
+  it('uses disclosure semantics for the More overflow and intent-labelled groups', () => {
     const markup = renderHeader('sessions');
 
-    expect(markup).toContain('role="menu"');
-    expect(markup).toContain('aria-label="More"');
-    expect(markup).toContain('>Train<');
-    expect(markup).toContain('>Configure<');
-    expect(markup).toContain('>Understand<');
+    expect(markup).toContain('aria-controls="desktop-more-panel"');
+    expect(markup).toContain('id="desktop-more-panel"');
+    expect(markup).not.toContain('role="menu"');
+    expect(markup).not.toContain('role="menuitem"');
+    expect(markup).toContain('aria-labelledby="desktop-more-train-title"');
+    expect(markup).toContain('aria-labelledby="desktop-more-configure-title"');
+    expect(markup).toContain('aria-labelledby="desktop-more-understand-title"');
     expect(markup).toContain(`${SCREEN_LABELS.sessions}</button>`);
     expect(markup).toContain(`${SCREEN_LABELS.plan}</button>`);
     expect(markup).toContain(`${SCREEN_LABELS.brief}</button>`);
   });
 
   it('keeps the More button inactive on primary screens', () => {
-    for (const screen of ['home', 'checkin', 'plan'] as const) {
+    for (const { screen } of PRIMARY_NAV_ITEMS) {
       const markup = renderHeader(screen, false);
       expect(markup).not.toContain('nav-link more-btn active');
     }
   });
 
-  it('marks the More button active on overflow screens with exact item state', () => {
+  it('marks the More button active on overflow screens with exact current-page state', () => {
     const markup = renderHeader('sessions');
 
     expect(markup).toContain('nav-link more-btn active');
-    expect(markup).toMatch(/class="dropdown-item active"[^>]*>.*?Sessions/s);
+    expect(markup).toMatch(/class="dropdown-item active"[^>]*aria-current="page"[^>]*>.*?Sessions/s);
   });
 
   it('keeps Plan current in both the primary set and the Train group', () => {
     const markup = renderHeader('plan');
 
-    expect(markup).toMatch(/class="nav-link active"[^>]*>.*?Plan/s);
-    expect(markup).toMatch(/class="dropdown-item active"[^>]*>.*?Plan/s);
+    expect(markup.match(/aria-current="page"/g)).toHaveLength(2);
+    expect(markup).toMatch(/class="nav-link active"[^>]*aria-current="page"[^>]*>.*?Plan/s);
+    expect(markup).toMatch(/class="dropdown-item active"[^>]*aria-current="page"[^>]*>.*?Plan/s);
   });
 });

--- a/app/src/components/Header.test.tsx
+++ b/app/src/components/Header.test.tsx
@@ -1,0 +1,71 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import type { Screen } from '../types/navigation';
+import { SCREEN_LABELS } from '../types/navigation';
+import { Header } from './Header';
+
+function renderHeader(screen: Screen, desktopSettingsOpen = true): string {
+  return renderToStaticMarkup(
+    <Header
+      screen={screen}
+      handleNavigate={vi.fn()}
+      loadDecisionInput={vi.fn()}
+      desktopSettingsOpen={desktopSettingsOpen}
+      setDesktopSettingsOpen={vi.fn()}
+    />,
+  );
+}
+
+describe('Header primary navigation', () => {
+  it('promotes the daily-loop primaries with canonical labels', () => {
+    const markup = renderHeader('home', false);
+
+    expect(markup).toContain(`>${SCREEN_LABELS.home}<`);
+    expect(markup).toContain(`>${SCREEN_LABELS.checkin}<`);
+    expect(markup).toContain(`>${SCREEN_LABELS.plan}<`);
+    expect(markup).toContain('>More<');
+  });
+
+  it('does not promote secondary destinations to the top level', () => {
+    const markup = renderHeader('home', false);
+
+    expect(markup).not.toContain(`>${SCREEN_LABELS.sessions}<`);
+    expect(markup).not.toContain(`>${SCREEN_LABELS.testing}<`);
+    expect(markup).not.toContain(`>${SCREEN_LABELS.goals}<`);
+    expect(markup).not.toContain(`>${SCREEN_LABELS.data}<`);
+  });
+
+  it('groups the More overflow by intent like the mobile drawer', () => {
+    const markup = renderHeader('sessions');
+
+    expect(markup).toContain('role="menu"');
+    expect(markup).toContain('aria-label="More"');
+    expect(markup).toContain('>Train<');
+    expect(markup).toContain('>Configure<');
+    expect(markup).toContain('>Understand<');
+    expect(markup).toContain(`${SCREEN_LABELS.sessions}</button>`);
+    expect(markup).toContain(`${SCREEN_LABELS.plan}</button>`);
+    expect(markup).toContain(`${SCREEN_LABELS.brief}</button>`);
+  });
+
+  it('keeps the More button inactive on primary screens', () => {
+    for (const screen of ['home', 'checkin', 'plan'] as const) {
+      const markup = renderHeader(screen, false);
+      expect(markup).not.toContain('nav-link more-btn active');
+    }
+  });
+
+  it('marks the More button active on overflow screens with exact item state', () => {
+    const markup = renderHeader('sessions');
+
+    expect(markup).toContain('nav-link more-btn active');
+    expect(markup).toMatch(/class="dropdown-item active"[^>]*>.*?Sessions/s);
+  });
+
+  it('keeps Plan current in both the primary set and the Train group', () => {
+    const markup = renderHeader('plan');
+
+    expect(markup).toMatch(/class="nav-link active"[^>]*>.*?Plan/s);
+    expect(markup).toMatch(/class="dropdown-item active"[^>]*>.*?Plan/s);
+  });
+});

--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -1,7 +1,12 @@
 import React, { useRef, useEffect } from 'react';
 import type { Screen } from '../types/navigation';
 import { SCREEN_LABELS } from '../types/navigation';
-import { DRAWER_GROUPS, type DrawerDestination } from './navigationGroups';
+import {
+  DRAWER_GROUPS,
+  PRIMARY_NAV_ITEMS,
+  isPrimaryNavigationScreen,
+  type DrawerDestination,
+} from './navigationGroups';
 import { getAuthInstance } from '../firebase';
 import { buildInfo } from '../buildInfo';
 import { GarminSyncBadge } from './GarminSyncBadge';
@@ -26,6 +31,7 @@ export const Header: React.FC<HeaderProps> = ({
   date,
 }) => {
   const desktopSettingsRef = useRef<HTMLDivElement>(null);
+  const desktopMoreButtonRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     const handlePointerDown = (event: MouseEvent) => {
@@ -34,8 +40,9 @@ export const Header: React.FC<HeaderProps> = ({
       }
     };
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        if (desktopSettingsOpen) setDesktopSettingsOpen(false);
+      if (event.key === 'Escape' && desktopSettingsOpen) {
+        setDesktopSettingsOpen(false);
+        desktopMoreButtonRef.current?.focus();
       }
     };
 
@@ -58,7 +65,7 @@ export const Header: React.FC<HeaderProps> = ({
   // mobile bottom bar. Every other destination lives in the More overflow
   // under the same intent groups as the mobile drawer, so muscle memory
   // transfers between form factors.
-  const moreMenuActive = screen !== 'home' && screen !== 'checkin' && screen !== 'plan';
+  const moreMenuActive = !isPrimaryNavigationScreen(screen);
 
   const navigateToOverflowDestination = (destination: DrawerDestination) => {
     if (destination.refreshDecisionInput) {
@@ -83,53 +90,58 @@ export const Header: React.FC<HeaderProps> = ({
         </div>
 
         <nav className="navbar-desktop-menu" aria-label="Primary">
-          <button
-            className={`nav-link ${screen === 'home' ? 'active' : ''}`}
-            onClick={() => handleNavigate('home')}
-          >
-            {SCREEN_LABELS.home}
-          </button>
-          <button
-            className={`nav-link ${screen === 'checkin' ? 'active' : ''}`}
-            onClick={() => handleNavigate('checkin')}
-          >
-            {SCREEN_LABELS.checkin}
-          </button>
-          <button
-            className={`nav-link ${screen === 'plan' ? 'active' : ''}`}
-            onClick={() => handleNavigate('plan')}
-          >
-            {SCREEN_LABELS.plan}
-          </button>
+          {PRIMARY_NAV_ITEMS.map((destination) => {
+            const active = screen === destination.screen;
+            return (
+              <button
+                key={destination.screen}
+                className={`nav-link ${active ? 'active' : ''}`}
+                onClick={() => handleNavigate(destination.screen)}
+                aria-current={active ? 'page' : undefined}
+              >
+                {SCREEN_LABELS[destination.screen]}
+              </button>
+            );
+          })}
 
           <div className="more-menu-container" ref={desktopSettingsRef}>
             <button
+              ref={desktopMoreButtonRef}
               className={`nav-link more-btn ${moreMenuActive ? 'active' : ''}`}
               onClick={() => setDesktopSettingsOpen((isOpen) => !isOpen)}
               aria-expanded={desktopSettingsOpen}
-              aria-haspopup="menu"
+              aria-controls="desktop-more-panel"
             >
               <span>More</span>
               <span className="caret">▾</span>
             </button>
 
             {desktopSettingsOpen && (
-              <div className="dropdown-menu" role="menu" aria-label="More">
-                {DRAWER_GROUPS.map((group) => (
-                  <div key={group.id} role="group" aria-label={group.title}>
-                    <div className="dropdown-group-title">{group.title}</div>
-                    {group.items.map((destination) => (
-                      <button
-                        key={destination.screen}
-                        className={`dropdown-item ${screen === destination.screen ? 'active' : ''}`}
-                        onClick={() => navigateToOverflowDestination(destination)}
-                        role="menuitem"
-                      >
-                        <span className="item-icon">{destination.icon}</span> {SCREEN_LABELS[destination.screen]}
-                      </button>
-                    ))}
-                  </div>
-                ))}
+              // This is navigation disclosure content rather than an ARIA `menu` widget.
+              // Keeping ordinary buttons in the normal Tab order avoids promising roving
+              // menu keyboard behavior that this lightweight navigation does not need.
+              <div id="desktop-more-panel" className="dropdown-menu">
+                {DRAWER_GROUPS.map((group) => {
+                  const titleId = `desktop-more-${group.id}-title`;
+                  return (
+                    <div key={group.id} role="group" aria-labelledby={titleId}>
+                      <div id={titleId} className="dropdown-group-title">{group.title}</div>
+                      {group.items.map((destination) => {
+                        const active = screen === destination.screen;
+                        return (
+                          <button
+                            key={destination.screen}
+                            className={`dropdown-item ${active ? 'active' : ''}`}
+                            onClick={() => navigateToOverflowDestination(destination)}
+                            aria-current={active ? 'page' : undefined}
+                          >
+                            <span className="item-icon">{destination.icon}</span> {SCREEN_LABELS[destination.screen]}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  );
+                })}
                 <div className="dropdown-divider" />
                 <div
                   className="dropdown-item"
@@ -140,7 +152,7 @@ export const Header: React.FC<HeaderProps> = ({
                   <span className="item-icon">ℹ️</span> Build {buildInfo.label}
                 </div>
                 <div className="dropdown-divider" />
-                <button className="dropdown-item logout" onClick={handleLogout} role="menuitem">
+                <button className="dropdown-item logout" onClick={handleLogout}>
                   <span className="item-icon">🚪</span> Sign Out
                 </button>
               </div>

--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useEffect } from 'react';
 import type { Screen } from '../types/navigation';
 import { SCREEN_LABELS } from '../types/navigation';
+import { DRAWER_GROUPS, type DrawerDestination } from './navigationGroups';
 import { getAuthInstance } from '../firebase';
 import { buildInfo } from '../buildInfo';
 import { GarminSyncBadge } from './GarminSyncBadge';
@@ -53,6 +54,19 @@ export const Header: React.FC<HeaderProps> = ({
 
   const buildTitle = `Git commit ${buildInfo.gitSha}${buildInfo.dirty ? ' (local working tree has uncommitted changes)' : ''}`;
 
+  // Daily-loop primaries own the desktop top level (#482), mirroring the
+  // mobile bottom bar. Every other destination lives in the More overflow
+  // under the same intent groups as the mobile drawer, so muscle memory
+  // transfers between form factors.
+  const moreMenuActive = screen !== 'home' && screen !== 'checkin' && screen !== 'plan';
+
+  const navigateToOverflowDestination = (destination: DrawerDestination) => {
+    if (destination.refreshDecisionInput) {
+      loadDecisionInput();
+    }
+    handleNavigate(destination.screen);
+  };
+
   return (
     <header className="global-navbar">
       <div className="navbar-container">
@@ -68,7 +82,7 @@ export const Header: React.FC<HeaderProps> = ({
           {userId && <GarminSyncBadge userId={userId} date={date} onSynced={loadDecisionInput} />}
         </div>
 
-        <nav className="navbar-desktop-menu">
+        <nav className="navbar-desktop-menu" aria-label="Primary">
           <button
             className={`nav-link ${screen === 'home' ? 'active' : ''}`}
             onClick={() => handleNavigate('home')}
@@ -82,77 +96,40 @@ export const Header: React.FC<HeaderProps> = ({
             {SCREEN_LABELS.checkin}
           </button>
           <button
-            className={`nav-link ${screen === 'sessions' ? 'active' : ''}`}
-            onClick={() => handleNavigate('sessions')}
+            className={`nav-link ${screen === 'plan' ? 'active' : ''}`}
+            onClick={() => handleNavigate('plan')}
           >
-            {SCREEN_LABELS.sessions}
-          </button>
-          <button
-            className={`nav-link ${screen === 'testing' ? 'active' : ''}`}
-            onClick={() => handleNavigate('testing')}
-          >
-            {SCREEN_LABELS.testing}
-          </button>
-          <button
-            className={`nav-link ${screen === 'goals' ? 'active' : ''}`}
-            onClick={() => handleNavigate('goals')}
-          >
-            {SCREEN_LABELS.goals}
-          </button>
-          <button
-            className={`nav-link ${screen === 'data' ? 'active' : ''}`}
-            onClick={() => {
-              loadDecisionInput();
-              handleNavigate('data');
-            }}
-          >
-            {SCREEN_LABELS.data}
+            {SCREEN_LABELS.plan}
           </button>
 
           <div className="more-menu-container" ref={desktopSettingsRef}>
             <button
-              className={`nav-link more-btn ${['constraints', 'preferences', 'plan', 'brief'].includes(screen) ? 'active' : ''}`}
+              className={`nav-link more-btn ${moreMenuActive ? 'active' : ''}`}
               onClick={() => setDesktopSettingsOpen((isOpen) => !isOpen)}
               aria-expanded={desktopSettingsOpen}
               aria-haspopup="menu"
             >
-              <span>Settings</span>
+              <span>More</span>
               <span className="caret">▾</span>
             </button>
 
             {desktopSettingsOpen && (
-              <div className="dropdown-menu" role="menu" aria-label="Settings">
-                <button
-                  className={`dropdown-item ${screen === 'plan' ? 'active' : ''}`}
-                  onClick={() => handleNavigate('plan')}
-                  role="menuitem"
-                >
-                  <span className="item-icon">📋</span> {SCREEN_LABELS.plan}
-                </button>
-                <button
-                  className={`dropdown-item ${screen === 'brief' ? 'active' : ''}`}
-                  onClick={() => {
-                    loadDecisionInput();
-                    handleNavigate('brief');
-                  }}
-                  role="menuitem"
-                >
-                  <span className="item-icon">📤</span> {SCREEN_LABELS.brief}
-                </button>
-                <button
-                  className={`dropdown-item ${screen === 'constraints' ? 'active' : ''}`}
-                  onClick={() => handleNavigate('constraints')}
-                  role="menuitem"
-                >
-                  <span className="item-icon">⚙️</span> {SCREEN_LABELS.constraints}
-                </button>
-                <button
-                  className={`dropdown-item ${screen === 'preferences' ? 'active' : ''}`}
-                  onClick={() => handleNavigate('preferences')}
-                  role="menuitem"
-                >
-                  <span className="item-icon">⚙️</span> {SCREEN_LABELS.preferences}
-                </button>
+              <div className="dropdown-menu" role="menu" aria-label="More">
+                {DRAWER_GROUPS.map((group) => (
+                  <div key={group.id} role="group" aria-label={group.title}>
+                    <div className="dropdown-group-title">{group.title}</div>
+                    {group.items.map((destination) => (
+                      <button
+                        key={destination.screen}
+                        className={`dropdown-item ${screen === destination.screen ? 'active' : ''}`}
+                        onClick={() => navigateToOverflowDestination(destination)}
+                        role="menuitem"
+                      >
+                        <span className="item-icon">{destination.icon}</span> {SCREEN_LABELS[destination.screen]}
+                      </button>
+                    ))}
+                  </div>
+                ))}
                 <div className="dropdown-divider" />
                 <div
                   className="dropdown-item"

--- a/app/src/components/MobileNav.tsx
+++ b/app/src/components/MobileNav.tsx
@@ -3,7 +3,12 @@ import type { Screen } from '../types/navigation';
 import { SCREEN_LABELS } from '../types/navigation';
 import { getAuthInstance } from '../firebase';
 import { buildInfo } from '../buildInfo';
-import { DRAWER_GROUPS, type DrawerDestination } from './navigationGroups';
+import {
+  DRAWER_GROUPS,
+  PRIMARY_NAV_ITEMS,
+  isPrimaryNavigationScreen,
+  type DrawerDestination,
+} from './navigationGroups';
 import './MobileNav.css';
 
 interface MobileNavProps {
@@ -13,16 +18,6 @@ interface MobileNavProps {
   mobileMoreOpen: boolean;
   setMobileMoreOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
-
-const MOBILE_MORE_SCREENS: readonly Screen[] = [
-  'goals',
-  'constraints',
-  'preferences',
-  'data',
-  'brief',
-  'sessions',
-  'testing',
-];
 
 export const MobileNav: React.FC<MobileNavProps> = ({ screen, handleNavigate, loadDecisionInput, mobileMoreOpen, setMobileMoreOpen }) => {
   const mobileMoreBtnRef = useRef<HTMLButtonElement>(null);
@@ -89,36 +84,24 @@ export const MobileNav: React.FC<MobileNavProps> = ({ screen, handleNavigate, lo
   return (
     <>
       <nav className="bottom-nav" aria-label="Primary">
-        <button
-          className={`nav-item ${screen === 'home' ? 'active' : ''}`}
-          onClick={() => handleNavigate('home')}
-          aria-current={screen === 'home' ? 'page' : undefined}
-        >
-          <span className="nav-icon">🏠</span>
-          <span className="nav-label">{SCREEN_LABELS.home}</span>
-        </button>
-
-        <button
-          className={`nav-item ${screen === 'checkin' ? 'active' : ''}`}
-          onClick={() => handleNavigate('checkin')}
-          aria-current={screen === 'checkin' ? 'page' : undefined}
-        >
-          <span className="nav-icon">✓</span>
-          <span className="nav-label">{SCREEN_LABELS.checkin}</span>
-        </button>
-
-        <button
-          className={`nav-item ${screen === 'plan' ? 'active' : ''}`}
-          onClick={() => handleNavigate('plan')}
-          aria-current={screen === 'plan' ? 'page' : undefined}
-        >
-          <span className="nav-icon">📋</span>
-          <span className="nav-label">{SCREEN_LABELS.plan}</span>
-        </button>
+        {PRIMARY_NAV_ITEMS.map((destination) => {
+          const active = screen === destination.screen;
+          return (
+            <button
+              key={destination.screen}
+              className={`nav-item ${active ? 'active' : ''}`}
+              onClick={() => handleNavigate(destination.screen)}
+              aria-current={active ? 'page' : undefined}
+            >
+              <span className="nav-icon">{destination.icon}</span>
+              <span className="nav-label">{SCREEN_LABELS[destination.screen]}</span>
+            </button>
+          );
+        })}
 
         <button
           ref={mobileMoreBtnRef}
-          className={`nav-item ${MOBILE_MORE_SCREENS.includes(screen) ? 'active' : ''}`}
+          className={`nav-item ${!isPrimaryNavigationScreen(screen) ? 'active' : ''}`}
           onClick={() => setMobileMoreOpen((isOpen) => !isOpen)}
           aria-expanded={mobileMoreOpen}
           aria-haspopup="dialog"

--- a/app/src/components/MobileNav.tsx
+++ b/app/src/components/MobileNav.tsx
@@ -3,6 +3,7 @@ import type { Screen } from '../types/navigation';
 import { SCREEN_LABELS } from '../types/navigation';
 import { getAuthInstance } from '../firebase';
 import { buildInfo } from '../buildInfo';
+import { DRAWER_GROUPS, type DrawerDestination } from './navigationGroups';
 import './MobileNav.css';
 
 interface MobileNavProps {
@@ -13,20 +14,6 @@ interface MobileNavProps {
   setMobileMoreOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-interface DrawerDestination {
-  screen: Screen;
-  icon: string;
-  description: string;
-  refreshDecisionInput?: boolean;
-}
-
-interface DrawerGroup {
-  id: string;
-  title: string;
-  description: string;
-  items: readonly DrawerDestination[];
-}
-
 const MOBILE_MORE_SCREENS: readonly Screen[] = [
   'goals',
   'constraints',
@@ -35,72 +22,6 @@ const MOBILE_MORE_SCREENS: readonly Screen[] = [
   'brief',
   'sessions',
   'testing',
-];
-
-const DRAWER_GROUPS: readonly DrawerGroup[] = [
-  {
-    id: 'train',
-    title: 'Train',
-    description: 'Sessions, assessments, and the week-ahead plan',
-    items: [
-      {
-        screen: 'sessions',
-        icon: '🚀',
-        description: 'Run a multidomain fixture and record native measures',
-      },
-      {
-        screen: 'testing',
-        icon: '🧪',
-        description: 'Run a locked assessment and record comparable raw outcomes',
-      },
-      {
-        screen: 'plan',
-        icon: '📋',
-        description: 'Compare the coach plan against the adaptive forecast',
-      },
-    ],
-  },
-  {
-    id: 'configure',
-    title: 'Configure',
-    description: 'Goals, setup, and coaching preferences',
-    items: [
-      {
-        screen: 'goals',
-        icon: '🎯',
-        description: 'Manage events and target milestones',
-      },
-      {
-        screen: 'constraints',
-        icon: '⚠️',
-        description: 'Manage physical cautions & equipment',
-      },
-      {
-        screen: 'preferences',
-        icon: '⚙️',
-        description: 'Configure modalities & strain caps',
-      },
-    ],
-  },
-  {
-    id: 'understand',
-    title: 'Understand',
-    description: 'Data review and AI context export',
-    items: [
-      {
-        screen: 'data',
-        icon: '📊',
-        description: 'View analytics and snapshot telemetry',
-        refreshDecisionInput: true,
-      },
-      {
-        screen: 'brief',
-        icon: '📤',
-        description: 'Compile recent metrics & prompt for your AI',
-        refreshDecisionInput: true,
-      },
-    ],
-  },
 ];
 
 export const MobileNav: React.FC<MobileNavProps> = ({ screen, handleNavigate, loadDecisionInput, mobileMoreOpen, setMobileMoreOpen }) => {

--- a/app/src/components/navigationGroups.ts
+++ b/app/src/components/navigationGroups.ts
@@ -1,0 +1,88 @@
+import type { Screen } from '../types/navigation';
+
+export interface DrawerDestination {
+  screen: Screen;
+  icon: string;
+  description: string;
+  refreshDecisionInput?: boolean;
+}
+
+export interface DrawerGroup {
+  id: string;
+  title: string;
+  description: string;
+  items: readonly DrawerDestination[];
+}
+
+/**
+ * Intent-grouped overflow destinations (#486), shared by the mobile
+ * `MobileNav` drawer and the desktop `Header` More menu (#482) so both
+ * shells demote the same destinations under the same group titles.
+ * Destination labels still render from `navigation.ts` `SCREEN_LABELS`;
+ * this model owns grouping and order only.
+ */
+export const DRAWER_GROUPS: readonly DrawerGroup[] = [
+  {
+    id: 'train',
+    title: 'Train',
+    description: 'Sessions, assessments, and the week-ahead plan',
+    items: [
+      {
+        screen: 'sessions',
+        icon: '🚀',
+        description: 'Run a multidomain fixture and record native measures',
+      },
+      {
+        screen: 'testing',
+        icon: '🧪',
+        description: 'Run a locked assessment and record comparable raw outcomes',
+      },
+      {
+        screen: 'plan',
+        icon: '📋',
+        description: 'Compare the coach plan against the adaptive forecast',
+      },
+    ],
+  },
+  {
+    id: 'configure',
+    title: 'Configure',
+    description: 'Goals, setup, and coaching preferences',
+    items: [
+      {
+        screen: 'goals',
+        icon: '🎯',
+        description: 'Manage events and target milestones',
+      },
+      {
+        screen: 'constraints',
+        icon: '⚠️',
+        description: 'Manage physical cautions & equipment',
+      },
+      {
+        screen: 'preferences',
+        icon: '⚙️',
+        description: 'Configure modalities & strain caps',
+      },
+    ],
+  },
+  {
+    id: 'understand',
+    title: 'Understand',
+    description: 'Data review and AI context export',
+    items: [
+      {
+        screen: 'data',
+        icon: '📊',
+        description: 'View analytics and snapshot telemetry',
+        refreshDecisionInput: true,
+      },
+      {
+        screen: 'brief',
+        icon: '📤',
+        description: 'Compile recent metrics & prompt for your AI',
+        refreshDecisionInput: true,
+      },
+    ],
+  },
+];

--- a/app/src/components/navigationGroups.ts
+++ b/app/src/components/navigationGroups.ts
@@ -1,5 +1,25 @@
 import type { Screen } from '../types/navigation';
 
+export interface PrimaryNavigationDestination {
+  screen: Screen;
+  icon: string;
+}
+
+/**
+ * The daily-loop destinations promoted at the top level on every shell (#482).
+ * Both Header and MobileNav render from this list so the primary set and order
+ * cannot drift between desktop and mobile.
+ */
+export const PRIMARY_NAV_ITEMS: readonly PrimaryNavigationDestination[] = [
+  { screen: 'home', icon: '🏠' },
+  { screen: 'checkin', icon: '✓' },
+  { screen: 'plan', icon: '📋' },
+];
+
+export function isPrimaryNavigationScreen(screen: Screen): boolean {
+  return PRIMARY_NAV_ITEMS.some((destination) => destination.screen === screen);
+}
+
 export interface DrawerDestination {
   screen: Screen;
   icon: string;
@@ -16,10 +36,10 @@ export interface DrawerGroup {
 
 /**
  * Intent-grouped overflow destinations (#486), shared by the mobile
- * `MobileNav` drawer and the desktop `Header` More menu (#482) so both
+ * `MobileNav` drawer and the desktop `Header` More disclosure (#482) so both
  * shells demote the same destinations under the same group titles.
  * Destination labels still render from `navigation.ts` `SCREEN_LABELS`;
- * this model owns grouping and order only.
+ * this model owns overflow grouping and order.
  */
 export const DRAWER_GROUPS: readonly DrawerGroup[] = [
   {

--- a/app/tests/visual/capture.pw.ts
+++ b/app/tests/visual/capture.pw.ts
@@ -117,9 +117,11 @@ test('captures navigation interaction states', async ({ page }) => {
     await expect(page.getByRole('dialog', { name: 'Navigation & Settings' })).toBeVisible();
     await capture(page, scenario, 'more-drawer-open', ['The mobile drawer is distinct from the page beneath it and presents secondary destinations clearly.']);
   } else {
-    await page.getByRole('button', { name: 'More' }).click();
-    await expect(page.getByRole('menu', { name: 'More' })).toBeVisible();
-    await capture(page, scenario, 'more-menu-open', ['Desktop More opens an anchored menu without activating the mobile drawer.']);
+    const moreButton = page.getByRole('button', { name: 'More' });
+    await moreButton.click();
+    await expect(moreButton).toHaveAttribute('aria-expanded', 'true');
+    await expect(page.locator('#desktop-more-panel')).toBeVisible();
+    await capture(page, scenario, 'more-panel-open', ['Desktop More opens an anchored disclosure without activating the mobile drawer.']);
   }
 });
 

--- a/app/tests/visual/capture.pw.ts
+++ b/app/tests/visual/capture.pw.ts
@@ -117,9 +117,9 @@ test('captures navigation interaction states', async ({ page }) => {
     await expect(page.getByRole('dialog', { name: 'Navigation & Settings' })).toBeVisible();
     await capture(page, scenario, 'more-drawer-open', ['The mobile drawer is distinct from the page beneath it and presents secondary destinations clearly.']);
   } else {
-    await page.getByRole('button', { name: 'Settings' }).click();
-    await expect(page.getByRole('menu', { name: 'Settings' })).toBeVisible();
-    await capture(page, scenario, 'settings-menu-open', ['Desktop Settings opens an anchored menu without activating the mobile drawer.']);
+    await page.getByRole('button', { name: 'More' }).click();
+    await expect(page.getByRole('menu', { name: 'More' })).toBeVisible();
+    await capture(page, scenario, 'more-menu-open', ['Desktop More opens an anchored menu without activating the mobile drawer.']);
   }
 });
 

--- a/docs/architecture/user-flows.md
+++ b/docs/architecture/user-flows.md
@@ -125,35 +125,43 @@ There are no dedicated `login` or `onboarding` routes; both are conditional rend
 
 ## Navigation chrome
 
-Desktop and mobile expose all ten `Screen` values, but with different prominence.
+Desktop and mobile share the same top-level destinations (#482): the daily-loop
+primaries `home`, `checkin`, and `plan`, plus a `More` overflow. Every `Screen`
+remains reachable on both form factors; only prominence differs by placement.
 
 | Screen | Desktop `Header` | Mobile `MobileNav` |
 |---|---|---|
 | `home` | `Home` plus brand → Home | Bottom `Home` |
 | `checkin` | `Check-in` | Bottom `Check-in` |
-| `plan` | Settings → `Plan` | Bottom `Plan`, also listed under More → Train |
-| `sessions` | `Sessions` | More → `Sessions` |
-| `testing` | `Testing` | More → `Testing` |
-| `goals` | `Goals` | More → `Goals` |
-| `data` | `Data` (refreshes decision input first) | More → `Data` (refreshes first) |
-| `brief` | Settings → `Export Context for AI` | More → `Export Context for AI` |
-| `constraints` | Settings → `Training Setup` | More → `Training Setup` |
-| `preferences` | Settings → `Coach Preferences` | More → `Coach Preferences` |
+| `plan` | `Plan` | Bottom `Plan`, also listed under More → Train |
+| `sessions` | More → `Sessions` | More → `Sessions` |
+| `testing` | More → `Testing` | More → `Testing` |
+| `goals` | More → `Goals` | More → `Goals` |
+| `data` | More → `Data` (refreshes decision input first) | More → `Data` (refreshes first) |
+| `brief` | More → `Export Context for AI` (refreshes first) | More → `Export Context for AI` (refreshes first) |
+| `constraints` | More → `Training Setup` | More → `Training Setup` |
+| `preferences` | More → `Coach Preferences` | More → `Coach Preferences` |
 
 Every label above renders from `navigation.ts` `SCREEN_LABELS`, the single source of
 truth shared by `Header`, `MobileNav`, and each screen's heading (#485).
 
 Current chrome details worth preserving when changing navigation:
 
-* The mobile More drawer groups its destinations by intent — Train (`Sessions`,
-  `Testing`, `Plan`), Configure (`Goals`, `Training Setup`, `Coach Preferences`),
-  Understand (`Data`, `Export Context for AI`). Each group is a programmatically labelled
-  `role="group"` with short descriptive sub-copy whose typography matches the existing
-  drawer `item-sub` pattern; destination labels still render from `navigation.ts`
-  `SCREEN_LABELS`.
+* Both shells demote the same seven destinations into the same intent groups —
+  Train (`Sessions`, `Testing`, plus `Plan` for group completeness), Configure
+  (`Goals`, `Training Setup`, `Coach Preferences`), Understand (`Data`,
+  `Export Context for AI`). The grouping model is `navigationGroups.ts`
+  `DRAWER_GROUPS`, shared by `Header` and `MobileNav`, so group titles and order cannot drift
+  between shells; destination labels still render from `navigation.ts`
+  `SCREEN_LABELS`. The mobile drawer shows short descriptive sub-copy per
+  destination; the desktop More menu omits it for compactness. `Plan` stays
+  listed under Train in the overflow on both shells so the Train group reads
+  complete; the primary tab owns the active affordance on `plan`.
 * Desktop active-state rule (`Header`): top-level links are active on their exact
-  `Screen`; the Settings button is active for `constraints`, `preferences`, `plan`, and
-  `brief`; each Settings dropdown item is active on its exact `Screen`.
+  `Screen`; the More button is active for every overflow destination
+  (`sessions`, `testing`, `goals`, `constraints`, `preferences`, `data`,
+  `brief`) but not on `home`, `checkin`, or `plan`; each More menu item is
+  active on its exact `Screen`.
 * Mobile active-state rule (`MobileNav`): bottom tabs are active on their exact
   `Screen` (`home`, `checkin`, `plan`); the More tab is active for every other drawer
   destination (`goals`, `constraints`, `preferences`, `data`, `brief`, `sessions`,
@@ -419,6 +427,9 @@ living-reference section when implementing them.
 3. ~~Group Mobile More by intent (train / configure / understand) rather than one flat list.~~
    Done (#486): Train, Configure, and Understand are labelled drawer groups with short
    descriptions and per-destination visible/current state.
+   Done (#482): the same three groups are now the shared cross-shell overflow model —
+   `navigationGroups.ts` `DRAWER_GROUPS` renders in the mobile drawer and the desktop `Header`
+    More menu, so both shells demote the same destinations under the same titles.
 
 ### Daily loop and repair
 


### PR DESCRIPTION
## Summary
- Desktop and mobile now share the same daily-loop primaries — `Home`, `Check-in`, `Plan` — from `navigationGroups.ts` `PRIMARY_NAV_ITEMS`, so both the set **and order** are encoded once instead of duplicated across `Header` and `MobileNav`.
- Sessions, Testing, Goals, Data, Export Context for AI, Training Setup, and Coach Preferences remain in the shared `DRAWER_GROUPS` Train / Configure / Understand overflow model. `Plan` is intentionally also listed under Train for group completeness, matching the mobile behavior from #486.
- Desktop `More` is implemented as a navigation **disclosure**, not an ARIA `menu` widget: the trigger exposes `aria-expanded` / `aria-controls`, destinations remain ordinary buttons in the normal Tab order, current destinations expose `aria-current="page"`, and Escape closes the disclosure and restores focus to `More`. This follows the W3C APG disclosure-navigation guidance and avoids advertising menu/menuitem keyboard semantics that the component does not implement.
- `docs/architecture/user-flows.md` documents the converged chrome, shared overflow groups, active-state behavior, and the deliberate compact desktop presentation. No additional architecture-doc change was needed for the follow-up accessibility fix because the doc describes the user-facing More overflow rather than asserting an ARIA menu role.
- Closes #482. Builds on #485 (canonical labels) and merged #486 / PR #511 (mobile intent groups) without undoing either.

## Review fixes added
- Centralized Home / Check-in / Plan in `PRIMARY_NAV_ITEMS`; removed the separate mobile `MOBILE_MORE_SCREENS` list and the desktop hard-coded primary set.
- Added desktop `aria-current="page"` coverage and exact current-state regression tests.
- Replaced incomplete `role="menu"` / `role="menuitem"` semantics with the disclosure pattern appropriate for ordinary site navigation.
- Restored focus to the desktop More trigger when Escape closes the disclosure.
- Updated the Playwright navigation-interaction assertion to verify the disclosure trigger/panel rather than a `menu` role.
- Normalized `MobileNav.tsx` line endings while touching the shared navigation model.

## Validation
- [x] **Final GitHub Actions CI Pipeline #2923** on reviewed head `dd35f688e02d3630678b33a0950f676e8611036e`: **success**.
  - Frontend Hygiene & Static Gates: dependency audit, TypeScript, ESLint, sports-knowledge validation, knowledge-coverage validation, workout validation, policy-version drift, production bundle — pass.
  - Frontend Unit Tests & Firestore Rules: coverage suite + Firestore emulator rules suite — pass.
  - Engine Simulations & AI Gates — pass.
  - Python 3.14 test/lint/type/coverage/audit path — pass.
  - Docker build / Compose / routing-and-header smoke — pass.
- [x] Original implementation validation before the review fix: `npm run check` in `app/` passed (tsc, eslint, 4340 Vitest tests at that head, knowledge + coverage + workout validators); pre-commit hooks passed.
- [x] Original visual evidence covered desktop 1440px and mobile-narrow 360px across the committed visual scenarios, plus explicit open-overflow captures confirming the converged primaries and shared groups.
- [x] Full `visual:refresh` still has the previously documented harness/environment failures (`home-*` stuck at `Loading dashboard...` and the Plan AI-forecast assertion); both were reproduced on clean `origin/main`, so they are not introduced by this PR. The committed nav-interaction harness is updated for the final disclosure semantics.
- [x] While this review was finishing, #513 advanced `main` to `c9b78c1f`. #514 then merged successfully on top of that base as **`e0b6a6511eb7dd8b93174c3eaa8e427398d4f162`**. Post-merge verification confirms `user-flows.md` contains both this PR's converged navigation documentation and #513's delivered #494 follow-up/assessment-abandonment documentation.

## Review / comments
- No human review submissions or inline review threads were present during this pass, so there was nothing to reply to or resolve.
- A manual `@coderabbitai review` was requested after the final fix. CodeRabbit selected the complete 7-file diff but reported its review quota is currently rate-limited, so it produced no actionable review threads.

## Risk and reviewer guidance
- `navigationGroups.ts` `PRIMARY_NAV_ITEMS` is the cross-shell primary authority; `DRAWER_GROUPS` remains the cross-shell overflow authority.
- In `Header.tsx`, `More` is active for non-primary screens and inactive on Home / Check-in / Plan. `Plan` can still be current both in the primary set and inside the Train group when the disclosure is open, intentionally matching mobile.
- `capture.pw.ts` now clicks `More`, asserts `aria-expanded="true"`, and checks `#desktop-more-panel`; its first visual scenario has the same pre-existing `Loading dashboard...` limitation noted above.
- Rollback after merge is code-only: revert merged commit `e0b6a6511`. No migration or deployment step is involved.

## Domain invariants
- Firestore writes remain user-scoped — no Firestore path or persistence code changed.
- Calendar-date logic remains `Europe/Warsaw`; `totalSteps` remains `D - 1` — no date/step logic changed.
- No credentials, tokens, service-account files, or raw health payloads are included.
- Decision logic changed: **NO** — navigation chrome only, so no `POLICY_VERSION` bump and no `recommendation-engine.md` change.

## Screenshots / visual artifacts
Visual artifacts are intentionally gitignored by repository design. The original implementation captured desktop + mobile-narrow navigation states locally; the committed Playwright harness reflects the final desktop disclosure semantics.