### PR TITLE
✍️ Scribe: add missing architectural features to README

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -9,3 +9,7 @@
 ## 2026-09-02 - docs/README.md Index Missing Recent Analysis Documents
 **Learning:** The documentation hub (docs/README.md) acts as the routing table but can easily fall out of sync with newly added review/analysis files in docs/analysis/.
 **Action:** Always verify that newly added files in docs/analysis/ are indexed in the root docs/README.md.
+
+## 2026-09-07 - Root README.md Missing Technical Features
+**Learning:** `README.md` was missing several features corresponding to ADRs 0019-0038 from the 'Technical Features' section. These include Explicit Rest-Day Authoring, Source-Aware Multisource Health, and Canonical Performed Training Occurrence.
+**Action:** When auditing documentation drift, always compare feature lists in READMEs against the accepted Architectural Decision Records (ADRs) to ensure the high-level documentation reflects recent architectural additions.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ Adaptive Training Recommendations & Native Session Execution
 17. **Multi-User Family Accounts & Self-Service Linking**: Single-project multi-tenant architecture supporting family members via self-service Garmin login with MFA, server-side identity hashing, and automated multi-user batch sync without hardcoded deployment lists.
 18. **Automated Garmin Workout Push & Calendar Scheduling**: Direct structured workout export queueing from the web app (`garmin_workout_queue`) to Garmin Connect with power zone and interval repeat resolution (`workout_export.py`).
 19. **First-Class Email Authentication & Wearable-Free Operation**: Native email/password sign-in with automatic post-signup authentication, best-effort background email verification, and enumeration-resistant password reset alongside Garmin linking. Athletes whose provider status is confirmed as disconnected can generate daily recommendations and 7-day plans from the safety check-in, revisioned training history, availability, and injury/equipment gates; missing data on a connected or unknown account still fails closed.
+20. **Externally-Authored Plans & Adjudication (ADR-0019)**: First-class support for imported third-party plans where the plan owns selection and the engine owns daily safety, dose, and weekly critique.
+21. **Subjective Baselines & Cause-Aware Symptom Gating (ADR-0020, ADR-0032)**: Self-normalising subjective drift tightening and structured symptom check-ins differentiating ambient fatigue from illness risk.
+22. **Strength Session Logging (ADR-0021)**: Durable raw strength-session logging, gauge semantics, and safe estimated-1RM write-back.
+23. **Source-Aware Multisource Health (ADR-0027, ADR-0030)**: Provenance-separated Google Health and Eight Sleep ingestion, source-specific baselines, and evidence-gated fusion without arithmetic cross-sensor averaging.
+24. **Physiological Identity Passport (ADR-0028)**: Provider-neutral identity-attribution and measurement-trust layer evaluating multi-source cross-night concordance.
+25. **Sports Knowledge Registry (ADR-0033)**: Versioned, claim-level evidence lineage separating sports science from athlete observations.
+26. **Canonical Performed Training Occurrence (ADR-0034)**: Reconciles structured executions and vendor (Garmin) evidence into a single training record distinct from planning authority.
+27. **Advanced Execution Scheduling (ADR-0035, ADR-0036, ADR-0037, ADR-0038)**: Explicit rest-day authoring in external plans, intraday training windows, block intent progression, and engine-generated recovery placement.
 
 ---
 


### PR DESCRIPTION
* **📄 What:** Updated the "Technical Features" section in the root `README.md` to include recent architectural additions.
* **⚠️ Problem:** The `README.md`'s feature list was stale and missing several major capabilities that have been accepted via Architecture Decision Records (ADRs 0019-0038), such as Externally-Authored Plans, Strength Session Logging, Multisource Health, and Canonical Performed Training Occurrence.
* **📚 Source of truth:** The `docs/adr/` directory containing the accepted immutable decisions.
* **✅ Verification:** Verified formatting and code correctness by running `make check`.
* **🎯 Impact:** Ensures that new contributors, operators, and users reading the root README have an accurate understanding of the system's current high-level capabilities.
* **🔒 Governance:** This change only describes existing, accepted policy and architecture more accurately; product scope, authority, privacy, licensing, and operational limits remain unchanged.

---
*PR created automatically by Jules for task [14608336032827270441](https://jules.google.com/task/14608336032827270441) started by @Szczepanov*