### PR TITLE
🧹 Refactor broad exception handling in raw health observation service archive

### DIFF
--- a/src/garmin_sync/health_observation_service.py
+++ b/src/garmin_sync/health_observation_service.py
@@ -185,8 +185,10 @@ class HealthObservationService:
                         stored_ref = self.archive_store.archive_health(archive_rec)
                         if stored_ref:
                             archive_ref = stored_ref
-                    except Exception as arch_err:
-                        logger.warning("Failed to archive raw health observations: %s", arch_err)
+                    except (OSError, ValueError, TypeError, AttributeError) as arch_err:
+                        logger.warning(
+                            "Failed to archive raw health observations: %s", arch_err, exc_info=True
+                        )
 
                 provider_results: dict[str, Any] = {}
                 for (obs_provider, obs_transport), source_obs in grouped.items():

--- a/tests/test_health_observation_service.py
+++ b/tests/test_health_observation_service.py
@@ -365,7 +365,7 @@ def test_health_observation_service_archive_exception_handled(
     )
 
     mock_archive_store = MagicMock(spec=RawArchiveStore)
-    mock_archive_store.archive_health.side_effect = Exception("Simulated archive error")
+    mock_archive_store.archive_health.side_effect = OSError("Simulated archive error")
     service = HealthObservationService(
         user_id="test_uid",
         repository=mock_repo,


### PR DESCRIPTION
🎯 **What:** Replaced broad `except Exception` in `HealthObservationService.sync_date` around `self.archive_store.archive_health(...)` with specific exceptions `(OSError, ValueError, TypeError, AttributeError)` and added `exc_info=True` to the warning log. Updated `tests/test_health_observation_service.py` mock error handling to match.

💡 **Why:** Broad exception clauses can obscure unexpected runtime/programming errors (such as `KeyboardInterrupt`, unexpected typos, or system exceptions). Narrowing down to specific expected failure modes improves debuggability and code maintainability without suppressing unexpected failures.

✅ **Verification:**
- Ran `uv run ruff check .` and `uv run mypy src` (all passed).
- Ran full test suite via `uv run pytest` (816 tests passed).

✨ **Result:** Clean, robust exception handling for raw health observation archiving with full exception tracebacks in warning logs.

---
*PR created automatically by Jules for task [9955355162986497365](https://jules.google.com/task/9955355162986497365) started by @Szczepanov*