### PR TITLE
🧪 Add runtime checkability and protocol conformance tests for Provider interfaces

### DIFF
--- a/src/garmin_sync/provider.py
+++ b/src/garmin_sync/provider.py
@@ -3,7 +3,7 @@ eventually the recommendation engine) depends on instead of any single vendor's 
 A second provider (real or fake-for-tests) only needs to satisfy WearableProvider."""
 
 from dataclasses import dataclass
-from typing import Any, Protocol
+from typing import Any, Protocol, runtime_checkable
 
 from .canonical import (
     CanonicalActivity,
@@ -71,6 +71,7 @@ class ProviderGearResult:
     raw_payloads: dict[str, Any]
 
 
+@runtime_checkable
 class WearableProvider(Protocol):
     capabilities: ProviderCapabilities
 
@@ -94,6 +95,7 @@ class WearableProvider(Protocol):
         ...
 
 
+@runtime_checkable
 class RecoveryObservationProvider(Protocol):
     """Capability-specific provider boundary for source-aware recovery observations (MS3/ADR-0027).
 
@@ -108,6 +110,7 @@ class RecoveryObservationProvider(Protocol):
     def clear_cache(self) -> None: ...
 
 
+@runtime_checkable
 class ActivityProvider(Protocol):
     """Capability-specific provider boundary for workouts and recorded activities."""
 
@@ -119,6 +122,7 @@ class ActivityProvider(Protocol):
     ) -> ProviderActivitiesResult: ...
 
 
+@runtime_checkable
 class ProfileProvider(Protocol):
     """Capability-specific provider boundary for user performance targets and gear."""
 

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -1,4 +1,5 @@
 from dataclasses import FrozenInstanceError
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -7,13 +8,20 @@ from garmin_sync.canonical import (
     CanonicalDailyMetrics,
     CanonicalPerformanceTargets,
 )
+from garmin_sync.eight_sleep_provider import EightSleepDirectProvider
+from garmin_sync.garmin_provider import GarminProviderAdapter
+from garmin_sync.google_health_provider import GoogleHealthProvider
 from garmin_sync.provider import (
+    ActivityProvider,
+    ProfileProvider,
     ProviderActivitiesResult,
     ProviderActivityDetailResult,
     ProviderCapabilities,
     ProviderFetchResult,
     ProviderGearResult,
     ProviderPerformanceTargetsResult,
+    RecoveryObservationProvider,
+    WearableProvider,
 )
 
 
@@ -136,3 +144,47 @@ def test_provider_gear_result_instantiation() -> None:
 
     assert result.canonical == []
     assert result.raw_payloads == {}
+
+
+def test_garmin_provider_adapter_runtime_protocol_conformance() -> None:
+    mock_client = MagicMock()
+    adapter = GarminProviderAdapter(mock_client)
+
+    # GarminProviderAdapter must satisfy ProfileProvider, WearableProvider, ActivityProvider
+    assert isinstance(adapter, ProfileProvider)
+    assert isinstance(adapter, WearableProvider)
+    assert isinstance(adapter, ActivityProvider)
+    assert not isinstance(adapter, RecoveryObservationProvider)
+
+
+def test_eight_sleep_provider_runtime_protocol_conformance() -> None:
+    mock_client = MagicMock()
+    provider = EightSleepDirectProvider(mock_client)
+
+    # EightSleepDirectProvider satisfies RecoveryObservationProvider, but not ProfileProvider or WearableProvider
+    assert isinstance(provider, RecoveryObservationProvider)
+    assert not isinstance(provider, ProfileProvider)
+    assert not isinstance(provider, WearableProvider)
+
+
+def test_google_health_provider_runtime_protocol_conformance() -> None:
+    mock_client = MagicMock()
+    mock_mapper = MagicMock()
+    provider = GoogleHealthProvider(client=mock_client, mapper=mock_mapper)
+
+    # GoogleHealthProvider satisfies RecoveryObservationProvider, but not ProfileProvider or WearableProvider
+    assert isinstance(provider, RecoveryObservationProvider)
+    assert not isinstance(provider, ProfileProvider)
+    assert not isinstance(provider, WearableProvider)
+
+
+def test_runtime_checkable_protocol_rejections() -> None:
+    class IncompleteProfileProvider:
+        def fetch_performance_targets(self) -> ProviderPerformanceTargetsResult:
+            raise NotImplementedError
+
+    incomplete = IncompleteProfileProvider()
+    assert not isinstance(incomplete, ProfileProvider)
+    assert not isinstance(incomplete, WearableProvider)
+    assert not isinstance(incomplete, ActivityProvider)
+    assert not isinstance(incomplete, RecoveryObservationProvider)


### PR DESCRIPTION
🎯 What
Added `@runtime_checkable` decorator to `ProfileProvider`, `ActivityProvider`, `RecoveryObservationProvider`, and `WearableProvider` protocols in `src/garmin_sync/provider.py`. Added comprehensive tests in `tests/test_provider.py` to verify protocol conformance across real provider implementations (`GarminProviderAdapter`, `EightSleepDirectProvider`, `GoogleHealthProvider`) and negative type assertions for incomplete objects.

📊 Coverage
- Protocol conformance for `ProfileProvider` (including `fetch_performance_targets` and `fetch_gear`), `WearableProvider`, `ActivityProvider`, and `RecoveryObservationProvider`.
- Verified positive `isinstance()` checks against real adapter implementations (`GarminProviderAdapter`, `EightSleepDirectProvider`, `GoogleHealthProvider`).
- Verified negative `isinstance()` checks for incomplete class objects lacking required protocol methods.

✨ Result
Improves interface safety at runtime and validates provider class behavior against protocol specifications.

---
*PR created automatically by Jules for task [1916900589696096289](https://jules.google.com/task/1916900589696096289) started by @Szczepanov*