### PR TITLE
🔒 fix: prevent DoS via payload size check prior to parsing in webhook receiver

### DIFF
--- a/src/garmin_sync/webhook_receiver.py
+++ b/src/garmin_sync/webhook_receiver.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_KEYSET_URL = "https://health.googleapis.com/v4/webhooks/public_keyset.json"
 KEYSET_CACHE_TTL_SECONDS = 86400  # 24 hours
+MAX_PAYLOAD_SIZE_BYTES = 1_048_576  # 1 MB
 
 
 @dataclass
@@ -108,6 +109,9 @@ class GoogleHealthWebhookHandler:
         signature: str | None,
     ) -> tuple[int, dict[str, Any]]:
         """Validate signature, parse event, and enqueue task. Returns (status_code, response_body)."""
+        if len(raw_body) > MAX_PAYLOAD_SIZE_BYTES:
+            return 413, {"error": "Payload exceeds maximum allowed size"}
+
         if not self.verifier.verify_signature(raw_body, signature):
             return 401, {"error": "Invalid signature"}
 

--- a/tests/test_webhook_receiver.py
+++ b/tests/test_webhook_receiver.py
@@ -66,6 +66,17 @@ def test_handle_request_payload_too_large() -> None:
     assert body == {"error": "Payload exceeds maximum allowed size"}
 
 
+def test_handle_request_payload_at_limit_still_reaches_signature_check() -> None:
+    verifier = WebhookSignatureVerifier(static_shared_secret="secret")
+    handler = GoogleHealthWebhookHandler(verifier=verifier)
+
+    payload_at_limit = b"a" * (1024 * 1024)
+    status, body = handler.handle_request(payload_at_limit, "invalid_sig")
+
+    assert status == 401
+    assert body == {"error": "Invalid signature"}
+
+
 def test_handle_request_invalid_signature_before_json_parse() -> None:
     verifier = WebhookSignatureVerifier(static_shared_secret="secret")
     handler = GoogleHealthWebhookHandler(verifier=verifier)

--- a/tests/test_webhook_receiver.py
+++ b/tests/test_webhook_receiver.py
@@ -54,3 +54,23 @@ def test_webhook_receiver_no_shared_secret_fails_closed() -> None:
     status, body = handler.handle_request(payload, "forged_signature_header")
     assert status == 401
     assert body == {"error": "Invalid signature"}
+
+
+def test_handle_request_payload_too_large() -> None:
+    verifier = WebhookSignatureVerifier(static_shared_secret="secret")
+    handler = GoogleHealthWebhookHandler(verifier=verifier)
+
+    large_payload = b"a" * (1024 * 1024 + 1)
+    status, body = handler.handle_request(large_payload, "some_signature")
+    assert status == 413
+    assert body == {"error": "Payload exceeds maximum allowed size"}
+
+
+def test_handle_request_invalid_signature_before_json_parse() -> None:
+    verifier = WebhookSignatureVerifier(static_shared_secret="secret")
+    handler = GoogleHealthWebhookHandler(verifier=verifier)
+
+    invalid_json_payload = b"invalid json body {{{"
+    status, body = handler.handle_request(invalid_json_payload, "invalid_sig")
+    assert status == 401
+    assert body == {"error": "Invalid signature"}


### PR DESCRIPTION
## What
Adds a 1 MiB application-level payload cap in `GoogleHealthWebhookHandler.handle_request` before signature verification and JSON decoding.

## Why
This is a defense-in-depth CPU/parser guard, not an ingress-memory limit: `raw_body` has already been materialized by the time this handler is called. The value is intentionally well below Cloud Run's platform HTTP request ceiling while remaining generous for Google Health notifications, which Google documents as batching at most 99 notifications per delivery.

References:
- Google Health webhook batching: https://developers.google.com/health/webhooks
- Cloud Run request limits: https://cloud.google.com/run/quotas

## Behavior
- Payloads larger than 1 MiB return HTTP 413 before signature verification/JSON parsing.
- A payload exactly at the limit continues to signature verification.
- Invalid signatures continue to fail before JSON parsing.

## Review follow-up
Commit `4e51251` adds an explicit exact-boundary regression test so the `>` rather than `>=` contract is pinned.

No persistence schema or public API changes.