### PR TITLE
✍️ Scribe: Index missing architecture documents in docs/README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -236,7 +236,13 @@ In-depth technical design documents covering system subsystems:
 * [**External Plan Import Schema**](./external-plan-schema.md) — *Implemented.* JSON contract for importing an externally-authored plan, plus the placement/revision scheduling model.
 * [**Sustained Multidirectional Field Macrocycle (v5)**](./macrocycle-v5.md) — Target multidirectional speed, strength, and endurance field macrocycle specification.
 * [**Visual Review Workflow**](./visual-review.md) — Visual regression and layout review test harness using Playwright.
+* [**Account-Scoped UI State**](./architecture/account-scoped-ui-state.md) — Invariants for isolating authenticated browser state by Firebase Authentication UID.
+* [**Canonical Weekly Coverage Credit Authority**](./architecture/canonical-coverage-credit.md) — Implementation details for canonical weekly coverage credit from ADR-0034.
+* [**Catalogue Lookup Indexes**](./architecture/catalogue-lookup-indexes.md) — Static catalogue access patterns for templates, exercises, and workouts.
+* [**Morning Decision UX Contracts**](./architecture/morning-decision-ux.md) — Implementation contracts for the morning-decision progressive-disclosure UI.
+* [**Session Execution and Saved-Template Lifecycle**](./architecture/session-execution.md) — Living reference for source-neutral session execution and template behavior.
 * [**Sports Knowledge Registry**](./architecture/sports-knowledge-registry.md) — Implementation details of the versioned sports knowledge layer.
+* [**Canonical Strength Spacing Policy**](./architecture/strength-spacing-policy.md) — Implementation details for canonical strength spacing policy from ADR-0034.
 * [**User Flows**](./architecture/user-flows.md) — Current navigation, per-screen flows, and flow-improvement recommendations.
 
 ---


### PR DESCRIPTION
* **📄 What:** Updated `docs/README.md` to include links to several technical design documents from `docs/architecture/` that were missing from the index.
* **⚠️ Problem:** The `System Architecture` section in the root documentation hub (`docs/README.md`) omitted several key architectural references (e.g., UI state, coverage credit, morning UX, session execution). This caused a discoverability problem where users and agents could easily miss these canonical documents.
* **📚 Source of truth:** The actual presence of these files in the `docs/architecture/` directory, which were not linked in `docs/README.md`.
* **✅ Verification:** Read the architecture files directly to confirm their intent, verified the `README.md` structure, and ran `make check` and `uv run pre-commit run --all-files` successfully to ensure no links were broken or formatting rules violated.
* **🎯 Impact:** Enhances discoverability for engineers and subsequent agents. Readers can now easily find the living references for canonical coverage credit, catalogue indexes, UX invariants, session execution, and UI state isolation right from the documentation index.
* **🔒 Governance:** Confirmed that product scope, authority boundaries, privacy, licensing, and operational limits are unchanged. This is purely a discoverability improvement, describing existing state.

---
*PR created automatically by Jules for task [14291230079650962129](https://jules.google.com/task/14291230079650962129) started by @Szczepanov*