### PR TITLE
🧹 Replace broad exception in backfill single date handler

### DIFF
--- a/src/garmin_sync/service.py
+++ b/src/garmin_sync/service.py
@@ -10,7 +10,13 @@ from pathlib import Path
 from typing import Any
 
 from firebase_admin import firestore
-from garminconnect import GarminConnectTooManyRequestsError
+from garminconnect import (
+    GarminConnectAuthenticationError,
+    GarminConnectConnectionError,
+    GarminConnectInvalidFileFormatError,
+    GarminConnectNotFoundError,
+    GarminConnectTooManyRequestsError,
+)
 
 from .archive import ArchiveRecord, RawArchiveStore, create_archive_store
 from .canonical import (
@@ -856,7 +862,16 @@ class GarminSyncService:
             )
             logger.info(f"[{target_iso}] Backfill sync completed.")
             return True, True
-        except Exception as e:
+        except (
+            GarminConnectAuthenticationError,
+            GarminConnectConnectionError,
+            GarminConnectInvalidFileFormatError,
+            GarminConnectNotFoundError,
+            GarminConnectTooManyRequestsError,
+            OSError,
+            KeyError,
+            ValueError,
+        ) as e:
             logger.error(f"[{target_iso}] Backfill failed: {e}")
             return False, True
 

--- a/tests/test_sync_service.py
+++ b/tests/test_sync_service.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -1591,3 +1592,25 @@ def test_sync_service_builds_target_snapshot_after_lookback_dates_are_corrected(
     # Target's 7d baseline -- (60 + 50 + 50 + 50) / 4 -- used the corrected D-1 value
     # because D-1 was rebuilt and stored before the target snapshot was.
     assert repo.snapshots["2026-08-06"]["derived"]["restingHr7dAvg"] == 52.5
+
+
+def test_backfill_single_date_failure_handling() -> None:
+    """_process_single_backfill_date catches API/runtime exceptions and records date failure."""
+    from garminconnect import GarminConnectConnectionError
+
+    settings = Settings(app_user_id="test_uid_789")
+    repo = MagicMock()
+    repo.get_historical_snapshots.return_value = {}
+
+    provider = DetailFakeProvider()
+
+    def raise_connection_error(target_date_iso: str, yesterday_iso: str) -> Any:
+        if target_date_iso == "2026-08-07":
+            raise GarminConnectConnectionError("Connection timeout")
+        return provider.fetch_daily_metrics(target_date_iso, yesterday_iso)
+
+    failing_provider = MagicMock(wraps=provider)
+    failing_provider.fetch_daily_metrics.side_effect = raise_connection_error
+
+    service = GarminSyncService(settings=settings, repository=repo, provider=failing_provider)
+    assert not service.backfill(start_date_str="2026-08-06", end_date_str="2026-08-08", force=True)


### PR DESCRIPTION
🎯 **What:** Replaced broad `except Exception as e:` in `GarminSyncService._process_single_backfill_date` with explicit API and operational exception types (`GarminConnectAuthenticationError`, `GarminConnectConnectionError`, `GarminConnectInvalidFileFormatError`, `GarminConnectNotFoundError`, `GarminConnectTooManyRequestsError`, `OSError`, `KeyError`, `ValueError`).

💡 **Why:** Catching broad `Exception` in `_process_single_backfill_date` risked silencing unexpected programming or logic errors. Replacing it with specific expected operational exceptions ensures API/connection and data-parsing failures for single backfill dates are handled gracefully while allowing unexpected bugs to fail fast.

✅ **Verification:** Added unit test `test_backfill_single_date_failure_handling` in `tests/test_sync_service.py` to verify backfill failure handling on API exception. Ran the complete test suite (`uv run pytest`), linter (`uv run ruff check .`), and type checker (`uv run mypy src`).

✨ **Result:** Enhanced codebase health and error visibility without changing existing backfill sync behavior.

---
*PR created automatically by Jules for task [9384927652259429634](https://jules.google.com/task/9384927652259429634) started by @Szczepanov*