### PR TITLE
🧹 Replace broad except Exception in garmin_sync/archive.py

### DIFF
--- a/src/garmin_sync/archive.py
+++ b/src/garmin_sync/archive.py
@@ -143,7 +143,7 @@ class LocalRawArchiveStore:
                             f"Skipping archive for {record.endpoint}/{record.logical_date}: identical payload already archived."
                         )
                         return None
-                except Exception:
+                except (json.JSONDecodeError, OSError, UnicodeDecodeError):
                     continue
 
         target_dir.mkdir(parents=True, exist_ok=True)
@@ -193,7 +193,7 @@ class LocalRawArchiveStore:
                             f"Skipping health archive for {log_label}/{record.logical_date}: identical payload already archived."
                         )
                         return None
-                except Exception:
+                except (json.JSONDecodeError, OSError, UnicodeDecodeError):
                     continue
 
         target_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -151,3 +151,51 @@ def test_create_archive_store_gcs_requires_bucket() -> None:
 
     with pytest.raises(ValueError, match="bucket"):
         create_archive_store(enabled=True, store_type="gcs", bucket_name=None)
+
+
+def test_local_archive_handles_corrupt_meta_json(tmp_path: Path) -> None:
+    store = LocalRawArchiveStore(base_dir=tmp_path)
+    payload = {"restingHeartRate": 50}
+
+    # First archive creates valid metadata
+    first = store.archive(ArchiveRecord("stats", "2026-08-06", payload, "run-1", "0.3.8"))
+    assert first is not None
+
+    # Corrupt the meta file
+    target_dir = store._dir("stats", "2026-08-06")
+    meta_file = target_dir / "run-1.meta.json"
+    meta_file.write_text("invalid json {")
+
+    # Second archive should handle the JSONDecodeError gracefully and complete archive
+    second = store.archive(ArchiveRecord("stats", "2026-08-06", payload, "run-2", "0.3.8"))
+    assert second is not None
+
+
+def test_local_archive_health_handles_corrupt_meta_json(tmp_path: Path) -> None:
+    store = LocalRawArchiveStore(base_dir=tmp_path)
+    record1 = HealthArchiveRecord(
+        user_id="user123",
+        provider="google_health",
+        transport="bundle",
+        logical_date="2026-08-07",
+        payload=[{"metric": "sleep_duration_seconds", "value": 27000}],
+        revision=1,
+    )
+
+    first = store.archive_health(record1)
+    assert first is not None
+
+    target_dir = Path(first).parent
+    meta_file = target_dir / "rev_1.meta.json"
+    meta_file.write_text("invalid json {")
+
+    record2 = HealthArchiveRecord(
+        user_id="user123",
+        provider="google_health",
+        transport="bundle",
+        logical_date="2026-08-07",
+        payload=[{"metric": "sleep_duration_seconds", "value": 27000}],
+        revision=2,
+    )
+    second = store.archive_health(record2)
+    assert second is not None


### PR DESCRIPTION
🎯 **What:** Replaced broad `except Exception` blocks in `LocalRawArchiveStore` (`archive` and `archive_health`) with specific expected exception types (`(json.JSONDecodeError, OSError, UnicodeDecodeError)`). Added unit tests in `tests/test_archive.py` to cover corrupt metadata file scenarios.

💡 **Why:** Catching `Exception` broadly can swallow unexpected system exceptions or bugs (such as `KeyboardInterrupt`, programming errors, or unexpected runtime exceptions). Specifying the exact file I/O and parsing errors ensures maintainability, clarity, and safer error handling.

✅ **Verification:**
- `uv run ruff check .` passed without issues.
- `uv run mypy src` passed with no type errors.
- `uv run pytest` executed 818 unit tests successfully.

✨ **Result:** Improved error handling specificity in archive metadata reads without altering runtime behavior.

---
*PR created automatically by Jules for task [3995023648492867567](https://jules.google.com/task/3995023648492867567) started by @Szczepanov*