### PR TITLE
🧹 Replace broad exception handling in token store

### DIFF
--- a/src/garmin_sync/token_store.py
+++ b/src/garmin_sync/token_store.py
@@ -63,7 +63,7 @@ def _set_secure_permissions(file_path: Path) -> None:
             _chmod_secure(parent, 0o700)
             if file_path.exists():
                 _chmod_secure(file_path, 0o600)
-    except Exception as e:
+    except OSError as e:
         logger.debug(f"Failed to set permissions on '{file_path}': {type(e).__name__}")
 
 

--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -26,3 +26,18 @@ def test_local_token_store_persist_returns_false_when_source_missing(tmp_path: P
     store = LocalTokenStore(local_path=tmp_path / "store" / "tokens.json")
 
     assert store.persist(tmp_path / "missing.json") is False
+
+
+def test_set_secure_permissions_handles_os_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from garmin_sync.token_store import _set_secure_permissions
+
+    target_file = tmp_path / "tokens.json"
+    target_file.write_text("{}")
+
+    def mock_chmod_secure(path: Path, mode: int) -> None:
+        raise OSError("Permission denied")
+
+    monkeypatch.setattr("garmin_sync.token_store._chmod_secure", mock_chmod_secure)
+
+    # Should catch OSError and log debug without raising exception
+    _set_secure_permissions(target_file)

--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -28,7 +28,9 @@ def test_local_token_store_persist_returns_false_when_source_missing(tmp_path: P
     assert store.persist(tmp_path / "missing.json") is False
 
 
-def test_set_secure_permissions_handles_os_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_set_secure_permissions_handles_os_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     from garmin_sync.token_store import _set_secure_permissions
 
     target_file = tmp_path / "tokens.json"


### PR DESCRIPTION
🎯 **What:**
Replaced broad `except Exception` with `except OSError` in `_set_secure_permissions` (`src/garmin_sync/token_store.py`) and added corresponding unit tests in `tests/test_token_store.py`.

💡 **Why:**
Using broad exception handling in permission modifications risks masking unrelated errors or control-flow exceptions. Restricting exception handling to `OSError` ensures file/permission-related failures are caught and logged appropriately while preventing other unexpected exceptions from being swallowed.

✅ **Verification:**
- Ran `uv run ruff check .` and `uv run mypy src` (0 issues).
- Ran `uv run pytest tests/` (all 817 tests passed, including new test `test_set_secure_permissions_handles_os_error`).
- Verified files with `read_file`.

✨ **Result:**
Improved maintainability, safety, and code health without changing existing runtime behavior.

---
*PR created automatically by Jules for task [2306717261592532369](https://jules.google.com/task/2306717261592532369) started by @Szczepanov*