### PR TITLE
fix(ui): give every audited terminal state a forward action (#493)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -349,6 +349,7 @@ function App() {
                 decisionInput={decisionInput}
                 userId={userId!}
                 onBack={() => handleNavigate('home')}
+                onRetry={() => { void loadDecisionInput(); }}
                 onNavigateToBrief={() => handleNavigate('brief')}
               />
               {decisionInput && (
@@ -371,6 +372,7 @@ function App() {
               userId={userId!}
               initialTab="brief"
               onBack={() => handleNavigate('home')}
+              onRetry={() => { void loadDecisionInput(); }}
             />
           )}
 

--- a/app/src/components/DataView.test.tsx
+++ b/app/src/components/DataView.test.tsx
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { DataView } from './DataView';
+
+describe('DataView null-input empty state', () => {
+  it('offers retry and a way home instead of a dead-end banner (#493)', () => {
+    const html = renderToStaticMarkup(
+      <DataView decisionInput={null} userId="athlete-1" onBack={() => {}} onRetry={() => {}} />,
+    );
+
+    expect(html).toContain('No data available');
+    expect(html).toContain('Retry');
+    expect(html).toContain('Back to Home');
+  });
+
+  it('still offers a way home when no retry handler is injected (#493)', () => {
+    const html = renderToStaticMarkup(
+      <DataView decisionInput={null} userId="athlete-1" onBack={() => {}} />,
+    );
+
+    expect(html).toContain('No data available');
+    expect(html).toContain('Back to Home');
+    // No retry button without an injected handler (the guidance copy may still
+    // name the dashboard refresh as the recourse).
+    expect(html).not.toContain('>Retry<');
+  });
+});

--- a/app/src/components/DataView.tsx
+++ b/app/src/components/DataView.tsx
@@ -26,6 +26,10 @@ interface DataViewProps {
   decisionInput: DailyDecisionInput | null;
   userId: string;
   onBack: () => void;
+  /** Retry recomposing the daily decision input (App `loadDecisionInput`). Rendered as
+   * the forward action on the null-input empty state (#493); absent only in harnesses
+   * that render DataView without the App shell. */
+  onRetry?: () => void;
   initialTab?: DataViewTab;
   /** When provided, Context-brief and AI-export affordances deep-link to the canonical
    * `brief` screen. The canonical `brief` screen omits this prop so it renders the full
@@ -91,7 +95,7 @@ function formatCandidateBaseline(
   return `7d med ${formatCandidateNumber(median7d)} · 28d med ${formatCandidateNumber(median28d)} · MAD ${formatCandidateNumber(mad28d)} · Δ7 ${formatCandidateDelta(delta7d)} · Δ28 ${formatCandidateDelta(delta28d)}`;
 }
 
-export function DataView({ decisionInput, userId, initialTab = 'recovery', onNavigateToBrief }: DataViewProps) {
+export function DataView({ decisionInput, userId, initialTab = 'recovery', onNavigateToBrief, onRetry, onBack }: DataViewProps) {
   const [activeTab, setActiveTab] = useState<DataViewTab>(initialTab);
   const [brief, setBrief] = useState<ContextBriefResult | null>(null);
   // Tagged with the date it belongs to, so a failure for one date is not rendered
@@ -254,6 +258,17 @@ export function DataView({ decisionInput, userId, initialTab = 'recovery', onNav
         </div>
         <div className="no-data">
           <p>No data available</p>
+          <p className="data-state-notice">Today&apos;s decision input could not be composed. Retry the dashboard refresh, or return Home.</p>
+          <div className="brief-actions">
+            {onRetry && (
+              <button type="button" className="brief-copy" onClick={onRetry}>
+                Retry
+              </button>
+            )}
+            <button type="button" className="brief-copy" onClick={onBack}>
+              Back to Home
+            </button>
+          </div>
         </div>
       </div>
     );

--- a/app/src/components/OnboardingWizard.test.tsx
+++ b/app/src/components/OnboardingWizard.test.tsx
@@ -54,8 +54,9 @@ describe('OnboardingWizard', () => {
     const goalWrite = vi.spyOn(goalService, 'createGoal');
     const onCompleted = vi.fn();
 
-    skipOnboardingForNow('athlete-1', 'focus', 1500, onCompleted);
+    const persisted = skipOnboardingForNow('athlete-1', 'focus', 1500, onCompleted);
 
+    expect(persisted).toBe(true);
     expect(settingsWrite).not.toHaveBeenCalled();
     expect(intentWrite).not.toHaveBeenCalled();
     expect(goalList).not.toHaveBeenCalled();
@@ -66,6 +67,25 @@ describe('OnboardingWizard', () => {
     const report = usabilityMetrics.generateSummaryReport();
     expect(report.wizardSkips).toBe(1);
     expect(report.wizardSkipsByStage).toEqual({ focus: 1 });
+  });
+
+  it('reports a blocked dismissal so the wizard can show storage-blocked guidance (#493)', () => {
+    vi.stubGlobal('window', {
+      localStorage: {
+        getItem: () => null,
+        setItem: () => { throw new Error('blocked'); },
+        removeItem: () => {},
+      },
+    });
+    const onCompleted = vi.fn();
+
+    const persisted = skipOnboardingForNow('athlete-1', 'welcome', 500, onCompleted);
+
+    expect(persisted).toBe(false);
+    // Telemetry still records the skip; the caller decides whether to dismiss.
+    expect(onCompleted).toHaveBeenCalledTimes(1);
+    const report = usabilityMetrics.generateSummaryReport();
+    expect(report.wizardSkips).toBe(1);
   });
 });
 

--- a/app/src/components/OnboardingWizard.test.tsx
+++ b/app/src/components/OnboardingWizard.test.tsx
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { ExerciseDaysSlider, OnboardingWizard } from './OnboardingWizard';
-import { skipOnboardingForNow } from './onboarding/skipOnboarding';
+import { continueOnboardingSkipForSessionOnly, skipOnboardingForNow } from './onboarding/skipOnboarding';
 import { weeklyCommitmentFromExerciseDays } from './onboarding/weeklyCommitment';
 import { goalService } from '../services/goalService';
 import { trainingSettingsService } from '../services/trainingSettingsService';
@@ -69,7 +69,7 @@ describe('OnboardingWizard', () => {
     expect(report.wizardSkipsByStage).toEqual({ focus: 1 });
   });
 
-  it('reports a blocked dismissal so the wizard can show storage-blocked guidance (#493)', () => {
+  it('does not complete or record a blocked Skip until session-only continuation is explicit (#493)', () => {
     vi.stubGlobal('window', {
       localStorage: {
         getItem: () => null,
@@ -82,10 +82,15 @@ describe('OnboardingWizard', () => {
     const persisted = skipOnboardingForNow('athlete-1', 'welcome', 500, onCompleted);
 
     expect(persisted).toBe(false);
-    // Telemetry still records the skip; the caller decides whether to dismiss.
+    expect(onCompleted).not.toHaveBeenCalled();
+    expect(usabilityMetrics.generateSummaryReport().wizardSkips).toBe(0);
+
+    continueOnboardingSkipForSessionOnly('athlete-1', 'welcome', 750, onCompleted);
+
     expect(onCompleted).toHaveBeenCalledTimes(1);
     const report = usabilityMetrics.generateSummaryReport();
     expect(report.wizardSkips).toBe(1);
+    expect(report.wizardSkipsByStage).toEqual({ welcome: 1 });
   });
 });
 

--- a/app/src/components/OnboardingWizard.tsx
+++ b/app/src/components/OnboardingWizard.tsx
@@ -65,6 +65,10 @@ export const OnboardingWizard = memo(function OnboardingWizard({ userId, onCompl
     const [sportAccess, setSportAccess] = useState({ outdoor_bike: false, swim_access: false });
     const [saving, setSaving] = useState(false);
     const [saveError, setSaveError] = useState<string | null>(null);
+    // #493: storage-blocked Skip guidance. skipOnboardingForNow reports whether the
+    // dismissal persisted; a blocked write is session-only and the wizard may
+    // resurface on refresh, so say so with recourse instead of failing silently.
+    const [skipStorageBlocked, setSkipStorageBlocked] = useState(false);
     // Mount time anchors the wizard-completion telemetry, mirroring the
     // first-view TTR clock in `usabilityMetrics`.
     const [wizardStartMs] = useState(() => (typeof performance !== 'undefined' ? performance.now() : 0));
@@ -83,9 +87,20 @@ export const OnboardingWizard = memo(function OnboardingWizard({ userId, onCompl
     const handleSkip = () => {
         if (saving) return;
         // Skip persists dismissal only: no goal is created and training
-        // settings are left untouched. When browser storage is blocked the
-        // dismissal is session-only and the wizard may resurface on refresh.
-        skipOnboardingForNow(userId, currentWizardStage, wizardElapsedMs(), onCompleted);
+        // settings are left untouched. Defer `onCompleted` until persistence is
+        // confirmed: when browser storage is blocked the dismissal would be
+        // session-only and the wizard would resurface on refresh, so keep the
+        // wizard open with guidance instead of failing silently.
+        const persisted = skipOnboardingForNow(userId, currentWizardStage, wizardElapsedMs(), () => {});
+        if (persisted) {
+            onCompleted();
+        } else {
+            setSkipStorageBlocked(true);
+        }
+    };
+
+    const handleContinueSessionOnly = () => {
+        onCompleted();
     };
 
     const handleFinish = async () => {
@@ -170,6 +185,19 @@ export const OnboardingWizard = memo(function OnboardingWizard({ userId, onCompl
     return (
         <main className="onboarding-modal-backdrop" role="main" aria-label="Rapid Onboarding Setup">
             <div className="onboarding-card">
+                {skipStorageBlocked && (
+                    <p className="form-error-msg" role="alert">
+                        Skip could not be saved — browser storage is blocked, so setup would
+                        reappear on refresh. Enable storage and skip again to dismiss
+                        permanently, or continue for this session only and re-run setup later
+                        from Coach Preferences.
+                        <span className="onboarding-action-row">
+                            <button type="button" className="btn-primary" onClick={handleContinueSessionOnly}>
+                                Continue for this session
+                            </button>
+                        </span>
+                    </p>
+                )}
                 {step === 1 && (
                     <div className="onboarding-step step-1">
                         <span className="onboarding-kicker">Welcome to Adaptive Training</span>

--- a/app/src/components/OnboardingWizard.tsx
+++ b/app/src/components/OnboardingWizard.tsx
@@ -4,7 +4,7 @@ import { trainingSettingsService } from '../services/trainingSettingsService';
 import { trainingIntentProfileService } from '../services/trainingIntentProfileService';
 import { usabilityMetrics, type OnboardingWizardStage } from '../utils/usabilityMetrics';
 import { getLocalDateString } from '../utils/localDate';
-import { skipOnboardingForNow } from './onboarding/skipOnboarding';
+import { continueOnboardingSkipForSessionOnly, skipOnboardingForNow } from './onboarding/skipOnboarding';
 import { weeklyCommitmentFromExerciseDays } from './onboarding/weeklyCommitment';
 import './OnboardingWizard.css';
 
@@ -65,10 +65,10 @@ export const OnboardingWizard = memo(function OnboardingWizard({ userId, onCompl
     const [sportAccess, setSportAccess] = useState({ outdoor_bike: false, swim_access: false });
     const [saving, setSaving] = useState(false);
     const [saveError, setSaveError] = useState<string | null>(null);
-    // #493: storage-blocked Skip guidance. skipOnboardingForNow reports whether the
-    // dismissal persisted; a blocked write is session-only and the wizard may
-    // resurface on refresh, so say so with recourse instead of failing silently.
-    const [skipStorageBlocked, setSkipStorageBlocked] = useState(false);
+    // #493: retain the stage where a durable Skip was attempted. If storage is blocked,
+    // completion telemetry must wait until the athlete either retries a durable Skip or
+    // explicitly chooses the session-only continuation.
+    const [blockedSkipStage, setBlockedSkipStage] = useState<OnboardingWizardStage | null>(null);
     // Mount time anchors the wizard-completion telemetry, mirroring the
     // first-view TTR clock in `usabilityMetrics`.
     const [wizardStartMs] = useState(() => (typeof performance !== 'undefined' ? performance.now() : 0));
@@ -86,21 +86,26 @@ export const OnboardingWizard = memo(function OnboardingWizard({ userId, onCompl
 
     const handleSkip = () => {
         if (saving) return;
-        // Skip persists dismissal only: no goal is created and training
-        // settings are left untouched. Defer `onCompleted` until persistence is
-        // confirmed: when browser storage is blocked the dismissal would be
-        // session-only and the wizard would resurface on refresh, so keep the
-        // wizard open with guidance instead of failing silently.
-        const persisted = skipOnboardingForNow(userId, currentWizardStage, wizardElapsedMs(), () => {});
-        if (persisted) {
-            onCompleted();
-        } else {
-            setSkipStorageBlocked(true);
-        }
+        // Skip persists dismissal only: no goal is created and training settings are left
+        // untouched. If browser storage rejects the dismissal, keep the wizard open and do
+        // not record a completed skip until the athlete explicitly chooses how to proceed.
+        const persisted = skipOnboardingForNow(
+            userId,
+            currentWizardStage,
+            wizardElapsedMs(),
+            onCompleted,
+        );
+        if (!persisted) setBlockedSkipStage(currentWizardStage);
     };
 
     const handleContinueSessionOnly = () => {
-        onCompleted();
+        if (!blockedSkipStage) return;
+        continueOnboardingSkipForSessionOnly(
+            userId,
+            blockedSkipStage,
+            wizardElapsedMs(),
+            onCompleted,
+        );
     };
 
     const handleFinish = async () => {
@@ -185,18 +190,20 @@ export const OnboardingWizard = memo(function OnboardingWizard({ userId, onCompl
     return (
         <main className="onboarding-modal-backdrop" role="main" aria-label="Rapid Onboarding Setup">
             <div className="onboarding-card">
-                {skipStorageBlocked && (
-                    <p className="form-error-msg" role="alert">
-                        Skip could not be saved — browser storage is blocked, so setup would
-                        reappear on refresh. Enable storage and skip again to dismiss
-                        permanently, or continue for this session only and re-run setup later
-                        from Coach Preferences.
-                        <span className="onboarding-action-row">
+                {blockedSkipStage && (
+                    <>
+                        <p className="form-error-msg" role="alert">
+                            Skip could not be saved — browser storage is blocked, so setup would
+                            reappear on refresh. Enable storage and skip again to dismiss
+                            permanently, or continue for this session only and re-run setup later
+                            from Coach Preferences.
+                        </p>
+                        <div className="onboarding-action-row">
                             <button type="button" className="btn-primary" onClick={handleContinueSessionOnly}>
                                 Continue for this session
                             </button>
-                        </span>
-                    </p>
+                        </div>
+                    </>
                 )}
                 {step === 1 && (
                     <div className="onboarding-step step-1">

--- a/app/src/components/onboarding/skipOnboarding.ts
+++ b/app/src/components/onboarding/skipOnboarding.ts
@@ -2,12 +2,20 @@ import { dismissOnboardingForUser } from '../../utils/onboardingStorage';
 import { getLocalDateString } from '../../utils/localDate';
 import { usabilityMetrics, type OnboardingWizardStage } from '../../utils/usabilityMetrics';
 
+function recordOnboardingSkip(
+  userId: string,
+  stage: OnboardingWizardStage,
+  elapsedMs: number | undefined,
+): void {
+  usabilityMetrics.recordWizardCompleted(userId, getLocalDateString(), 'skipped', elapsedMs, stage);
+}
+
 /**
  * Explicit dismissal action kept separate from the Firestore-writing completion path.
  * This narrow seam is intentionally testable so Skip cannot regress into a partial setup
- * write when onboarding evolves. Returns whether the dismissal persisted: false means
- * browser storage is blocked, the dismissal is session-only, and the wizard may
- * resurface on refresh (#493).
+ * write when onboarding evolves. Returns whether the dismissal persisted. A false result
+ * means browser storage is blocked, so neither completion telemetry nor `onCompleted` fires:
+ * the wizard is still open and the athlete has not completed the skip yet (#493).
  */
 export function skipOnboardingForNow(
   userId: string,
@@ -16,7 +24,24 @@ export function skipOnboardingForNow(
   onCompleted: () => void,
 ): boolean {
   const persisted = dismissOnboardingForUser(userId);
-  usabilityMetrics.recordWizardCompleted(userId, getLocalDateString(), 'skipped', elapsedMs, stage);
+  if (!persisted) return false;
+
+  recordOnboardingSkip(userId, stage, elapsedMs);
   onCompleted();
-  return persisted;
+  return true;
+}
+
+/**
+ * Explicitly accepts a session-only dismissal after durable browser storage was unavailable.
+ * The skip is now complete from the athlete's perspective, so record it once and dismiss the
+ * wizard without pretending that a durable dismissal key was written.
+ */
+export function continueOnboardingSkipForSessionOnly(
+  userId: string,
+  stage: OnboardingWizardStage,
+  elapsedMs: number | undefined,
+  onCompleted: () => void,
+): void {
+  recordOnboardingSkip(userId, stage, elapsedMs);
+  onCompleted();
 }

--- a/app/src/components/onboarding/skipOnboarding.ts
+++ b/app/src/components/onboarding/skipOnboarding.ts
@@ -5,15 +5,18 @@ import { usabilityMetrics, type OnboardingWizardStage } from '../../utils/usabil
 /**
  * Explicit dismissal action kept separate from the Firestore-writing completion path.
  * This narrow seam is intentionally testable so Skip cannot regress into a partial setup
- * write when onboarding evolves.
+ * write when onboarding evolves. Returns whether the dismissal persisted: false means
+ * browser storage is blocked, the dismissal is session-only, and the wizard may
+ * resurface on refresh (#493).
  */
 export function skipOnboardingForNow(
   userId: string,
   stage: OnboardingWizardStage,
   elapsedMs: number | undefined,
   onCompleted: () => void,
-): void {
-  dismissOnboardingForUser(userId);
+): boolean {
+  const persisted = dismissOnboardingForUser(userId);
   usabilityMetrics.recordWizardCompleted(userId, getLocalDateString(), 'skipped', elapsedMs, stage);
   onCompleted();
+  return persisted;
 }

--- a/app/src/components/session/SessionRunner.test.tsx
+++ b/app/src/components/session/SessionRunner.test.tsx
@@ -170,7 +170,7 @@ describe('SessionRunner session picker', () => {
         expect(html).not.toContain('Locked assessment');
     });
 
-    it('offers a forward action when the stored prescription cannot be restored (#493)', () => {
+    it('offers a Home recovery action when the stored prescription cannot be restored (#493)', () => {
         vi.mocked(useSessionRunner).mockReturnValueOnce({
             activeStep: null,
             activeBlock: null,
@@ -184,10 +184,12 @@ describe('SessionRunner session picker', () => {
         const html = renderToStaticMarkup(<SessionRunner userId="user-1" onClose={() => {}} />);
 
         expect(html).toContain('Active session needs its stored prescription');
-        expect(html).toContain('Back to');
+        expect(html).toContain('Back to Home');
+        expect(html).toContain('Return Home, then reopen the session that started it');
+        expect(html).not.toContain('Back to Sessions');
     });
 
-    it('leaves the prescription-missing state without a dead end even when no close handler is injected (#493)', () => {
+    it('keeps explicit recovery guidance in isolated harnesses without a close handler (#493)', () => {
         vi.mocked(useSessionRunner).mockReturnValueOnce({
             activeStep: null,
             activeBlock: null,
@@ -201,9 +203,7 @@ describe('SessionRunner session picker', () => {
         const html = renderToStaticMarkup(<SessionRunner userId="user-1" />);
 
         expect(html).toContain('Active session needs its stored prescription');
-        // No onClose: the copy still names the recovery path (return via the
-        // session that started it) instead of stranding the athlete silently.
-        expect(html).toContain('Return from the session that started it');
+        expect(html).toContain('Return Home, then reopen the session that started it');
     });
 });
 

--- a/app/src/components/session/SessionRunner.test.tsx
+++ b/app/src/components/session/SessionRunner.test.tsx
@@ -169,6 +169,42 @@ describe('SessionRunner session picker', () => {
         expect(html).not.toContain('runner-mode-assessment');
         expect(html).not.toContain('Locked assessment');
     });
+
+    it('offers a forward action when the stored prescription cannot be restored (#493)', () => {
+        vi.mocked(useSessionRunner).mockReturnValueOnce({
+            activeStep: null,
+            activeBlock: null,
+            activeBlockIndex: 0,
+            activeStepIndex: 0,
+            definition: null,
+            entries: [],
+            execution: { state: 'in_progress' },
+            isRestoring: false,
+        } as unknown as ReturnType<typeof useSessionRunner>);
+        const html = renderToStaticMarkup(<SessionRunner userId="user-1" onClose={() => {}} />);
+
+        expect(html).toContain('Active session needs its stored prescription');
+        expect(html).toContain('Back to');
+    });
+
+    it('leaves the prescription-missing state without a dead end even when no close handler is injected (#493)', () => {
+        vi.mocked(useSessionRunner).mockReturnValueOnce({
+            activeStep: null,
+            activeBlock: null,
+            activeBlockIndex: 0,
+            activeStepIndex: 0,
+            definition: null,
+            entries: [],
+            execution: { state: 'in_progress' },
+            isRestoring: false,
+        } as unknown as ReturnType<typeof useSessionRunner>);
+        const html = renderToStaticMarkup(<SessionRunner userId="user-1" />);
+
+        expect(html).toContain('Active session needs its stored prescription');
+        // No onClose: the copy still names the recovery path (return via the
+        // session that started it) instead of stranding the athlete silently.
+        expect(html).toContain('Return from the session that started it');
+    });
 });
 
 describe('resolveCompanionPromptCopy', () => {

--- a/app/src/components/session/SessionRunner.tsx
+++ b/app/src/components/session/SessionRunner.tsx
@@ -656,6 +656,13 @@ export const SessionRunner: React.FC<SessionRunnerProps> = ({
                 <div className="session-runner-container no-active">
                     <h2>Active session needs its stored prescription</h2>
                     <p>Return from the session that started it so the exact snapshot can be restored. Starting another session is disabled.</p>
+                    {onClose && (
+                        <div className="session-authoring-actions">
+                            <button type="button" className="start-fixture-btn secondary-authoring-btn" onClick={onClose}>
+                                ← Back to {SCREEN_LABELS.sessions}
+                            </button>
+                        </div>
+                    )}
                 </div>
             );
         }

--- a/app/src/components/session/SessionRunner.tsx
+++ b/app/src/components/session/SessionRunner.tsx
@@ -655,11 +655,11 @@ export const SessionRunner: React.FC<SessionRunnerProps> = ({
             return (
                 <div className="session-runner-container no-active">
                     <h2>Active session needs its stored prescription</h2>
-                    <p>Return from the session that started it so the exact snapshot can be restored. Starting another session is disabled.</p>
+                    <p>Return Home, then reopen the session that started it so the exact snapshot can be restored. Starting another session is disabled.</p>
                     {onClose && (
                         <div className="session-authoring-actions">
                             <button type="button" className="start-fixture-btn secondary-authoring-btn" onClick={onClose}>
-                                ← Back to {SCREEN_LABELS.sessions}
+                                ← Back to {SCREEN_LABELS.home}
                             </button>
                         </div>
                     )}

--- a/docs/architecture/user-flows.md
+++ b/docs/architecture/user-flows.md
@@ -86,7 +86,9 @@ Successful onboarding writes training settings, the training-intent profile, and
 athlete is still goal-less) an active goal before `onCompleted` stores the per-user browser
 dismissal key. Skip persists only that dismissal key — it never creates a goal and never
 writes training settings — and is logged to local usability telemetry as a skipped wizard
-completion with the stage where Skip was chosen. A skipped (goal-less, dismissed) account
+completion with the stage where Skip was chosen. When Skip itself cannot persist because
+browser storage is blocked, the wizard stays open with guidance and a Continue-for-session
+action instead of dismissing silently and resurfacing on refresh. A skipped (goal-less, dismissed) account
 can re-launch the wizard from the Coach Preferences surface, which clears the dismissal key
 and reloads; the relaunch action is disabled while Coach Preferences has unsaved edits so the
 reload cannot silently discard them. A blocked `localStorage` write alone does not make a
@@ -272,7 +274,8 @@ at the `App` level.
 
 An in-progress structured execution is global account state for resume purposes. A stored
 prescription that cannot be resolved is fail-closed instead of allowing a second session to
-start over ambiguous execution state.
+start over ambiguous execution state, and that state offers Back to `Sessions` rather than
+stranding the athlete.
 
 ### 6. Week plan
 
@@ -342,8 +345,9 @@ screen, the same Activities action returns to the local Context brief tab, so th
 clipboard exporter is not reachable there either. Only the `brief` screen renders the daily
 (2-day) / full (14-day) brief with char and token counts. The Data and brief navigation
 entries refresh decision input before navigating. If `decisionInput` is null, DataView shows
-`No data available`; that state has no in-component retry action, although the global
-navigation chrome remains available.
+`No data available` with Retry (recomposes via `App` `loadDecisionInput`) and Back to Home,
+so the empty state is never a dead end even though the global navigation chrome also
+remains available.
 
 ### 10. Protocol testing
 
@@ -398,11 +402,14 @@ moving an input across an authority boundary.
 
 6. `sessions` and `testing` share `SessionRunner`, so the execution UI alone does not strongly
    communicate provenance.
-7. Several recovery states are weak rather than truly terminal: DataView's no-data state has
-   no local retry, some PlanView invalid states have limited repair affordance, a missing
-   stored session prescription is fail-closed, testing abandonment is terminal for that
-   attempt, and a skipped onboarding with blocked browser storage resurfaces the wizard on
-   refresh (dismissal persistence needs working `localStorage`).
+7. Every audited terminal state now carries a forward action (#493): DataView's no-data
+   state offers Retry (recompose via `App` `loadDecisionInput`) and Back to Home; PlanView
+   invalid/unavailable states offer repair navigation, forced resync, corrected-plan import,
+   and Retry; a missing stored session prescription stays fail-closed but offers Back to
+   `Sessions`; testing abandonment names the loss and offers a fresh attempt or Done
+   (abandonment itself stays terminal for that attempt); and a storage-blocked Skip keeps
+   the wizard open with guidance plus Continue-for-session instead of silently resurfacing
+   on refresh.
 8. Garmin is used both as an app sign-in path and as a wearable/provider connection, which
    can read as one task even though the flows and credentials have different purposes.
 
@@ -513,5 +520,16 @@ living-reference section when implementing them.
     when already on the canonical screen). The legacy raw Activities clipboard exporter is
     removed from the UI. Exported brief content is unchanged (daily 2d vs full 14d windows,
     char and token counts).
-16. Add local retry/repair affordances to weak recovery states, starting with DataView's
-    null-input state and PlanView source failures.
+16. ~~Add local retry/repair affordances to weak recovery states, starting with DataView's
+    null-input state and PlanView source failures.~~
+    Done (#493): audited every terminal state from the issue against the merged tree.
+    Already covered, kept as-is: PlanView INVALID/UNAVAILABLE repair navigation, forced
+    resync, and corrected-plan import (`PlanView` `forecastRepairTargets`,
+    `planImportRepairOffered`); testing-abandonment fresh-attempt path (`TestingWorkflow`
+    `startFreshAttempt`, `describeAbandonedAssessment`, `canStartFreshAssessmentAttempt`);
+    onboarding Skip with relaunch (#490); the check-in stepper (#488); and the Home/PlanView
+    repair triplet (#483). Fixed by the audit itself: DataView null-input Retry plus Back to
+    Home (`DataView` `onRetry` wired to `App` `loadDecisionInput`); a Back to `Sessions`
+    action on the fail-closed SessionRunner prescription-missing state; and storage-blocked
+    Skip guidance with Continue-for-session (`OnboardingWizard` `skipStorageBlocked`,
+    `skipOnboardingForNow` persistence result). No engine or persistence semantic change.

--- a/docs/architecture/user-flows.md
+++ b/docs/architecture/user-flows.md
@@ -86,14 +86,16 @@ Successful onboarding writes training settings, the training-intent profile, and
 athlete is still goal-less) an active goal before `onCompleted` stores the per-user browser
 dismissal key. Skip persists only that dismissal key — it never creates a goal and never
 writes training settings — and is logged to local usability telemetry as a skipped wizard
-completion with the stage where Skip was chosen. When Skip itself cannot persist because
-browser storage is blocked, the wizard stays open with guidance and a Continue-for-session
-action instead of dismissing silently and resurfacing on refresh. A skipped (goal-less, dismissed) account
-can re-launch the wizard from the Coach Preferences surface, which clears the dismissal key
-and reloads; the relaunch action is disabled while Coach Preferences has unsaved edits so the
-reload cannot silently discard them. A blocked `localStorage` write alone does not make a
-successfully onboarded athlete loop forever, because the active-goal gate also suppresses the
-overlay.
+completion with the stage where Skip was chosen only after the dismissal actually completes.
+When browser storage blocks a durable Skip, the wizard stays open with guidance and does not
+fire `onCompleted` or completion telemetry yet. `Continue for this session` explicitly accepts
+a session-only dismissal, records one skipped completion against the original blocked stage,
+and closes the current wizard without pretending that durable storage succeeded. A skipped
+(goal-less, dismissed) account can re-launch the wizard from the Coach Preferences surface,
+which clears the dismissal key and reloads; the relaunch action is disabled while Coach
+Preferences has unsaved edits so the reload cannot silently discard them. A blocked
+`localStorage` write alone does not make a successfully onboarded athlete loop forever,
+because the active-goal gate also suppresses the overlay.
 
 `App` can also render two resume/cleanup banners above `<main>`:
 
@@ -274,8 +276,9 @@ at the `App` level.
 
 An in-progress structured execution is global account state for resume purposes. A stored
 prescription that cannot be resolved is fail-closed instead of allowing a second session to
-start over ambiguous execution state, and that state offers Back to `Sessions` rather than
-stranding the athlete.
+start over ambiguous execution state. The recovery action returns to Home, matching the
+`App`-level `onClose` contract, and the copy tells the athlete to reopen the originating
+session so the exact snapshot can be restored.
 
 ### 6. Week plan
 
@@ -405,11 +408,11 @@ moving an input across an authority boundary.
 7. Every audited terminal state now carries a forward action (#493): DataView's no-data
    state offers Retry (recompose via `App` `loadDecisionInput`) and Back to Home; PlanView
    invalid/unavailable states offer repair navigation, forced resync, corrected-plan import,
-   and Retry; a missing stored session prescription stays fail-closed but offers Back to
-   `Sessions`; testing abandonment names the loss and offers a fresh attempt or Done
-   (abandonment itself stays terminal for that attempt); and a storage-blocked Skip keeps
-   the wizard open with guidance plus Continue-for-session instead of silently resurfacing
-   on refresh.
+   and Retry; a missing stored session prescription stays fail-closed but offers Back to Home
+   with explicit reopen guidance; testing abandonment names the loss and offers a fresh
+   attempt or Done (abandonment itself stays terminal for that attempt); and a storage-blocked
+   Skip keeps the wizard open with guidance plus an explicit Continue-for-session choice
+   instead of counting a failed persistence attempt as a completed skip.
 8. Garmin is used both as an app sign-in path and as a wearable/provider connection, which
    can read as one task even though the flows and credentials have different purposes.
 
@@ -529,7 +532,11 @@ living-reference section when implementing them.
     `startFreshAttempt`, `describeAbandonedAssessment`, `canStartFreshAssessmentAttempt`);
     onboarding Skip with relaunch (#490); the check-in stepper (#488); and the Home/PlanView
     repair triplet (#483). Fixed by the audit itself: DataView null-input Retry plus Back to
-    Home (`DataView` `onRetry` wired to `App` `loadDecisionInput`); a Back to `Sessions`
-    action on the fail-closed SessionRunner prescription-missing state; and storage-blocked
-    Skip guidance with Continue-for-session (`OnboardingWizard` `skipStorageBlocked`,
-    `skipOnboardingForNow` persistence result). No engine or persistence semantic change.
+    Home (`DataView` `onRetry` wired to `App` `loadDecisionInput`); a Back to Home action plus
+    reopen guidance on the fail-closed SessionRunner prescription-missing state; and
+    storage-blocked Skip guidance with explicit Continue-for-session
+    (`OnboardingWizard` `blockedSkipStage`, `skipOnboardingForNow`,
+    `continueOnboardingSkipForSessionOnly`). A failed storage attempt no longer fires
+    completion telemetry or `onCompleted`; the event is recorded only after durable or
+    explicit session-only dismissal. No decision-engine, Firestore, or schema semantics
+    changed.


### PR DESCRIPTION
## Summary
- Audited all five terminal states from #493 against current `main`. PlanView INVALID/UNAVAILABLE repair and testing-abandonment fresh-attempt recovery were already covered and remain unchanged.
- Fixed the three genuine gaps: DataView null input now offers Retry (`App.loadDecisionInput`) plus Back to Home; the fail-closed SessionRunner missing-prescription state now offers Back to Home with explicit reopen guidance; and a storage-blocked onboarding Skip stays open until the athlete explicitly chooses a durable or session-only dismissal.
- Hardened onboarding semantics found during review: a failed `localStorage` dismissal no longer calls `onCompleted` or records a `wizard_completed` event. `Continue for this session` is an explicit fallback that records exactly one skip against the original blocked stage without pretending durable persistence succeeded.
- Updated `docs/architecture/user-flows.md` to match the final runtime contracts and mark recommendation #16 complete.
- Closes #493.

## Review fixes
- Corrected the prescription-recovery destination from misleading `Back to Sessions` copy to `Back to Home`, matching the production `App`/`TestingWorkflow` `onClose` contract.
- Removed the noop-callback coupling from `skipOnboardingForNow`; its return value and callback behavior now directly reflect whether durable dismissal completed.
- Kept the storage-error `role="alert"` text-only and moved the interactive session-only continuation into a sibling action row.
- Added regression coverage for both successful and blocked Skip semantics and for the exact Home recovery copy.

## Validation
- [x] CI Pipeline #2937 on final head `b69cda8`: **success**
- [x] Frontend Hygiene & Static Gates: dependency audit, TypeScript, ESLint, knowledge/workout validation, policy-drift check, production bundle
- [x] Frontend Unit Tests & Firestore Rules: coverage suite and Firestore emulator rules suite
- [x] Python Test Suite (3.14): pre-commit hygiene, ruff, mypy, pytest/coverage, dependency audit
- [x] Engine Simulations & AI Gates: simulation bounds, deterministic AI-plan/persona corpora, semantic diff
- [x] Docker Build & Compose Smoke: both images, compose validation/build, healthchecks, routing/header smoke test
- [x] PR remains mergeable against unchanged `main`; no unresolved review threads

## Reviewer notes / risk
- No decision-engine, Firestore, schema, or policy behavior changed.
- Local onboarding telemetry semantics are intentionally tighter: a skip is counted only after a durable dismissal or the athlete's explicit session-only continuation.
- DataView `onRetry` remains optional for isolated harnesses; the production App supplies it.
- CodeRabbit review was explicitly requested after the fixes but was rate-limited; it produced no actionable review findings or inline threads.

## Domain invariants
- Firestore writes remain user-scoped; no Firestore persistence path changed.
- Calendar/date and session-step semantics are untouched.
- No credentials, tokens, service-account files, or raw health payloads were added.
- `POLICY_VERSION` and decision logic are unchanged.