### PR TITLE
Wire confirmed IntentBlock progressions into evergreen selection

### DIFF
--- a/app/src/components/Home.tsx
+++ b/app/src/components/Home.tsx
@@ -25,7 +25,6 @@ import { computeDailyLedger } from '../engine/dailyLedger';
 import { planBlockService } from '../services/planBlockService';
 import { intentBlockService } from '../services/intentBlockService';
 import { deriveDurationOverridesForDate } from '../engine/confirmedProgressionOverrides';
-import type { IntentBlock } from '../engine/blockIntent';
 import { decisionJournalService } from '../services/decisionJournalService';
 import { resolveEngineShadowVerdict } from '../engine/shadowAgreement';
 import { getPreviousLocalDateString, addDaysToLocalDateString } from '../utils/localDate';
@@ -770,10 +769,15 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
         };
         setRecommendation(todayRec);
 
+        // ADR-0037 D-DOSE: confirmedProgressionOverrides is derived for input.date only
+        // (today) and deliberately not passed to tomorrow's forecast here -- a block whose
+        // active window ends today must not leak into tomorrow's evaluation, and one
+        // starting tomorrow was never loaded for today's date. Progression influence is
+        // scoped to same-day planning until the packer has a date-scoped resolver.
         const tomorrowPlan = await evaluateNextDayPlanWithIntent(
           userId, events, { subjective, objective }, forecastContext, input.date, todayRec, undefined, preparedSnapshot,
           todayAndTomorrowFixedActivities, todayAndTomorrowPlanBlocks, input.trainingIntentProfile, input.preferences,
-          'max', undefined, undefined, input.scheduleOverlays, confirmedProgressionOverrides,
+          'max', undefined, undefined, input.scheduleOverlays,
         );
         if (!isCurrent()) return;
         setNextDayPlan(tomorrowPlan);
@@ -1137,32 +1141,6 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
     [planBlocksState]
   );
 
-  // ADR-0037 D-DOSE: confirmed IntentBlock progressions active over the week-ahead window,
-  // used below to derive per-role duration overrides for evergreen selection.
-  const [confirmedBlocksState, setConfirmedBlocksState] = useState<DataState<IntentBlock[]>>({ status: 'AVAILABLE', data: [], revision: null });
-  useEffect(() => {
-    let cancelled = false;
-    if (!decisionInput) {
-      setConfirmedBlocksState({ status: 'AVAILABLE', data: [], revision: null });
-      return () => { cancelled = true; };
-    }
-    intentBlockService.getActiveBlocks(userId, decisionInput.date)
-      .then(state => { if (!cancelled) setConfirmedBlocksState(state); })
-      .catch(err => {
-        console.warn('Failed to load confirmed intent blocks:', err);
-        if (!cancelled) setConfirmedBlocksState({ status: 'UNAVAILABLE', operation: 'read confirmed intent blocks', retryable: true });
-      });
-    return () => { cancelled = true; };
-  }, [userId, decisionInput]);
-  const weekAheadProgressionOverrides = useMemo((): ReadonlyMap<string, number> => {
-    if (confirmedBlocksState.status !== 'AVAILABLE' || !decisionInput) return new Map();
-    const { overrides, unsupported } = deriveDurationOverridesForDate(confirmedBlocksState.data, decisionInput.date);
-    if (unsupported.length > 0) {
-      console.warn('Confirmed progression(s) bound to a coverage key not yet wired into selection:', unsupported);
-    }
-    return overrides;
-  }, [confirmedBlocksState, decisionInput]);
-
   const [selectedNextDayTier, setSelectedNextDayTier] = useState<'green' | 'yellow' | 'red'>('green');
   const [weekAheadPlan, setWeekAheadPlan] = useState<WeekAheadPlan | null>(null);
   useEffect(() => {
@@ -1189,7 +1167,11 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
       decisionInput.date,
       activeRec,
       tomorrowRec,
-      { days: WEEK_AHEAD_DAYS, fixedActivities, authoredPlanBlocks, scheduleOverlays: decisionInput.scheduleOverlays, progressionOverrides: weekAheadProgressionOverrides },
+      // ADR-0037 D-DOSE: no progressionOverrides here -- a confirmed progression's duration
+      // override is date-scoped to a single day, but week-ahead packs the whole horizon in
+      // one call. Progression influence is scoped to same-day planning until the packer has
+      // a date-scoped resolver (see the same-day evaluateTrainingWithIntent call above).
+      { days: WEEK_AHEAD_DAYS, fixedActivities, authoredPlanBlocks, scheduleOverlays: decisionInput.scheduleOverlays },
       undefined,
       historySnapshot,
       decisionInput.trainingIntentProfile,
@@ -1202,7 +1184,7 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
       }
     });
     return () => { cancelled = true; };
-  }, [userId, forecastEngineInputs, decisionInput, activeRec, canGenerateNormalPlan, nextDayPlan, selectedNextDayTier, eventPeriodization, historySnapshot, fixedActivitiesState, fixedActivities, planBlocksState, authoredPlanBlocks, weekAheadProgressionOverrides]);
+  }, [userId, forecastEngineInputs, decisionInput, activeRec, canGenerateNormalPlan, nextDayPlan, selectedNextDayTier, eventPeriodization, historySnapshot, fixedActivitiesState, fixedActivities, planBlocksState, authoredPlanBlocks]);
 
   if (loading) {
     return (

--- a/app/src/components/Home.tsx
+++ b/app/src/components/Home.tsx
@@ -23,6 +23,9 @@ import { fixedActivityService } from '../services/fixedActivityService';
 import { scheduleWindowService } from '../services/scheduleWindowService';
 import { computeDailyLedger } from '../engine/dailyLedger';
 import { planBlockService } from '../services/planBlockService';
+import { intentBlockService } from '../services/intentBlockService';
+import { deriveDurationOverridesForDate } from '../engine/confirmedProgressionOverrides';
+import type { IntentBlock } from '../engine/blockIntent';
 import { decisionJournalService } from '../services/decisionJournalService';
 import { resolveEngineShadowVerdict } from '../engine/shadowAgreement';
 import { getPreviousLocalDateString, addDaysToLocalDateString } from '../utils/localDate';
@@ -362,6 +365,7 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
         yesterdaySnapState,
         todayAndTomorrowFixedActivities,
         todayAndTomorrowPlanBlocks,
+        activeIntentBlocks,
         loadedOverrides,
         activitiesState,
       ] = await Promise.all([
@@ -387,11 +391,31 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
             console.warn('Failed to load authored plan blocks for today/tomorrow:', err);
             return [];
           }),
+        // ADR-0037 D-DOSE: confirmed IntentBlock progressions active on input.date, used
+        // below to derive per-role duration overrides for evergreen selection. A read
+        // failure here must never block today's recommendation -- it just means no
+        // confirmed progression affects today's selection.
+        intentBlockService.getActiveBlocks(userId, input.date)
+          .then(state => {
+            if (state.status === 'AVAILABLE') return state.data;
+            if (state.status !== 'MISSING') console.warn(`Failed to load confirmed intent blocks: ${state.status}`);
+            return [];
+          })
+          .catch(err => {
+            console.warn('Failed to load confirmed intent blocks:', err);
+            return [];
+          }),
         activityOverrideService.getAllOverrides(userId).catch(() => ({})),
         activityService.getActivitiesInRange(userId, addDaysToLocalDateString(input.date, -6), addDaysToLocalDateString(input.date, 1)).catch(() => ({ status: 'MISSING' as const })),
       ]);
 
       if (!isCurrent()) return;
+
+      const { overrides: confirmedProgressionOverrides, unsupported: unsupportedProgressionObjectives } =
+        deriveDurationOverridesForDate(activeIntentBlocks, input.date);
+      if (unsupportedProgressionObjectives.length > 0) {
+        console.warn('Confirmed progression(s) bound to a coverage key not yet wired into selection:', unsupportedProgressionObjectives);
+      }
 
       setYesterdayRecommendation(yesterdayRec);
       setYesterdaySnapshot(yesterdaySnapState.status === 'AVAILABLE' ? yesterdaySnapState.data : null);
@@ -514,6 +538,7 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
           userId, { subjective, objective, subjectiveBaseline: input.subjectiveBaseline }, context, events, input.date, yesterdayRec?.mode, undefined, preparedSnapshot,
           todayAndTomorrowFixedActivities, todayAndTomorrowPlanBlocks, input.trainingIntentProfile, input.preferences,
           'max', externalContext, undefined, undefined, externalRestContext, false, input.scheduleOverlays,
+          confirmedProgressionOverrides,
         );
         if (!isCurrent()) return;
         const recommendationWithPrescription = {
@@ -748,7 +773,7 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
         const tomorrowPlan = await evaluateNextDayPlanWithIntent(
           userId, events, { subjective, objective }, forecastContext, input.date, todayRec, undefined, preparedSnapshot,
           todayAndTomorrowFixedActivities, todayAndTomorrowPlanBlocks, input.trainingIntentProfile, input.preferences,
-          'max', undefined, undefined, input.scheduleOverlays,
+          'max', undefined, undefined, input.scheduleOverlays, confirmedProgressionOverrides,
         );
         if (!isCurrent()) return;
         setNextDayPlan(tomorrowPlan);
@@ -1112,6 +1137,32 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
     [planBlocksState]
   );
 
+  // ADR-0037 D-DOSE: confirmed IntentBlock progressions active over the week-ahead window,
+  // used below to derive per-role duration overrides for evergreen selection.
+  const [confirmedBlocksState, setConfirmedBlocksState] = useState<DataState<IntentBlock[]>>({ status: 'AVAILABLE', data: [], revision: null });
+  useEffect(() => {
+    let cancelled = false;
+    if (!decisionInput) {
+      setConfirmedBlocksState({ status: 'AVAILABLE', data: [], revision: null });
+      return () => { cancelled = true; };
+    }
+    intentBlockService.getActiveBlocks(userId, decisionInput.date)
+      .then(state => { if (!cancelled) setConfirmedBlocksState(state); })
+      .catch(err => {
+        console.warn('Failed to load confirmed intent blocks:', err);
+        if (!cancelled) setConfirmedBlocksState({ status: 'UNAVAILABLE', operation: 'read confirmed intent blocks', retryable: true });
+      });
+    return () => { cancelled = true; };
+  }, [userId, decisionInput]);
+  const weekAheadProgressionOverrides = useMemo((): ReadonlyMap<string, number> => {
+    if (confirmedBlocksState.status !== 'AVAILABLE' || !decisionInput) return new Map();
+    const { overrides, unsupported } = deriveDurationOverridesForDate(confirmedBlocksState.data, decisionInput.date);
+    if (unsupported.length > 0) {
+      console.warn('Confirmed progression(s) bound to a coverage key not yet wired into selection:', unsupported);
+    }
+    return overrides;
+  }, [confirmedBlocksState, decisionInput]);
+
   const [selectedNextDayTier, setSelectedNextDayTier] = useState<'green' | 'yellow' | 'red'>('green');
   const [weekAheadPlan, setWeekAheadPlan] = useState<WeekAheadPlan | null>(null);
   useEffect(() => {
@@ -1138,7 +1189,7 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
       decisionInput.date,
       activeRec,
       tomorrowRec,
-      { days: WEEK_AHEAD_DAYS, fixedActivities, authoredPlanBlocks, scheduleOverlays: decisionInput.scheduleOverlays },
+      { days: WEEK_AHEAD_DAYS, fixedActivities, authoredPlanBlocks, scheduleOverlays: decisionInput.scheduleOverlays, progressionOverrides: weekAheadProgressionOverrides },
       undefined,
       historySnapshot,
       decisionInput.trainingIntentProfile,
@@ -1151,7 +1202,7 @@ export function Home({ userId, onNavigate, onViewData, onStartSession }: HomePro
       }
     });
     return () => { cancelled = true; };
-  }, [userId, forecastEngineInputs, decisionInput, activeRec, canGenerateNormalPlan, nextDayPlan, selectedNextDayTier, eventPeriodization, historySnapshot, fixedActivitiesState, fixedActivities, planBlocksState, authoredPlanBlocks]);
+  }, [userId, forecastEngineInputs, decisionInput, activeRec, canGenerateNormalPlan, nextDayPlan, selectedNextDayTier, eventPeriodization, historySnapshot, fixedActivitiesState, fixedActivities, planBlocksState, authoredPlanBlocks, weekAheadProgressionOverrides]);
 
   if (loading) {
     return (

--- a/app/src/components/ProgressionBlockEditor.css
+++ b/app/src/components/ProgressionBlockEditor.css
@@ -39,6 +39,16 @@
   color: #1e7e34;
 }
 
+.progression-block-unsupported-notice {
+  margin: 4px 0 0;
+  padding: 6px 10px;
+  border: 1px solid #b98900;
+  border-radius: 4px;
+  background: #fff8e1;
+  color: #7a5c00;
+  font-size: 0.9em;
+}
+
 .progression-block-list .setting-row {
   padding: 6px 0;
   border-bottom: 1px solid #eee;

--- a/app/src/components/ProgressionBlockEditor.test.tsx
+++ b/app/src/components/ProgressionBlockEditor.test.tsx
@@ -3,6 +3,7 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { ProgressionBlockEditor } from './ProgressionBlockEditor';
 import { buildBlock, defaultDraft } from './progressionBlockDraft';
 import { validateIntentBlock } from '../engine/blockIntent';
+import { SELECTION_WIRED_COVERAGE_KEYS } from '../engine/confirmedProgressionOverrides';
 
 const TODAY = '2026-09-01';
 
@@ -42,5 +43,9 @@ describe('ProgressionBlockEditor', () => {
         const block = buildBlock(draft);
         expect(block.progressionContract?.reviewCadenceDays).toBe(21);
         expect(validateIntentBlock(block).valid).toBe(true);
+    });
+
+    it('defaults to a coverage key already wired into evergreen selection, so the unsupported notice does not fire unprompted', () => {
+        expect(SELECTION_WIRED_COVERAGE_KEYS).toContain(defaultDraft(TODAY).coverageKey);
     });
 });

--- a/app/src/components/ProgressionBlockEditor.tsx
+++ b/app/src/components/ProgressionBlockEditor.tsx
@@ -15,6 +15,7 @@ import {
   type IntentBlockHeader,
 } from '../services/intentBlockService';
 import { getLocalDateString } from '../utils/localDate';
+import { SELECTION_WIRED_COVERAGE_KEYS } from '../engine/confirmedProgressionOverrides';
 import {
   defaultDraft,
   buildBlock,
@@ -176,6 +177,13 @@ export function ProgressionBlockEditor({ userId, onBlockSaved }: ProgressionBloc
               bound to this block&apos;s source revision. This manual form does not create those session prescriptions;
               without a compatible binding, reviews hold rather than guessing that performed work matched the target.
             </p>
+            {!SELECTION_WIRED_COVERAGE_KEYS.includes(draft.coverageKey) && (
+              <p role="status" className="progression-block-unsupported-notice">
+                Confirmed changes to this objective are recorded but do not yet affect today&apos;s or this
+                week&apos;s recommendations — &quot;{coverageKeyLabels[draft.coverageKey]}&quot; has no evergreen
+                selection role wired up yet.
+              </p>
+            )}
             <div className="form-row">
               <label>Increment per step (min)
                 <input type="number" min={1} value={draft.progressionIncrement} onChange={event => setDraft(current => ({ ...current, progressionIncrement: Number(event.target.value) }))} />

--- a/app/src/components/ProgressionReviewPanel.css
+++ b/app/src/components/ProgressionReviewPanel.css
@@ -42,3 +42,13 @@
 .progression-review-confirmed {
   color: #1e7e34;
 }
+
+.progression-review-selection-unsupported {
+  margin: 8px 0;
+  padding: 6px 10px;
+  border: 1px solid #b98900;
+  border-radius: 4px;
+  background: #fff8e1;
+  color: #7a5c00;
+  font-size: 0.9em;
+}

--- a/app/src/components/ProgressionReviewPanel.test.tsx
+++ b/app/src/components/ProgressionReviewPanel.test.tsx
@@ -1,9 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { ProgressionReviewPanel } from './ProgressionReviewPanel';
-import { claimBelongsToReviewedRevision, deriveProposalId } from './progressionReviewPanelLogic';
+import { claimBelongsToReviewedRevision, deriveProposalId, isProgressionSelectionUnsupported } from './progressionReviewPanelLogic';
 import type { ProposedProgressionChange } from '../engine/progressionReview';
 import type { ProgressionExperimentClaim } from '../services/progressionClaimService';
+import type { BlockObjectiveDefinition, IntentBlock } from '../engine/blockIntent';
 
 function change(overrides: Partial<ProposedProgressionChange> = {}): ProposedProgressionChange {
     return {
@@ -72,6 +73,65 @@ describe('deriveProposalId', () => {
     it('differs when the target binding differs even if the before/after dose is identical', () => {
         expect(deriveProposalId(1, '2026-09-15', change({ targetBinding: { objectiveId: 'obj_1' } })))
             .not.toBe(deriveProposalId(1, '2026-09-15', change({ targetBinding: { objectiveId: 'obj_2' } })));
+    });
+});
+
+function objective(overrides: Partial<BlockObjectiveDefinition> = {}): BlockObjectiveDefinition {
+    return {
+        id: 'obj_1',
+        sport: 'cycling',
+        adaptationScope: 'threshold_quality',
+        coverageKey: 'sustained_quality',
+        intent: 'develop',
+        priority: 'must_have',
+        doseEnvelope: { min: 60, target: 90, max: 120, unit: 'minutes', floorSemantics: 'hard_floor' },
+        knowledgeLineage: [],
+        successCriteria: {},
+        ...overrides,
+    };
+}
+
+function blockWithContract(objectiveOverrides: Partial<BlockObjectiveDefinition> = {}): IntentBlock {
+    return {
+        id: 'block_1',
+        revision: 1,
+        sourcePlanId: 'block_1',
+        sourcePlanRevision: 1,
+        dateRange: { startDate: '2026-09-01', endDate: '2026-09-30' },
+        objectives: [objective(objectiveOverrides)],
+        reviewSchedule: { reviewCadenceDays: 14, nextReviewDate: '2026-09-15' },
+        progressionContract: {
+            targetBinding: { objectiveId: 'obj_1' },
+            variable: 'duration_min',
+            unit: 'minutes',
+            currentValue: 100,
+            permittedRange: { min: 60, max: 120 },
+            increment: 10,
+            knowledgeLineage: [],
+            observationWindowDays: 14,
+            minCompletedExposures: 3,
+            requiredFollowUpCoveragePct: 66,
+            reviewCadenceDays: 14,
+        },
+    };
+}
+
+describe('isProgressionSelectionUnsupported', () => {
+    it('is false for a wired coverage key', () => {
+        expect(isProgressionSelectionUnsupported(blockWithContract({ coverageKey: 'sustained_quality' }))).toBe(false);
+    });
+
+    it('is true for a coverage key not yet packed into evergreen selection', () => {
+        expect(isProgressionSelectionUnsupported(blockWithContract({ coverageKey: 'short_surges' }))).toBe(true);
+    });
+
+    it('is false when there is no progression contract', () => {
+        expect(isProgressionSelectionUnsupported({ ...blockWithContract(), progressionContract: undefined })).toBe(false);
+    });
+
+    it('is false when nothing is selected yet', () => {
+        expect(isProgressionSelectionUnsupported(null)).toBe(false);
+        expect(isProgressionSelectionUnsupported(undefined)).toBe(false);
     });
 });
 

--- a/app/src/components/ProgressionReviewPanel.tsx
+++ b/app/src/components/ProgressionReviewPanel.tsx
@@ -12,7 +12,7 @@ import {
   type ProgressionExperimentClaim,
 } from '../services/progressionClaimService';
 import { getLocalDateString } from '../utils/localDate';
-import { claimBelongsToReviewedRevision, deriveProposalId } from './progressionReviewPanelLogic';
+import { claimBelongsToReviewedRevision, deriveProposalId, isProgressionSelectionUnsupported } from './progressionReviewPanelLogic';
 import './ProgressionReviewPanel.css';
 
 interface ProgressionReviewPanelProps {
@@ -89,6 +89,11 @@ export function ProgressionReviewPanel({ userId }: ProgressionReviewPanelProps) 
     activeClaim,
     selectedBlockId,
     selectedDue?.header.revision ?? null,
+  );
+
+  const selectionUnsupported = useMemo(
+    () => isProgressionSelectionUnsupported(selectedDue?.block),
+    [selectedDue],
   );
 
   const runReview = useCallback(async (blockId: string) => {
@@ -205,6 +210,12 @@ export function ProgressionReviewPanel({ userId }: ProgressionReviewPanelProps) 
       {result && (
         <div className="progression-review-result">
           <h3>{ACTION_LABELS[result.action]}</h3>
+          {selectionUnsupported && (
+            <p role="status" className="progression-review-selection-unsupported">
+              Confirmed changes to this objective are recorded but do not yet affect today&apos;s or this
+              week&apos;s recommendations.
+            </p>
+          )}
           {result.reasons.length > 0 && (
             <ul className="progression-review-reasons">
               {result.reasons.map((reason, index) => <li key={index}>{reason}</li>)}

--- a/app/src/components/progressionReviewPanelLogic.ts
+++ b/app/src/components/progressionReviewPanelLogic.ts
@@ -1,6 +1,8 @@
+import type { IntentBlock } from '../engine/blockIntent';
 import type { ProposedProgressionChange } from '../engine/progressionReview';
 import type { ProgressionExperimentClaim } from '../services/progressionClaimService';
 import { deriveProgressionProposalId } from '../services/progressionProposalIdentity';
+import { SELECTION_WIRED_COVERAGE_KEYS } from '../engine/confirmedProgressionOverrides';
 
 /** UI-facing alias retained so the panel/tests stay decoupled from persistence naming. */
 export function deriveProposalId(sourcePlanRevision: number, asOfDate: string, change: ProposedProgressionChange): string {
@@ -22,4 +24,18 @@ export function claimBelongsToReviewedRevision(
         && revision !== null
         && claim.blockId === blockId
         && claim.activationRevisionId === String(revision);
+}
+
+/**
+ * ADR-0037 D-DOSE: whether the objective a block's progression contract targets has a
+ * coverage key evergreen selection actually wires up yet
+ * (`engine/confirmedProgressionOverrides.ts`). A review can still run and a change can
+ * still be confirmed and recorded either way; this only drives a visible, non-blocking
+ * notice rather than a silent gap.
+ */
+export function isProgressionSelectionUnsupported(block: IntentBlock | null | undefined): boolean {
+    const contract = block?.progressionContract;
+    if (!contract) return false;
+    const objective = block.objectives.find(item => item.id === contract.targetBinding.objectiveId);
+    return objective ? !SELECTION_WIRED_COVERAGE_KEYS.includes(objective.coverageKey) : false;
 }

--- a/app/src/engine/confirmedProgressionOverrides.test.ts
+++ b/app/src/engine/confirmedProgressionOverrides.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+import { deriveDurationOverridesForDate, SELECTION_WIRED_COVERAGE_KEYS } from './confirmedProgressionOverrides';
+import type { BlockObjectiveDefinition, IntentBlock } from './blockIntent';
+
+function objective(overrides: Partial<BlockObjectiveDefinition> = {}): BlockObjectiveDefinition {
+    return {
+        id: 'obj_threshold_dev',
+        sport: 'cycling',
+        adaptationScope: 'threshold_quality',
+        coverageKey: 'sustained_quality',
+        intent: 'develop',
+        priority: 'must_have',
+        doseEnvelope: { min: 60, target: 90, max: 120, unit: 'minutes', floorSemantics: 'hard_floor' },
+        knowledgeLineage: ['claim_threshold_interval_adaptation_v1'],
+        successCriteria: { minCompletedExposures: 3 },
+        ...overrides,
+    };
+}
+
+function block(overrides: Partial<IntentBlock> = {}, objectiveOverrides: Partial<BlockObjectiveDefinition> = {}): IntentBlock {
+    return {
+        id: 'block_a',
+        revision: 1,
+        sourcePlanId: 'block_a',
+        sourcePlanRevision: 1,
+        dateRange: { startDate: '2026-09-01', endDate: '2026-09-30' },
+        objectives: [objective(objectiveOverrides)],
+        reviewSchedule: { reviewCadenceDays: 14, nextReviewDate: '2026-09-15' },
+        progressionContract: {
+            targetBinding: { objectiveId: 'obj_threshold_dev' },
+            variable: 'duration_min',
+            unit: 'minutes',
+            currentValue: 100,
+            permittedRange: { min: 60, max: 120 },
+            increment: 10,
+            knowledgeLineage: ['policy_progression_duration_v1'],
+            observationWindowDays: 14,
+            minCompletedExposures: 3,
+            requiredFollowUpCoveragePct: 66,
+            reviewCadenceDays: 14,
+        },
+        ...overrides,
+    };
+}
+
+describe('SELECTION_WIRED_COVERAGE_KEYS', () => {
+    it('is exactly the 3 roles EVERGREEN_PACKING_COVERAGE defines', () => {
+        expect([...SELECTION_WIRED_COVERAGE_KEYS].sort()).toEqual(['aerobic_volume', 'primary_strength', 'sustained_quality']);
+    });
+});
+
+describe('deriveDurationOverridesForDate', () => {
+    it('applies a confirmed progression for a wired coverage key within the active date range', () => {
+        const result = deriveDurationOverridesForDate([block()], '2026-09-10');
+        expect(result.overrides.get('sustained_quality')).toBe(100);
+        expect(result.unsupported).toEqual([]);
+    });
+
+    it('ignores a block whose date range does not cover the requested date', () => {
+        const before = deriveDurationOverridesForDate([block()], '2026-08-31');
+        const after = deriveDurationOverridesForDate([block()], '2026-10-01');
+        expect(before.overrides.size).toBe(0);
+        expect(after.overrides.size).toBe(0);
+    });
+
+    it('ignores a block with no progression contract', () => {
+        const noContract = block({ progressionContract: undefined });
+        const result = deriveDurationOverridesForDate([noContract], '2026-09-10');
+        expect(result.overrides.size).toBe(0);
+        expect(result.unsupported).toEqual([]);
+    });
+
+    it('classifies each ObjectiveKey by whether its coverageKey is wired', () => {
+        const wired: Array<[BlockObjectiveDefinition['adaptationScope'], BlockObjectiveDefinition['coverageKey']]> = [
+            ['zone2_aerobic', 'aerobic_volume'],
+            ['strength_maintenance', 'primary_strength'],
+            ['strength_development', 'primary_strength'],
+            ['threshold_quality', 'sustained_quality'],
+        ];
+        for (const [adaptationScope, coverageKey] of wired) {
+            const result = deriveDurationOverridesForDate([block({}, { adaptationScope, coverageKey })], '2026-09-10');
+            expect(result.overrides.get(coverageKey)).toBe(100);
+            expect(result.unsupported).toEqual([]);
+        }
+
+        const unsupported: Array<[BlockObjectiveDefinition['adaptationScope'], BlockObjectiveDefinition['coverageKey']]> = [
+            ['surge_repeatability', 'short_surges'],
+            ['race_specific_endurance', 'outdoor_event_specific'],
+            ['vo2_max', 'gap_closing'],
+        ];
+        for (const [adaptationScope, coverageKey] of unsupported) {
+            const result = deriveDurationOverridesForDate([block({}, { adaptationScope, coverageKey })], '2026-09-10');
+            expect(result.overrides.size).toBe(0);
+            expect(result.unsupported).toEqual([
+                { blockId: 'block_a', objectiveId: 'obj_threshold_dev', coverageKey, adaptationScope },
+            ]);
+        }
+    });
+
+    it('clamps currentValue into the objective dose envelope defensively', () => {
+        const outOfRange = block(
+            { progressionContract: { ...block().progressionContract!, currentValue: 999 } },
+            { doseEnvelope: { min: 60, target: 90, max: 120, unit: 'minutes', floorSemantics: 'hard_floor' } },
+        );
+        const result = deriveDurationOverridesForDate([outOfRange], '2026-09-10');
+        expect(result.overrides.get('sustained_quality')).toBe(120);
+    });
+
+    it('resolves a same-coverage-key collision deterministically by lexicographically smaller blockId', () => {
+        const first = block({ id: 'block_a', progressionContract: { ...block().progressionContract!, currentValue: 90 } });
+        const second = block({ id: 'block_b', progressionContract: { ...block().progressionContract!, currentValue: 110 } });
+        const result = deriveDurationOverridesForDate([second, first], '2026-09-10');
+        expect(result.overrides.get('sustained_quality')).toBe(90);
+        expect(result.overrides.size).toBe(1);
+    });
+
+    it('ignores a progression contract whose targetBinding.objectiveId has no matching objective', () => {
+        const dangling = block({
+            progressionContract: { ...block().progressionContract!, targetBinding: { objectiveId: 'does_not_exist' } },
+        });
+        const result = deriveDurationOverridesForDate([dangling], '2026-09-10');
+        expect(result.overrides.size).toBe(0);
+        expect(result.unsupported).toEqual([]);
+    });
+});

--- a/app/src/engine/confirmedProgressionOverrides.test.ts
+++ b/app/src/engine/confirmedProgressionOverrides.test.ts
@@ -1,6 +1,19 @@
 import { describe, expect, it } from 'vitest';
-import { deriveDurationOverridesForDate, SELECTION_WIRED_COVERAGE_KEYS } from './confirmedProgressionOverrides';
+import { deriveDurationOverridesForDate, progressionOverrideKey, SELECTION_WIRED_COVERAGE_KEYS } from './confirmedProgressionOverrides';
+import { EVERGREEN_PACKING_COVERAGE, packWeeklyDose } from './weeklyDosePacking';
+import type { EvidenceBackedStrategy } from './evergreenStrategy';
+import type { ResolvedTrainingCapacity } from './trainingCapacity';
 import type { BlockObjectiveDefinition, IntentBlock } from './blockIntent';
+
+/**
+ * `cycling_zone2_standard_01` (aerobic_volume), `strength_full_body_maintenance_01`
+ * (primary_strength) and `cycling_controlled_threshold_4x8_01` (sustained_quality) are the
+ * real catalog workouts these fixtures target. Every `currentValue` below is chosen to fit
+ * inside that workout's real `duration.minimumMin`/`maximumMin` bounds -- a value that
+ * doesn't is deliberately exercised as its own "unsupported" case, since
+ * `exactWorkoutTargets` (confirmedProgressionOverrides.ts) rejects a confirmed target no
+ * catalog workout can physically represent rather than crediting it as accounting metadata.
+ */
 
 function objective(overrides: Partial<BlockObjectiveDefinition> = {}): BlockObjectiveDefinition {
     return {
@@ -10,7 +23,7 @@ function objective(overrides: Partial<BlockObjectiveDefinition> = {}): BlockObje
         coverageKey: 'sustained_quality',
         intent: 'develop',
         priority: 'must_have',
-        doseEnvelope: { min: 60, target: 90, max: 120, unit: 'minutes', floorSemantics: 'hard_floor' },
+        doseEnvelope: { min: 45, target: 70, max: 90, unit: 'minutes', floorSemantics: 'hard_floor' },
         knowledgeLineage: ['claim_threshold_interval_adaptation_v1'],
         successCriteria: { minCompletedExposures: 3 },
         ...overrides,
@@ -30,8 +43,8 @@ function block(overrides: Partial<IntentBlock> = {}, objectiveOverrides: Partial
             targetBinding: { objectiveId: 'obj_threshold_dev' },
             variable: 'duration_min',
             unit: 'minutes',
-            currentValue: 100,
-            permittedRange: { min: 60, max: 120 },
+            currentValue: 70,
+            permittedRange: { min: 45, max: 90 },
             increment: 10,
             knowledgeLineage: ['policy_progression_duration_v1'],
             observationWindowDays: 14,
@@ -50,9 +63,9 @@ describe('SELECTION_WIRED_COVERAGE_KEYS', () => {
 });
 
 describe('deriveDurationOverridesForDate', () => {
-    it('applies a confirmed progression for a wired coverage key within the active date range', () => {
+    it('applies a confirmed progression for a wired coverage key within the active date range, keyed to the exact catalog workout', () => {
         const result = deriveDurationOverridesForDate([block()], '2026-09-10');
-        expect(result.overrides.get('sustained_quality')).toBe(100);
+        expect(result.overrides.get(progressionOverrideKey('sustained_quality', 'cycling_controlled_threshold_4x8_01'))).toBe(70);
         expect(result.unsupported).toEqual([]);
     });
 
@@ -70,16 +83,16 @@ describe('deriveDurationOverridesForDate', () => {
         expect(result.unsupported).toEqual([]);
     });
 
-    it('classifies each ObjectiveKey by whether its coverageKey is wired', () => {
-        const wired: Array<[BlockObjectiveDefinition['adaptationScope'], BlockObjectiveDefinition['coverageKey']]> = [
-            ['zone2_aerobic', 'aerobic_volume'],
-            ['strength_maintenance', 'primary_strength'],
-            ['strength_development', 'primary_strength'],
-            ['threshold_quality', 'sustained_quality'],
+    it('classifies each wired ObjectiveKey against its real catalog workout, sport-matched', () => {
+        const wired: Array<[BlockObjectiveDefinition['adaptationScope'], BlockObjectiveDefinition['coverageKey'], BlockObjectiveDefinition['sport'], string]> = [
+            ['zone2_aerobic', 'aerobic_volume', 'cycling', 'cycling_zone2_standard_01'],
+            ['strength_maintenance', 'primary_strength', 'strength', 'strength_full_body_maintenance_01'],
+            ['strength_development', 'primary_strength', 'strength', 'strength_full_body_maintenance_01'],
+            ['threshold_quality', 'sustained_quality', 'cycling', 'cycling_controlled_threshold_4x8_01'],
         ];
-        for (const [adaptationScope, coverageKey] of wired) {
-            const result = deriveDurationOverridesForDate([block({}, { adaptationScope, coverageKey })], '2026-09-10');
-            expect(result.overrides.get(coverageKey)).toBe(100);
+        for (const [adaptationScope, coverageKey, sport, workoutId] of wired) {
+            const result = deriveDurationOverridesForDate([block({}, { adaptationScope, coverageKey, sport })], '2026-09-10');
+            expect(result.overrides.get(progressionOverrideKey(coverageKey, workoutId))).toBe(70);
             expect(result.unsupported).toEqual([]);
         }
 
@@ -92,18 +105,25 @@ describe('deriveDurationOverridesForDate', () => {
             const result = deriveDurationOverridesForDate([block({}, { adaptationScope, coverageKey })], '2026-09-10');
             expect(result.overrides.size).toBe(0);
             expect(result.unsupported).toEqual([
-                { blockId: 'block_a', objectiveId: 'obj_threshold_dev', coverageKey, adaptationScope },
+                { blockId: 'block_a', objectiveId: 'obj_threshold_dev', coverageKey, adaptationScope, reason: 'coverage_not_wired' },
             ]);
         }
     });
 
-    it('clamps currentValue into the objective dose envelope defensively when units match', () => {
+    it('rejects a confirmed value no real catalog workout can physically represent, rather than crediting it', () => {
+        // cycling_controlled_threshold_4x8_01's real maximumMin is 90; clamping alone would
+        // let 999 through as 90 (matching the objective envelope's max), but 90 does still
+        // fit that workout -- push the envelope itself past the workout's ceiling so the
+        // clamped value has nothing left it can represent.
         const outOfRange = block(
-            { progressionContract: { ...block().progressionContract!, currentValue: 999 } },
-            { doseEnvelope: { min: 60, target: 90, max: 120, unit: 'minutes', floorSemantics: 'hard_floor' } },
+            { progressionContract: { ...block().progressionContract!, currentValue: 999, permittedRange: { min: 45, max: 200 } } },
+            { doseEnvelope: { min: 45, target: 70, max: 200, unit: 'minutes', floorSemantics: 'hard_floor' } },
         );
         const result = deriveDurationOverridesForDate([outOfRange], '2026-09-10');
-        expect(result.overrides.get('sustained_quality')).toBe(120);
+        expect(result.overrides.size).toBe(0);
+        expect(result.unsupported).toEqual([
+            { blockId: 'block_a', objectiveId: 'obj_threshold_dev', coverageKey: 'sustained_quality', adaptationScope: 'threshold_quality', reason: 'no_exact_prescription_target' },
+        ]);
     });
 
     it('does not clamp minute progression against an objective envelope expressed in sessions', () => {
@@ -112,15 +132,20 @@ describe('deriveDurationOverridesForDate', () => {
             { doseEnvelope: { min: 2, target: 3, max: 4, unit: 'sessions', floorSemantics: 'hard_floor' } },
         );
         const result = deriveDurationOverridesForDate([mixedUnits], '2026-09-10');
-        expect(result.overrides.get('sustained_quality')).toBe(100);
+        expect(result.overrides.get(progressionOverrideKey('sustained_quality', 'cycling_controlled_threshold_4x8_01'))).toBe(70);
     });
 
-    it('resolves a same-coverage-key collision deterministically by lexicographically smaller blockId', () => {
-        const first = block({ id: 'block_a', progressionContract: { ...block().progressionContract!, currentValue: 90 } });
-        const second = block({ id: 'block_b', progressionContract: { ...block().progressionContract!, currentValue: 110 } });
+    it('treats two active blocks confirming the same coverage key as ambiguous, retracting both rather than silently favoring one', () => {
+        const first = block({ id: 'block_a', progressionContract: { ...block().progressionContract!, currentValue: 60 } });
+        const second = block({ id: 'block_b', progressionContract: { ...block().progressionContract!, currentValue: 80 } });
         const result = deriveDurationOverridesForDate([second, first], '2026-09-10');
-        expect(result.overrides.get('sustained_quality')).toBe(90);
-        expect(result.overrides.size).toBe(1);
+        expect(result.overrides.size).toBe(0);
+        expect(result.unsupported.map(entry => ({ blockId: entry.blockId, reason: entry.reason }))).toEqual(
+            expect.arrayContaining([
+                { blockId: 'block_a', reason: 'ambiguous_active_role_progression' },
+                { blockId: 'block_b', reason: 'ambiguous_active_role_progression' },
+            ]),
+        );
     });
 
     it('ignores a progression contract whose targetBinding.objectiveId has no matching objective', () => {
@@ -130,5 +155,68 @@ describe('deriveDurationOverridesForDate', () => {
         const result = deriveDurationOverridesForDate([dangling], '2026-09-10');
         expect(result.overrides.size).toBe(0);
         expect(result.unsupported).toEqual([]);
+    });
+});
+
+describe('deriveDurationOverridesForDate -> packWeeklyDose (production key contract, end to end)', () => {
+    const capacity: ResolvedTrainingCapacity = {
+        minSessions: 2, targetSessions: 2, maxSessions: 2,
+        weekdayMinutes: 90, weekendMinutes: 90,
+        usableWindows: [
+            { date: '2026-09-08', availableMinutes: 90 },
+            { date: '2026-09-09', availableMinutes: 90 },
+        ],
+        estimatedTargetWeeklyMinutes: 180, warnings: [],
+    };
+    const strategy: EvidenceBackedStrategy = {
+        requirements: [{
+            adaptation: 'aerobic_endurance', priority: 'required',
+            floor: { dose: { unit: 'minutes', value: 150 }, semantics: 'guideline_recommended_minimum' },
+            target: { unit: 'minutes', minimum: 150, target: 150, maximum: 300 },
+            // Restricted to cycling only, so the packer's eligible-workout set for this
+            // requirement is exactly the one workout the confirmed progression targets --
+            // not the sibling running/walking workouts also on the aerobic_volume role.
+            substitutionPolicy: { equivalentModalitiesAllowed: false, permittedModalities: ['Cycling'] },
+            knowledgeRefs: ['test.claim'],
+            evidence: {
+                knowledgeClaimId: 'test.claim', knowledgeClaimVersion: 1, sourceId: 'test', sourceIds: ['test'],
+                population: 'test', outcome: 'test', confidence: 'high', evidenceCertainty: 'moderate',
+                maturity: 'established', status: 'active', applicability: [], authority: 'guideline_target',
+                policyVersion: 'test', reviewedOn: '2026-08-10',
+            },
+        }], warnings: [],
+    };
+
+    it('carries a confirmed progression from the real derivation helper through to weekly delivered-dose accounting', () => {
+        const confirmedBlock = block({}, { adaptationScope: 'zone2_aerobic', coverageKey: 'aerobic_volume', sport: 'cycling' });
+        const overrides = deriveDurationOverridesForDate([confirmedBlock], '2026-09-08');
+        expect(overrides.overrides.get(progressionOverrideKey('aerobic_volume', 'cycling_zone2_standard_01'))).toBe(70);
+
+        const baseline = packWeeklyDose(strategy, capacity, EVERGREEN_PACKING_COVERAGE);
+        const withConfirmedProgression = packWeeklyDose(strategy, capacity, EVERGREEN_PACKING_COVERAGE, overrides.overrides);
+
+        // cycling_zone2_standard_01's catalog duration is 60 min; 2 sessions credit 120 min,
+        // below the 150-minute floor. The confirmed 70-minute progression raises that to 140
+        // -- still short, but the two budgets must differ, proving the exact-scoped key the
+        // real helper emits is understood by the packer, not silently ignored.
+        expect(baseline.shortfalls).toEqual([expect.objectContaining({ code: 'below_guideline_range' })]);
+        expect(withConfirmedProgression.shortfalls).toEqual([expect.objectContaining({ code: 'below_guideline_range', message: expect.stringContaining('140') })]);
+        expect(withConfirmedProgression).not.toEqual(baseline);
+    });
+
+    it('does not apply the override when the eligible workout set for the requirement is not the one the progression was confirmed against', () => {
+        const confirmedBlock = block({}, { adaptationScope: 'zone2_aerobic', coverageKey: 'aerobic_volume', sport: 'cycling' });
+        const overrides = deriveDurationOverridesForDate([confirmedBlock], '2026-09-08');
+
+        // Widen the requirement's permitted modalities so the packer's eligible set for
+        // aerobic_volume also includes the running/walking workouts the progression was
+        // never confirmed against -- the override must not leak onto those.
+        const multiModalStrategy: EvidenceBackedStrategy = {
+            ...strategy,
+            requirements: [{ ...strategy.requirements[0], substitutionPolicy: { equivalentModalitiesAllowed: true, permittedModalities: ['Cycling', 'Running', 'Walking'] } }],
+        };
+        const withConfirmedProgression = packWeeklyDose(multiModalStrategy, capacity, EVERGREEN_PACKING_COVERAGE, overrides.overrides);
+        const baseline = packWeeklyDose(multiModalStrategy, capacity, EVERGREEN_PACKING_COVERAGE);
+        expect(withConfirmedProgression).toEqual(baseline);
     });
 });

--- a/app/src/engine/confirmedProgressionOverrides.test.ts
+++ b/app/src/engine/confirmedProgressionOverrides.test.ts
@@ -97,13 +97,22 @@ describe('deriveDurationOverridesForDate', () => {
         }
     });
 
-    it('clamps currentValue into the objective dose envelope defensively', () => {
+    it('clamps currentValue into the objective dose envelope defensively when units match', () => {
         const outOfRange = block(
             { progressionContract: { ...block().progressionContract!, currentValue: 999 } },
             { doseEnvelope: { min: 60, target: 90, max: 120, unit: 'minutes', floorSemantics: 'hard_floor' } },
         );
         const result = deriveDurationOverridesForDate([outOfRange], '2026-09-10');
         expect(result.overrides.get('sustained_quality')).toBe(120);
+    });
+
+    it('does not clamp minute progression against an objective envelope expressed in sessions', () => {
+        const mixedUnits = block(
+            {},
+            { doseEnvelope: { min: 2, target: 3, max: 4, unit: 'sessions', floorSemantics: 'hard_floor' } },
+        );
+        const result = deriveDurationOverridesForDate([mixedUnits], '2026-09-10');
+        expect(result.overrides.get('sustained_quality')).toBe(100);
     });
 
     it('resolves a same-coverage-key collision deterministically by lexicographically smaller blockId', () => {

--- a/app/src/engine/confirmedProgressionOverrides.ts
+++ b/app/src/engine/confirmedProgressionOverrides.ts
@@ -1,48 +1,61 @@
 /**
  * ADR-0037 D-DOSE: translates confirmed `IntentBlock` progression revisions (H5c,
- * `services/progressionClaimService.ts`) into per-role duration overrides for evergreen
- * weekly dose packing (`weeklyDosePacking.ts`).
+ * `services/progressionClaimService.ts`) into exact-workout-scoped duration overrides for
+ * evergreen weekly dose packing (`weeklyDosePacking.ts`).
  *
- * `BlockObjectiveDefinition.coverageKey` (`blockIntent.ts`) already binds an objective to a
- * concrete coverage role, using the same `PlanCoverageKey` vocabulary
- * `EVERGREEN_PACKING_COVERAGE` uses to bind a role to an `AdaptationKey` -- there is no
- * separate `ObjectiveKey -> AdaptationKey` table to maintain here. The real constraint is
- * that `EVERGREEN_PACKING_COVERAGE` only defines roles for 3 of the 18 `PlanCoverageKey`s.
- * A confirmed progression bound to any other coverage key has no role to attach to in
- * evergreen packing yet, so it is reported as `unsupported` rather than silently dropped --
- * a decision-affecting change must fail visibly, never invisibly (CLAUDE.md I5).
+ * `BlockObjectiveDefinition.coverageKey` already binds an objective to the same
+ * `PlanCoverageKey` vocabulary used by evergreen packing. That is necessary, but not
+ * sufficient: ADR-0037 also makes objective sport plus optional session/step bindings part
+ * of prescription authority. Collapsing those facts to only `coverageKey -> minutes` can
+ * accidentally apply a cycling progression to a running substitute, or a session-specific
+ * progression to every workout in a role. This module therefore retains exact catalog
+ * workout identity in the map key (`<coverageRoleId>::<workoutId>`).
  *
- * `requirement.floor`/`requirement.target` (the WHO-guideline numbers in
- * `evergreenStrategy.ts`) are one level above `CoverageRoleDescriptor.durationMinutes` and
- * are never touched here -- overriding a role's assumed per-session minutes never lowers or
- * bypasses a guideline floor.
- *
- * `develop` vs `maintain` needs no special-casing here: that distinction lives entirely in
- * `progressionReview.ts` (H5b), which governs how `currentValue` is proposed to move over
- * time. This module only ever consumes whatever the currently-confirmed value is.
+ * `requirement.floor`/`requirement.target` (the guideline/product-policy numbers in
+ * `evergreenStrategy.ts`) remain one level above this adapter and are never modified.
  */
 
-import type { BlockObjectiveDefinition, BlockProgressionContract, IntentBlock } from './blockIntent';
+import type {
+    BlockObjectiveDefinition,
+    BlockProgressionContract,
+    BlockSport,
+    IntentBlock,
+} from './blockIntent';
 import { EVERGREEN_PACKING_COVERAGE } from './weeklyDosePacking';
-import type { ObjectiveKey } from './models';
+import type { DoseVariation, ObjectiveKey, SessionTemplate } from './models';
 import type { PlanCoverageKey } from '../workouts/event-plan';
+import { WORKOUTS_BY_ID } from '../workouts/catalog';
+import { workoutForTemplate } from '../workouts/prescription';
 
-/** Derived, not hardcoded, so it can never drift out of sync with the roles the packer
- * actually iterates over. Every `EVERGREEN_PACKING_COVERAGE` role's `id` today is identical
- * to its `PlanCoverageKey`. */
+/** Derived, not hardcoded, so it cannot drift from the roles the packer actually iterates. */
 export const SELECTION_WIRED_COVERAGE_KEYS: readonly PlanCoverageKey[] =
     EVERGREEN_PACKING_COVERAGE.roles.map(role => role.id as PlanCoverageKey);
+
+export type UnsupportedProgressionReason =
+    | 'coverage_not_wired'
+    | 'no_exact_prescription_target'
+    | 'ambiguous_active_role_progression';
 
 export interface UnsupportedProgressionObjective {
     blockId: string;
     objectiveId: string;
     coverageKey: PlanCoverageKey;
     adaptationScope: ObjectiveKey;
+    reason?: UnsupportedProgressionReason;
 }
 
 export interface DerivedProgressionOverrides {
-    overrides: ReadonlyMap<PlanCoverageKey, number>;
+    /**
+     * Production derivation uses exact scoped keys (`role::workoutId`). `packWeeklyDose`
+     * intentionally still accepts a legacy direct role key for deterministic unit tests and
+     * backwards-compatible injected callers.
+     */
+    overrides: ReadonlyMap<string, number>;
     unsupported: readonly UnsupportedProgressionObjective[];
+}
+
+export function progressionOverrideKey(coverageRoleId: string, workoutId: string): string {
+    return `${coverageRoleId}::${workoutId}`;
 }
 
 function isActiveOn(block: IntentBlock, date: string): boolean {
@@ -53,17 +66,23 @@ function findBoundObjective(block: IntentBlock, objectiveId: string): BlockObjec
     return block.objectives.find(objective => objective.id === objectiveId) ?? null;
 }
 
+function roleFor(coverageKey: PlanCoverageKey) {
+    return EVERGREEN_PACKING_COVERAGE.roles.find(role => role.id === coverageKey) ?? null;
+}
+
 function isWiredCoverageKey(coverageKey: PlanCoverageKey): boolean {
     return SELECTION_WIRED_COVERAGE_KEYS.includes(coverageKey);
 }
 
+function workoutModalityMatchesSport(modality: string, sport: BlockSport): boolean {
+    if (sport === 'multisport') return true;
+    return modality === sport;
+}
+
 /**
- * Defense-in-depth only: `validateProgressionContract` already enforces `currentValue`
- * against `permittedRange` at author/confirm/read time. The objective dose envelope is a
- * second bound only when it uses the *same unit* as the progression variable. ADR-0037
- * deliberately allows an objective to be expressed in (for example) sessions while the
- * one registered progression variable changes per-session duration in minutes; clamping a
- * minute value against a session-count envelope would be a unit error.
+ * Defense-in-depth only: persisted blocks are already validated. The objective envelope is
+ * a second numeric bound only when it uses the same unit as the progression variable; an
+ * objective may validly be expressed in sessions while `duration_min` remains minutes.
  */
 function clampConfirmedDuration(
     contract: BlockProgressionContract,
@@ -77,9 +96,6 @@ function clampConfirmedDuration(
         upper = Math.min(upper, objective.doseEnvelope.max);
     }
 
-    // A validated block cannot produce an inverted intersection. Keep this helper total for
-    // defense-in-depth callers nevertheless: fall back to the progression contract's own
-    // validated range instead of inventing a cross-unit/objective bound.
     if (lower > upper) {
         lower = contract.permittedRange.min;
         upper = contract.permittedRange.max;
@@ -88,13 +104,94 @@ function clampConfirmedDuration(
     return Math.min(upper, Math.max(lower, contract.currentValue));
 }
 
-/** Pure. No Firestore, no `Date.now()` -- `blocks` and `date` are both caller-supplied. */
+function exactWorkoutTargets(
+    objective: BlockObjectiveDefinition,
+    contract: BlockProgressionContract,
+): string[] {
+    const role = roleFor(objective.coverageKey);
+    if (!role) return [];
+    const duration = clampConfirmedDuration(contract, objective);
+    const { sessionId, stepId } = contract.targetBinding;
+
+    return role.exactWorkoutIds.filter(workoutId => {
+        const workout = WORKOUTS_BY_ID.get(workoutId);
+        if (!workout || workout.status !== 'active') return false;
+        if (!workoutModalityMatchesSport(workout.modality, objective.sport)) return false;
+        // In generated evergreen planning, a session binding can only be honored without
+        // guessing when it names the exact catalog workout identity used by coverage.
+        if (sessionId && sessionId !== workoutId) return false;
+        if (stepId && !workout.blocks.some(block => block.steps.some(step => step.id === stepId))) return false;
+        // A confirmed authored target that no exact prescription can physically represent
+        // must not be credited merely as accounting metadata.
+        if (duration < workout.duration.minimumMin || duration > workout.duration.maximumMin) return false;
+        return true;
+    });
+}
+
+export function progressionSelectionUnsupportedReason(
+    block: IntentBlock | null | undefined,
+): UnsupportedProgressionReason | null {
+    const contract = block?.progressionContract;
+    if (!block || !contract) return null;
+    const objective = findBoundObjective(block, contract.targetBinding.objectiveId);
+    if (!objective) return null;
+    if (!isWiredCoverageKey(objective.coverageKey)) return 'coverage_not_wired';
+    if (contract.variable !== 'duration_min' || contract.unit !== 'minutes') return 'no_exact_prescription_target';
+    return exactWorkoutTargets(objective, contract).length > 0 ? null : 'no_exact_prescription_target';
+}
+
+/**
+ * Returns an executable dose only when the selected template resolves to one of the exact
+ * workout identities authorized by the progression override. Runtime availability/safety
+ * still decides whether callers actually use this dose on a given date.
+ */
+export function progressionDoseForTemplate(
+    template: SessionTemplate,
+    overrides: ReadonlyMap<string, number>,
+): DoseVariation | null {
+    const workout = workoutForTemplate(template.id);
+    if (!workout) return null;
+    const role = EVERGREEN_PACKING_COVERAGE.roles.find(item => item.exactWorkoutIds.includes(workout.id));
+    if (!role) return null;
+    const duration = overrides.get(progressionOverrideKey(role.id, workout.id)) ?? overrides.get(role.id);
+    if (duration === undefined || !Number.isFinite(duration)) return null;
+    if (duration < workout.duration.minimumMin || duration > workout.duration.maximumMin) return null;
+    const fullDuration = workout.variants.find(variant => variant.id === 'full')?.targetDurationMin
+        ?? workout.duration.defaultMin
+        ?? template.durationMin;
+    const doseRatio = fullDuration > 0 ? duration / fullDuration : 1;
+    return {
+        label: `Confirmed progression · ${duration} min`,
+        durationMin: duration,
+        durationMax: duration,
+        doseRatio,
+        prescriptionSummary: `Use the confirmed ${duration}-minute progression dose for ${workout.name}.`,
+    };
+}
+
+function unsupportedEntry(
+    block: IntentBlock,
+    objective: BlockObjectiveDefinition,
+    reason: UnsupportedProgressionReason,
+): UnsupportedProgressionObjective {
+    return {
+        blockId: block.id,
+        objectiveId: objective.id,
+        coverageKey: objective.coverageKey,
+        adaptationScope: objective.adaptationScope,
+        reason,
+    };
+}
+
+/** Pure. No Firestore, no `Date.now()` -- `blocks` and `date` are caller-supplied. */
 export function deriveDurationOverridesForDate(
     blocks: readonly IntentBlock[],
     date: string,
 ): DerivedProgressionOverrides {
-    const overrides = new Map<PlanCoverageKey, number>();
+    const overrides = new Map<string, number>();
     const unsupported: UnsupportedProgressionObjective[] = [];
+    const claimedRoles = new Map<string, { block: IntentBlock; objective: BlockObjectiveDefinition; keys: string[] }>();
+    const conflictedRoles = new Set<string>();
 
     const activeWithContract = blocks
         .filter(block => block.progressionContract && isActiveOn(block, date))
@@ -105,29 +202,31 @@ export function deriveDurationOverridesForDate(
         const objective = findBoundObjective(block, contract.targetBinding.objectiveId);
         if (!objective) continue;
 
-        if (!isWiredCoverageKey(objective.coverageKey)) {
-            unsupported.push({
-                blockId: block.id,
-                objectiveId: objective.id,
-                coverageKey: objective.coverageKey,
-                adaptationScope: objective.adaptationScope,
-            });
+        const reason = progressionSelectionUnsupportedReason(block);
+        if (reason) {
+            unsupported.push(unsupportedEntry(block, objective, reason));
             continue;
         }
 
-        // The persisted service revalidates this before returning a block, but keep the
-        // selection boundary fail-closed if a non-service caller supplies malformed runtime
-        // data. `duration_min` is the only registered variable and it is minute-valued.
-        if (contract.variable !== 'duration_min' || contract.unit !== 'minutes') continue;
+        const roleId = objective.coverageKey;
+        if (conflictedRoles.has(roleId)) {
+            unsupported.push(unsupportedEntry(block, objective, 'ambiguous_active_role_progression'));
+            continue;
+        }
+        const prior = claimedRoles.get(roleId);
+        if (prior) {
+            prior.keys.forEach(key => overrides.delete(key));
+            unsupported.push(unsupportedEntry(prior.block, prior.objective, 'ambiguous_active_role_progression'));
+            unsupported.push(unsupportedEntry(block, objective, 'ambiguous_active_role_progression'));
+            claimedRoles.delete(roleId);
+            conflictedRoles.add(roleId);
+            continue;
+        }
 
-        // Deterministic collision handling: an athlete is expected to have at most one
-        // active block per objective coverage key. If two collide, the lexicographically
-        // first blockId wins (stable given the sort above) and the loser is dropped from
-        // selection without erroring -- a pre-existing data-modeling edge case, not
-        // something this module needs to arbitrate further.
-        if (overrides.has(objective.coverageKey)) continue;
-
-        overrides.set(objective.coverageKey, clampConfirmedDuration(contract, objective));
+        const duration = clampConfirmedDuration(contract, objective);
+        const keys = exactWorkoutTargets(objective, contract).map(workoutId => progressionOverrideKey(roleId, workoutId));
+        keys.forEach(key => overrides.set(key, duration));
+        claimedRoles.set(roleId, { block, objective, keys });
     }
 
     return { overrides, unsupported };

--- a/app/src/engine/confirmedProgressionOverrides.ts
+++ b/app/src/engine/confirmedProgressionOverrides.ts
@@ -1,0 +1,104 @@
+/**
+ * ADR-0037 D-DOSE: translates confirmed `IntentBlock` progression revisions (H5c,
+ * `services/progressionClaimService.ts`) into per-role duration overrides for evergreen
+ * weekly dose packing (`weeklyDosePacking.ts`).
+ *
+ * `BlockObjectiveDefinition.coverageKey` (`blockIntent.ts`) already binds an objective to a
+ * concrete coverage role, using the same `PlanCoverageKey` vocabulary
+ * `EVERGREEN_PACKING_COVERAGE` uses to bind a role to an `AdaptationKey` -- there is no
+ * separate `ObjectiveKey -> AdaptationKey` table to maintain here. The real constraint is
+ * that `EVERGREEN_PACKING_COVERAGE` only defines roles for 3 of the 18 `PlanCoverageKey`s.
+ * A confirmed progression bound to any other coverage key has no role to attach to in
+ * evergreen packing yet, so it is reported as `unsupported` rather than silently dropped --
+ * a decision-affecting change must fail visibly, never invisibly (CLAUDE.md I5).
+ *
+ * `requirement.floor`/`requirement.target` (the WHO-guideline numbers in
+ * `evergreenStrategy.ts`) are one level above `CoverageRoleDescriptor.durationMinutes` and
+ * are never touched here -- overriding a role's assumed per-session minutes never lowers or
+ * bypasses a guideline floor.
+ *
+ * `develop` vs `maintain` needs no special-casing here: that distinction lives entirely in
+ * `progressionReview.ts` (H5b), which governs how `currentValue` is proposed to move over
+ * time. This module only ever consumes whatever the currently-confirmed value is.
+ */
+
+import type { BlockObjectiveDefinition, IntentBlock } from './blockIntent';
+import { EVERGREEN_PACKING_COVERAGE } from './weeklyDosePacking';
+import type { ObjectiveKey } from './models';
+import type { PlanCoverageKey } from '../workouts/event-plan';
+
+/** Derived, not hardcoded, so it can never drift out of sync with the roles the packer
+ * actually iterates over. Every `EVERGREEN_PACKING_COVERAGE` role's `id` today is identical
+ * to its `PlanCoverageKey`. */
+export const SELECTION_WIRED_COVERAGE_KEYS: readonly PlanCoverageKey[] =
+    EVERGREEN_PACKING_COVERAGE.roles.map(role => role.id as PlanCoverageKey);
+
+export interface UnsupportedProgressionObjective {
+    blockId: string;
+    objectiveId: string;
+    coverageKey: PlanCoverageKey;
+    adaptationScope: ObjectiveKey;
+}
+
+export interface DerivedProgressionOverrides {
+    overrides: ReadonlyMap<PlanCoverageKey, number>;
+    unsupported: readonly UnsupportedProgressionObjective[];
+}
+
+function isActiveOn(block: IntentBlock, date: string): boolean {
+    return date >= block.dateRange.startDate && date <= block.dateRange.endDate;
+}
+
+function findBoundObjective(block: IntentBlock, objectiveId: string): BlockObjectiveDefinition | null {
+    return block.objectives.find(objective => objective.id === objectiveId) ?? null;
+}
+
+function isWiredCoverageKey(coverageKey: PlanCoverageKey): boolean {
+    return SELECTION_WIRED_COVERAGE_KEYS.includes(coverageKey);
+}
+
+/** Defense-in-depth only: `validateProgressionContract` already enforces this range at
+ * confirm time. */
+function clampToEnvelope(value: number, objective: BlockObjectiveDefinition): number {
+    return Math.min(objective.doseEnvelope.max, Math.max(objective.doseEnvelope.min, value));
+}
+
+/** Pure. No Firestore, no `Date.now()` -- `blocks` and `date` are both caller-supplied. */
+export function deriveDurationOverridesForDate(
+    blocks: readonly IntentBlock[],
+    date: string,
+): DerivedProgressionOverrides {
+    const overrides = new Map<PlanCoverageKey, number>();
+    const unsupported: UnsupportedProgressionObjective[] = [];
+
+    const activeWithContract = blocks
+        .filter(block => block.progressionContract && isActiveOn(block, date))
+        .sort((left, right) => left.id.localeCompare(right.id));
+
+    for (const block of activeWithContract) {
+        const contract = block.progressionContract!;
+        const objective = findBoundObjective(block, contract.targetBinding.objectiveId);
+        if (!objective) continue;
+
+        if (!isWiredCoverageKey(objective.coverageKey)) {
+            unsupported.push({
+                blockId: block.id,
+                objectiveId: objective.id,
+                coverageKey: objective.coverageKey,
+                adaptationScope: objective.adaptationScope,
+            });
+            continue;
+        }
+
+        // Deterministic collision handling: an athlete is expected to have at most one
+        // active block per objective coverage key. If two collide, the lexicographically
+        // first blockId wins (stable given the sort above) and the loser is dropped from
+        // selection without erroring -- a pre-existing data-modeling edge case, not
+        // something this module needs to arbitrate further.
+        if (overrides.has(objective.coverageKey)) continue;
+
+        overrides.set(objective.coverageKey, clampToEnvelope(contract.currentValue, objective));
+    }
+
+    return { overrides, unsupported };
+}

--- a/app/src/engine/confirmedProgressionOverrides.ts
+++ b/app/src/engine/confirmedProgressionOverrides.ts
@@ -22,7 +22,7 @@
  * time. This module only ever consumes whatever the currently-confirmed value is.
  */
 
-import type { BlockObjectiveDefinition, IntentBlock } from './blockIntent';
+import type { BlockObjectiveDefinition, BlockProgressionContract, IntentBlock } from './blockIntent';
 import { EVERGREEN_PACKING_COVERAGE } from './weeklyDosePacking';
 import type { ObjectiveKey } from './models';
 import type { PlanCoverageKey } from '../workouts/event-plan';
@@ -57,10 +57,35 @@ function isWiredCoverageKey(coverageKey: PlanCoverageKey): boolean {
     return SELECTION_WIRED_COVERAGE_KEYS.includes(coverageKey);
 }
 
-/** Defense-in-depth only: `validateProgressionContract` already enforces this range at
- * confirm time. */
-function clampToEnvelope(value: number, objective: BlockObjectiveDefinition): number {
-    return Math.min(objective.doseEnvelope.max, Math.max(objective.doseEnvelope.min, value));
+/**
+ * Defense-in-depth only: `validateProgressionContract` already enforces `currentValue`
+ * against `permittedRange` at author/confirm/read time. The objective dose envelope is a
+ * second bound only when it uses the *same unit* as the progression variable. ADR-0037
+ * deliberately allows an objective to be expressed in (for example) sessions while the
+ * one registered progression variable changes per-session duration in minutes; clamping a
+ * minute value against a session-count envelope would be a unit error.
+ */
+function clampConfirmedDuration(
+    contract: BlockProgressionContract,
+    objective: BlockObjectiveDefinition,
+): number {
+    let lower = contract.permittedRange.min;
+    let upper = contract.permittedRange.max;
+
+    if (objective.doseEnvelope.unit === contract.unit) {
+        lower = Math.max(lower, objective.doseEnvelope.min);
+        upper = Math.min(upper, objective.doseEnvelope.max);
+    }
+
+    // A validated block cannot produce an inverted intersection. Keep this helper total for
+    // defense-in-depth callers nevertheless: fall back to the progression contract's own
+    // validated range instead of inventing a cross-unit/objective bound.
+    if (lower > upper) {
+        lower = contract.permittedRange.min;
+        upper = contract.permittedRange.max;
+    }
+
+    return Math.min(upper, Math.max(lower, contract.currentValue));
 }
 
 /** Pure. No Firestore, no `Date.now()` -- `blocks` and `date` are both caller-supplied. */
@@ -90,6 +115,11 @@ export function deriveDurationOverridesForDate(
             continue;
         }
 
+        // The persisted service revalidates this before returning a block, but keep the
+        // selection boundary fail-closed if a non-service caller supplies malformed runtime
+        // data. `duration_min` is the only registered variable and it is minute-valued.
+        if (contract.variable !== 'duration_min' || contract.unit !== 'minutes') continue;
+
         // Deterministic collision handling: an athlete is expected to have at most one
         // active block per objective coverage key. If two collide, the lexicographically
         // first blockId wins (stable given the sort above) and the loser is dropped from
@@ -97,7 +127,7 @@ export function deriveDurationOverridesForDate(
         // something this module needs to arbitrate further.
         if (overrides.has(objective.coverageKey)) continue;
 
-        overrides.set(objective.coverageKey, clampToEnvelope(contract.currentValue, objective));
+        overrides.set(objective.coverageKey, clampConfirmedDuration(contract, objective));
     }
 
     return { overrides, unsupported };

--- a/app/src/engine/confirmedProgressionOverrides.ts
+++ b/app/src/engine/confirmedProgressionOverrides.ts
@@ -26,6 +26,9 @@ import type { DoseVariation, ObjectiveKey, SessionTemplate } from './models';
 import type { PlanCoverageKey } from '../workouts/event-plan';
 import { WORKOUTS_BY_ID } from '../workouts/catalog';
 import { workoutForTemplate } from '../workouts/prescription';
+import { progressionOverrideKey } from './progressionOverrideKey';
+
+export { progressionOverrideKey };
 
 /** Derived, not hardcoded, so it cannot drift from the roles the packer actually iterates. */
 export const SELECTION_WIRED_COVERAGE_KEYS: readonly PlanCoverageKey[] =
@@ -52,10 +55,6 @@ export interface DerivedProgressionOverrides {
      */
     overrides: ReadonlyMap<string, number>;
     unsupported: readonly UnsupportedProgressionObjective[];
-}
-
-export function progressionOverrideKey(coverageRoleId: string, workoutId: string): string {
-    return `${coverageRoleId}::${workoutId}`;
 }
 
 function isActiveOn(block: IntentBlock, date: string): boolean {

--- a/app/src/engine/evergreenPlanning.test.ts
+++ b/app/src/engine/evergreenPlanning.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { resolveEvergreenPlan } from './evergreenPlanning';
+import { resolvePlanningContext } from './planningMode';
+import { evaluatePeriodizationPhase } from './periodization';
+import type { UserContext, UserPreferences, TrainingIntentProfile } from './models';
+
+/**
+ * End-to-end check (ADR-0037 D-DOSE) that a confirmed progression's per-session duration
+ * actually reaches `packWeeklyDose` through `resolveEvergreenPlan`'s new
+ * `progressionOverrides` parameter -- the lower-level substitution itself is covered by
+ * `weeklyDosePacking.test.ts`; this proves the wiring between them is not lost.
+ */
+
+const DATE = '2026-09-07';
+
+const evergreenProfile: TrainingIntentProfile = {
+    userId: 'u1', planningMode: 'evergreen', priorities: ['balanced_performance'],
+    weeklyCommitment: { minSessions: 2, targetSessions: 3, maxSessions: 3 },
+    organizationPreference: 'auto', schemaVersion: 1, createdAt: '', updatedAt: '',
+};
+const preferences: UserPreferences = {
+    userId: 'u1', preferredRecoveryStyle: 'mixed', defaultWeekdayTimeMin: 60, defaultWeekendTimeMin: 60,
+    preferredTimeOfDay: 'flexible', preferredModalities: [], deprioritizedModalities: [], avoidedModalities: [],
+    explanationVerbosity: 'detailed', conservativeBias: false, preferredUnits: { distance: 'km', weight: 'kg', temperature: 'celsius' },
+    schemaVersion: 1, createdAt: '', updatedAt: '',
+};
+const context: UserContext = {
+    goals: { shortTerm: '', midTerm: '', longTerm: '' },
+    constraints: { hasCableMachine: true, hasFreeWeights: true, hasTreadmill: false, hasIndoorBike: true, restrictedModalities: [], maxTimeMinutes: 90 },
+    preferences: { avoidedModalities: [], deprioritizedModalities: [], preferredModalities: [], conservativeBias: false },
+};
+
+function resolve(progressionOverrides?: ReadonlyMap<string, number>) {
+    const planningContext = resolvePlanningContext(evergreenProfile, evaluatePeriodizationPhase([], DATE), DATE);
+    return resolveEvergreenPlan(
+        planningContext,
+        evaluatePeriodizationPhase([], DATE).phase,
+        [],
+        null,
+        preferences,
+        context,
+        DATE,
+        [],
+        7,
+        false,
+        [],
+        progressionOverrides,
+    );
+}
+
+describe('resolveEvergreenPlan progressionOverrides wiring', () => {
+    it('threads a confirmed progression override into the packed weekly budget', () => {
+        const baseline = resolve();
+        expect(baseline).not.toBeNull();
+
+        const overridden = resolve(new Map([['aerobic_volume', 200]]));
+        expect(overridden).not.toBeNull();
+
+        // The override raises aerobic_volume's per-session credited minutes well above its
+        // catalog duration, so the same capacity now either clears a shortfall the baseline
+        // had or packs fewer aerobic_volume sessions to reach the same target -- either way
+        // the budgets must differ once the override is applied, proving it reached the packer.
+        expect(overridden!.budget).not.toEqual(baseline!.budget);
+    });
+
+    it('is a no-op when no confirmed progression targets a wired coverage key', () => {
+        const withEmptyMap = resolve(new Map());
+        const withDefault = resolve();
+        expect(withEmptyMap!.budget).toEqual(withDefault!.budget);
+    });
+});

--- a/app/src/engine/evergreenPlanning.ts
+++ b/app/src/engine/evergreenPlanning.ts
@@ -33,6 +33,9 @@ export function resolveEvergreenPlan(
     days: number = 7,
     isAdverseRecovery: boolean = false,
     scheduleOverlays: readonly ScheduleOverlay[] = [],
+    /** ADR-0037 D-DOSE: a confirmed `IntentBlock` progression's per-session duration
+     * (`engine/confirmedProgressionOverrides.ts`), keyed by coverage role id. */
+    progressionOverrides: ReadonlyMap<string, number> = new Map(),
 ): ResolvedEvergreenPlan | null {
     if (planningContext.mode !== 'evergreen' || !preferences) return null;
     const availability = Array.from({ length: Math.max(1, days) }, (_, index) => {
@@ -51,7 +54,7 @@ export function resolveEvergreenPlan(
             stateEvidence?.observedWindowDays ?? historySnapshot?.windowDays ?? 0,
         ),
     );
-    const budget = packWeeklyDose(strategy, capacity, EVERGREEN_PACKING_COVERAGE);
+    const budget = packWeeklyDose(strategy, capacity, EVERGREEN_PACKING_COVERAGE, progressionOverrides);
     const result = buildEvergreenPlanDefinition(strategy, capacity, budget, date);
     if (result.status !== 'AVAILABLE') return null;
     return {

--- a/app/src/engine/planner.ts
+++ b/app/src/engine/planner.ts
@@ -170,6 +170,9 @@ export interface WeekAheadOptions {
     planDefinition?: PlanDefinition | null;
     /** Simulation-only fatigue comparison. Live callers use the default `max`. */
     fatigueFusionPolicy?: FatigueFusionPolicy;
+    /** ADR-0037 D-DOSE: a confirmed `IntentBlock` progression's per-session duration
+     * (`engine/confirmedProgressionOverrides.ts`), keyed by coverage role id. */
+    progressionOverrides?: ReadonlyMap<string, number>;
 }
 
 const ZERO_COST: WorkoutCostProfile = {
@@ -1612,7 +1615,7 @@ export async function generateWeekAheadPlanWithIntent(
     const evergreen = resolveEvergreenPlan(
         intent.planningContext, intent.periodization.phase, intent.history, intent.historySnapshot,
         preferences, context, todayDate, options.fixedActivities ?? [], options.days ?? 7,
-        isAdverseRecovery, options.scheduleOverlays ?? [],
+        isAdverseRecovery, options.scheduleOverlays ?? [], options.progressionOverrides ?? new Map(),
     );
     return generateWeekAheadPlan(
         todayReadiness,

--- a/app/src/engine/planner.ts
+++ b/app/src/engine/planner.ts
@@ -170,9 +170,6 @@ export interface WeekAheadOptions {
     planDefinition?: PlanDefinition | null;
     /** Simulation-only fatigue comparison. Live callers use the default `max`. */
     fatigueFusionPolicy?: FatigueFusionPolicy;
-    /** ADR-0037 D-DOSE: a confirmed `IntentBlock` progression's per-session duration
-     * (`engine/confirmedProgressionOverrides.ts`), keyed by coverage role id. */
-    progressionOverrides?: ReadonlyMap<string, number>;
 }
 
 const ZERO_COST: WorkoutCostProfile = {
@@ -1612,10 +1609,14 @@ export async function generateWeekAheadPlanWithIntent(
     const fatigueFusionPolicy = options.fatigueFusionPolicy ?? 'max';
     const intent = await resolveTrainingIntent(userId, events, todayDate, todayReadiness, 7, historyProvider, preparedHistorySnapshot, options.authoredPlanBlocks, trainingIntentProfile, fatigueFusionPolicy);
     const isAdverseRecovery = isSevereAdverseRecoveryReadiness(todayReadiness, todayRec.mode);
+    // ADR-0037 D-DOSE: no progressionOverrides here -- a confirmed progression's duration
+    // override is date-scoped to a single day, but this packs the whole week-ahead horizon
+    // in one call. Progression influence is deliberately scoped to same-day planning
+    // (rules.ts's evaluateTrainingWithIntent) until the packer has a date-scoped resolver.
     const evergreen = resolveEvergreenPlan(
         intent.planningContext, intent.periodization.phase, intent.history, intent.historySnapshot,
         preferences, context, todayDate, options.fixedActivities ?? [], options.days ?? 7,
-        isAdverseRecovery, options.scheduleOverlays ?? [], options.progressionOverrides ?? new Map(),
+        isAdverseRecovery, options.scheduleOverlays ?? [],
     );
     return generateWeekAheadPlan(
         todayReadiness,

--- a/app/src/engine/policy.test.ts
+++ b/app/src/engine/policy.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, it } from 'vitest';
 import { isHistoricalPolicyVersion, HISTORICAL_POLICY_VERSIONS, POLICY_VERSION } from './policy';
 
 describe('isHistoricalPolicyVersion', () => {
-    it('records the exact fixed-activity dedup-identity-unification transition once', () => {
-        expect(POLICY_VERSION).toBe('2026-09-fixed-activity-dedup-identity-unification-v1');
+    it('records the exact progression-confirmed-selection-wiring transition once', () => {
+        expect(POLICY_VERSION).toBe('2026-09-progression-confirmed-selection-wiring-v1');
         expect(
             HISTORICAL_POLICY_VERSIONS.filter(
-                (version) => version === '2026-09-h4-d-ledger-planner-admission-v2',
+                (version) => version === '2026-09-fixed-activity-dedup-identity-unification-v1',
             ),
         ).toHaveLength(1);
     });

--- a/app/src/engine/policy.ts
+++ b/app/src/engine/policy.ts
@@ -1,11 +1,12 @@
 /** Increment whenever a change can alter a persisted recommendation decision. (Refactoring does not require a bump) */
 
-export const POLICY_VERSION = '2026-09-fixed-activity-dedup-identity-unification-v1';
+export const POLICY_VERSION = '2026-09-progression-confirmed-selection-wiring-v1';
 
 /** Historical versions are intentionally not re-executed by this build. Their compact
  * audits remain readable evidence, but replay is rejected explicitly because the old
  * decision function is not bundled alongside the current policy. */
 export const HISTORICAL_POLICY_VERSIONS = [
+    '2026-09-fixed-activity-dedup-identity-unification-v1',
     '2026-09-h4-d-ledger-planner-admission-v2',
     '2026-09-h4-d-ledger-planner-admission-v1',
     '2026-09-h4-intraday-bundle-member-launch-v1',

--- a/app/src/engine/progressionOverrideKey.ts
+++ b/app/src/engine/progressionOverrideKey.ts
@@ -1,0 +1,11 @@
+/**
+ * Shared key format for a confirmed `IntentBlock` progression's per-workout duration
+ * override (ADR-0037 D-DOSE). Pulled into its own file, rather than living in either
+ * `confirmedProgressionOverrides.ts` or `weeklyDosePacking.ts`, because both of those
+ * modules need it and each already imports from the other (`confirmedProgressionOverrides.ts`
+ * reads `EVERGREEN_PACKING_COVERAGE` from `weeklyDosePacking.ts`) -- a third, dependency-free
+ * file avoids the cycle.
+ */
+export function progressionOverrideKey(coverageRoleId: string, workoutId: string): string {
+    return `${coverageRoleId}::${workoutId}`;
+}

--- a/app/src/engine/rules.ts
+++ b/app/src/engine/rules.ts
@@ -1423,9 +1423,6 @@ export async function evaluateNextDayPlanWithIntent(
     subjectiveDriftPolicy: SubjectiveDriftPolicy = 'off',
     subjectiveDriftWeights: SubjectiveDriftWeights = REFERENCE_SUBJECTIVE_DRIFT_WEIGHTS,
     scheduleOverlays: readonly ScheduleOverlay[] = [],
-    /** ADR-0037 D-DOSE: a confirmed `IntentBlock` progression's per-session duration
-     * (`engine/confirmedProgressionOverrides.ts`), keyed by coverage role id. */
-    confirmedProgressionOverrides: ReadonlyMap<string, number> = new Map(),
 ): Promise<NextDayPotentialPlan> {
     const scenarios = buildNextDayScenarios(todayReadiness, context, todayDate, todayRec);
     const projectedProvider = await projectedProviderForTomorrow(
@@ -1438,12 +1435,17 @@ export async function evaluateNextDayPlanWithIntent(
         historyProvider,
         preparedHistorySnapshot,
     );
+    // ADR-0037 D-DOSE: no confirmedProgressionOverrides here -- a confirmed progression's
+    // duration override is date-scoped to a single day, and this evaluates *tomorrow*'s
+    // scenarios from *today*'s call. Progression influence is deliberately scoped to
+    // same-day planning (evaluateTrainingWithIntent's own confirmedProgressionOverrides
+    // parameter) until the packer has a date-scoped resolver.
     const evaluate = async (scenario: NextDayScenario) => evaluatedBranch(
         scenario,
         await evaluateTrainingWithIntent(
             userId, scenario.readiness, context, events, scenarios.date, todayRec.mode, projectedProvider, null,
             fixedActivities, authoredPlanBlocks, trainingIntentProfile, preferences, fatigueFusionPolicy, null,
-            subjectiveDriftPolicy, subjectiveDriftWeights, null, false, scheduleOverlays, confirmedProgressionOverrides,
+            subjectiveDriftPolicy, subjectiveDriftWeights, null, false, scheduleOverlays,
         ),
     );
     const [green, yellow, red] = await Promise.all([

--- a/app/src/engine/rules.ts
+++ b/app/src/engine/rules.ts
@@ -763,6 +763,9 @@ export async function evaluateTrainingWithIntent(
      *  gate below and is retained in provenance as an explicit override. */
     athleteOverridesAuthoredRest: boolean = false,
     scheduleOverlays: readonly ScheduleOverlay[] = [],
+    /** ADR-0037 D-DOSE: a confirmed `IntentBlock` progression's per-session duration
+     * (`engine/confirmedProgressionOverrides.ts`), keyed by coverage role id. */
+    confirmedProgressionOverrides: ReadonlyMap<string, number> = new Map(),
 ): Promise<Recommendation> {
     const envelopeState = evaluateReadinessAndSafetyEnvelope(readiness, context, date, previousMode, subjectiveDriftPolicy, subjectiveDriftWeights);
     const { mode, envelopes, telemetry } = envelopeState;
@@ -830,6 +833,7 @@ export async function evaluateTrainingWithIntent(
     const evergreen = resolveEvergreenPlan(
         intent.planningContext, intent.periodization.phase, intent.history, intent.historySnapshot,
         preferences, context, date, fixedActivities, 7, isAdverseRecovery, scheduleOverlays,
+        confirmedProgressionOverrides,
     );
     if (evergreen) {
         const unresolvedObjectives = getUnresolvedObjectives(evergreen.microcycle);
@@ -1419,6 +1423,9 @@ export async function evaluateNextDayPlanWithIntent(
     subjectiveDriftPolicy: SubjectiveDriftPolicy = 'off',
     subjectiveDriftWeights: SubjectiveDriftWeights = REFERENCE_SUBJECTIVE_DRIFT_WEIGHTS,
     scheduleOverlays: readonly ScheduleOverlay[] = [],
+    /** ADR-0037 D-DOSE: a confirmed `IntentBlock` progression's per-session duration
+     * (`engine/confirmedProgressionOverrides.ts`), keyed by coverage role id. */
+    confirmedProgressionOverrides: ReadonlyMap<string, number> = new Map(),
 ): Promise<NextDayPotentialPlan> {
     const scenarios = buildNextDayScenarios(todayReadiness, context, todayDate, todayRec);
     const projectedProvider = await projectedProviderForTomorrow(
@@ -1436,7 +1443,7 @@ export async function evaluateNextDayPlanWithIntent(
         await evaluateTrainingWithIntent(
             userId, scenario.readiness, context, events, scenarios.date, todayRec.mode, projectedProvider, null,
             fixedActivities, authoredPlanBlocks, trainingIntentProfile, preferences, fatigueFusionPolicy, null,
-            subjectiveDriftPolicy, subjectiveDriftWeights, null, false, scheduleOverlays,
+            subjectiveDriftPolicy, subjectiveDriftWeights, null, false, scheduleOverlays, confirmedProgressionOverrides,
         ),
     );
     const [green, yellow, red] = await Promise.all([

--- a/app/src/engine/weeklyDosePacking.test.ts
+++ b/app/src/engine/weeklyDosePacking.test.ts
@@ -256,4 +256,33 @@ describe('weekly dose packing', () => {
         expect(budget.requiredRoles.map(role => role.date)).toEqual(['2026-08-10', '2026-08-13']);
         expect(budget.shortfalls).toEqual([]);
     });
+
+    describe('durationOverridesByRoleId (ADR-0037 D-DOSE confirmed progression)', () => {
+        it('credits the overridden per-session minutes instead of the role\'s catalog duration, closing a floor shortfall', () => {
+            const wideWindows = capacity(90, 2);
+            const baseline = packWeeklyDose(healthStrategy, wideWindows, coverage);
+            expect(baseline.requiredRoles).toHaveLength(2);
+            expect(baseline.shortfalls).toEqual([expect.objectContaining({ code: 'below_guideline_range' })]);
+
+            const withOverride = packWeeklyDose(healthStrategy, wideWindows, coverage, new Map([['aerobic-ride', 90]]));
+            expect(withOverride.requiredRoles).toHaveLength(2);
+            expect(withOverride.shortfalls).toEqual([]);
+        });
+
+        it('leaves packing unchanged when the override key does not match any role id', () => {
+            const withUnmatchedOverride = packWeeklyDose(healthStrategy, capacity(60, 2), coverage, new Map([['no-such-role', 999]]));
+            const withoutOverride = packWeeklyDose(healthStrategy, capacity(60, 2), coverage);
+            expect(withUnmatchedOverride).toEqual(withoutOverride);
+        });
+
+        it('never changes the requirement-level guideline floor/target, only the role\'s per-session credit', () => {
+            const wideWindows = capacity(200, 1);
+            const budget = packWeeklyDose(healthStrategy, wideWindows, coverage, new Map([['aerobic-ride', 200]]));
+            // A single 200-minute session now fully covers the 150-minute floor -- but the
+            // floor value itself (from `strategy.requirements[0].floor`) is untouched; only
+            // the role's delivered-dose credit changed.
+            expect(budget.requirements[0].floor?.dose.value).toBe(150);
+            expect(budget.shortfalls).toEqual([]);
+        });
+    });
 });

--- a/app/src/engine/weeklyDosePacking.ts
+++ b/app/src/engine/weeklyDosePacking.ts
@@ -3,6 +3,7 @@ import type { ResolvedTrainingCapacity } from './trainingCapacity';
 import { EVERGREEN_GENERAL_COVERAGE_SET } from '../workouts/event-plan';
 import { WORKOUTS_BY_ID } from '../workouts/catalog';
 import { getDayDiff } from '../utils/localDate';
+import { progressionOverrideKey } from './progressionOverrideKey';
 
 export interface CoverageRoleDescriptor {
     /** Stable authored identity; never a category/modality similarity match. */
@@ -93,6 +94,57 @@ function permittedWorkoutIds(role: CoverageRoleDescriptor, requirement: Adaptati
     });
 }
 
+/**
+ * A confirmed progression is scoped to the exact workout(s)
+ * `confirmedProgressionOverrides.ts` validated it against (matching sport, session binding
+ * and duration bounds) -- never to the whole role, whose `exactWorkoutIds` can span multiple
+ * sports (e.g. `aerobic_volume` covers cycling, running and walking). Applying it here only
+ * when *every* currently-eligible workout for this specific requirement shares the exact
+ * same override value means a role whose substitution policy still allows a non-progression
+ * modality is left at its catalog duration rather than crediting a workout the progression
+ * was never validated against.
+ */
+function resolveExactOverrideDuration(
+    role: CoverageRoleDescriptor,
+    eligibleWorkoutIds: readonly string[],
+    overrides: ReadonlyMap<string, number>,
+): number | null {
+    if (eligibleWorkoutIds.length === 0) return null;
+    const values = eligibleWorkoutIds.map(workoutId => overrides.get(progressionOverrideKey(role.id, workoutId)));
+    if (values.some(value => value === undefined)) return null;
+    const [first, ...rest] = values as number[];
+    return rest.every(value => value === first) ? first : null;
+}
+
+/** The plain role-id key is an explicit, unconditional "override this whole role" signal --
+ * kept for deterministic unit tests and backwards-compatible injected callers (see
+ * `confirmedProgressionOverrides.ts`'s own doc comment) -- and always wins over the
+ * exact-scoped key. */
+function effectiveRole(
+    role: CoverageRoleDescriptor,
+    eligibleWorkoutIds: readonly string[],
+    overrides: ReadonlyMap<string, number>,
+): CoverageRoleDescriptor {
+    if (overrides.size === 0) return role;
+    if (overrides.has(role.id)) return { ...role, durationMinutes: overrides.get(role.id)! };
+    const exact = resolveExactOverrideDuration(role, eligibleWorkoutIds, overrides);
+    return exact === null ? role : { ...role, durationMinutes: exact };
+}
+
+/** Roles matching the requirement's adaptation, with at least one permitted exact workout,
+ * resolved to their effective (possibly overridden) duration for this specific requirement. */
+function eligibleCandidates(
+    roles: readonly CoverageRoleDescriptor[],
+    requirement: AdaptationDoseRequirement,
+    overrides: ReadonlyMap<string, number>,
+): Array<{ role: CoverageRoleDescriptor; permitted: string[] }> {
+    return roles
+        .filter(role => role.adaptations.includes(requirement.adaptation))
+        .map(role => ({ role, permitted: permittedWorkoutIds(role, requirement) }))
+        .filter((entry): entry is { role: CoverageRoleDescriptor; permitted: string[] } => entry.permitted.length > 0)
+        .map(entry => ({ role: effectiveRole(entry.role, entry.permitted, overrides), permitted: entry.permitted }));
+}
+
 function placementTieBreakerPenalty(
     date: string,
     packed: readonly MutableOccurrence[],
@@ -126,25 +178,20 @@ function warningFor(requirement: AdaptationDoseRequirement, delivered: number): 
  * no modality/category similarity is used for bundling.
  *
  * `durationOverridesByRoleId` (ADR-0037 D-DOSE): a confirmed `IntentBlock` progression's
- * per-session `currentValue` (`engine/confirmedProgressionOverrides.ts`), keyed by role id.
- * It substitutes for a role's catalog-derived `durationMinutes` everywhere below -- both the
- * capacity-fit estimate and the literal delivered-dose accounting -- without touching
+ * per-session `currentValue` (`engine/confirmedProgressionOverrides.ts`), keyed either by
+ * plain role id (legacy/back-compat, applies to the whole role unconditionally) or by
+ * `progressionOverrideKey(roleId, workoutId)` (production; see `effectiveRole` below for how
+ * an exact-scoped key is resolved per requirement rather than applied to the whole role). It
+ * substitutes for a role's catalog-derived `durationMinutes` -- both the capacity-fit
+ * estimate and the literal delivered-dose accounting -- without touching
  * `requirement.floor`/`requirement.target`, which stay WHO-guideline-owned one level above
- * this function. An id with no matching role is simply inert. */
+ * this function. A key with no matching role/workout is simply inert. */
 export function packWeeklyDose(
     strategy: EvidenceBackedStrategy,
     capacity: ResolvedTrainingCapacity,
     coverage: CoverageSetDescriptor,
     durationOverridesByRoleId: ReadonlyMap<string, number> = new Map(),
 ): WeeklyBudget {
-    const effectiveCoverage: CoverageSetDescriptor = durationOverridesByRoleId.size === 0
-        ? coverage
-        : {
-            id: coverage.id,
-            roles: coverage.roles.map(role => durationOverridesByRoleId.has(role.id)
-                ? { ...role, durationMinutes: durationOverridesByRoleId.get(role.id)! }
-                : role),
-        };
     const slots = capacity.usableWindows.map(window => ({ ...window, used: false }));
     const packed: MutableOccurrence[] = [];
     const shortfalls: PackingWarning[] = [];
@@ -162,10 +209,7 @@ export function packWeeklyDose(
      * the best dose each individual window can actually host instead of assuming the role's
      * globally best per-session dose fits every window. */
     const sessionsNeededFor = (requirement: AdaptationDoseRequirement): number => {
-        const candidates = effectiveCoverage.roles.filter(role =>
-            role.adaptations.includes(requirement.adaptation)
-            && permittedWorkoutIds(role, requirement).length > 0,
-        );
+        const candidates = eligibleCandidates(coverage.roles, requirement, durationOverridesByRoleId).map(entry => entry.role);
         if (candidates.length === 0) return 0;
         const delivered = packed
             .filter(occurrence => occurrence.adaptations.includes(requirement.adaptation))
@@ -192,15 +236,10 @@ export function packWeeklyDose(
     };
 
     for (const requirement of requirements) {
-        const adaptationCandidates = effectiveCoverage.roles.filter(role => role.adaptations.includes(requirement.adaptation));
-        const permittedByRole = new Map<CoverageRoleDescriptor, string[]>();
-        for (const role of adaptationCandidates) {
-            const permitted = permittedWorkoutIds(role, requirement);
-            if (permitted.length > 0) {
-                permittedByRole.set(role, permitted);
-            }
-        }
-        const candidates = adaptationCandidates.filter(role => permittedByRole.has(role));
+        const adaptationCandidates = coverage.roles.filter(role => role.adaptations.includes(requirement.adaptation));
+        const eligible = eligibleCandidates(coverage.roles, requirement, durationOverridesByRoleId);
+        const permittedByRole = new Map<CoverageRoleDescriptor, string[]>(eligible.map(entry => [entry.role, entry.permitted]));
+        const candidates = eligible.map(entry => entry.role);
         if (candidates.length === 0) {
             const code = adaptationCandidates.length > 0 ? 'goal_constraint_conflict' : 'no_exact_eligible_role';
             shortfalls.push({ code, adaptation: requirement.adaptation, message: code === 'goal_constraint_conflict'

--- a/app/src/engine/weeklyDosePacking.ts
+++ b/app/src/engine/weeklyDosePacking.ts
@@ -123,12 +123,28 @@ function warningFor(requirement: AdaptationDoseRequirement, delivered: number): 
 /** Converts evidence-derived dose into exact authored roles. Every selected occurrence is
  * attached to one real availability date and one authored descriptor. A role may satisfy
  * more than one adaptation only when that descriptor explicitly grants each adaptation;
- * no modality/category similarity is used for bundling. */
+ * no modality/category similarity is used for bundling.
+ *
+ * `durationOverridesByRoleId` (ADR-0037 D-DOSE): a confirmed `IntentBlock` progression's
+ * per-session `currentValue` (`engine/confirmedProgressionOverrides.ts`), keyed by role id.
+ * It substitutes for a role's catalog-derived `durationMinutes` everywhere below -- both the
+ * capacity-fit estimate and the literal delivered-dose accounting -- without touching
+ * `requirement.floor`/`requirement.target`, which stay WHO-guideline-owned one level above
+ * this function. An id with no matching role is simply inert. */
 export function packWeeklyDose(
     strategy: EvidenceBackedStrategy,
     capacity: ResolvedTrainingCapacity,
     coverage: CoverageSetDescriptor,
+    durationOverridesByRoleId: ReadonlyMap<string, number> = new Map(),
 ): WeeklyBudget {
+    const effectiveCoverage: CoverageSetDescriptor = durationOverridesByRoleId.size === 0
+        ? coverage
+        : {
+            id: coverage.id,
+            roles: coverage.roles.map(role => durationOverridesByRoleId.has(role.id)
+                ? { ...role, durationMinutes: durationOverridesByRoleId.get(role.id)! }
+                : role),
+        };
     const slots = capacity.usableWindows.map(window => ({ ...window, used: false }));
     const packed: MutableOccurrence[] = [];
     const shortfalls: PackingWarning[] = [];
@@ -146,7 +162,7 @@ export function packWeeklyDose(
      * the best dose each individual window can actually host instead of assuming the role's
      * globally best per-session dose fits every window. */
     const sessionsNeededFor = (requirement: AdaptationDoseRequirement): number => {
-        const candidates = coverage.roles.filter(role =>
+        const candidates = effectiveCoverage.roles.filter(role =>
             role.adaptations.includes(requirement.adaptation)
             && permittedWorkoutIds(role, requirement).length > 0,
         );
@@ -176,7 +192,7 @@ export function packWeeklyDose(
     };
 
     for (const requirement of requirements) {
-        const adaptationCandidates = coverage.roles.filter(role => role.adaptations.includes(requirement.adaptation));
+        const adaptationCandidates = effectiveCoverage.roles.filter(role => role.adaptations.includes(requirement.adaptation));
         const permittedByRole = new Map<CoverageRoleDescriptor, string[]>();
         for (const role of adaptationCandidates) {
             const permitted = permittedWorkoutIds(role, requirement);

--- a/app/src/services/intentBlockService.test.ts
+++ b/app/src/services/intentBlockService.test.ts
@@ -184,3 +184,32 @@ describe('IntentBlockService.getHeaderState / getRevisionState', () => {
         expect(state.status).toBe('INVALID');
     });
 });
+
+describe('IntentBlockService.getActiveBlocks', () => {
+    it('keeps only blocks whose latest revision is AVAILABLE and whose dateRange covers the date', async () => {
+        firestore.getDocs.mockResolvedValue({ docs: [{ id: 'active' }, { id: 'expired' }, { id: 'header_missing' }, { id: 'revision_invalid' }] });
+        const service = new IntentBlockService();
+        const activeBlock = block({ id: 'active', dateRange: { startDate: '2026-09-01', endDate: '2026-09-30' } });
+        const expiredBlock = block({ id: 'expired', dateRange: { startDate: '2026-01-01', endDate: '2026-01-31' } });
+        vi.spyOn(service, 'getHeaderState').mockImplementation(async (_userId, blockId) => {
+            if (blockId === 'header_missing') return { status: 'MISSING' };
+            return { status: 'AVAILABLE', data: { revision: 1 } as unknown as IntentBlockHeader, revision: 'x' };
+        });
+        vi.spyOn(service, 'getRevisionState').mockImplementation(async (_userId, blockId) => {
+            if (blockId === 'active') return { status: 'AVAILABLE', data: { block: activeBlock } as never, revision: '1' };
+            if (blockId === 'expired') return { status: 'AVAILABLE', data: { block: expiredBlock } as never, revision: '1' };
+            return { status: 'INVALID', issues: [] };
+        });
+
+        const result = await service.getActiveBlocks(USER_ID, '2026-09-10');
+        expect(result.status).toBe('AVAILABLE');
+        expect(result.status === 'AVAILABLE' && result.data.map(b => b.id)).toEqual(['active']);
+    });
+
+    it('passes through a non-AVAILABLE listBlockIds result unchanged', async () => {
+        firestore.getDocs.mockRejectedValue(new Error('offline'));
+        const service = new IntentBlockService();
+        const result = await service.getActiveBlocks(USER_ID, '2026-09-10');
+        expect(result.status).toBe('UNAVAILABLE');
+    });
+});

--- a/app/src/services/intentBlockService.ts
+++ b/app/src/services/intentBlockService.ts
@@ -220,6 +220,31 @@ export class IntentBlockService {
     }
 
     /**
+     * Convenience read for engine wiring (ADR-0037 D-DOSE,
+     * `engine/confirmedProgressionOverrides.ts`): every block whose latest revision reads
+     * back `AVAILABLE` (validated shape and content-hash, per `getRevisionState`) and whose
+     * `dateRange` covers `date`. A block whose header or latest revision is missing,
+     * unavailable, or fails its own hash/shape check is skipped rather than failing the
+     * whole read -- one athlete's corrupted block must never blank out every other block's
+     * confirmed progression.
+     */
+    async getActiveBlocks(userId: string, date: string): Promise<DataState<IntentBlock[]>> {
+        const idsState = await this.listBlockIds(userId);
+        if (idsState.status !== 'AVAILABLE') return idsState;
+
+        const blocks = await Promise.all(idsState.data.map(async blockId => {
+            const headerState = await this.getHeaderState(userId, blockId);
+            if (headerState.status !== 'AVAILABLE') return null;
+            const revisionState = await this.getRevisionState(userId, blockId, headerState.data.revision);
+            return revisionState.status === 'AVAILABLE' ? revisionState.data.block : null;
+        }));
+
+        const activeBlocks = blocks.filter((block): block is IntentBlock =>
+            block !== null && date >= block.dateRange.startDate && date <= block.dateRange.endDate);
+        return { status: 'AVAILABLE', data: activeBlocks, revision: null };
+    }
+
+    /**
      * Transaction-composable primitive. `existingHeader` must already have been read via
      * `transaction.get` in the *same* transaction (Firestore's reads-before-writes rule) --
      * this re-verifies the revision-not-newer precondition from that transactional read

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -98,10 +98,15 @@ H5a intent contracts and canonical replay (`engine/blockIntent.ts`,
 `progressionReviewInputService.ts` (real evidence assembly), `progressionClaimService.ts`
 (the athlete-scoped singleton claim/confirmation transaction), and an athlete-facing
 authoring + review UI (`ProgressionBlockEditor.tsx`/`ProgressionReviewPanel.tsx`, mounted in
-`TrainingSettings.tsx`). None of it is wired into daily recommendation selection --
-confirming a progression revision persists an audited `IntentBlock` revision but does not
-yet change any recommendation; that wiring, and cumulative `external-plan@5`, remain
-separate, later, separately policy-reviewed work.
+`TrainingSettings.tsx`). A confirmed progression revision is now also wired into live
+evergreen selection (`engine/confirmedProgressionOverrides.ts`, `POLICY_VERSION`
+`2026-09-progression-confirmed-selection-wiring-v1`) for the 4 `ObjectiveKey`s whose
+`coverageKey` has a packed evergreen role (`zone2_aerobic`, `strength_maintenance`,
+`strength_development`, `threshold_quality`); `surge_repeatability`,
+`race_specific_endurance` and `vo2_max` are explicitly flagged unsupported-for-selection
+rather than silently ignored -- see
+[the cycling hybrid evaluation plan](./cycling-primary-hybrid-evaluation.md)'s H5 section.
+Cumulative `external-plan@5` remains separate, later, unstarted work.
 H4's same-day canonical performed-fact boundary is verified;
 H5 runtime needs validated intent mappings and linked response evidence. H5
 delivers intent authoring, report-only review, then confirmed bounded revisions. The work

--- a/docs/plans/cycling-primary-hybrid-evaluation.md
+++ b/docs/plans/cycling-primary-hybrid-evaluation.md
@@ -22,9 +22,10 @@ not persisted). A bundle's resolved placement is also now persisted for
 display, at `users/{userId}/intraday_bundle_placements/{date}` -- a separate sibling
 document rather than a `recommendationAudit.externalPlan` field, since that document's
 rule-evaluation budget was re-verified insufficient. H5 design is
-accepted as ADR-0037 with H5a/H5b/H5c now all delivered -- see below for what H5c's
-delivery does and deliberately does not cover; only cumulative `external-plan@5` remains
-unstarted.
+accepted as ADR-0037 with H5a/H5b/H5c now all delivered, and a confirmed progression
+revision now wired into live evergreen selection for 4 of 7 `ObjectiveKey`s -- see below for
+what H5c's delivery and the selection-wiring delivery each do and deliberately do not
+cover; only cumulative `external-plan@5` remains unstarted.
 **Blocked by:** Personal M00/M01 prescription requires current workload/restriction
 confirmation; H4's live release is delivered through PR 3 Phase 6, recorded in
 [the PR 3 plan](./h4-434-pr3-bundle-second-member-launch.md). H4's non-gating follow-up work
@@ -582,8 +583,11 @@ unscoped follow-up.
 ## H5 — Explicit develop/maintain intent and progression
 
 **Status:** Accepted design in [ADR-0037](../adr/0037-block-intent-and-controlled-progression.md);
-**H5a, H5b and H5c all delivered as of 2026-09-09**. Only cumulative `external-plan@5`
-remains unstarted.
+**H5a, H5b and H5c all delivered as of 2026-09-09; a confirmed progression revision is now
+wired into live evergreen selection as of 2026-09-10** for the 4 `ObjectiveKey`s whose
+`coverageKey` already has a packed evergreen role (`zone2_aerobic`,
+`strength_maintenance`, `strength_development`, `threshold_quality`). Only cumulative
+`external-plan@5` remains unstarted.
 **Dependencies:** `external-plan@5` acceptance depends on the landed H4 v4 contract (landed)
 and on H5c's shape (now delivered); it remains separately scoped work.
 
@@ -622,9 +626,35 @@ delivery therefore built the full chain, per
 
 `POLICY_VERSION` is unchanged by all of H5c (verified via `check-policy-drift.mjs` and
 `simulate:diff` on every commit): confirming a progression revision persists an audited
-`IntentBlock` revision, but nothing yet reads that revision from any recommendation
-selection path. Wiring a confirmed revision into live selection is separate, later,
-separately policy-reviewed work -- not part of this delivery.
+`IntentBlock` revision, but nothing read that revision from any recommendation selection
+path.
+
+**Wiring into live selection (2026-09-10, `2026-09-progression-confirmed-selection-wiring-v1`):**
+a `BlockObjectiveDefinition.coverageKey` already binds an objective directly onto
+`weeklyDosePacking.ts`'s coverage-role vocabulary -- the same `PlanCoverageKey` values
+`EVERGREEN_PACKING_COVERAGE` uses to bind a role to an `AdaptationKey` -- so there was no
+separate `ObjectiveKey -> AdaptationKey` table to build. The real constraint is that
+`EVERGREEN_PACKING_COVERAGE` only defines roles for 3 of the 18 `PlanCoverageKey`s
+(`aerobic_volume`, `primary_strength`, `sustained_quality`). This delivery:
+
+- `engine/confirmedProgressionOverrides.ts` (new) derives a per-role duration-minutes
+  override from an athlete's active confirmed `IntentBlock`s for a given date, classified
+  against `SELECTION_WIRED_COVERAGE_KEYS` (derived from `EVERGREEN_PACKING_COVERAGE`, so it
+  cannot drift out of sync with it).
+- `weeklyDosePacking.ts`'s `packWeeklyDose` takes the override map, substituting a role's
+  catalog-derived `durationMinutes` for capacity-fit and delivered-dose accounting only --
+  `requirement.floor`/`requirement.target` (the WHO-guideline numbers from
+  `evergreenStrategy.ts`) are never touched, so a guideline floor can never be lowered or
+  bypassed by a confirmed progression.
+- `zone2_aerobic`, `strength_maintenance`, `strength_development` and `threshold_quality`
+  are wired (their natural `coverageKey` has a packed role). `surge_repeatability`,
+  `race_specific_endurance` and `vo2_max` are explicitly classified unsupported-for-selection
+  -- a visible notice in `ProgressionBlockEditor.tsx`/`ProgressionReviewPanel.tsx`, not a
+  silent no-op -- pending a future evergreen coverage-role expansion, which is separate,
+  unscoped work.
+- `develop` vs. `maintain` needed no new packing logic: that distinction already lives
+  entirely in `engine/progressionReview.ts` (H5b), governing how `currentValue` is proposed
+  to move over time: the packer only ever consumes whatever value is currently confirmed.
 
 ## Reproduction and verification
 
@@ -666,6 +696,10 @@ archived that version and activated `2026-09-h4-d-ledger-planner-admission-v1`, 
 superseded by `-v2` for the fixed-activity cost-reduce reduce consolidation. The
 fixed-activity dedup-identity unification then archived `-v2` and activated
 `2026-09-fixed-activity-dedup-identity-unification-v1` -- another mechanical bump, not a
-behavior change (`simulate:diff` clean). H5c will require normal policy review when it
-changes decision behavior. Do not enable experimental personalization simply to improve a
-judge score.
+behavior change (`simulate:diff` clean). H5c itself required no policy bump (report-and-
+confirm-only, no selection-time read). Wiring a confirmed progression into live evergreen
+selection then archived `-v1` and activated
+`2026-09-progression-confirmed-selection-wiring-v1` -- a real behavior change gated on an
+athlete actually confirming a progression (`simulate:diff` clean against the committed
+baseline, since no simulation fixture has one). Do not enable experimental personalization
+simply to improve a judge score.

--- a/docs/plans/h5c-progression-claim-design.md
+++ b/docs/plans/h5c-progression-claim-design.md
@@ -4,17 +4,15 @@
 assembly (`progressionReviewInputService.ts`), the claim/confirmation transaction
 (`progressionClaimService.ts`), an athlete-facing authoring UI
 (`ProgressionBlockEditor.tsx`) and a review/confirmation UI (`ProgressionReviewPanel.tsx`,
-mounted in `TrainingSettings.tsx`) are all delivered. **What remains explicitly unstarted**:
-wiring a confirmed `IntentBlock`/progression revision into live recommendation *selection*
-(planner/rules ranking) -- this delivery makes progression review/confirmation a real,
-usable, fully audited feature; it does not make any recommendation actually change because
-of one. That is H5's next, separately policy-reviewed step, and `POLICY_VERSION` is
-correctly unchanged by everything delivered here (verified via `check-policy-drift.mjs` and
-`simulate:diff`, both clean, on every commit of this delivery).
-**Unlocks:** wiring confirmed progression revisions into live recommendation selection
-(separate, later, separately policy-reviewed); cumulative `external-plan@5` acceptance,
-which the cycling hybrid evaluation plan already notes is otherwise unblocked now that H4's
-v4 contract has landed.
+mounted in `TrainingSettings.tsx`) are all delivered. `POLICY_VERSION` was correctly
+unchanged by everything delivered here (verified via `check-policy-drift.mjs` and
+`simulate:diff`, both clean, on every commit of this delivery). **Wiring a confirmed
+revision into live recommendation selection was the next step below this document's original
+scope -- it is now also delivered (2026-09-10)**, for the `ObjectiveKey`s whose `coverageKey`
+has a packed evergreen role; see `docs/plans/cycling-primary-hybrid-evaluation.md`'s H5
+section for that delivery's own detail and its `POLICY_VERSION` bump.
+**Unlocks:** cumulative `external-plan@5` acceptance, which the cycling hybrid evaluation
+plan already notes is otherwise unblocked now that H4's v4 contract has landed.
 **Governs:** [ADR-0037](../adr/0037-block-intent-and-controlled-progression.md) D-AUTHORITY,
 D-CHANGE's one-active-experiment rule.
 **Builds on:** H5a (`engine/blockIntent.ts`, `engine/blockIntentReplay.ts`) and H5b
@@ -341,8 +339,9 @@ recommendation-time read or latency path.
 ## Out of scope (delivered elsewhere or deliberately not part of this delivery)
 
 - Wiring `progressionReview.ts` output or a confirmed `IntentBlock` revision into live
-  recommendation selection — H5b/H5c remain report-and-confirm-only; this is separate,
-  later, separately policy-reviewed work.
+  recommendation selection was out of scope for H5c itself (H5b/H5c remain
+  report-and-confirm-only) — that separate, later, separately policy-reviewed step is now
+  also delivered; see `docs/plans/cycling-primary-hybrid-evaluation.md`'s H5 section.
 - Cumulative `external-plan@5` (depends on H5c's shape, separately scoped).
 - Exposing `IntentBlock`'s full schema generality in the authoring UI (protected roles,
   substitutions, prerequisites, exit criteria, `evaluationRef`-bound success criteria) --


### PR DESCRIPTION
## Review status — BLOCKED (2026-09-10)

A current-main second-pass review found two correctness blockers that supersede the historical green verification below:

1. `deriveDurationOverridesForDate()` now emits exact-workout-scoped keys (`coverageRoleId::workoutId`), but `packWeeklyDose()` still applies only direct `coverageRoleId` keys. Production-derived progression durations are therefore ignored by weekly capacity/dose accounting even though candidate-level `progressionDoseForTemplate()` understands the exact key.
2. Progression authority is date-bounded, but Home derives a map from blocks active on the current date and reuses that map for tomorrow/week-ahead planning. A block ending today can leak into future planning, while a block beginning tomorrow can be missed.

Current frontend CI also has 5 failing tests in `confirmedProgressionOverrides.test.ts` because they still assert the older direct-role key shape. Updating those assertions alone is not sufficient; the runtime contract above must be made consistent first.

**Do not merge this PR until** weekly packing consumes exact-workout-aware progression authority and forecast planning derives/uses progression authority for the date being planned (or the feature is deliberately constrained to same-day planning).

---

## Summary

ADR-0037 D-DOSE: a confirmed progression revision (H5c, #517) previously had no
effect on what an athlete was actually prescribed. This wires it into evergreen
weekly dose packing.

**Mapping finding:** `BlockObjectiveDefinition.coverageKey` already binds an
objective directly onto `weeklyDosePacking.ts`'s coverage-role vocabulary — the
same `PlanCoverageKey` values `EVERGREEN_PACKING_COVERAGE` uses to bind a role
to an `AdaptationKey`. There is no separate `ObjectiveKey -> AdaptationKey`
table to build. The real constraint: `EVERGREEN_PACKING_COVERAGE` only defines
roles for 3 of 18 `PlanCoverageKey`s, so only 4 of 7 `ObjectiveKey`s
(`zone2_aerobic`, `strength_maintenance`, `strength_development`,
`threshold_quality`) are wired here. `surge_repeatability`,
`race_specific_endurance`, and `vo2_max` are explicitly classified
unsupported-for-selection (a visible UI notice, not a silent gap) pending a
future coverage-role expansion — confirmed with the user as this PR's scope.

**Mechanism:** `packWeeklyDose` takes an optional `durationOverridesByRoleId`
map, substituting a confirmed progression's per-session `currentValue` for a
role's catalog-derived `durationMinutes` — for capacity-fit and delivered-dose
accounting only. `requirement.floor`/`requirement.target` (the WHO-guideline
numbers) are never touched, so a guideline floor can never be lowered or
bypassed. `develop` vs `maintain` needs no packer-level special-casing; that
distinction already lives in `progressionReview.ts` (H5b).

## Changes

- `engine/confirmedProgressionOverrides.ts` (new): derives the override map +
  unsupported-objective list from an athlete's active confirmed `IntentBlock`s.
- `engine/weeklyDosePacking.ts`: `packWeeklyDose` accepts the override map.
- `engine/evergreenPlanning.ts`, `engine/rules.ts`, `engine/planner.ts`: thread
  the override through, mirroring how `AuthoredPlanBlock` is already threaded.
- `services/intentBlockService.ts`: new `getActiveBlocks(userId, date)`.
- `components/Home.tsx`: fetches confirmed blocks the same way
  `authoredPlanBlocks` already is; derives and passes the override map into
  both the daily and week-ahead recommendation paths.
- `components/ProgressionBlockEditor.tsx` / `ProgressionReviewPanel.tsx`:
  non-blocking inline notice when a progression targets an unsupported
  coverage key.
- `engine/policy.ts`: bumps `POLICY_VERSION` to
  `2026-09-progression-confirmed-selection-wiring-v1`.
- Docs: `docs/plans/README.md`, `cycling-primary-hybrid-evaluation.md`,
  `h5c-progression-claim-design.md` updated to record this as delivered.

## Historical branch verification (superseded by current blocker status above)

The original branch author reported `npm run check`, policy drift, simulation, plan-judge, and targeted rules checks as green before subsequent exact-key changes. The current PR head is not green: current CI reports 5 frontend failures around the old role-key expectation, and the runtime inconsistencies described above remain unresolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)