### PR TITLE
⚡ Bolt: Filter garminConnections status at Firestore query level

### DIFF
--- a/src/garmin_sync/account_link.py
+++ b/src/garmin_sync/account_link.py
@@ -19,6 +19,7 @@ from garminconnect import (
 )
 from google.cloud import firestore as google_firestore
 from google.cloud.exceptions import GoogleCloudError
+from google.cloud.firestore_v1.base_query import FieldFilter
 
 from .firestore_repository import init_firestore_client
 from .token_store import GcsTokenStore
@@ -259,8 +260,15 @@ class GarminConnectionRepository:
         """
         connections: list[tuple[str, str | None]] = []
         seen: set[str] = set()
-        for snapshot in self.db.collection("garminConnections").stream():
+        snapshots = (
+            self.db.collection("garminConnections")
+            .where(filter=FieldFilter("status", "==", "active"))
+            .stream()
+        )
+        for snapshot in snapshots:
             data = snapshot.to_dict() or {}
+            # Defense in depth for mocks/emulators and malformed documents; the Firestore
+            # query is authoritative for production-side filtering.
             if data.get("status") != "active":
                 continue
             uid = data.get("userId") or snapshot.id

--- a/tests/test_account_link_active_connections.py
+++ b/tests/test_account_link_active_connections.py
@@ -1,0 +1,75 @@
+from typing import Any
+
+from garmin_sync.account_link import GarminConnectionRepository
+
+
+class _Snapshot:
+    def __init__(self, doc_id: str, data: dict[str, Any]) -> None:
+        self.id = doc_id
+        self._data = data
+
+    def to_dict(self) -> dict[str, Any]:
+        return dict(self._data)
+
+
+class _Query:
+    def __init__(self, documents: dict[str, dict[str, Any]]) -> None:
+        self._documents = documents
+        self.filter: Any = None
+
+    def where(self, *, filter: Any) -> "_Query":
+        self.filter = filter
+        return self
+
+    def stream(self) -> list[_Snapshot]:
+        assert self.filter is not None
+        assert self.filter.field_path == "status"
+        assert self.filter.op_string == "=="
+        assert self.filter.value == "active"
+        return [
+            _Snapshot(doc_id, data)
+            for doc_id, data in self._documents.items()
+            if data.get("status") == "active"
+        ]
+
+
+class _Db:
+    def __init__(self, documents: dict[str, dict[str, Any]]) -> None:
+        self.documents = documents
+        self.last_query: _Query | None = None
+
+    def collection(self, name: str) -> _Query:
+        assert name == "garminConnections"
+        self.last_query = _Query(self.documents)
+        return self.last_query
+
+
+def test_list_active_connections_filters_at_query_and_preserves_token_object() -> None:
+    db = _Db(
+        {
+            "user-active-1": {
+                "userId": "user-active-1",
+                "status": "active",
+                "tokenObject": "garmin/users/user-active-1/tokens.json",
+            },
+            "user-inactive": {
+                "userId": "user-inactive",
+                "status": "inactive",
+                "tokenObject": "garmin/users/user-inactive/tokens.json",
+            },
+            "user-active-2": {
+                "status": "active",
+                "tokenObject": "garmin/users/user-active-2/tokens.json",
+            },
+        }
+    )
+
+    repository = GarminConnectionRepository(db=db)
+
+    assert repository.list_active_connections() == [
+        ("user-active-1", "garmin/users/user-active-1/tokens.json"),
+        ("user-active-2", "garmin/users/user-active-2/tokens.json"),
+    ]
+    assert db.last_query is not None
+    assert db.last_query.filter is not None
+    assert db.last_query.filter.field_path == "status"


### PR DESCRIPTION
## What
Pushes the Garmin connection `status == "active"` predicate into the Firestore query used by `GarminConnectionRepository.list_active_connections()`.

## Why
The worker only needs active links. Streaming the complete `garminConnections` collection and discarding inactive/revoked documents in Python wastes Firestore transfer, deserialization, and client memory as historical links accumulate.

## Conflict-resolution follow-up
The original branch conflicted after #543 changed the same import/test regions. This PR has been rebuilt directly on current `main` (`15223a5a`) instead of choosing one conflict side wholesale:

- preserves #543's `GoogleCloudError` import and narrowed `_delete_token_object()` catch;
- adds `FieldFilter("status", "==", "active")` only to `list_active_connections()`;
- keeps a defensive in-process status check for malformed mocks/documents;
- replaces invasive changes to the shared `tests/test_account_link.py` fake stack with focused `tests/test_account_link_active_connections.py` coverage.

## Verification target
The new test verifies the query predicate itself, excludes an inactive document, preserves the stored `tokenObject`, and covers fallback to snapshot ID when `userId` is absent.

No schema or public API changes.