### PR TITLE
🔒 Enforce secure file permission setting for token store

### DIFF
--- a/src/garmin_sync/token_store.py
+++ b/src/garmin_sync/token_store.py
@@ -40,9 +40,7 @@ def _chmod_secure(path: Path, mode: int) -> None:
             finally:
                 os.close(fd)
         except OSError as exc:
-            raise RuntimeError(
-                f"Failed to set secure permissions on '{path}': {exc}"
-            ) from exc
+            raise RuntimeError(f"Failed to set secure permissions on '{path}': {exc}") from exc
 
     raise RuntimeError(
         f"Secure file permission setting (fchmod/O_NOFOLLOW or follow_symlinks=False) "

--- a/src/garmin_sync/token_store.py
+++ b/src/garmin_sync/token_store.py
@@ -27,44 +27,37 @@ def _chmod_secure(path: Path, mode: int) -> None:
         return
 
     # Fallback to fchmod using file descriptors with O_NOFOLLOW if available
-    if hasattr(os, "fchmod"):
-        try:
-            flags = os.O_RDONLY
-            if hasattr(os, "O_NOFOLLOW"):
-                flags |= getattr(os, "O_NOFOLLOW", 0)
-            if path.is_dir() and hasattr(os, "O_DIRECTORY"):
-                flags |= getattr(os, "O_DIRECTORY", 0)
+    if hasattr(os, "fchmod") and hasattr(os, "O_NOFOLLOW"):
+        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+        if path.is_dir() and hasattr(os, "O_DIRECTORY"):
+            flags |= getattr(os, "O_DIRECTORY", 0)
 
+        try:
             fd = os.open(path, flags)
             try:
-                fchmod_fn = getattr(os, "fchmod", None)
-                if fchmod_fn is not None:
-                    fchmod_fn(fd, mode)
+                os.fchmod(fd, mode)
+                return
             finally:
                 os.close(fd)
-            return
-        except OSError:
-            pass
+        except OSError as exc:
+            raise RuntimeError(
+                f"Failed to set secure permissions on '{path}': {exc}"
+            ) from exc
 
-    # Fallback if fchmod/O_NOFOLLOW isn't supported and symlinks exist
-    logger.warning(
-        f"Secure file permission setting (fchmod/O_NOFOLLOW) is not supported on this platform. "
-        f"Skipping chmod for '{path}' to avoid TOCTOU vulnerability."
+    raise RuntimeError(
+        f"Secure file permission setting (fchmod/O_NOFOLLOW or follow_symlinks=False) "
+        f"is not supported on this platform for '{path}'."
     )
-    return
 
 
 def _set_secure_permissions(file_path: Path) -> None:
     """Ensure token file permissions are 0600 and parent directory is 0700 where OS permits."""
-    try:
-        parent = file_path.parent
-        parent.mkdir(parents=True, exist_ok=True)
-        if hasattr(os, "chmod"):
-            _chmod_secure(parent, 0o700)
-            if file_path.exists():
-                _chmod_secure(file_path, 0o600)
-    except Exception as e:
-        logger.debug(f"Failed to set permissions on '{file_path}': {type(e).__name__}")
+    parent = file_path.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    if hasattr(os, "chmod"):
+        _chmod_secure(parent, 0o700)
+        if file_path.exists():
+            _chmod_secure(file_path, 0o600)
 
 
 class TokenStore(Protocol):

--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -26,3 +26,49 @@ def test_local_token_store_persist_returns_false_when_source_missing(tmp_path: P
     store = LocalTokenStore(local_path=tmp_path / "store" / "tokens.json")
 
     assert store.persist(tmp_path / "missing.json") is False
+
+
+def test_chmod_secure_raises_when_unsupported(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from garmin_sync.token_store import _chmod_secure
+
+    target = tmp_path / "test.txt"
+    target.write_text("data")
+
+    # Disable supports_follow_symlinks and O_NOFOLLOW
+    monkeypatch.setattr("garmin_sync.token_store.os.supports_follow_symlinks", set(), raising=False)
+    monkeypatch.delattr("garmin_sync.token_store.os.O_NOFOLLOW", raising=False)
+
+    with pytest.raises(RuntimeError, match="not supported on this platform"):
+        _chmod_secure(target, 0o600)
+
+
+def test_chmod_secure_raises_on_open_oserror(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from garmin_sync.token_store import _chmod_secure
+
+    target = tmp_path / "test.txt"
+    target.write_text("data")
+
+    # Force supports_follow_symlinks to be empty set
+    monkeypatch.setattr("garmin_sync.token_store.os.supports_follow_symlinks", set(), raising=False)
+
+    def mock_open(*args, **kwargs):
+        raise OSError("Symlink detected or access denied")
+
+    monkeypatch.setattr("garmin_sync.token_store.os.open", mock_open)
+
+    with pytest.raises(RuntimeError, match="Failed to set secure permissions"):
+        _chmod_secure(target, 0o600)
+
+
+def test_set_secure_permissions_propagates_exception(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from garmin_sync.token_store import _set_secure_permissions
+
+    target = tmp_path / "subdir" / "tokens.json"
+
+    def mock_chmod_secure(path: Path, mode: int) -> None:
+        raise RuntimeError("Secure chmod failed")
+
+    monkeypatch.setattr("garmin_sync.token_store._chmod_secure", mock_chmod_secure)
+
+    with pytest.raises(RuntimeError, match="Secure chmod failed"):
+        _set_secure_permissions(target)

--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -28,7 +28,9 @@ def test_local_token_store_persist_returns_false_when_source_missing(tmp_path: P
     assert store.persist(tmp_path / "missing.json") is False
 
 
-def test_chmod_secure_raises_when_unsupported(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_chmod_secure_raises_when_unsupported(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     from garmin_sync.token_store import _chmod_secure
 
     target = tmp_path / "test.txt"
@@ -42,7 +44,9 @@ def test_chmod_secure_raises_when_unsupported(tmp_path: Path, monkeypatch: pytes
         _chmod_secure(target, 0o600)
 
 
-def test_chmod_secure_raises_on_open_oserror(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_chmod_secure_raises_on_open_oserror(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     from garmin_sync.token_store import _chmod_secure
 
     target = tmp_path / "test.txt"
@@ -60,7 +64,9 @@ def test_chmod_secure_raises_on_open_oserror(tmp_path: Path, monkeypatch: pytest
         _chmod_secure(target, 0o600)
 
 
-def test_set_secure_permissions_propagates_exception(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_set_secure_permissions_propagates_exception(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     from garmin_sync.token_store import _set_secure_permissions
 
     target = tmp_path / "subdir" / "tokens.json"


### PR DESCRIPTION
🎯 **What:**
Replaced the silent warning fallback and exception suppression in `_chmod_secure` and `_set_secure_permissions` with explicit `RuntimeError` exceptions when secure permission setting (`follow_symlinks=False` or `fchmod` with `O_NOFOLLOW`) is unsupported or fails.

⚠️ **Risk:**
Environments lacking secure permission setting support or facing TOCTOU symlink manipulation previously logged a warning and returned silently, leaving sensitive Garmin OAuth token files with permissive default permissions or allowing execution with unfortified permissions.

🛡️ **Solution:**
- Updated `_chmod_secure` to raise a `RuntimeError` if secure permission mechanisms are unavailable on the platform or if descriptor opening/fchmod fails (e.g., `OSError` due to `O_NOFOLLOW` symlink detection).
- Removed exception suppression from `_set_secure_permissions` so permission failures propagate and fail securely.
- Added comprehensive unit tests in `tests/test_token_store.py` covering unsupported platforms, descriptor open failures, and exception propagation.

---
*PR created automatically by Jules for task [165816428487825980](https://jules.google.com/task/165816428487825980) started by @Szczepanov*