### PR TITLE
🧹 Log diagnostic warnings on audit query fallbacks instead of swallowing broad exceptions

### DIFF
--- a/src/garmin_sync/audit.py
+++ b/src/garmin_sync/audit.py
@@ -70,7 +70,10 @@ def run_audit(
     if callable(get_historical):
         try:
             snapshots_by_date = repository.get_historical_snapshots(start_iso, end_iso)
-        except Exception:
+        except Exception as exc:
+            logger.warning(
+                "Historical snapshot retrieval failed in audit, falling back: %s", exc
+            )
             snapshots_by_date = None
 
     if snapshots_by_date is None:
@@ -79,7 +82,11 @@ def run_audit(
             date_isos = [get_date_string(d) for d in expected_dates]
             try:
                 snapshots_by_date = repository.get_snapshots_batch(date_isos)
-            except Exception:
+            except Exception as exc:
+                logger.warning(
+                    "Batch snapshot retrieval failed in audit, falling back to point reads: %s",
+                    exc,
+                )
                 # Preserve the pre-batching behavior when the optimized read is unavailable:
                 # an audit should remain useful even if it has to fall back to point reads.
                 snapshots_by_date = {}

--- a/src/garmin_sync/audit.py
+++ b/src/garmin_sync/audit.py
@@ -71,9 +71,7 @@ def run_audit(
         try:
             snapshots_by_date = repository.get_historical_snapshots(start_iso, end_iso)
         except Exception as exc:
-            logger.warning(
-                "Historical snapshot retrieval failed in audit, falling back: %s", exc
-            )
+            logger.warning("Historical snapshot retrieval failed in audit, falling back: %s", exc)
             snapshots_by_date = None
 
     if snapshots_by_date is None:


### PR DESCRIPTION
🎯 **What:**
Replaced bare broad exception handlers (`except Exception:`) in `src/garmin_sync/audit.py` (during historical and batch snapshot retrieval fallbacks) with `except Exception as exc:` and warning log messages (`logger.warning`).

💡 **Why:**
Bare `except Exception:` without logging silently swallows errors when querying historical or batch snapshots fails. Capturing the exception and logging a warning provides necessary observability and diagnostic context while preserving the intended graceful fallback behavior to point reads.

✅ **Verification:**
- Verified code changes using `read_file`.
- Ran linters (`uv run ruff check .`) and type checker (`uv run mypy src`).
- Ran full test suite (`uv run pytest tests/`), including `tests/test_audit.py` and `tests/test_rebuild_and_audit.py`.

✨ **Result:**
Improved maintainability and observability without breaking existing fallback logic in the audit module.

---
*PR created automatically by Jules for task [4990627389910851225](https://jules.google.com/task/4990627389910851225) started by @Szczepanov*