### PR TITLE
🧹 Replace broad Exception with GoogleCloudError/ImportError in _delete_token_object

### DIFF
--- a/src/garmin_sync/account_link.py
+++ b/src/garmin_sync/account_link.py
@@ -18,6 +18,7 @@ from garminconnect import (
     GarminConnectTooManyRequestsError,
 )
 from google.cloud import firestore as google_firestore
+from google.cloud.exceptions import GoogleCloudError
 
 from .firestore_repository import init_firestore_client
 from .token_store import GcsTokenStore
@@ -395,8 +396,10 @@ class GarminAccountLinkService:
             from google.cloud import storage  # type: ignore[attr-defined]
 
             storage.Client().bucket(self.token_bucket).blob(token_object).delete()
-        except Exception:
-            logger.warning("Failed to remove orphaned Garmin token object after link error.")
+        except (GoogleCloudError, ImportError) as exc:
+            logger.warning(
+                "Failed to remove orphaned Garmin token object after link error: %s", exc
+            )
 
     def _finalize(
         self,

--- a/tests/test_account_link.py
+++ b/tests/test_account_link.py
@@ -651,3 +651,43 @@ def test_finalize_does_not_stomp_a_live_in_flight_sync_request(
     )
     # Untouched: still the live worker's claim, not the queued initial_backfill.
     assert sync_req == live_request
+
+
+def test_delete_token_object_handles_google_cloud_error(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    import logging
+    import sys
+
+    from google.cloud.exceptions import GoogleCloudError
+
+    service = GarminAccountLinkService("bucket", repository=DummyRepository())  # type: ignore[arg-type]
+
+    class FailingStorageModule:
+        class Client:
+            def bucket(self, name: str) -> Any:
+                raise GoogleCloudError("GCS deletion failed")
+
+    monkeypatch.setitem(sys.modules, "google.cloud.storage", FailingStorageModule)
+
+    with caplog.at_level(logging.WARNING):
+        service._delete_token_object("test-object.json")
+
+    assert "Failed to remove orphaned Garmin token object after link error:" in caplog.text
+    assert "GCS deletion failed" in caplog.text
+
+
+def test_delete_token_object_handles_import_error(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    import logging
+    import sys
+
+    service = GarminAccountLinkService("bucket", repository=DummyRepository())  # type: ignore[arg-type]
+
+    monkeypatch.setitem(sys.modules, "google.cloud.storage", None)
+
+    with caplog.at_level(logging.WARNING):
+        service._delete_token_object("test-object.json")
+
+    assert "Failed to remove orphaned Garmin token object after link error" in caplog.text


### PR DESCRIPTION
🎯 **What:**
Replaced the broad `except Exception` handling in `_delete_token_object` in `src/garmin_sync/account_link.py` with specific exception handling (`GoogleCloudError`, `ImportError`) and included the exception details in the log output. Added unit tests covering both exception branches.

💡 **Why:**
Catching broad `Exception` in best-effort cleanup can accidentally swallow unexpected runtime errors (such as `KeyboardInterrupt`, `NameError`, or syntax/type issues) and hide underlying problems during debugging. Catching specific GCS/import exceptions ensures expected storage or import errors are caught and logged cleanly, while unexpected errors bubble up.

✅ **Verification:**
- Ran `uv run ruff check --fix .` and `uv run ruff format .`
- Ran static type checks with `uv run mypy src`
- Executed unit test suite with `uv run pytest` (818 tests passing)
- Passed code review

✨ **Result:**
Improved maintainability, exception safety, and debuggability in `GarminAccountLinkService._delete_token_object`.

---
*PR created automatically by Jules for task [8573169883156838413](https://jules.google.com/task/8573169883156838413) started by @Szczepanov*