### PR TITLE
🧹 Refactor broad exception handling in presence_filter

### DIFF
--- a/src/garmin_sync/presence_filter.py
+++ b/src/garmin_sync/presence_filter.py
@@ -71,7 +71,7 @@ def _calculate_session_overlap_minutes(start_a: str, end_a: str, start_b: str, e
         overlap_end = min(dt_end_a, dt_end_b)
         diff = (overlap_end - overlap_start).total_seconds()
         return max(0, int(diff // 60))
-    except Exception:
+    except (ValueError, TypeError, AttributeError):
         return 0
 
 

--- a/tests/test_presence_filter.py
+++ b/tests/test_presence_filter.py
@@ -157,10 +157,28 @@ def test_calculate_session_overlap_minutes_invalid_inputs() -> None:
     from garmin_sync.presence_filter import _calculate_session_overlap_minutes
 
     # Invalid ISO date format strings
-    assert _calculate_session_overlap_minutes("invalid-date", "2026-08-28T06:30:00Z", "2026-08-27T22:45:00Z", "2026-08-28T06:15:00Z") == 0
+    assert (
+        _calculate_session_overlap_minutes(
+            "invalid-date", "2026-08-28T06:30:00Z", "2026-08-27T22:45:00Z", "2026-08-28T06:15:00Z"
+        )
+        == 0
+    )
 
     # Non-string inputs (e.g. integer or None)
-    assert _calculate_session_overlap_minutes(12345, "2026-08-28T06:30:00Z", "2026-08-27T22:45:00Z", "2026-08-28T06:15:00Z") == 0  # type: ignore[arg-type]
+    assert (
+        _calculate_session_overlap_minutes(
+            12345, "2026-08-28T06:30:00Z", "2026-08-27T22:45:00Z", "2026-08-28T06:15:00Z"
+        )
+        == 0
+    )  # type: ignore[arg-type]
 
     # Mixed naive and aware datetimes leading to TypeError/AttributeError
-    assert _calculate_session_overlap_minutes("2026-08-27 22:30:00", "2026-08-28T06:30:00Z", "2026-08-27T22:45:00Z", "2026-08-28T06:15:00Z") == 0
+    assert (
+        _calculate_session_overlap_minutes(
+            "2026-08-27 22:30:00",
+            "2026-08-28T06:30:00Z",
+            "2026-08-27T22:45:00Z",
+            "2026-08-28T06:15:00Z",
+        )
+        == 0
+    )

--- a/tests/test_presence_filter.py
+++ b/tests/test_presence_filter.py
@@ -151,3 +151,16 @@ def test_co_presence_quarantines_equally_regardless_of_divergence_magnitude() ->
     assert extreme.concordanceStatus == "DISCORDANT_SECONDARY"
     assert moderate.verifiedAthlete is False
     assert extreme.verifiedAthlete is False
+
+
+def test_calculate_session_overlap_minutes_invalid_inputs() -> None:
+    from garmin_sync.presence_filter import _calculate_session_overlap_minutes
+
+    # Invalid ISO date format strings
+    assert _calculate_session_overlap_minutes("invalid-date", "2026-08-28T06:30:00Z", "2026-08-27T22:45:00Z", "2026-08-28T06:15:00Z") == 0
+
+    # Non-string inputs (e.g. integer or None)
+    assert _calculate_session_overlap_minutes(12345, "2026-08-28T06:30:00Z", "2026-08-27T22:45:00Z", "2026-08-28T06:15:00Z") == 0  # type: ignore[arg-type]
+
+    # Mixed naive and aware datetimes leading to TypeError/AttributeError
+    assert _calculate_session_overlap_minutes("2026-08-27 22:30:00", "2026-08-28T06:30:00Z", "2026-08-27T22:45:00Z", "2026-08-28T06:15:00Z") == 0


### PR DESCRIPTION
🎯 **What:** Replaced broad `except Exception` catch block in `_calculate_session_overlap_minutes` in `src/garmin_sync/presence_filter.py` with specific exception handling `except (ValueError, TypeError, AttributeError):`.

💡 **Why:** Catching `Exception` broadly can silently hide unexpected programming errors (e.g. `KeyboardInterrupt`, `SystemExit`, or unrelated errors). Explicitly listing expected parsing and datetime operations exceptions improves code health and maintainability.

✅ **Verification:**
- Ran `uv run pytest tests/test_presence_filter.py` (added unit tests for invalid strings, non-string types, and datetime parsing errors).
- Ran `uv run ruff check src/garmin_sync/presence_filter.py tests/test_presence_filter.py`.
- Ran `uv run mypy src`.

✨ **Result:** Clean, safe exception handling and increased test coverage for invalid datetime inputs in session overlap calculations.

---
*PR created automatically by Jules for task [5930936054109033038](https://jules.google.com/task/5930936054109033038) started by @Szczepanov*