### PR TITLE
🧹 Replace broad exception handling for garminconnect version lookup

### DIFF
--- a/src/garmin_sync/service.py
+++ b/src/garmin_sync/service.py
@@ -121,7 +121,7 @@ class GarminSyncService:
         )
         try:
             self.garminconnect_version: str | None = importlib.metadata.version("garminconnect")
-        except Exception:
+        except importlib.metadata.PackageNotFoundError:
             self.garminconnect_version = None
 
     def _init_garmin_client(self) -> GarminClientWrapper:

--- a/tests/test_sync_service.py
+++ b/tests/test_sync_service.py
@@ -1591,3 +1591,24 @@ def test_sync_service_builds_target_snapshot_after_lookback_dates_are_corrected(
     # Target's 7d baseline -- (60 + 50 + 50 + 50) / 4 -- used the corrected D-1 value
     # because D-1 was rebuilt and stored before the target snapshot was.
     assert repo.snapshots["2026-08-06"]["derived"]["restingHr7dAvg"] == 52.5
+
+
+def test_garminconnect_version_initialization(monkeypatch: pytest.MonkeyPatch) -> None:
+    import importlib.metadata
+
+    settings = Settings(app_user_id="test_uid_version")
+
+    # Case 1: garminconnect package version available
+    monkeypatch.setattr(
+        "importlib.metadata.version", lambda pkg: "0.2.1" if pkg == "garminconnect" else "0.0.0"
+    )
+    service = GarminSyncService(settings=settings, repository=MagicMock(db=None))
+    assert service.garminconnect_version == "0.2.1"
+
+    # Case 2: PackageNotFoundError raised when retrieving version
+    def mock_version_not_found(pkg: str) -> str:
+        raise importlib.metadata.PackageNotFoundError(pkg)
+
+    monkeypatch.setattr("importlib.metadata.version", mock_version_not_found)
+    service_missing = GarminSyncService(settings=settings, repository=MagicMock(db=None))
+    assert service_missing.garminconnect_version is None


### PR DESCRIPTION
🎯 **What:** Replaced broad `except Exception:` with specific `except importlib.metadata.PackageNotFoundError:` when retrieving `garminconnect` version in `GarminSyncService.__init__`.

💡 **Why:** Catching broad exceptions can obscure unexpected errors or bugs (e.g. system errors, syntax errors, or keyboard interrupts). Specifying `PackageNotFoundError` ensures only missing package metadata error is handled gracefully while preventing unintended exception swallowing.

✅ **Verification:**
- Added `test_garminconnect_version_initialization` in `tests/test_sync_service.py` verifying both success and `PackageNotFoundError` scenarios.
- Verified syntax, formatting, typing, and test suite execution via `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy src`, and `uv run pytest`.

✨ **Result:** Improved code health and exception safety in `GarminSyncService` without changing any existing functionality.

---
*PR created automatically by Jules for task [7949965987750966175](https://jules.google.com/task/7949965987750966175) started by @Szczepanov*