### PR TITLE
fix(progression): enforce exact date-scoped confirmed progression execution

### DIFF
--- a/app/src/engine/confirmedProgressionExecution.test.ts
+++ b/app/src/engine/confirmedProgressionExecution.test.ts
@@ -1,9 +1,32 @@
-import { describe, expect, it } from 'vitest';
-import { evaluateTrainingWithIntent } from './rules';
+import { describe, expect, it, vi } from 'vitest';
 import { progressionOverrideKey } from './confirmedProgressionOverrides';
 import type { DailyReadiness, EngineObjectiveInput, SubjectiveInput, UserContext } from './models';
 import type { TrainingHistoryProvider } from './trainingHistory';
 import { workoutForTemplate } from '../workouts/prescription';
+
+const PROGRESSED_WORKOUT_ID = 'cycling_zone2_standard_01';
+
+vi.mock('./optimizer', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('./optimizer')>();
+    const { workoutForTemplate: resolveWorkout } = await import('../workouts/prescription');
+
+    return {
+        ...actual,
+        rankCandidates: (...args: Parameters<typeof actual.rankCandidates>) => {
+            const result = actual.rankCandidates(...args);
+            const accepted = [...result.accepted];
+            const targetIndex = accepted.findIndex(
+                candidate => resolveWorkout(candidate.template.id)?.id === PROGRESSED_WORKOUT_ID,
+            );
+            if (targetIndex <= 0) return result;
+
+            const [target] = accepted.splice(targetIndex, 1);
+            return { ...result, accepted: [target, ...accepted] };
+        },
+    };
+});
+
+import { evaluateTrainingWithIntent } from './rules';
 
 const EMPTY_HISTORY: TrainingHistoryProvider = {
     reconstruct: async () => [],
@@ -101,27 +124,27 @@ async function recommend(
 
 describe('confirmed progression execution authority', () => {
     const overrides = new Map([
-        [progressionOverrideKey('aerobic_volume', 'cycling_zone2_standard_01'), 70],
+        [progressionOverrideKey('aerobic_volume', PROGRESSED_WORKOUT_ID), 70],
     ]);
 
-    it('materializes the confirmed duration on the selected exact workout', async () => {
+    it('materializes the confirmed duration once the exact progressed workout is selected', async () => {
         const rec = await recommend(
             { subjective: subjective(), objective: objective() },
             overrides,
         );
 
-        expect(workoutForTemplate(rec.template.id)?.id).toBe('cycling_zone2_standard_01');
+        expect(workoutForTemplate(rec.template.id)?.id).toBe(PROGRESSED_WORKOUT_ID);
         expect(rec.activeDose).toEqual(expect.objectContaining({ durationMin: 70, durationMax: 70 }));
         expect(rec.rationale).toContain('confirmed progression');
     });
 
-    it('keeps a smaller time-cap dose authoritative over a larger confirmed progression', async () => {
+    it('keeps a smaller time-cap dose authoritative over a selected confirmed progression', async () => {
         const rec = await recommend(
             { subjective: subjective({ timeAvailable: 45 }), objective: objective() },
             overrides,
         );
 
-        expect(workoutForTemplate(rec.template.id)?.id).toBe('cycling_zone2_standard_01');
+        expect(workoutForTemplate(rec.template.id)?.id).toBe(PROGRESSED_WORKOUT_ID);
         expect(rec.activeDose?.durationMin).not.toBe(70);
         expect(rec.activeDose?.durationMax).toBeLessThanOrEqual(45);
         expect(rec.rationale).toContain('could not be applied because today’s safety/readiness/time ceiling is lower');

--- a/app/src/engine/confirmedProgressionExecution.test.ts
+++ b/app/src/engine/confirmedProgressionExecution.test.ts
@@ -135,7 +135,7 @@ describe('confirmed progression execution authority', () => {
 
         expect(workoutForTemplate(rec.template.id)?.id).toBe(PROGRESSED_WORKOUT_ID);
         expect(rec.activeDose).toEqual(expect.objectContaining({ durationMin: 70, durationMax: 70 }));
-        expect(rec.rationale).toContain('confirmed progression');
+        expect(rec.rationale).toContain('Use the confirmed 70-minute progression dose');
     });
 
     it('keeps a smaller time-cap dose authoritative over a selected confirmed progression', async () => {
@@ -147,6 +147,7 @@ describe('confirmed progression execution authority', () => {
         expect(workoutForTemplate(rec.template.id)?.id).toBe(PROGRESSED_WORKOUT_ID);
         expect(rec.activeDose?.durationMin).not.toBe(70);
         expect(rec.activeDose?.durationMax).toBeLessThanOrEqual(45);
-        expect(rec.rationale).toContain('could not be applied because today’s safety/readiness/time ceiling is lower');
+        expect(rec.rationale).toContain('The confirmed progression remains the authored target');
+        expect(rec.rationale).toContain('today’s readiness/time ceiling is lower');
     });
 });

--- a/app/src/engine/confirmedProgressionExecution.test.ts
+++ b/app/src/engine/confirmedProgressionExecution.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+import { evaluateTrainingWithIntent } from './rules';
+import { progressionOverrideKey } from './confirmedProgressionOverrides';
+import type { DailyReadiness, EngineObjectiveInput, SubjectiveInput, UserContext } from './models';
+import type { TrainingHistoryProvider } from './trainingHistory';
+import { workoutForTemplate } from '../workouts/prescription';
+
+const EMPTY_HISTORY: TrainingHistoryProvider = {
+    reconstruct: async () => [],
+};
+
+function context(): UserContext {
+    return {
+        goals: { shortTerm: '', midTerm: '', longTerm: '' },
+        constraints: {
+            hasCableMachine: false,
+            hasFreeWeights: false,
+            hasTreadmill: false,
+            hasIndoorBike: true,
+            restrictedModalities: [],
+            maxTimeMinutes: 90,
+        },
+        preferences: {
+            avoidedModalities: [],
+            deprioritizedModalities: [],
+            preferredModalities: ['Cycling'],
+            conservativeBias: false,
+        },
+    };
+}
+
+function subjective(overrides: Partial<SubjectiveInput> = {}): SubjectiveInput {
+    return {
+        readiness: 9,
+        sleepQuality: 9,
+        fatigue: 2,
+        soreness: 2,
+        stress: 2,
+        motivation: 9,
+        timeAvailable: 90,
+        painFlag: false,
+        alreadyTrainedToday: false,
+        preferredModalityToday: 'Cycling',
+        ...overrides,
+    };
+}
+
+function objective(): EngineObjectiveInput {
+    return {
+        total_steps: 8000,
+        sleep_score: 85,
+        sleep_duration_min: 450,
+        rhr: 50,
+        rhr_7d_avg: 50,
+        rhr_delta: 0,
+        hrv_weekly_avg: 50,
+        hrv_last_night: 50,
+        hrv_delta: 0,
+        respiration: 14,
+        body_battery_wake: 85,
+        last_3_days_hard_sessions_count: 0,
+        yesterday_training: null,
+        today_training: null,
+        sleep_score_delta_7d: 0,
+        rhr_delta_28d: 0,
+        hrv_delta_28d: 0,
+        sleep_score_delta_28d: 0,
+        hrv_stdev_28d: 8.5,
+        rhr_stdev_28d: 3.5,
+        sleep_score_stdev_28d: 7.8,
+    };
+}
+
+async function recommend(
+    readiness: DailyReadiness,
+    overrides: ReadonlyMap<string, number>,
+) {
+    return evaluateTrainingWithIntent(
+        'progression-execution-test',
+        readiness,
+        context(),
+        [],
+        '2026-09-10',
+        undefined,
+        EMPTY_HISTORY,
+        null,
+        [],
+        [],
+        null,
+        null,
+        undefined,
+        null,
+        undefined,
+        undefined,
+        null,
+        false,
+        [],
+        overrides,
+    );
+}
+
+describe('confirmed progression execution authority', () => {
+    const overrides = new Map([
+        [progressionOverrideKey('aerobic_volume', 'cycling_zone2_standard_01'), 70],
+    ]);
+
+    it('materializes the confirmed duration on the selected exact workout', async () => {
+        const rec = await recommend(
+            { subjective: subjective(), objective: objective() },
+            overrides,
+        );
+
+        expect(workoutForTemplate(rec.template.id)?.id).toBe('cycling_zone2_standard_01');
+        expect(rec.activeDose).toEqual(expect.objectContaining({ durationMin: 70, durationMax: 70 }));
+        expect(rec.rationale).toContain('confirmed progression');
+    });
+
+    it('keeps a smaller time-cap dose authoritative over a larger confirmed progression', async () => {
+        const rec = await recommend(
+            { subjective: subjective({ timeAvailable: 45 }), objective: objective() },
+            overrides,
+        );
+
+        expect(workoutForTemplate(rec.template.id)?.id).toBe('cycling_zone2_standard_01');
+        expect(rec.activeDose?.durationMin).not.toBe(70);
+        expect(rec.activeDose?.durationMax).toBeLessThanOrEqual(45);
+        expect(rec.rationale).toContain('could not be applied because today’s safety/readiness/time ceiling is lower');
+    });
+});

--- a/app/src/engine/confirmedProgressionOverrides.test.ts
+++ b/app/src/engine/confirmedProgressionOverrides.test.ts
@@ -111,10 +111,6 @@ describe('deriveDurationOverridesForDate', () => {
     });
 
     it('rejects a confirmed value no real catalog workout can physically represent, rather than crediting it', () => {
-        // cycling_controlled_threshold_4x8_01's real maximumMin is 90; clamping alone would
-        // let 999 through as 90 (matching the objective envelope's max), but 90 does still
-        // fit that workout -- push the envelope itself past the workout's ceiling so the
-        // clamped value has nothing left it can represent.
         const outOfRange = block(
             { progressionContract: { ...block().progressionContract!, currentValue: 999, permittedRange: { min: 45, max: 200 } } },
             { doseEnvelope: { min: 45, target: 70, max: 200, unit: 'minutes', floorSemantics: 'hard_floor' } },
@@ -173,9 +169,6 @@ describe('deriveDurationOverridesForDate -> packWeeklyDose (production key contr
             adaptation: 'aerobic_endurance', priority: 'required',
             floor: { dose: { unit: 'minutes', value: 150 }, semantics: 'guideline_recommended_minimum' },
             target: { unit: 'minutes', minimum: 150, target: 150, maximum: 300 },
-            // Restricted to cycling only, so the packer's eligible-workout set for this
-            // requirement is exactly the one workout the confirmed progression targets --
-            // not the sibling running/walking workouts also on the aerobic_volume role.
             substitutionPolicy: { equivalentModalitiesAllowed: false, permittedModalities: ['Cycling'] },
             knowledgeRefs: ['test.claim'],
             evidence: {
@@ -195,28 +188,23 @@ describe('deriveDurationOverridesForDate -> packWeeklyDose (production key contr
         const baseline = packWeeklyDose(strategy, capacity, EVERGREEN_PACKING_COVERAGE);
         const withConfirmedProgression = packWeeklyDose(strategy, capacity, EVERGREEN_PACKING_COVERAGE, overrides.overrides);
 
-        // cycling_zone2_standard_01's catalog duration is 60 min; 2 sessions credit 120 min,
-        // below the 150-minute floor. The confirmed 70-minute progression raises that to 140
-        // -- still short, but the two budgets must differ, proving the exact-scoped key the
-        // real helper emits is understood by the packer, not silently ignored.
         expect(baseline.shortfalls).toEqual([expect.objectContaining({ code: 'below_guideline_range' })]);
         expect(withConfirmedProgression.shortfalls).toEqual([expect.objectContaining({ code: 'below_guideline_range', message: expect.stringContaining('140') })]);
         expect(withConfirmedProgression).not.toEqual(baseline);
     });
 
-    it('does not apply the override when the eligible workout set for the requirement is not the one the progression was confirmed against', () => {
+    it('keeps a production-derived cycling progression authoritative even when the evergreen requirement also permits running/walking substitutes', () => {
         const confirmedBlock = block({}, { adaptationScope: 'zone2_aerobic', coverageKey: 'aerobic_volume', sport: 'cycling' });
         const overrides = deriveDurationOverridesForDate([confirmedBlock], '2026-09-08');
-
-        // Widen the requirement's permitted modalities so the packer's eligible set for
-        // aerobic_volume also includes the running/walking workouts the progression was
-        // never confirmed against -- the override must not leak onto those.
         const multiModalStrategy: EvidenceBackedStrategy = {
             ...strategy,
             requirements: [{ ...strategy.requirements[0], substitutionPolicy: { equivalentModalitiesAllowed: true, permittedModalities: ['Cycling', 'Running', 'Walking'] } }],
         };
         const withConfirmedProgression = packWeeklyDose(multiModalStrategy, capacity, EVERGREEN_PACKING_COVERAGE, overrides.overrides);
-        const baseline = packWeeklyDose(multiModalStrategy, capacity, EVERGREEN_PACKING_COVERAGE);
-        expect(withConfirmedProgression).toEqual(baseline);
+
+        expect(withConfirmedProgression.requiredRoles).toHaveLength(2);
+        expect(withConfirmedProgression.requiredRoles.every(role => role.exactWorkoutIds.includes('cycling_zone2_standard_01'))).toBe(true);
+        expect(withConfirmedProgression.requiredRoles.every(role => role.exactWorkoutIds.length === 1)).toBe(true);
+        expect(withConfirmedProgression.shortfalls).toEqual([expect.objectContaining({ code: 'below_guideline_range', message: expect.stringContaining('140') })]);
     });
 });

--- a/app/src/engine/evergreenPlanning.ts
+++ b/app/src/engine/evergreenPlanning.ts
@@ -33,8 +33,9 @@ export function resolveEvergreenPlan(
     days: number = 7,
     isAdverseRecovery: boolean = false,
     scheduleOverlays: readonly ScheduleOverlay[] = [],
-    /** ADR-0037 D-DOSE: a confirmed `IntentBlock` progression's per-session duration
-     * (`engine/confirmedProgressionOverrides.ts`), keyed by coverage role id. */
+    /** ADR-0037 D-DOSE: exact-workout duration authority derived for `date` only. The
+     * weekly packer receives `date` separately so this map cannot alter sibling dates in
+     * the rolling horizon. */
     progressionOverrides: ReadonlyMap<string, number> = new Map(),
 ): ResolvedEvergreenPlan | null {
     if (planningContext.mode !== 'evergreen' || !preferences) return null;
@@ -54,7 +55,7 @@ export function resolveEvergreenPlan(
             stateEvidence?.observedWindowDays ?? historySnapshot?.windowDays ?? 0,
         ),
     );
-    const budget = packWeeklyDose(strategy, capacity, EVERGREEN_PACKING_COVERAGE, progressionOverrides);
+    const budget = packWeeklyDose(strategy, capacity, EVERGREEN_PACKING_COVERAGE, progressionOverrides, date);
     const result = buildEvergreenPlanDefinition(strategy, capacity, budget, date);
     if (result.status !== 'AVAILABLE') return null;
     return {

--- a/app/src/engine/policy.test.ts
+++ b/app/src/engine/policy.test.ts
@@ -3,10 +3,10 @@ import { isHistoricalPolicyVersion, HISTORICAL_POLICY_VERSIONS, POLICY_VERSION }
 
 describe('isHistoricalPolicyVersion', () => {
     it('records the exact progression-confirmed-selection-wiring transition once', () => {
-        expect(POLICY_VERSION).toBe('2026-09-progression-confirmed-selection-wiring-v1');
+        expect(POLICY_VERSION).toBe('2026-09-progression-confirmed-selection-wiring-v2');
         expect(
             HISTORICAL_POLICY_VERSIONS.filter(
-                (version) => version === '2026-09-fixed-activity-dedup-identity-unification-v1',
+                (version) => version === '2026-09-progression-confirmed-selection-wiring-v1',
             ),
         ).toHaveLength(1);
     });

--- a/app/src/engine/policy.ts
+++ b/app/src/engine/policy.ts
@@ -1,11 +1,12 @@
 /** Increment whenever a change can alter a persisted recommendation decision. (Refactoring does not require a bump) */
 
-export const POLICY_VERSION = '2026-09-progression-confirmed-selection-wiring-v1';
+export const POLICY_VERSION = '2026-09-progression-confirmed-selection-wiring-v2';
 
 /** Historical versions are intentionally not re-executed by this build. Their compact
  * audits remain readable evidence, but replay is rejected explicitly because the old
  * decision function is not bundled alongside the current policy. */
 export const HISTORICAL_POLICY_VERSIONS = [
+    '2026-09-progression-confirmed-selection-wiring-v1',
     '2026-09-fixed-activity-dedup-identity-unification-v1',
     '2026-09-h4-d-ledger-planner-admission-v2',
     '2026-09-h4-d-ledger-planner-admission-v1',

--- a/app/src/engine/rules.ts
+++ b/app/src/engine/rules.ts
@@ -52,6 +52,7 @@ import { isSevereAdverseRecoveryReadiness } from './evergreenStrategy';
 import { buildCoverageState, resolveCoverageHistory } from './coverage';
 import { applyPlanningOverlays } from './planningOverlays';
 import { mergeKnowledgeRefs, readinessKnowledgeRefs, trainingIntentKnowledgeRefs } from './knowledgeLineage';
+import { progressionDoseForTemplate } from './confirmedProgressionOverrides';
 
 function pickTemplate(options: SessionTemplate[], seedDate: string): SessionTemplate | undefined {
     if (options.length === 0) return undefined;
@@ -114,10 +115,6 @@ function calibrationTrace(
             count: todayActivities.length,
             cost,
             stimulus,
-            // Per-occurrence identity alongside the aggregate above so a later date's
-            // projection (`unrepresentedFixedActivityProjection`) can diff by
-            // `occurrenceId` instead of inferring an unrepresented activity from a bare
-            // count/aggregate-profile subtraction.
             entries: todayActivities.map(activity => ({
                 occurrenceId: fixedActivityOccurrenceKey(activity),
                 cost: { systemic: 0, cardiovascular: 0, lowerBody: 0, upperBody: 0, impactTissue: 0, neuromuscular: 0, ...(activity.expectedCost ?? {}) },
@@ -164,18 +161,10 @@ function applyModalityPreference(
 const HRV_STRAIN_WEIGHT = 0.5;
 const RHR_STRAIN_WEIGHT = 0.3;
 const SLEEP_STRAIN_WEIGHT = 0.2;
-// A sustained nocturnal/resting respiration-rate rise can precede respiratory infection,
-// including in athlete wearable cohorts, and can also reflect other physiological stress.
-// It is intentionally treated as contextual rather than diagnostic: intense exercise,
-// poor sleep, emotional stress, alcohol, altitude/environment and measurement conditions
-// can also shift the signal. The 0.3 weight remains product calibration, not an
-// evidence-derived illness or readiness coefficient.
 const RESPIRATION_STRAIN_WEIGHT = 0.3;
 const HRV_STDEV_FLOOR_MS = 3;
 const RHR_STDEV_FLOOR_BPM = 1.5;
 const SLEEP_STDEV_FLOOR_PTS = 4;
-// 1 br/min is a product variability floor chosen to avoid overreacting to small wearable
-// fluctuations; it is not an evidence-derived illness or training-action threshold.
 const RESPIRATION_MAD_FLOOR_BR = 1.0;
 const STRAIN_Z_CAP = 2.0;
 const CHRONIC_STRAIN_MULTIPLIER = 1.5;
@@ -191,62 +180,17 @@ const STRAIN_MODIFY_THRESHOLD = 1.0;
 const STRAIN_RECOVER_THRESHOLD = 2.2;
 const MODIFY_MAX_SYSTEMIC_COST = 0.5;
 
-// --- Phase 9.3: subjective drift, behind a default-off selector ---------------------------
-
-/**
- * `'off'` (the default at every production call site) is bit-identical to pre-Phase-9
- * behaviour. The other member of this union is unreachable from production callers -- see
- * `rules.test.ts`'s architecture guard -- and exists only for the 9.6 simulation
- * comparison harness to measure. Mirrors `FatigueFusionPolicy`'s plumbing pattern: a
- * selector threaded through the real evaluator, not a second implementation.
- */
 export type SubjectiveDriftPolicy = 'off' | 'drift';
-
-/** Experimental per-metric weights (D-SUBJCAL: "fatigue, soreness, sleepQuality,
- *  readiness, motivation, and stress need not share weights or even all participate").
- *  Equal weighting is the reference starting point for 9.6 to challenge, not a considered
- *  choice -- a weight of 0 excludes a metric from the aggregate entirely. */
 export type SubjectiveDriftWeights = Record<SubjectiveBaselineMetric, number>;
-
 export const REFERENCE_SUBJECTIVE_DRIFT_WEIGHTS: SubjectiveDriftWeights = {
     readiness: 1, sleepQuality: 1, fatigue: 1, soreness: 1, mentalStress: 1, motivation: 1,
 };
-
-/** Phase 9.7/D-SUBJAUDIT: identifies the *scoring* policy (weights + cap-source convention)
- *  that turns a `SubjectiveBaseline` into a strain contribution, independent of a baseline's
- *  own `estimatorId` (which identifies the baseline estimator's windows/floor/coverage --
- *  see the 9.6 sensitivity configs, which mint a new `estimatorId` per baseline variant).
- *  Bump this when the drift-scoring arithmetic, cap source, or reference weights change, so
- *  a persisted audit can distinguish a scoring-policy change from a baseline-estimator
- *  change. */
 export const SUBJECTIVE_DRIFT_ESTIMATOR_POLICY_VERSION = 'subjective-drift-score-v1-equal-weights-strain-z-cap';
-
-/** Adverse movement is signed positive for every metric regardless of scale direction --
- *  duplicated from `contextBrief.ts`'s equivalent `higherIsBetter` table rather than
- *  imported, the same reasoning `subjectiveBaseline.ts`'s own header comment gives for
- *  keeping this module free of a dependency on the brief renderer. */
 const SUBJECTIVE_DRIFT_HIGHER_IS_BETTER: Record<SubjectiveBaselineMetric, boolean> = {
     readiness: true, sleepQuality: true, motivation: true,
     fatigue: false, soreness: false, mentalStress: false,
 };
 
-/**
- * The 9.1 reference estimator's drift term (D-SUBJDRIFT / D-SUBJEST): recent-vs-long
- * prior history only -- today never enters this comparison, `computeSubjectiveBaseline`
- * already enforces that (D-SUBJHIST). Every per-metric contribution is floored at zero
- * before weighting and summed -- there is structurally **no subtraction path** (D-SUBJADD):
- * a `Math.max(weight, 0) * clamp(z, 0, cap)` term can only ever add to the total, for any
- * baseline and any weight, including a hypothetical negative weight. `'off'` or a missing
- * baseline (D-SUBJCOV: below-floor coverage already resolves to `null` in
- * `computeSubjectiveBaseline`) both return exactly `0` -- no relative subjective signal is
- * the same as today's behaviour, never a fabricated neutral value.
- *
- * The cap reuses `STRAIN_Z_CAP` -- matching `SubjectiveBaselinePolicy.contributionCap`'s
- * reference value by convention (9.1's own comment), not by runtime reference: the
- * baseline this function receives carries `estimatorId` for provenance, not the policy
- * object that produced it. If 9.6 needs the cap to vary independently of `STRAIN_Z_CAP`,
- * thread it explicitly rather than assuming this coupling.
- */
 export function subjectiveDriftStrain(
     baseline: SubjectiveBaseline | null | undefined,
     policy: SubjectiveDriftPolicy,
@@ -288,9 +232,6 @@ function metricStrain(
 }
 
 export interface EvaluateReadinessOptions {
-    /** ADR-0036 (H4) D-LEDGER/D-REASSESS: an intraday bundle member whose predecessor
-     * completed as planned accounts for its same-day load via the shared daily ledger debit,
-     * rather than tripping the single-session-per-day alreadyTrainedOverride fail-stop. */
     ignoreAlreadyTrainedOverride?: boolean;
 }
 
@@ -299,11 +240,7 @@ export function evaluateReadinessAndSafetyEnvelope(
     context: UserContext,
     _date?: string,
     previousMode?: 'train' | 'modify' | 'recover',
-    /** Phase 9.3: defaults to `'off'` at every call site -- see `SubjectiveDriftPolicy`'s
-     *  doc comment. Only a future 9.6 comparison harness passes the other member of that union. */
     subjectiveDriftPolicy: SubjectiveDriftPolicy = 'off',
-    /** Phase 9.3/D-SUBJCAL: experimental, not yet tuned. Only reachable by explicitly
-     *  passing a non-default value -- no production call site does. */
     subjectiveDriftWeights: SubjectiveDriftWeights = REFERENCE_SUBJECTIVE_DRIFT_WEIGHTS,
     options?: EvaluateReadinessOptions,
 ): {
@@ -322,9 +259,6 @@ export function evaluateReadinessAndSafetyEnvelope(
     const invertedSleepQual = 10 - subjective.sleepQuality;
     const invertedReadiness = 10 - subjective.readiness;
 
-    // SEP-C2: Motivation is excluded from the physical fatigue composite.
-    // When answeredDimensions is provided (e.g. from check-in), average only the answered physical dimensions.
-    // When omitted/undefined (e.g. in legacy fixtures), average all 4 physical dimensions.
     let overallFatigueScore: number;
     if (subjective.answeredDimensions && subjective.answeredDimensions.length > 0) {
         const physicalEntries: number[] = [];
@@ -342,9 +276,6 @@ export function evaluateReadinessAndSafetyEnvelope(
     const hrvStrain = metricStrain(objective.hrv_delta, objective.hrv_delta_28d, objective.hrv_stdev_28d, HRV_STDEV_FLOOR_MS, HRV_STRAIN_WEIGHT, 1);
     const rhrStrain = metricStrain(objective.rhr_delta, objective.rhr_delta_28d, objective.rhr_stdev_28d, RHR_STDEV_FLOOR_BPM, RHR_STRAIN_WEIGHT, -1);
     const sleepStrain = metricStrain(objective.sleep_score_delta_7d, objective.sleep_score_delta_28d, objective.sleep_score_stdev_28d, SLEEP_STDEV_FLOOR_PTS, SLEEP_STRAIN_WEIGHT, 1);
-    // Elevated respiration is worse (sign -1, same convention as RHR); the MAD arg is a
-    // robust spread estimator, not the population stdev metricStrain's name suggests --
-    // see RESPIRATION_MAD_FLOOR_BR above. ?? null covers documents predating this field.
     const respirationStrain = metricStrain(objective.respiration_delta ?? null, objective.respiration_delta_28d ?? null, objective.respiration_mad_28d ?? null, RESPIRATION_MAD_FLOOR_BR, RESPIRATION_STRAIN_WEIGHT, -1);
     const totalAcuteDeviation = hrvStrain.acuteDeviation + rhrStrain.acuteDeviation + sleepStrain.acuteDeviation + respirationStrain.acuteDeviation;
     const totalMultiDayDrift = hrvStrain.multiDayDrift + rhrStrain.multiDayDrift + sleepStrain.multiDayDrift + respirationStrain.multiDayDrift;
@@ -360,9 +291,6 @@ export function evaluateReadinessAndSafetyEnvelope(
     }
     const conservativeBias = context.preferences.conservativeBias ? CONSERVATIVE_BIAS_STRAIN_OFFSET : 0;
     const clinicalRecoverOverride = subjective.painFlag;
-    // SEP-C2 absolute override: an 8/10 or higher fatigue/soreness report (>= 8)
-    // independently forces recovery even when other answered physical dimensions are green.
-    // Floating-point profile fixtures with baseline 7 + noise stay below 8.
     const severeFatigue = subjective.fatigue >= 8 || subjective.soreness >= 8;
     const extremeFatigue = severeFatigue || clinicalRecoverOverride;
     const severeSubjectiveDistress = (subjective.fatigue >= 8 && subjective.readiness <= 4) ||
@@ -386,13 +314,6 @@ export function evaluateReadinessAndSafetyEnvelope(
     const recentHardSessionsCount = objective.last_3_days_hard_sessions_count || 0;
     const recentHardSessionsPenalty = recentHardSessionsCount >= 2 ? RECENT_HARD_SESSIONS_STRAIN : 0;
     const objectiveStrain = totalMetricStrain + sleepFloorPenalty + bodyBatteryDeficit + conservativeBias + recentHardSessionsPenalty;
-
-    // Phase 9.3 (D-SUBJADD): a separate, structurally non-negative contribution -- see
-    // subjectiveDriftStrain's own doc comment for why no baseline/weight can subtract from
-    // it. Under 'off' (every production call site today) this is always exactly 0, so
-    // strainForThresholds below is byte-identical to objectiveStrain and every absolute
-    // subjective trigger (overallFatigueScore/soreness, checked separately below) stays
-    // untouched either way (D-SUBJFLOOR).
     const subjectiveDrift = subjectiveDriftStrain(readiness.subjectiveBaseline, subjectiveDriftPolicy, subjectiveDriftWeights);
     const strainForThresholds = objectiveStrain + subjectiveDrift;
 
@@ -412,11 +333,6 @@ export function evaluateReadinessAndSafetyEnvelope(
     const counterfactualModeWithoutDrift = counterfactualRecover ? 'recover' : (counterfactualModify ? 'modify' : 'train');
     const multiDayDriftIsDecisionRelevant = (mode !== 'train') && (mode !== counterfactualModeWithoutDrift);
 
-    // Phase 9.7: the analogous counterfactual for the *subjective* term above -- computed
-    // from objectiveStrain alone (not strainWithoutDrift, which subtracts the unrelated
-    // objective multi-day-drift axis) through the same threshold logic, so a caller can tell
-    // whether subjective drift specifically changed the mode. Inert under 'off' (subjectiveDrift
-    // is always 0 there, so modeWithoutSubjectiveDrift always equals mode).
     const recoverWithoutSubjectiveDrift = overallFatigueScore > 7 || extremeFatigue || severeSubjectiveDistress || lowBodyBatteryRecovery || combinedAcuteBiometricRecover || physicalWorkRecover || objectiveStrain >= STRAIN_RECOVER_THRESHOLD;
     const modifyWithoutSubjectiveDrift = recoverWithoutSubjectiveDrift || overallFatigueScore > 5 || subjective.soreness > 6 || acuteSubjectiveModify || physicalWorkModify || acuteBiometricStrainFloor || objectiveStrain >= STRAIN_MODIFY_THRESHOLD;
     const modeWithoutSubjectiveDrift = recoverWithoutSubjectiveDrift ? 'recover' : (modifyWithoutSubjectiveDrift ? 'modify' : 'train');
@@ -427,9 +343,6 @@ export function evaluateReadinessAndSafetyEnvelope(
     const alreadyTrainedOverride = options?.ignoreAlreadyTrainedOverride === true
         ? false
         : (subjective.alreadyTrainedToday === true || objective.today_training !== null);
-    // Mirror evaluateEnvelopes' red-flag predicate: a disclosed red flag that resolved to
-    // no findings still surfaces as clinicalEnvelopeSources: ['red_flag'] and must force
-    // recover, not just a non-empty redFlagFindings list.
     const redFlagOverride =
         (subjective.redFlagFindings?.length ?? 0) > 0
         || subjective.clinicalEnvelopeSources?.includes('red_flag') === true;
@@ -448,9 +361,6 @@ export function evaluateReadinessAndSafetyEnvelope(
             sleepFloorPenalty: round2(sleepFloorPenalty),
             conservativeBias: round2(conservativeBias),
         },
-        // Phase 9.7: reconciles metricStrain.totalMetricStrain + contextPenalties.* +
-        // subjectiveDrift === totalDecisionScore. subjectiveDrift is always 0 under the
-        // production 'off' default, so this stays byte-identical to pre-Phase-9.7 output.
         subjectiveDrift: round2(subjectiveDrift),
         totalDecisionScore: round2(objectiveStrain + subjectiveDrift),
     };
@@ -484,9 +394,6 @@ function hasWearableObjectiveData(objective: EngineObjectiveInput): boolean {
         objective.body_battery_wake,
         objective.yesterday_training,
         objective.today_training,
-        // sleep_score_delta_7d, not sleep_score itself: metricStrain() short-circuits to
-        // zero strain whenever deltaVs7d is null (see metricStrain above), so a delta-only
-        // snapshot with sleep_score already null can still move the mode via sleepStrain.
         objective.sleep_score_delta_7d,
     ].some(value => value !== null && value !== undefined)
         || objective.last_3_days_hard_sessions_count > 0;
@@ -580,28 +487,18 @@ export function evaluateTraining(
     return { template: selectedTemplate, rationale, mode, envelopes, telemetry, knowledgeRefs: state.knowledgeRefs };
 }
 
-/** Identifies which imported session is placed on the evaluation date. */
 export interface ExternalPlanContext {
     planId: string;
     revision: number;
     session: ExternalPlanSession;
-    /** SHA-256 of the stored revision this session was read from (ADR-0019 D-IMMUT).
-     * Recorded on the decision audit so replay verifies against the same bytes. */
     contentHash: string;
 }
 
-/** ADR-0035: identifies the authored rest directive resolved for the evaluation date.
- * Resolved by the caller through `externalPlacement.ts`'s `resolveRestDatesByDate`, the
- * same way `externalPlan` above is resolved through placement -- this function performs
- * no placement/resolution itself. Mutually exclusive with `externalPlan` by construction:
- * a date cannot carry both a placed session and a rest directive (validated at import). */
 export interface ExternalRestContext {
     planId: string;
     revision: number;
     directive: ExternalRestDirective;
     date: string;
-    /** SHA-256 of the stored revision this directive was read from, same role as
-     * `ExternalPlanContext.contentHash`. */
     contentHash: string;
 }
 
@@ -635,11 +532,6 @@ function externalPrescriptionFor(externalPlan: ExternalPlanContext): NonNullable
     };
 }
 
-/**
- * Builds the recommendation for an imported prescribed session. Events deliberately do
- * not use this path: D-EVENT reconciles them onto FixedActivity and keeps their verdict as
- * advice alongside the normal recommendation rather than recommending the event itself.
- */
 function adjudicatedExternalRecommendation(
     externalPlan: ExternalPlanContext,
     readiness: DailyReadiness,
@@ -652,9 +544,6 @@ function adjudicatedExternalRecommendation(
 ): Recommendation {
     const { session, planId, revision, contentHash } = externalPlan;
     const availability = resolveAvailability(date, readiness.subjective, fixedActivities, context, scheduleOverlays);
-    // Keep the adjudicator responsible for validating the raw authored dose before it can
-    // be reduced by an overlay. The recommendation surface still records the same adjusted
-    // planned dose that catalog planning would expose for this date.
     const adjustedPlannedDose = applyPlanningOverlays(
         intent.plannedDose,
         date,
@@ -664,7 +553,6 @@ function adjudicatedExternalRecommendation(
     );
     const verdict = adjudicateExternalSession(session, readiness, context, envelopeState, intent.plannedDose, date, availability);
     const actionable = verdict.decision === 'proceed' || verdict.decision === 'scale';
-
     const restTemplate = getCanonicalRestTemplate();
 
     return {
@@ -690,20 +578,6 @@ function adjudicatedExternalRecommendation(
     };
 }
 
-/**
- * ADR-0035: builds the recommendation for a date an authored rest directive closed to
- * discretionary planning. Deliberately does **not** run eligibility/ranking -- there is
- * nothing to rank against; the plan's own instruction is the decision.
- *
- * `mode` is set to the genuine `envelopeState.mode` (the readiness/safety envelope's own
- * train/modify/recover classification), not forced to `'recover'`, even though the
- * recommended template is Rest. The ADR is explicit that authored rest must not fabricate
- * a physiological `recover` verdict: `previousMode` is threaded into tomorrow's evaluation
- * (see the `evaluateNextDayPlanWithIntent` call site) and drives things like
- * `postRecoverBufferApplied` -- reporting `'recover'` here when readiness was actually
- * `'train'` would falsely trigger tomorrow's "ease back in after a mandated recovery day"
- * behavior for an athlete whose own readiness never called for it.
- */
 function authoredRestRecommendation(
     externalRest: ExternalRestContext,
     envelopeState: ReturnType<typeof evaluateReadinessAndSafetyEnvelope>,
@@ -749,22 +623,12 @@ export async function evaluateTrainingWithIntent(
     preferences: UserPreferences | null = null,
     fatigueFusionPolicy: FatigueFusionPolicy = 'max',
     externalPlan: ExternalPlanContext | null = null,
-    /** Phase 9.6: only the simulation comparison harness overrides this. Every production
-     *  entry point uses the default 'off', mirroring `fatigueFusionPolicy` above. */
     subjectiveDriftPolicy: SubjectiveDriftPolicy = 'off',
     subjectiveDriftWeights: SubjectiveDriftWeights = REFERENCE_SUBJECTIVE_DRIFT_WEIGHTS,
-    /** ADR-0035: the rest directive resolved for `date` by the caller (mirrors how
-     *  `externalPlan` above is resolved through placement), or null when none applies. */
     externalRest: ExternalRestContext | null = null,
-    /** ADR-0035: an explicit, athlete-initiated request to train despite an authored rest
-     *  directive. Never inferred from favorable readiness. Production also treats a non-empty
-     *  same-day `preferredModalityToday` check-in answer as an explicit workout request.
-     *  Either route still passes every normal safety/clinical/availability/equipment/readiness
-     *  gate below and is retained in provenance as an explicit override. */
     athleteOverridesAuthoredRest: boolean = false,
     scheduleOverlays: readonly ScheduleOverlay[] = [],
-    /** ADR-0037 D-DOSE: a confirmed `IntentBlock` progression's per-session duration
-     * (`engine/confirmedProgressionOverrides.ts`), keyed by coverage role id. */
+    /** ADR-0037 D-DOSE: exact-workout duration authority derived for `date`. */
     confirmedProgressionOverrides: ReadonlyMap<string, number> = new Map(),
 ): Promise<Recommendation> {
     const envelopeState = evaluateReadinessAndSafetyEnvelope(readiness, context, date, previousMode, subjectiveDriftPolicy, subjectiveDriftWeights);
@@ -916,20 +780,37 @@ export async function evaluateTrainingWithIntent(
         ? 'You explicitly overrode a protected rest day; normal safety, availability, readiness, and ranking still apply. '
         : '';
     const pick = rankingResult.accepted[0];
-    // A 'modify' mode whose top-ranked candidate is already low-cost enough to survive
-    // the modify ceiling unchanged (a bad subjective checkin on an already-easy day, most
-    // commonly) previously fell through as a same-template, same-duration recommendation
-    // -- 'modify' meant nothing an athlete could see. Auto-applying the template's own
-    // easier dose (the same mechanism `adjustSessionRecommendation('easier', ...)` uses
-    // for an explicit athlete request) keeps 'modify' visibly distinct from 'train'
-    // whenever the template offers a lighter variant, without inventing a second
-    // eligibility/ranking path. It also covers the time-cap case: see
-    // resolveTimeCapDoseAdjustment for why eligibility alone cannot guarantee the
-    // recommended duration respects a hard cap. This same helper is used for forecast days
-    // in planner.ts -- keep the two call sites in sync.
+    const progressionDose = pick
+        ? progressionDoseForTemplate(pick.template, confirmedProgressionOverrides)
+        : null;
+    const progressionDoseAllowed = progressionDose && pick
+        && progressionDose.durationMin <= availability.maxTimeMinutes
+        && !exceedsPlanCeiling(pick.template.systemicCost * progressionDose.doseRatio, envelopes.plan)
+        ? progressionDose
+        : null;
     const doseAdjustment = pick
         ? resolveTimeCapDoseAdjustment(pick.template, availability.maxTimeMinutes, mode === 'modify')
         : null;
+    const appliedProgressionDose = progressionDoseAllowed
+        && (!doseAdjustment || progressionDoseAllowed.durationMin <= doseAdjustment.activeDose.durationMin)
+        ? progressionDoseAllowed
+        : null;
+    const effectiveDoseAdjustment = doseAdjustment && appliedProgressionDose
+        ? {
+            ...doseAdjustment,
+            activeDose: appliedProgressionDose,
+            adjustment: {
+                ...doseAdjustment.adjustment,
+                adjustedDoseLabel: appliedProgressionDose.label,
+                rationale: `Today's readiness/time ceiling still applies; the confirmed progression dose (${appliedProgressionDose.label}) is no larger than that reduced ceiling, so the lower confirmed dose is used.`,
+            },
+        }
+        : doseAdjustment;
+    const progressionConstrained = Boolean(
+        progressionDose
+        && (!progressionDoseAllowed || (doseAdjustment && progressionDose.durationMin > doseAdjustment.activeDose.durationMin)),
+    );
+
     if (!pick) {
         const safeRecovery = candidates.find(template => template.category === 'Rest' || template.category === 'Mobility/Recovery')
             ?? getCanonicalRestTemplate();
@@ -949,9 +830,6 @@ export async function evaluateTrainingWithIntent(
                 policyVersion: POLICY_VERSION,
                 candidateScores: rankingResult.all.map(candidate => ({ templateId: candidate.template.id, utilityScore: candidate.utilityScore, benefitScore: candidate.benefitScore, costPenalty: candidate.costPenalty, excludedReasons: candidate.excludedReasons })),
                 droppedContributorObjectives: intent.droppedContributorObjectives,
-                // No candidate survived the hard constraints (rankingResult.accepted is
-                // empty in this branch -- see `if (!pick)` above), so there is no
-                // counterfactual to report.
                 rankingAudit: null,
                 calibration,
                 ...(externalEventAdvisory ? { externalPlan: externalEventAdvisory.provenance } : {}),
@@ -959,11 +837,16 @@ export async function evaluateTrainingWithIntent(
             },
         };
     }
+    const progressionRationale = progressionConstrained
+        ? ' The confirmed progression remains the authored target, but today’s readiness/time ceiling is lower, so it is not forced above that ceiling.'
+        : appliedProgressionDose && !effectiveDoseAdjustment
+            ? ` ${appliedProgressionDose.prescriptionSummary}`
+            : '';
     const finalRationale = envelopes.safety.redFlagActive
         ? `${authoredRestOverridePrefix}${envelopes.safety.clinicalReason ?? 'Clinical evaluation recommended: red-flag findings reported.'} All training prescriptions are paused.`
-        : doseAdjustment
-            ? `${authoredRestOverridePrefix}${externalFallbackPrefix}${phaseContext} ${pick.rationale} ${doseAdjustment.adjustment.rationale}`
-            : `${authoredRestOverridePrefix}${externalFallbackPrefix}${phaseContext} ${pick.rationale}`;
+        : effectiveDoseAdjustment
+            ? `${authoredRestOverridePrefix}${externalFallbackPrefix}${phaseContext} ${pick.rationale} ${effectiveDoseAdjustment.adjustment.rationale}${progressionRationale}`
+            : `${authoredRestOverridePrefix}${externalFallbackPrefix}${phaseContext} ${pick.rationale}${progressionRationale}`;
     return {
         template: pick.template,
         plannedDose: intent.plannedDose,
@@ -971,7 +854,7 @@ export async function evaluateTrainingWithIntent(
         rationale: finalRationale,
         mode, envelopes, telemetry,
         knowledgeRefs: decisionKnowledgeRefs,
-        ...(doseAdjustment ?? {}),
+        ...(effectiveDoseAdjustment ?? (appliedProgressionDose ? { activeDose: appliedProgressionDose } : {})),
         ...(externalEventAdvisory ? {
             externalPrescription: externalEventAdvisory.prescription,
             externalVerdict: externalEventAdvisory.verdict,
@@ -997,8 +880,6 @@ export function evaluateEnvelopes(
     const restrictedModalities = [...(context.constraints.restrictedModalities ?? [])];
     const hasActiveInjury = restrictedModalities.length > 0 || (context.constraints.impliedGuardrails ?? []).length > 0 || (context.constraints.restrictedCategories ?? []).length > 0;
 
-    // `painFlag` is retained as a backward-compatible aggregate. New inputs name their
-    // clinical origin explicitly; a legacy true flag with no source fails closed as pain/injury.
     const sources: NonNullable<typeof readiness.subjective.clinicalEnvelopeSources> =
         readiness.subjective.clinicalEnvelopeSources ?? (legacyClinicalFlag ? ['pain_or_injury'] : []);
     const hasPainOrInjury = sources.includes('pain_or_injury');
@@ -1009,10 +890,6 @@ export function evaluateEnvelopes(
     const redFlagCategories = redFlagFindings.map(f => f.category);
     const hasCurrentClinicalSymptoms = legacyClinicalFlag || sources.length > 0 || redFlagActive;
 
-    // The generic Running restriction belongs to the pain/injury branch only. Current
-    // structured tissue-response regions may contextualize that fallback; standing injury
-    // trace facts are intentionally NOT consulted because provenance must not become policy
-    // authority and an unrelated old shoulder/hip/back constraint cannot locate today's pain.
     const currentPainFamilies = readiness.subjective.painOrInjuryRegionFamilies ?? [];
     const hasStructuredCurrentPainLocation = currentPainFamilies.length > 0;
     const hasLowerLimbImpactPain = currentPainFamilies.includes('lower_limb_impact');
@@ -1269,7 +1146,7 @@ function recommendationProjection(date: string, rec: Recommendation): CompletedE
         ...(workoutId ? { workoutId } : {}),
         modality: rec.template.modality,
         category: rec.template.category,
-        trainingRecordLike: { type: `${rec.template.modality} ${rec.template.category}`, duration_min: rec.template.durationMin, training_effect: 0, intensity_tag: '' },
+        trainingRecordLike: { type: `${rec.template.modality} ${rec.template.category}`, duration_min: rec.activeDose?.durationMin ?? rec.template.durationMin, training_effect: 0, intensity_tag: '' },
     };
 }
 
@@ -1283,14 +1160,6 @@ function fixedActivityProjection(activity: FixedActivity): CompletedExposure | n
     };
 }
 
-/**
- * `evaluateTrainingWithIntent` may synthesize an in-memory FixedActivity for an imported
- * target event. That object deliberately is not persisted and therefore is not in the
- * caller's `fixedActivities` array when Home asks for tomorrow's forecast. The decision
- * trace already records the aggregate fixed-activity profiles that today's ranking saw.
- * Project only the positive delta between that trace and the caller-owned activities, so
- * the event load survives into tomorrow without double-counting ordinary commitments.
- */
 function unrepresentedFixedActivityProjection(
     date: string,
     rec: Recommendation,
@@ -1299,10 +1168,6 @@ function unrepresentedFixedActivityProjection(
     const trace = rec.decisionTrace?.calibration?.fixedActivity;
     if (!trace) return null;
     const represented = fixedActivities.filter(activity => activity.date === date && !activity.isCompleted);
-    // Identity-based diff (ADR-0036 D-LEDGER's occurrenceId model) rather than a
-    // count-triggered aggregate-profile subtraction: exactly the occurrences today's
-    // ranking saw but that are absent from the caller's own array are unrepresented,
-    // regardless of whether an unrelated activity was also added or removed meanwhile.
     const representedIds = new Set(represented.map(fixedActivityOccurrenceKey));
     const unrepresentedEntries = trace.entries.filter(entry => !representedIds.has(entry.occurrenceId));
     if (unrepresentedEntries.length === 0) return null;
@@ -1343,10 +1208,6 @@ function unrepresentedFixedActivityProjection(
     };
 }
 
-/** Carries the non-training load reserved by schedule overlays on a completed forecast
- * date into the next date's history. Same-day availability already reserves this cost, so
- * the projection is added only after that date has passed and never to the current-day
- * availability ledger itself. */
 function scheduleOverlayProjection(
     date: string,
     scheduleOverlays: readonly ScheduleOverlay[],
@@ -1419,7 +1280,6 @@ export async function evaluateNextDayPlanWithIntent(
     trainingIntentProfile: TrainingIntentProfile | null = null,
     preferences: UserPreferences | null = null,
     fatigueFusionPolicy: FatigueFusionPolicy = 'max',
-    /** Phase 9.6: only the simulation comparison harness overrides this. */
     subjectiveDriftPolicy: SubjectiveDriftPolicy = 'off',
     subjectiveDriftWeights: SubjectiveDriftWeights = REFERENCE_SUBJECTIVE_DRIFT_WEIGHTS,
     scheduleOverlays: readonly ScheduleOverlay[] = [],
@@ -1435,11 +1295,6 @@ export async function evaluateNextDayPlanWithIntent(
         historyProvider,
         preparedHistorySnapshot,
     );
-    // ADR-0037 D-DOSE: no confirmedProgressionOverrides here -- a confirmed progression's
-    // duration override is date-scoped to a single day, and this evaluates *tomorrow*'s
-    // scenarios from *today*'s call. Progression influence is deliberately scoped to
-    // same-day planning (evaluateTrainingWithIntent's own confirmedProgressionOverrides
-    // parameter) until the packer has a date-scoped resolver.
     const evaluate = async (scenario: NextDayScenario) => evaluatedBranch(
         scenario,
         await evaluateTrainingWithIntent(

--- a/app/src/engine/rules.ts
+++ b/app/src/engine/rules.ts
@@ -26,7 +26,7 @@ import type {
 import type { ExternalRestDecisionProvenance } from './externalRestProvenance';
 import { TEMPLATES, ENRICHED_TEMPLATES, ENRICHED_TEMPLATES_BY_ID, TEMPLATES_BY_ID } from './templates';
 import { eligibleTemplates, evaluateTemplateEligibility, resolveMaximumSessionMinutes } from './eligibility';
-import { buildOptimizationContext, computeRankingCounterfactual, rankCandidates, resolveRecoveryStyle, resolveTimeCapDoseAdjustment } from './optimizer';
+import { buildOptimizationContext, computeRankingCounterfactual, materializeEffectiveDose, rankCandidates, resolveRecoveryStyle, resolveTimeCapDoseAdjustment } from './optimizer';
 import { addDaysToLocalDateString } from '../utils/localDate';
 import type { CompletedExposure, TrainingHistoryProvider } from './trainingHistory';
 import type { TrainingHistorySnapshot } from './trainingHistorySnapshot';
@@ -1136,17 +1136,18 @@ const ZERO_STIMULUS: WorkoutStimulusProfile = { aerobicEndurance: 0, thresholdPo
 
 function recommendationProjection(date: string, rec: Recommendation): CompletedExposure {
     const workoutId = workoutForTemplate(rec.template.id)?.id;
+    const effectiveTemplate = materializeEffectiveDose(rec.template, rec.activeDose);
     return {
         occurrenceKey: `recommendation:${date}`,
         date,
-        costProfile: rec.template.costProfile ?? ZERO_COST,
-        stimulusProfile: rec.template.stimulusProfile,
+        costProfile: effectiveTemplate.costProfile ?? ZERO_COST,
+        stimulusProfile: effectiveTemplate.stimulusProfile,
         stimulusConfidence: 'exact',
         templateId: rec.template.id,
         ...(workoutId ? { workoutId } : {}),
         modality: rec.template.modality,
         category: rec.template.category,
-        trainingRecordLike: { type: `${rec.template.modality} ${rec.template.category}`, duration_min: rec.activeDose?.durationMin ?? rec.template.durationMin, training_effect: 0, intensity_tag: '' },
+        trainingRecordLike: { type: `${rec.template.modality} ${rec.template.category}`, duration_min: effectiveTemplate.durationMin, training_effect: 0, intensity_tag: '' },
     };
 }
 

--- a/app/src/engine/weeklyDosePacking.test.ts
+++ b/app/src/engine/weeklyDosePacking.test.ts
@@ -327,12 +327,12 @@ describe('weekly dose packing', () => {
 
             expect(global.shortfalls).toEqual([]); // 70 + 70
             expect(dateScoped.shortfalls).toEqual([]); // 70 + baseline 60 = 130
-            const stricter = {
+            const stricter: EvidenceBackedStrategy = {
                 ...scopedStrategy,
                 requirements: [{
                     ...scopedStrategy.requirements[0],
-                    floor: { dose: { unit: 'minutes', value: 140 }, semantics: 'goal_required_minimum' as const },
-                    target: { unit: 'minutes' as const, minimum: 140, target: 140, maximum: 180 },
+                    floor: { dose: { unit: 'minutes', value: 140 }, semantics: 'goal_required_minimum' },
+                    target: { unit: 'minutes', minimum: 140, target: 140, maximum: 180 },
                 }],
             };
             expect(packWeeklyDose(stricter, windows, coverage, override).shortfalls).toEqual([]);

--- a/app/src/engine/weeklyDosePacking.test.ts
+++ b/app/src/engine/weeklyDosePacking.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { EvidenceBackedStrategy } from './evergreenStrategy';
 import { packWeeklyDose, type CoverageSetDescriptor } from './weeklyDosePacking';
 import type { ResolvedTrainingCapacity } from './trainingCapacity';
+import { progressionOverrideKey } from './progressionOverrideKey';
 
 const healthStrategy: EvidenceBackedStrategy = {
     requirements: [{
@@ -107,10 +108,6 @@ describe('weekly dose packing', () => {
     });
 
     it('splits a shared required-tier ceiling fairly across peers instead of letting the first one exhaust it', () => {
-        // Regression for the former-elite-return persona: 'endurance' and 'strength_muscle'
-        // both resolve to 'required' priority (see evergreenStrategy.ts), and previously the
-        // first requirement processed (aerobic) claimed the whole minSessions ceiling,
-        // leaving strength — a second 'required' requirement — with zero packed sessions.
         const strategy: EvidenceBackedStrategy = {
             requirements: [
                 { ...healthStrategy.requirements[0], target: { unit: 'minutes', minimum: 150, target: 150, maximum: 300 } },
@@ -278,11 +275,69 @@ describe('weekly dose packing', () => {
         it('never changes the requirement-level guideline floor/target, only the role\'s per-session credit', () => {
             const wideWindows = capacity(200, 1);
             const budget = packWeeklyDose(healthStrategy, wideWindows, coverage, new Map([['aerobic-ride', 200]]));
-            // A single 200-minute session now fully covers the 150-minute floor -- but the
-            // floor value itself (from `strategy.requirements[0].floor`) is untouched; only
-            // the role's delivered-dose credit changed.
             expect(budget.requirements[0].floor?.dose.value).toBe(150);
             expect(budget.shortfalls).toEqual([]);
+        });
+
+        it('keeps an exact progression on its confirmed workout instead of transferring it to cross-modal substitutes', () => {
+            const multiModalStrategy: EvidenceBackedStrategy = {
+                ...healthStrategy,
+                requirements: [{
+                    ...healthStrategy.requirements[0],
+                    floor: { dose: { unit: 'minutes', value: 70 }, semantics: 'goal_required_minimum' },
+                    target: { unit: 'minutes', minimum: 70, target: 70, maximum: 120 },
+                    substitutionPolicy: { equivalentModalitiesAllowed: true, permittedModalities: ['Cycling', 'Running'] },
+                }],
+            };
+            const mixedCoverage: CoverageSetDescriptor = {
+                id: 'mixed-progressed-role',
+                roles: [{
+                    id: 'aerobic', adaptations: ['aerobic_endurance'],
+                    exactWorkoutIds: ['cycling_zone2_standard_01', 'running_easy_continuous_01'],
+                    durationMinutes: 60,
+                }],
+            };
+            const override = new Map([[progressionOverrideKey('aerobic', 'cycling_zone2_standard_01'), 70]]);
+            const budget = packWeeklyDose(multiModalStrategy, capacity(90, 1), mixedCoverage, override);
+
+            expect(budget.requiredRoles).toHaveLength(1);
+            expect(budget.requiredRoles[0].exactWorkoutIds).toEqual(['cycling_zone2_standard_01']);
+            expect(budget.shortfalls).toEqual([]);
+        });
+
+        it('applies a date-derived override only on its effective date inside a multi-day horizon', () => {
+            const scopedStrategy: EvidenceBackedStrategy = {
+                ...healthStrategy,
+                requirements: [{
+                    ...healthStrategy.requirements[0],
+                    floor: { dose: { unit: 'minutes', value: 130 }, semantics: 'goal_required_minimum' },
+                    target: { unit: 'minutes', minimum: 130, target: 130, maximum: 180 },
+                }],
+            };
+            const windows: ResolvedTrainingCapacity = {
+                ...capacity(90, 2),
+                usableWindows: [
+                    { date: '2026-08-10', availableMinutes: 90 },
+                    { date: '2026-08-11', availableMinutes: 90 },
+                ],
+            };
+            const override = new Map([[progressionOverrideKey('aerobic-ride', 'cycling_zone2_standard_01'), 70]]);
+            const global = packWeeklyDose(scopedStrategy, windows, coverage, override);
+            const dateScoped = packWeeklyDose(scopedStrategy, windows, coverage, override, '2026-08-10');
+
+            expect(global.shortfalls).toEqual([]); // 70 + 70
+            expect(dateScoped.shortfalls).toEqual([]); // 70 + baseline 60 = 130
+            const stricter = {
+                ...scopedStrategy,
+                requirements: [{
+                    ...scopedStrategy.requirements[0],
+                    floor: { dose: { unit: 'minutes', value: 140 }, semantics: 'goal_required_minimum' as const },
+                    target: { unit: 'minutes' as const, minimum: 140, target: 140, maximum: 180 },
+                }],
+            };
+            expect(packWeeklyDose(stricter, windows, coverage, override).shortfalls).toEqual([]);
+            expect(packWeeklyDose(stricter, windows, coverage, override, '2026-08-10').shortfalls)
+                .toEqual([expect.objectContaining({ code: 'goal_requirement_shortfall', message: expect.stringContaining('130') })]);
         });
     });
 });

--- a/app/src/engine/weeklyDosePacking.test.ts
+++ b/app/src/engine/weeklyDosePacking.test.ts
@@ -339,5 +339,36 @@ describe('weekly dose packing', () => {
             expect(packWeeklyDose(stricter, windows, coverage, override, '2026-08-10').shortfalls)
                 .toEqual([expect.objectContaining({ code: 'goal_requirement_shortfall', message: expect.stringContaining('130') })]);
         });
+
+        it('prioritizes an active exact effective-date override over a shorter best-fit baseline candidate, avoiding a false shortfall', () => {
+            // A single-session budget spans a 90-minute window (the override's effective
+            // date) and a shorter 60-minute sibling-date window that only the unprogressed
+            // baseline role fits. Best-fit-by-availableMinutes alone would place the 60-min
+            // baseline first and strand the confirmed 90-min override, under-delivering the
+            // floor even though the override's own window can satisfy it exactly.
+            const scopedStrategy: EvidenceBackedStrategy = {
+                ...healthStrategy,
+                requirements: [{
+                    ...healthStrategy.requirements[0],
+                    floor: { dose: { unit: 'minutes', value: 90 }, semantics: 'goal_required_minimum' },
+                    target: { unit: 'minutes', minimum: 90, target: 90, maximum: 90 },
+                }],
+            };
+            const tightCapacity: ResolvedTrainingCapacity = {
+                ...capacity(90, 2),
+                minSessions: 1, targetSessions: 1, maxSessions: 1,
+                usableWindows: [
+                    { date: '2026-08-10', availableMinutes: 60 },
+                    { date: '2026-08-11', availableMinutes: 90 },
+                ],
+            };
+            const override = new Map([[progressionOverrideKey('aerobic-ride', 'cycling_zone2_standard_01'), 90]]);
+
+            const budget = packWeeklyDose(scopedStrategy, tightCapacity, coverage, override, '2026-08-11');
+
+            expect(budget.requiredRoles).toHaveLength(1);
+            expect(budget.requiredRoles[0].date).toBe('2026-08-11');
+            expect(budget.shortfalls).toEqual([]);
+        });
     });
 });

--- a/app/src/engine/weeklyDosePacking.ts
+++ b/app/src/engine/weeklyDosePacking.ts
@@ -76,6 +76,13 @@ interface MutableOccurrence extends PackedRoleOccurrence {
     descriptor: CoverageRoleDescriptor;
 }
 
+interface EligibleCandidate {
+    role: CoverageRoleDescriptor;
+    permitted: string[];
+}
+
+const NO_DURATION_OVERRIDES: ReadonlyMap<string, number> = new Map();
+
 function doseFor(role: CoverageRoleDescriptor, requirement: AdaptationDoseRequirement): number {
     return requirement.target.unit === 'minutes' ? role.durationMinutes : 1;
 }
@@ -95,54 +102,61 @@ function permittedWorkoutIds(role: CoverageRoleDescriptor, requirement: Adaptati
 }
 
 /**
- * A confirmed progression is scoped to the exact workout(s)
- * `confirmedProgressionOverrides.ts` validated it against (matching sport, session binding
- * and duration bounds) -- never to the whole role, whose `exactWorkoutIds` can span multiple
- * sports (e.g. `aerobic_volume` covers cycling, running and walking). Applying it here only
- * when *every* currently-eligible workout for this specific requirement shares the exact
- * same override value means a role whose substitution policy still allows a non-progression
- * modality is left at its catalog duration rather than crediting a workout the progression
- * was never validated against.
+ * Resolve an authored progression at the same identity granularity it was confirmed at.
+ * A role can span several sports, but an exact `role::workout` key authorizes only those
+ * exact workouts. Once at least one exact key matches the requirement, non-authorized
+ * substitutes are deliberately removed from this occurrence instead of inheriting the
+ * progressed duration or silently defeating the progression by winning as a shorter
+ * baseline alternative. Production derivation emits one value per claimed role; if an
+ * injected caller supplies conflicting exact values we fail closed to baseline role
+ * semantics rather than guessing which confirmed value owns the role.
+ *
+ * The plain role-id key remains an explicit unconditional legacy/test override.
  */
-function resolveExactOverrideDuration(
+function eligibleCandidateForRole(
     role: CoverageRoleDescriptor,
-    eligibleWorkoutIds: readonly string[],
+    requirement: AdaptationDoseRequirement,
     overrides: ReadonlyMap<string, number>,
-): number | null {
-    if (eligibleWorkoutIds.length === 0) return null;
-    const values = eligibleWorkoutIds.map(workoutId => overrides.get(progressionOverrideKey(role.id, workoutId)));
-    if (values.some(value => value === undefined)) return null;
-    const [first, ...rest] = values as number[];
-    return rest.every(value => value === first) ? first : null;
+): EligibleCandidate | null {
+    const permitted = permittedWorkoutIds(role, requirement);
+    if (permitted.length === 0) return null;
+    if (overrides.size === 0) return { role, permitted };
+
+    const direct = overrides.get(role.id);
+    if (direct !== undefined) return { role: { ...role, durationMinutes: direct }, permitted };
+
+    const exact = permitted.flatMap(workoutId => {
+        const duration = overrides.get(progressionOverrideKey(role.id, workoutId));
+        return duration === undefined ? [] : [{ workoutId, duration }];
+    });
+    if (exact.length === 0) return { role, permitted };
+
+    const values = new Set(exact.map(entry => entry.duration));
+    if (values.size !== 1) return { role, permitted };
+
+    return {
+        role: { ...role, durationMinutes: exact[0].duration },
+        permitted: exact.map(entry => entry.workoutId),
+    };
 }
 
-/** The plain role-id key is an explicit, unconditional "override this whole role" signal --
- * kept for deterministic unit tests and backwards-compatible injected callers (see
- * `confirmedProgressionOverrides.ts`'s own doc comment) -- and always wins over the
- * exact-scoped key. */
-function effectiveRole(
-    role: CoverageRoleDescriptor,
-    eligibleWorkoutIds: readonly string[],
-    overrides: ReadonlyMap<string, number>,
-): CoverageRoleDescriptor {
-    if (overrides.size === 0) return role;
-    if (overrides.has(role.id)) return { ...role, durationMinutes: overrides.get(role.id)! };
-    const exact = resolveExactOverrideDuration(role, eligibleWorkoutIds, overrides);
-    return exact === null ? role : { ...role, durationMinutes: exact };
-}
-
-/** Roles matching the requirement's adaptation, with at least one permitted exact workout,
- * resolved to their effective (possibly overridden) duration for this specific requirement. */
 function eligibleCandidates(
     roles: readonly CoverageRoleDescriptor[],
     requirement: AdaptationDoseRequirement,
     overrides: ReadonlyMap<string, number>,
-): Array<{ role: CoverageRoleDescriptor; permitted: string[] }> {
+): EligibleCandidate[] {
     return roles
         .filter(role => role.adaptations.includes(requirement.adaptation))
-        .map(role => ({ role, permitted: permittedWorkoutIds(role, requirement) }))
-        .filter((entry): entry is { role: CoverageRoleDescriptor; permitted: string[] } => entry.permitted.length > 0)
-        .map(entry => ({ role: effectiveRole(entry.role, entry.permitted, overrides), permitted: entry.permitted }));
+        .map(role => eligibleCandidateForRole(role, requirement, overrides))
+        .filter((entry): entry is EligibleCandidate => entry !== null);
+}
+
+function overridesForSlot(
+    overrides: ReadonlyMap<string, number>,
+    effectiveDate: string | undefined,
+    slotDate: string,
+): ReadonlyMap<string, number> {
+    return effectiveDate === undefined || effectiveDate === slotDate ? overrides : NO_DURATION_OVERRIDES;
 }
 
 function placementTieBreakerPenalty(
@@ -177,20 +191,20 @@ function warningFor(requirement: AdaptationDoseRequirement, delivered: number): 
  * more than one adaptation only when that descriptor explicitly grants each adaptation;
  * no modality/category similarity is used for bundling.
  *
- * `durationOverridesByRoleId` (ADR-0037 D-DOSE): a confirmed `IntentBlock` progression's
- * per-session `currentValue` (`engine/confirmedProgressionOverrides.ts`), keyed either by
- * plain role id (legacy/back-compat, applies to the whole role unconditionally) or by
- * `progressionOverrideKey(roleId, workoutId)` (production; see `effectiveRole` below for how
- * an exact-scoped key is resolved per requirement rather than applied to the whole role). It
- * substitutes for a role's catalog-derived `durationMinutes` -- both the capacity-fit
- * estimate and the literal delivered-dose accounting -- without touching
- * `requirement.floor`/`requirement.target`, which stay WHO-guideline-owned one level above
- * this function. A key with no matching role/workout is simply inert. */
+ * `durationOverridesByRoleId` (ADR-0037 D-DOSE) accepts either a plain role id
+ * (legacy/test: unconditional role override) or production exact keys from
+ * `progressionOverrideKey(roleId, workoutId)`. Exact keys narrow the occurrence to the
+ * confirmed workout identities and never transfer duration credit onto a sibling sport.
+ * `overrideEffectiveDate` scopes those overrides to one calendar date inside a multi-day
+ * packing horizon; production callers must supply it when their map was derived for one
+ * active date. Omitting it preserves the legacy injected whole-horizon behavior used by
+ * deterministic unit tests. Requirement floors/targets are never changed. */
 export function packWeeklyDose(
     strategy: EvidenceBackedStrategy,
     capacity: ResolvedTrainingCapacity,
     coverage: CoverageSetDescriptor,
     durationOverridesByRoleId: ReadonlyMap<string, number> = new Map(),
+    overrideEffectiveDate?: string,
 ): WeeklyBudget {
     const slots = capacity.usableWindows.map(window => ({ ...window, used: false }));
     const packed: MutableOccurrence[] = [];
@@ -205,12 +219,11 @@ export function packWeeklyDose(
 
     /** Estimate how many of the *remaining feasible windows* a requirement can still use.
      * This feeds only fair-share reservation; it must not reserve capacity for a later peer
-     * whose role cannot fit any remaining window. For minute-based requirements, calculate
-     * the best dose each individual window can actually host instead of assuming the role's
-     * globally best per-session dose fits every window. */
+     * whose role cannot fit any remaining window. Candidates are resolved per slot because
+     * a confirmed progression may be active on exactly one date inside the weekly horizon. */
     const sessionsNeededFor = (requirement: AdaptationDoseRequirement): number => {
-        const candidates = eligibleCandidates(coverage.roles, requirement, durationOverridesByRoleId).map(entry => entry.role);
-        if (candidates.length === 0) return 0;
+        const hasBaselineCandidate = eligibleCandidates(coverage.roles, requirement, NO_DURATION_OVERRIDES).length > 0;
+        if (!hasBaselineCandidate) return 0;
         const delivered = packed
             .filter(occurrence => occurrence.adaptations.includes(requirement.adaptation))
             .reduce((total, occurrence) => total + doseFor(occurrence.descriptor, requirement), 0);
@@ -219,9 +232,16 @@ export function packWeeklyDose(
 
         const feasibleDoseBySlot = slots
             .filter(slot => !slot.used)
-            .map(slot => candidates
-                .filter(role => slot.availableMinutes >= role.durationMinutes)
-                .reduce((bestDose, role) => Math.max(bestDose, doseFor(role, requirement)), 0))
+            .map(slot => {
+                const candidates = eligibleCandidates(
+                    coverage.roles,
+                    requirement,
+                    overridesForSlot(durationOverridesByRoleId, overrideEffectiveDate, slot.date),
+                ).map(entry => entry.role);
+                return candidates
+                    .filter(role => slot.availableMinutes >= role.durationMinutes)
+                    .reduce((bestDose, role) => Math.max(bestDose, doseFor(role, requirement)), 0);
+            })
             .filter(dose => dose > 0)
             .sort((left, right) => right - left);
 
@@ -237,10 +257,8 @@ export function packWeeklyDose(
 
     for (const requirement of requirements) {
         const adaptationCandidates = coverage.roles.filter(role => role.adaptations.includes(requirement.adaptation));
-        const eligible = eligibleCandidates(coverage.roles, requirement, durationOverridesByRoleId);
-        const permittedByRole = new Map<CoverageRoleDescriptor, string[]>(eligible.map(entry => [entry.role, entry.permitted]));
-        const candidates = eligible.map(entry => entry.role);
-        if (candidates.length === 0) {
+        const baselineEligible = eligibleCandidates(coverage.roles, requirement, NO_DURATION_OVERRIDES);
+        if (baselineEligible.length === 0) {
             const code = adaptationCandidates.length > 0 ? 'goal_constraint_conflict' : 'no_exact_eligible_role';
             shortfalls.push({ code, adaptation: requirement.adaptation, message: code === 'goal_constraint_conflict'
                 ? `The available exact roles cannot satisfy ${requirement.adaptation} within its permitted modalities.`
@@ -282,9 +300,13 @@ export function packWeeklyDose(
                 }
             }
 
-            const assignment = candidates
-                .flatMap(role => unusedSlots.filter(slot => slot.availableMinutes >= role.durationMinutes)
-                    .map(slot => ({ role, slot })))
+            const assignment = unusedSlots
+                .flatMap(slot => eligibleCandidates(
+                    coverage.roles,
+                    requirement,
+                    overridesForSlot(durationOverridesByRoleId, overrideEffectiveDate, slot.date),
+                ).filter(candidate => slot.availableMinutes >= candidate.role.durationMinutes)
+                    .map(candidate => ({ ...candidate, slot })))
                 .sort((left, right) =>
                     // Best-fit placement is the primary constraint: consume the shortest
                     // window that can host the current requirement before preferring a
@@ -304,7 +326,7 @@ export function packWeeklyDose(
                 coverageSetId: coverage.id,
                 coverageRoleId: assignment.role.id,
                 date: assignment.slot.date,
-                exactWorkoutIds: permittedByRole.get(assignment.role) ?? permittedWorkoutIds(assignment.role, requirement),
+                exactWorkoutIds: assignment.permitted,
                 adaptations: assignment.role.adaptations,
                 priority: requirement.priority,
                 descriptor: assignment.role,

--- a/app/src/engine/weeklyDosePacking.ts
+++ b/app/src/engine/weeklyDosePacking.ts
@@ -79,6 +79,9 @@ interface MutableOccurrence extends PackedRoleOccurrence {
 interface EligibleCandidate {
     role: CoverageRoleDescriptor;
     permitted: string[];
+    /** True when `role.durationMinutes` was narrowed by an active exact/direct override
+     * for the slot's effective date, rather than the authored baseline descriptor. */
+    isActiveOverride: boolean;
 }
 
 const NO_DURATION_OVERRIDES: ReadonlyMap<string, number> = new Map();
@@ -120,23 +123,24 @@ function eligibleCandidateForRole(
 ): EligibleCandidate | null {
     const permitted = permittedWorkoutIds(role, requirement);
     if (permitted.length === 0) return null;
-    if (overrides.size === 0) return { role, permitted };
+    if (overrides.size === 0) return { role, permitted, isActiveOverride: false };
 
     const direct = overrides.get(role.id);
-    if (direct !== undefined) return { role: { ...role, durationMinutes: direct }, permitted };
+    if (direct !== undefined) return { role: { ...role, durationMinutes: direct }, permitted, isActiveOverride: true };
 
     const exact = permitted.flatMap(workoutId => {
         const duration = overrides.get(progressionOverrideKey(role.id, workoutId));
         return duration === undefined ? [] : [{ workoutId, duration }];
     });
-    if (exact.length === 0) return { role, permitted };
+    if (exact.length === 0) return { role, permitted, isActiveOverride: false };
 
     const values = new Set(exact.map(entry => entry.duration));
-    if (values.size !== 1) return { role, permitted };
+    if (values.size !== 1) return { role, permitted, isActiveOverride: false };
 
     return {
         role: { ...role, durationMinutes: exact[0].duration },
         permitted: exact.map(entry => entry.workoutId),
+        isActiveOverride: true,
     };
 }
 
@@ -308,11 +312,17 @@ export function packWeeklyDose(
                 ).filter(candidate => slot.availableMinutes >= candidate.role.durationMinutes)
                     .map(candidate => ({ ...candidate, slot })))
                 .sort((left, right) =>
+                    // An active exact effective-date override represents a confirmed
+                    // progression bound to this occurrence; it must win placement even when
+                    // a shorter-window baseline candidate would otherwise best-fit first,
+                    // or the override's date-scoped session is silently dropped in favor of
+                    // an interchangeable baseline one, reporting a false shortfall.
+                    (right.isActiveOverride ? 1 : 0) - (left.isActiveOverride ? 1 : 0)
                     // Best-fit placement is the primary constraint: consume the shortest
                     // window that can host the current requirement before preferring a
                     // larger-dose role. This preserves scarce long windows for later roles
                     // that have no short-window alternative.
-                    left.slot.availableMinutes - right.slot.availableMinutes
+                    || left.slot.availableMinutes - right.slot.availableMinutes
                     || right.role.durationMinutes - left.role.durationMinutes
                     || (penaltyByDate.get(left.slot.date) ?? 0)
                         - (penaltyByDate.get(right.slot.date) ?? 0)


### PR DESCRIPTION
## Context

Follow-up to merged PR #519. During a second-pass review after #519 had already been merged, three additional semantic gaps were found in the confirmed `IntentBlock` progression wiring.

#519 correctly introduced exact `coverageRoleId::workoutId` progression keys and deliberately limited persistence reads to same-day planning, but the live behavior was still incomplete:

1. **A date-derived override map was still consumed by a seven-day packer without an effective-date boundary.** The map was derived for `date`, yet `resolveEvergreenPlan(..., days = 7)` reused it across every packing slot. This allowed today's progression authority to alter future occurrences in the same rolling plan.
2. **Exact progression authority became inert when the evergreen role allowed sibling modalities.** `aerobic_volume`, for example, can contain cycling/running/walking workouts. Requiring every eligible sibling to carry the same exact override meant a confirmed cycling progression could be ignored as soon as running/walking were also permitted.
3. **The selected recommendation did not execute the confirmed duration.** `progressionDoseForTemplate()` already converted an exact confirmed value into a `DoseVariation`, but the recommendation path never consumed it. Weekly accounting could therefore change while the athlete still received the catalog/default duration.

## Fix

### Exact-workout authority

`weeklyDosePacking.ts` now resolves overrides at the same identity granularity at which they were confirmed:

- plain role-id overrides remain an explicit legacy/test whole-role override;
- exact `role::workout` overrides narrow that occurrence to the exact confirmed workout identity;
- sibling cross-modal substitutions do not inherit the confirmed duration and cannot silently defeat it by remaining baseline alternatives;
- conflicting injected exact values fail closed to baseline semantics rather than guessing.

### Effective-date scoping

`packWeeklyDose` accepts an optional `overrideEffectiveDate`. `resolveEvergreenPlan` passes the date for which the map was derived. Candidate feasibility and assignment are resolved per slot, so the override is visible only on that date inside the multi-day horizon; sibling dates use baseline catalog durations.

This preserves the current product boundary: ordinary tomorrow/week-ahead forecast surfaces still do not preload future `IntentBlock` authority. When a recommendation is actually evaluated for a date and its active blocks are loaded, the map is scoped correctly inside that date's rolling plan.

### Executable recommendation dose

For the selected exact workout, `evaluateTrainingWithIntent` now consumes `progressionDoseForTemplate()` and exposes the confirmed duration as `activeDose` when it remains inside the active constraints.

Safety remains authoritative:

- the progression is never forced beyond today's available minutes;
- the scaled systemic cost must stay inside the current plan tier;
- an existing time/readiness dose reduction remains the ceiling;
- if that ceiling is lower than the confirmed target, the safer lower dose wins and the rationale says the progression target was constrained rather than silently discarded.

Projected next-day history also uses `activeDose.durationMin` when present, so a progressed recommendation is not projected as its old catalog duration.

### Policy audit contract

Because these executable changes can alter a persisted recommendation decision, the engine policy is bumped from `2026-09-progression-confirmed-selection-wiring-v1` to `2026-09-progression-confirmed-selection-wiring-v2`. v1 is retained in `HISTORICAL_POLICY_VERSIONS` so historical audit records remain explicitly recognizable without pretending the old decision function can be replayed by the current build.

## Tests

Added/updated regressions for:

- production-derived exact cycling progression remaining authoritative when the requirement also permits running/walking;
- exact progression never transferring duration credit to sibling modalities;
- one-day override scoping inside a multi-day packing horizon (`70 + baseline 60`, not `70 + 70`);
- live selected-recommendation execution materializing the confirmed 70-minute dose;
- a smaller same-day time cap remaining authoritative over a larger confirmed progression;
- existing legacy whole-role override behavior and guideline floor ownership remaining unchanged.

## Invariants retained

- WHO/guideline `requirement.floor` and `requirement.target` remain untouched.
- Local availability/readiness/safety constraints outrank progression.
- Unsupported coverage keys remain unsupported/visible; this PR does not broaden the H5 coverage vocabulary.
- No new recommendation-time Firestore query is introduced by the engine change.
- Accepted ADR-0037 is not edited; mutable implementation documentation/PR metadata records the delivered correction.

## Verification

GitHub CI is the authoritative verification environment for this follow-up because the repository connection does not provide a local authenticated checkout. The branch is being revalidated after the policy bump and added live-path regression tests.

Related: #519