### PR TITLE
⚡ Bolt: [performance improvement] O(1) template ID lookups

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,34 @@
-## 2025-02-12 - Frontend Engine ID Lookups
-**Learning:** React component and engine components should use Maps for lookups where possible instead of linear `.find()` scans to avoid O(N) penalties, especially for frequently accessed or rendered content. `ENRICHED_TEMPLATES_BY_ID` and `TEMPLATES_BY_ID` are exported alongside their base arrays specifically for this purpose.
-**Action:** When working on engine files like `app/src/engine/*.ts`, refactor `.find()` array operations to Map `.get()` lookups for ID-based queries.
+## 2025-02-12 - [Redundant array filtering in React renders]
+**Learning:** React components containing inline `.filter()` calls on arrays inside render methods (like `activeSettings.filter(s => s.kind === 'guardrail')`) can be optimized by extracting the filtered result into a `useMemo` hook, avoiding O(N) redundant operations on every render, especially when the filtered result is used multiple times.
+**Action:** Always memoize derived array computations (like filtering and mapping) that rely on props or state, especially if they are used more than once in the JSX.
+
+## 2024-05-18 - Use Map for O(1) template lookup by ID
+**Learning:** Creating a Map for template lookups by ID avoids repeated O(N) array scans for the 655 templates in `ENRICHED_TEMPLATES`. Using `.find(t => t.id === ...)` on a 655-element array is an anti-pattern when it's done repeatedly inside loops or frequently called engine functions like `enrichedCostProfile`. A simple dictionary/Map speeds up lookups by 40x.
+**Action:** When performing repeated lookups by ID in static data like templates or workouts, always build a Map on initialization and use `.get()` rather than iterating arrays.
+
+## 2024-05-18 - [N+1 Firestore Writes in _archive_activities]
+**Learning:** Looping over records to write documents sequentially to Firestore using individual network requests causes severe N+1 latency problems.
+**Action:** Use Firestore batched writes (`db.batch()`) combined with chunking (max 500 documents per batch) when writing multiple documents to greatly reduce network latency. Always update mock tests properly, as batched methods take `call_args` as single large data structures.
+
+## 2024-05-18 - Concurrent Fetching for Garmin API during Backfill
+**Learning:** Sequential API calls within loops (like `fetch_detail(activity.activity_id)` over many activities) create substantial bottlenecks, especially in historical data backfills. Using `concurrent.futures.ThreadPoolExecutor` along with `as_completed` allows concurrent processing while avoiding shared state issues by collecting results in the main thread loop.
+**Action:** When implementing any data backfill logic hitting external APIs in the Python backend, default to `concurrent.futures.ThreadPoolExecutor` if the rate limits allow it. Always make sure to properly cancel futures when a `GarminConnectTooManyRequestsError` or equivalent is encountered to avoid further requests when limits are already hit.
+
+## 2026-08-24 - Optimize Exercise Catalog Lookups
+**Learning:** React components and engine functions were scanning the canonical `EXERCISES` catalog with `.find()` in repeated lookup paths even though `exercises.ts` already exports `EXERCISES_BY_ID` for constant-time identity resolution.
+**Action:** Reuse the canonical `EXERCISES_BY_ID` map for repeated exercise-ID lookups; do not introduce a second exercise map or duplicate catalog index.
+
+## 2026-08-26 - Prevent Redundant Array Filtering on Render
+**Learning:** In components with frequent state changes (like form inputs updating `notes`), inline array operations like `.filter()` that rely on static props (like `steps`) will re-execute on every keystroke, causing unnecessary O(N) operations.
+**Action:** Always wrap derived data calculations that iterate over arrays using `useMemo` when the input array is stable and the component is subject to frequent re-renders from other state changes.
+
+## 2026-08-27 - Avoid useMemo for trivial arrays
+**Learning:** Wrapping trivial arrays (e.g., 2-3 elements) in `useMemo` to prevent an inline `.filter()` on render is an anti-pattern. The overhead of the React hook (memory allocation, dependency checking) is heavier than the sub-millisecond cost of filtering a tiny array.
+**Action:** Only apply `useMemo` optimizations to arrays that are meaningfully large or computations that are actually expensive. For UI components, prioritize lists like `savedDefinitions` or `EXERCISES` rather than small arrays like `fidelityIssues`.
+
+## 2026-09-07 - Use Map lookup for Canonical Rest Template
+**Learning:** The `getCanonicalRestTemplate()` function was performing an O(N) lookup across the `ENRICHED_TEMPLATES` and `TEMPLATES` arrays via `.find(t => t.category === 'Rest')` to retrieve the canonical `rest_01` fallback template. Since this function is called extremely frequently (especially during optimization branching and when falling back on constraints), replacing it with an O(1) dictionary lookup via `ENRICHED_TEMPLATES_BY_ID.get('rest_01')` avoids redundant iteration.
+**Action:** When a fallback or canonical item is known by its ID (like `rest_01`), prefer O(1) dictionary lookups via `_BY_ID` maps rather than scanning arrays via `.find()` on category strings.
+## 2026-09-08 - Use Map lookup for known default Rest templates
+**Learning:** Throughout the codebase (like in `planner.ts` and `safetyCheckin.ts`), fetching the fallback rest template via an array scan like `ENRICHED_TEMPLATES.find(t => t.category === 'Rest')` is unnecessary O(N) overhead when we just want the default Rest template. The `rest_01` template is the universal fallback.
+**Action:** Always fetch the fallback Rest template directly via `ENRICHED_TEMPLATES_BY_ID.get('rest_01')` (or `TEMPLATES_BY_ID`) rather than iterating the entire array looking for the 'Rest' category.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,34 +1,3 @@
-## 2025-02-12 - [Redundant array filtering in React renders]
-**Learning:** React components containing inline `.filter()` calls on arrays inside render methods (like `activeSettings.filter(s => s.kind === 'guardrail')`) can be optimized by extracting the filtered result into a `useMemo` hook, avoiding O(N) redundant operations on every render, especially when the filtered result is used multiple times.
-**Action:** Always memoize derived array computations (like filtering and mapping) that rely on props or state, especially if they are used more than once in the JSX.
-
-## 2024-05-18 - Use Map for O(1) template lookup by ID
-**Learning:** Creating a Map for template lookups by ID avoids repeated O(N) array scans for the 655 templates in `ENRICHED_TEMPLATES`. Using `.find(t => t.id === ...)` on a 655-element array is an anti-pattern when it's done repeatedly inside loops or frequently called engine functions like `enrichedCostProfile`. A simple dictionary/Map speeds up lookups by 40x.
-**Action:** When performing repeated lookups by ID in static data like templates or workouts, always build a Map on initialization and use `.get()` rather than iterating arrays.
-
-## 2024-05-18 - [N+1 Firestore Writes in _archive_activities]
-**Learning:** Looping over records to write documents sequentially to Firestore using individual network requests causes severe N+1 latency problems.
-**Action:** Use Firestore batched writes (`db.batch()`) combined with chunking (max 500 documents per batch) when writing multiple documents to greatly reduce network latency. Always update mock tests properly, as batched methods take `call_args` as single large data structures.
-
-## 2024-05-18 - Concurrent Fetching for Garmin API during Backfill
-**Learning:** Sequential API calls within loops (like `fetch_detail(activity.activity_id)` over many activities) create substantial bottlenecks, especially in historical data backfills. Using `concurrent.futures.ThreadPoolExecutor` along with `as_completed` allows concurrent processing while avoiding shared state issues by collecting results in the main thread loop.
-**Action:** When implementing any data backfill logic hitting external APIs in the Python backend, default to `concurrent.futures.ThreadPoolExecutor` if the rate limits allow it. Always make sure to properly cancel futures when a `GarminConnectTooManyRequestsError` or equivalent is encountered to avoid further requests when limits are already hit.
-
-## 2026-08-24 - Optimize Exercise Catalog Lookups
-**Learning:** React components and engine functions were scanning the canonical `EXERCISES` catalog with `.find()` in repeated lookup paths even though `exercises.ts` already exports `EXERCISES_BY_ID` for constant-time identity resolution.
-**Action:** Reuse the canonical `EXERCISES_BY_ID` map for repeated exercise-ID lookups; do not introduce a second exercise map or duplicate catalog index.
-
-## 2026-08-26 - Prevent Redundant Array Filtering on Render
-**Learning:** In components with frequent state changes (like form inputs updating `notes`), inline array operations like `.filter()` that rely on static props (like `steps`) will re-execute on every keystroke, causing unnecessary O(N) operations.
-**Action:** Always wrap derived data calculations that iterate over arrays using `useMemo` when the input array is stable and the component is subject to frequent re-renders from other state changes.
-
-## 2026-08-27 - Avoid useMemo for trivial arrays
-**Learning:** Wrapping trivial arrays (e.g., 2-3 elements) in `useMemo` to prevent an inline `.filter()` on render is an anti-pattern. The overhead of the React hook (memory allocation, dependency checking) is heavier than the sub-millisecond cost of filtering a tiny array.
-**Action:** Only apply `useMemo` optimizations to arrays that are meaningfully large or computations that are actually expensive. For UI components, prioritize lists like `savedDefinitions` or `EXERCISES` rather than small arrays like `fidelityIssues`.
-
-## 2026-09-07 - Use Map lookup for Canonical Rest Template
-**Learning:** The `getCanonicalRestTemplate()` function was performing an O(N) lookup across the `ENRICHED_TEMPLATES` and `TEMPLATES` arrays via `.find(t => t.category === 'Rest')` to retrieve the canonical `rest_01` fallback template. Since this function is called extremely frequently (especially during optimization branching and when falling back on constraints), replacing it with an O(1) dictionary lookup via `ENRICHED_TEMPLATES_BY_ID.get('rest_01')` avoids redundant iteration.
-**Action:** When a fallback or canonical item is known by its ID (like `rest_01`), prefer O(1) dictionary lookups via `_BY_ID` maps rather than scanning arrays via `.find()` on category strings.
-## 2026-09-08 - Use Map lookup for known default Rest templates
-**Learning:** Throughout the codebase (like in `planner.ts` and `safetyCheckin.ts`), fetching the fallback rest template via an array scan like `ENRICHED_TEMPLATES.find(t => t.category === 'Rest')` is unnecessary O(N) overhead when we just want the default Rest template. The `rest_01` template is the universal fallback.
-**Action:** Always fetch the fallback Rest template directly via `ENRICHED_TEMPLATES_BY_ID.get('rest_01')` (or `TEMPLATES_BY_ID`) rather than iterating the entire array looking for the 'Rest' category.
+## 2025-02-12 - Frontend Engine ID Lookups
+**Learning:** React component and engine components should use Maps for lookups where possible instead of linear `.find()` scans to avoid O(N) penalties, especially for frequently accessed or rendered content. `ENRICHED_TEMPLATES_BY_ID` and `TEMPLATES_BY_ID` are exported alongside their base arrays specifically for this purpose.
+**Action:** When working on engine files like `app/src/engine/*.ts`, refactor `.find()` array operations to Map `.get()` lookups for ID-based queries.

--- a/app/src/engine/performedTrainingFacts.ts
+++ b/app/src/engine/performedTrainingFacts.ts
@@ -14,7 +14,7 @@ import type { SessionTemplate, EvidenceTier, NormalizedGarminActivity, Completed
 import type { CoverageSetId, PlanCoverageKey, CoverageSetDescriptor } from '../workouts/event-plan';
 import { EVERGREEN_GENERAL_COVERAGE_SET } from '../workouts/event-plan';
 import { workoutForTemplate } from '../workouts/prescription';
-import { ENRICHED_TEMPLATES } from './templates';
+import { ENRICHED_TEMPLATES, ENRICHED_TEMPLATES_BY_ID } from './templates';
 import type { PerformedTrainingOccurrence } from '../training-occurrence/models';
 import { getLocalDateString } from '../utils/localDate';
 import { classifyGarminTier } from './completedTraining';
@@ -213,7 +213,7 @@ export function deriveFactsFromOccurrence(
 
     const workoutId = hydrated.structured?.workoutId;
     const explicitTemplate = hydrated.structured?.templateId
-        ? ENRICHED_TEMPLATES.find(template => template.id === hydrated.structured?.templateId)
+        ? ENRICHED_TEMPLATES_BY_ID.get(hydrated.structured?.templateId)
         : undefined;
     const templateId = hydrated.structured?.templateId ?? (workoutId ? templateIdForWorkoutId(workoutId) : undefined);
     const category = normalizeCategory(

--- a/app/src/engine/rules.planJudgeCalibration.test.ts
+++ b/app/src/engine/rules.planJudgeCalibration.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { evaluateEnvelopes, evaluateReadinessAndSafetyEnvelope, evaluateTrainingWithIntent } from './rules';
 import { evaluateRecoveryConstraints, rankCandidates } from './optimizer';
-import { ENRICHED_TEMPLATES } from './templates';
+import { ENRICHED_TEMPLATES, ENRICHED_TEMPLATES_BY_ID } from './templates';
 import type { DailyReadiness, EngineObjectiveInput, FatigueState, SubjectiveInput, UserContext, UserEvent, UserPreferences } from './models';
 import type { ResolvedAvailability } from './schedule';
 import type { TrainingHistoryProvider } from './trainingHistory';
@@ -311,7 +311,7 @@ describe('plan-judge calibration policy guards', () => {
     });
 
     it('modulates Priority B event race-specific session benefits when 1 is already in recent history', () => {
-        const critSurgeTemplate = ENRICHED_TEMPLATES.find(t => t.id === 'end_crit_surges_01')!;
+        const critSurgeTemplate = ENRICHED_TEMPLATES_BY_ID.get('end_crit_surges_01')!;
         const focusEventB: UserEvent = {
             id: 'race-b',
             title: 'Local Crit',
@@ -367,7 +367,7 @@ describe('plan-judge calibration policy guards', () => {
     });
 
     it('boosts upper-body and core strength sessions when lower-body guardrail is active', () => {
-        const upperStrengthTemplate = ENRICHED_TEMPLATES.find(t => t.id === 'str_upper_01' || t.category === 'Upper-body Strength')!;
+        const upperStrengthTemplate = (ENRICHED_TEMPLATES_BY_ID.get('str_upper_01') ?? ENRICHED_TEMPLATES.find(t => t.category === 'Upper-body Strength'))!;
         const result = rankCandidates(
             [upperStrengthTemplate],
             [{ id: 'obj-str', key: 'strength_maintenance', title: 'Strength Maintenance', targetExposures: 2, completedExposures: 0, targetStimulus: { maxStrength: 0.8 } }],


### PR DESCRIPTION
## What
Replaces repeated exact-ID scans of `ENRICHED_TEMPLATES` with the existing `ENRICHED_TEMPLATES_BY_ID` map in hot/repeated engine and test paths.

## Why
When the caller already has an exact template ID, `.find(template => template.id === id)` is unnecessary O(N) work over the static template catalog. The canonical map provides the same identity lookup in O(1) without adding another index.

## Review follow-up
The generated branch also replaced `.jules/bolt.md` with a single generalized note, unintentionally deleting the existing performance-learning history. Commit `27bcae9` restores that file to current-main content, leaving this PR scoped to the intended lookup changes only.

## Verification
- Current head `27bcae9` passes the complete repository CI Pipeline (run #3053).
- The remaining `.find()` calls are semantic/category searches rather than exact-ID lookups and are intentionally unchanged.
- No runtime behavior, schema, or public API changes are intended.