### PR TITLE
🧹 clarify non-fatal exception handling in performance targets and gear sync

### DIFF
--- a/src/garmin_sync/service.py
+++ b/src/garmin_sync/service.py
@@ -542,6 +542,7 @@ class GarminSyncService:
         except Exception as e:
             # Performance targets enrich prescription but are never allowed to make a
             # recovery snapshot fail after its core data was safely persisted.
+            # Intentionally non-fatal: catch all standard exceptions from provider/repository/token_store.
             logger.warning(
                 f"[{target_iso}] Garmin performance-target import failed, continuing: {e}"
             )
@@ -562,6 +563,7 @@ class GarminSyncService:
             persist_gear(result.canonical)
             self.token_store.persist(self.token_file_path)
         except Exception as e:
+            # Best-effort gear import is deliberately non-fatal to allow recovery sync completion.
             logger.warning(f"[{target_iso}] Garmin gear import failed, continuing: {e}")
 
     def sync_daily(

--- a/tests/test_sync_service.py
+++ b/tests/test_sync_service.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime, timedelta
 from unittest.mock import MagicMock
 
@@ -1591,3 +1592,29 @@ def test_sync_service_builds_target_snapshot_after_lookback_dates_are_corrected(
     # Target's 7d baseline -- (60 + 50 + 50 + 50) / 4 -- used the corrected D-1 value
     # because D-1 was rebuilt and stored before the target snapshot was.
     assert repo.snapshots["2026-08-06"]["derived"]["restingHr7dAvg"] == 52.5
+
+
+def test_sync_current_performance_targets_handles_exception(caplog):
+    settings = Settings(app_user_id="test_uid_789")
+    repo = MagicMock()
+    failing_provider = FakeTestProvider()
+    failing_provider.fetch_performance_targets = MagicMock(side_effect=RuntimeError("API error"))  # type: ignore[attr-defined]
+
+    service = GarminSyncService(settings=settings, repository=repo, provider=failing_provider)
+    with caplog.at_level(logging.WARNING):
+        service._sync_current_performance_targets("2026-08-06")
+
+    assert "Garmin performance-target import failed, continuing: API error" in caplog.text
+
+
+def test_sync_current_gear_handles_exception(caplog):
+    settings = Settings(app_user_id="test_uid_789")
+    repo = MagicMock()
+    failing_provider = FakeTestProvider()
+    failing_provider.fetch_gear = MagicMock(side_effect=RuntimeError("Gear API error"))  # type: ignore[attr-defined]
+
+    service = GarminSyncService(settings=settings, repository=repo, provider=failing_provider)
+    with caplog.at_level(logging.WARNING):
+        service._sync_current_gear("2026-08-06")
+
+    assert "Garmin gear import failed, continuing: Gear API error" in caplog.text


### PR DESCRIPTION
🎯 **What:**
Documented and clarified intentional `except Exception` handling in `_sync_current_performance_targets` and `_sync_current_gear` in `src/garmin_sync/service.py`. Added unit test coverage for exception handling in both methods in `tests/test_sync_service.py`.

💡 **Why:**
Importing profile performance targets and current gear/shoes is best-effort data enrichment performed outside the daily snapshot pipeline. Catching standard exceptions is required to ensure transient provider/repository errors do not fail the primary daily recovery sync after core telemetry has been safely persisted. Documenting this design intent and adding explicit unit tests improves maintainability and prevents accidental regression.

✅ **Verification:**
- Ran unit tests via `uv run pytest tests/test_sync_service.py` (57 passing).
- Checked linting with `uv run ruff check .` and typing with `uv run mypy src`.
- Executed full repository test suite and validation via `make check`.

✨ **Result:**
The codebase explicitly documents the non-fatal nature of performance target and gear imports during Garmin sync, with full unit test coverage verifying error logging and non-blocking sync execution.

---
*PR created automatically by Jules for task [11456387042530260482](https://jules.google.com/task/11456387042530260482) started by @Szczepanov*