### PR TITLE
🧹 replace broad exception handling in health probe with GoogleHealthError

### DIFF
--- a/src/garmin_sync/health_probe.py
+++ b/src/garmin_sync/health_probe.py
@@ -10,7 +10,11 @@ from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from typing import Any
 
-from .google_health_client import GoogleHealthAccountNotLinkedError, GoogleHealthClient
+from .google_health_client import (
+    GoogleHealthAccountNotLinkedError,
+    GoogleHealthClient,
+    GoogleHealthError,
+)
 from .google_health_mapper import resolve_provider_from_package
 
 logger = logging.getLogger(__name__)
@@ -120,7 +124,7 @@ class HealthProvenanceProbe:
                     notes.append(
                         f"ACCOUNT_NOT_LINKED: Google account has not completed Google Health onboarding. Complete setup at: {e.redirect_uri or 'https://fitbit.google.com/auth/signup'}"
                     )
-            except Exception as e:
+            except GoogleHealthError as e:
                 logger.warning("Probe query failed for %s: %s", dtype, e)
                 notes.append(f"Query failed for {dtype}: {e}")
 

--- a/tests/test_health_probe.py
+++ b/tests/test_health_probe.py
@@ -1,6 +1,10 @@
 from unittest.mock import MagicMock
 
-from garmin_sync.google_health_client import GoogleHealthClient
+from garmin_sync.google_health_client import (
+    GoogleHealthAccountNotLinkedError,
+    GoogleHealthClient,
+    GoogleHealthError,
+)
 from garmin_sync.health_probe import HealthProvenanceProbe
 
 
@@ -66,3 +70,25 @@ def test_health_provenance_probe_eight_sleep_fail():
 
     assert result.garminStatus == "PRESENT"
     assert result.eightSleepStatus == "FAIL"
+
+
+def test_health_provenance_probe_account_not_linked_error():
+    mock_client = MagicMock(spec=GoogleHealthClient)
+    mock_client.list_data_points.side_effect = GoogleHealthAccountNotLinkedError(
+        "Account not linked", redirect_uri="https://fitbit.google.com/auth/signup"
+    )
+
+    probe = HealthProvenanceProbe(client=mock_client)
+    result = probe.run_probe()
+
+    assert any("ACCOUNT_NOT_LINKED" in note for note in result.notes)
+
+
+def test_health_provenance_probe_google_health_error():
+    mock_client = MagicMock(spec=GoogleHealthClient)
+    mock_client.list_data_points.side_effect = GoogleHealthError("API failure")
+
+    probe = HealthProvenanceProbe(client=mock_client)
+    result = probe.run_probe()
+
+    assert any("Query failed for sleep: API failure" in note for note in result.notes)


### PR DESCRIPTION
🎯 **What:**
Replaced broad `except Exception` handling in `HealthProvenanceProbe.run_probe` (`src/garmin_sync/health_probe.py`) with specific domain exception `GoogleHealthError`.

💡 **Why:**
Catching broad `Exception` swallowed unexpected system and programming errors (e.g., `AttributeError`, `TypeError`, cancellation signals) and masked them as data query failures. Catching `GoogleHealthError` ensures that domain-specific API failures are handled gracefully while allowing unexpected errors to surface for debugging.

✅ **Verification:**
- Ran linter and type checker: `uv run ruff check .` and `uv run mypy src`
- Added unit tests in `tests/test_health_probe.py` covering `GoogleHealthAccountNotLinkedError` and `GoogleHealthError`
- Executed full test suite: `uv run pytest` (818 passed)

✨ **Result:**
Improved maintainability and error visibility in `health_probe.py` without changing behavior for Google Health API query error handling.

---
*PR created automatically by Jules for task [12787584273420394733](https://jules.google.com/task/12787584273420394733) started by @Szczepanov*